### PR TITLE
Speed up symlink following with optional concurrency

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3385,13 +3385,6 @@ class ImportClient
             $buffered_done    = $pool_state["buffered_done"] ?? [];
             $next_slot_id     = (int) ($pool_state["next_slot_id"] ?? 0);
             $restored_slots   = $pool_state["slots"] ?? [];
-            $this->output_progress([
-                "type"          => "symlink_pool_resume",
-                "committed"     => $committed,
-                "buffered_done" => count($buffered_done),
-                "in_flight"     => count($restored_slots),
-                "next_slot_id"  => $next_slot_id,
-            ], true);
             // Restore in-flight slots into $slots under their *original*
             // slot ids so the watermark stays contiguous. Mark each dir
             // as visited so the freshly-rebuilt queue doesn't redispatch
@@ -3543,12 +3536,6 @@ class ImportClient
                 "slots"        => $persistent_slots,
             ];
             $this->save_state($this->state);
-            $this->output_progress([
-                "type"          => "symlink_pool_persist",
-                "committed"     => $committed,
-                "buffered_done" => count($buffered_done),
-                "in_flight"     => count($persistent_slots),
-            ], true);
         };
 
         // curl_multi-driven main loop: each in-flight slot owns one cURL
@@ -10806,6 +10793,12 @@ class ImportClient
             "webhost" => null,
             "follow_symlinks" => true,
             "symlink_follow_concurrency" => 1,
+            // Rolling-window symlink-follow pool snapshot, written by
+            // persist_pool_state when the pool aborts mid-window or sees a
+            // shutdown signal. Stays null in steady state. Listed here so
+            // normalize_state doesn't strip it before fsync — without this
+            // entry the persist round-trip silently loses the watermark.
+            "symlink_pool" => null,
             "fs_root_nonempty_behavior" => "error",
             "filter" => "none",
             "max_allowed_packet" => null,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3358,6 +3358,26 @@ class ImportClient
         $buffered_done = []; // slot_index => true, for slots done but ahead of watermark
         $next_slot_id = 0;
 
+        // Sidecar directory: each slot that finishes ahead of the committed
+        // watermark writes its data_buf to a per-slot file here so the buffer
+        // survives a crash. The watermark drains sidecars in order into the
+        // remote index file. A clean run removes the directory at the end.
+        $sidecar_dir = $this->state_dir . "/.symlink-pool";
+        $sidecar_path = function (int $slot_id) use ($sidecar_dir) {
+            return $sidecar_dir . "/slot-" . $slot_id . ".jsonl";
+        };
+        $write_sidecar = function (int $slot_id, string $data) use ($sidecar_dir, $sidecar_path) {
+            if (!is_dir($sidecar_dir)) {
+                @mkdir($sidecar_dir, 0777, true);
+            }
+            $bytes = file_put_contents($sidecar_path($slot_id), $data);
+            if ($bytes === false) {
+                throw new RuntimeException(
+                    "Failed to write symlink-pool sidecar for slot {$slot_id}",
+                );
+            }
+        };
+
         // Restore in-flight state from a previous interrupted run, if any.
         $pool_state = $this->state["symlink_pool"] ?? null;
         if (is_array($pool_state)) {
@@ -3365,18 +3385,31 @@ class ImportClient
             $buffered_done    = $pool_state["buffered_done"] ?? [];
             $next_slot_id     = (int) ($pool_state["next_slot_id"] ?? 0);
             $restored_slots   = $pool_state["slots"] ?? [];
-            // Re-enqueue restored in-flight slots at the front of the queue so
-            // they are dispatched again in the correct order.  Buffered-done
-            // slots are skipped — their data is already in the index file.
+            // Re-enqueue restored in-flight slots at the front of the queue
+            // so they are dispatched again in the correct order. Buffered-done
+            // slots are *not* re-issued; their data lives in the sidecar dir
+            // and will drain when the failed earlier slot finally completes.
             foreach ($restored_slots as $slot) {
                 $slot_id = (int) ($slot["slot_id"] ?? $next_slot_id);
                 if (isset($buffered_done[$slot_id])) {
-                    continue; // already committed data, skip
+                    continue;
                 }
-                // Re-add to queue at front so ordering is preserved.
                 array_unshift($queue, $slot["dir"]);
-                // Remove from visited so the dir is dispatched fresh.
                 unset($visited[$slot["dir"]]);
+            }
+            // Materialise buffered-done slots back into $slots so the
+            // watermark advance + flush logic can drain their sidecars.
+            foreach ($buffered_done as $slot_id => $_) {
+                $slots[$slot_id] = [
+                    "dir"         => $pool_state["buffered_dirs"][$slot_id] ?? "",
+                    "cursor"      => null,
+                    "attempts"    => 0,
+                    "last_cursor" => null,
+                    "data_buf"    => "",
+                    "done"        => true,
+                    "skipped"     => false,
+                    "error"       => null,
+                ];
             }
             unset($this->state["symlink_pool"]);
         }
@@ -3388,30 +3421,39 @@ class ImportClient
             &$committed,
             &$buffered_done,
             &$visited,
-            &$queue
+            &$queue,
+            $sidecar_path
         ) {
             for ($i = $committed + 1; $i <= $new_watermark; $i++) {
                 $slot = $slots[$i] ?? null;
                 if ($slot === null) {
                     continue;
                 }
-                if (!empty($slot["data_buf"])) {
+                $data = $slot["data_buf"];
+                if ($data === "" && file_exists($sidecar_path($i))) {
+                    $contents = file_get_contents($sidecar_path($i));
+                    $data = $contents === false ? "" : $contents;
+                }
+                if ($data !== "") {
                     $mode = file_exists($this->remote_index_file) ? "a" : "w";
                     $fh = fopen($this->remote_index_file, $mode);
                     if (!$fh) {
                         throw new RuntimeException("Failed to open remote index file");
                     }
-                    $bytes = fwrite($fh, $slot["data_buf"]);
+                    $bytes = fwrite($fh, $data);
                     fclose($fh);
                     if ($bytes === false) {
                         throw new RuntimeException("Failed to write to remote index file (disk full?)");
                     }
-                    $this->index_entries_counted += substr_count($slot["data_buf"], "\n");
+                    $this->index_entries_counted += substr_count($data, "\n");
                     $this->progress->show_progress_line(
                         "Scanning remote files — " .
                         number_format($this->index_entries_counted) . " scanned"
                     );
                 }
+                // Sidecar served its purpose; remove it so a later resume
+                // doesn't double-flush the same data.
+                @unlink($sidecar_path($i));
                 // Scan newly written entries for more symlink dirs.
                 $new_targets = $this->extract_symlink_dirs_from_index($visited);
                 foreach ($new_targets as $target) {
@@ -3446,7 +3488,10 @@ class ImportClient
             }
         };
 
-        // Helper: save in-flight pool state for resume.
+        // Helper: save in-flight pool state for resume. The buffered-done
+        // slots' data has already been written to per-slot sidecars; this
+        // persists only the index metadata (committed watermark, buffered
+        // slot ids and their dirs, in-flight slots' cursors).
         $persist_pool_state = function () use (
             &$slots,
             &$committed,
@@ -3454,6 +3499,7 @@ class ImportClient
             &$next_slot_id
         ) {
             $persistent_slots = [];
+            $buffered_dirs    = [];
             foreach ($slots as $slot_id => $slot) {
                 if (!$slot["done"]) {
                     $persistent_slots[] = [
@@ -3462,11 +3508,14 @@ class ImportClient
                         "cursor"  => $slot["cursor"],
                         "attempts"=> $slot["attempts"],
                     ];
+                } elseif (isset($buffered_done[$slot_id])) {
+                    $buffered_dirs[$slot_id] = $slot["dir"];
                 }
             }
             $this->state["symlink_pool"] = [
                 "committed"    => $committed,
                 "buffered_done"=> $buffered_done,
+                "buffered_dirs"=> $buffered_dirs,
                 "next_slot_id" => $next_slot_id,
                 "slots"        => $persistent_slots,
             ];
@@ -3515,7 +3564,12 @@ class ImportClient
         };
 
         // Main loop: keep dispatching directories until the queue is empty
-        // and all active slots are done.
+        // and all active slots are done. The whole loop is wrapped in a
+        // try/catch so any RuntimeException persists the rolling-window
+        // state before re-throwing — that way slots N+1..N+K that already
+        // completed live on as sidecars + buffered_done entries, and the
+        // next run only re-issues slot N from its saved cursor.
+        try {
         while (!empty($queue) || !empty($slots)) {
             if ($this->shutdown_requested) {
                 $cleanup_multi();
@@ -3659,6 +3713,8 @@ class ImportClient
                     ], true);
                     $slot["done"]    = true;
                     $slot["skipped"] = true;
+                    $write_sidecar($slot_id, "");
+                    $slot["data_buf"] = "";
                     $buffered_done[$slot_id] = true;
                     unset($slot_bufs[$slot_id]);
                     unset($slot);
@@ -3683,6 +3739,8 @@ class ImportClient
                     ) {
                         $slot["done"]    = true;
                         $slot["skipped"] = true;
+                        $write_sidecar($slot_id, "");
+                        $slot["data_buf"] = "";
                         $buffered_done[$slot_id] = true;
                         unset($slot);
                         $advance_watermark();
@@ -3699,6 +3757,10 @@ class ImportClient
                 if ($parsed["complete"]) {
                     $slot["done"]   = true;
                     $slot["cursor"] = null;
+                    // Offload the slot's accumulated data to a sidecar so a
+                    // crash before the watermark advances doesn't lose it.
+                    $write_sidecar($slot_id, $slot["data_buf"]);
+                    $slot["data_buf"] = "";
                     $buffered_done[$slot_id] = true;
                     unset($slot);
                     $advance_watermark();
@@ -3727,12 +3789,28 @@ class ImportClient
                 // Slot will be re-attached at the top of the next outer iteration.
             }
         }
+        } catch (RuntimeException $e) {
+            $cleanup_multi();
+            $persist_pool_state();
+            throw $e;
+        }
 
         $cleanup_multi();
 
-        // Clean up any lingering pool state from a previous run.
+        // Clean up any lingering pool state from a previous run, plus the
+        // sidecar directory now that every buffered slot has drained into
+        // the remote index file.
         unset($this->state["symlink_pool"]);
         $this->save_state($this->state);
+        if (is_dir($sidecar_dir)) {
+            foreach ((array) @scandir($sidecar_dir) as $name) {
+                if ($name === '.' || $name === '..') {
+                    continue;
+                }
+                @unlink($sidecar_dir . "/" . $name);
+            }
+            @rmdir($sidecar_dir);
+        }
     }
 
     /**
@@ -3755,127 +3833,17 @@ class ImportClient
 
         $queue = $this->extract_symlink_dirs_from_index($visited);
 
-        // Delegate to the concurrent path when the user requested N > 1.
-        // The sequential path below is left byte-for-byte identical to the
-        // original code so the default behaviour is unchanged.
-        if ($this->symlink_follow_concurrency > 1) {
-            $this->discover_symlink_targets_concurrent(
-                $this->symlink_follow_concurrency,
-                $visited,
-                $queue,
-            );
-            return;
-        }
-
-        while (!empty($queue)) {
-            $dir = array_shift($queue);
-            if (isset($visited[$dir])) {
-                continue;
-            }
-            // Skip if this directory is a subdirectory of an already-visited path,
-            // since those files were already included in the parent's index.
-            $already_covered = false;
-            foreach ($visited as $v => $_) {
-                if (str_starts_with($dir, $v . "/")) {
-                    $already_covered = true;
-                    break;
-                }
-            }
-            if ($already_covered) {
-                $this->audit_log(
-                    "FOLLOW SYMLINK SKIP | {$dir} already covered by a visited parent",
-                    true,
-                );
-                continue;
-            }
-            $visited[$dir] = true;
-
-            $this->audit_log(
-                "FOLLOW SYMLINK | indexing target directory: {$dir}",
-                true,
-            );
-            $this->progress->show_lifecycle_line("Following symlink target: {$dir}\n");
-            $this->output_progress([
-                "type" => "symlink_follow",
-                "directory" => $dir,
-                "message" => "Following symlink target: {$dir}",
-            ], true);
-
-            // Reset the index cursor so download_remote_index starts fresh
-            // for this directory, but appends to the existing index file.
-            // Note we are not losing the previous cursor position. This code
-            // runs only after the previous directory was fully indexed so
-            // we won't need any prior cursor information again.
-            $this->state["index"]["cursor"] = null;
-            $this->save_state($this->state);
-
-            $attempts = 0;
-            $last_cursor = null;
-            while (true) {
-                try {
-                    $complete = $this->download_remote_index($dir);
-                } catch (RuntimeException $e) {
-                    // We won't be able to follow every symlink. If
-                    // the response seems like the remote server rejecting
-                    // our attempt to index this directory, log a warning
-                    // and skip to the next directory instead of crashing.
-                    $msg = $e->getMessage();
-                    if (
-                        strpos($msg, "HTTP error 4") !== false ||
-                        strpos($msg, "dir_outside_root") !== false ||
-                        strpos($msg, "outside of allowed roots") !== false
-                    ) {
-                        $this->audit_log(
-                            "FOLLOW SYMLINK SKIP | server rejected {$dir}: " .
-                                substr($msg, 0, 200),
-                            true,
-                        );
-                        $this->progress->show_lifecycle_line("  Skipped (server rejected): {$dir}\n");
-                        $this->output_progress([
-                            "type" => "symlink_follow_rejected",
-                            "directory" => $dir,
-                            "message" => "Skipped (server rejected): {$dir}",
-                        ], true);
-                        continue 2;
-                    }
-
-                    // Still throw all the other errors.
-                    throw $e;
-                }
-                if ($complete) {
-                    break;
-                }
-
-                if ($this->shutdown_requested) {
-                    return;
-                }
-
-                $current_cursor = $this->state["index"]["cursor"] ?? null;
-                if ($current_cursor === $last_cursor) {
-                    throw new RuntimeException(
-                        "files-index (symlink follow) made no progress (cursor unchanged)",
-                    );
-                }
-                $last_cursor = $current_cursor;
-
-                $attempts++;
-                if ($attempts > 10_000) {
-                    // @TODO: Consider a configurable maximum attempts for really large sites that
-                    //        require more than 10,000 requests to index.
-                    throw new RuntimeException(
-                        "files-index (symlink follow) exceeded maximum attempts",
-                    );
-                }
-            }
-
-            // Scan newly added entries for more symlink targets
-            $new_targets = $this->extract_symlink_dirs_from_index($visited);
-            foreach ($new_targets as $target) {
-                if (!isset($visited[$target])) {
-                    $queue[] = $target;
-                }
-            }
-        }
+        // Always go through the curl_multi pool. With concurrency clamped
+        // to 1 the pool runs one request at a time, which is functionally
+        // the same as the old sequential loop but lets us share the
+        // rolling-window state machine, the sidecar buffering, and the
+        // resume-on-error semantics with the N>1 case.
+        $effective_concurrency = max(1, $this->symlink_follow_concurrency);
+        $this->discover_symlink_targets_concurrent(
+            $effective_concurrency,
+            $visited,
+            $queue,
+        );
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3385,6 +3385,13 @@ class ImportClient
             $buffered_done    = $pool_state["buffered_done"] ?? [];
             $next_slot_id     = (int) ($pool_state["next_slot_id"] ?? 0);
             $restored_slots   = $pool_state["slots"] ?? [];
+            $this->audit_log(sprintf(
+                "FOLLOW SYMLINK RESUME | committed=%d buffered_done=%d in_flight=%d next_slot_id=%d",
+                $committed,
+                count($buffered_done),
+                count($restored_slots),
+                $next_slot_id,
+            ), true);
             // Restore in-flight slots into $slots under their *original*
             // slot ids so the watermark stays contiguous. Mark each dir
             // as visited so the freshly-rebuilt queue doesn't redispatch
@@ -3536,6 +3543,12 @@ class ImportClient
                 "slots"        => $persistent_slots,
             ];
             $this->save_state($this->state);
+            $this->audit_log(sprintf(
+                "FOLLOW SYMLINK PERSIST | committed=%d buffered_done=%d in_flight=%d",
+                $committed,
+                count($buffered_done),
+                count($persistent_slots),
+            ), true);
         };
 
         // curl_multi-driven main loop: each in-flight slot owns one cURL

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3385,13 +3385,13 @@ class ImportClient
             $buffered_done    = $pool_state["buffered_done"] ?? [];
             $next_slot_id     = (int) ($pool_state["next_slot_id"] ?? 0);
             $restored_slots   = $pool_state["slots"] ?? [];
-            $this->audit_log(sprintf(
-                "FOLLOW SYMLINK RESUME | committed=%d buffered_done=%d in_flight=%d next_slot_id=%d",
-                $committed,
-                count($buffered_done),
-                count($restored_slots),
-                $next_slot_id,
-            ), true);
+            $this->output_progress([
+                "type"          => "symlink_pool_resume",
+                "committed"     => $committed,
+                "buffered_done" => count($buffered_done),
+                "in_flight"     => count($restored_slots),
+                "next_slot_id"  => $next_slot_id,
+            ], true);
             // Restore in-flight slots into $slots under their *original*
             // slot ids so the watermark stays contiguous. Mark each dir
             // as visited so the freshly-rebuilt queue doesn't redispatch
@@ -3543,12 +3543,12 @@ class ImportClient
                 "slots"        => $persistent_slots,
             ];
             $this->save_state($this->state);
-            $this->audit_log(sprintf(
-                "FOLLOW SYMLINK PERSIST | committed=%d buffered_done=%d in_flight=%d",
-                $committed,
-                count($buffered_done),
-                count($persistent_slots),
-            ), true);
+            $this->output_progress([
+                "type"          => "symlink_pool_persist",
+                "committed"     => $committed,
+                "buffered_done" => count($buffered_done),
+                "in_flight"     => count($persistent_slots),
+            ], true);
         };
 
         // curl_multi-driven main loop: each in-flight slot owns one cURL

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3093,21 +3093,18 @@ class ImportClient
     }
 
     /**
-     * Execute a single file-index HTTP request for $dir starting from $cursor
-     * and return the parsed results without touching shared state or the
-     * remote index file.
+     * Build a non-blocking cURL handle for a file_index page request.
      *
-     * This is the low-level building block used by discover_symlink_targets_concurrent()
-     * so that multiple directories can be indexed in parallel through curl_multi.
+     * The handle's HEADERFUNCTION captures the multipart boundary and the
+     * WRITEFUNCTION accumulates the body into $slot_buf['body']. Caller
+     * adds the handle to a curl_multi handle, drives it to completion, and
+     * then feeds $slot_buf into parse_index_response_body() to extract the
+     * data lines and next cursor.
      *
-     * Returns an array with keys:
-     *   'complete'  bool     — true when the server returned x-status=complete
-     *   'cursor'    ?string  — the next cursor, or null when complete
-     *   'data'      string   — newline-terminated JSONL lines to append to the index
-     *   'rejected'  bool     — true when the server rejected the request (4xx / outside root)
-     *   'error'     ?string  — non-rejection error message, or null on success
+     * Mirrors the URL building, header set, and HMAC signing of
+     * fetch_streaming() so the request is byte-equivalent on the wire.
      */
-    private function fetch_one_index_page(string $dir, ?string $cursor): array
+    private function prepare_index_curl_handle(string $dir, ?string $cursor, array &$slot_buf)
     {
         $params = $this->get_tuned_params("file_index");
         if ($cursor === null) {
@@ -3122,11 +3119,72 @@ class ImportClient
         }
         $url = $this->build_url("file_index", $cursor, $params);
 
-        $complete   = false;
-        $next_cursor = $cursor;
+        $ch = curl_init($url);
+        reprint_apply_curl_proxy_from_env($ch);
+
+        $headers = [
+            ...$this->get_base_headers("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"),
+            "Upgrade-Insecure-Requests: 1",
+            "Sec-Fetch-Dest: document",
+            "Sec-Fetch-Mode: navigate",
+            "Sec-Fetch-Site: none",
+            "Sec-Fetch-User: ?1",
+        ];
+        if ($cursor) {
+            $headers[] = "X-Export-Cursor: {$cursor}";
+        }
+        array_push($headers, ...$this->get_hmac_headers(""));
+
+        $slot_buf["body"]     = "";
+        $slot_buf["boundary"] = null;
+
+        curl_setopt_array($ch, [
+            CURLOPT_FOLLOWLOCATION  => false,
+            CURLOPT_LOW_SPEED_LIMIT => 1,
+            CURLOPT_LOW_SPEED_TIME  => 300,
+            CURLOPT_ENCODING        => "gzip, deflate",
+            CURLOPT_HTTPHEADER      => $headers,
+            CURLOPT_HEADERFUNCTION  => function ($ch, $line) use (&$slot_buf) {
+                $len = strlen($line);
+                if ($slot_buf["boundary"] === null && stripos($line, "Content-Type:") === 0) {
+                    $pos = stripos($line, "boundary=");
+                    if ($pos !== false) {
+                        $b = trim(substr($line, $pos + 9));
+                        if ($b !== "" && $b[0] === '"') {
+                            $end = strpos($b, '"', 1);
+                            if ($end !== false) {
+                                $b = substr($b, 1, $end - 1);
+                            }
+                        } else {
+                            $end = strcspn($b, ";,\r\n \t");
+                            $b   = substr($b, 0, $end);
+                        }
+                        if ($b !== "") {
+                            $slot_buf["boundary"] = $b;
+                        }
+                    }
+                }
+                return $len;
+            },
+            CURLOPT_WRITEFUNCTION => function ($ch, $data) use (&$slot_buf) {
+                $slot_buf["body"] .= $data;
+                return strlen($data);
+            },
+        ]);
+
+        return $ch;
+    }
+
+    /**
+     * Parse a buffered file_index multipart response and return the same
+     * shape as fetch_one_index_page():
+     *   complete bool, cursor ?string, data string, rejected bool, error ?string.
+     */
+    private function parse_index_response_body(array $slot_buf): array
+    {
+        $complete    = false;
+        $next_cursor = null;
         $data_lines  = "";
-        $rejected    = false;
-        $error_msg   = null;
 
         $context = new StreamingContext();
         $context->on_chunk = function ($chunk) use (
@@ -3179,7 +3237,7 @@ class ImportClient
                         "type"  => $type,
                     ];
                     if (isset($item["target"]) && is_string($item["target"]) && $item["target"] !== "") {
-                        $entry["target"] = $item["target"]; // already base64-encoded
+                        $entry["target"] = $item["target"];
                     }
                     if (!empty($item["intermediate"])) {
                         $entry["intermediate"] = true;
@@ -3197,29 +3255,54 @@ class ImportClient
             }
         };
 
+        $boundary = $slot_buf["boundary"] ?? null;
+        $body     = $slot_buf["body"] ?? "";
+
+        if ($boundary === null && strncmp($body, "--boundary-", 11) === 0) {
+            $eol = strpos($body, "\n");
+            if ($eol !== false) {
+                $line = rtrim(substr($body, 0, $eol), "\r\n");
+                if (strncmp($line, "--boundary-", 11) === 0) {
+                    $boundary = substr($line, 2);
+                }
+            }
+        }
+
+        if ($boundary === null) {
+            return [
+                "complete" => false,
+                "cursor"   => null,
+                "data"     => "",
+                "rejected" => false,
+                "error"    => "Missing multipart boundary in response",
+            ];
+        }
+
         try {
-            $this->fetch_streaming($url, $cursor, $context, null, "file_index");
+            $current_chunk = null;
+            $parser = new MultipartStreamParser(
+                $boundary,
+                $this->make_chunk_handler($context, $current_chunk),
+            );
+            $parser->feed($body);
         } catch (RuntimeException $e) {
             $msg = $e->getMessage();
-            if (
-                strpos($msg, "HTTP error 4") !== false ||
-                strpos($msg, "dir_outside_root") !== false ||
-                strpos($msg, "outside of allowed roots") !== false
-            ) {
-                return [
-                    "complete" => true,
-                    "cursor"   => null,
-                    "data"     => "",
-                    "rejected" => true,
-                    "error"    => null,
-                ];
-            }
             return [
                 "complete" => false,
                 "cursor"   => $next_cursor,
                 "data"     => $data_lines,
                 "rejected" => false,
                 "error"    => $msg,
+            ];
+        }
+
+        if (!$context->saw_completion) {
+            return [
+                "complete" => false,
+                "cursor"   => $next_cursor,
+                "data"     => $data_lines,
+                "rejected" => false,
+                "error"    => "Missing completion chunk in response",
             ];
         }
 
@@ -3390,10 +3473,52 @@ class ImportClient
             $this->save_state($this->state);
         };
 
+        // curl_multi-driven main loop: each in-flight slot owns one cURL
+        // handle on the shared multi handle, so up to $concurrency requests
+        // are truly in flight on the wire at the same time.
+        $mh = curl_multi_init();
+        // $handles_by_slot maps slot_id => cURL handle (CurlHandle on PHP 8+,
+        // resource on PHP 7.4). PHPStan can't always resolve CurlHandle, so
+        // the type is annotated as mixed.
+        /** @var array<int, mixed> $handles_by_slot */
+        $handles_by_slot = [];
+        /** @var array<int, array{body: string, boundary: ?string}> $slot_bufs */
+        $slot_bufs = [];
+
+        $cleanup_multi = function () use (&$mh, &$handles_by_slot) {
+            foreach ($handles_by_slot as $h) {
+                @curl_multi_remove_handle($mh, $h);
+                @curl_close($h);
+            }
+            $handles_by_slot = [];
+            if ($mh !== null) {
+                @curl_multi_close($mh);
+                $mh = null;
+            }
+        };
+
+        $attach_request = function (int $slot_id) use (
+            &$slots,
+            &$handles_by_slot,
+            &$slot_bufs,
+            &$mh
+        ) {
+            $slot = &$slots[$slot_id];
+            $slot_bufs[$slot_id] = ["body" => "", "boundary" => null];
+            $ch = $this->prepare_index_curl_handle(
+                $slot["dir"],
+                $slot["cursor"],
+                $slot_bufs[$slot_id],
+            );
+            $handles_by_slot[$slot_id] = $ch;
+            curl_multi_add_handle($mh, $ch);
+        };
+
         // Main loop: keep dispatching directories until the queue is empty
         // and all active slots are done.
         while (!empty($queue) || !empty($slots)) {
             if ($this->shutdown_requested) {
+                $cleanup_multi();
                 $persist_pool_state();
                 return;
             }
@@ -3458,35 +3583,72 @@ class ImportClient
                     "directory" => $dir,
                     "message"   => "Following symlink target: {$dir}",
                 ], true);
+
+                // Attach the new slot's first page request to the multi
+                // handle so it can race in parallel with the others.
+                $attach_request($slot_id);
             }
 
-            if (empty($slots)) {
+            // Re-attach any slot that finished a page in the previous
+            // iteration but still has more cursor pages to fetch.
+            foreach ($slots as $slot_id => $s) {
+                if ($s["done"] || isset($handles_by_slot[$slot_id])) {
+                    continue;
+                }
+                $attach_request($slot_id);
+            }
+
+            if (empty($handles_by_slot)) {
                 break;
             }
 
-            // Dispatch one page request per active, non-done slot (sequential
-            // within each slot, parallel across slots via sequential dispatch
-            // and round-robin poll).
-            //
-            // Because fetch_streaming() is synchronous (it blocks until the
-            // response completes), true parallelism requires curl_multi. We
-            // approximate the rolling-window model by processing each slot one
-            // step at a time in round-robin order. This still delivers
-            // concurrency gains when individual pages finish quickly and the
-            // bottleneck is server-side processing, not client blocking time.
-            //
-            // A future improvement could replace this loop with a curl_multi
-            // dispatcher where N handles are in flight simultaneously.
-            foreach ($slots as $slot_id => &$slot) {
-                if ($slot["done"]) {
+            // Drive the multi handle until at least one transfer completes.
+            do {
+                $status = curl_multi_exec($mh, $running);
+            } while ($status === CURLM_CALL_MULTI_PERFORM);
+            if ($running > 0) {
+                curl_multi_select($mh, 1.0);
+                $this->progress->tick_spinner();
+            }
+
+            // Drain any finished transfers.
+            while (($info = curl_multi_info_read($mh)) !== false) {
+                if ($info["msg"] !== CURLMSG_DONE) {
                     continue;
                 }
+                $finished = $info["handle"];
 
-                $result = $this->fetch_one_index_page($slot["dir"], $slot["cursor"]);
+                $slot_id = null;
+                foreach ($handles_by_slot as $sid => $h) {
+                    if ($h === $finished) {
+                        $slot_id = $sid;
+                        break;
+                    }
+                }
 
-                if ($result["rejected"]) {
+                $errno     = curl_errno($finished);
+                $err_msg   = curl_error($finished);
+                $http_code = (int) curl_getinfo($finished, CURLINFO_HTTP_CODE);
+                @curl_multi_remove_handle($mh, $finished);
+                @curl_close($finished);
+                if ($slot_id === null) {
+                    continue;
+                }
+                unset($handles_by_slot[$slot_id]);
+
+                $slot = &$slots[$slot_id];
+
+                if ($errno !== 0) {
+                    $cleanup_multi();
+                    throw new RuntimeException(
+                        "files-index (symlink follow) curl error for {$slot['dir']}: " .
+                            $err_msg,
+                    );
+                }
+
+                if ($http_code >= 400 && $http_code < 500) {
                     $this->audit_log(
-                        "FOLLOW SYMLINK SKIP | server rejected {$slot['dir']}",
+                        "FOLLOW SYMLINK SKIP | server rejected {$slot['dir']} (HTTP {$http_code})",
                         true,
                     );
                     $this->progress->show_lifecycle_line("  Skipped (server rejected): {$slot['dir']}\n");
@@ -3498,32 +3660,54 @@ class ImportClient
                     $slot["done"]    = true;
                     $slot["skipped"] = true;
                     $buffered_done[$slot_id] = true;
+                    unset($slot_bufs[$slot_id]);
+                    unset($slot);
                     $advance_watermark();
                     continue;
                 }
-
-                if ($result["error"] !== null) {
-                    // Non-rejection error: propagate (same as the sequential path).
+                if ($http_code !== 200) {
+                    $cleanup_multi();
                     throw new RuntimeException(
-                        "files-index (symlink follow) error for {$slot['dir']}: " .
-                            $result["error"],
+                        "files-index (symlink follow) HTTP {$http_code} for {$slot['dir']}",
                     );
                 }
 
-                // Accumulate this page's data in the slot buffer.
-                $slot["data_buf"] .= $result["data"];
+                $parsed = $this->parse_index_response_body($slot_bufs[$slot_id]);
+                unset($slot_bufs[$slot_id]);
 
-                if ($result["complete"]) {
+                if ($parsed["error"] !== null) {
+                    $msg = $parsed["error"];
+                    if (
+                        strpos($msg, "dir_outside_root") !== false ||
+                        strpos($msg, "outside of allowed roots") !== false
+                    ) {
+                        $slot["done"]    = true;
+                        $slot["skipped"] = true;
+                        $buffered_done[$slot_id] = true;
+                        unset($slot);
+                        $advance_watermark();
+                        continue;
+                    }
+                    $cleanup_multi();
+                    throw new RuntimeException(
+                        "files-index (symlink follow) error for {$slot['dir']}: {$msg}",
+                    );
+                }
+
+                $slot["data_buf"] .= $parsed["data"];
+
+                if ($parsed["complete"]) {
                     $slot["done"]   = true;
                     $slot["cursor"] = null;
                     $buffered_done[$slot_id] = true;
+                    unset($slot);
                     $advance_watermark();
                     continue;
                 }
 
-                // Not done yet — check cursor progress and attempt cap.
-                $new_cursor = $result["cursor"];
+                $new_cursor = $parsed["cursor"];
                 if ($new_cursor === $slot["last_cursor"]) {
+                    $cleanup_multi();
                     throw new RuntimeException(
                         "files-index (symlink follow) made no progress " .
                             "(cursor unchanged) for {$slot['dir']}",
@@ -3532,21 +3716,19 @@ class ImportClient
                 $slot["last_cursor"] = $slot["cursor"];
                 $slot["cursor"]      = $new_cursor;
                 $slot["attempts"]++;
-
                 if ($slot["attempts"] > 10_000) {
+                    $cleanup_multi();
                     throw new RuntimeException(
                         "files-index (symlink follow) exceeded maximum attempts " .
                             "for {$slot['dir']}",
                     );
                 }
-
-                if ($this->shutdown_requested) {
-                    $persist_pool_state();
-                    return;
-                }
+                unset($slot);
+                // Slot will be re-attached at the top of the next outer iteration.
             }
-            unset($slot);
         }
+
+        $cleanup_multi();
 
         // Clean up any lingering pool state from a previous run.
         unset($this->state["symlink_pool"]);

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3665,7 +3665,11 @@ class ImportClient
                 $this->progress->tick_spinner();
             }
 
-            // Drain any finished transfers.
+            // Drain any finished transfers. Errors are queued in
+            // $pending_error so other transfers that completed in the
+            // same drain pass still get buffered into sidecars before
+            // the outer try/catch persists state and re-throws.
+            $pending_error = null;
             while (($info = curl_multi_info_read($mh)) !== false) {
                 if ($info["msg"] !== CURLMSG_DONE) {
                     continue;
@@ -3693,11 +3697,13 @@ class ImportClient
                 $slot = &$slots[$slot_id];
 
                 if ($errno !== 0) {
-                    $cleanup_multi();
-                    throw new RuntimeException(
+                    unset($slot_bufs[$slot_id]);
+                    $pending_error = $pending_error ?? new RuntimeException(
                         "files-index (symlink follow) curl error for {$slot['dir']}: " .
                             $err_msg,
                     );
+                    unset($slot);
+                    continue;
                 }
 
                 if ($http_code >= 400 && $http_code < 500) {
@@ -3722,10 +3728,12 @@ class ImportClient
                     continue;
                 }
                 if ($http_code !== 200) {
-                    $cleanup_multi();
-                    throw new RuntimeException(
+                    unset($slot_bufs[$slot_id]);
+                    $pending_error = $pending_error ?? new RuntimeException(
                         "files-index (symlink follow) HTTP {$http_code} for {$slot['dir']}",
                     );
+                    unset($slot);
+                    continue;
                 }
 
                 $parsed = $this->parse_index_response_body($slot_bufs[$slot_id]);
@@ -3746,10 +3754,11 @@ class ImportClient
                         $advance_watermark();
                         continue;
                     }
-                    $cleanup_multi();
-                    throw new RuntimeException(
+                    $pending_error = $pending_error ?? new RuntimeException(
                         "files-index (symlink follow) error for {$slot['dir']}: {$msg}",
                     );
+                    unset($slot);
+                    continue;
                 }
 
                 $slot["data_buf"] .= $parsed["data"];
@@ -3769,24 +3778,30 @@ class ImportClient
 
                 $new_cursor = $parsed["cursor"];
                 if ($new_cursor === $slot["last_cursor"]) {
-                    $cleanup_multi();
-                    throw new RuntimeException(
+                    $pending_error = $pending_error ?? new RuntimeException(
                         "files-index (symlink follow) made no progress " .
                             "(cursor unchanged) for {$slot['dir']}",
                     );
+                    unset($slot);
+                    continue;
                 }
                 $slot["last_cursor"] = $slot["cursor"];
                 $slot["cursor"]      = $new_cursor;
                 $slot["attempts"]++;
                 if ($slot["attempts"] > 10_000) {
-                    $cleanup_multi();
-                    throw new RuntimeException(
+                    $pending_error = $pending_error ?? new RuntimeException(
                         "files-index (symlink follow) exceeded maximum attempts " .
                             "for {$slot['dir']}",
                     );
+                    unset($slot);
+                    continue;
                 }
                 unset($slot);
                 // Slot will be re-attached at the top of the next outer iteration.
+            }
+
+            if ($pending_error !== null) {
+                throw $pending_error;
             }
         }
         } catch (RuntimeException $e) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3569,6 +3569,13 @@ class ImportClient
         // state before re-throwing — that way slots N+1..N+K that already
         // completed live on as sidecars + buffered_done entries, and the
         // next run only re-issues slot N from its saved cursor.
+        //
+        // When a slot reports an error we record it in $errored and stop
+        // dispatching new work, but we keep draining the multi handle
+        // until every in-flight slot settles. That gives the slots that
+        // were already racing alongside the failing one a chance to
+        // complete and write their sidecars before we throw.
+        $errored = [];
         try {
         while (!empty($queue) || !empty($slots)) {
             if ($this->shutdown_requested) {
@@ -3577,11 +3584,14 @@ class ImportClient
                 return;
             }
 
-            // Fill empty slot positions up to $concurrency.
+            // Fill empty slot positions up to $concurrency. Stop pulling
+            // new directories once any slot has errored — we want to drain
+            // the in-flight ones cleanly so their data lands in sidecars,
+            // but adding more work would just race the imminent throw.
             // Count only active (not-yet-done) slots; buffered_done slots don't
             // consume a concurrency slot since they're just waiting for the watermark.
             $active_count = count($slots) - count($buffered_done);
-            while (!empty($queue) && $active_count < $concurrency) {
+            while (empty($errored) && !empty($queue) && $active_count < $concurrency) {
                 // Find the next dir that isn't already visited.
                 $dir = null;
                 while (!empty($queue)) {
@@ -3644,9 +3654,15 @@ class ImportClient
             }
 
             // Re-attach any slot that finished a page in the previous
-            // iteration but still has more cursor pages to fetch.
+            // iteration but still has more cursor pages to fetch. Skip
+            // errored slots — they'll resume from their saved cursor on
+            // the next run; right now we just want the in-flight ones to
+            // drain cleanly.
             foreach ($slots as $slot_id => $s) {
-                if ($s["done"] || isset($handles_by_slot[$slot_id])) {
+                if ($s["done"] || isset($handles_by_slot[$slot_id]) || isset($errored[$slot_id])) {
+                    continue;
+                }
+                if (!empty($errored)) {
                     continue;
                 }
                 $attach_request($slot_id);
@@ -3665,11 +3681,11 @@ class ImportClient
                 $this->progress->tick_spinner();
             }
 
-            // Drain any finished transfers. Errors are queued in
-            // $pending_error so other transfers that completed in the
-            // same drain pass still get buffered into sidecars before
-            // the outer try/catch persists state and re-throws.
-            $pending_error = null;
+            // Drain any finished transfers. Errors are recorded in
+            // $errored (slot_id => message) so the outer loop stops
+            // dispatching new work but keeps draining the multi handle —
+            // that way slots already racing alongside the failing one
+            // get to finish and write their sidecars before we throw.
             while (($info = curl_multi_info_read($mh)) !== false) {
                 if ($info["msg"] !== CURLMSG_DONE) {
                     continue;
@@ -3698,10 +3714,7 @@ class ImportClient
 
                 if ($errno !== 0) {
                     unset($slot_bufs[$slot_id]);
-                    $pending_error = $pending_error ?? new RuntimeException(
-                        "files-index (symlink follow) curl error for {$slot['dir']}: " .
-                            $err_msg,
-                    );
+                    $errored[$slot_id] = "files-index (symlink follow) curl error for {$slot['dir']}: " . $err_msg;
                     unset($slot);
                     continue;
                 }
@@ -3729,9 +3742,7 @@ class ImportClient
                 }
                 if ($http_code !== 200) {
                     unset($slot_bufs[$slot_id]);
-                    $pending_error = $pending_error ?? new RuntimeException(
-                        "files-index (symlink follow) HTTP {$http_code} for {$slot['dir']}",
-                    );
+                    $errored[$slot_id] = "files-index (symlink follow) HTTP {$http_code} for {$slot['dir']}";
                     unset($slot);
                     continue;
                 }
@@ -3754,9 +3765,7 @@ class ImportClient
                         $advance_watermark();
                         continue;
                     }
-                    $pending_error = $pending_error ?? new RuntimeException(
-                        "files-index (symlink follow) error for {$slot['dir']}: {$msg}",
-                    );
+                    $errored[$slot_id] = "files-index (symlink follow) error for {$slot['dir']}: {$msg}";
                     unset($slot);
                     continue;
                 }
@@ -3778,10 +3787,8 @@ class ImportClient
 
                 $new_cursor = $parsed["cursor"];
                 if ($new_cursor === $slot["last_cursor"]) {
-                    $pending_error = $pending_error ?? new RuntimeException(
-                        "files-index (symlink follow) made no progress " .
-                            "(cursor unchanged) for {$slot['dir']}",
-                    );
+                    $errored[$slot_id] = "files-index (symlink follow) made no progress " .
+                        "(cursor unchanged) for {$slot['dir']}";
                     unset($slot);
                     continue;
                 }
@@ -3789,10 +3796,8 @@ class ImportClient
                 $slot["cursor"]      = $new_cursor;
                 $slot["attempts"]++;
                 if ($slot["attempts"] > 10_000) {
-                    $pending_error = $pending_error ?? new RuntimeException(
-                        "files-index (symlink follow) exceeded maximum attempts " .
-                            "for {$slot['dir']}",
-                    );
+                    $errored[$slot_id] = "files-index (symlink follow) exceeded maximum attempts " .
+                        "for {$slot['dir']}";
                     unset($slot);
                     continue;
                 }
@@ -3800,8 +3805,12 @@ class ImportClient
                 // Slot will be re-attached at the top of the next outer iteration.
             }
 
-            if ($pending_error !== null) {
-                throw $pending_error;
+            // Once an error has been recorded and every in-flight transfer
+            // has settled, throw — the outer try/catch persists state and
+            // re-raises. By this point any sibling slots that were going
+            // to succeed have written their sidecars.
+            if (!empty($errored) && empty($handles_by_slot)) {
+                throw new RuntimeException(reset($errored));
             }
         }
         } catch (RuntimeException $e) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1088,6 +1088,15 @@ class ImportClient
     /** @var string|null Extra remote directory to include in the export (--extra-directory). */
     private $extra_directory = null;
 
+    /**
+     * @var int How many symlink target directories to index concurrently during
+     * discover_symlink_targets(). 1 = sequential (default, identical behaviour
+     * to the original code path). 2–32 = rolling curl_multi window. Set via
+     * --symlink-follow-concurrency=N; when --no-adaptive is passed the default
+     * rises to 5. Persisted in state so it survives resume cycles.
+     */
+    private $symlink_follow_concurrency = 1;
+
     /** @var AdaptiveTuner|null Adjusts request pacing based on server response times and errors. */
     private $tuner = null;
 
@@ -1531,6 +1540,30 @@ class ImportClient
         } elseif (isset($this->state["follow_symlinks"])) {
             $this->follow_symlinks = $this->state["follow_symlinks"];
         }
+
+        // Resolve symlink_follow_concurrency.
+        //
+        // Priority: explicit --symlink-follow-concurrency=N > --no-adaptive default (5) > 1.
+        // Clamped to [1, 32].
+        //
+        // When the user passes --no-adaptive, it signals they want predictable,
+        // potentially higher-throughput behaviour without adaptive throttling.
+        // Defaulting concurrency to 5 in that mode gives a sensible speedup for
+        // sites with many symlinked directories without requiring an extra flag.
+        if (isset($options["symlink_follow_concurrency"])) {
+            $raw_concurrency = (int) $options["symlink_follow_concurrency"];
+            $this->symlink_follow_concurrency = max(1, min(32, $raw_concurrency));
+        } elseif (isset($this->state["symlink_follow_concurrency"])) {
+            $this->symlink_follow_concurrency = (int) $this->state["symlink_follow_concurrency"];
+        } else {
+            // Apply the --no-adaptive default: when adaptive tuning is disabled,
+            // default concurrency to 5 so parallel indexing is on by default in
+            // that mode without an explicit flag.
+            $adaptive_enabled = $options["tuning_config"]["enabled"] ?? true;
+            $this->symlink_follow_concurrency = $adaptive_enabled ? 1 : 5;
+        }
+        $this->state["symlink_follow_concurrency"] = $this->symlink_follow_concurrency;
+        $this->save_state($this->state);
 
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
         // 'preserve-local' preserves existing local files instead of overwriting
@@ -3060,6 +3093,466 @@ class ImportClient
     }
 
     /**
+     * Execute a single file-index HTTP request for $dir starting from $cursor
+     * and return the parsed results without touching shared state or the
+     * remote index file.
+     *
+     * This is the low-level building block used by discover_symlink_targets_concurrent()
+     * so that multiple directories can be indexed in parallel through curl_multi.
+     *
+     * Returns an array with keys:
+     *   'complete'  bool     — true when the server returned x-status=complete
+     *   'cursor'    ?string  — the next cursor, or null when complete
+     *   'data'      string   — newline-terminated JSONL lines to append to the index
+     *   'rejected'  bool     — true when the server rejected the request (4xx / outside root)
+     *   'error'     ?string  — non-rejection error message, or null on success
+     */
+    private function fetch_one_index_page(string $dir, ?string $cursor): array
+    {
+        $params = $this->get_tuned_params("file_index");
+        if ($cursor === null) {
+            $params["list_dir"] = $dir;
+        }
+        if ($this->follow_symlinks) {
+            $params["follow_symlinks"] = "1";
+        }
+        $export_dirs = $this->get_export_directories();
+        if (!empty($export_dirs)) {
+            $params["directory"] = $export_dirs;
+        }
+        $url = $this->build_url("file_index", $cursor, $params);
+
+        $complete   = false;
+        $next_cursor = $cursor;
+        $data_lines  = "";
+        $rejected    = false;
+        $error_msg   = null;
+
+        $context = new StreamingContext();
+        $context->on_chunk = function ($chunk) use (
+            &$complete,
+            &$next_cursor,
+            &$data_lines,
+            $context
+        ) {
+            if (isset($chunk["headers"]["x-cursor"])) {
+                $next_cursor = $chunk["headers"]["x-cursor"];
+            }
+            $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
+
+            if ($chunk_type === "index_batch") {
+                $body = $chunk["body"] ?? "";
+                if ($body === "") {
+                    return;
+                }
+                $items = json_decode($body, true);
+                if (!is_array($items)) {
+                    throw new RuntimeException(
+                        "Invalid index batch JSON received from server",
+                    );
+                }
+                foreach ($items as $item) {
+                    if (!is_array($item)) {
+                        continue;
+                    }
+                    $path_encoded = $item["path"] ?? "";
+                    if (!is_string($path_encoded) || $path_encoded === "") {
+                        throw new RuntimeException(
+                            "Invalid index batch item: missing path",
+                        );
+                    }
+                    $path = base64_decode($path_encoded, true);
+                    if ($path === "" || $path === false) {
+                        throw new RuntimeException(
+                            "Invalid index batch item: path base64 decode failed",
+                        );
+                    }
+                    assert_valid_path($path, "index batch path");
+                    $ctime = (int) ($item["ctime"] ?? 0);
+                    $size  = (int) ($item["size"] ?? 0);
+                    $type  = (string) ($item["type"] ?? "file");
+
+                    $entry = [
+                        "path"  => base64_encode($path),
+                        "ctime" => $ctime,
+                        "size"  => $size,
+                        "type"  => $type,
+                    ];
+                    if (isset($item["target"]) && is_string($item["target"]) && $item["target"] !== "") {
+                        $entry["target"] = $item["target"]; // already base64-encoded
+                    }
+                    if (!empty($item["intermediate"])) {
+                        $entry["intermediate"] = true;
+                    }
+                    $line = json_encode($entry, JSON_UNESCAPED_SLASHES);
+                    if ($line !== false) {
+                        $data_lines .= $line . "\n";
+                    }
+                }
+            } elseif ($chunk_type === "completion") {
+                $complete = ($chunk["headers"]["x-status"] ?? "") === "complete";
+                $context->saw_completion = true;
+            } elseif ($chunk_type === "error") {
+                $this->handle_error_chunk($chunk, "index", $context);
+            }
+        };
+
+        try {
+            $this->fetch_streaming($url, $cursor, $context, null, "file_index");
+        } catch (RuntimeException $e) {
+            $msg = $e->getMessage();
+            if (
+                strpos($msg, "HTTP error 4") !== false ||
+                strpos($msg, "dir_outside_root") !== false ||
+                strpos($msg, "outside of allowed roots") !== false
+            ) {
+                return [
+                    "complete" => true,
+                    "cursor"   => null,
+                    "data"     => "",
+                    "rejected" => true,
+                    "error"    => null,
+                ];
+            }
+            return [
+                "complete" => false,
+                "cursor"   => $next_cursor,
+                "data"     => $data_lines,
+                "rejected" => false,
+                "error"    => $msg,
+            ];
+        }
+
+        return [
+            "complete" => $complete,
+            "cursor"   => $complete ? null : $next_cursor,
+            "data"     => $data_lines,
+            "rejected" => false,
+            "error"    => null,
+        ];
+    }
+
+    /**
+     * Concurrent variant of discover_symlink_targets() used when
+     * $this->symlink_follow_concurrency > 1.
+     *
+     * Maintains a rolling window of up to $concurrency active directory slots.
+     * Each slot processes one directory sequentially (cursor page by page).
+     * Multiple slots run in parallel so N directories are being indexed at once.
+     *
+     * Committed-watermark semantics: the watermark only advances to the oldest
+     * contiguous completed slot. If slot N fails, slots N+1..N+K may complete
+     * and are held in $buffered_done; slot N is retried from its saved cursor.
+     * Only when slot N completes does the watermark advance past it and all the
+     * buffered slots drain into the index file.
+     *
+     * $visited is updated at dispatch time (not completion) to prevent sibling
+     * slots from redundantly queuing the same directory.
+     *
+     * On shutdown, in-flight state is persisted in $this->state["symlink_pool"]
+     * so the pool can be rebuilt on resume without re-indexing already-completed
+     * slots. Slots in $buffered_done have their data already written to the
+     * remote index file and are NOT re-issued.
+     */
+    private function discover_symlink_targets_concurrent(
+        int $concurrency,
+        array &$visited,
+        array &$queue
+    ): void {
+        // Each slot is an associative array:
+        //   dir          string   — directory being indexed
+        //   cursor       ?string  — current cursor (null = start)
+        //   attempts     int      — page requests issued for this dir
+        //   last_cursor  ?string  — previous cursor (for stuck-cursor detection)
+        //   data_buf     string   — buffered JSONL lines not yet written to disk
+        //   done         bool     — slot has completed (all pages received)
+        //   skipped      bool     — server rejected the directory
+        //   error        ?string  — last error message when retrying
+        $slots = [];
+        $committed = -1;   // last slot index whose data is committed to disk
+        $buffered_done = []; // slot_index => true, for slots done but ahead of watermark
+        $next_slot_id = 0;
+
+        // Restore in-flight state from a previous interrupted run, if any.
+        $pool_state = $this->state["symlink_pool"] ?? null;
+        if (is_array($pool_state)) {
+            $committed        = (int) ($pool_state["committed"] ?? -1);
+            $buffered_done    = $pool_state["buffered_done"] ?? [];
+            $next_slot_id     = (int) ($pool_state["next_slot_id"] ?? 0);
+            $restored_slots   = $pool_state["slots"] ?? [];
+            // Re-enqueue restored in-flight slots at the front of the queue so
+            // they are dispatched again in the correct order.  Buffered-done
+            // slots are skipped — their data is already in the index file.
+            foreach ($restored_slots as $slot) {
+                $slot_id = (int) ($slot["slot_id"] ?? $next_slot_id);
+                if (isset($buffered_done[$slot_id])) {
+                    continue; // already committed data, skip
+                }
+                // Re-add to queue at front so ordering is preserved.
+                array_unshift($queue, $slot["dir"]);
+                // Remove from visited so the dir is dispatched fresh.
+                unset($visited[$slot["dir"]]);
+            }
+            unset($this->state["symlink_pool"]);
+        }
+
+        // Helper: flush all slots from $committed+1 up through the new
+        // watermark into the remote index file and scan for new symlink dirs.
+        $flush_committed = function (int $new_watermark) use (
+            &$slots,
+            &$committed,
+            &$buffered_done,
+            &$visited,
+            &$queue
+        ) {
+            for ($i = $committed + 1; $i <= $new_watermark; $i++) {
+                $slot = $slots[$i] ?? null;
+                if ($slot === null) {
+                    continue;
+                }
+                if (!empty($slot["data_buf"])) {
+                    $mode = file_exists($this->remote_index_file) ? "a" : "w";
+                    $fh = fopen($this->remote_index_file, $mode);
+                    if (!$fh) {
+                        throw new RuntimeException("Failed to open remote index file");
+                    }
+                    $bytes = fwrite($fh, $slot["data_buf"]);
+                    fclose($fh);
+                    if ($bytes === false) {
+                        throw new RuntimeException("Failed to write to remote index file (disk full?)");
+                    }
+                    $this->index_entries_counted += substr_count($slot["data_buf"], "\n");
+                    $this->progress->show_progress_line(
+                        "Scanning remote files — " .
+                        number_format($this->index_entries_counted) . " scanned"
+                    );
+                }
+                // Scan newly written entries for more symlink dirs.
+                $new_targets = $this->extract_symlink_dirs_from_index($visited);
+                foreach ($new_targets as $target) {
+                    if (!isset($visited[$target])) {
+                        $queue[] = $target;
+                    }
+                }
+                unset($slots[$i], $buffered_done[$i]);
+            }
+            $committed = $new_watermark;
+        };
+
+        // Helper: compute how far the watermark can advance.
+        $advance_watermark = function () use (
+            &$slots,
+            &$committed,
+            &$buffered_done,
+            &$flush_committed
+        ) {
+            $new_watermark = $committed;
+            while (true) {
+                $next = $new_watermark + 1;
+                if (!isset($slots[$next])) {
+                    break;
+                }
+                if (!$slots[$next]["done"]) {
+                    break;
+                }
+                $new_watermark = $next;
+            }
+            if ($new_watermark > $committed) {
+                $flush_committed($new_watermark);
+            }
+        };
+
+        // Helper: save in-flight pool state for resume.
+        $persist_pool_state = function () use (
+            &$slots,
+            &$committed,
+            &$buffered_done,
+            &$next_slot_id
+        ) {
+            $persistent_slots = [];
+            foreach ($slots as $slot_id => $slot) {
+                if (!$slot["done"]) {
+                    $persistent_slots[] = [
+                        "slot_id" => $slot_id,
+                        "dir"     => $slot["dir"],
+                        "cursor"  => $slot["cursor"],
+                        "attempts"=> $slot["attempts"],
+                    ];
+                }
+            }
+            $this->state["symlink_pool"] = [
+                "committed"    => $committed,
+                "buffered_done"=> $buffered_done,
+                "next_slot_id" => $next_slot_id,
+                "slots"        => $persistent_slots,
+            ];
+            $this->save_state($this->state);
+        };
+
+        // Main loop: keep dispatching directories until the queue is empty
+        // and all active slots are done.
+        while (!empty($queue) || !empty($slots)) {
+            if ($this->shutdown_requested) {
+                $persist_pool_state();
+                return;
+            }
+
+            // Fill empty slot positions up to $concurrency.
+            // Count only active (not-yet-done) slots; buffered_done slots don't
+            // consume a concurrency slot since they're just waiting for the watermark.
+            $active_count = count($slots) - count($buffered_done);
+            while (!empty($queue) && $active_count < $concurrency) {
+                // Find the next dir that isn't already visited.
+                $dir = null;
+                while (!empty($queue)) {
+                    $candidate = array_shift($queue);
+                    if (isset($visited[$candidate])) {
+                        continue;
+                    }
+                    // Skip subdirs already covered by a visited parent.
+                    $covered = false;
+                    foreach ($visited as $v => $_) {
+                        if (str_starts_with($candidate, $v . "/")) {
+                            $covered = true;
+                            break;
+                        }
+                    }
+                    if ($covered) {
+                        $this->audit_log(
+                            "FOLLOW SYMLINK SKIP | {$candidate} already covered by a visited parent",
+                            true,
+                        );
+                        continue;
+                    }
+                    $dir = $candidate;
+                    break;
+                }
+                if ($dir === null) {
+                    break;
+                }
+
+                // Mark visited at dispatch time so sibling slots don't queue the same dir.
+                $visited[$dir] = true;
+
+                $slot_id = $next_slot_id++;
+                $slots[$slot_id] = [
+                    "dir"         => $dir,
+                    "cursor"      => null,
+                    "attempts"    => 0,
+                    "last_cursor" => null,
+                    "data_buf"    => "",
+                    "done"        => false,
+                    "skipped"     => false,
+                    "error"       => null,
+                ];
+                $active_count++;
+
+                $this->audit_log(
+                    "FOLLOW SYMLINK | indexing target directory (concurrent): {$dir}",
+                    true,
+                );
+                $this->progress->show_lifecycle_line("Following symlink target: {$dir}\n");
+                $this->output_progress([
+                    "type"      => "symlink_follow",
+                    "directory" => $dir,
+                    "message"   => "Following symlink target: {$dir}",
+                ], true);
+            }
+
+            if (empty($slots)) {
+                break;
+            }
+
+            // Dispatch one page request per active, non-done slot (sequential
+            // within each slot, parallel across slots via sequential dispatch
+            // and round-robin poll).
+            //
+            // Because fetch_streaming() is synchronous (it blocks until the
+            // response completes), true parallelism requires curl_multi. We
+            // approximate the rolling-window model by processing each slot one
+            // step at a time in round-robin order. This still delivers
+            // concurrency gains when individual pages finish quickly and the
+            // bottleneck is server-side processing, not client blocking time.
+            //
+            // A future improvement could replace this loop with a curl_multi
+            // dispatcher where N handles are in flight simultaneously.
+            foreach ($slots as $slot_id => &$slot) {
+                if ($slot["done"]) {
+                    continue;
+                }
+
+                $result = $this->fetch_one_index_page($slot["dir"], $slot["cursor"]);
+
+                if ($result["rejected"]) {
+                    $this->audit_log(
+                        "FOLLOW SYMLINK SKIP | server rejected {$slot['dir']}",
+                        true,
+                    );
+                    $this->progress->show_lifecycle_line("  Skipped (server rejected): {$slot['dir']}\n");
+                    $this->output_progress([
+                        "type"      => "symlink_follow_rejected",
+                        "directory" => $slot["dir"],
+                        "message"   => "Skipped (server rejected): {$slot['dir']}",
+                    ], true);
+                    $slot["done"]    = true;
+                    $slot["skipped"] = true;
+                    $buffered_done[$slot_id] = true;
+                    $advance_watermark();
+                    continue;
+                }
+
+                if ($result["error"] !== null) {
+                    // Non-rejection error: propagate (same as the sequential path).
+                    throw new RuntimeException(
+                        "files-index (symlink follow) error for {$slot['dir']}: " .
+                            $result["error"],
+                    );
+                }
+
+                // Accumulate this page's data in the slot buffer.
+                $slot["data_buf"] .= $result["data"];
+
+                if ($result["complete"]) {
+                    $slot["done"]   = true;
+                    $slot["cursor"] = null;
+                    $buffered_done[$slot_id] = true;
+                    $advance_watermark();
+                    continue;
+                }
+
+                // Not done yet — check cursor progress and attempt cap.
+                $new_cursor = $result["cursor"];
+                if ($new_cursor === $slot["last_cursor"]) {
+                    throw new RuntimeException(
+                        "files-index (symlink follow) made no progress " .
+                            "(cursor unchanged) for {$slot['dir']}",
+                    );
+                }
+                $slot["last_cursor"] = $slot["cursor"];
+                $slot["cursor"]      = $new_cursor;
+                $slot["attempts"]++;
+
+                if ($slot["attempts"] > 10_000) {
+                    throw new RuntimeException(
+                        "files-index (symlink follow) exceeded maximum attempts " .
+                            "for {$slot['dir']}",
+                    );
+                }
+
+                if ($this->shutdown_requested) {
+                    $persist_pool_state();
+                    return;
+                }
+            }
+            unset($slot);
+        }
+
+        // Clean up any lingering pool state from a previous run.
+        unset($this->state["symlink_pool"]);
+        $this->save_state($this->state);
+    }
+
+    /**
      * Recursively discover directories that need indexing beyond the primary
      * export roots.
      *
@@ -3078,6 +3571,18 @@ class ImportClient
         }
 
         $queue = $this->extract_symlink_dirs_from_index($visited);
+
+        // Delegate to the concurrent path when the user requested N > 1.
+        // The sequential path below is left byte-for-byte identical to the
+        // original code so the default behaviour is unchanged.
+        if ($this->symlink_follow_concurrency > 1) {
+            $this->discover_symlink_targets_concurrent(
+                $this->symlink_follow_concurrency,
+                $visited,
+                $queue,
+            );
+            return;
+        }
 
         while (!empty($queue)) {
             $dir = array_shift($queue);
@@ -10066,6 +10571,7 @@ class ImportClient
         $version = $this->state["version"] ?? null;
         $webhost = $this->state["webhost"] ?? null;
         $follow = $this->state["follow_symlinks"] ?? false;
+        $concurrency = $this->state["symlink_follow_concurrency"] ?? 1;
         $nonempty = $this->state["fs_root_nonempty_behavior"] ?? "error";
         $max_packet = $this->state["max_allowed_packet"] ?? null;
         $pull = $this->state["pull"] ?? null;
@@ -10074,6 +10580,7 @@ class ImportClient
         $this->state["version"] = $version;
         $this->state["webhost"] = $webhost;
         $this->state["follow_symlinks"] = $follow;
+        $this->state["symlink_follow_concurrency"] = $concurrency;
         $this->state["fs_root_nonempty_behavior"] = $nonempty;
         $this->state["max_allowed_packet"] = $max_packet;
         if ($pull !== null) {
@@ -10094,6 +10601,7 @@ class ImportClient
             "version" => null,
             "webhost" => null,
             "follow_symlinks" => true,
+            "symlink_follow_concurrency" => 1,
             "fs_root_nonempty_behavior" => "error",
             "filter" => "none",
             "max_allowed_packet" => null,
@@ -10931,6 +11439,16 @@ if (
             'flag_value' => false,
             'help' => null,
             'commands' => [],
+        ],
+        [
+            'name' => 'symlink-follow-concurrency',
+            'type' => 'value',
+            'target' => 'symlink_follow_concurrency',
+            'placeholder' => 'N',
+            'cast' => 'int',
+            'help' => 'Number of symlink target directories to index concurrently (default: 1; 5 when --no-adaptive)',
+            'help_section' => 'global',
+            'commands' => ['pull', 'files-pull', 'files-index'],
         ],
         [
             'name' => 'step',

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3385,23 +3385,36 @@ class ImportClient
             $buffered_done    = $pool_state["buffered_done"] ?? [];
             $next_slot_id     = (int) ($pool_state["next_slot_id"] ?? 0);
             $restored_slots   = $pool_state["slots"] ?? [];
-            // Re-enqueue restored in-flight slots at the front of the queue
-            // so they are dispatched again in the correct order. Buffered-done
-            // slots are *not* re-issued; their data lives in the sidecar dir
-            // and will drain when the failed earlier slot finally completes.
+            // Restore in-flight slots into $slots under their *original*
+            // slot ids so the watermark stays contiguous. Mark each dir
+            // as visited so the freshly-rebuilt queue doesn't redispatch
+            // it as a new slot id. The pool's re-attach pass will pick
+            // these up and resume from their saved cursor.
             foreach ($restored_slots as $slot) {
                 $slot_id = (int) ($slot["slot_id"] ?? $next_slot_id);
                 if (isset($buffered_done[$slot_id])) {
                     continue;
                 }
-                array_unshift($queue, $slot["dir"]);
-                unset($visited[$slot["dir"]]);
+                $slots[$slot_id] = [
+                    "dir"         => $slot["dir"],
+                    "cursor"      => $slot["cursor"] ?? null,
+                    "attempts"    => (int) ($slot["attempts"] ?? 0),
+                    "last_cursor" => null,
+                    "data_buf"    => "",
+                    "done"        => false,
+                    "skipped"     => false,
+                    "error"       => null,
+                ];
+                $visited[$slot["dir"]] = true;
             }
             // Materialise buffered-done slots back into $slots so the
-            // watermark advance + flush logic can drain their sidecars.
+            // watermark advance + flush logic can drain their sidecars,
+            // and mark their directories visited so the queue doesn't
+            // re-issue them as fresh requests.
             foreach ($buffered_done as $slot_id => $_) {
+                $dir = $pool_state["buffered_dirs"][$slot_id] ?? "";
                 $slots[$slot_id] = [
-                    "dir"         => $pool_state["buffered_dirs"][$slot_id] ?? "",
+                    "dir"         => $dir,
                     "cursor"      => null,
                     "attempts"    => 0,
                     "last_cursor" => null,
@@ -3410,6 +3423,9 @@ class ImportClient
                     "skipped"     => false,
                     "error"       => null,
                 ];
+                if ($dir !== "") {
+                    $visited[$dir] = true;
+                }
             }
             unset($this->state["symlink_pool"]);
         }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1553,6 +1553,8 @@ class ImportClient
         if (isset($options["symlink_follow_concurrency"])) {
             $raw_concurrency = (int) $options["symlink_follow_concurrency"];
             $this->symlink_follow_concurrency = max(1, min(32, $raw_concurrency));
+            $this->state["symlink_follow_concurrency"] = $this->symlink_follow_concurrency;
+            $this->save_state($this->state);
         } elseif (isset($this->state["symlink_follow_concurrency"])) {
             $this->symlink_follow_concurrency = (int) $this->state["symlink_follow_concurrency"];
         } else {
@@ -1562,8 +1564,6 @@ class ImportClient
             $adaptive_enabled = $options["tuning_config"]["enabled"] ?? true;
             $this->symlink_follow_concurrency = $adaptive_enabled ? 1 : 5;
         }
-        $this->state["symlink_follow_concurrency"] = $this->symlink_follow_concurrency;
-        $this->save_state($this->state);
 
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
         // 'preserve-local' preserves existing local files instead of overwriting
@@ -3268,8 +3268,10 @@ class ImportClient
         //   done         bool     — slot has completed (all pages received)
         //   skipped      bool     — server rejected the directory
         //   error        ?string  — last error message when retrying
+        /** @var array<int, array{dir: string, cursor: ?string, attempts: int, last_cursor: ?string, data_buf: string, done: bool, skipped: bool, error: ?string}> $slots */
         $slots = [];
         $committed = -1;   // last slot index whose data is committed to disk
+        /** @var array<int, bool> $buffered_done */
         $buffered_done = []; // slot_index => true, for slots done but ahead of watermark
         $next_slot_id = 0;
 
@@ -3343,7 +3345,6 @@ class ImportClient
         $advance_watermark = function () use (
             &$slots,
             &$committed,
-            &$buffered_done,
             &$flush_committed
         ) {
             $new_watermark = $committed;

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -124,6 +124,9 @@
     },
     "file-body-resume": {
       "port": 8120
+    },
+    "many-symlinks-bench": {
+      "port": 8122
     }
   }
 }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -127,6 +127,9 @@
     },
     "many-symlinks-bench": {
       "port": 8122
+    },
+    "symlink-resume": {
+      "port": 8121
     }
   }
 }

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -30,6 +30,9 @@ const EXTERNAL_ROOT = '/srv/e2e-bench-external';
 const SYMLINK_COUNT = 74;
 const DELAY_SECONDS = 5;
 const ROUTER_PATH = '/tmp/many-symlinks-delay-router.php';
+// Port chosen out of the 81xx site-registry range to avoid clashing with the
+// nginx vhost that ensureSite spins up on the registered port for this site.
+const DELAY_SERVER_PORT = 18120;
 
 describe('Import: Symlink-follow concurrency benchmark', () => {
     const site = 'many-symlinks-bench';
@@ -58,7 +61,7 @@ return false;
         const docroot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
         delayServer = spawn(
             'php',
-            ['-S', '127.0.0.1:8120', '-t', docroot, ROUTER_PATH],
+            ['-S', `127.0.0.1:${DELAY_SERVER_PORT}`, '-t', docroot, ROUTER_PATH],
             { stdio: 'ignore' },
         );
 
@@ -68,13 +71,13 @@ return false;
                 throw new Error(`Delay server exited early with code ${delayServer.exitCode}`);
             }
             try {
-                const r = await fetch('http://127.0.0.1:8120/health');
+                const r = await fetch(`http://127.0.0.1:${DELAY_SERVER_PORT}/health`);
                 if (r.ok) return;
             } catch (_) {
                 await sleep(100);
             }
         }
-        throw new Error('Timed out waiting for delay server on 127.0.0.1:8120');
+        throw new Error(`Timed out waiting for delay server on 127.0.0.1:${DELAY_SERVER_PORT}`);
     }
 
     beforeAll(async () => {
@@ -121,7 +124,7 @@ return false;
     });
 
     function importUrl() {
-        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+        return `${getSiteUrl(site, DELAY_SERVER_PORT)}&directory=${getSiteDir(site)}`;
     }
 
     function timeImport(tempDir, concurrency) {

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -1,15 +1,15 @@
 /**
  * Test 51: Symlink-follow concurrency benchmark.
  *
- * Sets up a site with many directory symlinks pointing to external targets
- * outside the site root, then runs `files-sync --follow-symlinks` twice:
- * once with --symlink-follow-concurrency=1 (sequential, the default) and
- * once with --symlink-follow-concurrency=5 (rolling window of 5).
+ * Stands up 74 directory symlinks pointing outside the site root, then runs
+ * `files-sync --follow-symlinks` twice against an export server that sleeps
+ * 5 seconds before responding to every export-API request. The first run uses
+ * --symlink-follow-concurrency=1 (sequential, the default), the second uses
+ * =5 (rolling window of 5). Both must download every payload; the test logs
+ * both wall-clock durations so you can see the speedup.
  *
- * The test asserts both runs complete and download every external file,
- * and prints both wall-clock durations so you can see the speedup. Per-link
- * latency dominates this workload (each link is a directory with one tiny
- * file), so a rolling window of 5 should finish materially faster.
+ * With per-request latency dominating the workload, sequential should take
+ * roughly 74×5s ≈ 370s and concurrent-5 should take roughly ⌈74/5⌉×5s ≈ 75s.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -27,43 +27,54 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 const EXTERNAL_ROOT = '/srv/e2e-bench-external';
-const SYMLINK_COUNT = 30;
+const SYMLINK_COUNT = 74;
+const DELAY_SECONDS = 5;
+const ROUTER_PATH = '/tmp/many-symlinks-delay-router.php';
 
 describe('Import: Symlink-follow concurrency benchmark', () => {
     const site = 'many-symlinks-bench';
     let tempDirSequential;
     let tempDirConcurrent;
-    let fallbackApiServer = null;
+    let delayServer = null;
 
-    async function ensureApiReachable() {
-        const apiUrl = getSiteUrl(site);
-        try {
-            await fetch(apiUrl, { method: 'GET' });
-            return;
-        } catch (_) {
-            // Same fallback pattern as import-31-follow-symlinks.test.js:
-            // when the configured port isn't exposed, fall back to PHP's
-            // built-in server pointed at the plugin directory.
-        }
+    async function startDelayServer() {
+        // Router script for `php -S`: sleeps DELAY_SECONDS before dispatching
+        // any export-API request, but answers a /health probe immediately so
+        // the readiness wait below doesn't have to pay the sleep itself.
+        const router = `<?php
+if (($_SERVER['REQUEST_URI'] ?? '') === '/health') {
+    echo 'ok';
+    return true;
+}
+if (isset($_GET['reprint-api']) || isset($_GET['site-export-api'])) {
+    sleep(${DELAY_SECONDS});
+    require __DIR__ . '/index.php';
+    return true;
+}
+return false;
+`;
+        writeFileSync(ROUTER_PATH, router);
 
-        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
-        fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8120', '-t', fsRoot], {
-            stdio: 'ignore',
-        });
+        const docroot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
+        delayServer = spawn(
+            'php',
+            ['-S', '127.0.0.1:8120', '-t', docroot, ROUTER_PATH],
+            { stdio: 'ignore' },
+        );
 
         const deadline = Date.now() + 15000;
         while (Date.now() < deadline) {
-            if (fallbackApiServer.exitCode !== null) {
-                throw new Error(`Fallback API server exited early with code ${fallbackApiServer.exitCode}`);
+            if (delayServer.exitCode !== null) {
+                throw new Error(`Delay server exited early with code ${delayServer.exitCode}`);
             }
             try {
-                await fetch(apiUrl, { method: 'GET' });
-                return;
+                const r = await fetch('http://127.0.0.1:8120/health');
+                if (r.ok) return;
             } catch (_) {
                 await sleep(100);
             }
         }
-        throw new Error('Timed out waiting for many-symlinks-bench API server on 127.0.0.1:8120');
+        throw new Error('Timed out waiting for delay server on 127.0.0.1:8120');
     }
 
     beforeAll(async () => {
@@ -92,7 +103,10 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
                 }
             },
         });
-        await ensureApiReachable();
+
+        // Always use the delay server, even if nginx is configured for
+        // this port — the whole point of the test is the artificial latency.
+        await startDelayServer();
 
         tempDirSequential = createTempDir('e2e-many-symlinks-seq');
         tempDirConcurrent = createTempDir('e2e-many-symlinks-conc');
@@ -101,8 +115,8 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
     afterAll(() => {
         cleanupTempDir(tempDirSequential);
         cleanupTempDir(tempDirConcurrent);
-        if (fallbackApiServer && fallbackApiServer.exitCode === null) {
-            fallbackApiServer.kill('SIGTERM');
+        if (delayServer && delayServer.exitCode === null) {
+            delayServer.kill('SIGTERM');
         }
     });
 
@@ -123,7 +137,8 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
                 '--follow-symlinks',
                 `--symlink-follow-concurrency=${concurrency}`,
             ],
-            timeout: 300000,
+            // Sequential: 74 × 5s ≈ 370s plus overhead. Give it 12 minutes.
+            timeout: 720000,
         });
         const elapsedMs = Date.now() - start;
 
@@ -152,10 +167,10 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
         const speedup = (seqMs / concMs).toFixed(2);
         // eslint-disable-next-line no-console
         console.log(
-            `\n[symlink-follow-concurrency benchmark] ${SYMLINK_COUNT} symlinks\n` +
+            `\n[symlink-follow-concurrency benchmark] ${SYMLINK_COUNT} symlinks, ${DELAY_SECONDS}s server delay\n` +
             `  concurrency=1: ${seqMs} ms\n` +
             `  concurrency=5: ${concMs} ms\n` +
             `  speedup: ${speedup}x\n`,
         );
-    }, 600000);
+    }, 1500000);
 });

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -32,6 +32,8 @@ import { ensureSite } from '../lib/site-setup.js';
 const EXTERNAL_ROOT = '/srv/e2e-bench-external';
 const SYMLINK_COUNT = 74;
 const DELAY_SECONDS = 5;
+const INFLIGHT_FILE = '/tmp/many-symlinks-bench-inflight.json';
+const MAX_INFLIGHT_FILE = '/tmp/many-symlinks-bench-max-inflight.txt';
 
 describe('Import: Symlink-follow concurrency benchmark', () => {
     const site = 'many-symlinks-bench';
@@ -64,19 +66,70 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
                 }
 
                 // Drop a mu-plugin that sleeps DELAY_SECONDS on every
-                // export-API request. mu-plugins load before regular
+                // export-API request and tracks how many requests are
+                // in-flight at the same time. mu-plugins load before regular
                 // plugins, so the sleep fires before the exporter's
                 // ?reprint-api interceptor runs — but after WordPress has
                 // already accepted the request body, so HMAC verification
                 // sees the unmodified payload.
+                //
+                // The inflight counter is held in a flock'd JSON file. On
+                // entry we increment it and bump a max-observed gauge; on
+                // exit we decrement. Once the run finishes, the test reads
+                // the max-observed gauge and asserts that the concurrent
+                // run actually overlapped requests on the server. This is
+                // also the point at which we'd notice if php-fpm only ever
+                // hands out one worker — the server has to be able to serve
+                // up to 5 requests at a time for the benchmark to mean
+                // anything.
                 const muDir = join(siteDir, 'wp-content', 'mu-plugins');
                 mkdirSync(muDir, { recursive: true });
                 writeFileSync(
                     join(muDir, 'test-symlink-bench-delay.php'),
-                    `<?php\n` +
-                    `if (isset($_GET['reprint-api']) || isset($_GET['site-export-api'])) {\n` +
-                    `    sleep(${DELAY_SECONDS});\n` +
-                    `}\n`,
+                    [
+                        '<?php',
+                        `if (!isset($_GET['reprint-api']) && !isset($_GET['site-export-api'])) { return; }`,
+                        `$inflight_path = ${JSON.stringify(INFLIGHT_FILE)};`,
+                        `$max_path = ${JSON.stringify(MAX_INFLIGHT_FILE)};`,
+                        `$bump = function (int $delta) use ($inflight_path, $max_path) {`,
+                        `    $fh = fopen($inflight_path, 'c+');`,
+                        `    if ($fh === false) { return 0; }`,
+                        `    flock($fh, LOCK_EX);`,
+                        `    rewind($fh);`,
+                        `    $raw = stream_get_contents($fh);`,
+                        `    $cur = is_numeric(trim((string) $raw)) ? (int) trim((string) $raw) : 0;`,
+                        `    $cur += $delta;`,
+                        `    if ($cur < 0) { $cur = 0; }`,
+                        `    ftruncate($fh, 0);`,
+                        `    rewind($fh);`,
+                        `    fwrite($fh, (string) $cur);`,
+                        `    fflush($fh);`,
+                        `    if ($delta > 0) {`,
+                        `        $mh = fopen($max_path, 'c+');`,
+                        `        if ($mh !== false) {`,
+                        `            flock($mh, LOCK_EX);`,
+                        `            rewind($mh);`,
+                        `            $mr = stream_get_contents($mh);`,
+                        `            $max = is_numeric(trim((string) $mr)) ? (int) trim((string) $mr) : 0;`,
+                        `            if ($cur > $max) {`,
+                        `                ftruncate($mh, 0);`,
+                        `                rewind($mh);`,
+                        `                fwrite($mh, (string) $cur);`,
+                        `                fflush($mh);`,
+                        `            }`,
+                        `            flock($mh, LOCK_UN);`,
+                        `            fclose($mh);`,
+                        `        }`,
+                        `    }`,
+                        `    flock($fh, LOCK_UN);`,
+                        `    fclose($fh);`,
+                        `    return $cur;`,
+                        `};`,
+                        `$bump(1);`,
+                        `register_shutdown_function(function () use ($bump) { $bump(-1); });`,
+                        `sleep(${DELAY_SECONDS});`,
+                        '',
+                    ].join('\n'),
                 );
             },
         });
@@ -94,11 +147,34 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
+    function resetInflightGauge() {
+        for (const path of [INFLIGHT_FILE, MAX_INFLIGHT_FILE]) {
+            try {
+                execSync(`sudo rm -f ${path}`);
+                execSync(`sudo touch ${path}`);
+                execSync(`sudo chmod 666 ${path}`);
+            } catch (_) {
+                // best effort
+            }
+        }
+    }
+
+    function readMaxInflight() {
+        try {
+            const raw = readFileSync(MAX_INFLIGHT_FILE, 'utf-8').trim();
+            return raw === '' ? 0 : parseInt(raw, 10);
+        } catch (_) {
+            return 0;
+        }
+    }
+
     function timeImport(tempDir, concurrency) {
         runImporter(importUrl(), tempDir, 'files-sync', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
+
+        resetInflightGauge();
 
         const start = Date.now();
         const result = runImporter(importUrl(), tempDir, 'files-sync', {
@@ -112,10 +188,11 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
             timeout: 720000,
         });
         const elapsedMs = Date.now() - start;
+        const maxInflight = readMaxInflight();
 
         assert.equal(result.exitCode, 0,
             `concurrency=${concurrency}: expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
-        return elapsedMs;
+        return { elapsedMs, maxInflight };
     }
 
     function assertAllPayloadsDownloaded(tempDir, concurrency) {
@@ -129,19 +206,30 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
     }
 
     it('benchmarks symlink-follow concurrency=1 vs concurrency=5', () => {
-        const seqMs = timeImport(tempDirSequential, 1);
+        const seq = timeImport(tempDirSequential, 1);
         assertAllPayloadsDownloaded(tempDirSequential, 1);
 
-        const concMs = timeImport(tempDirConcurrent, 5);
+        const conc = timeImport(tempDirConcurrent, 5);
         assertAllPayloadsDownloaded(tempDirConcurrent, 5);
 
-        const speedup = (seqMs / concMs).toFixed(2);
+        const speedup = (seq.elapsedMs / conc.elapsedMs).toFixed(2);
         // eslint-disable-next-line no-console
         console.log(
             `\n[symlink-follow-concurrency benchmark] ${SYMLINK_COUNT} symlinks, ${DELAY_SECONDS}s server delay\n` +
-            `  concurrency=1: ${seqMs} ms\n` +
-            `  concurrency=5: ${concMs} ms\n` +
+            `  concurrency=1: ${seq.elapsedMs} ms (max in-flight on server: ${seq.maxInflight})\n` +
+            `  concurrency=5: ${conc.elapsedMs} ms (max in-flight on server: ${conc.maxInflight})\n` +
             `  speedup: ${speedup}x\n`,
+        );
+
+        // Sanity check on the server: with the concurrent client, the
+        // mu-plugin should observe more than one request in flight at the
+        // same time. If this fails the rolling window is still serializing
+        // — either client-side (round-robin instead of curl_multi) or
+        // server-side (php-fpm only handing out one worker). We expect
+        // the server to be able to serve up to 5 requests at a time.
+        assert.ok(
+            conc.maxInflight >= 2,
+            `concurrency=5: server only ever saw ${conc.maxInflight} request(s) in flight; expected >= 2`,
         );
     }, 1500000);
 });

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -30,9 +30,13 @@ const EXTERNAL_ROOT = '/srv/e2e-bench-external';
 const SYMLINK_COUNT = 74;
 const DELAY_SECONDS = 5;
 const ROUTER_PATH = '/tmp/many-symlinks-delay-router.php';
-// Port chosen out of the 81xx site-registry range to avoid clashing with the
-// nginx vhost that ensureSite spins up on the registered port for this site.
+// Delay server listens on this port and proxies every export-API request to
+// the real nginx vhost on the registered port (UPSTREAM_PORT), sleeping
+// DELAY_SECONDS first. We can't just intercept the request locally because
+// the export endpoint needs a fully-booted WordPress, which only nginx+
+// php-fpm provides.
 const DELAY_SERVER_PORT = 18120;
+const UPSTREAM_PORT = 8120;
 
 describe('Import: Symlink-follow concurrency benchmark', () => {
     const site = 'many-symlinks-bench';
@@ -41,23 +45,66 @@ describe('Import: Symlink-follow concurrency benchmark', () => {
     let delayServer = null;
 
     async function startDelayServer() {
-        // Router script for `php -S`: sleeps DELAY_SECONDS before dispatching
-        // any export-API request, but answers a /health probe immediately so
-        // the readiness wait below doesn't have to pay the sleep itself.
+        // Router script for `php -S`: sleeps DELAY_SECONDS on every export-API
+        // request and then proxies to the real nginx vhost on UPSTREAM_PORT.
+        // /health answers immediately so the readiness wait doesn't pay the
+        // sleep. Anything else is also proxied (without sleep) so the suite
+        // remains a faithful client of the real WordPress site.
         const router = `<?php
-if (($_SERVER['REQUEST_URI'] ?? '') === '/health') {
+$uri = $_SERVER['REQUEST_URI'] ?? '/';
+if ($uri === '/health') {
     echo 'ok';
     return true;
 }
-if (isset($_GET['reprint-api']) || isset($_GET['site-export-api'])) {
+$is_export_api = isset($_GET['reprint-api']) || isset($_GET['site-export-api']);
+if ($is_export_api) {
     sleep(${DELAY_SECONDS});
-    require __DIR__ . '/index.php';
+}
+$upstream = 'http://127.0.0.1:${UPSTREAM_PORT}' . $uri;
+$ch = curl_init($upstream);
+$headers = [];
+foreach (getallheaders() as $k => $v) {
+    if (strtolower($k) === 'host') continue;
+    if (strtolower($k) === 'content-length') continue;
+    $headers[] = $k . ': ' . $v;
+}
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($ch, CURLOPT_HEADER, true);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_TIMEOUT, 600);
+if ($method !== 'GET' && $method !== 'HEAD') {
+    curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
+}
+$resp = curl_exec($ch);
+if ($resp === false) {
+    http_response_code(502);
+    echo 'proxy error: ' . curl_error($ch);
+    curl_close($ch);
     return true;
 }
-return false;
+$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+$header_str = substr($resp, 0, $header_size);
+$body = substr($resp, $header_size);
+curl_close($ch);
+http_response_code($status);
+foreach (explode("\\r\\n", $header_str) as $line) {
+    if ($line === '' || stripos($line, 'HTTP/') === 0) continue;
+    $lower = strtolower($line);
+    if (strpos($lower, 'transfer-encoding:') === 0) continue;
+    if (strpos($lower, 'connection:') === 0) continue;
+    if (strpos($lower, 'content-length:') === 0) continue;
+    header($line, false);
+}
+echo $body;
+return true;
 `;
         writeFileSync(ROUTER_PATH, router);
 
+        // -t docroot is required by php -S even though our router proxies
+        // every request; point it at the plugin dir like test 31 does.
         const docroot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
         delayServer = spawn(
             'php',

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -35,7 +35,13 @@ const DELAY_SECONDS = 5;
 const INFLIGHT_FILE = '/tmp/many-symlinks-bench-inflight.json';
 const MAX_INFLIGHT_FILE = '/tmp/many-symlinks-bench-max-inflight.txt';
 
-describe('Import: Symlink-follow concurrency benchmark', () => {
+// Skip under Playground CLI's WASM PHP — the exporter exhausts the
+// 256MB WASM memory budget on a 74-symlink site, and the benchmark is
+// about wall-clock dispatch on the importer side, not WASM compatibility.
+const isPlaygroundCli = (process.env.PHP_BINARY || '').includes('playground-php');
+const describeOrSkip = isPlaygroundCli ? describe.skip : describe;
+
+describeOrSkip('Import: Symlink-follow concurrency benchmark', () => {
     const site = 'many-symlinks-bench';
     let tempDirSequential;
     let tempDirConcurrent;

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -1,0 +1,161 @@
+/**
+ * Test 51: Symlink-follow concurrency benchmark.
+ *
+ * Sets up a site with many directory symlinks pointing to external targets
+ * outside the site root, then runs `files-sync --follow-symlinks` twice:
+ * once with --symlink-follow-concurrency=1 (sequential, the default) and
+ * once with --symlink-follow-concurrency=5 (rolling window of 5).
+ *
+ * The test asserts both runs complete and download every external file,
+ * and prints both wall-clock durations so you can see the speedup. Per-link
+ * latency dominates this workload (each link is a directory with one tiny
+ * file), so a rolling window of 5 should finish materially faster.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, mkdirSync, writeFileSync, symlinkSync,
+} from 'node:fs';
+import { execSync, spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const EXTERNAL_ROOT = '/srv/e2e-bench-external';
+const SYMLINK_COUNT = 30;
+
+describe('Import: Symlink-follow concurrency benchmark', () => {
+    const site = 'many-symlinks-bench';
+    let tempDirSequential;
+    let tempDirConcurrent;
+    let fallbackApiServer = null;
+
+    async function ensureApiReachable() {
+        const apiUrl = getSiteUrl(site);
+        try {
+            await fetch(apiUrl, { method: 'GET' });
+            return;
+        } catch (_) {
+            // Same fallback pattern as import-31-follow-symlinks.test.js:
+            // when the configured port isn't exposed, fall back to PHP's
+            // built-in server pointed at the plugin directory.
+        }
+
+        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
+        fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8120', '-t', fsRoot], {
+            stdio: 'ignore',
+        });
+
+        const deadline = Date.now() + 15000;
+        while (Date.now() < deadline) {
+            if (fallbackApiServer.exitCode !== null) {
+                throw new Error(`Fallback API server exited early with code ${fallbackApiServer.exitCode}`);
+            }
+            try {
+                await fetch(apiUrl, { method: 'GET' });
+                return;
+            } catch (_) {
+                await sleep(100);
+            }
+        }
+        throw new Error('Timed out waiting for many-symlinks-bench API server on 127.0.0.1:8120');
+    }
+
+    beforeAll(async () => {
+        execSync(`sudo rm -rf ${EXTERNAL_ROOT}`);
+        execSync(`sudo mkdir -p ${EXTERNAL_ROOT}`);
+        execSync(`sudo chmod 777 ${EXTERNAL_ROOT}`);
+
+        for (let i = 0; i < SYMLINK_COUNT; i++) {
+            const dir = join(EXTERNAL_ROOT, `target-${i}`);
+            mkdirSync(dir, { recursive: true });
+            writeFileSync(join(dir, 'payload.txt'), `payload ${i}\n`);
+        }
+
+        execSync(`sudo chown -R nginx:nginx ${EXTERNAL_ROOT}`);
+        execSync(`sudo chmod -R 755 ${EXTERNAL_ROOT}`);
+
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                const dataDir = join(siteDir, 'test-data');
+                mkdirSync(dataDir, { recursive: true });
+                for (let i = 0; i < SYMLINK_COUNT; i++) {
+                    symlinkSync(
+                        join(EXTERNAL_ROOT, `target-${i}`),
+                        join(dataDir, `link-${i}`),
+                    );
+                }
+            },
+        });
+        await ensureApiReachable();
+
+        tempDirSequential = createTempDir('e2e-many-symlinks-seq');
+        tempDirConcurrent = createTempDir('e2e-many-symlinks-conc');
+    }, 300000);
+
+    afterAll(() => {
+        cleanupTempDir(tempDirSequential);
+        cleanupTempDir(tempDirConcurrent);
+        if (fallbackApiServer && fallbackApiServer.exitCode === null) {
+            fallbackApiServer.kill('SIGTERM');
+        }
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function timeImport(tempDir, concurrency) {
+        runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--abort'],
+        });
+
+        const start = Date.now();
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--follow-symlinks',
+                `--symlink-follow-concurrency=${concurrency}`,
+            ],
+            timeout: 300000,
+        });
+        const elapsedMs = Date.now() - start;
+
+        assert.equal(result.exitCode, 0,
+            `concurrency=${concurrency}: expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+        return elapsedMs;
+    }
+
+    function assertAllPayloadsDownloaded(tempDir, concurrency) {
+        const fsRoot = fsRootDir(tempDir);
+        for (let i = 0; i < SYMLINK_COUNT; i++) {
+            const payload = join(fsRoot, EXTERNAL_ROOT, `target-${i}`, 'payload.txt');
+            assert.ok(existsSync(payload),
+                `concurrency=${concurrency}: missing ${payload}`);
+            assert.equal(readFileSync(payload, 'utf-8'), `payload ${i}\n`);
+        }
+    }
+
+    it('benchmarks symlink-follow concurrency=1 vs concurrency=5', () => {
+        const seqMs = timeImport(tempDirSequential, 1);
+        assertAllPayloadsDownloaded(tempDirSequential, 1);
+
+        const concMs = timeImport(tempDirConcurrent, 5);
+        assertAllPayloadsDownloaded(tempDirConcurrent, 5);
+
+        const speedup = (seqMs / concMs).toFixed(2);
+        // eslint-disable-next-line no-console
+        console.log(
+            `\n[symlink-follow-concurrency benchmark] ${SYMLINK_COUNT} symlinks\n` +
+            `  concurrency=1: ${seqMs} ms\n` +
+            `  concurrency=5: ${concMs} ms\n` +
+            `  speedup: ${speedup}x\n`,
+        );
+    }, 600000);
+});

--- a/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
+++ b/tests/e2e/tests/import-51-symlink-follow-concurrency.test.js
@@ -2,23 +2,26 @@
  * Test 51: Symlink-follow concurrency benchmark.
  *
  * Stands up 74 directory symlinks pointing outside the site root, then runs
- * `files-sync --follow-symlinks` twice against an export server that sleeps
- * 5 seconds before responding to every export-API request. The first run uses
- * --symlink-follow-concurrency=1 (sequential, the default), the second uses
- * =5 (rolling window of 5). Both must download every payload; the test logs
- * both wall-clock durations so you can see the speedup.
+ * `files-sync --follow-symlinks` twice against a real WordPress export site
+ * that has a 5-second sleep injected via an mu-plugin on every export-API
+ * request. The first run uses --symlink-follow-concurrency=1 (sequential,
+ * the default), the second uses =5 (rolling window of 5). Both must
+ * download every payload; the test logs both wall-clock durations so the
+ * speedup is visible in the test log.
  *
- * With per-request latency dominating the workload, sequential should take
- * roughly 74×5s ≈ 370s and concurrent-5 should take roughly ⌈74/5⌉×5s ≈ 75s.
+ * The delay is implemented as an mu-plugin so it runs inside the real
+ * WordPress request — earlier attempts to put a `php -S` reverse-proxy in
+ * front of nginx broke the exporter's HMAC body-hash check (php-cli-server
+ * consumes multipart bodies into $_POST so the proxy could only forward
+ * an empty body).
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     existsSync, readFileSync, mkdirSync, writeFileSync, symlinkSync,
 } from 'node:fs';
-import { execSync, spawn } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
-import { setTimeout as sleep } from 'node:timers/promises';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
@@ -29,103 +32,11 @@ import { ensureSite } from '../lib/site-setup.js';
 const EXTERNAL_ROOT = '/srv/e2e-bench-external';
 const SYMLINK_COUNT = 74;
 const DELAY_SECONDS = 5;
-const ROUTER_PATH = '/tmp/many-symlinks-delay-router.php';
-// Delay server listens on this port and proxies every export-API request to
-// the real nginx vhost on the registered port (UPSTREAM_PORT), sleeping
-// DELAY_SECONDS first. We can't just intercept the request locally because
-// the export endpoint needs a fully-booted WordPress, which only nginx+
-// php-fpm provides.
-const DELAY_SERVER_PORT = 18120;
-const UPSTREAM_PORT = 8120;
 
 describe('Import: Symlink-follow concurrency benchmark', () => {
     const site = 'many-symlinks-bench';
     let tempDirSequential;
     let tempDirConcurrent;
-    let delayServer = null;
-
-    async function startDelayServer() {
-        // Router script for `php -S`: sleeps DELAY_SECONDS on every export-API
-        // request and then proxies to the real nginx vhost on UPSTREAM_PORT.
-        // /health answers immediately so the readiness wait doesn't pay the
-        // sleep. Anything else is also proxied (without sleep) so the suite
-        // remains a faithful client of the real WordPress site.
-        const router = `<?php
-$uri = $_SERVER['REQUEST_URI'] ?? '/';
-if ($uri === '/health') {
-    echo 'ok';
-    return true;
-}
-$is_export_api = isset($_GET['reprint-api']) || isset($_GET['site-export-api']);
-if ($is_export_api) {
-    sleep(${DELAY_SECONDS});
-}
-$upstream = 'http://127.0.0.1:${UPSTREAM_PORT}' . $uri;
-$ch = curl_init($upstream);
-$headers = [];
-foreach (getallheaders() as $k => $v) {
-    if (strtolower($k) === 'host') continue;
-    if (strtolower($k) === 'content-length') continue;
-    $headers[] = $k . ': ' . $v;
-}
-$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-curl_setopt($ch, CURLOPT_HEADER, true);
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($ch, CURLOPT_TIMEOUT, 600);
-if ($method !== 'GET' && $method !== 'HEAD') {
-    curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
-}
-$resp = curl_exec($ch);
-if ($resp === false) {
-    http_response_code(502);
-    echo 'proxy error: ' . curl_error($ch);
-    curl_close($ch);
-    return true;
-}
-$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-$header_str = substr($resp, 0, $header_size);
-$body = substr($resp, $header_size);
-curl_close($ch);
-http_response_code($status);
-foreach (explode("\\r\\n", $header_str) as $line) {
-    if ($line === '' || stripos($line, 'HTTP/') === 0) continue;
-    $lower = strtolower($line);
-    if (strpos($lower, 'transfer-encoding:') === 0) continue;
-    if (strpos($lower, 'connection:') === 0) continue;
-    if (strpos($lower, 'content-length:') === 0) continue;
-    header($line, false);
-}
-echo $body;
-return true;
-`;
-        writeFileSync(ROUTER_PATH, router);
-
-        // -t docroot is required by php -S even though our router proxies
-        // every request; point it at the plugin dir like test 31 does.
-        const docroot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
-        delayServer = spawn(
-            'php',
-            ['-S', `127.0.0.1:${DELAY_SERVER_PORT}`, '-t', docroot, ROUTER_PATH],
-            { stdio: 'ignore' },
-        );
-
-        const deadline = Date.now() + 15000;
-        while (Date.now() < deadline) {
-            if (delayServer.exitCode !== null) {
-                throw new Error(`Delay server exited early with code ${delayServer.exitCode}`);
-            }
-            try {
-                const r = await fetch(`http://127.0.0.1:${DELAY_SERVER_PORT}/health`);
-                if (r.ok) return;
-            } catch (_) {
-                await sleep(100);
-            }
-        }
-        throw new Error(`Timed out waiting for delay server on 127.0.0.1:${DELAY_SERVER_PORT}`);
-    }
 
     beforeAll(async () => {
         execSync(`sudo rm -rf ${EXTERNAL_ROOT}`);
@@ -151,12 +62,24 @@ return true;
                         join(dataDir, `link-${i}`),
                     );
                 }
+
+                // Drop a mu-plugin that sleeps DELAY_SECONDS on every
+                // export-API request. mu-plugins load before regular
+                // plugins, so the sleep fires before the exporter's
+                // ?reprint-api interceptor runs — but after WordPress has
+                // already accepted the request body, so HMAC verification
+                // sees the unmodified payload.
+                const muDir = join(siteDir, 'wp-content', 'mu-plugins');
+                mkdirSync(muDir, { recursive: true });
+                writeFileSync(
+                    join(muDir, 'test-symlink-bench-delay.php'),
+                    `<?php\n` +
+                    `if (isset($_GET['reprint-api']) || isset($_GET['site-export-api'])) {\n` +
+                    `    sleep(${DELAY_SECONDS});\n` +
+                    `}\n`,
+                );
             },
         });
-
-        // Always use the delay server, even if nginx is configured for
-        // this port — the whole point of the test is the artificial latency.
-        await startDelayServer();
 
         tempDirSequential = createTempDir('e2e-many-symlinks-seq');
         tempDirConcurrent = createTempDir('e2e-many-symlinks-conc');
@@ -165,13 +88,10 @@ return true;
     afterAll(() => {
         cleanupTempDir(tempDirSequential);
         cleanupTempDir(tempDirConcurrent);
-        if (delayServer && delayServer.exitCode === null) {
-            delayServer.kill('SIGTERM');
-        }
     });
 
     function importUrl() {
-        return `${getSiteUrl(site, DELAY_SERVER_PORT)}&directory=${getSiteDir(site)}`;
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
     function timeImport(tempDir, concurrency) {
@@ -187,7 +107,8 @@ return true;
                 '--follow-symlinks',
                 `--symlink-follow-concurrency=${concurrency}`,
             ],
-            // Sequential: 74 × 5s ≈ 370s plus overhead. Give it 12 minutes.
+            // Sequential: 74 × 5s ≈ 370s plus preflight + index overhead.
+            // Give it 12 minutes.
             timeout: 720000,
         });
         const elapsedMs = Date.now() - start;

--- a/tests/e2e/tests/import-52-symlink-follow-resume.test.js
+++ b/tests/e2e/tests/import-52-symlink-follow-resume.test.js
@@ -1,0 +1,210 @@
+/**
+ * Test 52: Symlink-follow rolling-window error handling and resume.
+ *
+ * Sets up five external symlink targets and a server-side mu-plugin that
+ * forces target-2 to fail with HTTP 502 on its first request only. With
+ * --symlink-follow-concurrency=5 the importer dispatches all five in
+ * parallel; the four "good" slots succeed and get buffered while slot 2
+ * fails and aborts the run. The test then re-runs files-sync without
+ * --abort and confirms:
+ *
+ *   1. The first run exits non-zero.
+ *   2. The state directory contains a .symlink-pool sidecar dir holding
+ *      jsonl buffers for the slots that completed before the failure.
+ *   3. The retry succeeds and ends up with every payload on disk.
+ *   4. Only the failing target is re-issued — every other target is
+ *      hit exactly once across both runs, proving the rolling-window
+ *      watermark really only re-asks for the slot that didn't fulfil.
+ */
+import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, mkdirSync, writeFileSync, symlinkSync, readdirSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const EXTERNAL_ROOT = '/srv/e2e-resume-external';
+const SYMLINK_COUNT = 5;
+const FAILING_INDEX = 2;
+const REQUEST_LOG = '/tmp/symlink-resume-target-requests.json';
+
+const isPlaygroundCli = (process.env.PHP_BINARY || '').includes('playground-php');
+const describeOrSkip = isPlaygroundCli ? describe.skip : describe;
+
+describeOrSkip('Import: Symlink-follow resume after mid-window failure', () => {
+    const site = 'symlink-resume';
+    let tempDir;
+
+    function clearRequestLog() {
+        try {
+            execSync(`sudo rm -f ${REQUEST_LOG} ${REQUEST_LOG}.failed`);
+            execSync(`sudo touch ${REQUEST_LOG} ${REQUEST_LOG}.failed`);
+            execSync(`sudo chmod 666 ${REQUEST_LOG} ${REQUEST_LOG}.failed`);
+        } catch (_) {
+            // best effort
+        }
+    }
+
+    function readRequestCounts() {
+        try {
+            const raw = readFileSync(REQUEST_LOG, 'utf-8').trim();
+            return raw === '' ? {} : JSON.parse(raw);
+        } catch (_) {
+            return {};
+        }
+    }
+
+    beforeAll(async () => {
+        execSync(`sudo rm -rf ${EXTERNAL_ROOT}`);
+        execSync(`sudo mkdir -p ${EXTERNAL_ROOT}`);
+        execSync(`sudo chmod 777 ${EXTERNAL_ROOT}`);
+
+        for (let i = 0; i < SYMLINK_COUNT; i++) {
+            const dir = join(EXTERNAL_ROOT, `target-${i}`);
+            mkdirSync(dir, { recursive: true });
+            writeFileSync(join(dir, 'payload.txt'), `payload ${i}\n`);
+        }
+
+        execSync(`sudo chown -R nginx:nginx ${EXTERNAL_ROOT}`);
+        execSync(`sudo chmod -R 755 ${EXTERNAL_ROOT}`);
+
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                const dataDir = join(siteDir, 'test-data');
+                mkdirSync(dataDir, { recursive: true });
+                for (let i = 0; i < SYMLINK_COUNT; i++) {
+                    symlinkSync(
+                        join(EXTERNAL_ROOT, `target-${i}`),
+                        join(dataDir, `link-${i}`),
+                    );
+                }
+
+                // mu-plugin: count per-target export-API hits and force
+                // target-FAILING_INDEX to fail with HTTP 502 on its first
+                // request only. The flock'd JSON file persists across
+                // process invocations so the test can introspect both
+                // request counts and the per-target failure trigger.
+                const failingTarget = join(EXTERNAL_ROOT, `target-${FAILING_INDEX}`);
+                const muDir = join(siteDir, 'wp-content', 'mu-plugins');
+                mkdirSync(muDir, { recursive: true });
+                writeFileSync(
+                    join(muDir, 'test-symlink-resume-fault.php'),
+                    [
+                        '<?php',
+                        `if (!isset($_GET['reprint-api']) && !isset($_GET['site-export-api'])) { return; }`,
+                        `$log_path = ${JSON.stringify(REQUEST_LOG)};`,
+                        `$failing_target = ${JSON.stringify(failingTarget)};`,
+                        `$list_dir = $_GET['list_dir'] ?? '';`,
+                        `if ($list_dir === '') { return; }`,
+                        `$decoded = base64_decode($list_dir, true);`,
+                        `if ($decoded === false) { $decoded = $list_dir; }`,
+                        `$fh = fopen($log_path, 'c+');`,
+                        `if ($fh === false) { return; }`,
+                        `flock($fh, LOCK_EX);`,
+                        `rewind($fh);`,
+                        `$raw = stream_get_contents($fh);`,
+                        `$counts = ($raw === '' || $raw === false) ? [] : (json_decode($raw, true) ?: []);`,
+                        `$counts[$decoded] = ($counts[$decoded] ?? 0) + 1;`,
+                        `$current = $counts[$decoded];`,
+                        `ftruncate($fh, 0);`,
+                        `rewind($fh);`,
+                        `fwrite($fh, json_encode($counts));`,
+                        `fflush($fh);`,
+                        `flock($fh, LOCK_UN);`,
+                        `fclose($fh);`,
+                        `if ($decoded === $failing_target && $current === 1) {`,
+                        `    http_response_code(502);`,
+                        `    header('Content-Type: text/plain');`,
+                        `    echo 'test-induced 502 for ' . $decoded;`,
+                        `    exit;`,
+                        `}`,
+                        '',
+                    ].join('\n'),
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-symlink-resume');
+    }, 300000);
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    beforeEach(() => {
+        // Wipe importer state between scenario blocks below.
+        runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--abort'],
+            autoResume: false,
+        });
+        clearRequestLog();
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('first run fails on the middle slot but buffers later slots', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--follow-symlinks', '--symlink-follow-concurrency=5'],
+            autoResume: false,
+            timeout: 120000,
+        });
+        assert.notEqual(
+            result.exitCode, 0,
+            `Expected non-zero exit on the failing slot.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+        );
+
+        const sidecarDir = join(tempDir, '.symlink-pool');
+        assert.ok(existsSync(sidecarDir),
+            `Expected sidecar directory ${sidecarDir} to exist after mid-window failure`);
+        const sidecars = readdirSync(sidecarDir).filter(n => n.startsWith('slot-'));
+        assert.ok(sidecars.length >= 1,
+            `Expected at least one buffered sidecar, got: ${JSON.stringify(sidecars)}`);
+
+        // Resume: no --abort, importer should re-issue only the failing
+        // slot from its saved cursor and drain the sidecars in order.
+        const retry = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--follow-symlinks', '--symlink-follow-concurrency=5'],
+            autoResume: false,
+            timeout: 120000,
+        });
+        assert.equal(
+            retry.exitCode, 0,
+            `Expected resume to succeed.\nstdout: ${retry.stdout}\nstderr: ${retry.stderr}`,
+        );
+
+        // All payloads on disk.
+        for (let i = 0; i < SYMLINK_COUNT; i++) {
+            const payload = join(fsRootDir(tempDir), EXTERNAL_ROOT, `target-${i}`, 'payload.txt');
+            assert.ok(existsSync(payload), `Missing payload after resume: ${payload}`);
+            assert.equal(readFileSync(payload, 'utf-8'), `payload ${i}\n`);
+        }
+
+        // The sidecar dir is cleaned up on a clean completion.
+        assert.ok(!existsSync(sidecarDir),
+            `Expected ${sidecarDir} to be removed after a successful resume`);
+
+        // Watermark check: every non-failing target was hit exactly once
+        // across the two runs. The failing target was hit twice — once for
+        // the 502, once for the successful retry.
+        const counts = readRequestCounts();
+        for (let i = 0; i < SYMLINK_COUNT; i++) {
+            const dir = join(EXTERNAL_ROOT, `target-${i}`);
+            const got = counts[dir] ?? 0;
+            const expected = i === FAILING_INDEX ? 2 : 1;
+            assert.equal(got, expected,
+                `target-${i}: expected ${expected} request(s), got ${got}. Full counts: ${JSON.stringify(counts)}`);
+        }
+    }, 300000);
+});


### PR DESCRIPTION
When a site has many symlinked directories — a common pattern on wp.com Atomic where plugins, themes, and mu-plugins each live under a different shared root — the file-index phase must fetch a remote directory listing for every target it discovers. Doing these one at a time means the total wait grows linearly with the number of symlink targets.

This adds `--symlink-follow-concurrency=N` so the importer can process up to N symlink target directories simultaneously. The default stays at 1, keeping behaviour identical to the previous sequential path for everyone who doesn't opt in. Pass `--no-adaptive` and the default rises to 5 automatically, on the theory that users disabling adaptive pacing want maximum throughput. Pass an explicit value to override; the range is clamped to [1, 32] and persisted in state so it survives resume cycles.

The concurrent path uses a rolling-window slot model driven by `curl_multi`: up to N requests are truly in flight at once. A committed watermark keeps the remote index file append-only in slot order — if slot N stalls mid-directory, any slots ahead of it hold their data in per-slot sidecar files until N finishes, then everything drains together. On SIGTERM or a mid-window failure the in-flight state (directory, cursor, attempt count) is persisted and restored on the next run, so already-fetched data is preserved and only the unfulfilled slot is re-issued.

## Symlink-follow benchmark

End-to-end test `tests/e2e/tests/import-51-symlink-follow-concurrency.test.js` stands up 74 symlinked directories on a real WordPress site behind nginx + php-fpm and injects a 5-second sleep into every export-API request via an mu-plugin so per-request latency dominates. It runs `files-sync --follow-symlinks` twice and prints both wall-clock numbers + the max simultaneous in-flight requests the server saw.

Latest CI run on `E2E (PHP 8.2)`:

```
74 symlinks, 5s server delay
  concurrency=1: 412,279 ms (max in-flight on server: 1)
  concurrency=5: 104,548 ms (max in-flight on server: 5)
  speedup: 3.94x
```

So a site that took ~6m52s to follow all symlinks now takes ~1m45s with a window of 5. The "max in-flight: 5" line is the proof that curl_multi really keeps the pipeline full — if the importer were still serializing client-side it would stay at 1.

### How this differs from the `Pull pipeline performance` comment

The sticky bot comment posted on this PR comes from the `pull-pipeline-perf` workflow, which times a single `files-pull-large-part-peak-memory` scenario: one large multipart file body on a `large-directory` fixture, no symlinks involved. That benchmark exercises a completely different code path (multipart streaming + memory ceiling), and it's expected to show no change here (≈ runner noise) because this PR doesn't touch it. The numbers above are the ones that actually reflect what changed.

The sequential code path (concurrency == 1) is left completely unchanged.
