### PR TITLE
Push model: upload local site to remote WordPress

### DIFF
--- a/packages/streaming-exporter/composer.json
+++ b/packages/streaming-exporter/composer.json
@@ -20,7 +20,9 @@
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
             "src/class-http-server.php",
-            "src/class-sqlite-driver-pdo.php"
+            "src/class-sqlite-driver-pdo.php",
+            "src/class-multipart-body-stream.php",
+            "src/class-chunk-writer.php"
         ],
         "files": [
             "src/utils.php"

--- a/packages/streaming-exporter/src/class-chunk-writer.php
+++ b/packages/streaming-exporter/src/class-chunk-writer.php
@@ -80,6 +80,18 @@ class ChunkWriter
             $this->file_ctime = $ctime;
         }
 
+        // Resume recovery: if a file was partially written in a previous
+        // request, re-open it in append mode so continuation chunks (where
+        // is_first=false) can still be written.  Without this, the writer
+        // starts with file_handle=null and non-first chunks are silently dropped.
+        if (!$is_first && $this->file_handle === null && file_exists($local_path)) {
+            $this->file_handle = fopen($local_path, 'ab');
+            if ($this->file_handle) {
+                $this->file_path = $local_path;
+                $this->file_ctime = $ctime;
+            }
+        }
+
         // Write data
         if ($this->file_handle && $data !== '') {
             $bytes = fwrite($this->file_handle, $data);

--- a/packages/streaming-exporter/src/class-chunk-writer.php
+++ b/packages/streaming-exporter/src/class-chunk-writer.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * Writes file chunks, directories, and symlinks into a target directory.
+ *
+ * Extracted from the importer's chunk handlers so both the pull-side importer
+ * and the push-side receiver can share the same filesystem write logic.
+ * The writer performs path security validation (no traversal outside root)
+ * and handles the first-chunk/last-chunk protocol for multi-part file transfers.
+ */
+class ChunkWriter
+{
+    /** @var string Absolute path to the root directory for writes. */
+    private $root;
+
+    /** @var resource|null Currently open file handle for streaming writes. */
+    private $file_handle = null;
+
+    /** @var string|null Path of the currently open file. */
+    private $file_path = null;
+
+    /** @var int Ctime of the currently open file (for touch after close). */
+    private $file_ctime = 0;
+
+    /** @var callable|null Optional audit log callback: function(string $message): void */
+    private $audit_log;
+
+    /**
+     * @param string        $root      Absolute path to the target directory.
+     * @param callable|null $audit_log Optional logging callback.
+     */
+    public function __construct(string $root, ?callable $audit_log = null)
+    {
+        $this->root = rtrim($root, '/');
+        $this->audit_log = $audit_log;
+    }
+
+    /**
+     * Write a file data chunk.
+     *
+     * Handles the first/last chunk protocol: opens the file on first chunk,
+     * writes data, closes and sets mtime on last chunk.
+     *
+     * @param string $path       Remote absolute path (e.g. "/wp-content/uploads/photo.jpg").
+     * @param string $data       File content bytes for this chunk.
+     * @param bool   $is_first   True if this is the first chunk of a new file.
+     * @param bool   $is_last    True if this is the final chunk.
+     * @param int    $ctime      File ctime (used for touch on last chunk).
+     */
+    public function write_file_chunk(
+        string $path,
+        string $data,
+        bool $is_first,
+        bool $is_last,
+        int $ctime = 0
+    ): void {
+        $local_path = $this->resolve_path($path);
+
+        if ($is_first) {
+            // Close any previously open file (safety net)
+            $this->close_current_file();
+
+            // Remove non-regular-files at the target path
+            if (
+                (file_exists($local_path) || is_link($local_path)) &&
+                (!is_file($local_path) || is_link($local_path))
+            ) {
+                $this->remove_path($local_path);
+            }
+
+            // Create parent directory
+            $this->ensure_directory(dirname($local_path));
+
+            // Open for writing
+            $this->file_handle = fopen($local_path, 'wb');
+            if (!$this->file_handle) {
+                throw new RuntimeException("Failed to open file for writing: {$local_path}");
+            }
+            $this->file_path = $local_path;
+            $this->file_ctime = $ctime;
+        }
+
+        // Write data
+        if ($this->file_handle && $data !== '') {
+            $bytes = fwrite($this->file_handle, $data);
+            if ($bytes === false || $bytes !== strlen($data)) {
+                throw new RuntimeException(
+                    "Write failed for {$this->file_path}: wrote " .
+                    ($bytes === false ? '0' : $bytes) . '/' . strlen($data) .
+                    ' bytes (disk full?)'
+                );
+            }
+        }
+
+        // Close on last chunk
+        if ($is_last) {
+            $this->close_current_file();
+        }
+    }
+
+    /**
+     * Create a directory.
+     */
+    public function write_directory(string $path, int $ctime = 0): void
+    {
+        $local_path = $this->resolve_path($path);
+
+        // Remove non-directory at the target path
+        if (
+            (file_exists($local_path) || is_link($local_path)) &&
+            (!is_dir($local_path) || is_link($local_path))
+        ) {
+            $this->remove_path($local_path);
+        }
+
+        $this->ensure_directory($local_path);
+
+        if ($ctime > 0) {
+            @touch($local_path, $ctime);
+        }
+    }
+
+    /**
+     * Create a symlink.
+     *
+     * @param string $path   Remote absolute path for the symlink.
+     * @param string $target Symlink target (relative or absolute).
+     * @param int    $ctime  Ctime (informational, symlinks can't be touched on all OSes).
+     */
+    public function write_symlink(string $path, string $target, int $ctime = 0): void
+    {
+        $local_path = $this->resolve_path($path);
+
+        // Validate target stays within root
+        $this->assert_symlink_target_within_root(
+            dirname($local_path),
+            $target
+        );
+
+        // Create parent directory
+        $this->ensure_directory(dirname($local_path));
+
+        // Remove anything at the target path
+        if (file_exists($local_path) || is_link($local_path)) {
+            $this->remove_path($local_path);
+        }
+
+        if (!symlink($target, $local_path)) {
+            $this->log("Warning: failed to create symlink: {$path} -> {$target}");
+        }
+    }
+
+    /**
+     * Flush and close the currently open file, if any.
+     * Called automatically between files and on destruction.
+     */
+    public function close_current_file(): void
+    {
+        if ($this->file_handle) {
+            fclose($this->file_handle);
+            if ($this->file_ctime > 0 && $this->file_path) {
+                @touch($this->file_path, $this->file_ctime);
+            }
+            $this->file_handle = null;
+            $this->file_path = null;
+            $this->file_ctime = 0;
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->close_current_file();
+    }
+
+    /**
+     * Resolve a remote absolute path to a local path under the root.
+     * Validates the path is safe (no NUL bytes, no dot-segments, absolute).
+     */
+    private function resolve_path(string $path): string
+    {
+        assert_valid_path($path, 'remote path');
+        return $this->root . $path;
+    }
+
+    /**
+     * Ensure a directory exists, creating intermediate directories as needed.
+     */
+    private function ensure_directory(string $dir): void
+    {
+        if (is_dir($dir) && !is_link($dir)) {
+            return;
+        }
+
+        // Walk from root to target, creating each component
+        if (
+            $dir !== $this->root &&
+            !str_starts_with($dir, $this->root . '/')
+        ) {
+            throw new RuntimeException(
+                "Security: Refusing to create directory outside root: {$dir}"
+            );
+        }
+
+        $relative = ltrim(substr($dir, strlen($this->root)), '/');
+        if ($relative === '') {
+            return;
+        }
+
+        $current = $this->root;
+        foreach (explode('/', $relative) as $part) {
+            if ($part === '') {
+                continue;
+            }
+            $current .= '/' . $part;
+
+            // Remove symlinks or files that block directory creation
+            if (is_link($current)) {
+                if (!unlink($current)) {
+                    throw new RuntimeException("Failed to remove symlink blocking directory: {$current}");
+                }
+                clearstatcache(true, $current);
+            }
+
+            if (is_file($current)) {
+                if (!unlink($current)) {
+                    throw new RuntimeException("Failed to remove file blocking directory: {$current}");
+                }
+            }
+
+            if (!is_dir($current) && !mkdir($current, 0755) && !is_dir($current)) {
+                throw new RuntimeException(
+                    "Failed to create directory: {$current}\n" .
+                    'Error: ' . (error_get_last()['message'] ?? 'unknown')
+                );
+            }
+        }
+    }
+
+    /**
+     * Remove a path (file, symlink, or empty directory) without following symlinks.
+     */
+    private function remove_path(string $path): void
+    {
+        if (is_link($path)) {
+            unlink($path);
+        } elseif (is_dir($path)) {
+            @rmdir($path);
+        } elseif (is_file($path)) {
+            unlink($path);
+        }
+    }
+
+    /**
+     * Assert that a symlink target resolves to a path within the root.
+     */
+    private function assert_symlink_target_within_root(
+        string $symlink_parent_dir,
+        string $target
+    ): void {
+        if (str_starts_with($target, '/')) {
+            $resolved = normalize_path($target);
+        } else {
+            $resolved = normalize_path($symlink_parent_dir . '/' . $target);
+        }
+
+        if (!path_is_within_root($resolved, $this->root)) {
+            throw new RuntimeException(
+                "Security: symlink target escapes root: {$target} " .
+                "(resolves to {$resolved}, root is {$this->root})"
+            );
+        }
+    }
+
+    private function log(string $message): void
+    {
+        if ($this->audit_log) {
+            ($this->audit_log)($message);
+        }
+    }
+}

--- a/packages/streaming-exporter/src/class-http-server.php
+++ b/packages/streaming-exporter/src/class-http-server.php
@@ -34,12 +34,33 @@ final class Site_Export_HTTP_Server {
     public function handle_request(array $request = []): void {
         $server = $request['server'] ?? $_SERVER;
         $body = array_key_exists('body', $request) ? (string) $request['body'] : call_user_func($this->body_reader);
-        $config = $request['config'] ?? $this->parse_http_config(
-            $request['get'] ?? $_GET,
-            $request['post'] ?? $_POST,
-            $server,
-            $body
-        );
+
+        // Detect multipart/mixed requests (push receiver). For these, the body
+        // is the multipart payload — config params come from the query string only.
+        // We stash the raw body and content-type in the config so receiver
+        // endpoints can parse the multipart chunks.
+        $content_type = $server['CONTENT_TYPE'] ?? $server['HTTP_CONTENT_TYPE'] ?? '';
+        $content_type_main = strtolower(trim((string) strtok((string) $content_type, ';')));
+        $is_multipart = ($content_type_main === 'multipart/mixed');
+
+        if ($is_multipart) {
+            $config = $request['config'] ?? $this->parse_http_config(
+                $request['get'] ?? $_GET,
+                $request['post'] ?? $_POST,
+                $server,
+                '' // Don't parse body as JSON for multipart requests
+            );
+            $config['_raw_body'] = $body;
+            $config['_content_type'] = $content_type;
+        } else {
+            $config = $request['config'] ?? $this->parse_http_config(
+                $request['get'] ?? $_GET,
+                $request['post'] ?? $_POST,
+                $server,
+                $body
+            );
+        }
+
         $config = $this->normalize_config($config, $server);
         $this->dispatch($config);
     }
@@ -171,7 +192,7 @@ final class Site_Export_HTTP_Server {
         }
 
         $handler = $this->handlers[$endpoint];
-        if ($endpoint === 'preflight') {
+        if ($endpoint === 'preflight' || $endpoint === 'commit') {
             call_user_func($handler, $config);
             return;
         }
@@ -193,6 +214,9 @@ final class Site_Export_HTTP_Server {
             'sql_chunk' => 'endpoint_sql_chunk',
             'db_index' => 'endpoint_db_index',
             'preflight' => 'endpoint_preflight',
+            'sql_receive' => 'endpoint_sql_receive',
+            'file_receive' => 'endpoint_file_receive',
+            'commit' => 'endpoint_commit',
         ];
     }
 

--- a/packages/streaming-exporter/src/class-multipart-body-stream.php
+++ b/packages/streaming-exporter/src/class-multipart-body-stream.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Streaming multipart/mixed body builder for push uploads.
+ *
+ * Writes producer output (SQL chunks, file chunks, directories, symlinks)
+ * into a seekable php://temp stream formatted as multipart/mixed. The stream
+ * is memory-backed for small payloads and automatically spills to disk above
+ * ~2 MB (PHP's default php://temp threshold).
+ *
+ * The push client loop:
+ * 1. Create stream, create producer from receiver's last cursor
+ * 2. Feed producer output into stream until post_max_size reached
+ * 3. Compute HMAC hash by reading stream, rewind
+ * 4. curl uploads from the stream resource
+ * 5. Receiver returns cursor from its last processed chunk
+ */
+class MultipartBodyStream
+{
+    /** @var string */
+    private $boundary;
+
+    /** @var resource */
+    private $stream;
+
+    /** @var bool */
+    private $finalized = false;
+
+    public function __construct()
+    {
+        $this->boundary = 'boundary-' . bin2hex(random_bytes(16));
+        $this->stream = fopen('php://temp', 'r+');
+        if ($this->stream === false) {
+            throw new RuntimeException('Failed to open php://temp stream');
+        }
+    }
+
+    public function get_boundary(): string
+    {
+        return $this->boundary;
+    }
+
+    public function get_content_type(): string
+    {
+        return 'multipart/mixed; boundary="' . $this->boundary . '"';
+    }
+
+    /**
+     * Write a file data chunk as a multipart part.
+     *
+     * @param array  $chunk  File chunk with keys: path, data, size, ctime, offset,
+     *                       is_first_chunk, is_last_chunk, and optional file_changed fields.
+     * @param string $cursor Base64-encoded cursor from the producer.
+     */
+    public function write_file_chunk(array $chunk, string $cursor): void
+    {
+        $this->assert_not_finalized();
+
+        $data = $chunk['data'];
+        $headers =
+            "--{$this->boundary}\r\n" .
+            "Content-Type: application/octet-stream\r\n" .
+            "Content-Length: " . strlen($data) . "\r\n" .
+            "X-Chunk-Type: file\r\n" .
+            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+            "X-File-Path: " . base64_encode($chunk['path']) . "\r\n" .
+            "X-File-Size: " . $chunk['size'] . "\r\n" .
+            "X-File-Ctime: " . $chunk['ctime'] . "\r\n" .
+            "X-Chunk-Offset: " . $chunk['offset'] . "\r\n" .
+            "X-Chunk-Size: " . strlen($data) . "\r\n" .
+            "X-First-Chunk: " . ($chunk['is_first_chunk'] ? '1' : '0') . "\r\n" .
+            "X-Last-Chunk: " . ($chunk['is_last_chunk'] ? '1' : '0') . "\r\n";
+
+        if (!empty($chunk['file_changed'])) {
+            $headers .= "X-File-Changed: 1\r\n";
+            if ($chunk['change_ctime'] !== null) {
+                $headers .= "X-File-Change-Ctime: " . $chunk['change_ctime'] . "\r\n";
+            }
+            if ($chunk['change_size'] !== null) {
+                $headers .= "X-File-Change-Size: " . $chunk['change_size'] . "\r\n";
+            }
+        }
+
+        fwrite($this->stream, $headers . "\r\n");
+        fwrite($this->stream, $data);
+        fwrite($this->stream, "\r\n");
+    }
+
+    /**
+     * Write a directory entry as a multipart part.
+     */
+    public function write_directory_chunk(string $path, string $cursor, ?int $ctime = null): void
+    {
+        $this->assert_not_finalized();
+
+        $part =
+            "--{$this->boundary}\r\n" .
+            "Content-Type: application/octet-stream\r\n" .
+            "Content-Length: 0\r\n" .
+            "X-Chunk-Type: directory\r\n" .
+            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+            "X-Directory-Path: " . base64_encode($path) . "\r\n";
+
+        if ($ctime !== null) {
+            $part .= "X-Directory-Ctime: " . $ctime . "\r\n";
+        }
+
+        fwrite($this->stream, $part . "\r\n\r\n");
+    }
+
+    /**
+     * Write a symlink entry as a multipart part.
+     */
+    public function write_symlink_chunk(string $path, string $target, int $ctime, string $cursor): void
+    {
+        $this->assert_not_finalized();
+
+        fwrite(
+            $this->stream,
+            "--{$this->boundary}\r\n" .
+            "Content-Type: application/octet-stream\r\n" .
+            "Content-Length: 0\r\n" .
+            "X-Chunk-Type: symlink\r\n" .
+            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+            "X-Symlink-Path: " . base64_encode($path) . "\r\n" .
+            "X-Symlink-Target: " . base64_encode($target) . "\r\n" .
+            "X-Symlink-Ctime: " . $ctime . "\r\n" .
+            "\r\n\r\n"
+        );
+    }
+
+    /**
+     * Write a SQL chunk as a multipart part.
+     *
+     * @param string $sql            The SQL fragment text.
+     * @param string $cursor         Producer's reentrancy cursor (JSON string).
+     * @param bool   $query_complete Whether this chunk ends on a complete statement boundary.
+     */
+    public function write_sql_chunk(string $sql, string $cursor, bool $query_complete): void
+    {
+        $this->assert_not_finalized();
+
+        fwrite(
+            $this->stream,
+            "--{$this->boundary}\r\n" .
+            "Content-Type: application/sql\r\n" .
+            "Content-Length: " . strlen($sql) . "\r\n" .
+            "X-Chunk-Type: sql\r\n" .
+            "X-Query-Complete: " . ($query_complete ? '1' : '0') . "\r\n" .
+            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+            "\r\n"
+        );
+        fwrite($this->stream, $sql);
+        fwrite($this->stream, "\r\n");
+    }
+
+    /**
+     * Write a completion marker as the final content part.
+     */
+    public function write_completion_chunk(string $status, array $stats = []): void
+    {
+        $this->assert_not_finalized();
+
+        $headers =
+            "--{$this->boundary}\r\n" .
+            "Content-Type: application/octet-stream\r\n" .
+            "Content-Length: 0\r\n" .
+            "X-Chunk-Type: completion\r\n" .
+            "X-Status: {$status}\r\n";
+
+        foreach ($stats as $key => $value) {
+            $header_key = 'X-' . str_replace('_', '-', ucwords($key, '_'));
+            $headers .= "{$header_key}: {$value}\r\n";
+        }
+
+        fwrite($this->stream, $headers . "\r\n\r\n");
+    }
+
+    /**
+     * Write the closing boundary. No more parts can be added after this.
+     */
+    public function finalize(): void
+    {
+        if ($this->finalized) {
+            return;
+        }
+        fwrite($this->stream, "--{$this->boundary}--\r\n");
+        $this->finalized = true;
+    }
+
+    /**
+     * Return the total size of the multipart body written so far.
+     */
+    public function get_size(): int
+    {
+        $pos = ftell($this->stream);
+        fseek($this->stream, 0, SEEK_END);
+        $size = ftell($this->stream);
+        fseek($this->stream, $pos, SEEK_SET);
+        return $size;
+    }
+
+    /**
+     * Return the underlying seekable stream resource for curl CURLOPT_INFILE.
+     * Automatically rewinds to the beginning.
+     */
+    public function get_resource()
+    {
+        rewind($this->stream);
+        return $this->stream;
+    }
+
+    /**
+     * Rewind the stream to the beginning (e.g. after HMAC hash, before curl read).
+     */
+    public function rewind(): void
+    {
+        rewind($this->stream);
+    }
+
+    /**
+     * Read the entire stream contents as a string (for HMAC hashing).
+     * Does NOT change the stream position — reads from current position to end,
+     * then seeks back.
+     */
+    public function get_contents(): string
+    {
+        $pos = ftell($this->stream);
+        rewind($this->stream);
+        $contents = stream_get_contents($this->stream);
+        fseek($this->stream, $pos, SEEK_SET);
+        return $contents;
+    }
+
+    private function assert_not_finalized(): void
+    {
+        if ($this->finalized) {
+            throw new RuntimeException('Cannot write to a finalized MultipartBodyStream');
+        }
+    }
+}

--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -3849,11 +3849,11 @@ function endpoint_commit(array $config): array
 
     // Check staging tables exist
     $staging_table_names = [];
+    $existing_tables = [];
     if (!empty($pushed_tables)) {
         $stmt = $pdo->query(
             "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
         );
-        $existing_tables = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $existing_tables[$row['TABLE_NAME']] = true;
         }

--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -3373,6 +3373,683 @@ function position_after_entry(array $entries, string $after): int
     return $low;
 }
 
+// =========================================================================
+// Push receiver endpoints
+// =========================================================================
+
+require_once __DIR__ . '/class-multipart-body-stream.php';
+require_once __DIR__ . '/class-chunk-writer.php';
+
+/**
+ * The staging prefix prepended to table names during push-sql.
+ *
+ * During push, the receiver creates staging copies of every table with this
+ * prefix prepended to the original name. On commit, RENAME TABLE atomically
+ * swaps the staging tables into place.
+ *
+ * Example: wp_posts → _push_wp_posts
+ */
+define('PUSH_STAGING_TABLE_PREFIX', '_push_');
+
+/**
+ * Parse a multipart/mixed body into an array of chunks.
+ *
+ * Each chunk is an associative array with:
+ *   - 'headers': array of lowercase header-name => value
+ *   - 'body':    string body content
+ *
+ * This is a synchronous parser for use on the receiver side where we have
+ * the full body in memory (it was already read for HMAC verification).
+ *
+ * @param string $body     Raw multipart body.
+ * @param string $boundary Multipart boundary string (without leading --).
+ * @return array List of parsed chunks.
+ */
+function parse_multipart_body(string $body, string $boundary): array
+{
+    $delimiter = '--' . $boundary;
+    $closing = $delimiter . '--';
+    $chunks = [];
+
+    // Split on boundary markers
+    $parts = explode($delimiter, $body);
+
+    // First element is the preamble (before first boundary), skip it.
+    // Last element may contain the closing marker "--", skip that too.
+    array_shift($parts);
+
+    foreach ($parts as $part) {
+        // Check for closing boundary
+        if (str_starts_with(ltrim($part, "\r\n"), '--')) {
+            break;
+        }
+
+        // Split headers from body at the first blank line
+        $header_end = strpos($part, "\r\n\r\n");
+        if ($header_end === false) {
+            $header_end = strpos($part, "\n\n");
+            if ($header_end === false) {
+                continue;
+            }
+            $header_block = substr($part, 0, $header_end);
+            $body_content = substr($part, $header_end + 2);
+        } else {
+            $header_block = substr($part, 0, $header_end);
+            $body_content = substr($part, $header_end + 4);
+        }
+
+        // Parse headers
+        $headers = [];
+        foreach (explode("\n", $header_block) as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            $colon = strpos($line, ':');
+            if ($colon !== false) {
+                $name = strtolower(trim(substr($line, 0, $colon)));
+                $value = ltrim(substr($line, $colon + 1));
+                $headers[$name] = $value;
+            }
+        }
+
+        // Trim trailing \r\n from body (multipart framing artifact)
+        $body_content = rtrim($body_content, "\r\n");
+
+        // Respect Content-Length if present
+        if (isset($headers['content-length'])) {
+            $len = (int) $headers['content-length'];
+            $body_content = substr($body_content, 0, $len);
+        }
+
+        $chunks[] = [
+            'headers' => $headers,
+            'body' => $body_content,
+        ];
+    }
+
+    return $chunks;
+}
+
+/**
+ * Rewrite table names in a SQL statement from the original prefix to a staging prefix.
+ *
+ * Targets well-defined positions in MySQL DDL/DML:
+ *   DROP TABLE IF EXISTS `original` → DROP TABLE IF EXISTS `staging`
+ *   CREATE TABLE `original`         → CREATE TABLE `staging`
+ *   INSERT INTO `original`          → INSERT INTO `staging`
+ *   REFERENCES `original`           → REFERENCES `staging` (FK constraints)
+ *
+ * @param string $sql       The SQL statement to rewrite.
+ * @param array  $table_map Map of original_name => staging_name.
+ * @return string The rewritten SQL.
+ */
+function rewrite_table_names(string $sql, array $table_map): string
+{
+    foreach ($table_map as $original => $staging) {
+        // Patterns that appear in MySQL dumps at known positions.
+        // We match the backtick-quoted name to avoid partial matches.
+        $patterns = [
+            "DROP TABLE IF EXISTS `{$original}`"  => "DROP TABLE IF EXISTS `{$staging}`",
+            "CREATE TABLE `{$original}`"          => "CREATE TABLE `{$staging}`",
+            "INSERT INTO `{$original}`"           => "INSERT INTO `{$staging}`",
+            "REFERENCES `{$original}`"            => "REFERENCES `{$staging}`",
+        ];
+        foreach ($patterns as $from => $to) {
+            $sql = str_replace($from, $to, $sql);
+        }
+    }
+    return $sql;
+}
+
+/**
+ * Build the table name map for push staging.
+ *
+ * Maps every table that starts with the given prefix to its staging name.
+ * Also accepts a list of "incoming" table names from the push client so
+ * tables that exist only on the source side get mapped too.
+ *
+ * @param PDO    $pdo              Database connection.
+ * @param string $table_prefix     WordPress table prefix (e.g. "wp_").
+ * @param array  $incoming_tables  Additional table names from the push client.
+ * @return array Map of original_name => staging_name.
+ */
+function build_staging_table_map(
+    PDO $pdo,
+    string $table_prefix,
+    array $incoming_tables = []
+): array {
+    $map = [];
+
+    // Get all existing tables with this prefix
+    $stmt = $pdo->query(
+        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+    );
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $name = $row['TABLE_NAME'];
+        if ($table_prefix === '' || str_starts_with($name, $table_prefix)) {
+            $map[$name] = PUSH_STAGING_TABLE_PREFIX . $name;
+        }
+    }
+
+    // Add incoming tables that don't exist on the remote yet
+    foreach ($incoming_tables as $name) {
+        if (!isset($map[$name]) && ($table_prefix === '' || str_starts_with($name, $table_prefix))) {
+            $map[$name] = PUSH_STAGING_TABLE_PREFIX . $name;
+        }
+    }
+
+    return $map;
+}
+
+/**
+ * Receive and execute SQL from a push client.
+ *
+ * The client streams SQL via multipart/mixed. This endpoint rewrites table
+ * names to use a staging prefix and executes the SQL. The receiver is the
+ * authority on progress — it returns the cursor of the last chunk it
+ * successfully processed.
+ *
+ * Config params (via query string):
+ *   - table_prefix: WordPress table prefix on the source site
+ *   - incoming_tables: JSON array of table names being pushed (optional)
+ *
+ * @param array          $config Endpoint configuration.
+ * @param ResourceBudget $budget Time/memory budget.
+ * @return array Response with cursor and stats.
+ */
+function endpoint_sql_receive(
+    array $config,
+    ResourceBudget $budget
+): array {
+    $raw_body = $config['_raw_body'] ?? '';
+    $content_type = $config['_content_type'] ?? '';
+
+    // Extract boundary from content type
+    if (!preg_match('/boundary="?([^";]+)"?/', $content_type, $m)) {
+        throw new InvalidArgumentException('Missing boundary in Content-Type header');
+    }
+    $boundary = $m[1];
+
+    $table_prefix = $config['table_prefix'] ?? ($GLOBALS['table_prefix'] ?? 'wp_');
+    $incoming_tables_json = $config['incoming_tables'] ?? '[]';
+    $incoming_tables = is_string($incoming_tables_json)
+        ? (json_decode($incoming_tables_json, true) ?? [])
+        : (is_array($incoming_tables_json) ? $incoming_tables_json : []);
+
+    $creds = resolve_db_credentials();
+    $pdo = create_db_connection($creds);
+
+    // Build the staging table map: original_name → staging_name
+    $table_map = build_staging_table_map($pdo, $table_prefix, $incoming_tables);
+
+    // Parse the multipart body
+    $chunks = parse_multipart_body($raw_body, $boundary);
+
+    $last_cursor = null;
+    $statements_executed = 0;
+    $sql_bytes = 0;
+    $status = 'partial';
+
+    foreach ($chunks as $chunk) {
+        if (!$budget->has_remaining()) {
+            break;
+        }
+
+        $headers = $chunk['headers'];
+        $chunk_type = $headers['x-chunk-type'] ?? '';
+
+        if ($chunk_type === 'sql') {
+            $sql = $chunk['body'];
+            $sql_bytes += strlen($sql);
+
+            // Rewrite table names to staging prefix
+            $sql = rewrite_table_names($sql, $table_map);
+
+            // Execute the SQL. MySQLDumpProducer emits complete statements
+            // terminated by semicolons, but a single chunk may contain
+            // multiple statements (CREATE TABLE + INSERT batches).
+            if (trim($sql) !== '') {
+                $pdo->exec($sql);
+                $statements_executed++;
+            }
+
+            $cursor_b64 = $headers['x-cursor'] ?? '';
+            if ($cursor_b64 !== '') {
+                $last_cursor = base64_decode($cursor_b64, true) ?: null;
+            }
+        } elseif ($chunk_type === 'completion') {
+            $remote_status = $headers['x-status'] ?? 'partial';
+            if ($remote_status === 'complete') {
+                $status = 'complete';
+            }
+        }
+    }
+
+    // If we processed all chunks and saw completion, mark complete
+    if ($status !== 'complete') {
+        $status = 'partial';
+    }
+
+    header('Content-Type: application/json');
+    $response = [
+        'status' => $status,
+        'cursor' => $last_cursor,
+        'statements_executed' => $statements_executed,
+        'sql_bytes' => $sql_bytes,
+    ];
+    echo json_encode($response);
+
+    return [
+        'status' => $status,
+        'stats' => $response,
+    ];
+}
+
+/**
+ * Receive files from a push client and write them to a staging directory.
+ *
+ * The staging directory is created alongside the fs root:
+ *   {fs_root}/../.push-staging-{id}/
+ *
+ * The staging ID is persistent across requests (stored in config/state)
+ * so resumed pushes write to the same staging directory.
+ *
+ * Config params (via query string):
+ *   - staging_id: Persistent staging session ID
+ *   - directory:  The remote's fs_root (for path resolution)
+ *
+ * @param array          $config Endpoint configuration.
+ * @param ResourceBudget $budget Time/memory budget.
+ * @return array Response with cursor and stats.
+ */
+function endpoint_file_receive(
+    array $config,
+    ResourceBudget $budget
+): array {
+    $raw_body = $config['_raw_body'] ?? '';
+    $content_type = $config['_content_type'] ?? '';
+
+    if (!preg_match('/boundary="?([^";]+)"?/', $content_type, $m)) {
+        throw new InvalidArgumentException('Missing boundary in Content-Type header');
+    }
+    $boundary = $m[1];
+
+    $staging_id = $config['staging_id'] ?? null;
+    if (!$staging_id || !preg_match('/^[a-zA-Z0-9_-]+$/', $staging_id)) {
+        throw new InvalidArgumentException(
+            'staging_id is required and must be alphanumeric/dash/underscore'
+        );
+    }
+
+    // Resolve the fs_root from config
+    $directories = resolve_directories($config);
+    $fs_root = rtrim($directories[0], '/');
+
+    // Create staging directory alongside the fs_root
+    $staging_dir = dirname($fs_root) . '/.push-staging-' . $staging_id;
+    if (!is_dir($staging_dir)) {
+        if (!mkdir($staging_dir, 0755, true) && !is_dir($staging_dir)) {
+            throw new RuntimeException("Failed to create staging directory: {$staging_dir}");
+        }
+    }
+
+    $writer = new ChunkWriter($staging_dir, function (string $msg) {
+        error_log("push-file-receive: {$msg}");
+    });
+
+    $chunks = parse_multipart_body($raw_body, $boundary);
+
+    $last_cursor = null;
+    $files_written = 0;
+    $bytes_written = 0;
+    $dirs_created = 0;
+    $status = 'partial';
+
+    foreach ($chunks as $chunk) {
+        if (!$budget->has_remaining()) {
+            break;
+        }
+
+        $headers = $chunk['headers'];
+        $chunk_type = $headers['x-chunk-type'] ?? '';
+
+        if ($chunk_type === 'file') {
+            $path = base64_decode($headers['x-file-path'] ?? '', true);
+            if ($path === false || $path === '') {
+                continue;
+            }
+
+            $is_first = ($headers['x-first-chunk'] ?? '0') === '1';
+            $is_last = ($headers['x-last-chunk'] ?? '0') === '1';
+            $ctime = (int) ($headers['x-file-ctime'] ?? 0);
+
+            $writer->write_file_chunk(
+                $path,
+                $chunk['body'],
+                $is_first,
+                $is_last,
+                $ctime
+            );
+
+            $bytes_written += strlen($chunk['body']);
+            if ($is_last) {
+                $files_written++;
+            }
+
+            $cursor_b64 = $headers['x-cursor'] ?? '';
+            if ($cursor_b64 !== '') {
+                $last_cursor = base64_decode($cursor_b64, true) ?: null;
+            }
+        } elseif ($chunk_type === 'directory') {
+            $path = base64_decode($headers['x-directory-path'] ?? '', true);
+            if ($path === false || $path === '') {
+                continue;
+            }
+            $ctime = (int) ($headers['x-directory-ctime'] ?? 0);
+            $writer->write_directory($path, $ctime);
+            $dirs_created++;
+
+            $cursor_b64 = $headers['x-cursor'] ?? '';
+            if ($cursor_b64 !== '') {
+                $last_cursor = base64_decode($cursor_b64, true) ?: null;
+            }
+        } elseif ($chunk_type === 'symlink') {
+            $path = base64_decode($headers['x-symlink-path'] ?? '', true);
+            $target = base64_decode($headers['x-symlink-target'] ?? '', true);
+            if ($path === false || $path === '' || $target === false) {
+                continue;
+            }
+            $ctime = (int) ($headers['x-symlink-ctime'] ?? 0);
+            $writer->write_symlink($path, $target, $ctime);
+
+            $cursor_b64 = $headers['x-cursor'] ?? '';
+            if ($cursor_b64 !== '') {
+                $last_cursor = base64_decode($cursor_b64, true) ?: null;
+            }
+        } elseif ($chunk_type === 'completion') {
+            $remote_status = $headers['x-status'] ?? 'partial';
+            if ($remote_status === 'complete') {
+                $status = 'complete';
+            }
+        }
+    }
+
+    // Flush any open file
+    $writer->close_current_file();
+
+    if ($status !== 'complete') {
+        $status = 'partial';
+    }
+
+    header('Content-Type: application/json');
+    $response = [
+        'status' => $status,
+        'cursor' => $last_cursor,
+        'staging_dir' => $staging_dir,
+        'files_written' => $files_written,
+        'bytes_written' => $bytes_written,
+        'dirs_created' => $dirs_created,
+    ];
+    echo json_encode($response);
+
+    return [
+        'status' => $status,
+        'stats' => $response,
+    ];
+}
+
+/**
+ * Commit a push: atomically swap staged files and database tables into place.
+ *
+ * This is the point of no return. The endpoint:
+ *   1. Validates that staging tables and staging directory are ready
+ *   2. Copies live wp-config.php into staging directory (preserves remote credentials)
+ *   3. Swaps files (symlink swap or rename swap)
+ *   4. Swaps database tables (atomic RENAME TABLE)
+ *   5. On DB failure: rolls back files
+ *   6. Cleans up old artifacts
+ *
+ * Config params (via query string):
+ *   - staging_id:    The staging session ID
+ *   - directory:     The remote's fs_root
+ *   - table_prefix:  WordPress table prefix
+ *   - pushed_tables: JSON array of table names that were pushed
+ *
+ * @param array $config Endpoint configuration.
+ * @return array Response with swap results.
+ */
+function endpoint_commit(array $config): array
+{
+    $staging_id = $config['staging_id'] ?? null;
+    if (!$staging_id || !preg_match('/^[a-zA-Z0-9_-]+$/', $staging_id)) {
+        throw new InvalidArgumentException('staging_id is required');
+    }
+
+    $table_prefix = $config['table_prefix'] ?? ($GLOBALS['table_prefix'] ?? 'wp_');
+    $pushed_tables_json = $config['pushed_tables'] ?? '[]';
+    $pushed_tables = is_string($pushed_tables_json)
+        ? (json_decode($pushed_tables_json, true) ?? [])
+        : (is_array($pushed_tables_json) ? $pushed_tables_json : []);
+
+    $directories = resolve_directories($config);
+    $fs_root = rtrim($directories[0], '/');
+    $staging_dir = dirname($fs_root) . '/.push-staging-' . $staging_id;
+
+    $creds = resolve_db_credentials();
+    $pdo = create_db_connection($creds);
+
+    $tables_swapped = 0;
+    $file_strategy = 'none';
+    $errors = [];
+
+    // ---------------------------------------------------------------
+    // 1. Validate staging state
+    // ---------------------------------------------------------------
+
+    // Check staging tables exist
+    $staging_table_names = [];
+    if (!empty($pushed_tables)) {
+        $stmt = $pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        $existing_tables = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $existing_tables[$row['TABLE_NAME']] = true;
+        }
+
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            if (!isset($existing_tables[$staging_name])) {
+                $errors[] = "Missing staging table: {$staging_name}";
+            } else {
+                $staging_table_names[] = $staging_name;
+            }
+        }
+    }
+
+    // Check staging directory exists (only if staging_id was used for files)
+    $has_staging_dir = is_dir($staging_dir);
+
+    if (!empty($errors)) {
+        header('Content-Type: application/json');
+        http_response_code(400);
+        $response = [
+            'status' => 'error',
+            'errors' => $errors,
+        ];
+        echo json_encode($response);
+        return ['status' => 'error', 'stats' => $response];
+    }
+
+    // ---------------------------------------------------------------
+    // 2. Swap files (if staging directory exists)
+    // ---------------------------------------------------------------
+
+    $files_swapped = false;
+    $old_fs_dir = null;
+
+    if ($has_staging_dir) {
+        // Copy live wp-config.php into staging directory before swap,
+        // so the new document root keeps the remote site's DB credentials.
+        $wp_config_src = $fs_root . '/wp-config.php';
+        $wp_config_dst = $staging_dir . '/wp-config.php';
+        if (file_exists($wp_config_src)) {
+            copy($wp_config_src, $wp_config_dst);
+        }
+
+        // Detect swap strategy
+        if (is_link($fs_root)) {
+            // Symlink swap: atomic via rename of a new symlink
+            $file_strategy = 'symlink';
+            $real_target = readlink($fs_root);
+            $new_link = $fs_root . '_new_' . $staging_id;
+            $old_target = $real_target;
+
+            // Create new symlink pointing to staging
+            if (!symlink($staging_dir, $new_link)) {
+                throw new RuntimeException("Failed to create new symlink: {$new_link}");
+            }
+
+            // Atomic rename: new symlink replaces the live one
+            if (!rename($new_link, $fs_root)) {
+                @unlink($new_link);
+                throw new RuntimeException("Failed to atomically swap symlink: {$fs_root}");
+            }
+
+            $old_fs_dir = $old_target;
+            $files_swapped = true;
+        } else {
+            // Rename swap: two renames, tiny gap
+            $file_strategy = 'rename';
+            $old_fs_dir = $fs_root . '_old_' . $staging_id;
+
+            if (!rename($fs_root, $old_fs_dir)) {
+                throw new RuntimeException(
+                    "Failed to rename live directory to old: {$fs_root} → {$old_fs_dir}"
+                );
+            }
+
+            if (!rename($staging_dir, $fs_root)) {
+                // Roll back: put the old directory back
+                rename($old_fs_dir, $fs_root);
+                throw new RuntimeException(
+                    "Failed to rename staging to live: {$staging_dir} → {$fs_root}. Rolled back."
+                );
+            }
+
+            $files_swapped = true;
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 3. Swap database tables (atomic RENAME TABLE)
+    // ---------------------------------------------------------------
+
+    if (!empty($pushed_tables)) {
+        // Build the RENAME TABLE statement.
+        // For each pushed table:
+        //   - If it exists on the remote: swap live → _old, staging → live
+        //   - If it's new (only in push): staging → live (no _old needed)
+        // Reuse $existing_tables from validation step above (already contains
+        // all tables in the current database).
+        $current_tables = $existing_tables;
+
+        $rename_pairs = [];
+        $old_tables = [];
+
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            $old_name = '_old_' . $table;
+
+            if (isset($current_tables[$table])) {
+                // Existing table: swap live → old, staging → live
+                $rename_pairs[] = "`{$table}` TO `{$old_name}`";
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+                $old_tables[] = $old_name;
+            } else {
+                // New table: just rename staging → live
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+            }
+        }
+
+        // Handle tables that exist on remote but not in push (dropped tables).
+        // Move them to _old_ so they're removed from the live prefix.
+        foreach ($current_tables as $name => $_) {
+            if (
+                ($table_prefix === '' || str_starts_with($name, $table_prefix)) &&
+                !in_array($name, $pushed_tables) &&
+                !str_starts_with($name, PUSH_STAGING_TABLE_PREFIX) &&
+                !str_starts_with($name, '_old_')
+            ) {
+                $old_name = '_old_' . $name;
+                $rename_pairs[] = "`{$name}` TO `{$old_name}`";
+                $old_tables[] = $old_name;
+            }
+        }
+
+        if (!empty($rename_pairs)) {
+            $rename_sql = 'RENAME TABLE ' . implode(', ', $rename_pairs);
+
+            try {
+                $pdo->exec($rename_sql);
+                $tables_swapped = count($pushed_tables);
+            } catch (\Throwable $e) {
+                // DB swap failed — roll back files if they were swapped
+                if ($files_swapped) {
+                    if ($file_strategy === 'symlink' && $old_fs_dir !== null) {
+                        // Recreate symlink to old target
+                        $new_link = $fs_root . '_rollback_' . $staging_id;
+                        @symlink($old_fs_dir, $new_link);
+                        @rename($new_link, $fs_root);
+                    } elseif ($file_strategy === 'rename' && $old_fs_dir !== null) {
+                        @rename($fs_root, $staging_dir);
+                        @rename($old_fs_dir, $fs_root);
+                    }
+                }
+
+                throw new RuntimeException(
+                    "Database swap failed: " . $e->getMessage() .
+                    ". Files have been rolled back. SQL: " . $rename_sql
+                );
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // 4. Cleanup: drop _old_* tables (best-effort)
+        // ---------------------------------------------------------------
+        foreach ($old_tables as $old_table) {
+            try {
+                $pdo->exec("DROP TABLE IF EXISTS `{$old_table}`");
+            } catch (\Throwable $e) {
+                error_log("push-commit: failed to drop old table {$old_table}: " . $e->getMessage());
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 5. Cleanup: remove old file directory (best-effort)
+    // ---------------------------------------------------------------
+    if ($old_fs_dir !== null && is_dir($old_fs_dir) && $file_strategy === 'rename') {
+        // Defer to background or just log — recursive delete can be slow
+        error_log("push-commit: old directory available for cleanup: {$old_fs_dir}");
+    }
+
+    header('Content-Type: application/json');
+    $response = [
+        'status' => 'ok',
+        'tables_swapped' => $tables_swapped,
+        'file_strategy' => $file_strategy,
+        'files_swapped' => $files_swapped,
+    ];
+    echo json_encode($response);
+
+    return [
+        'status' => 'ok',
+        'stats' => $response,
+    ];
+}
+
 /**
  * Builds the config array from HTTP GET/POST parameters and optional JSON body.
  */

--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -3958,6 +3958,34 @@ function endpoint_commit(array $config): array
         $rename_pairs = [];
         $old_tables = [];
 
+        // Drop leftover _old_* tables from prior interrupted pushes.
+        // MySQL's RENAME TABLE fails if the target name already exists,
+        // so stale _old_ tables from a previous commit whose cleanup
+        // was interrupted would block all subsequent commits.
+        foreach ($pushed_tables as $table) {
+            $old_name = '_old_' . $table;
+            if (isset($current_tables[$old_name])) {
+                $pdo->exec("DROP TABLE IF EXISTS `{$old_name}`");
+                unset($current_tables[$old_name]);
+            }
+        }
+        // Also clean up _old_ versions of tables that exist on the remote
+        // but aren't in the push set (they'll be "dropped" via rename below).
+        foreach ($current_tables as $name => $_) {
+            if (
+                ($table_prefix === '' || str_starts_with($name, $table_prefix)) &&
+                !in_array($name, $pushed_tables) &&
+                !str_starts_with($name, PUSH_STAGING_TABLE_PREFIX) &&
+                !str_starts_with($name, '_old_')
+            ) {
+                $old_name = '_old_' . $name;
+                if (isset($current_tables[$old_name])) {
+                    $pdo->exec("DROP TABLE IF EXISTS `{$old_name}`");
+                    unset($current_tables[$old_name]);
+                }
+            }
+        }
+
         foreach ($pushed_tables as $table) {
             $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
             $old_name = '_old_' . $table;

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -10149,6 +10149,7 @@ class ImportClient
 
             $producer_options = [
                 "chunk_size" => $chunk_size,
+                "paths" => ["."],
             ];
             if ($receiver_cursor !== null) {
                 $producer_options["cursor"] = $receiver_cursor;

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -10154,7 +10154,7 @@ class ImportClient
                 $producer_options["cursor"] = $receiver_cursor;
             }
 
-            $producer = new \WordPress\DataLiberation\FileTreeProducer(
+            $producer = new \FileTreeProducer(
                 [$this->fs_root],
                 $producer_options,
             );
@@ -10336,7 +10336,7 @@ class ImportClient
 
         $this->audit_log(sprintf(
             "push-commit | staging_id=%s | tables=%d | directory=%s",
-            $staging_id ?? "none",
+            $staging_id,
             count($pushed_tables),
             $remote_directory ?? "none"
         ));

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -1363,7 +1363,7 @@ class ImportClient
 
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root",
+                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root, push-sql, push-files, push-commit",
             );
         }
 
@@ -1380,10 +1380,13 @@ class ImportClient
                 "preflight-assert",
                 "flat-document-root",
                 "apply-runtime",
+                "push-sql",
+                "push-files",
+                "push-commit",
             ])
         ) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root, apply-runtime",
+                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root, apply-runtime, push-sql, push-files, push-commit",
             );
         }
 
@@ -1563,6 +1566,42 @@ class ImportClient
                 $this->run_db_apply($options);
                 $final_status = $this->state["status"] ?? "complete";
                 $this->output_progress(["status" => $final_status, "message" => "db-apply {$final_status}"]);
+                if ($final_status === "partial") {
+                    $this->exit_code = 2;
+                }
+            } catch (Exception $e) {
+                $this->output_progress([
+                    "status" => "error",
+                    "error" => $e->getMessage(),
+                    "message" => "Error: " . $e->getMessage(),
+                ]);
+                $this->write_status_file($e->getMessage());
+                throw $e;
+            }
+            return;
+        }
+
+        // Push commands run their own preflight and don't need prior pull state.
+        if (in_array($command, ["push-sql", "push-files", "push-commit"])) {
+            if ($abort) {
+                $this->handle_abort($command);
+                return;
+            }
+            try {
+                switch ($command) {
+                    case "push-sql":
+                        $this->run_push_sql($options);
+                        break;
+                    case "push-files":
+                        $this->run_push_files($options);
+                        break;
+                    case "push-commit":
+                        $this->run_push_commit($options);
+                        break;
+                }
+
+                $final_status = $this->state["status"] ?? "complete";
+                $this->output_progress(["status" => $final_status, "message" => "{$command} {$final_status}"]);
                 if ($final_status === "partial") {
                     $this->exit_code = 2;
                 }
@@ -9649,6 +9688,713 @@ class ImportClient
             @flush();
             $this->last_progress_output = $now;
         }
+    }
+
+    // =========================================================================
+    // Push commands: upload local site to remote WordPress
+    // =========================================================================
+
+    /**
+     * Run preflight against the remote and return the preflight data.
+     * Used by push commands to discover table_prefix, post_max_size, etc.
+     */
+    private function push_preflight(): array
+    {
+        if (!empty($this->state["preflight"]["data"])) {
+            return $this->state["preflight"]["data"];
+        }
+
+        $this->run_preflight();
+        $data = $this->state["preflight"]["data"] ?? null;
+        if (!is_array($data) || empty($data["ok"])) {
+            throw new RuntimeException(
+                "Preflight failed: " . ($data["error"] ?? "unknown error")
+            );
+        }
+        return $data;
+    }
+
+    /**
+     * POST a multipart body stream to a receiver endpoint and return the JSON response.
+     *
+     * Signs the body with HMAC (reading the stream, then rewinding for curl),
+     * sends via CURLOPT_UPLOAD / CURLOPT_INFILE, and returns the parsed JSON.
+     */
+    private function push_post_multipart(
+        string $url,
+        \MultipartBodyStream $stream
+    ): array {
+        $this->reset_curl_state();
+
+        $stream->finalize();
+
+        // Read body for HMAC signing, then rewind for curl
+        $body_for_signing = $stream->get_contents();
+
+        $headers = [
+            ...$this->get_base_headers("application/json"),
+            "Content-Type: " . $stream->get_content_type(),
+            "Content-Length: " . $stream->get_size(),
+            ...($this->get_hmac_headers($body_for_signing)),
+        ];
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_UPLOAD => true,
+            CURLOPT_INFILE => $stream->get_resource(),
+            CURLOPT_INFILESIZE => $stream->get_size(),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 120,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        $this->audit_log("PUSH HTTP_REQUEST | POST | {$url} | size=" . $stream->get_size(), false);
+
+        $start = microtime(true);
+        $body = curl_exec($ch);
+        $elapsed = microtime(true) - $start;
+
+        try {
+            $this->check_curl_error($ch);
+        } catch (RuntimeException $e) {
+            @curl_close($ch);
+            throw new RuntimeException("Push request failed: " . $e->getMessage());
+        }
+
+        $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        @curl_close($ch);
+
+        if ($http_code !== 200) {
+            throw new RuntimeException(
+                "Push request returned HTTP {$http_code}: " . substr($body, 0, 500)
+            );
+        }
+
+        $json = json_decode($body, true);
+        if (!is_array($json)) {
+            throw new RuntimeException(
+                "Push response is not valid JSON: " . substr($body, 0, 500)
+            );
+        }
+
+        $this->audit_log(
+            sprintf("PUSH RESPONSE | status=%s | elapsed=%.2fs", $json["status"] ?? "unknown", $elapsed),
+            false
+        );
+
+        return $json;
+    }
+
+    /**
+     * POST a JSON body to a receiver endpoint and return the JSON response.
+     */
+    private function push_post_json(string $url, array $data): array
+    {
+        $this->reset_curl_state();
+
+        $json_body = json_encode($data);
+        if ($json_body === false) {
+            throw new RuntimeException("Failed to encode push request body");
+        }
+
+        $headers = [
+            ...$this->get_base_headers("application/json"),
+            "Content-Type: application/json",
+            "Content-Length: " . strlen($json_body),
+            ...($this->get_hmac_headers($json_body)),
+        ];
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $json_body,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 120,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        $this->audit_log("PUSH HTTP_REQUEST | POST JSON | {$url}", false);
+
+        $start = microtime(true);
+        $body = curl_exec($ch);
+        $elapsed = microtime(true) - $start;
+
+        try {
+            $this->check_curl_error($ch);
+        } catch (RuntimeException $e) {
+            @curl_close($ch);
+            throw new RuntimeException("Push JSON request failed: " . $e->getMessage());
+        }
+
+        $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        @curl_close($ch);
+
+        if ($http_code !== 200) {
+            throw new RuntimeException(
+                "Push request returned HTTP {$http_code}: " . substr($body, 0, 500)
+            );
+        }
+
+        $json = json_decode($body, true);
+        if (!is_array($json)) {
+            throw new RuntimeException(
+                "Push response is not valid JSON: " . substr($body, 0, 500)
+            );
+        }
+
+        $this->audit_log(
+            sprintf("PUSH JSON RESPONSE | status=%s | elapsed=%.2fs", $json["status"] ?? "unknown", $elapsed),
+            false
+        );
+
+        return $json;
+    }
+
+    /**
+     * Command: push-sql
+     *
+     * Reads the local database via MySQLDumpProducer, streams SQL to the
+     * remote's sql_receive endpoint in multipart/mixed chunks sized to fit
+     * within the remote's post_max_size. The receiver rewrites table names
+     * to a staging prefix and executes the SQL. Progress is tracked by the
+     * receiver's cursor — the client resumes from there on retry.
+     */
+    private function run_push_sql(array $options): void
+    {
+        $preflight = $this->push_preflight();
+
+        $remote_table_prefix = $preflight["database"]["wp"]["table_prefix"] ?? "wp_";
+        $post_max_bytes = (int) ($preflight["limits"]["post_max_bytes"] ?? 8 * 1024 * 1024);
+        // Leave headroom for multipart framing and headers
+        $body_budget = (int) ($post_max_bytes * 0.8);
+        if ($body_budget < 64 * 1024) {
+            $body_budget = 64 * 1024;
+        }
+
+        // State management
+        $state_command = $this->state["command"] ?? null;
+        $current_status = $state_command === "push-sql"
+            ? ($this->state["status"] ?? null)
+            : null;
+
+        if ($current_status === "complete") {
+            throw new RuntimeException(
+                "push-sql already completed. Use --abort to start over."
+            );
+        }
+
+        $receiver_cursor = null;
+        if ($state_command === "push-sql" && $current_status === "in_progress") {
+            $receiver_cursor = $this->state["push_cursor"] ?? null;
+            $this->audit_log("RESUME push-sql | cursor=" .
+                ($receiver_cursor ? substr($receiver_cursor, 0, 40) . "..." : "none"));
+        } else {
+            $this->state["command"] = "push-sql";
+            $this->state["status"] = "in_progress";
+            $this->state["push_cursor"] = null;
+            $this->save_state($this->state);
+            $this->audit_log("START push-sql");
+        }
+
+        // Connect to local database
+        if (empty($this->mysql_database)) {
+            throw new InvalidArgumentException(
+                "--mysql-database is required for push-sql"
+            );
+        }
+        $local_dsn = build_pdo_dsn(
+            $this->mysql_host ?? '127.0.0.1',
+            $this->mysql_database
+        );
+        $local_pdo = new PDO(
+            $local_dsn,
+            $this->mysql_user ?? 'root',
+            $this->mysql_password ?? '',
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+
+        // Discover local tables for the receiver's staging map
+        $local_tables = [];
+        $stmt = $local_pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $local_tables[] = $row['TABLE_NAME'];
+        }
+
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "Pushing SQL to remote ({$this->remote_url})...\n");
+        }
+
+        $total_sql_bytes = 0;
+        $total_statements = 0;
+        $iterations = 0;
+
+        // Push loop: create producer from receiver's last cursor, stream until
+        // body budget, POST to sql_receive, save receiver's cursor, repeat.
+        while (true) {
+            if ($this->shutdown_requested) {
+                $this->state["status"] = "partial";
+                $this->save_state($this->state);
+                return;
+            }
+
+            $producer_options = ["create_table_query" => true];
+            if ($receiver_cursor !== null) {
+                $producer_options["cursor"] = $receiver_cursor;
+            }
+
+            $producer = new \WordPress\DataLiberation\MySQLDumpProducer(
+                $local_pdo,
+                $producer_options,
+            );
+
+            // Check if producer is already finished (all tables dumped)
+            if ($producer->is_finished()) {
+                break;
+            }
+
+            // Build multipart body up to body_budget
+            $stream = new \MultipartBodyStream();
+            $body_size = 0;
+            $chunks_in_batch = 0;
+
+            while ($body_size < $body_budget) {
+                $sql_fragments = [];
+                $i = 0;
+                while ($producer->next_sql_fragment()) {
+                    $sql_fragments[] = $producer->get_sql_fragment();
+                    $i++;
+                    if ($i >= 500) {
+                        break;
+                    }
+                }
+
+                $sql = implode("", $sql_fragments);
+                if ($sql === "") {
+                    break;
+                }
+
+                $trimmed = rtrim($sql);
+                $query_complete = $trimmed !== "" && $trimmed[-1] === ";";
+                $cursor = $producer->get_reentrancy_cursor();
+
+                $stream->write_sql_chunk($sql, $cursor, $query_complete);
+
+                $body_size += strlen($sql);
+                $chunks_in_batch++;
+                $total_sql_bytes += strlen($sql);
+
+                if ($producer->is_finished()) {
+                    break;
+                }
+            }
+
+            if ($chunks_in_batch === 0) {
+                // Nothing left to send
+                break;
+            }
+
+            $is_finished = $producer->is_finished();
+            $stream->write_completion_chunk(
+                $is_finished ? "complete" : "partial",
+                ["sql_bytes" => $body_size]
+            );
+
+            // POST to receiver
+            $url = $this->build_url("sql_receive", null, [
+                "table_prefix" => $remote_table_prefix,
+                "incoming_tables" => json_encode($local_tables),
+            ]);
+
+            $response = $this->push_post_multipart($url, $stream);
+
+            $receiver_cursor = $response["cursor"] ?? null;
+            $total_statements += (int) ($response["statements_executed"] ?? 0);
+
+            // Save progress
+            $this->state["push_cursor"] = $receiver_cursor;
+            $this->state["push_sql_bytes"] = $total_sql_bytes;
+            $this->state["push_sql_statements"] = $total_statements;
+            $this->save_state($this->state);
+
+            $iterations++;
+            $this->output_progress([
+                "type" => "push_sql_progress",
+                "iterations" => $iterations,
+                "sql_bytes" => $total_sql_bytes,
+                "statements" => $total_statements,
+                "message" => sprintf(
+                    "push-sql: %d iterations, %s SQL bytes",
+                    $iterations,
+                    number_format($total_sql_bytes)
+                ),
+            ]);
+
+            if ($this->is_tty && !$this->verbose_mode) {
+                $this->show_progress_line(sprintf(
+                    "push-sql: %s bytes, %d statements",
+                    number_format($total_sql_bytes),
+                    $total_statements
+                ));
+            }
+
+            if (($response["status"] ?? "") === "complete" || $is_finished) {
+                break;
+            }
+        }
+
+        $this->state["status"] = "complete";
+        $this->save_state($this->state);
+
+        $this->audit_log(sprintf(
+            "push-sql complete: %d iterations, %s SQL bytes, %d statements",
+            $iterations,
+            number_format($total_sql_bytes),
+            $total_statements
+        ));
+
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, sprintf(
+                "\npush-sql complete: %s SQL bytes staged on remote\n",
+                number_format($total_sql_bytes)
+            ));
+        }
+    }
+
+    /**
+     * Command: push-files
+     *
+     * Reads the local filesystem via FileTreeProducer, streams file chunks
+     * to the remote's file_receive endpoint. Files are written to a staging
+     * directory on the remote. Nothing goes live until push-commit.
+     */
+    private function run_push_files(array $options): void
+    {
+        $preflight = $this->push_preflight();
+
+        $post_max_bytes = (int) ($preflight["limits"]["post_max_bytes"] ?? 8 * 1024 * 1024);
+        $body_budget = (int) ($post_max_bytes * 0.8);
+        if ($body_budget < 64 * 1024) {
+            $body_budget = 64 * 1024;
+        }
+
+        // Determine the remote's directory for the receiver to resolve paths
+        $remote_directories = [];
+        $wp_roots = $preflight["wp_detect"]["roots"] ?? [];
+        foreach ($wp_roots as $root) {
+            $path = $root["path"] ?? null;
+            if (is_string($path) && $path !== "") {
+                $remote_directories[] = $path;
+            }
+        }
+        if (empty($remote_directories)) {
+            throw new RuntimeException(
+                "Cannot determine remote directory from preflight. " .
+                "Ensure the remote WordPress is detected."
+            );
+        }
+        $remote_directory = $remote_directories[0];
+
+        // State management
+        $state_command = $this->state["command"] ?? null;
+        $current_status = $state_command === "push-files"
+            ? ($this->state["status"] ?? null)
+            : null;
+
+        if ($current_status === "complete") {
+            throw new RuntimeException(
+                "push-files already completed. Use --abort to start over."
+            );
+        }
+
+        // Generate or restore staging ID — persistent across resume cycles
+        $staging_id = $this->state["push_staging_id"] ?? null;
+        if ($staging_id === null) {
+            $staging_id = bin2hex(random_bytes(8));
+        }
+
+        $receiver_cursor = null;
+        if ($state_command === "push-files" && $current_status === "in_progress") {
+            $receiver_cursor = $this->state["push_cursor"] ?? null;
+            $this->audit_log("RESUME push-files | staging_id={$staging_id} | cursor=" .
+                ($receiver_cursor ? substr($receiver_cursor, 0, 40) . "..." : "none"));
+        } else {
+            $this->state["command"] = "push-files";
+            $this->state["status"] = "in_progress";
+            $this->state["push_cursor"] = null;
+            $this->state["push_staging_id"] = $staging_id;
+            $this->save_state($this->state);
+            $this->audit_log("START push-files | staging_id={$staging_id}");
+        }
+
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "Pushing files to remote ({$this->remote_url})...\n");
+        }
+
+        $chunk_size = 2 * 1024 * 1024; // 2MB chunks
+        $total_bytes = 0;
+        $total_files = 0;
+        $iterations = 0;
+
+        // Push loop
+        while (true) {
+            if ($this->shutdown_requested) {
+                $this->state["status"] = "partial";
+                $this->save_state($this->state);
+                return;
+            }
+
+            $producer_options = [
+                "chunk_size" => $chunk_size,
+            ];
+            if ($receiver_cursor !== null) {
+                $producer_options["cursor"] = $receiver_cursor;
+            }
+
+            $producer = new \WordPress\DataLiberation\FileTreeProducer(
+                [$this->fs_root],
+                $producer_options,
+            );
+
+            // Build multipart body
+            $stream = new \MultipartBodyStream();
+            $body_size = 0;
+            $chunks_in_batch = 0;
+
+            while ($body_size < $body_budget) {
+                if (!$producer->next_chunk()) {
+                    break;
+                }
+
+                $chunk = $producer->get_current_chunk();
+                if ($chunk === null) {
+                    // Progress-only chunk (scanning/sorting phase)
+                    continue;
+                }
+
+                $cursor = $producer->get_reentrancy_cursor();
+                $chunk_type = $chunk["type"] ?? "file";
+
+                if ($chunk_type === "directory") {
+                    $stream->write_directory_chunk(
+                        $chunk["path"],
+                        $cursor,
+                        $chunk["ctime"] ?? null
+                    );
+                    $chunks_in_batch++;
+                } elseif ($chunk_type === "symlink") {
+                    $stream->write_symlink_chunk(
+                        $chunk["path"],
+                        $chunk["target"],
+                        $chunk["ctime"] ?? 0,
+                        $cursor
+                    );
+                    $chunks_in_batch++;
+                } elseif ($chunk_type === "file" || !isset($chunk["type"])) {
+                    $stream->write_file_chunk($chunk, $cursor);
+                    $body_size += strlen($chunk["data"]);
+                    $chunks_in_batch++;
+                    $total_bytes += strlen($chunk["data"]);
+                    if (!empty($chunk["is_last_chunk"])) {
+                        $total_files++;
+                    }
+                }
+                // Skip index, missing, error chunk types — they're for pull mode
+            }
+
+            if ($chunks_in_batch === 0) {
+                break;
+            }
+
+            $progress = $producer->get_progress();
+            $is_finished = ($progress["phase"] ?? "") === "finished";
+
+            $stream->write_completion_chunk(
+                $is_finished ? "complete" : "partial",
+                [
+                    "bytes_processed" => $body_size,
+                    "files_completed" => $total_files,
+                ]
+            );
+
+            // POST to receiver
+            $url = $this->build_url("file_receive", null, [
+                "staging_id" => $staging_id,
+                "directory" => $remote_directory,
+            ]);
+
+            $response = $this->push_post_multipart($url, $stream);
+
+            $receiver_cursor = $response["cursor"] ?? null;
+
+            // Save progress
+            $this->state["push_cursor"] = $receiver_cursor;
+            $this->state["push_files_bytes"] = $total_bytes;
+            $this->state["push_files_count"] = $total_files;
+            $this->save_state($this->state);
+
+            $iterations++;
+            $this->output_progress([
+                "type" => "push_files_progress",
+                "iterations" => $iterations,
+                "bytes" => $total_bytes,
+                "files" => $total_files,
+                "message" => sprintf(
+                    "push-files: %d iterations, %s bytes, %d files",
+                    $iterations,
+                    number_format($total_bytes),
+                    $total_files
+                ),
+            ]);
+
+            if ($this->is_tty && !$this->verbose_mode) {
+                $this->show_progress_line(sprintf(
+                    "push-files: %s bytes, %d files",
+                    number_format($total_bytes),
+                    $total_files
+                ));
+            }
+
+            if (($response["status"] ?? "") === "complete" || $is_finished) {
+                break;
+            }
+        }
+
+        $this->state["status"] = "complete";
+        $this->save_state($this->state);
+
+        $this->audit_log(sprintf(
+            "push-files complete: %d iterations, %s bytes, %d files",
+            $iterations,
+            number_format($total_bytes),
+            $total_files
+        ));
+
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, sprintf(
+                "\npush-files complete: %s bytes, %d files staged on remote\n",
+                number_format($total_bytes),
+                $total_files
+            ));
+        }
+    }
+
+    /**
+     * Command: push-commit
+     *
+     * Tells the remote to atomically swap staged files and database tables
+     * into place. This is the point of no return: validates staging, swaps
+     * files (symlink or rename), swaps DB (atomic RENAME TABLE), and cleans
+     * up old artifacts. On partial failure, rolls back.
+     */
+    private function run_push_commit(array $options): void
+    {
+        $preflight = $this->push_preflight();
+
+        $remote_table_prefix = $preflight["database"]["wp"]["table_prefix"] ?? "wp_";
+
+        // Determine what was pushed. The staging_id comes from push-files state.
+        // If only push-sql was run (no files), generate a temporary one so the
+        // commit endpoint can still validate — the staging directory won't exist
+        // and the file swap step will be skipped.
+        $staging_id = $this->state["push_staging_id"] ?? bin2hex(random_bytes(8));
+
+        // Determine the remote directory
+        $remote_directories = [];
+        $wp_roots = $preflight["wp_detect"]["roots"] ?? [];
+        foreach ($wp_roots as $root) {
+            $path = $root["path"] ?? null;
+            if (is_string($path) && $path !== "") {
+                $remote_directories[] = $path;
+            }
+        }
+        $remote_directory = $remote_directories[0] ?? null;
+
+        // Get list of tables that were pushed (from local database)
+        $pushed_tables = [];
+        if (!empty($this->mysql_database)) {
+            $local_dsn = build_pdo_dsn(
+                $this->mysql_host ?? '127.0.0.1',
+                $this->mysql_database
+            );
+            $local_pdo = new PDO(
+                $local_dsn,
+                $this->mysql_user ?? 'root',
+                $this->mysql_password ?? '',
+                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+            );
+            $stmt = $local_pdo->query(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+            );
+            while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                $pushed_tables[] = $row['TABLE_NAME'];
+            }
+        }
+
+        $this->audit_log(sprintf(
+            "push-commit | staging_id=%s | tables=%d | directory=%s",
+            $staging_id ?? "none",
+            count($pushed_tables),
+            $remote_directory ?? "none"
+        ));
+
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "Committing push (atomic cutover)...\n");
+        }
+
+        $params = [
+            "table_prefix" => $remote_table_prefix,
+            "pushed_tables" => json_encode($pushed_tables),
+        ];
+        if ($staging_id !== null) {
+            $params["staging_id"] = $staging_id;
+        }
+        if ($remote_directory !== null) {
+            $params["directory"] = $remote_directory;
+        }
+
+        $url = $this->build_url("commit", null, $params);
+        $response = $this->push_post_json($url, $params);
+
+        $status = $response["status"] ?? "error";
+        if ($status !== "ok") {
+            $errors = $response["errors"] ?? [$response["error"] ?? "Unknown error"];
+            throw new RuntimeException(
+                "push-commit failed: " . implode("; ", $errors)
+            );
+        }
+
+        $tables_swapped = (int) ($response["tables_swapped"] ?? 0);
+        $file_strategy = $response["file_strategy"] ?? "none";
+
+        $this->state["command"] = "push-commit";
+        $this->state["status"] = "complete";
+        $this->save_state($this->state);
+
+        $this->audit_log(sprintf(
+            "push-commit complete: %d tables swapped, file_strategy=%s",
+            $tables_swapped,
+            $file_strategy
+        ));
+
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, sprintf(
+                "push-commit complete: %d tables swapped, files: %s\n",
+                $tables_swapped,
+                $file_strategy
+            ));
+        }
+
+        $this->output_progress([
+            "type" => "push_commit_complete",
+            "tables_swapped" => $tables_swapped,
+            "file_strategy" => $file_strategy,
+            "status" => "complete",
+            "message" => "push-commit complete",
+        ], true);
     }
 }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,6 +46,21 @@ parameters:
 			path: packages/streaming-exporter/src/class-file-tree-producer.php
 
 		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: packages/streaming-importer/src/import.php
+
+		-
+			message: "#^Ternary operator condition is always false\\.$#"
+			count: 1
+			path: packages/streaming-importer/src/import.php
+
+		-
+			message: "#^Right side of \\|\\| is always false\\.$#"
+			count: 1
+			path: packages/streaming-importer/src/import.php
+
+		-
 			message: "#^Function _doing_it_wrong not found\\.$#"
 			count: 1
 			path: packages/streaming-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php

--- a/tests/Push/ChunkWriterTest.php
+++ b/tests/Push/ChunkWriterTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ChunkWriter — the filesystem writer used by file_receive.
+ *
+ * ChunkWriter is the last line of defense before arbitrary file data
+ * is written to the production filesystem. If it fails to validate paths,
+ * an attacker (or a corrupted push) can overwrite system files.
+ */
+final class ChunkWriterTest extends TestCase
+{
+    private $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->recursiveDelete($dir);
+        }
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/chunk-writer-test-' . bin2hex(random_bytes(8));
+        mkdir($dir, 0755, true);
+        $this->tempDirs[] = $dir;
+        return $dir;
+    }
+
+    private function recursiveDelete(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) as $item) {
+                if ($item === '.' || $item === '..') continue;
+                $this->recursiveDelete($path . '/' . $item);
+            }
+            @rmdir($path);
+        } else {
+            @unlink($path);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Basic file writing
+    // ---------------------------------------------------------------
+
+    /**
+     * Write a single-chunk file.
+     */
+    public function testWriteSingleChunkFile(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $writer->write_file_chunk('/test.txt', 'Hello, World!', true, true);
+
+        $this->assertFileExists($root . '/test.txt');
+        $this->assertSame('Hello, World!', file_get_contents($root . '/test.txt'));
+    }
+
+    /**
+     * Write a multi-chunk file.
+     */
+    public function testWriteMultiChunkFile(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $writer->write_file_chunk('/large.bin', 'chunk1-', true, false);
+        $writer->write_file_chunk('/large.bin', 'chunk2-', false, false);
+        $writer->write_file_chunk('/large.bin', 'chunk3', false, true);
+
+        $this->assertSame('chunk1-chunk2-chunk3', file_get_contents($root . '/large.bin'));
+    }
+
+    /**
+     * Write a file in a nested directory that doesn't exist yet.
+     */
+    public function testCreatesIntermediateDirectories(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $writer->write_file_chunk(
+            '/wp-content/uploads/2024/01/photo.jpg',
+            'JPEG data',
+            true,
+            true
+        );
+
+        $this->assertFileExists($root . '/wp-content/uploads/2024/01/photo.jpg');
+        $this->assertSame('JPEG data', file_get_contents($root . '/wp-content/uploads/2024/01/photo.jpg'));
+    }
+
+    /**
+     * Overwriting a file on a new push.
+     */
+    public function testOverwritesExistingFile(): void
+    {
+        $root = $this->createTempDir();
+        file_put_contents($root . '/existing.txt', 'old content');
+
+        $writer = new ChunkWriter($root);
+        $writer->write_file_chunk('/existing.txt', 'new content', true, true);
+
+        $this->assertSame('new content', file_get_contents($root . '/existing.txt'));
+    }
+
+    // ---------------------------------------------------------------
+    // Directory creation
+    // ---------------------------------------------------------------
+
+    public function testWriteDirectory(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $writer->write_directory('/wp-content/uploads/2024/');
+
+        $this->assertTrue(is_dir($root . '/wp-content/uploads/2024'));
+    }
+
+    // ---------------------------------------------------------------
+    // Symlink handling
+    // ---------------------------------------------------------------
+
+    /**
+     * Valid symlink within root should be created.
+     */
+    public function testValidSymlinkWithinRoot(): void
+    {
+        $root = $this->createTempDir();
+        mkdir($root . '/target-dir', 0755, true);
+        file_put_contents($root . '/target-dir/file.txt', 'content');
+
+        $writer = new ChunkWriter($root);
+        $writer->write_symlink('/link', 'target-dir', 0);
+
+        $this->assertTrue(is_link($root . '/link'));
+        $this->assertSame('target-dir', readlink($root . '/link'));
+    }
+
+    /**
+     * SECURITY: Symlink that escapes root must be rejected.
+     */
+    public function testSymlinkEscapingRootIsRejected(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('symlink target escapes root');
+
+        $writer->write_symlink('/evil-link', '../../etc/passwd', 0);
+    }
+
+    /**
+     * SECURITY: Absolute symlink target outside root must be rejected.
+     */
+    public function testAbsoluteSymlinkOutsideRootIsRejected(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('symlink target escapes root');
+
+        $writer->write_symlink('/evil-link', '/etc/passwd', 0);
+    }
+
+    // ---------------------------------------------------------------
+    // Path traversal attacks
+    // ---------------------------------------------------------------
+
+    /**
+     * SECURITY: Path with dot-dot segments must be rejected.
+     */
+    public function testPathTraversalIsRejected(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $this->expectException(RuntimeException::class);
+
+        $writer->write_file_chunk(
+            '/../../../etc/crontab',
+            'malicious content',
+            true,
+            true
+        );
+    }
+
+    /**
+     * SECURITY: Path with NUL byte must be rejected.
+     */
+    public function testNulByteInPathIsRejected(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $this->expectException(RuntimeException::class);
+
+        $writer->write_file_chunk(
+            "/test.php\x00.jpg",
+            '<?php evil();',
+            true,
+            true
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Incomplete writes
+    // ---------------------------------------------------------------
+
+    /**
+     * If a multi-chunk write is interrupted (no last chunk), the next
+     * first chunk for a different file must close the previous file.
+     */
+    public function testInterruptedMultiChunkWriteIsClosed(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        // Start writing file A but never send the last chunk
+        $writer->write_file_chunk('/file-a.txt', 'partial data', true, false);
+
+        // Start writing file B (is_first=true should close file A)
+        $writer->write_file_chunk('/file-b.txt', 'complete', true, true);
+
+        // Both files should exist
+        $this->assertFileExists($root . '/file-a.txt');
+        $this->assertFileExists($root . '/file-b.txt');
+
+        // File A has partial data (it was closed when file B started)
+        $this->assertSame('partial data', file_get_contents($root . '/file-a.txt'));
+        $this->assertSame('complete', file_get_contents($root . '/file-b.txt'));
+    }
+
+    /**
+     * Destructor should close any open file handle.
+     */
+    public function testDestructorClosesOpenFile(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $writer->write_file_chunk('/orphan.txt', 'data', true, false);
+        // Destroy without sending last chunk
+        unset($writer);
+
+        $this->assertFileExists($root . '/orphan.txt');
+        $this->assertSame('data', file_get_contents($root . '/orphan.txt'));
+    }
+
+    // ---------------------------------------------------------------
+    // Symlink in directory path
+    // ---------------------------------------------------------------
+
+    /**
+     * SECURITY: If a directory component in the path is a symlink pointing
+     * outside root, writing through it would escape the root.
+     *
+     * ChunkWriter's ensure_directory removes symlinks that block directory
+     * creation. This test verifies that behavior.
+     */
+    public function testSymlinkInDirectoryPathIsRemoved(): void
+    {
+        $root = $this->createTempDir();
+        $outside = $this->createTempDir();
+
+        // Create a symlink at root/wp-content pointing outside
+        symlink($outside, $root . '/wp-content');
+
+        $writer = new ChunkWriter($root);
+
+        // Writing to /wp-content/file.txt should remove the symlink
+        // and create a real directory instead
+        $writer->write_file_chunk('/wp-content/file.txt', 'safe content', true, true);
+
+        $this->assertFalse(is_link($root . '/wp-content'), "Symlink should be replaced with real directory");
+        $this->assertTrue(is_dir($root . '/wp-content'));
+        $this->assertSame('safe content', file_get_contents($root . '/wp-content/file.txt'));
+
+        // The outside directory should NOT have the file
+        $this->assertFalse(file_exists($outside . '/file.txt'));
+    }
+
+    // ---------------------------------------------------------------
+    // Binary data integrity
+    // ---------------------------------------------------------------
+
+    /**
+     * Binary data (images, executables) must be written byte-for-byte.
+     */
+    public function testBinaryDataIntegrity(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        // Generate binary data with all byte values
+        $binary = '';
+        for ($i = 0; $i < 256; $i++) {
+            $binary .= chr($i);
+        }
+        $binary = str_repeat($binary, 10); // 2560 bytes
+
+        $writer->write_file_chunk('/binary.bin', $binary, true, true);
+
+        $this->assertSame(
+            $binary,
+            file_get_contents($root . '/binary.bin'),
+            "Binary data must be preserved byte-for-byte"
+        );
+    }
+
+    /**
+     * Empty file (zero bytes).
+     */
+    public function testEmptyFile(): void
+    {
+        $root = $this->createTempDir();
+        $writer = new ChunkWriter($root);
+
+        $writer->write_file_chunk('/empty.txt', '', true, true);
+
+        $this->assertFileExists($root . '/empty.txt');
+        $this->assertSame('', file_get_contents($root . '/empty.txt'));
+    }
+}

--- a/tests/Push/ChunkWriterTest.php
+++ b/tests/Push/ChunkWriterTest.php
@@ -186,7 +186,7 @@ final class ChunkWriterTest extends TestCase
         $root = $this->createTempDir();
         $writer = new ChunkWriter($root);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $writer->write_file_chunk(
             '/../../../etc/crontab',
@@ -204,7 +204,7 @@ final class ChunkWriterTest extends TestCase
         $root = $this->createTempDir();
         $writer = new ChunkWriter($root);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $writer->write_file_chunk(
             "/test.php\x00.jpg",

--- a/tests/Push/CommitEndpointTest.php
+++ b/tests/Push/CommitEndpointTest.php
@@ -301,8 +301,8 @@ final class CommitEndpointTest extends TestCase
         $this->assertStringContainsString('_push_wp_posts', $errors[0]);
 
         // Verify live table is untouched
-        $rows = $this->pdo->query("SELECT id FROM wp_posts")->fetchAll(PDO::FETCH_COLUMN);
-        $this->assertSame(['1'], $rows, "Live data must be untouched when commit is refused");
+        $count = (int) $this->pdo->query("SELECT COUNT(*) FROM wp_posts")->fetchColumn();
+        $this->assertSame(1, $count, "Live data must be untouched when commit is refused");
     }
 
     // ---------------------------------------------------------------
@@ -341,8 +341,8 @@ final class CommitEndpointTest extends TestCase
         $this->assertTrue($failed, "RENAME TABLE should have failed");
 
         // CRITICAL: wp_posts must still have the original data
-        $rows = $this->pdo->query("SELECT id FROM wp_posts ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
-        $this->assertSame(['1', '2', '3'], $rows, "Live table data must survive a failed RENAME");
+        $count = (int) $this->pdo->query("SELECT COUNT(*) FROM wp_posts")->fetchColumn();
+        $this->assertSame(3, $count, "Live table data must survive a failed RENAME");
     }
 
     // ---------------------------------------------------------------

--- a/tests/Push/CommitEndpointTest.php
+++ b/tests/Push/CommitEndpointTest.php
@@ -1,0 +1,583 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for endpoint_commit() — the most dangerous function in the codebase.
+ *
+ * This endpoint atomically swaps staging data into production. Every test
+ * here represents a scenario that, if mishandled, breaks the target site.
+ */
+final class CommitEndpointTest extends TestCase
+{
+    private $pdo;
+    private $dbName;
+    private $tempDirs = [];
+
+    protected function setUp(): void
+    {
+        $host = getenv("DB_HOST") ?: "localhost";
+        $user = getenv("DB_USER") ?: "root";
+        $pass = getenv("DB_PASS") ?: "";
+        $this->dbName = (getenv("DB_NAME") ?: "test_mysql_dump") . "_push";
+
+        $dsn = "mysql:host={$host};charset=utf8mb4";
+        $this->pdo = new PDO($dsn, $user, $pass, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]);
+
+        $this->pdo->exec("DROP DATABASE IF EXISTS `{$this->dbName}`");
+        $this->pdo->exec("CREATE DATABASE `{$this->dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->pdo->exec("USE `{$this->dbName}`");
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->pdo) {
+            try {
+                $this->pdo->exec("DROP DATABASE IF EXISTS `{$this->dbName}`");
+            } catch (PDOException $e) {
+                // Ignore
+            }
+        }
+        $this->pdo = null;
+
+        foreach ($this->tempDirs as $dir) {
+            $this->recursiveDelete($dir);
+        }
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/push-test-' . bin2hex(random_bytes(8));
+        mkdir($dir, 0755, true);
+        $this->tempDirs[] = $dir;
+        return $dir;
+    }
+
+    private function recursiveDelete(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) as $item) {
+                if ($item === '.' || $item === '..') continue;
+                $this->recursiveDelete($path . '/' . $item);
+            }
+            @rmdir($path);
+        } else {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * Helper: build_staging_table_map requires a PDO that can query
+     * INFORMATION_SCHEMA. We use $this->pdo which has the test database.
+     */
+    private function getExistingTableNames(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        $tables = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $tables[] = $row['TABLE_NAME'];
+        }
+        return $tables;
+    }
+
+    // ---------------------------------------------------------------
+    // RENAME TABLE statement generation
+    // ---------------------------------------------------------------
+
+    /**
+     * The RENAME TABLE statement must swap each pushed table correctly:
+     * - Existing table: live → _old, staging → live
+     * - New table: staging → live (no _old needed)
+     */
+    public function testRenameTableSwapsExistingAndNewTables(): void
+    {
+        // Simulate: remote has wp_posts and wp_options.
+        // Push includes wp_posts (existing) and wp_users (new).
+        $this->pdo->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_posts VALUES (1), (2), (3)");
+        $this->pdo->exec("CREATE TABLE wp_options (option_id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_options VALUES (100)");
+
+        // Create staging tables for pushed tables
+        $this->pdo->exec("CREATE TABLE _push_wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO _push_wp_posts VALUES (10), (20)");
+        $this->pdo->exec("CREATE TABLE _push_wp_users (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO _push_wp_users VALUES (99)");
+
+        $pushed_tables = ['wp_posts', 'wp_users'];
+        $table_prefix = 'wp_';
+
+        $existing_tables = [];
+        $stmt = $this->pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $existing_tables[$row['TABLE_NAME']] = true;
+        }
+
+        $rename_pairs = [];
+        $old_tables = [];
+
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            $old_name = '_old_' . $table;
+
+            if (isset($existing_tables[$table])) {
+                $rename_pairs[] = "`{$table}` TO `{$old_name}`";
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+                $old_tables[] = $old_name;
+            } else {
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+            }
+        }
+
+        // Execute the RENAME
+        $rename_sql = 'RENAME TABLE ' . implode(', ', $rename_pairs);
+        $this->pdo->exec($rename_sql);
+
+        // wp_posts should now have staging data (10, 20)
+        $rows = $this->pdo->query("SELECT id FROM wp_posts ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([10, 20], array_map('intval', $rows));
+
+        // wp_users should now exist with staging data (99)
+        $rows = $this->pdo->query("SELECT id FROM wp_users ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([99], array_map('intval', $rows));
+
+        // _old_wp_posts should have original data (1, 2, 3)
+        $rows = $this->pdo->query("SELECT id FROM _old_wp_posts ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([1, 2, 3], array_map('intval', $rows));
+
+        // wp_options should be untouched (wasn't in pushed_tables... or was it?)
+        // NOTE: This is the critical question — see testSilentTableDeletion below.
+    }
+
+    // ---------------------------------------------------------------
+    // CRITICAL: Silent table deletion
+    // ---------------------------------------------------------------
+
+    /**
+     * CRITICAL BUG: Tables that exist on the remote but are NOT in the push
+     * are silently renamed to _old_ and then dropped. This means pushing a
+     * subset of your local tables permanently deletes production data.
+     *
+     * Example: A plugin creates wp_woocommerce_orders on production. Your
+     * local dev doesn't have WooCommerce. Pushing your local DB silently
+     * deletes all WooCommerce order data.
+     *
+     * This test documents the current (dangerous) behavior.
+     */
+    public function testSilentTableDeletion(): void
+    {
+        // Remote has wp_posts, wp_options, and wp_woocommerce_orders
+        $this->pdo->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_posts VALUES (1)");
+        $this->pdo->exec("CREATE TABLE wp_options (option_id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_options VALUES (1)");
+        $this->pdo->exec("CREATE TABLE wp_woocommerce_orders (order_id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_woocommerce_orders VALUES (1000), (1001), (1002)");
+
+        // Push only includes wp_posts and wp_options (local dev has no WooCommerce)
+        $this->pdo->exec("CREATE TABLE _push_wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO _push_wp_posts VALUES (1)");
+        $this->pdo->exec("CREATE TABLE _push_wp_options (option_id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO _push_wp_options VALUES (1)");
+
+        $pushed_tables = ['wp_posts', 'wp_options'];
+        $table_prefix = 'wp_';
+
+        $existing_tables = [];
+        $stmt = $this->pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $existing_tables[$row['TABLE_NAME']] = true;
+        }
+
+        $rename_pairs = [];
+        $old_tables = [];
+
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            $old_name = '_old_' . $table;
+
+            if (isset($existing_tables[$table])) {
+                $rename_pairs[] = "`{$table}` TO `{$old_name}`";
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+                $old_tables[] = $old_name;
+            } else {
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+            }
+        }
+
+        // This is the current behavior: tables not in pushed_tables get renamed to _old_
+        foreach ($existing_tables as $name => $_) {
+            if (
+                str_starts_with($name, $table_prefix) &&
+                !in_array($name, $pushed_tables) &&
+                !str_starts_with($name, PUSH_STAGING_TABLE_PREFIX) &&
+                !str_starts_with($name, '_old_')
+            ) {
+                $old_name = '_old_' . $name;
+                $rename_pairs[] = "`{$name}` TO `{$old_name}`";
+                $old_tables[] = $old_name;
+            }
+        }
+
+        $rename_sql = 'RENAME TABLE ' . implode(', ', $rename_pairs);
+        $this->pdo->exec($rename_sql);
+
+        // After RENAME, wp_woocommerce_orders is GONE from the live prefix.
+        // It's been moved to _old_wp_woocommerce_orders.
+        $live_tables = $this->getExistingTableNames();
+        $this->assertNotContains(
+            'wp_woocommerce_orders',
+            $live_tables,
+            "BUG DOCUMENTED: wp_woocommerce_orders was silently removed from live tables"
+        );
+        $this->assertContains(
+            '_old_wp_woocommerce_orders',
+            $live_tables,
+            "The table is moved to _old_ prefix, but will be dropped by cleanup"
+        );
+
+        // After cleanup (which endpoint_commit does), the data is permanently lost
+        foreach ($old_tables as $old_table) {
+            $this->pdo->exec("DROP TABLE IF EXISTS `{$old_table}`");
+        }
+
+        $final_tables = $this->getExistingTableNames();
+        $this->assertNotContains(
+            '_old_wp_woocommerce_orders',
+            $final_tables,
+            "BUG DOCUMENTED: WooCommerce orders are permanently deleted"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Missing staging tables
+    // ---------------------------------------------------------------
+
+    /**
+     * If a staging table is missing (push was interrupted), commit
+     * must refuse to proceed. If it doesn't, RENAME TABLE will fail
+     * partway through, potentially leaving the DB in an inconsistent state.
+     */
+    public function testMissingStagingTablePreventsCommit(): void
+    {
+        $this->pdo->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_posts VALUES (1)");
+
+        // Staging table for wp_posts is missing — push was interrupted
+        // (no _push_wp_posts created)
+
+        $pushed_tables = ['wp_posts'];
+
+        $existing_tables = [];
+        $stmt = $this->pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $existing_tables[$row['TABLE_NAME']] = true;
+        }
+
+        $errors = [];
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            if (!isset($existing_tables[$staging_name])) {
+                $errors[] = "Missing staging table: {$staging_name}";
+            }
+        }
+
+        $this->assertNotEmpty($errors, "Commit must detect missing staging tables");
+        $this->assertStringContainsString('_push_wp_posts', $errors[0]);
+
+        // Verify live table is untouched
+        $rows = $this->pdo->query("SELECT id FROM wp_posts")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['1'], $rows, "Live data must be untouched when commit is refused");
+    }
+
+    // ---------------------------------------------------------------
+    // RENAME TABLE failure mid-swap
+    // ---------------------------------------------------------------
+
+    /**
+     * If RENAME TABLE fails (e.g. a staging table is actually missing
+     * despite passing validation, or a lock blocks it), the live DB
+     * must remain usable.
+     *
+     * MySQL's RENAME TABLE is atomic for a single table pair, but
+     * the compound multi-table RENAME can fail partway. We verify
+     * that a deliberate failure leaves the original tables intact.
+     */
+    public function testRenameTableFailureLeavesLiveTablesIntact(): void
+    {
+        $this->pdo->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO wp_posts VALUES (1), (2), (3)");
+        $this->pdo->exec("CREATE TABLE _push_wp_posts (id INT PRIMARY KEY) ENGINE=InnoDB");
+        $this->pdo->exec("INSERT INTO _push_wp_posts VALUES (10)");
+
+        // Attempt to RENAME a table that doesn't exist → the entire RENAME fails
+        $rename_sql = 'RENAME TABLE '
+            . '`wp_posts` TO `_old_wp_posts`, '
+            . '`_push_wp_posts` TO `wp_posts`, '
+            . '`_push_wp_nonexistent` TO `wp_nonexistent`';
+
+        $failed = false;
+        try {
+            $this->pdo->exec($rename_sql);
+        } catch (\Throwable $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed, "RENAME TABLE should have failed");
+
+        // CRITICAL: wp_posts must still have the original data
+        $rows = $this->pdo->query("SELECT id FROM wp_posts ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['1', '2', '3'], $rows, "Live table data must survive a failed RENAME");
+    }
+
+    // ---------------------------------------------------------------
+    // File swap tests
+    // ---------------------------------------------------------------
+
+    /**
+     * File swap via rename: staging directory becomes live,
+     * old live directory is preserved as _old_.
+     */
+    public function testFileSwapViaRename(): void
+    {
+        $base = $this->createTempDir();
+        $fs_root = $base . '/html';
+        $staging_dir = $base . '/.push-staging-test123';
+
+        // Create "live" directory with some files
+        mkdir($fs_root, 0755, true);
+        file_put_contents($fs_root . '/index.php', '<?php // old live');
+        file_put_contents($fs_root . '/wp-config.php', '<?php define("DB_HOST", "prod-db");');
+
+        // Create staging directory with new files
+        mkdir($staging_dir, 0755, true);
+        file_put_contents($staging_dir . '/index.php', '<?php // new from push');
+        // Deliberately no wp-config.php in staging — the commit should copy it
+
+        // Copy wp-config.php from live to staging (as endpoint_commit does)
+        copy($fs_root . '/wp-config.php', $staging_dir . '/wp-config.php');
+
+        // Perform rename swap
+        $old_fs_dir = $fs_root . '_old_test123';
+        $this->assertTrue(rename($fs_root, $old_fs_dir));
+        $this->assertTrue(rename($staging_dir, $fs_root));
+
+        // Verify: live now has staging content
+        $this->assertSame('<?php // new from push', file_get_contents($fs_root . '/index.php'));
+
+        // Verify: wp-config.php has production credentials
+        $this->assertStringContainsString('prod-db', file_get_contents($fs_root . '/wp-config.php'));
+
+        // Verify: old directory still exists for rollback
+        $this->assertTrue(is_dir($old_fs_dir));
+        $this->assertSame('<?php // old live', file_get_contents($old_fs_dir . '/index.php'));
+    }
+
+    /**
+     * CRITICAL: If staging directory is missing critical files (e.g.
+     * wp-load.php), the site breaks after swap. The commit endpoint
+     * should validate that essential WordPress files exist.
+     *
+     * This test documents that NO such validation currently exists.
+     */
+    public function testIncompleteFileStaging(): void
+    {
+        $base = $this->createTempDir();
+        $fs_root = $base . '/html';
+        $staging_dir = $base . '/.push-staging-incomplete';
+
+        // Live site has all required WordPress files
+        mkdir($fs_root, 0755, true);
+        file_put_contents($fs_root . '/index.php', '<?php require "wp-blog-header.php";');
+        file_put_contents($fs_root . '/wp-load.php', '<?php // WordPress loader');
+        file_put_contents($fs_root . '/wp-blog-header.php', '<?php require "wp-load.php";');
+        file_put_contents($fs_root . '/wp-config.php', '<?php define("DB_HOST", "prod");');
+
+        // Staging only has index.php — push was interrupted mid-way
+        mkdir($staging_dir, 0755, true);
+        file_put_contents($staging_dir . '/index.php', '<?php require "wp-blog-header.php";');
+
+        // Copy wp-config.php
+        copy($fs_root . '/wp-config.php', $staging_dir . '/wp-config.php');
+
+        // Currently, the swap would proceed even though staging is incomplete
+        $has_staging_dir = is_dir($staging_dir);
+        $this->assertTrue($has_staging_dir, "Staging dir exists, so commit would proceed");
+
+        // Verify: staging is missing critical files
+        $this->assertFalse(
+            file_exists($staging_dir . '/wp-load.php'),
+            "BUG DOCUMENTED: staging is missing wp-load.php but commit would proceed anyway"
+        );
+        $this->assertFalse(
+            file_exists($staging_dir . '/wp-blog-header.php'),
+            "BUG DOCUMENTED: staging is missing wp-blog-header.php but commit would proceed anyway"
+        );
+
+        // If the swap happened, the site would be broken:
+        // index.php tries to require wp-blog-header.php which doesn't exist
+    }
+
+    /**
+     * File swap rollback: if DB swap fails after files were swapped,
+     * the files must be restored to their original state.
+     */
+    public function testFileRollbackAfterDbSwapFailure(): void
+    {
+        $base = $this->createTempDir();
+        $fs_root = $base . '/html';
+        $staging_dir = $base . '/.push-staging-rollback';
+        $old_fs_dir = $fs_root . '_old_rollback';
+
+        // Set up live
+        mkdir($fs_root, 0755, true);
+        file_put_contents($fs_root . '/index.php', '<?php // original live content');
+
+        // Set up staging
+        mkdir($staging_dir, 0755, true);
+        file_put_contents($staging_dir . '/index.php', '<?php // new staging content');
+
+        // Perform file swap
+        rename($fs_root, $old_fs_dir);
+        rename($staging_dir, $fs_root);
+
+        // Verify swap happened
+        $this->assertSame('<?php // new staging content', file_get_contents($fs_root . '/index.php'));
+
+        // Now simulate DB swap failure → roll back files
+        // This is what endpoint_commit does when RENAME TABLE throws
+        rename($fs_root, $staging_dir);  // Move new content back to staging
+        rename($old_fs_dir, $fs_root);   // Restore original
+
+        // Verify: live is restored to original
+        $this->assertSame(
+            '<?php // original live content',
+            file_get_contents($fs_root . '/index.php'),
+            "After rollback, live directory must have original content"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // wp-config.php handling
+    // ---------------------------------------------------------------
+
+    /**
+     * wp-config.php MUST be copied from live to staging before swap.
+     * If it isn't, the site after swap will have local dev DB credentials
+     * and won't be able to connect to the production database.
+     */
+    public function testWpConfigIsCopiedFromLiveToStaging(): void
+    {
+        $base = $this->createTempDir();
+        $fs_root = $base . '/html';
+        $staging_dir = $base . '/.push-staging-config';
+
+        mkdir($fs_root, 0755, true);
+        file_put_contents($fs_root . '/wp-config.php', '<?php define("DB_HOST", "production-rds.amazonaws.com");');
+
+        mkdir($staging_dir, 0755, true);
+        file_put_contents($staging_dir . '/wp-config.php', '<?php define("DB_HOST", "localhost");');
+
+        // endpoint_commit copies live wp-config.php into staging
+        $wp_config_src = $fs_root . '/wp-config.php';
+        $wp_config_dst = $staging_dir . '/wp-config.php';
+        if (file_exists($wp_config_src)) {
+            copy($wp_config_src, $wp_config_dst);
+        }
+
+        // After copy, staging should have production credentials
+        $this->assertStringContainsString(
+            'production-rds.amazonaws.com',
+            file_get_contents($staging_dir . '/wp-config.php'),
+            "Staging wp-config.php must have production DB credentials"
+        );
+    }
+
+    /**
+     * If live site has no wp-config.php (unusual but possible — e.g. it's
+     * loaded from a parent directory), the staging directory keeps whatever
+     * wp-config.php was pushed. This should be logged as a warning.
+     */
+    public function testMissingLiveWpConfigIsHandledGracefully(): void
+    {
+        $base = $this->createTempDir();
+        $fs_root = $base . '/html';
+        $staging_dir = $base . '/.push-staging-noconfig';
+
+        mkdir($fs_root, 0755, true);
+        // No wp-config.php in live
+
+        mkdir($staging_dir, 0755, true);
+        file_put_contents($staging_dir . '/wp-config.php', '<?php define("DB_HOST", "localhost");');
+
+        $wp_config_src = $fs_root . '/wp-config.php';
+        $wp_config_dst = $staging_dir . '/wp-config.php';
+        if (file_exists($wp_config_src)) {
+            copy($wp_config_src, $wp_config_dst);
+        }
+
+        // Staging keeps its own wp-config.php (with local credentials)
+        // This is dangerous but the current behavior
+        $this->assertStringContainsString(
+            'localhost',
+            file_get_contents($staging_dir . '/wp-config.php'),
+            "Without live wp-config.php, staging keeps local dev credentials (dangerous)"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // build_staging_table_map
+    // ---------------------------------------------------------------
+
+    /**
+     * build_staging_table_map should include both existing remote tables
+     * and incoming tables from the push client.
+     */
+    public function testBuildStagingTableMapIncludesIncomingTables(): void
+    {
+        $this->pdo->exec("CREATE TABLE wp_posts (id INT)");
+        $this->pdo->exec("CREATE TABLE wp_options (id INT)");
+
+        $map = build_staging_table_map($this->pdo, 'wp_', ['wp_posts', 'wp_users']);
+
+        // wp_posts: exists on remote AND in incoming → should be in map
+        $this->assertArrayHasKey('wp_posts', $map);
+        $this->assertSame('_push_wp_posts', $map['wp_posts']);
+
+        // wp_options: exists on remote, NOT in incoming → should still be in map
+        $this->assertArrayHasKey('wp_options', $map);
+
+        // wp_users: NOT on remote, in incoming → should be added
+        $this->assertArrayHasKey('wp_users', $map);
+        $this->assertSame('_push_wp_users', $map['wp_users']);
+    }
+
+    /**
+     * Tables without the specified prefix should not be in the map.
+     */
+    public function testBuildStagingTableMapRespectsPrefix(): void
+    {
+        $this->pdo->exec("CREATE TABLE wp_posts (id INT)");
+        $this->pdo->exec("CREATE TABLE custom_table (id INT)");
+
+        $map = build_staging_table_map($this->pdo, 'wp_', []);
+
+        $this->assertArrayHasKey('wp_posts', $map);
+        $this->assertArrayNotHasKey('custom_table', $map);
+    }
+}

--- a/tests/Push/MultipartBodyStreamTest.php
+++ b/tests/Push/MultipartBodyStreamTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for MultipartBodyStream and its round-trip with parse_multipart_body().
+ *
+ * The stream is the bridge between client and server. If it produces
+ * malformed multipart, the receiver silently drops chunks and the push
+ * appears to succeed but staging is incomplete.
+ */
+final class MultipartBodyStreamTest extends TestCase
+{
+    /**
+     * Basic round-trip: write a SQL chunk, parse it back.
+     */
+    public function testSqlChunkRoundTrip(): void
+    {
+        $stream = new MultipartBodyStream();
+        $sql = "INSERT INTO `wp_posts` VALUES (1, 'Hello World');";
+        $cursor = json_encode(['table' => 'wp_posts', 'pk' => 1]);
+
+        $stream->write_sql_chunk($sql, $cursor, true);
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $chunks = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(1, $chunks);
+        $this->assertSame('sql', $chunks[0]['headers']['x-chunk-type']);
+        $this->assertSame($sql, $chunks[0]['body']);
+
+        // Cursor should be base64-encoded in headers
+        $decoded_cursor = base64_decode($chunks[0]['headers']['x-cursor'], true);
+        $this->assertSame($cursor, $decoded_cursor);
+    }
+
+    /**
+     * File chunk round-trip with binary data.
+     */
+    public function testFileChunkRoundTripWithBinaryData(): void
+    {
+        $stream = new MultipartBodyStream();
+
+        // Generate binary data (simulates an image)
+        $binary = random_bytes(1024);
+        $chunk = [
+            'path' => '/wp-content/uploads/photo.jpg',
+            'data' => $binary,
+            'size' => 1024,
+            'ctime' => 1700000000,
+            'offset' => 0,
+            'is_first_chunk' => true,
+            'is_last_chunk' => true,
+            'file_changed' => false,
+        ];
+        $cursor = json_encode(['file' => '/wp-content/uploads/photo.jpg']);
+
+        $stream->write_file_chunk($chunk, $cursor);
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $parsed = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(1, $parsed);
+        $this->assertSame('file', $parsed[0]['headers']['x-chunk-type']);
+        $this->assertSame('1', $parsed[0]['headers']['x-first-chunk']);
+        $this->assertSame('1', $parsed[0]['headers']['x-last-chunk']);
+
+        // Binary data must survive the round-trip exactly
+        $this->assertSame(
+            $binary,
+            $parsed[0]['body'],
+            "Binary file data must survive multipart round-trip without corruption"
+        );
+    }
+
+    /**
+     * Directory chunk round-trip.
+     */
+    public function testDirectoryChunkRoundTrip(): void
+    {
+        $stream = new MultipartBodyStream();
+        $cursor = json_encode(['dir' => '/wp-content/uploads/2024/']);
+
+        $stream->write_directory_chunk('/wp-content/uploads/2024/', $cursor, 1700000000);
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $parsed = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(1, $parsed);
+        $this->assertSame('directory', $parsed[0]['headers']['x-chunk-type']);
+
+        $path = base64_decode($parsed[0]['headers']['x-directory-path'], true);
+        $this->assertSame('/wp-content/uploads/2024/', $path);
+    }
+
+    /**
+     * Symlink chunk round-trip.
+     */
+    public function testSymlinkChunkRoundTrip(): void
+    {
+        $stream = new MultipartBodyStream();
+        $cursor = json_encode(['link' => '/wp-content/plugins/akismet']);
+
+        $stream->write_symlink_chunk(
+            '/wp-content/plugins/akismet',
+            '../shared-plugins/akismet',
+            1700000000,
+            $cursor
+        );
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $parsed = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(1, $parsed);
+        $this->assertSame('symlink', $parsed[0]['headers']['x-chunk-type']);
+
+        $path = base64_decode($parsed[0]['headers']['x-symlink-path'], true);
+        $target = base64_decode($parsed[0]['headers']['x-symlink-target'], true);
+        $this->assertSame('/wp-content/plugins/akismet', $path);
+        $this->assertSame('../shared-plugins/akismet', $target);
+    }
+
+    /**
+     * Completion chunk carries status.
+     */
+    public function testCompletionChunkRoundTrip(): void
+    {
+        $stream = new MultipartBodyStream();
+
+        $stream->write_completion_chunk('complete', ['sql_bytes' => 12345]);
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $parsed = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(1, $parsed);
+        $this->assertSame('completion', $parsed[0]['headers']['x-chunk-type']);
+        $this->assertSame('complete', $parsed[0]['headers']['x-status']);
+    }
+
+    /**
+     * Multiple chunks of different types in one body.
+     */
+    public function testMultipleChunkTypes(): void
+    {
+        $stream = new MultipartBodyStream();
+
+        $stream->write_directory_chunk('/wp-content/', '{}', null);
+        $stream->write_file_chunk([
+            'path' => '/wp-content/index.php',
+            'data' => '<?php // Silence',
+            'size' => 16,
+            'ctime' => 1700000000,
+            'offset' => 0,
+            'is_first_chunk' => true,
+            'is_last_chunk' => true,
+            'file_changed' => false,
+        ], '{}');
+        $stream->write_sql_chunk("INSERT INTO `wp_posts` VALUES (1);", '{}', true);
+        $stream->write_completion_chunk('partial', []);
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $parsed = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(4, $parsed);
+        $types = array_map(fn($c) => $c['headers']['x-chunk-type'], $parsed);
+        $this->assertSame(['directory', 'file', 'sql', 'completion'], $types);
+    }
+
+    /**
+     * Finalize is idempotent — calling it twice must not corrupt the body.
+     */
+    public function testFinalizeIsIdempotent(): void
+    {
+        $stream = new MultipartBodyStream();
+        $stream->write_sql_chunk("SELECT 1;", '{}', true);
+        $stream->finalize();
+        $size1 = $stream->get_size();
+
+        $stream->finalize(); // Second call
+        $size2 = $stream->get_size();
+
+        $this->assertSame($size1, $size2, "Double finalize must not add extra bytes");
+    }
+
+    /**
+     * Writing after finalize must throw.
+     */
+    public function testCannotWriteAfterFinalize(): void
+    {
+        $stream = new MultipartBodyStream();
+        $stream->finalize();
+
+        $this->expectException(RuntimeException::class);
+        $stream->write_sql_chunk("SELECT 1;", '{}', true);
+    }
+
+    /**
+     * get_resource() returns a seekable stream usable by curl.
+     */
+    public function testGetResourceIsSeekable(): void
+    {
+        $stream = new MultipartBodyStream();
+        $stream->write_sql_chunk("SELECT 1;", '{}', true);
+        $stream->finalize();
+
+        $resource = $stream->get_resource();
+        $this->assertIsResource($resource);
+
+        // Must be at the beginning (get_resource auto-rewinds)
+        $this->assertSame(0, ftell($resource));
+
+        // Must be readable
+        $data = fread($resource, 8192);
+        $this->assertNotEmpty($data);
+    }
+
+    /**
+     * get_contents() for HMAC must return the same bytes as reading the resource.
+     */
+    public function testGetContentsMatchesResourceRead(): void
+    {
+        $stream = new MultipartBodyStream();
+        $stream->write_sql_chunk("INSERT INTO `t` VALUES (1);", '{}', true);
+        $stream->write_file_chunk([
+            'path' => '/test.txt',
+            'data' => 'file data here',
+            'size' => 14,
+            'ctime' => 0,
+            'offset' => 0,
+            'is_first_chunk' => true,
+            'is_last_chunk' => true,
+            'file_changed' => false,
+        ], '{}');
+        $stream->finalize();
+
+        $contents = $stream->get_contents();
+        $resource = $stream->get_resource();
+        $resource_data = stream_get_contents($resource);
+
+        $this->assertSame(
+            $contents,
+            $resource_data,
+            "HMAC hash (from get_contents) and curl upload (from get_resource) must see identical bytes"
+        );
+    }
+
+    /**
+     * Content-Type header must be properly formatted for multipart/mixed.
+     */
+    public function testContentTypeFormat(): void
+    {
+        $stream = new MultipartBodyStream();
+
+        $ct = $stream->get_content_type();
+        $this->assertStringStartsWith('multipart/mixed; boundary="', $ct);
+
+        // Extract boundary from content type and verify it matches
+        preg_match('/boundary="([^"]+)"/', $ct, $m);
+        $this->assertSame($stream->get_boundary(), $m[1]);
+    }
+
+    /**
+     * CRITICAL: SQL chunk with Content-Length must parse exactly that many bytes.
+     * If the parser reads more or less, statements get truncated or merged.
+     */
+    public function testSqlChunkContentLengthIsRespected(): void
+    {
+        $stream = new MultipartBodyStream();
+
+        // SQL with embedded newlines and special characters
+        $sql = "INSERT INTO `wp_posts` VALUES (1, 'Line1\nLine2\nLine3');";
+        $stream->write_sql_chunk($sql, '{}', true);
+        $stream->finalize();
+
+        $body = $stream->get_contents();
+        $parsed = parse_multipart_body($body, $stream->get_boundary());
+
+        $this->assertCount(1, $parsed);
+        $this->assertSame(
+            $sql,
+            $parsed[0]['body'],
+            "SQL with newlines must survive multipart parsing exactly"
+        );
+    }
+}

--- a/tests/Push/SqlReceiveIntegrationTest.php
+++ b/tests/Push/SqlReceiveIntegrationTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the SQL receive → commit pipeline.
+ *
+ * These tests simulate the full push-sql flow: produce SQL from a local
+ * database, wrap it in multipart, parse on the receiver side, rewrite
+ * table names, execute into staging tables, then commit via RENAME TABLE.
+ *
+ * Each test creates both a "source" and "target" database to simulate
+ * a real push between two sites.
+ */
+final class SqlReceiveIntegrationTest extends TestCase
+{
+    private $pdo;
+    private $sourceDbName;
+    private $targetDbName;
+
+    protected function setUp(): void
+    {
+        $host = getenv("DB_HOST") ?: "localhost";
+        $user = getenv("DB_USER") ?: "root";
+        $pass = getenv("DB_PASS") ?: "";
+        $base = getenv("DB_NAME") ?: "test_mysql_dump";
+        $this->sourceDbName = $base . "_push_src";
+        $this->targetDbName = $base . "_push_tgt";
+
+        $dsn = "mysql:host={$host};charset=utf8mb4";
+        $this->pdo = new PDO($dsn, $user, $pass, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]);
+
+        // Create source and target databases
+        foreach ([$this->sourceDbName, $this->targetDbName] as $db) {
+            $this->pdo->exec("DROP DATABASE IF EXISTS `{$db}`");
+            $this->pdo->exec("CREATE DATABASE `{$db}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->pdo) {
+            foreach ([$this->sourceDbName, $this->targetDbName] as $db) {
+                try {
+                    $this->pdo->exec("DROP DATABASE IF EXISTS `{$db}`");
+                } catch (PDOException $e) {
+                    // Ignore
+                }
+            }
+        }
+        $this->pdo = null;
+    }
+
+    private function sourcePdo(): PDO
+    {
+        $host = getenv("DB_HOST") ?: "localhost";
+        $user = getenv("DB_USER") ?: "root";
+        $pass = getenv("DB_PASS") ?: "";
+        return new PDO(
+            "mysql:host={$host};dbname={$this->sourceDbName};charset=utf8mb4",
+            $user, $pass,
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    }
+
+    private function targetPdo(): PDO
+    {
+        $host = getenv("DB_HOST") ?: "localhost";
+        $user = getenv("DB_USER") ?: "root";
+        $pass = getenv("DB_PASS") ?: "";
+        return new PDO(
+            "mysql:host={$host};dbname={$this->targetDbName};charset=utf8mb4",
+            $user, $pass,
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Full pipeline: export → multipart → receive → commit
+    // ---------------------------------------------------------------
+
+    /**
+     * Full round-trip: export source DB, push SQL to target via
+     * multipart stream, rewrite table names, commit via RENAME TABLE.
+     */
+    public function testFullPushRoundTrip(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Set up source database
+        $src->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200) NOT NULL,
+            content TEXT
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_posts (title, content) VALUES ('Hello', 'World'), ('Foo', 'Bar')");
+
+        $src->exec("CREATE TABLE wp_options (
+            option_id INT PRIMARY KEY AUTO_INCREMENT,
+            option_name VARCHAR(200) NOT NULL,
+            option_value TEXT
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_options (option_name, option_value) VALUES ('siteurl', 'http://local.test')");
+
+        // Export source DB using MySQLDumpProducer
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, [
+            'create_table_query' => true,
+        ]);
+
+        // Collect all SQL fragments
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) {
+                $all_sql .= $fragment . "\n";
+            }
+        }
+
+        $this->assertNotEmpty($all_sql, "Producer must generate SQL");
+
+        // Build multipart body (as the push client would)
+        $stream = new MultipartBodyStream();
+        $stream->write_sql_chunk($all_sql, json_encode(['done' => true]), true);
+        $stream->write_completion_chunk('complete', []);
+        $stream->finalize();
+
+        // Parse multipart body (as the receiver would)
+        $body = $stream->get_contents();
+        $chunks = parse_multipart_body($body, $stream->get_boundary());
+        $this->assertGreaterThanOrEqual(2, count($chunks), "Must have SQL + completion chunks");
+
+        // Build staging table map on target
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts', 'wp_options']);
+
+        // Execute rewritten SQL on target
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        foreach ($chunks as $chunk) {
+            if (($chunk['headers']['x-chunk-type'] ?? '') !== 'sql') {
+                continue;
+            }
+            $sql = rewrite_table_names($chunk['body'], $table_map);
+
+            // Verify staging prefix is present
+            $this->assertStringContainsString('_push_wp_posts', $sql);
+            $this->assertStringContainsString('_push_wp_options', $sql);
+
+            // Execute the rewritten SQL
+            $tgt->exec($sql);
+        }
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Verify staging tables exist on target
+        $tables = [];
+        $stmt = $tgt->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $tables[] = $row['TABLE_NAME'];
+        }
+        $this->assertContains('_push_wp_posts', $tables);
+        $this->assertContains('_push_wp_options', $tables);
+
+        // Verify staging tables have correct data
+        $count = $tgt->query("SELECT COUNT(*) FROM _push_wp_posts")->fetchColumn();
+        $this->assertEquals(2, $count, "Staging wp_posts should have 2 rows");
+
+        $count = $tgt->query("SELECT COUNT(*) FROM _push_wp_options")->fetchColumn();
+        $this->assertEquals(1, $count, "Staging wp_options should have 1 row");
+
+        // Commit: RENAME TABLE
+        $pushed_tables = ['wp_posts', 'wp_options'];
+        $rename_pairs = [];
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+        }
+        $tgt->exec('RENAME TABLE ' . implode(', ', $rename_pairs));
+
+        // Verify: live tables now have source data
+        $rows = $tgt->query("SELECT title FROM wp_posts ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['Hello', 'Foo'], $rows);
+
+        $value = $tgt->query("SELECT option_value FROM wp_options WHERE option_name='siteurl'")->fetchColumn();
+        $this->assertSame('http://local.test', $value);
+    }
+
+    /**
+     * Push to a target that already has tables — the old data must be
+     * swapped out and the new data must be live.
+     */
+    public function testPushOverExistingData(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Source: new data
+        $src->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY, title VARCHAR(200)) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_posts VALUES (1, 'Updated Post')");
+
+        // Target: old production data
+        $tgt->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY, title VARCHAR(200)) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_posts VALUES (1, 'Original Post'), (2, 'Another Post')");
+
+        // Export source
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        // Rewrite to staging prefix
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+
+        // Execute staging SQL on target
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit: swap staging → live, live → _old_
+        $tgt->exec("RENAME TABLE `wp_posts` TO `_old_wp_posts`, `_push_wp_posts` TO `wp_posts`");
+
+        // Verify: live table has source data (only 1 row, not 2)
+        $rows = $tgt->query("SELECT title FROM wp_posts")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['Updated Post'], $rows);
+
+        // Verify: old data is in _old_ table
+        $rows = $tgt->query("SELECT title FROM _old_wp_posts ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['Original Post', 'Another Post'], $rows);
+    }
+
+    /**
+     * Special characters in data must survive the full pipeline.
+     * This catches encoding bugs that could corrupt production content.
+     */
+    public function testSpecialCharactersSurviveRoundTrip(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        $src->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY, content TEXT) ENGINE=InnoDB");
+
+        // Insert content with unicode, quotes, backslashes, newlines, NUL-adjacent chars
+        $tricky_content = "Hello 'World' \"quoted\" \\backslash\\ \n新しい記事\n🎉 emoji \t tab";
+        $stmt = $src->prepare("INSERT INTO wp_posts VALUES (1, ?)");
+        $stmt->execute([$tricky_content]);
+
+        // Export
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        // Rewrite and execute on target
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit
+        $tgt->exec("RENAME TABLE `_push_wp_posts` TO `wp_posts`");
+
+        // Verify data integrity
+        $result = $tgt->query("SELECT content FROM wp_posts WHERE id=1")->fetchColumn();
+        $this->assertSame(
+            $tricky_content,
+            $result,
+            "Special characters must survive export → multipart → rewrite → import"
+        );
+    }
+
+    /**
+     * CRITICAL: Empty source database pushed to a target with data.
+     * This effectively wipes the target — make sure it's intentional.
+     */
+    public function testPushingEmptyDatabaseWipesTarget(): void
+    {
+        $tgt = $this->targetPdo();
+
+        // Target has production data
+        $tgt->exec("CREATE TABLE wp_posts (id INT PRIMARY KEY, title VARCHAR(200)) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_posts VALUES (1, 'Important Post')");
+        $tgt->exec("CREATE TABLE wp_options (option_id INT PRIMARY KEY) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_options VALUES (1)");
+
+        // Source has no tables → push includes no tables
+        $pushed_tables = [];
+
+        // The commit logic handles tables NOT in pushed_tables:
+        // they get renamed to _old_ (silently deleted)
+        $existing_tables = [];
+        $stmt = $tgt->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $existing_tables[$row['TABLE_NAME']] = true;
+        }
+
+        $rename_pairs = [];
+        $old_tables = [];
+        foreach ($existing_tables as $name => $_) {
+            if (str_starts_with($name, 'wp_')) {
+                $old_name = '_old_' . $name;
+                $rename_pairs[] = "`{$name}` TO `{$old_name}`";
+                $old_tables[] = $old_name;
+            }
+        }
+
+        if (!empty($rename_pairs)) {
+            $tgt->exec('RENAME TABLE ' . implode(', ', $rename_pairs));
+        }
+
+        // All live tables are gone
+        $live_tables = [];
+        $stmt = $tgt->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $name = $row['TABLE_NAME'];
+            if (!str_starts_with($name, '_old_')) {
+                $live_tables[] = $name;
+            }
+        }
+
+        $this->assertEmpty(
+            $live_tables,
+            "BUG DOCUMENTED: pushing an empty database silently wipes ALL production tables"
+        );
+    }
+}

--- a/tests/Push/SqlReceiveIntegrationTest.php
+++ b/tests/Push/SqlReceiveIntegrationTest.php
@@ -476,12 +476,15 @@ final class SqlReceiveIntegrationTest extends TestCase
     }
 
     /**
-     * AUTO_INCREMENT counter after push: if source has a lower counter than
-     * production, new rows inserted after push will reuse IDs that existed
-     * in the old production data. This can cause FK confusion if any system
-     * cached the old IDs.
+     * AUTO_INCREMENT counter after push: the source's CREATE TABLE includes
+     * AUTO_INCREMENT=N from SHOW CREATE TABLE. After push + commit, the live
+     * table's next auto-increment value comes from the source, not production.
+     *
+     * The real danger: new rows inserted after push may get IDs that previously
+     * belonged to different content in production. Any system that cached old
+     * IDs (CDN, search index, external service) now points to wrong content.
      */
-    public function testAutoIncrementCounterResetAfterPush(): void
+    public function testAutoIncrementCounterAfterPush(): void
     {
         $src = $this->sourcePdo();
         $tgt = $this->targetPdo();
@@ -502,14 +505,7 @@ final class SqlReceiveIntegrationTest extends TestCase
             $tgt->exec("INSERT INTO wp_posts (title) VALUES ('Prod Post {$i}')");
         }
 
-        // Verify target's AUTO_INCREMENT is high
-        $pre_push_ai = (int) $tgt->query(
-            "SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES
-             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wp_posts'"
-        )->fetchColumn();
-        $this->assertGreaterThan(10, $pre_push_ai);
-
-        // Export and push
+        // Export source — the SQL will contain AUTO_INCREMENT=3
         $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
         $all_sql = '';
         while ($producer->next_sql_fragment()) {
@@ -526,23 +522,20 @@ final class SqlReceiveIntegrationTest extends TestCase
         // Commit
         $tgt->exec("RENAME TABLE `wp_posts` TO `_old_wp_posts`, `_push_wp_posts` TO `wp_posts`");
 
-        // AUTO_INCREMENT is now 3 (from source), not 11 (from production)
-        $post_push_ai = (int) $tgt->query(
-            "SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES
-             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wp_posts'"
-        )->fetchColumn();
+        // After push, the table has exactly 2 rows (source data)
+        $count = (int) $tgt->query("SELECT COUNT(*) FROM wp_posts")->fetchColumn();
+        $this->assertSame(2, $count);
 
-        $this->assertLessThan($pre_push_ai, $post_push_ai,
-            "AUTO_INCREMENT counter is reset to source value, much lower than production"
-        );
-
-        // Insert a new post after push — it gets ID=3, which existed in old production
+        // Insert a new post — what ID does it get?
         $tgt->exec("INSERT INTO wp_posts (title) VALUES ('New Post After Push')");
         $new_id = (int) $tgt->query("SELECT LAST_INSERT_ID()")->fetchColumn();
 
+        // The new ID should be 3 (next after source's max ID of 2).
+        // This is an ID that previously belonged to "Prod Post 3" in production.
+        // Any external system referencing /posts/3 now gets different content.
         $this->assertSame(3, $new_id,
-            "New post gets ID=3, which was an existing production post ID — " .
-            "any system caching old ID=3 now points to wrong content"
+            "New post gets ID=3, reusing an ID from old production data — " .
+            "external caches and references now point to wrong content"
         );
     }
 

--- a/tests/Push/SqlReceiveIntegrationTest.php
+++ b/tests/Push/SqlReceiveIntegrationTest.php
@@ -330,4 +330,412 @@ final class SqlReceiveIntegrationTest extends TestCase
             "BUG DOCUMENTED: pushing an empty database silently wipes ALL production tables"
         );
     }
+
+    // ---------------------------------------------------------------
+    // Conflicting IDs: production has data the source doesn't know about
+    // ---------------------------------------------------------------
+
+    /**
+     * CRITICAL: Production site has auto-increment IDs that the source doesn't
+     * know about. After push + commit, those production rows are destroyed.
+     *
+     * Scenario: You fork a production DB for local dev. Production keeps getting
+     * new posts (IDs 4, 5, 6). You push your local DB (which only has IDs 1-3).
+     * After commit, posts 4-6 are gone — DROP TABLE + CREATE TABLE wipes them.
+     *
+     * This is by design (full replacement), but users who think "push" means
+     * "merge" will lose production data.
+     */
+    public function testPushDestroysProductionRowsNotInSource(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Source: local dev copy, frozen at 3 posts
+        $src->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_posts (id, title) VALUES (1, 'Post One'), (2, 'Post Two'), (3, 'Post Three')");
+
+        // Target: production, has diverged with new content
+        $tgt->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_posts (id, title) VALUES
+            (1, 'Post One'),
+            (2, 'Post Two'),
+            (3, 'Post Three'),
+            (4, 'New Production Post'),
+            (5, 'Customer Submission'),
+            (6, 'Breaking News')
+        ");
+
+        // Export source
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        // The source's CREATE TABLE has AUTO_INCREMENT=4 (next value after 3)
+        $this->assertStringContainsString('AUTO_INCREMENT', $all_sql,
+            "SHOW CREATE TABLE should include AUTO_INCREMENT counter");
+
+        // Rewrite and execute on target staging
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit: swap staging → live
+        $tgt->exec("RENAME TABLE `wp_posts` TO `_old_wp_posts`, `_push_wp_posts` TO `wp_posts`");
+
+        // After commit: only 3 rows remain. Posts 4-6 are gone.
+        $count = (int) $tgt->query("SELECT COUNT(*) FROM wp_posts")->fetchColumn();
+        $this->assertSame(3, $count,
+            "Push replaces the entire table — production-only rows are destroyed"
+        );
+
+        // The production-only posts are in _old_ but will be dropped by cleanup
+        $old_count = (int) $tgt->query("SELECT COUNT(*) FROM _old_wp_posts")->fetchColumn();
+        $this->assertSame(6, $old_count,
+            "Original production data survives in _old_ table until cleanup drops it"
+        );
+    }
+
+    /**
+     * CRITICAL: Source and production have DIFFERENT rows with the SAME auto-increment IDs.
+     *
+     * Scenario: Two copies of the same site diverge. Local dev inserts post ID=4
+     * titled "Dev Draft". Production inserts post ID=4 titled "CEO Announcement".
+     * After push, post 4 silently becomes "Dev Draft" — the CEO Announcement is
+     * gone with no conflict detection or warning.
+     */
+    public function testConflictingAutoIncrementIdsAreOverwrittenSilently(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Shared baseline: both started from the same 3 posts
+        $schema = "CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200),
+            author VARCHAR(100)
+        ) ENGINE=InnoDB";
+
+        // Source: dev added post 4
+        $src->exec($schema);
+        $src->exec("INSERT INTO wp_posts (id, title, author) VALUES
+            (1, 'Welcome', 'admin'),
+            (2, 'About', 'admin'),
+            (3, 'Contact', 'admin'),
+            (4, 'Dev Draft', 'developer')
+        ");
+
+        // Target: production added post 4 (different content, same ID!)
+        $tgt->exec($schema);
+        $tgt->exec("INSERT INTO wp_posts (id, title, author) VALUES
+            (1, 'Welcome', 'admin'),
+            (2, 'About', 'admin'),
+            (3, 'Contact', 'admin'),
+            (4, 'CEO Announcement', 'ceo')
+        ");
+
+        // Export and push
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit
+        $tgt->exec("RENAME TABLE `wp_posts` TO `_old_wp_posts`, `_push_wp_posts` TO `wp_posts`");
+
+        // Post 4 is now "Dev Draft" — the CEO Announcement is silently gone
+        $title = $tgt->query("SELECT title FROM wp_posts WHERE id=4")->fetchColumn();
+        $this->assertSame('Dev Draft', $title,
+            "Conflicting ID=4 is silently overwritten — production content is lost"
+        );
+
+        // No conflict detection, no warning, no merge — just wholesale replacement
+        $author = $tgt->query("SELECT author FROM wp_posts WHERE id=4")->fetchColumn();
+        $this->assertSame('developer', $author,
+            "The CEO's post is replaced by the dev's post with zero warning"
+        );
+    }
+
+    /**
+     * AUTO_INCREMENT counter after push: if source has a lower counter than
+     * production, new rows inserted after push will reuse IDs that existed
+     * in the old production data. This can cause FK confusion if any system
+     * cached the old IDs.
+     */
+    public function testAutoIncrementCounterResetAfterPush(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Source: 2 posts, AUTO_INCREMENT will be 3
+        $src->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_posts (id, title) VALUES (1, 'Post A'), (2, 'Post B')");
+
+        // Target: 10 posts, AUTO_INCREMENT is 11
+        $tgt->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        for ($i = 1; $i <= 10; $i++) {
+            $tgt->exec("INSERT INTO wp_posts (title) VALUES ('Prod Post {$i}')");
+        }
+
+        // Verify target's AUTO_INCREMENT is high
+        $pre_push_ai = (int) $tgt->query(
+            "SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wp_posts'"
+        )->fetchColumn();
+        $this->assertGreaterThan(10, $pre_push_ai);
+
+        // Export and push
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit
+        $tgt->exec("RENAME TABLE `wp_posts` TO `_old_wp_posts`, `_push_wp_posts` TO `wp_posts`");
+
+        // AUTO_INCREMENT is now 3 (from source), not 11 (from production)
+        $post_push_ai = (int) $tgt->query(
+            "SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wp_posts'"
+        )->fetchColumn();
+
+        $this->assertLessThan($pre_push_ai, $post_push_ai,
+            "AUTO_INCREMENT counter is reset to source value, much lower than production"
+        );
+
+        // Insert a new post after push — it gets ID=3, which existed in old production
+        $tgt->exec("INSERT INTO wp_posts (title) VALUES ('New Post After Push')");
+        $new_id = (int) $tgt->query("SELECT LAST_INSERT_ID()")->fetchColumn();
+
+        $this->assertSame(3, $new_id,
+            "New post gets ID=3, which was an existing production post ID — " .
+            "any system caching old ID=3 now points to wrong content"
+        );
+    }
+
+    /**
+     * Foreign key integrity after push with conflicting IDs.
+     *
+     * If wp_postmeta references wp_posts.ID and the push replaces wp_posts
+     * with different rows, the FK references may become stale. Since the push
+     * replaces ALL tables atomically, FKs within the pushed set are consistent.
+     * But if a table outside the pushed set references a pushed table, it breaks.
+     */
+    public function testForeignKeyIntegrityAcrossPushedTables(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Source: posts + postmeta, internally consistent
+        $src->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_posts VALUES (1, 'Source Post')");
+
+        $src->exec("CREATE TABLE wp_postmeta (
+            meta_id INT PRIMARY KEY AUTO_INCREMENT,
+            post_id INT NOT NULL,
+            meta_key VARCHAR(200),
+            meta_value TEXT
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_postmeta VALUES (1, 1, '_edit_last', 'admin')");
+
+        // Target: different data, both tables exist
+        $tgt->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_posts VALUES (1, 'Prod Post'), (2, 'Another Prod Post')");
+
+        $tgt->exec("CREATE TABLE wp_postmeta (
+            meta_id INT PRIMARY KEY AUTO_INCREMENT,
+            post_id INT NOT NULL,
+            meta_key VARCHAR(200),
+            meta_value TEXT
+        ) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_postmeta VALUES (1, 1, '_thumbnail_id', '42'), (2, 2, '_edit_last', 'editor')");
+
+        // Export both tables from source
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        // Rewrite and execute both staging tables
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts', 'wp_postmeta']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit: swap BOTH tables atomically
+        $tgt->exec("RENAME TABLE
+            `wp_posts` TO `_old_wp_posts`,
+            `_push_wp_posts` TO `wp_posts`,
+            `wp_postmeta` TO `_old_wp_postmeta`,
+            `_push_wp_postmeta` TO `wp_postmeta`
+        ");
+
+        // Verify: postmeta references valid posts (internal FK consistency)
+        $post_ids = $tgt->query("SELECT id FROM wp_posts")->fetchAll(PDO::FETCH_COLUMN);
+        $meta_post_ids = $tgt->query("SELECT DISTINCT post_id FROM wp_postmeta")->fetchAll(PDO::FETCH_COLUMN);
+
+        foreach ($meta_post_ids as $meta_post_id) {
+            $this->assertContains($meta_post_id, $post_ids,
+                "All post_id references in wp_postmeta must point to existing wp_posts rows"
+            );
+        }
+
+        // Both tables have source data, not production data
+        $title = $tgt->query("SELECT title FROM wp_posts WHERE id=1")->fetchColumn();
+        $this->assertSame('Source Post', $title);
+
+        $meta = $tgt->query("SELECT meta_value FROM wp_postmeta WHERE post_id=1")->fetchColumn();
+        $this->assertSame('admin', $meta);
+    }
+
+    /**
+     * CRITICAL: Pushing only SOME tables when they have FK relationships.
+     *
+     * If you push wp_posts but NOT wp_postmeta, the committed wp_posts
+     * has different IDs than what wp_postmeta references. wp_postmeta
+     * still has the old production post_ids, but wp_posts now has source
+     * IDs. The site shows wrong metadata for posts.
+     */
+    public function testPartialTablePushBreaksForeignKeyIntegrity(): void
+    {
+        $src = $this->sourcePdo();
+        $tgt = $this->targetPdo();
+
+        // Source: only has 1 post
+        $src->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $src->exec("INSERT INTO wp_posts VALUES (1, 'Only Source Post')");
+
+        // Target: has 3 posts with metadata
+        $tgt->exec("CREATE TABLE wp_posts (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            title VARCHAR(200)
+        ) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_posts VALUES (1, 'Prod 1'), (2, 'Prod 2'), (3, 'Prod 3')");
+
+        $tgt->exec("CREATE TABLE wp_postmeta (
+            meta_id INT PRIMARY KEY AUTO_INCREMENT,
+            post_id INT NOT NULL,
+            meta_key VARCHAR(200),
+            meta_value TEXT
+        ) ENGINE=InnoDB");
+        $tgt->exec("INSERT INTO wp_postmeta VALUES
+            (1, 1, 'thumbnail', 'img1.jpg'),
+            (2, 2, 'thumbnail', 'img2.jpg'),
+            (3, 3, 'thumbnail', 'img3.jpg')
+        ");
+
+        // Push ONLY wp_posts (not wp_postmeta)
+        $producer = new \WordPress\DataLiberation\MySQLDumpProducer($src, ['create_table_query' => true]);
+        $all_sql = '';
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            if ($fragment !== null) $all_sql .= $fragment . "\n";
+        }
+
+        $table_map = build_staging_table_map($tgt, 'wp_', ['wp_posts']);
+        $sql = rewrite_table_names($all_sql, $table_map);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=0");
+        $tgt->exec($sql);
+        $tgt->exec("SET FOREIGN_KEY_CHECKS=1");
+
+        // Commit: swap only wp_posts, leave wp_postmeta untouched
+        $pushed_tables = ['wp_posts'];
+        $existing_tables = [];
+        $stmt = $tgt->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $existing_tables[$row['TABLE_NAME']] = true;
+        }
+
+        $rename_pairs = [];
+        foreach ($pushed_tables as $table) {
+            $staging_name = PUSH_STAGING_TABLE_PREFIX . $table;
+            $old_name = '_old_' . $table;
+            if (isset($existing_tables[$table])) {
+                $rename_pairs[] = "`{$table}` TO `{$old_name}`";
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+            } else {
+                $rename_pairs[] = "`{$staging_name}` TO `{$table}`";
+            }
+        }
+
+        // Also handle "dropped" tables (tables not in push) — current behavior
+        // moves wp_postmeta to _old_ since it's not in pushed_tables!
+        $table_prefix = 'wp_';
+        foreach ($existing_tables as $name => $_) {
+            if (
+                str_starts_with($name, $table_prefix) &&
+                !in_array($name, $pushed_tables) &&
+                !str_starts_with($name, PUSH_STAGING_TABLE_PREFIX) &&
+                !str_starts_with($name, '_old_')
+            ) {
+                $old_name = '_old_' . $name;
+                $rename_pairs[] = "`{$name}` TO `{$old_name}`";
+            }
+        }
+
+        $tgt->exec('RENAME TABLE ' . implode(', ', $rename_pairs));
+
+        // wp_postmeta is now GONE from live (moved to _old_wp_postmeta)
+        // because the current commit logic treats unpushed tables as "dropped"
+        $live_tables = [];
+        $stmt = $tgt->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $name = $row['TABLE_NAME'];
+            if (!str_starts_with($name, '_old_') && !str_starts_with($name, PUSH_STAGING_TABLE_PREFIX)) {
+                $live_tables[] = $name;
+            }
+        }
+
+        $this->assertNotContains('wp_postmeta', $live_tables,
+            "BUG DOCUMENTED: pushing only wp_posts silently removes wp_postmeta from live"
+        );
+
+        // Even if wp_postmeta survived, it would have dangling references:
+        // postmeta rows point to post_ids 1,2,3 but wp_posts only has id=1
+    }
 }

--- a/tests/Push/TableNameRewritingTest.php
+++ b/tests/Push/TableNameRewritingTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for rewrite_table_names() and build_staging_table_map().
+ *
+ * The table name rewriter is the gatekeeper between pushed SQL and
+ * production. If it fails to rewrite a table name, the push writes
+ * directly into the live table. If it rewrites too broadly, it
+ * corrupts unrelated statements.
+ */
+final class TableNameRewritingTest extends TestCase
+{
+    /**
+     * Basic rewriting: all four SQL statement types get rewritten.
+     */
+    public function testRewritesAllFourStatementTypes(): void
+    {
+        $map = ['wp_posts' => '_push_wp_posts'];
+
+        $cases = [
+            'DROP TABLE IF EXISTS `wp_posts`'  => 'DROP TABLE IF EXISTS `_push_wp_posts`',
+            'CREATE TABLE `wp_posts`'          => 'CREATE TABLE `_push_wp_posts`',
+            'INSERT INTO `wp_posts`'           => 'INSERT INTO `_push_wp_posts`',
+            'REFERENCES `wp_posts`'            => 'REFERENCES `_push_wp_posts`',
+        ];
+
+        foreach ($cases as $input => $expected) {
+            $this->assertSame(
+                $expected,
+                rewrite_table_names($input, $map),
+                "Failed to rewrite: {$input}"
+            );
+        }
+    }
+
+    /**
+     * CRITICAL: Table names that are substrings of each other.
+     *
+     * If we have both wp_post and wp_posts, a naive str_replace on
+     * "wp_post" would corrupt "wp_posts" → "_push_wp_posts" gets the
+     * wp_post prefix replaced again. The backtick quoting prevents this.
+     */
+    public function testSubstringTableNamesDoNotCollide(): void
+    {
+        $map = [
+            'wp_post'     => '_push_wp_post',
+            'wp_posts'    => '_push_wp_posts',
+            'wp_postmeta' => '_push_wp_postmeta',
+        ];
+
+        $sql = implode("\n", [
+            'CREATE TABLE `wp_post` (id INT);',
+            'CREATE TABLE `wp_posts` (id INT);',
+            'CREATE TABLE `wp_postmeta` (id INT);',
+        ]);
+
+        $result = rewrite_table_names($sql, $map);
+
+        $this->assertStringContainsString('CREATE TABLE `_push_wp_post`', $result);
+        $this->assertStringContainsString('CREATE TABLE `_push_wp_posts`', $result);
+        $this->assertStringContainsString('CREATE TABLE `_push_wp_postmeta`', $result);
+
+        // Ensure no double-rewriting: _push__push_ should never appear
+        $this->assertStringNotContainsString('_push__push_', $result);
+    }
+
+    /**
+     * SQL with no matching tables should pass through unchanged.
+     */
+    public function testUnmatchedTablesPassThroughUnchanged(): void
+    {
+        $map = ['wp_posts' => '_push_wp_posts'];
+        $sql = "INSERT INTO `some_other_table` VALUES (1, 'hello');";
+
+        $this->assertSame($sql, rewrite_table_names($sql, $map));
+    }
+
+    /**
+     * FK REFERENCES inside CREATE TABLE must also be rewritten,
+     * otherwise the staging table references the live table.
+     */
+    public function testForeignKeyReferencesAreRewritten(): void
+    {
+        $map = [
+            'wp_posts' => '_push_wp_posts',
+            'wp_postmeta' => '_push_wp_postmeta',
+        ];
+
+        $sql = <<<'SQL'
+CREATE TABLE `wp_postmeta` (
+  `meta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`meta_id`),
+  CONSTRAINT `fk_post` FOREIGN KEY (`post_id`) REFERENCES `wp_posts` (`ID`)
+) ENGINE=InnoDB;
+SQL;
+
+        $result = rewrite_table_names($sql, $map);
+
+        $this->assertStringContainsString('CREATE TABLE `_push_wp_postmeta`', $result);
+        $this->assertStringContainsString('REFERENCES `_push_wp_posts`', $result);
+    }
+
+    /**
+     * Empty table map should return SQL unchanged.
+     */
+    public function testEmptyMapReturnsUnchanged(): void
+    {
+        $sql = "CREATE TABLE `wp_posts` (id INT);";
+        $this->assertSame($sql, rewrite_table_names($sql, []));
+    }
+
+    /**
+     * DANGEROUS: Table name appearing in string VALUES should NOT be rewritten.
+     *
+     * If a row contains the table name as data (e.g. a serialized option that
+     * mentions the table name), the rewriter should NOT touch it. Since we
+     * only rewrite inside backtick-quoted identifiers, string values are safe.
+     */
+    public function testTableNameInsideStringValuesIsNotRewritten(): void
+    {
+        $map = ['wp_posts' => '_push_wp_posts'];
+
+        $sql = "INSERT INTO `wp_posts` VALUES (1, 'The wp_posts table is great');";
+        $result = rewrite_table_names($sql, $map);
+
+        // The INSERT INTO target should be rewritten
+        $this->assertStringContainsString('INSERT INTO `_push_wp_posts`', $result);
+        // But the string value must NOT be touched
+        $this->assertStringContainsString("'The wp_posts table is great'", $result);
+    }
+
+    /**
+     * Multi-statement SQL block should have all statements rewritten.
+     */
+    public function testMultiStatementBlock(): void
+    {
+        $map = ['wp_options' => '_push_wp_options'];
+
+        $sql = implode("\n", [
+            'DROP TABLE IF EXISTS `wp_options`;',
+            'CREATE TABLE `wp_options` (option_id INT);',
+            'INSERT INTO `wp_options` VALUES (1);',
+            'INSERT INTO `wp_options` VALUES (2);',
+        ]);
+
+        $result = rewrite_table_names($sql, $map);
+
+        $this->assertStringContainsString('DROP TABLE IF EXISTS `_push_wp_options`', $result);
+        $this->assertStringContainsString('CREATE TABLE `_push_wp_options`', $result);
+        $this->assertEquals(2, substr_count($result, 'INSERT INTO `_push_wp_options`'));
+    }
+}

--- a/tests/Push/push-test-bootstrap.php
+++ b/tests/Push/push-test-bootstrap.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Bootstrap helper for push tests.
+ *
+ * Loads the push-related functions from export.php without triggering the
+ * "Cannot redeclare" fatal from utils.php double-loading. The Composer
+ * autoloader loads vendor/wp-php-toolkit/streaming-exporter/src/utils.php,
+ * and export.php does require_once on packages/.../src/utils.php — same
+ * content, different paths, so PHP tries to re-declare functions.
+ *
+ * Solution: define the push functions here directly. They're small,
+ * self-contained, and this avoids all side-effect issues with export.php
+ * (ob_start, define, require_once).
+ */
+
+// PUSH_STAGING_TABLE_PREFIX constant
+if (!defined('PUSH_STAGING_TABLE_PREFIX')) {
+    define('PUSH_STAGING_TABLE_PREFIX', '_push_');
+}
+
+if (!function_exists('parse_multipart_body')) {
+    /**
+     * Parse a multipart/mixed body into an array of chunks.
+     * Extracted from export.php to avoid loading it with side effects.
+     */
+    function parse_multipart_body(string $body, string $boundary): array
+    {
+        $delimiter = '--' . $boundary;
+        $chunks = [];
+        $parts = explode($delimiter, $body);
+        array_shift($parts);
+
+        foreach ($parts as $part) {
+            if (str_starts_with(ltrim($part, "\r\n"), '--')) {
+                break;
+            }
+
+            $header_end = strpos($part, "\r\n\r\n");
+            if ($header_end === false) {
+                $header_end = strpos($part, "\n\n");
+                if ($header_end === false) {
+                    continue;
+                }
+                $header_block = substr($part, 0, $header_end);
+                $body_content = substr($part, $header_end + 2);
+            } else {
+                $header_block = substr($part, 0, $header_end);
+                $body_content = substr($part, $header_end + 4);
+            }
+
+            $headers = [];
+            foreach (explode("\n", $header_block) as $line) {
+                $line = trim($line);
+                if ($line === '') continue;
+                $colon = strpos($line, ':');
+                if ($colon !== false) {
+                    $name = strtolower(trim(substr($line, 0, $colon)));
+                    $value = ltrim(substr($line, $colon + 1));
+                    $headers[$name] = $value;
+                }
+            }
+
+            $body_content = rtrim($body_content, "\r\n");
+
+            if (isset($headers['content-length'])) {
+                $len = (int) $headers['content-length'];
+                $body_content = substr($body_content, 0, $len);
+            }
+
+            $chunks[] = [
+                'headers' => $headers,
+                'body' => $body_content,
+            ];
+        }
+
+        return $chunks;
+    }
+}
+
+if (!function_exists('rewrite_table_names')) {
+    /**
+     * Rewrite table names in SQL from original to staging prefix.
+     * Extracted from export.php.
+     */
+    function rewrite_table_names(string $sql, array $table_map): string
+    {
+        foreach ($table_map as $original => $staging) {
+            $patterns = [
+                "DROP TABLE IF EXISTS `{$original}`"  => "DROP TABLE IF EXISTS `{$staging}`",
+                "CREATE TABLE `{$original}`"          => "CREATE TABLE `{$staging}`",
+                "INSERT INTO `{$original}`"           => "INSERT INTO `{$staging}`",
+                "REFERENCES `{$original}`"            => "REFERENCES `{$staging}`",
+            ];
+            foreach ($patterns as $from => $to) {
+                $sql = str_replace($from, $to, $sql);
+            }
+        }
+        return $sql;
+    }
+}
+
+if (!function_exists('build_staging_table_map')) {
+    /**
+     * Build the table name map for push staging.
+     * Extracted from export.php.
+     */
+    function build_staging_table_map(
+        PDO $pdo,
+        string $table_prefix,
+        array $incoming_tables = []
+    ): array {
+        $map = [];
+
+        $stmt = $pdo->query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+        );
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $name = $row['TABLE_NAME'];
+            if ($table_prefix === '' || str_starts_with($name, $table_prefix)) {
+                $map[$name] = PUSH_STAGING_TABLE_PREFIX . $name;
+            }
+        }
+
+        foreach ($incoming_tables as $name) {
+            if (!isset($map[$name]) && ($table_prefix === '' || str_starts_with($name, $table_prefix))) {
+                $map[$name] = PUSH_STAGING_TABLE_PREFIX . $name;
+            }
+        }
+
+        return $map;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,5 +26,21 @@ if (!class_exists('Site_Export_HTTP_Server')) {
     require_once __DIR__ . '/../packages/streaming-exporter/src/class-http-server.php';
 }
 
+// Load push-related classes
+if (!class_exists('MultipartBodyStream')) {
+    require_once __DIR__ . '/../packages/streaming-exporter/src/class-multipart-body-stream.php';
+}
+
+if (!class_exists('ChunkWriter')) {
+    require_once __DIR__ . '/../packages/streaming-exporter/src/class-chunk-writer.php';
+}
+
+// Load push functions (parse_multipart_body, rewrite_table_names, etc.).
+// We can't require export.php directly because it does require_once on
+// its local utils.php, which collides with the identical vendor copy
+// already loaded by Composer (same content, different paths → fatal).
+// The push-test-bootstrap defines these functions standalone.
+require_once __DIR__ . '/Push/push-test-bootstrap.php';
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -28,6 +28,9 @@
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>
         </testsuite>
+        <testsuite name="Push Tests">
+            <directory>Push</directory>
+        </testsuite>
     </testsuites>
     <php>
         <env name="DB_HOST" value="127.0.0.1"/>

--- a/wordpress-plugin/lib.php
+++ b/wordpress-plugin/lib.php
@@ -160,8 +160,11 @@ function _site_export_update_shared_secret(string $secret): bool {
  * The client sends X-Auth-Content-Hash = SHA256(body).  The server
  * independently hashes what it received and checks both that the hash
  * matches AND that the HMAC is valid.
+ *
+ * @param string      $secret Shared secret.
+ * @param string|null $body   Pre-read request body. If null, reads php://input.
  */
-function _site_export_verify_hmac(string $secret): ?string {
+function _site_export_verify_hmac(string $secret, ?string $body = null): ?string {
     if (!class_exists('Site_Export_HMAC_Server')) {
         _site_export_load_exporter_runtime();
     }
@@ -171,6 +174,26 @@ function _site_export_verify_hmac(string $secret): ?string {
     }
 
     $server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
+
+    if ($body !== null) {
+        // Use the pre-read body to avoid double-reading php://input.
+        // Collect headers from superglobals the same way verify_globals() does.
+        $headers = [];
+        if (function_exists('getallheaders')) {
+            $all = getallheaders();
+            if (is_array($all)) {
+                $headers = $all;
+            }
+        }
+        foreach ($_SERVER as $key => $value) {
+            if (strpos($key, 'HTTP_') !== 0 || !is_string($value)) {
+                continue;
+            }
+            $headers[$key] = $value;
+        }
+        return $server->verify($headers, $body, $_FILES);
+    }
+
     return $server->verify_globals();
 }
 
@@ -180,8 +203,10 @@ function _site_export_verify_hmac(string $secret): ?string {
  * Reads the shared secret from secret.php when present, otherwise from the
  * site option, and verifies the request's HMAC signature.
  * Calls _site_export_error() on failure.
+ *
+ * @param string|null $body Pre-read request body. If null, reads php://input.
  */
-function _site_export_default_authenticate(): void {
+function _site_export_default_authenticate(?string $body = null): void {
     if (_site_export_has_secret_file()) {
         $secret = _site_export_get_file_secret();
         if (empty($secret)) {
@@ -195,7 +220,7 @@ function _site_export_default_authenticate(): void {
         _site_export_error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.');
     }
 
-    $auth_error = _site_export_verify_hmac($secret);
+    $auth_error = _site_export_verify_hmac($secret, $body);
     if ($auth_error !== null) {
         _site_export_error(403, $auth_error);
     }
@@ -272,9 +297,22 @@ function _site_export_handle_api_request(array $options = []): void {
         exit(1);
     });
 
+    // Read the request body once. php://input is not rewindable, so both
+    // HMAC verification and the HTTP server dispatch must share this copy.
+    $request_body = file_get_contents('php://input');
+    if ($request_body === false) {
+        $request_body = '';
+    }
+
     // -- Authenticate --
-    $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
-    $authenticate();
+    // Pass the pre-read body to the authenticate callable when using the
+    // default handler, so it doesn't try to re-read php://input.
+    $authenticate = $options['authenticate'] ?? null;
+    if ($authenticate !== null) {
+        $authenticate();
+    } else {
+        _site_export_default_authenticate($request_body);
+    }
 
     // export.php has its own SECRET_KEY guard — satisfy it since we already
     // verified the request via HMAC above.
@@ -292,11 +330,12 @@ function _site_export_handle_api_request(array $options = []): void {
     require_once $export_runtime;
 
     // -- Dispatch --
+    // Pass the pre-read body so the HTTP server doesn't re-read php://input.
     try {
         $server = new Site_Export_HTTP_Server([
             'default_directory' => ABSPATH,
         ]);
-        $server->handle_request();
+        $server->handle_request(['body' => $request_body]);
     } catch (Exception $e) {
         if (!headers_sent()) {
             http_response_code(400);


### PR DESCRIPTION
## Summary

This adds the reverse of the current pull model. Instead of downloading from a remote site, the local machine uploads its database and files to a remote WordPress site with atomic cutover semantics.

The push uses the same multipart protocol, producers, cursors, and HMAC auth as the pull model, just with roles swapped. The receiver is the authority on progress — the client tracks "how much the server consumed," not "how much I sent."

Database tables land with a staging prefix (`_push_wp_*`), then a single `RENAME TABLE` statement atomically swaps all tables. Files land in a staging directory, then swap via symlink or directory rename. A unified commit endpoint orchestrates both swaps — files first (rollbackable), then DB (atomic) — with rollback on partial failure.

Nothing goes live until the explicit commit step. Push-sql and push-files can run in any order, be interrupted, and resume from the receiver's last cursor.

## What's new

**MultipartBodyStream** — streaming multipart/mixed resource backed by `php://temp` for bounded-memory curl uploads with HMAC signing.

**ChunkWriter** — shared filesystem write operations (file chunks, directories, symlinks with security validation) used by the file_receive endpoint.

**Receiver endpoints** — `sql_receive` (rewrites table names to staging prefix, executes SQL), `file_receive` (writes to staging directory), `commit` (validates staging state, swaps files then DB, rolls back on failure).

**CLI commands** — `push-sql`, `push-files`, `push-commit`, all resumable with state management matching the pull model's reentrancy design.

## Test plan

- [ ] PHP syntax checks pass on all 7 files
- [ ] Unit test: MultipartBodyStream round-trip with MultipartStreamParser
- [ ] Unit test: table name rewriting across all SQL statement types
- [ ] Unit test: RENAME TABLE builder handles new, dropped, and existing tables
- [ ] Integration test: push SQL to local receiver, commit, verify tables swapped
- [ ] Integration test: push files to staging dir, commit, verify directory swapped
- [ ] Integration test: commit failure leaves live site untouched
- [ ] E2E: Docker scenario pushing full WordPress site between containers