### PR TITLE
Prevent errors during compressibility checks

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -3448,6 +3448,10 @@ function file_fetch_paths_should_gzip(array $paths): bool
             // shouldn't compress around. Treat as a hard reject.
             return false;
         }
+        // Once true, we can skip checking the subsequent files.
+        if ($any_compressible) {
+            continue;
+        }
         $ext = path_extension_compressibility($path);
         if ($ext === 'yes') {
             $any_compressible = true;
@@ -3562,6 +3566,9 @@ function path_extension_compressibility(string $path): string
  */
 function path_head_looks_like_text(string $path): bool
 {
+    if (!is_file($path)) {
+        return false;
+    }
     $fp = @fopen($path, 'rb');
     if ($fp === false) {
         // Producer will surface a clearer error later; don't compress on

--- a/tests/FileFetchCompressionTest.php
+++ b/tests/FileFetchCompressionTest.php
@@ -188,6 +188,27 @@ final class FileFetchCompressionTest extends TestCase
         $this->assertStringContainsString('pretend-png-bytes', $decoded);
     }
 
+    public function testFileFetchDoesNotCrashOnDirectoryInList(): void
+    {
+        // A directory can appear in a file_fetch batch, and
+        // when the name has an unrecognized dotted extension
+        // (e.g. a theme dir like "sometheme-2.4.5") then the
+        // gzip heuristic probes its bytes: fopen() succeeds on a directory but
+        // the unguarded fread() would fatal, crashing the whole request.
+        $siteDir = $this->tempDir . '/site';
+        mkdir($siteDir, 0755, true);
+        $dirPath = $siteDir . '/storefront-2.4.5';
+        mkdir($dirPath, 0755, true);
+
+        // runFileFetch asserts the worker exits 0 — without the guard it exits
+        // 1 (the fread fatal is escalated by export.php's error handler).
+        $stdout = $this->runFileFetch($siteDir, [$dirPath]);
+
+        // The directory is handled (a 0-byte directory chunk), not read; the
+        // identity-framed multipart response is well-formed.
+        $this->assertStringStartsWith('--boundary-', $stdout);
+    }
+
     public function testFileFetchEmptyListStaysIdentity(): void
     {
         // Empty path list — nothing to compress → identity. (The endpoint
@@ -219,6 +240,12 @@ final class FileFetchCompressionTest extends TestCase
             'non-string entry rejects the batch');
         $this->assertFalse(file_fetch_paths_should_gzip([42]),                         /** @phpstan-ignore-line */
             'numeric entry rejects the batch');
+
+        // A non-string AFTER a compressible file must still reject — the
+        // any-compressible short-circuit skips classification work but must not
+        // skip the is_string check (i.e. it's a loop-skip, not a return-true).
+        $this->assertFalse(file_fetch_paths_should_gzip(['a.php', null]),              /** @phpstan-ignore-line */
+            'non-string after a compressible entry still rejects the batch');
     }
 
     public function testUnknownExtensionWithTextContentGetsGzipped(): void


### PR DESCRIPTION
The per-batch gzip compressibility check tries to call `fread()` on every entry, including directories which causes a fatal error. The `fopen()` succeeds but then `fread()` fatals, crashing the whole export mid files-sync with:

> PHP Error: fread(): Read of 8192 bytes failed with errno=21 Is a directory

Fix:
- Guard with `is_file()`,  skipping any non-regular path (directory, symlink, missing) instead of trying to read it.
- Performance improvement: Short-circuit the checking once the batch is already known compressible, skipping the remaining classification/byte-sniffing.

## Testing

Try a migration when you have a theme folder named something like `storefront-1.2.3` (a period somewhere in the name).