### PR TITLE
Batch SQLite db-apply transactions

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -960,6 +960,8 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const SQLITE_DB_APPLY_BATCH_SIZE = 500;
+    private const SQLITE_DB_APPLY_PROGRESS_TABLE = '_reprint_db_apply_progress';
 
     /**
      * Maximum number of consecutive cURL timeouts with no cursor progress
@@ -4989,6 +4991,262 @@ class ImportClient
         ];
     }
 
+    private function sqlite_db_apply_progress_table_sql(): string
+    {
+        return '"' . str_replace('"', '""', self::SQLITE_DB_APPLY_PROGRESS_TABLE) . '"';
+    }
+
+    private function initialize_sqlite_db_apply_progress_marker(PDO $sqlite_pdo): void
+    {
+        $table = $this->sqlite_db_apply_progress_table_sql();
+        $sqlite_pdo->exec(
+            "CREATE TABLE IF NOT EXISTS {$table} (" .
+            "id INTEGER PRIMARY KEY CHECK (id = 1), " .
+            "statements_executed INTEGER NOT NULL, " .
+            "bytes_read INTEGER NOT NULL, " .
+            "updated_at TEXT NOT NULL" .
+            ")"
+        );
+    }
+
+    /**
+     * @return array{statements_executed:int,bytes_read:int}|null
+     */
+    private function read_sqlite_db_apply_progress_marker(PDO $sqlite_pdo): ?array
+    {
+        $this->initialize_sqlite_db_apply_progress_marker($sqlite_pdo);
+
+        $table = $this->sqlite_db_apply_progress_table_sql();
+        $row = $sqlite_pdo
+            ->query("SELECT statements_executed, bytes_read FROM {$table} WHERE id = 1")
+            ->fetch(PDO::FETCH_ASSOC);
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return [
+            "statements_executed" => (int) $row["statements_executed"],
+            "bytes_read" => (int) $row["bytes_read"],
+        ];
+    }
+
+    private function update_sqlite_db_apply_progress_marker(
+        PDO $sqlite_pdo,
+        int $statements_executed,
+        int $bytes_read
+    ): void {
+        $table = $this->sqlite_db_apply_progress_table_sql();
+        $statement = $sqlite_pdo->prepare(
+            "INSERT INTO {$table} (id, statements_executed, bytes_read, updated_at) " .
+            "VALUES (1, :statements_executed, :bytes_read, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) " .
+            "ON CONFLICT(id) DO UPDATE SET " .
+            "statements_executed = excluded.statements_executed, " .
+            "bytes_read = excluded.bytes_read, " .
+            "updated_at = excluded.updated_at"
+        );
+        if (!$statement instanceof PDOStatement) {
+            throw new RuntimeException('Failed to prepare SQLite db-apply progress marker statement.');
+        }
+        $statement->bindValue(':statements_executed', $statements_executed, PDO::PARAM_INT);
+        $statement->bindValue(':bytes_read', $bytes_read, PDO::PARAM_INT);
+        if ($statement->execute() === false) {
+            throw new RuntimeException('Failed to update SQLite db-apply progress marker.');
+        }
+    }
+
+    private function begin_sqlite_db_apply_batch(PDO $pdo, bool &$batch_active): void
+    {
+        if ($batch_active) {
+            return;
+        }
+
+        $pdo->beginTransaction();
+        $batch_active = true;
+    }
+
+    private function commit_sqlite_db_apply_batch(
+        PDO $pdo,
+        PDO $sqlite_pdo,
+        bool &$batch_active,
+        int &$batch_statements,
+        int $statements_executed,
+        int $bytes_read
+    ): bool {
+        if (!$batch_active) {
+            return false;
+        }
+
+        $this->update_sqlite_db_apply_progress_marker($sqlite_pdo, $statements_executed, $bytes_read);
+        $pdo->commit();
+        $batch_active = false;
+        $batch_statements = 0;
+        return true;
+    }
+
+    private function rollback_sqlite_db_apply_transaction(PDO $pdo, bool &$transaction_active, int &$batch_statements): void
+    {
+        if (!$transaction_active) {
+            return;
+        }
+
+        try {
+            $pdo->rollBack();
+        } catch (Throwable $_) {
+            // The wrapper may already have rolled back after an execution error.
+        }
+
+        $transaction_active = false;
+        $batch_statements = 0;
+    }
+
+    private function sqlite_db_apply_statement_class(string $sql): string
+    {
+        $tokens = $this->sqlite_db_apply_leading_keywords($sql, 3);
+        if (empty($tokens)) {
+            return 'regular';
+        }
+
+        $first = $tokens[0];
+        $second = $tokens[1] ?? null;
+
+        if ($first === 'SET') {
+            return 'set';
+        }
+
+        if (in_array($first, ['ALTER', 'CREATE', 'DROP', 'RENAME', 'TRUNCATE'], true)) {
+            return 'ddl';
+        }
+
+        if ($first === 'START' && $second === 'TRANSACTION') {
+            return 'transaction_begin';
+        }
+
+        if ($first === 'BEGIN') {
+            return 'transaction_begin';
+        }
+
+        if ($first === 'COMMIT') {
+            return 'transaction_commit';
+        }
+
+        if ($first === 'ROLLBACK') {
+            return $second === 'TO' ? 'transaction_other' : 'transaction_rollback';
+        }
+
+        if ($first === 'LOCK') {
+            return 'transaction_begin';
+        }
+
+        if ($first === 'UNLOCK') {
+            return 'transaction_commit';
+        }
+
+        if ($first === 'SAVEPOINT' || $first === 'RELEASE') {
+            return 'transaction_other';
+        }
+
+        return 'regular';
+    }
+
+    /**
+     * @return string[]
+     */
+    private function sqlite_db_apply_leading_keywords(string $sql, int $max_tokens): array
+    {
+        $tokens = [];
+        $length = strlen($sql);
+        $i = 0;
+
+        while ($i < $length && count($tokens) < $max_tokens) {
+            while ($i < $length) {
+                $char = $sql[$i];
+                if ($char === ' ' || $char === "\t" || $char === "\n" || $char === "\r" || $char === ';') {
+                    $i++;
+                    continue;
+                }
+
+                if ($char === '#') {
+                    $newline = strpos($sql, "\n", $i + 1);
+                    $i = $newline === false ? $length : $newline + 1;
+                    continue;
+                }
+
+                if (
+                    $char === '-' &&
+                    $i + 2 < $length &&
+                    $sql[$i + 1] === '-' &&
+                    ($sql[$i + 2] === ' ' || $sql[$i + 2] === "\t" || $sql[$i + 2] === "\r" || $sql[$i + 2] === "\n")
+                ) {
+                    $newline = strpos($sql, "\n", $i + 2);
+                    $i = $newline === false ? $length : $newline + 1;
+                    continue;
+                }
+
+                if ($char === '/' && $i + 1 < $length && $sql[$i + 1] === '*') {
+                    if ($i + 2 < $length && $sql[$i + 2] === '!') {
+                        $i += 3;
+                        while ($i < $length && $sql[$i] >= '0' && $sql[$i] <= '9') {
+                            $i++;
+                        }
+                        continue;
+                    }
+
+                    $end = strpos($sql, '*/', $i + 2);
+                    $i = $end === false ? $length : $end + 2;
+                    continue;
+                }
+
+                if ($char === '*' && $i + 1 < $length && $sql[$i + 1] === '/') {
+                    $i += 2;
+                    continue;
+                }
+
+                break;
+            }
+
+            if ($i >= $length) {
+                break;
+            }
+
+            $char = $sql[$i];
+            $is_alpha = ($char >= 'A' && $char <= 'Z') || ($char >= 'a' && $char <= 'z') || $char === '_';
+            if (!$is_alpha) {
+                break;
+            }
+
+            $start = $i;
+            $i++;
+            while ($i < $length) {
+                $char = $sql[$i];
+                $is_keyword_char =
+                    ($char >= 'A' && $char <= 'Z') ||
+                    ($char >= 'a' && $char <= 'z') ||
+                    ($char >= '0' && $char <= '9') ||
+                    $char === '_';
+                if (!$is_keyword_char) {
+                    break;
+                }
+                $i++;
+            }
+
+            $tokens[] = strtoupper(substr($sql, $start, $i - $start));
+        }
+
+        return $tokens;
+    }
+
+    private function sqlite_db_apply_statement_flushes_batch(string $class): bool
+    {
+        return in_array($class, [
+            'set',
+            'ddl',
+            'transaction_begin',
+            'transaction_commit',
+            'transaction_rollback',
+            'transaction_other',
+        ], true);
+    }
+
     public function run_db_apply(array $options): void
     {
         $sql_file = $this->state_dir . "/db.sql";
@@ -5050,7 +5308,8 @@ class ImportClient
         $apply_state = $this->state["apply"] ?? $this->default_state()["apply"];
         $statements_executed = (int) ($apply_state["statements_executed"] ?? 0);
         $bytes_read = (int) ($apply_state["bytes_read"] ?? 0);
-        $is_resume = $current_status === "in_progress" && $statements_executed > 0;
+        $is_resume = in_array($current_status, ["in_progress", "partial"], true)
+            && ($statements_executed > 0 || $bytes_read > 0);
 
         if ($is_resume) {
             $this->audit_log(
@@ -5137,6 +5396,55 @@ class ImportClient
             );
         }
 
+        if ($sqlite_prepared_pdo !== null) {
+            $this->initialize_sqlite_db_apply_progress_marker($sqlite_prepared_pdo);
+            $marker = $this->read_sqlite_db_apply_progress_marker($sqlite_prepared_pdo);
+
+            if ($is_resume) {
+                if ($marker === null && ($statements_executed > 0 || $bytes_read > 0)) {
+                    // Legacy partial imports predate the in-target marker and
+                    // executed each statement in autocommit mode.
+                    $this->update_sqlite_db_apply_progress_marker(
+                        $sqlite_prepared_pdo,
+                        $statements_executed,
+                        $bytes_read,
+                    );
+                    $this->audit_log(
+                        sprintf(
+                            "SQLite db-apply progress marker initialized from JSON state | statements=%d | bytes_read=%d",
+                            $statements_executed,
+                            $bytes_read,
+                        ),
+                        true,
+                    );
+                } elseif (
+                    $marker !== null &&
+                    (
+                        $marker["statements_executed"] !== $statements_executed ||
+                        $marker["bytes_read"] !== $bytes_read
+                    )
+                ) {
+                    $this->audit_log(
+                        sprintf(
+                            "SQLite db-apply progress reconciled | json_statements=%d | json_bytes=%d | marker_statements=%d | marker_bytes=%d",
+                            $statements_executed,
+                            $bytes_read,
+                            $marker["statements_executed"],
+                            $marker["bytes_read"],
+                        ),
+                        true,
+                    );
+                    $statements_executed = $marker["statements_executed"];
+                    $bytes_read = $marker["bytes_read"];
+                    $this->state["apply"]["statements_executed"] = $statements_executed;
+                    $this->state["apply"]["bytes_read"] = $bytes_read;
+                    $this->save_state($this->state);
+                }
+            } else {
+                $this->update_sqlite_db_apply_progress_marker($sqlite_prepared_pdo, 0, 0);
+            }
+        }
+
         $this->audit_log(
             "CONNECTED | {$connection_label}",
             false,
@@ -5177,6 +5485,11 @@ class ImportClient
         $skipped = 0;
         $save_every = 100;
         $stmts_since_save = 0;
+        $stmts_since_progress = 0;
+        $last_committed_bytes_read = $bytes_read;
+        $sqlite_batch_active = false;
+        $sqlite_batch_statements = 0;
+        $sqlite_sql_transaction_active = false;
 
         // Load pre-computed statement count from db-pull for progress reporting
         $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
@@ -5210,6 +5523,211 @@ class ImportClient
             "message" => "Applying SQL" . ($statements_total !== null ? " ({$statements_total} statements)" : ""),
         ]);
 
+        $save_apply_state = function (int $statement_count, int $byte_offset, ?string $status = null): void {
+            $this->state["apply"]["statements_executed"] = $statement_count;
+            $this->state["apply"]["bytes_read"] = $byte_offset;
+            if ($status !== null) {
+                $this->state["status"] = $status;
+            }
+            $this->save_state($this->state);
+        };
+
+        $emit_apply_progress = function () use (&$total_bytes_read, $sql_file_size, &$statements_executed, $statements_total): void {
+            $apply_fraction = $sql_file_size > 0
+                ? $total_bytes_read / $sql_file_size
+                : null;
+            $pct = $apply_fraction !== null ? round($apply_fraction * 100, 1) : 0;
+
+            $progress_message = sprintf(
+                "%s statements",
+                $statements_total === null
+                    ? number_format($statements_executed)
+                    : number_format($statements_executed) . " / " . number_format($statements_total),
+            );
+
+            $this->output_progress([
+                "phase" => "db-apply",
+                "statements_executed" => $statements_executed,
+                "bytes_read" => $total_bytes_read,
+                "bytes_total" => $sql_file_size,
+                "pct" => $pct,
+                "statements_total" => $statements_total,
+                "message" => $progress_message,
+            ]);
+
+            $this->progress->show_progress_line($progress_message, $apply_fraction);
+        };
+
+        $process_db_apply_query = function (string $query) use (
+            $pdo,
+            $stmt_rewriter,
+            &$sqlite_prepared_pdo,
+            &$sqlite_prepared_statement_cache,
+            &$sqlite_prepared_statement_cache_order,
+            &$sqlite_batch_active,
+            &$sqlite_batch_statements,
+            &$sqlite_sql_transaction_active,
+            &$statements_executed,
+            &$last_committed_bytes_read,
+            &$stmts_since_save,
+            &$stmts_since_progress,
+            $save_every,
+            $query_stream,
+            $seek_offset,
+            $save_apply_state,
+            $emit_apply_progress,
+            &$stmt_count
+        ): void {
+            $query_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+            $sqlite_statement_class = $sqlite_prepared_pdo !== null
+                ? $this->sqlite_db_apply_statement_class($query)
+                : 'regular';
+            $sqlite_flushes_batch = $sqlite_prepared_pdo !== null
+                && $this->sqlite_db_apply_statement_flushes_batch($sqlite_statement_class);
+            $sqlite_pre_marked_commit = false;
+
+            if ($sqlite_prepared_pdo !== null && $sqlite_flushes_batch && $sqlite_batch_active) {
+                $this->commit_sqlite_db_apply_batch(
+                    $pdo,
+                    $sqlite_prepared_pdo,
+                    $sqlite_batch_active,
+                    $sqlite_batch_statements,
+                    $statements_executed,
+                    $last_committed_bytes_read,
+                );
+                $save_apply_state($statements_executed, $last_committed_bytes_read);
+                $stmts_since_save = 0;
+            }
+
+            if (
+                $sqlite_prepared_pdo !== null &&
+                $sqlite_sql_transaction_active &&
+                $sqlite_statement_class === 'transaction_begin'
+            ) {
+                $this->update_sqlite_db_apply_progress_marker(
+                    $sqlite_prepared_pdo,
+                    $statements_executed,
+                    $last_committed_bytes_read,
+                );
+            }
+
+            if (
+                $sqlite_prepared_pdo !== null &&
+                $sqlite_sql_transaction_active &&
+                $sqlite_statement_class === 'transaction_commit'
+            ) {
+                $this->update_sqlite_db_apply_progress_marker(
+                    $sqlite_prepared_pdo,
+                    $statements_executed + 1,
+                    $query_bytes_read,
+                );
+                $sqlite_pre_marked_commit = true;
+            }
+
+            if (
+                $sqlite_prepared_pdo !== null &&
+                !$sqlite_sql_transaction_active &&
+                !$sqlite_flushes_batch
+            ) {
+                $this->begin_sqlite_db_apply_batch($pdo, $sqlite_batch_active);
+            }
+
+            $executed_query = $query;
+            try {
+                $this->execute_db_apply_query(
+                    $pdo,
+                    $query,
+                    $stmt_rewriter,
+                    $sqlite_prepared_pdo,
+                    $sqlite_prepared_statement_cache,
+                    $sqlite_prepared_statement_cache_order,
+                    $executed_query,
+                );
+            } catch (PDOException $e) {
+                $this->audit_log(
+                    sprintf(
+                        "SQL ERROR | stmt=%d | %s | query=%.200s",
+                        $stmt_count,
+                        $e->getMessage(),
+                        $executed_query,
+                    ),
+                    true,
+                );
+                throw new RuntimeException(
+                    "SQL execution error at statement {$stmt_count}: " .
+                    $e->getMessage(),
+                );
+            }
+
+            $statements_executed++;
+            $last_committed_bytes_read = $query_bytes_read;
+            $stmts_since_save++;
+            $stmts_since_progress++;
+
+            if ($sqlite_prepared_pdo !== null) {
+                if ($sqlite_statement_class === 'transaction_begin') {
+                    $sqlite_sql_transaction_active = true;
+                } elseif ($sqlite_statement_class === 'transaction_commit') {
+                    $sqlite_sql_transaction_active = false;
+                    if (!$sqlite_pre_marked_commit) {
+                        $this->update_sqlite_db_apply_progress_marker(
+                            $sqlite_prepared_pdo,
+                            $statements_executed,
+                            $last_committed_bytes_read,
+                        );
+                    }
+                    $save_apply_state($statements_executed, $last_committed_bytes_read);
+                    $stmts_since_save = 0;
+                } elseif ($sqlite_statement_class === 'transaction_rollback') {
+                    $sqlite_sql_transaction_active = false;
+                    $this->update_sqlite_db_apply_progress_marker(
+                        $sqlite_prepared_pdo,
+                        $statements_executed,
+                        $last_committed_bytes_read,
+                    );
+                    $save_apply_state($statements_executed, $last_committed_bytes_read);
+                    $stmts_since_save = 0;
+                } elseif ($sqlite_flushes_batch) {
+                    if (!$sqlite_sql_transaction_active) {
+                        $this->update_sqlite_db_apply_progress_marker(
+                            $sqlite_prepared_pdo,
+                            $statements_executed,
+                            $last_committed_bytes_read,
+                        );
+                        if ($stmts_since_save >= $save_every) {
+                            $save_apply_state($statements_executed, $last_committed_bytes_read);
+                            $stmts_since_save = 0;
+                        }
+                    }
+                } elseif ($sqlite_sql_transaction_active) {
+                    // Source-controlled transaction: marker advances only when
+                    // COMMIT/ROLLBACK makes the transaction outcome durable.
+                } elseif ($sqlite_batch_active) {
+                    $sqlite_batch_statements++;
+                    if ($sqlite_batch_statements >= self::SQLITE_DB_APPLY_BATCH_SIZE) {
+                        $this->commit_sqlite_db_apply_batch(
+                            $pdo,
+                            $sqlite_prepared_pdo,
+                            $sqlite_batch_active,
+                            $sqlite_batch_statements,
+                            $statements_executed,
+                            $last_committed_bytes_read,
+                        );
+                        $save_apply_state($statements_executed, $last_committed_bytes_read);
+                        $stmts_since_save = 0;
+                    }
+                }
+            } elseif ($stmts_since_save >= $save_every) {
+                $save_apply_state($statements_executed, $last_committed_bytes_read);
+                $stmts_since_save = 0;
+            }
+
+            if ($stmts_since_progress >= $save_every) {
+                $emit_apply_progress();
+                $stmts_since_progress = 0;
+            }
+        };
+
         try {
             $chunk_size = 64 * 1024; // 64KB read chunks
 
@@ -5237,76 +5755,11 @@ class ImportClient
                     // Skip already-executed statements on resume
                     if ($stmts_to_skip > 0) {
                         $stmts_to_skip--;
+                        $last_committed_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
                         continue;
                     }
 
-                    // Execute against target database
-                    $executed_query = $query;
-                    try {
-                        $this->execute_db_apply_query(
-                            $pdo,
-                            $query,
-                            $stmt_rewriter,
-                            $sqlite_prepared_pdo,
-                            $sqlite_prepared_statement_cache,
-                            $sqlite_prepared_statement_cache_order,
-                            $executed_query,
-                        );
-                    } catch (PDOException $e) {
-                        $this->audit_log(
-                            sprintf(
-                                "SQL ERROR | stmt=%d | %s | query=%.200s",
-                                $stmt_count,
-                                $e->getMessage(),
-                                $executed_query,
-                            ),
-                            true,
-                        );
-                        throw new RuntimeException(
-                            "SQL execution error at statement {$stmt_count}: " .
-                            $e->getMessage(),
-                        );
-                    }
-
-                    $statements_executed++;
-                    $stmts_since_save++;
-
-                    // Save state periodically. bytes_read is the file offset
-                    // right after the last extracted query — NOT total_bytes_read,
-                    // which includes bytes buffered in the query stream that haven't
-                    // formed a complete query yet. This ensures resumption starts at
-                    // the exact boundary between executed and un-executed queries.
-                    if ($stmts_since_save >= $save_every) {
-                        $this->state["apply"]["statements_executed"] = $statements_executed;
-                        $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
-                        $this->save_state($this->state);
-                        $stmts_since_save = 0;
-
-                        // Progress output
-                        $apply_fraction = $sql_file_size > 0
-                            ? $total_bytes_read / $sql_file_size
-                            : null;
-                        $pct = $apply_fraction !== null ? round($apply_fraction * 100, 1) : 0;
-
-                        $progress_message = sprintf(
-                            "%s statements",
-                            $statements_total === null
-                                ? number_format($statements_executed)
-                                : number_format($statements_executed) . " / " . number_format($statements_total),
-                        );
-
-                        $this->output_progress([
-                            "phase" => "db-apply",
-                            "statements_executed" => $statements_executed,
-                            "bytes_read" => $total_bytes_read,
-                            "bytes_total" => $sql_file_size,
-                            "pct" => $pct,
-                            "statements_total" => $statements_total,
-                            "message" => $progress_message,
-                        ]);
-
-                        $this->progress->show_progress_line($progress_message, $apply_fraction);
-                    }
+                    $process_db_apply_query($query);
                 }
             }
 
@@ -5318,45 +5771,65 @@ class ImportClient
 
                 if ($stmts_to_skip > 0) {
                     $stmts_to_skip--;
+                    $last_committed_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
                     continue;
                 }
 
-                $executed_query = $query;
-                try {
-                    $this->execute_db_apply_query(
-                        $pdo,
-                        $query,
-                        $stmt_rewriter,
-                        $sqlite_prepared_pdo,
-                        $sqlite_prepared_statement_cache,
-                        $sqlite_prepared_statement_cache_order,
-                        $executed_query,
-                    );
-                } catch (PDOException $e) {
-                    $this->audit_log(
-                        sprintf(
-                            "SQL ERROR | stmt=%d | %s | query=%.200s",
-                            $stmt_count,
-                            $e->getMessage(),
-                            $executed_query,
-                        ),
-                        true,
-                    );
-                    throw new RuntimeException(
-                        "SQL execution error at statement {$stmt_count}: " .
-                        $e->getMessage(),
-                    );
-                }
+                $process_db_apply_query($query);
+            }
 
-                $statements_executed++;
+            if ($sqlite_prepared_pdo !== null) {
+                if ($this->shutdown_requested) {
+                    if ($sqlite_sql_transaction_active) {
+                        $this->rollback_sqlite_db_apply_transaction(
+                            $pdo,
+                            $sqlite_sql_transaction_active,
+                            $sqlite_batch_statements,
+                        );
+                        $marker = $this->read_sqlite_db_apply_progress_marker($sqlite_prepared_pdo);
+                        $statements_executed = $marker["statements_executed"] ?? 0;
+                        $last_committed_bytes_read = $marker["bytes_read"] ?? 0;
+                    } elseif ($sqlite_batch_active) {
+                        $this->commit_sqlite_db_apply_batch(
+                            $pdo,
+                            $sqlite_prepared_pdo,
+                            $sqlite_batch_active,
+                            $sqlite_batch_statements,
+                            $statements_executed,
+                            $last_committed_bytes_read,
+                        );
+                    }
+                } else {
+                    if ($sqlite_batch_active) {
+                        $this->commit_sqlite_db_apply_batch(
+                            $pdo,
+                            $sqlite_prepared_pdo,
+                            $sqlite_batch_active,
+                            $sqlite_batch_statements,
+                            $statements_executed,
+                            $last_committed_bytes_read,
+                        );
+                        $save_apply_state($statements_executed, $last_committed_bytes_read);
+                        $stmts_since_save = 0;
+                    }
+
+                    if ($sqlite_sql_transaction_active) {
+                        $this->update_sqlite_db_apply_progress_marker(
+                            $sqlite_prepared_pdo,
+                            $statements_executed,
+                            $last_committed_bytes_read,
+                        );
+                        $pdo->commit();
+                        $sqlite_sql_transaction_active = false;
+                        $save_apply_state($statements_executed, $last_committed_bytes_read);
+                        $stmts_since_save = 0;
+                    }
+                }
             }
 
             if ($this->shutdown_requested) {
                 // Save partial progress
-                $this->state["apply"]["statements_executed"] = $statements_executed;
-                $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
-                $this->state["status"] = "partial";
-                $this->save_state($this->state);
+                $save_apply_state($statements_executed, $last_committed_bytes_read, "partial");
                 $this->audit_log(
                     sprintf(
                         "PARTIAL db-apply | %d statements executed",
@@ -5398,10 +5871,7 @@ class ImportClient
                 }
 
                 // Mark complete
-                $this->state["apply"]["statements_executed"] = $statements_executed;
-                $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
-                $this->state["status"] = "complete";
-                $this->save_state($this->state);
+                $save_apply_state($statements_executed, $last_committed_bytes_read, "complete");
 
                 $this->audit_log(
                     sprintf(
@@ -5425,6 +5895,20 @@ class ImportClient
                 }
                 $this->progress->show_lifecycle_line("db-apply complete ({$statements_executed} statements executed)\n");
             }
+        } catch (Throwable $e) {
+            if ($sqlite_prepared_pdo !== null) {
+                $this->rollback_sqlite_db_apply_transaction(
+                    $pdo,
+                    $sqlite_batch_active,
+                    $sqlite_batch_statements,
+                );
+                $this->rollback_sqlite_db_apply_transaction(
+                    $pdo,
+                    $sqlite_sql_transaction_active,
+                    $sqlite_batch_statements,
+                );
+            }
+            throw $e;
         } finally {
             fclose($sql_handle);
         }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4991,262 +4991,6 @@ class ImportClient
         ];
     }
 
-    private function sqlite_db_apply_progress_table_sql(): string
-    {
-        return '"' . str_replace('"', '""', self::SQLITE_DB_APPLY_PROGRESS_TABLE) . '"';
-    }
-
-    private function initialize_sqlite_db_apply_progress_marker(PDO $sqlite_pdo): void
-    {
-        $table = $this->sqlite_db_apply_progress_table_sql();
-        $sqlite_pdo->exec(
-            "CREATE TABLE IF NOT EXISTS {$table} (" .
-            "id INTEGER PRIMARY KEY CHECK (id = 1), " .
-            "statements_executed INTEGER NOT NULL, " .
-            "bytes_read INTEGER NOT NULL, " .
-            "updated_at TEXT NOT NULL" .
-            ")"
-        );
-    }
-
-    /**
-     * @return array{statements_executed:int,bytes_read:int}|null
-     */
-    private function read_sqlite_db_apply_progress_marker(PDO $sqlite_pdo): ?array
-    {
-        $this->initialize_sqlite_db_apply_progress_marker($sqlite_pdo);
-
-        $table = $this->sqlite_db_apply_progress_table_sql();
-        $row = $sqlite_pdo
-            ->query("SELECT statements_executed, bytes_read FROM {$table} WHERE id = 1")
-            ->fetch(PDO::FETCH_ASSOC);
-        if (!is_array($row)) {
-            return null;
-        }
-
-        return [
-            "statements_executed" => (int) $row["statements_executed"],
-            "bytes_read" => (int) $row["bytes_read"],
-        ];
-    }
-
-    private function update_sqlite_db_apply_progress_marker(
-        PDO $sqlite_pdo,
-        int $statements_executed,
-        int $bytes_read
-    ): void {
-        $table = $this->sqlite_db_apply_progress_table_sql();
-        $statement = $sqlite_pdo->prepare(
-            "INSERT INTO {$table} (id, statements_executed, bytes_read, updated_at) " .
-            "VALUES (1, :statements_executed, :bytes_read, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) " .
-            "ON CONFLICT(id) DO UPDATE SET " .
-            "statements_executed = excluded.statements_executed, " .
-            "bytes_read = excluded.bytes_read, " .
-            "updated_at = excluded.updated_at"
-        );
-        if (!$statement instanceof PDOStatement) {
-            throw new RuntimeException('Failed to prepare SQLite db-apply progress marker statement.');
-        }
-        $statement->bindValue(':statements_executed', $statements_executed, PDO::PARAM_INT);
-        $statement->bindValue(':bytes_read', $bytes_read, PDO::PARAM_INT);
-        if ($statement->execute() === false) {
-            throw new RuntimeException('Failed to update SQLite db-apply progress marker.');
-        }
-    }
-
-    private function begin_sqlite_db_apply_batch(PDO $pdo, bool &$batch_active): void
-    {
-        if ($batch_active) {
-            return;
-        }
-
-        $pdo->beginTransaction();
-        $batch_active = true;
-    }
-
-    private function commit_sqlite_db_apply_batch(
-        PDO $pdo,
-        PDO $sqlite_pdo,
-        bool &$batch_active,
-        int &$batch_statements,
-        int $statements_executed,
-        int $bytes_read
-    ): bool {
-        if (!$batch_active) {
-            return false;
-        }
-
-        $this->update_sqlite_db_apply_progress_marker($sqlite_pdo, $statements_executed, $bytes_read);
-        $pdo->commit();
-        $batch_active = false;
-        $batch_statements = 0;
-        return true;
-    }
-
-    private function rollback_sqlite_db_apply_transaction(PDO $pdo, bool &$transaction_active, int &$batch_statements): void
-    {
-        if (!$transaction_active) {
-            return;
-        }
-
-        try {
-            $pdo->rollBack();
-        } catch (Throwable $_) {
-            // The wrapper may already have rolled back after an execution error.
-        }
-
-        $transaction_active = false;
-        $batch_statements = 0;
-    }
-
-    private function sqlite_db_apply_statement_class(string $sql): string
-    {
-        $tokens = $this->sqlite_db_apply_leading_keywords($sql, 3);
-        if (empty($tokens)) {
-            return 'regular';
-        }
-
-        $first = $tokens[0];
-        $second = $tokens[1] ?? null;
-
-        if ($first === 'SET') {
-            return 'set';
-        }
-
-        if (in_array($first, ['ALTER', 'CREATE', 'DROP', 'RENAME', 'TRUNCATE'], true)) {
-            return 'ddl';
-        }
-
-        if ($first === 'START' && $second === 'TRANSACTION') {
-            return 'transaction_begin';
-        }
-
-        if ($first === 'BEGIN') {
-            return 'transaction_begin';
-        }
-
-        if ($first === 'COMMIT') {
-            return 'transaction_commit';
-        }
-
-        if ($first === 'ROLLBACK') {
-            return $second === 'TO' ? 'transaction_other' : 'transaction_rollback';
-        }
-
-        if ($first === 'LOCK') {
-            return 'transaction_begin';
-        }
-
-        if ($first === 'UNLOCK') {
-            return 'transaction_commit';
-        }
-
-        if ($first === 'SAVEPOINT' || $first === 'RELEASE') {
-            return 'transaction_other';
-        }
-
-        return 'regular';
-    }
-
-    /**
-     * @return string[]
-     */
-    private function sqlite_db_apply_leading_keywords(string $sql, int $max_tokens): array
-    {
-        $tokens = [];
-        $length = strlen($sql);
-        $i = 0;
-
-        while ($i < $length && count($tokens) < $max_tokens) {
-            while ($i < $length) {
-                $char = $sql[$i];
-                if ($char === ' ' || $char === "\t" || $char === "\n" || $char === "\r" || $char === ';') {
-                    $i++;
-                    continue;
-                }
-
-                if ($char === '#') {
-                    $newline = strpos($sql, "\n", $i + 1);
-                    $i = $newline === false ? $length : $newline + 1;
-                    continue;
-                }
-
-                if (
-                    $char === '-' &&
-                    $i + 2 < $length &&
-                    $sql[$i + 1] === '-' &&
-                    ($sql[$i + 2] === ' ' || $sql[$i + 2] === "\t" || $sql[$i + 2] === "\r" || $sql[$i + 2] === "\n")
-                ) {
-                    $newline = strpos($sql, "\n", $i + 2);
-                    $i = $newline === false ? $length : $newline + 1;
-                    continue;
-                }
-
-                if ($char === '/' && $i + 1 < $length && $sql[$i + 1] === '*') {
-                    if ($i + 2 < $length && $sql[$i + 2] === '!') {
-                        $i += 3;
-                        while ($i < $length && $sql[$i] >= '0' && $sql[$i] <= '9') {
-                            $i++;
-                        }
-                        continue;
-                    }
-
-                    $end = strpos($sql, '*/', $i + 2);
-                    $i = $end === false ? $length : $end + 2;
-                    continue;
-                }
-
-                if ($char === '*' && $i + 1 < $length && $sql[$i + 1] === '/') {
-                    $i += 2;
-                    continue;
-                }
-
-                break;
-            }
-
-            if ($i >= $length) {
-                break;
-            }
-
-            $char = $sql[$i];
-            $is_alpha = ($char >= 'A' && $char <= 'Z') || ($char >= 'a' && $char <= 'z') || $char === '_';
-            if (!$is_alpha) {
-                break;
-            }
-
-            $start = $i;
-            $i++;
-            while ($i < $length) {
-                $char = $sql[$i];
-                $is_keyword_char =
-                    ($char >= 'A' && $char <= 'Z') ||
-                    ($char >= 'a' && $char <= 'z') ||
-                    ($char >= '0' && $char <= '9') ||
-                    $char === '_';
-                if (!$is_keyword_char) {
-                    break;
-                }
-                $i++;
-            }
-
-            $tokens[] = strtoupper(substr($sql, $start, $i - $start));
-        }
-
-        return $tokens;
-    }
-
-    private function sqlite_db_apply_statement_flushes_batch(string $class): bool
-    {
-        return in_array($class, [
-            'set',
-            'ddl',
-            'transaction_begin',
-            'transaction_commit',
-            'transaction_rollback',
-            'transaction_other',
-        ], true);
-    }
-
     public function run_db_apply(array $options): void
     {
         $sql_file = $this->state_dir . "/db.sql";
@@ -5395,33 +5139,74 @@ class ImportClient
             );
         }
 
-        if ($sqlite_prepared_pdo !== null) {
-            $this->initialize_sqlite_db_apply_progress_marker($sqlite_prepared_pdo);
-            $marker = $this->read_sqlite_db_apply_progress_marker($sqlite_prepared_pdo);
+        $this->audit_log(
+            "CONNECTED | {$connection_label}",
+            false,
+        );
 
-            if ($is_resume) {
-                if ($marker === null && ($statements_executed > 0 || $bytes_read > 0)) {
-                    // Legacy partial imports predate the in-target marker and
-                    // executed each statement in autocommit mode.
-                    $this->update_sqlite_db_apply_progress_marker(
-                        $sqlite_prepared_pdo,
-                        $statements_executed,
-                        $bytes_read,
+        $sqlite_write_marker = static function (int $statement_count, int $byte_offset): void {
+        };
+        $sqlite_read_marker = static function (): ?array {
+            return null;
+        };
+
+        if ($sqlite_prepared_pdo !== null) {
+            $sqlite_progress_table = '"' . str_replace('"', '""', self::SQLITE_DB_APPLY_PROGRESS_TABLE) . '"';
+            $sqlite_prepared_pdo->exec(
+                "CREATE TABLE IF NOT EXISTS {$sqlite_progress_table} (" .
+                "id INTEGER PRIMARY KEY CHECK (id = 1), " .
+                "statements_executed INTEGER NOT NULL, " .
+                "bytes_read INTEGER NOT NULL, " .
+                "updated_at TEXT NOT NULL" .
+                ")"
+            );
+
+            $sqlite_marker_statement = null;
+            $sqlite_write_marker = static function (
+                int $statement_count,
+                int $byte_offset
+            ) use ($sqlite_prepared_pdo, $sqlite_progress_table, &$sqlite_marker_statement): void {
+                if (!$sqlite_marker_statement instanceof PDOStatement) {
+                    $sqlite_marker_statement = $sqlite_prepared_pdo->prepare(
+                        "INSERT INTO {$sqlite_progress_table} (id, statements_executed, bytes_read, updated_at) " .
+                        "VALUES (1, :statements_executed, :bytes_read, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) " .
+                        "ON CONFLICT(id) DO UPDATE SET " .
+                        "statements_executed = excluded.statements_executed, " .
+                        "bytes_read = excluded.bytes_read, " .
+                        "updated_at = excluded.updated_at"
                     );
-                    $this->audit_log(
-                        sprintf(
-                            "SQLite db-apply progress marker initialized from JSON state | statements=%d | bytes_read=%d",
-                            $statements_executed,
-                            $bytes_read,
-                        ),
-                        true,
-                    );
-                } elseif (
-                    $marker !== null &&
-                    (
-                        $marker["statements_executed"] !== $statements_executed ||
-                        $marker["bytes_read"] !== $bytes_read
-                    )
+                    if (!$sqlite_marker_statement instanceof PDOStatement) {
+                        throw new RuntimeException('Failed to prepare SQLite db-apply progress marker statement.');
+                    }
+                }
+
+                $sqlite_marker_statement->bindValue(':statements_executed', $statement_count, PDO::PARAM_INT);
+                $sqlite_marker_statement->bindValue(':bytes_read', $byte_offset, PDO::PARAM_INT);
+                if ($sqlite_marker_statement->execute() === false) {
+                    throw new RuntimeException('Failed to update SQLite db-apply progress marker.');
+                }
+                $sqlite_marker_statement->closeCursor();
+            };
+
+            $sqlite_read_marker = static function () use ($sqlite_prepared_pdo, $sqlite_progress_table): ?array {
+                $row = $sqlite_prepared_pdo
+                    ->query("SELECT statements_executed, bytes_read FROM {$sqlite_progress_table} WHERE id = 1")
+                    ->fetch(PDO::FETCH_ASSOC);
+                if (!is_array($row)) {
+                    return null;
+                }
+
+                return [
+                    "statements_executed" => (int) $row["statements_executed"],
+                    "bytes_read" => (int) $row["bytes_read"],
+                ];
+            };
+
+            $marker = $sqlite_read_marker();
+            if ($is_resume && $marker !== null) {
+                if (
+                    $marker["statements_executed"] !== $statements_executed ||
+                    $marker["bytes_read"] !== $bytes_read
                 ) {
                     $this->audit_log(
                         sprintf(
@@ -5433,21 +5218,26 @@ class ImportClient
                         ),
                         true,
                     );
-                    $statements_executed = $marker["statements_executed"];
-                    $bytes_read = $marker["bytes_read"];
-                    $this->state["apply"]["statements_executed"] = $statements_executed;
-                    $this->state["apply"]["bytes_read"] = $bytes_read;
-                    $this->save_state($this->state);
                 }
+                $statements_executed = $marker["statements_executed"];
+                $bytes_read = $marker["bytes_read"];
+                $this->state["apply"]["statements_executed"] = $statements_executed;
+                $this->state["apply"]["bytes_read"] = $bytes_read;
+                $this->save_state($this->state);
+            } elseif ($is_resume && ($statements_executed > 0 || $bytes_read > 0)) {
+                $sqlite_write_marker($statements_executed, $bytes_read);
+                $this->audit_log(
+                    sprintf(
+                        "SQLite db-apply progress marker initialized from JSON state | statements=%d | bytes_read=%d",
+                        $statements_executed,
+                        $bytes_read,
+                    ),
+                    true,
+                );
             } else {
-                $this->update_sqlite_db_apply_progress_marker($sqlite_prepared_pdo, 0, 0);
+                $sqlite_write_marker(0, 0);
             }
         }
-
-        $this->audit_log(
-            "CONNECTED | {$connection_label}",
-            false,
-        );
 
         // Stream db.sql through the query stream and execute. Use the
         // fast strcspn-based parser by default; it self-falls-back to
@@ -5481,14 +5271,12 @@ class ImportClient
         $sql_file_size = filesize($sql_file);
         $total_bytes_read = 0;
         $stmt_count = 0;
-        $skipped = 0;
         $save_every = 100;
         $stmts_since_save = 0;
         $stmts_since_progress = 0;
-        $last_committed_bytes_read = $bytes_read;
+        $last_executed_bytes_read = $bytes_read;
         $sqlite_batch_active = false;
         $sqlite_batch_statements = 0;
-        $sqlite_sql_transaction_active = false;
 
         // Load pre-computed statement count from db-pull for progress reporting
         $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
@@ -5557,17 +5345,78 @@ class ImportClient
             $this->progress->show_progress_line($progress_message, $apply_fraction);
         };
 
+        $sqlite_skips_own_transaction_control = static function (string $query): bool {
+            $first_non_space = strspn($query, " \t\r\n\f\v");
+            if ($first_non_space >= strlen($query)) {
+                return false;
+            }
+
+            // Imports are mostly INSERTs. Only statements that could be a
+            // transaction/locking command, or a comment before one, pay for
+            // tokenization here.
+            $first_byte = $query[$first_non_space];
+            if (
+                stripos('BCSLRU', $first_byte) === false &&
+                $first_byte !== '/' &&
+                $first_byte !== '-' &&
+                $first_byte !== '#'
+            ) {
+                return false;
+            }
+
+            $tokens = [];
+            $lexer = new \WP_MySQL_Lexer($query);
+            while ($lexer->next_token()) {
+                $token = $lexer->get_token();
+                if (
+                    $token->id === \WP_MySQL_Lexer::WHITESPACE ||
+                    $token->id === \WP_MySQL_Lexer::COMMENT ||
+                    $token->id === \WP_MySQL_Lexer::MYSQL_COMMENT_START ||
+                    $token->id === \WP_MySQL_Lexer::MYSQL_COMMENT_END ||
+                    $token->id === \WP_MySQL_Lexer::EOF
+                ) {
+                    continue;
+                }
+
+                // Versioned MySQL comments lex their version tag before the
+                // executable statement, e.g. /*!40101 COMMIT */.
+                if (empty($tokens) && $first_byte === '/' && $token->id === \WP_MySQL_Lexer::INT_NUMBER) {
+                    continue;
+                }
+
+                $tokens[] = $token->id;
+                if (count($tokens) >= 2) {
+                    break;
+                }
+            }
+
+            $first_token = $tokens[0] ?? null;
+            if ($first_token === \WP_MySQL_Lexer::START_SYMBOL) {
+                return ($tokens[1] ?? null) === \WP_MySQL_Lexer::TRANSACTION_SYMBOL;
+            }
+
+            return in_array($first_token, [
+                \WP_MySQL_Lexer::BEGIN_SYMBOL,
+                \WP_MySQL_Lexer::COMMIT_SYMBOL,
+                \WP_MySQL_Lexer::ROLLBACK_SYMBOL,
+                \WP_MySQL_Lexer::LOCK_SYMBOL,
+                \WP_MySQL_Lexer::UNLOCK_SYMBOL,
+                \WP_MySQL_Lexer::SAVEPOINT_SYMBOL,
+                \WP_MySQL_Lexer::RELEASE_SYMBOL,
+            ], true);
+        };
+
         $process_db_apply_query = function (string $query) use (
             $pdo,
             $stmt_rewriter,
             &$sqlite_prepared_pdo,
             &$sqlite_prepared_statement_cache,
             &$sqlite_prepared_statement_cache_order,
+            $sqlite_write_marker,
             &$sqlite_batch_active,
             &$sqlite_batch_statements,
-            &$sqlite_sql_transaction_active,
             &$statements_executed,
-            &$last_committed_bytes_read,
+            &$last_executed_bytes_read,
             &$stmts_since_save,
             &$stmts_since_progress,
             $save_every,
@@ -5575,73 +5424,35 @@ class ImportClient
             $seek_offset,
             $save_apply_state,
             $emit_apply_progress,
+            $sqlite_skips_own_transaction_control,
             &$stmt_count
         ): void {
             $query_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
-            $sqlite_statement_class = $sqlite_prepared_pdo !== null
-                ? $this->sqlite_db_apply_statement_class($query)
-                : 'regular';
-            $sqlite_flushes_batch = $sqlite_prepared_pdo !== null
-                && $this->sqlite_db_apply_statement_flushes_batch($sqlite_statement_class);
-            $sqlite_pre_marked_commit = false;
 
-            if ($sqlite_prepared_pdo !== null && $sqlite_flushes_batch && $sqlite_batch_active) {
-                $this->commit_sqlite_db_apply_batch(
-                    $pdo,
-                    $sqlite_prepared_pdo,
-                    $sqlite_batch_active,
-                    $sqlite_batch_statements,
-                    $statements_executed,
-                    $last_committed_bytes_read,
-                );
-                $save_apply_state($statements_executed, $last_committed_bytes_read);
-                $stmts_since_save = 0;
-            }
-
-            if (
-                $sqlite_prepared_pdo !== null &&
-                $sqlite_sql_transaction_active &&
-                $sqlite_statement_class === 'transaction_begin'
-            ) {
-                $this->update_sqlite_db_apply_progress_marker(
-                    $sqlite_prepared_pdo,
-                    $statements_executed,
-                    $last_committed_bytes_read,
-                );
-            }
-
-            if (
-                $sqlite_prepared_pdo !== null &&
-                $sqlite_sql_transaction_active &&
-                $sqlite_statement_class === 'transaction_commit'
-            ) {
-                $this->update_sqlite_db_apply_progress_marker(
-                    $sqlite_prepared_pdo,
-                    $statements_executed + 1,
-                    $query_bytes_read,
-                );
-                $sqlite_pre_marked_commit = true;
-            }
-
-            if (
-                $sqlite_prepared_pdo !== null &&
-                !$sqlite_sql_transaction_active &&
-                !$sqlite_flushes_batch
-            ) {
-                $this->begin_sqlite_db_apply_batch($pdo, $sqlite_batch_active);
+            if ($sqlite_prepared_pdo !== null && !$sqlite_batch_active) {
+                $pdo->beginTransaction();
+                $sqlite_batch_active = true;
             }
 
             $executed_query = $query;
             try {
-                $this->execute_db_apply_query(
-                    $pdo,
-                    $query,
-                    $stmt_rewriter,
-                    $sqlite_prepared_pdo,
-                    $sqlite_prepared_statement_cache,
-                    $sqlite_prepared_statement_cache_order,
-                    $executed_query,
-                );
+                // The SQLite wrapper batch owns transaction durability. MySQL
+                // dump transaction-control statements would otherwise commit
+                // the wrapper transaction without advancing the in-db marker.
+                if (
+                    $sqlite_prepared_pdo === null ||
+                    !$sqlite_skips_own_transaction_control($query)
+                ) {
+                    $this->execute_db_apply_query(
+                        $pdo,
+                        $query,
+                        $stmt_rewriter,
+                        $sqlite_prepared_pdo,
+                        $sqlite_prepared_statement_cache,
+                        $sqlite_prepared_statement_cache_order,
+                        $executed_query,
+                    );
+                }
             } catch (PDOException $e) {
                 $this->audit_log(
                     sprintf(
@@ -5659,66 +5470,25 @@ class ImportClient
             }
 
             $statements_executed++;
-            $last_committed_bytes_read = $query_bytes_read;
-            $stmts_since_save++;
+            $last_executed_bytes_read = $query_bytes_read;
             $stmts_since_progress++;
 
             if ($sqlite_prepared_pdo !== null) {
-                if ($sqlite_statement_class === 'transaction_begin') {
-                    $sqlite_sql_transaction_active = true;
-                } elseif ($sqlite_statement_class === 'transaction_commit') {
-                    $sqlite_sql_transaction_active = false;
-                    if (!$sqlite_pre_marked_commit) {
-                        $this->update_sqlite_db_apply_progress_marker(
-                            $sqlite_prepared_pdo,
-                            $statements_executed,
-                            $last_committed_bytes_read,
-                        );
-                    }
-                    $save_apply_state($statements_executed, $last_committed_bytes_read);
+                $sqlite_batch_statements++;
+                if ($sqlite_batch_statements >= self::SQLITE_DB_APPLY_BATCH_SIZE) {
+                    $sqlite_write_marker($statements_executed, $last_executed_bytes_read);
+                    $pdo->commit();
+                    $sqlite_batch_active = false;
+                    $sqlite_batch_statements = 0;
+                    $save_apply_state($statements_executed, $last_executed_bytes_read);
                     $stmts_since_save = 0;
-                } elseif ($sqlite_statement_class === 'transaction_rollback') {
-                    $sqlite_sql_transaction_active = false;
-                    $this->update_sqlite_db_apply_progress_marker(
-                        $sqlite_prepared_pdo,
-                        $statements_executed,
-                        $last_committed_bytes_read,
-                    );
-                    $save_apply_state($statements_executed, $last_committed_bytes_read);
-                    $stmts_since_save = 0;
-                } elseif ($sqlite_flushes_batch) {
-                    if (!$sqlite_sql_transaction_active) {
-                        $this->update_sqlite_db_apply_progress_marker(
-                            $sqlite_prepared_pdo,
-                            $statements_executed,
-                            $last_committed_bytes_read,
-                        );
-                        if ($stmts_since_save >= $save_every) {
-                            $save_apply_state($statements_executed, $last_committed_bytes_read);
-                            $stmts_since_save = 0;
-                        }
-                    }
-                } elseif ($sqlite_sql_transaction_active) {
-                    // Source-controlled transaction: marker advances only when
-                    // COMMIT/ROLLBACK makes the transaction outcome durable.
-                } elseif ($sqlite_batch_active) {
-                    $sqlite_batch_statements++;
-                    if ($sqlite_batch_statements >= self::SQLITE_DB_APPLY_BATCH_SIZE) {
-                        $this->commit_sqlite_db_apply_batch(
-                            $pdo,
-                            $sqlite_prepared_pdo,
-                            $sqlite_batch_active,
-                            $sqlite_batch_statements,
-                            $statements_executed,
-                            $last_committed_bytes_read,
-                        );
-                        $save_apply_state($statements_executed, $last_committed_bytes_read);
-                        $stmts_since_save = 0;
-                    }
                 }
-            } elseif ($stmts_since_save >= $save_every) {
-                $save_apply_state($statements_executed, $last_committed_bytes_read);
-                $stmts_since_save = 0;
+            } else {
+                $stmts_since_save++;
+                if ($stmts_since_save >= $save_every) {
+                    $save_apply_state($statements_executed, $last_executed_bytes_read);
+                    $stmts_since_save = 0;
+                }
             }
 
             if ($stmts_since_progress >= $save_every) {
@@ -5754,7 +5524,7 @@ class ImportClient
                     // Skip already-executed statements on resume
                     if ($stmts_to_skip > 0) {
                         $stmts_to_skip--;
-                        $last_committed_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                        $last_executed_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
                         continue;
                     }
 
@@ -5770,65 +5540,25 @@ class ImportClient
 
                 if ($stmts_to_skip > 0) {
                     $stmts_to_skip--;
-                    $last_committed_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                    $last_executed_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
                     continue;
                 }
 
                 $process_db_apply_query($query);
             }
 
-            if ($sqlite_prepared_pdo !== null) {
-                if ($this->shutdown_requested) {
-                    if ($sqlite_sql_transaction_active) {
-                        $this->rollback_sqlite_db_apply_transaction(
-                            $pdo,
-                            $sqlite_sql_transaction_active,
-                            $sqlite_batch_statements,
-                        );
-                        $marker = $this->read_sqlite_db_apply_progress_marker($sqlite_prepared_pdo);
-                        $statements_executed = $marker["statements_executed"] ?? 0;
-                        $last_committed_bytes_read = $marker["bytes_read"] ?? 0;
-                    } elseif ($sqlite_batch_active) {
-                        $this->commit_sqlite_db_apply_batch(
-                            $pdo,
-                            $sqlite_prepared_pdo,
-                            $sqlite_batch_active,
-                            $sqlite_batch_statements,
-                            $statements_executed,
-                            $last_committed_bytes_read,
-                        );
-                    }
-                } else {
-                    if ($sqlite_batch_active) {
-                        $this->commit_sqlite_db_apply_batch(
-                            $pdo,
-                            $sqlite_prepared_pdo,
-                            $sqlite_batch_active,
-                            $sqlite_batch_statements,
-                            $statements_executed,
-                            $last_committed_bytes_read,
-                        );
-                        $save_apply_state($statements_executed, $last_committed_bytes_read);
-                        $stmts_since_save = 0;
-                    }
-
-                    if ($sqlite_sql_transaction_active) {
-                        $this->update_sqlite_db_apply_progress_marker(
-                            $sqlite_prepared_pdo,
-                            $statements_executed,
-                            $last_committed_bytes_read,
-                        );
-                        $pdo->commit();
-                        $sqlite_sql_transaction_active = false;
-                        $save_apply_state($statements_executed, $last_committed_bytes_read);
-                        $stmts_since_save = 0;
-                    }
-                }
+            if ($sqlite_prepared_pdo !== null && $sqlite_batch_active) {
+                $sqlite_write_marker($statements_executed, $last_executed_bytes_read);
+                $pdo->commit();
+                $sqlite_batch_active = false;
+                $sqlite_batch_statements = 0;
+                $save_apply_state($statements_executed, $last_executed_bytes_read);
+                $stmts_since_save = 0;
             }
 
             if ($this->shutdown_requested) {
                 // Save partial progress
-                $save_apply_state($statements_executed, $last_committed_bytes_read, "partial");
+                $save_apply_state($statements_executed, $last_executed_bytes_read, "partial");
                 $this->audit_log(
                     sprintf(
                         "PARTIAL db-apply | %d statements executed",
@@ -5870,7 +5600,7 @@ class ImportClient
                 }
 
                 // Mark complete
-                $save_apply_state($statements_executed, $last_committed_bytes_read, "complete");
+                $save_apply_state($statements_executed, $last_executed_bytes_read, "complete");
 
                 $this->audit_log(
                     sprintf(
@@ -5895,17 +5625,14 @@ class ImportClient
                 $this->progress->show_lifecycle_line("db-apply complete ({$statements_executed} statements executed)\n");
             }
         } catch (Throwable $e) {
-            if ($sqlite_prepared_pdo !== null) {
-                $this->rollback_sqlite_db_apply_transaction(
-                    $pdo,
-                    $sqlite_batch_active,
-                    $sqlite_batch_statements,
-                );
-                $this->rollback_sqlite_db_apply_transaction(
-                    $pdo,
-                    $sqlite_sql_transaction_active,
-                    $sqlite_batch_statements,
-                );
+            if ($sqlite_prepared_pdo !== null && $sqlite_batch_active) {
+                try {
+                    $pdo->rollBack();
+                } catch (Throwable $_) {
+                    // The wrapper may already have rolled back after an execution error.
+                }
+                $sqlite_batch_active = false;
+                $sqlite_batch_statements = 0;
             }
             throw $e;
         } finally {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5308,8 +5308,7 @@ class ImportClient
         $apply_state = $this->state["apply"] ?? $this->default_state()["apply"];
         $statements_executed = (int) ($apply_state["statements_executed"] ?? 0);
         $bytes_read = (int) ($apply_state["bytes_read"] ?? 0);
-        $is_resume = in_array($current_status, ["in_progress", "partial"], true)
-            && ($statements_executed > 0 || $bytes_read > 0);
+        $is_resume = in_array($current_status, ["in_progress", "partial"], true);
 
         if ($is_resume) {
             $this->audit_log(

--- a/tests/Import/SqliteDbApplyBatchingTest.php
+++ b/tests/Import/SqliteDbApplyBatchingTest.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace ImportTests;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class SqliteDbApplyBatchingTest extends TestCase
+{
+    private string $tempDir;
+    private string $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->tempDir = sys_get_temp_dir() . '/sqlite-db-apply-batching-' . uniqid();
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->tempDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testSetAutocommitAndTransactionControlStatementsDoNotCorruptBatching(): void
+    {
+        $sqlitePath = $this->tempDir . '/target.sqlite';
+        $statements = array_merge(
+            [
+                "SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;",
+                "SET AUTOCOMMIT=0;",
+            ],
+            $this->schemaStatements(),
+            [
+                "START TRANSACTION;",
+                $this->insertStatement(1, 'inside explicit transaction'),
+                "COMMIT;",
+                $this->insertStatement(2, 'after explicit transaction'),
+                "SET AUTOCOMMIT=1;",
+                "COMMIT;",
+            ],
+        );
+
+        $this->writeSql($statements);
+        $this->writeState();
+        $this->runDbApply($sqlitePath);
+
+        $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch ORDER BY id");
+        $this->assertSame([
+            ['id' => 1, 'name' => 'inside explicit transaction'],
+            ['id' => 2, 'name' => 'after explicit transaction'],
+        ], $rows);
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(count($statements), $state['apply']['statements_executed']);
+    }
+
+    public function testPreparedInsertFastPathHonorsRollbackAndCommit(): void
+    {
+        $sqlitePath = $this->tempDir . '/target.sqlite';
+        $statements = array_merge(
+            $this->schemaStatements(),
+            [
+                "START TRANSACTION;",
+                $this->insertStatement(1, 'rolled back'),
+                "ROLLBACK;",
+                "START TRANSACTION;",
+                $this->insertStatement(2, 'committed'),
+                "COMMIT;",
+            ],
+        );
+
+        $this->writeSql($statements);
+        $this->writeState();
+        $this->runDbApply($sqlitePath);
+
+        $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch ORDER BY id");
+        $this->assertSame([
+            ['id' => 2, 'name' => 'committed'],
+        ], $rows);
+    }
+
+    public function testMarkerAndDataAreAtomicWhenBatchRollsBackWithFallbackStatement(): void
+    {
+        $sqlitePath = $this->tempDir . '/target.sqlite';
+        $statements = array_merge(
+            $this->schemaStatements(),
+            [
+                $this->insertStatement(1, 'before fallback'),
+                $this->updateStatement(1, 'updated by fallback'),
+                $this->insertStatement(1, 'duplicate id'),
+            ],
+        );
+
+        $this->writeSql($statements);
+        $this->writeState();
+
+        $this->expectException(RuntimeException::class);
+        try {
+            $this->runDbApply($sqlitePath);
+        } finally {
+            $rows = $this->queryTarget($sqlitePath, "SELECT COUNT(*) AS c FROM wp_batch");
+            $this->assertSame(0, (int) $rows[0]['c']);
+
+            $marker = $this->readMarker($sqlitePath);
+            $this->assertSame(2, $marker['statements_executed']);
+            $this->assertSame($this->bytesThroughStatements($this->schemaStatements(), 2), $marker['bytes_read']);
+        }
+    }
+
+    public function testCommittedBatchSurvivesLaterBatchRollback(): void
+    {
+        $sqlitePath = $this->tempDir . '/target.sqlite';
+        $insertStatements = [];
+        for ($id = 1; $id <= 505; $id++) {
+            $insertStatements[] = $this->insertStatement($id, 'row ' . $id);
+        }
+
+        $statements = array_merge(
+            $this->schemaStatements(),
+            $insertStatements,
+            [
+                $this->insertStatement(501, 'duplicate in second batch'),
+            ],
+        );
+
+        $this->writeSql($statements);
+        $this->writeState();
+
+        $this->expectException(RuntimeException::class);
+        try {
+            $this->runDbApply($sqlitePath);
+        } finally {
+            $rows = $this->queryTarget($sqlitePath, "SELECT COUNT(*) AS c FROM wp_batch");
+            $this->assertSame(500, (int) $rows[0]['c']);
+
+            $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch WHERE id IN (500, 501) ORDER BY id");
+            $this->assertSame([
+                ['id' => 500, 'name' => 'row 500'],
+            ], $rows);
+
+            $committedStatements = array_merge(
+                $this->schemaStatements(),
+                array_slice($insertStatements, 0, 500),
+            );
+            $marker = $this->readMarker($sqlitePath);
+            $this->assertSame(count($committedStatements), $marker['statements_executed']);
+            $this->assertSame(
+                $this->bytesThroughStatements($statements, count($committedStatements)),
+                $marker['bytes_read'],
+            );
+        }
+    }
+
+    public function testResumeReconcilesJsonAheadOfCommittedMarker(): void
+    {
+        $sqlitePath = $this->tempDir . '/target.sqlite';
+        $prefixStatements = $this->schemaStatements();
+        $fullStatements = array_merge(
+            $prefixStatements,
+            [
+                $this->insertStatement(1, 'one'),
+                $this->insertStatement(2, 'two'),
+                $this->insertStatement(3, 'three'),
+            ],
+        );
+
+        $this->writeSql($prefixStatements);
+        $this->writeState();
+        $this->runDbApply($sqlitePath);
+
+        $this->writeSql($fullStatements);
+        $this->writeState([
+            'command' => 'db-apply',
+            'status' => 'in_progress',
+            'apply' => [
+                'statements_executed' => count($fullStatements),
+                'bytes_read' => strlen($this->sqlText($fullStatements)),
+                'target_engine' => 'sqlite',
+                'target_db' => 'wp_test',
+                'target_sqlite_path' => $sqlitePath,
+            ],
+        ]);
+        $this->runDbApply($sqlitePath);
+
+        $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch ORDER BY id");
+        $this->assertSame([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ], $rows);
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(count($fullStatements), $state['apply']['statements_executed']);
+        $this->assertSame(
+            $this->bytesThroughStatements($fullStatements, count($fullStatements)),
+            $state['apply']['bytes_read'],
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function schemaStatements(): array
+    {
+        return [
+            "DROP TABLE IF EXISTS `wp_batch`;",
+            "CREATE TABLE `wp_batch` (" .
+            "`id` bigint(20) unsigned NOT NULL, " .
+            "`name` longtext NOT NULL, " .
+            "PRIMARY KEY (`id`)" .
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+        ];
+    }
+
+    private function insertStatement(int $id, string $name): string
+    {
+        return sprintf(
+            "INSERT INTO `wp_batch` (`id`, `name`) VALUES (%d, FROM_BASE64('%s'));",
+            $id,
+            base64_encode($name),
+        );
+    }
+
+    private function updateStatement(int $id, string $name): string
+    {
+        return sprintf(
+            "UPDATE `wp_batch` SET `name` = FROM_BASE64('%s') WHERE `id` = %d;",
+            base64_encode($name),
+            $id,
+        );
+    }
+
+    /**
+     * @param string[] $statements
+     */
+    private function writeSql(array $statements): void
+    {
+        file_put_contents($this->tempDir . '/db.sql', $this->sqlText($statements));
+    }
+
+    /**
+     * @param string[] $statements
+     */
+    private function sqlText(array $statements): string
+    {
+        return implode("\n", $statements) . "\n";
+    }
+
+    /**
+     * @param string[] $statements
+     */
+    private function bytesThroughStatements(array $statements, int $count): int
+    {
+        $bytes = 0;
+        for ($i = 0; $i < $count; $i++) {
+            if ($i > 0) {
+                $bytes++;
+            }
+            $bytes += strlen($statements[$i]);
+        }
+        return $bytes;
+    }
+
+    private function writeState(array $state = []): void
+    {
+        file_put_contents(
+            $this->tempDir . '/.import-state.json',
+            json_encode($state, JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function readState(): array
+    {
+        $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
+        $this->assertIsArray($state);
+        return $state;
+    }
+
+    private function runDbApply(string $sqlitePath): void
+    {
+        $client = new \ImportClient(
+            'https://source.example/export.php',
+            $this->tempDir,
+            $this->fsRoot,
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+        ]);
+    }
+
+    private function queryTarget(string $sqlitePath, string $sql): array
+    {
+        $polyfills = resolve_sqlite_integration_path('/php-polyfills.php');
+        $driver = resolve_sqlite_integration_path('/wp-pdo-mysql-on-sqlite.php');
+        require_once $polyfills;
+        require_once $driver;
+
+        $pdo = new \WP_PDO_MySQL_On_SQLite(
+            "mysql-on-sqlite:path={$sqlitePath};dbname=wp_test",
+            null,
+            null,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ],
+        );
+
+        return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private function readMarker(string $sqlitePath): array
+    {
+        $pdo = new PDO('sqlite:' . $sqlitePath, null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+
+        $row = $pdo
+            ->query('SELECT statements_executed, bytes_read FROM _reprint_db_apply_progress WHERE id = 1')
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertIsArray($row);
+
+        return [
+            'statements_executed' => (int) $row['statements_executed'],
+            'bytes_read' => (int) $row['bytes_read'],
+        ];
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Import/SqliteDbApplyBatchingTest.php
+++ b/tests/Import/SqliteDbApplyBatchingTest.php
@@ -67,18 +67,18 @@ class SqliteDbApplyBatchingTest extends TestCase
         $this->assertSame(count($statements), $state['apply']['statements_executed']);
     }
 
-    public function testPreparedInsertFastPathHonorsRollbackAndCommit(): void
+    public function testSQLiteBatchOwnsDumpTransactionControlStatements(): void
     {
         $sqlitePath = $this->tempDir . '/target.sqlite';
         $statements = array_merge(
             $this->schemaStatements(),
             [
-                "START TRANSACTION;",
+                "-- dump transaction wrapper\nSTART TRANSACTION;",
                 $this->insertStatement(1, 'rolled back'),
-                "ROLLBACK;",
-                "START TRANSACTION;",
+                "/* dump transaction wrapper */ ROLLBACK;",
+                "/*!40101 START TRANSACTION */;",
                 $this->insertStatement(2, 'committed'),
-                "COMMIT;",
+                "/*!40101 COMMIT */;",
             ],
         );
 
@@ -88,6 +88,7 @@ class SqliteDbApplyBatchingTest extends TestCase
 
         $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch ORDER BY id");
         $this->assertSame([
+            ['id' => 1, 'name' => 'rolled back'],
             ['id' => 2, 'name' => 'committed'],
         ], $rows);
     }
@@ -144,16 +145,16 @@ class SqliteDbApplyBatchingTest extends TestCase
             $this->runDbApply($sqlitePath);
         } finally {
             $rows = $this->queryTarget($sqlitePath, "SELECT COUNT(*) AS c FROM wp_batch");
-            $this->assertSame(500, (int) $rows[0]['c']);
+            $this->assertSame(498, (int) $rows[0]['c']);
 
-            $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch WHERE id IN (500, 501) ORDER BY id");
+            $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch WHERE id IN (498, 499, 501) ORDER BY id");
             $this->assertSame([
-                ['id' => 500, 'name' => 'row 500'],
+                ['id' => 498, 'name' => 'row 498'],
             ], $rows);
 
             $committedStatements = array_merge(
                 $this->schemaStatements(),
-                array_slice($insertStatements, 0, 500),
+                array_slice($insertStatements, 0, 498),
             );
             $marker = $this->readMarker($sqlitePath);
             $this->assertSame(count($committedStatements), $marker['statements_executed']);

--- a/tests/Import/SqliteDbApplyBatchingTest.php
+++ b/tests/Import/SqliteDbApplyBatchingTest.php
@@ -211,6 +211,58 @@ class SqliteDbApplyBatchingTest extends TestCase
         );
     }
 
+    public function testResumeReconcilesCommittedMarkerAheadOfZeroJsonState(): void
+    {
+        $sqlitePath = $this->tempDir . '/target.sqlite';
+        $createTable = "CREATE TABLE `wp_batch` (" .
+            "`id` bigint(20) unsigned NOT NULL, " .
+            "`name` longtext NOT NULL, " .
+            "PRIMARY KEY (`id`)" .
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $prefixStatements = [
+            $createTable,
+            $this->insertStatement(1, 'one'),
+        ];
+        $fullStatements = array_merge(
+            $prefixStatements,
+            [
+                $this->insertStatement(2, 'two'),
+            ],
+        );
+
+        $this->writeSql($prefixStatements);
+        $this->writeState();
+        $this->runDbApply($sqlitePath);
+
+        $this->writeSql($fullStatements);
+        $this->writeState([
+            'command' => 'db-apply',
+            'status' => 'in_progress',
+            'apply' => [
+                'statements_executed' => 0,
+                'bytes_read' => 0,
+                'target_engine' => 'sqlite',
+                'target_db' => 'wp_test',
+                'target_sqlite_path' => $sqlitePath,
+            ],
+        ]);
+        $this->runDbApply($sqlitePath);
+
+        $rows = $this->queryTarget($sqlitePath, "SELECT id, name FROM wp_batch ORDER BY id");
+        $this->assertSame([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ], $rows);
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(count($fullStatements), $state['apply']['statements_executed']);
+        $this->assertSame(
+            $this->bytesThroughStatements($fullStatements, count($fullStatements)),
+            $state['apply']['bytes_read'],
+        );
+    }
+
     /**
      * @return string[]
      */


### PR DESCRIPTION
## What it does

Batches the SQLite `db-apply` path inside one simple wrapper-transaction model. SQLite now opens an import-owned transaction, commits every 500 applied statements, and writes `_reprint_db_apply_progress` in the same transaction as the target data.

## Rationale

The previous version tried to support both source dump transaction boundaries and importer batch transactions. That made the PR much larger: separate statement classification, DDL/SET flushing, transaction state tracking, and helper methods for a path that only exists to speed up SQLite imports.

This version goes all-in on importer-owned batches. MySQL dump transaction-control statements are counted for resume offsets but skipped on SQLite, because executing `START TRANSACTION`, `COMMIT`, `ROLLBACK`, `LOCK`, `UNLOCK`, `SAVEPOINT`, or `RELEASE` would let the MySQL-on-SQLite wrapper commit or roll back behind the importer’s progress marker.

The native MySQL parser does **not** make this change irrelevant. It speeds up parser/translation work inside MySQL-on-SQLite. This PR reduces SQLite transaction/progress-commit overhead. Those are different layers. With the native parser enabled, and with CI’s small fixture, less wall time remains for batching to remove, so the reported delta is smaller.

## Implementation

The SQLite path now does the minimum needed for atomic batched resume:

- Creates `_reprint_db_apply_progress` once before streaming `db.sql`.
- Reconciles JSON state from that in-target marker on resume.
- Starts a SQLite wrapper transaction before the first applied statement in each batch.
- Commits marker + data every `SQLITE_DB_APPLY_BATCH_SIZE` statements and at the end of the stream.
- Rolls back the active batch on execution errors.
- Uses a gated `WP_MySQL_Lexer` check only for possible transaction-control statements; normal `INSERT` statements avoid tokenization.

Compared with the prior PR head, the consolidation removes the statement-classification helpers and deletes 481 lines while adding 209 lines for the simplified code and adjusted adversarial coverage.

CI performance report for this head SHA uses the small fixture (`10,000` posts / `25,000` postmeta) with the native parser extension enabled:

| Run | Stage | PR | trunk | Delta |
|---|---|---:|---:|---:|
| CI bot comment | `playground-sqlite-db-apply` | 2.62 s | 2.82 s | -201 ms / -7.1% |
| CI bot comment | total reported stages | 9.88 s | 10.18 s | -294 ms / -2.9% |

The larger local focused benchmark below uses the default large fixture (`320,007` posts / `720,015` postmeta) with no native parser extension. It is not expected to match the bot comment; it isolates the batching payoff under a much larger statement count:

```bash
flock /tmp/reprint-bench.lock -c 'BENCH_STAGES=playground-sqlite-db-apply BENCH_LABEL=branch-rebased BENCH_JSON_OUT=/home/claude/reprint-opt-tx-batching-20260522010757/.context/bench-branch-rebased.json BENCH_MD_OUT=/home/claude/reprint-opt-tx-batching-20260522010757/.context/bench-branch-rebased.md node tests/e2e/benchmark/bench-pull.mjs 2>&1 | tee /home/claude/reprint-opt-tx-batching-20260522010757/.context/bench-branch-rebased.log'

flock /tmp/reprint-bench.lock -c 'IMPORTER_PATH=/home/claude/reprint-opt-tx-batching-20260522010757/.context/trunk-current-src-27c5f25/importer/import.php BENCH_STAGES=playground-sqlite-db-apply BENCH_LABEL=trunk-current BENCH_JSON_OUT=/home/claude/reprint-opt-tx-batching-20260522010757/.context/bench-trunk-current.json BENCH_MD_OUT=/home/claude/reprint-opt-tx-batching-20260522010757/.context/bench-trunk-current.md node tests/e2e/benchmark/bench-pull.mjs 2>&1 | tee /home/claude/reprint-opt-tx-batching-20260522010757/.context/bench-trunk-current.log'
```

| Run | Stage | Wall time | Attempts | Delta |
|---|---|---:|---:|---:|
| current `origin/trunk` | `playground-sqlite-db-apply` | 94.25 s | 1 | baseline |
| this branch | `playground-sqlite-db-apply` | 67.49 s | 1 | -26.77 s / -28.4% |

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/SqliteDbApplyBatchingTest.php
vendor/bin/phpunit --testdox tests/Import/SqliteDbApplyBatchingTest.php
vendor/bin/phpunit --testdox tests/Import/NewSiteUrlSqliteTest.php tests/Import/DeactivateHostPluginsTest.php
vendor/bin/phpstan analyze --memory-limit=1G --no-progress packages/reprint-importer/src/import.php
git diff --check origin/trunk...HEAD
```
