### PR TITLE
Refresh on re-run for completed pull sub-commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ In `preserve-local` mode:
 
 MySQLDumpProducer accumulates rows internally (default 250 rows per batch) and emits complete multi-row INSERT statements. This is memory-efficient and produces dumps compatible with standard MySQL import tools.
 
+### Re-run / Refresh Semantics
+
+Re-invoking a sub-command on a **completed** state performs a refresh instead of erroring or no-oping (matching the composite `pull` orchestrator's re-pull behavior):
+
+- `files-pull`: runs a **delta sync** — keeps the local index, re-indexes the remote, diffs, and fetches only changes. The stale remote index and download lists are deleted first (`download_remote_index()` appends when the file exists).
+- `db-pull`: runs a **full refresh** — `reset_db_pull_state()` clears DB state (`sql_bytes`, cursor, `db_index`, `apply`) and deletes `db.sql`, `.import-domains.json`, and the `.sql-buffer` crash-recovery file, then re-downloads the entire dump. There is no row-level DB delta; the dump is idempotent (`DROP TABLE IF EXISTS` + full INSERTs), so a re-dump + re-apply reproduces remote edits, inserts, and deletes exactly.
+- `db-apply`: re-applies the dump from statement 0.
+
+In-progress/partial states still resume from their cursors — the refresh only triggers on `status === "complete"` of the same command. `--abort` remains the way to clear state without running. Known limitation: a table dropped on the remote between pulls lingers in the local target (the new dump no longer mentions it).
+
 ### File Synchronization Phases
 
 FileTreeProducer operates in three phases visible via get_progress():

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1567,6 +1567,27 @@ class ImportClient
 
         $this->state = $this->load_state();
 
+        // Legacy state repair: older versions never marked a
+        // --filter=skipped-earlier run complete, leaving the state stuck at
+        // "in_progress" forever after a fully successful fetch (stage reset
+        // to null and the skipped download list deleted on completion).
+        // Detect that terminal shape and mark it complete so re-runs take
+        // the delta path instead of tripping the mid-flight filter guard.
+        if (
+            ($this->state["command"] ?? null) === "files-pull" &&
+            ($this->state["status"] ?? null) === "in_progress" &&
+            ($this->state["stage"] ?? null) === null &&
+            ($this->state["filter"] ?? null) === "skipped-earlier" &&
+            !file_exists($this->skipped_download_list_file)
+        ) {
+            $this->audit_log(
+                "STATE REPAIR | skipped-earlier run finished but was never marked complete — marking complete",
+                true,
+            );
+            $this->state["status"] = "complete";
+            $this->save_state($this->state);
+        }
+
         // Persist follow_symlinks in state so it survives across invocations.
         // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
         if (isset($options["follow_symlinks"])) {
@@ -1888,10 +1909,7 @@ class ImportClient
                     @unlink($this->download_list_file);
                     $this->audit_log("FILE DELETE | {$this->download_list_file}");
                 }
-                if (file_exists($this->skipped_download_list_file)) {
-                    @unlink($this->skipped_download_list_file);
-                    $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
-                }
+                $this->clear_skipped_download_list("abort files-pull");
                 if (file_exists($this->volatile_files_file)) {
                     @unlink($this->volatile_files_file);
                     $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
@@ -2615,35 +2633,64 @@ class ImportClient
                 $this->state["stage"] = "fetch-skipped";
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
+
+                // Pipeline returns early with partial status if interrupted.
+                if (($this->state["status"] ?? null) === "partial") {
+                    return;
+                }
+
+                // Mark the run complete — without this, the state stays
+                // "in_progress" forever after a successful skipped-files
+                // fetch, and later runs take the resume path instead of
+                // the complete/delta path.
+                $this->state["status"] = "complete";
+                $this->save_state($this->state);
+
+                $this->audit_log("files-pull (skipped files) complete", true);
+                $this->progress->show_lifecycle_line("files-pull (skipped files) complete\n");
+                $this->output_progress([
+                    "type" => "lifecycle",
+                    "event" => "complete",
+                    "command" => "files-pull",
+                    "stage" => "fetch-skipped",
+                    "message" => "files-pull (skipped files) complete",
+                ], true);
                 return;
             }
 
-            $index_size = $this->index_count();
-            $this->progress->clear_progress_line();
-
-            $skipped_note = $has_skipped
-                ? " (some files were skipped — re-run with --filter=skipped-earlier to download them)"
-                : "";
+            // Re-run on a completed sync = delta sync (matches the composite
+            // pull's re-pull behavior). Reset run state and fall through to
+            // the fresh-start path below, where $is_delta picks up the local
+            // index and turns the run into re-index → diff → fetch changes.
             $this->audit_log(
-                sprintf("files-pull already complete: %d files indexed%s", $index_size, $skipped_note),
+                "files-pull re-run on completed state — starting delta sync",
                 true,
             );
+            $this->mutate_state(function (array $state) {
+                $state["command"] = null;
+                $state["status"] = null;
+                $state["cursor"] = null;
+                $state["stage"] = null;
+                return $state;
+            });
 
-            $this->progress->show_lifecycle_line("files-pull already complete: {$index_size} files indexed\n");
-            if ($has_skipped) {
-                $this->progress->show_lifecycle_line("Some files were skipped. Re-run with --filter=skipped-earlier to download them.\n");
-            } else {
-                $this->progress->show_lifecycle_line("To re-sync, run with --abort first to clear state.\n");
+            // download_remote_index() appends when the remote index file
+            // exists, so a fresh delta start must clear it (and the derived
+            // download lists) — same as Pull::prepare_repull().
+            foreach ([
+                $this->remote_index_file,
+                $this->download_list_file,
+            ] as $stale_file) {
+                if (file_exists($stale_file)) {
+                    @unlink($stale_file);
+                    $this->audit_log(
+                        "FILE DELETE | {$stale_file} | clearing for delta re-sync",
+                    );
+                }
             }
-            $this->output_progress([
-                "type" => "lifecycle",
-                "event" => "already_complete",
-                "command" => "files-pull",
-                "files_indexed" => $index_size,
-                "has_skipped" => $has_skipped,
-                "message" => "files-pull already complete: {$index_size} files indexed",
-            ], true);
-            return;
+            $this->clear_skipped_download_list("clearing for delta re-sync");
+
+            $current_status = null;
         }
 
         // --filter=skipped-earlier is only valid after a completed
@@ -2828,12 +2875,7 @@ class ImportClient
                     "FILE DELETE | {$this->download_list_file} | clearing before diff stage",
                 );
             }
-            if (file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | clearing before diff stage",
-                );
-            }
+            $this->clear_skipped_download_list("clearing before diff stage");
             $this->save_state($this->state);
             $stage = "diff";
         }
@@ -2887,11 +2929,8 @@ class ImportClient
                     "FILE DELETE | {$this->download_list_file} | no files to fetch",
                 );
             }
-            if (!$has_skipped && file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | no skipped files to fetch",
-                );
+            if (!$has_skipped) {
+                $this->clear_skipped_download_list("no skipped files to fetch");
             }
         }
 
@@ -2960,12 +2999,7 @@ class ImportClient
             $this->state["fetch_skipped"] = $this->default_state()["fetch_skipped"];
             $this->save_state($this->state);
 
-            if (file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | skipped files fetch complete",
-                );
-            }
+            $this->clear_skipped_download_list("skipped files fetch complete");
         }
 
         // Recreate intermediate path symlinks so the full symlink chain
@@ -3449,8 +3483,8 @@ class ImportClient
      *
      * Rules:
      * - Stream next portion of SQL from last saved cursor
-     * - If already completed and db.sql exists: require --abort flag
-     * - If db.sql missing but state says complete: warn and require --abort flag
+     * - If already completed: reset DB state and start a full refresh
+     *   (re-download). Matches the composite pull's re-pull behavior.
      * - Otherwise: error
      */
     public function run_db_sync(): void
@@ -3466,24 +3500,18 @@ class ImportClient
                 ? $this->state["status"] ?? null
                 : null;
 
-        // Check if already completed
+        // Re-run on a completed pull = full database refresh (matches the
+        // composite pull's re-pull behavior). The dump is idempotent
+        // (DROP TABLE IF EXISTS + full INSERTs), so resetting state and
+        // re-downloading reproduces the remote exactly — updates, inserts,
+        // and deletes included.
         if ($current_status === "complete") {
-            if ($this->sql_output_mode === "file") {
-                $sql_exists = file_exists($sql_file);
-                if ($sql_exists) {
-                    throw new RuntimeException(
-                        "db-pull already completed and db.sql exists. Use --abort flag to start over.",
-                    );
-                } else {
-                    throw new RuntimeException(
-                        "db-pull marked complete but db.sql is missing. Use --abort flag to re-sync.",
-                    );
-                }
-            } else {
-                throw new RuntimeException(
-                    "db-pull already completed. Use --abort flag to start over.",
-                );
-            }
+            $this->audit_log(
+                "db-pull re-run on completed state — starting full refresh",
+                true,
+            );
+            $this->reset_db_pull_state();
+            $current_status = null;
         }
 
         if ($has_progress) {
@@ -5041,10 +5069,16 @@ class ImportClient
         $state_command = $this->state["command"] ?? null;
         $current_status = $state_command === "db-apply" ? ($this->state["status"] ?? null) : null;
 
+        // Re-run on a completed apply = re-apply the dump from the top
+        // (matches the composite pull's re-pull behavior). The dump carries
+        // DROP TABLE IF EXISTS, so re-applying rebuilds every table in it.
+        // Taking the fresh-apply path below resets apply progress to 0.
         if ($current_status === "complete") {
-            throw new RuntimeException(
-                "db-apply already completed. Use --abort flag to re-run.",
+            $this->audit_log(
+                "db-apply re-run on completed state — re-applying dump",
+                true,
             );
+            $current_status = null;
         }
 
         $apply_state = $this->state["apply"] ?? $this->default_state()["apply"];
@@ -5397,6 +5431,11 @@ class ImportClient
                     $this->audit_log("DB-APPLY | deactivated plugin {$basename} (path-incompatible siteurl)");
                 }
 
+                // Drop editor locks captured from the remote — on the
+                // imported copy they only produce phantom "X is currently
+                // editing" badges.
+                $this->strip_ephemeral_edit_locks($pdo);
+
                 // Mark complete
                 $this->state["apply"]["statements_executed"] = $statements_executed;
                 $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
@@ -5633,6 +5672,49 @@ class ImportClient
         );
 
         return $deactivated_plugins;
+    }
+
+    /**
+     * Delete ephemeral editor locks from the imported database.
+     *
+     * `_edit_lock` postmeta is runtime state — "user X has this post open
+     * in the editor right now" — that the SQL dump captures verbatim. On
+     * the imported copy the lock is meaningless (the remote editing
+     * session has no relationship to the local site), but WordPress
+     * renders it as a "X is currently editing" badge for up to 150
+     * seconds after the captured timestamp whenever the pull ran while a
+     * post was open remotely. WordPress regenerates the meta locally on
+     * the next edit, and core's own WXR exporter skips it too, so
+     * deleting it loses nothing.
+     *
+     * Runs at the end of db-apply while the PDO connection is open.
+     * A dump without a postmeta table is tolerated.
+     */
+    private function strip_ephemeral_edit_locks(PDO $pdo): void
+    {
+        $preflight_data = $this->state["preflight"]["data"] ?? [];
+        $table_prefix = $preflight_data["database"]["wp"]["table_prefix"] ?? 'wp_';
+        // Quote the table name to prevent SQL injection from a crafted prefix.
+        $postmeta_table = '`' . str_replace('`', '``', $table_prefix . 'postmeta') . '`';
+
+        try {
+            $deleted = $pdo->exec(
+                "DELETE FROM {$postmeta_table} WHERE meta_key = '_edit_lock'"
+            );
+            // The SQL dump runs with AUTOCOMMIT=0 and issues a final COMMIT,
+            // but autocommit stays off. Our DELETE needs an explicit COMMIT.
+            $pdo->exec('COMMIT');
+            if ($deleted) {
+                $this->audit_log(
+                    "DB-APPLY | removed {$deleted} _edit_lock meta(s) (ephemeral editor locks)",
+                );
+            }
+        } catch (\Throwable $e) {
+            // A dump without the postmeta table isn't an error.
+            $this->audit_log(
+                "DB-APPLY | skipped _edit_lock cleanup: " . $e->getMessage(),
+            );
+        }
     }
 
     /**
@@ -10188,6 +10270,68 @@ class ImportClient
      * Reset state to defaults while preserving cross-command data like
      * preflight results, version, and follow_symlinks.
      */
+    /**
+     * Empty the skipped-files download list by truncating it in place
+     * rather than deleting it.
+     *
+     * apply-runtime mounts this file into the generated runtime — the
+     * temporary remote-uploads proxy reads it to decide which paths are
+     * still remote-only. A running server re-resolves its mounts on every
+     * PHP runtime rotation (and on restart from a persisted config), so
+     * deleting the file breaks the mount with ENOENT. An empty file means
+     * "no remote-only files left", which is exactly what every caller
+     * wants — all has-skipped checks test for size > 0.
+     */
+    public function clear_skipped_download_list(string $reason): void
+    {
+        if (!file_exists($this->skipped_download_list_file)) {
+            return;
+        }
+        file_put_contents($this->skipped_download_list_file, "");
+        $this->audit_log(
+            "FILE TRUNCATE | {$this->skipped_download_list_file} | {$reason}",
+        );
+    }
+
+    /**
+     * Reset database pull/apply state so the next db-pull performs a full
+     * refresh (re-dump + re-apply) instead of resuming or refusing.
+     *
+     * Used by the db-pull auto-refresh path and by Pull::prepare_repull().
+     * Files-pull state (diff/fetch/index) is intentionally left alone —
+     * this helper is DB-scoped.
+     */
+    public function reset_db_pull_state(): void
+    {
+        $defaults = $this->default_state();
+        $this->mutate_state(function (array $state) use ($defaults) {
+            $state["command"] = null;
+            $state["status"] = null;
+            $state["cursor"] = null;
+            $state["stage"] = null;
+            $state["consecutive_timeouts"] = 0;
+            // Stale sql_bytes would corrupt the crash-recovery truncate and
+            // the stdout/mysql byte offsets on the next fresh download.
+            $state["sql_bytes"] = null;
+            $state["db_index"] = $defaults["db_index"];
+            $state["apply"] = $defaults["apply"];
+            return $state;
+        });
+
+        // .sql-buffer is the --sql-output=mysql crash-recovery buffer; a
+        // leftover from an interrupted run would be replayed into the
+        // target on the next fresh download.
+        foreach (["/db.sql", "/.import-domains.json", "/.sql-buffer"] as $name) {
+            $path = $this->state_dir . $name;
+            if (file_exists($path)) {
+                @unlink($path);
+                $this->audit_log(
+                    "FILE DELETE | {$path} | clearing for db refresh",
+                );
+            }
+        }
+    }
+
     private function reset_state(): void
     {
         $preflight = $this->state["preflight"] ?? null;
@@ -11812,8 +11956,9 @@ if (
                 "Downloads files from the remote site into --fs-root.\n" .
                 "\n" .
                 "On the first run, indexes the full remote directory tree and then\n" .
-                "downloads every file. On subsequent runs, re-indexes the remote tree,\n" .
-                "diffs against the local index, and downloads only what changed.\n" .
+                "downloads every file. On subsequent runs (including re-runs after a\n" .
+                "completed sync), re-indexes the remote tree, diffs against the local\n" .
+                "index, and downloads only what changed.\n" .
                 "Interrupted pulls resume from the last saved cursor.\n" .
                 "\n" .
                 "Runs files-index internally when no index exists yet.\n",
@@ -11870,6 +12015,7 @@ if (
                 "Indexes remote tables, then streams the full SQL dump into\n" .
                 "--state-dir/db.sql (default), to stdout, or directly into a\n" .
                 "MySQL connection. Resumes from the last cursor if interrupted.\n" .
+                "Re-running after completion performs a full refresh (re-dump).\n" .
                 "Discovered domains are cached for later use by db-apply.\n",
             "extra" =>
                 "Output modes:\n" .
@@ -11907,7 +12053,8 @@ if (
             "short" => "Import the SQL dump into a local MySQL or SQLite database",
             "description" =>
                 "Reads db.sql from --state-dir, optionally rewrites URLs, and executes\n" .
-                "all statements against a target database. Resumable. Saves target\n" .
+                "all statements against a target database. Resumable. Re-running after\n" .
+                "completion re-applies the dump from the top. Saves target\n" .
                 "database credentials to state for use by apply-runtime.\n",
             "extra" =>
                 "MySQL example:\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10264,13 +10264,6 @@ class ImportClient
     }
 
     /**
-     * Return the default compact state structure.
-     */
-    /**
-     * Reset state to defaults while preserving cross-command data like
-     * preflight results, version, and follow_symlinks.
-     */
-    /**
      * Empty the skipped-files download list by truncating it in place
      * rather than deleting it.
      *
@@ -10332,6 +10325,10 @@ class ImportClient
         }
     }
 
+    /**
+     * Reset state to defaults while preserving cross-command data like
+     * preflight results, version, and follow_symlinks.
+     */
     private function reset_state(): void
     {
         $preflight = $this->state["preflight"] ?? null;
@@ -10353,6 +10350,9 @@ class ImportClient
         }
     }
 
+    /**
+     * Return the default compact state structure.
+     */
     public function default_state(): array
     {
         return [

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -397,39 +397,37 @@ class Pull
     private function prepare_repull(): void
     {
         $state_dir = $this->client->state_dir;
+
+        // DB-scoped reset (command/status/cursor/stage, db_index, apply,
+        // sql_bytes) plus deletion of db.sql, .import-domains.json and the
+        // .sql-buffer crash-recovery file.
+        $this->client->reset_db_pull_state();
+
         $defaults = $this->client->default_state();
         $this->client->mutate_state(function (array $state) use ($defaults) {
             $state['pull']['stage'] = null;
             $state['pull']['files_filter'] = null;
             $state['pull']['skipped_pending'] = false;
-            $state['command'] = null;
-            $state['status'] = null;
-            $state['cursor'] = null;
-            $state['stage'] = null;
-            $state['consecutive_timeouts'] = 0;
-            $state['sql_bytes'] = null;
             $state['current_file'] = null;
             $state['current_file_bytes'] = null;
-            $state['db_index'] = $defaults['db_index'];
             $state['diff'] = $defaults['diff'];
             $state['fetch'] = $defaults['fetch'];
             $state['fetch_skipped'] = $defaults['fetch_skipped'];
-            $state['apply'] = $defaults['apply'];
             $state['sql_output'] = null;
             return $state;
         });
 
         foreach ([
-            $state_dir . "/db.sql",
-            $state_dir . "/.import-domains.json",
             $state_dir . "/.import-remote-index.jsonl",
             $state_dir . "/.import-download-list.jsonl",
-            $state_dir . "/.import-download-list-skipped.jsonl",
         ] as $path) {
             if (file_exists($path)) {
                 @unlink($path);
             }
         }
+        // Truncated, not deleted: the generated runtime may hold a mount
+        // of this file for the remote-uploads proxy.
+        $this->client->clear_skipped_download_list("prepared for delta re-pull");
 
         $this->client->audit_log("PULL | prepared for delta re-pull", true);
     }

--- a/tests/Import/DbResyncStateTest.php
+++ b/tests/Import/DbResyncStateTest.php
@@ -1,0 +1,400 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Test database re-sync behavior: re-running db-pull / db-apply on a
+ * completed state performs a refresh (full re-dump / re-apply) instead
+ * of throwing "already completed … use --abort".
+ *
+ * The round-trip test simulates the real re-pull flow: apply a dump,
+ * replace it with a newer dump containing an edited row, a new row, and
+ * a deleted row, re-apply, and verify the target matches the new dump
+ * exactly.
+ */
+class DbResyncStateTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fs_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/db-resync-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fs_root = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fs_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            "command" => null,
+            "status" => null,
+            "cursor" => null,
+            "stage" => null,
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "follow_symlinks" => false,
+            "max_allowed_packet" => null,
+        ];
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function readState(): array
+    {
+        return json_decode(
+            file_get_contents($this->stateDir . '/.import-state.json'),
+            true,
+        );
+    }
+
+    /**
+     * Build a minimal wp_posts dump in the real producer's format
+     * (DROP + CREATE + FROM_BASE64 INSERTs). $posts is ID => content.
+     */
+    private function buildPostsDump(array $posts): string
+    {
+        $stmts = [];
+        $stmts[] = "DROP TABLE IF EXISTS `wp_posts`;";
+        $stmts[] = "CREATE TABLE `wp_posts` ("
+            . "`ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`post_content` longtext NOT NULL, "
+            . "PRIMARY KEY (`ID`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $values = [];
+        foreach ($posts as $id => $content) {
+            $values[] = sprintf(
+                "(%d, FROM_BASE64('%s'))",
+                $id,
+                base64_encode($content),
+            );
+        }
+        if ($values) {
+            $stmts[] = "INSERT INTO `wp_posts` VALUES " . implode(", ", $values) . ";";
+        }
+        return implode("\n", $stmts) . "\n";
+    }
+
+    private function runDbApply(): void
+    {
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->stateDir,
+            $this->fs_root,
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $this->tempDir . '/database/wordpress.sqlite',
+            'target_db' => 'wp_test',
+        ]);
+    }
+
+    private function queryPosts(): array
+    {
+        $polyfills = resolve_sqlite_integration_path("/php-polyfills.php");
+        $driver = resolve_sqlite_integration_path("/wp-pdo-mysql-on-sqlite.php");
+        require_once $polyfills;
+        require_once $driver;
+
+        $dsn = "mysql-on-sqlite:path={$this->tempDir}/database/wordpress.sqlite;dbname=wp_test";
+        $pdo = new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+
+        $rows = $pdo->query("SELECT ID, post_content FROM wp_posts ORDER BY ID")->fetchAll();
+        $posts = [];
+        foreach ($rows as $row) {
+            $posts[(int) $row['ID']] = $row['post_content'];
+        }
+        return $posts;
+    }
+
+    /**
+     * Round-trip via the sub-command path: a completed db-apply re-run
+     * re-applies the (re-downloaded) dump from the top, so edited rows,
+     * new rows, and deleted rows are all reflected in the target.
+     */
+    public function testDbApplyRerunReappliesFreshDump(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        // First pull: posts 1 and 2.
+        file_put_contents(
+            $this->stateDir . '/db.sql',
+            $this->buildPostsDump([
+                1 => 'Hey there',
+                2 => 'Doomed post',
+            ]),
+        );
+        $this->writeState([]);
+        $this->runDbApply();
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame('db-apply', $state['command']);
+        $this->assertSame(
+            ['Hey there', 'Doomed post'],
+            array_values($this->queryPosts()),
+        );
+
+        // Remote changed: post 1 edited, post 2 deleted, post 3 added.
+        // (In the real flow db-pull re-downloads db.sql; here we just
+        // swap the file.)
+        file_put_contents(
+            $this->stateDir . '/db.sql',
+            $this->buildPostsDump([
+                1 => 'Hey there, dude, again',
+                3 => 'Brand new post',
+            ]),
+        );
+
+        // Re-run db-apply on the completed state — must refresh, not throw.
+        $this->runDbApply();
+
+        $posts = $this->queryPosts();
+        $this->assertSame(
+            'Hey there, dude, again',
+            $posts[1],
+            'Edited row must reflect the new dump after re-apply',
+        );
+        $this->assertArrayNotHasKey(
+            2,
+            $posts,
+            'Row deleted at the source must disappear after re-apply',
+        );
+        $this->assertSame(
+            'Brand new post',
+            $posts[3],
+            'Row added at the source must appear after re-apply',
+        );
+
+        // Apply progress must restart from zero, not accumulate.
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(
+            3,
+            $state['apply']['statements_executed'],
+            'Re-apply must reset statements_executed (3 statements in the new dump)',
+        );
+    }
+
+    /**
+     * db-apply strips `_edit_lock` postmeta captured from the remote —
+     * on the imported copy it only produces phantom "X is currently
+     * editing" badges — while leaving all other postmeta intact.
+     */
+    public function testDbApplyStripsEphemeralEditLocks(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $sql = $this->buildPostsDump([1 => 'Hey there']);
+        $sql .= "DROP TABLE IF EXISTS `wp_postmeta`;\n";
+        $sql .= "CREATE TABLE `wp_postmeta` ("
+            . "`meta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`post_id` bigint(20) unsigned NOT NULL DEFAULT 0, "
+            . "`meta_key` varchar(255) DEFAULT NULL, "
+            . "`meta_value` longtext, "
+            . "PRIMARY KEY (`meta_id`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n";
+        $sql .= sprintf(
+            "INSERT INTO `wp_postmeta` VALUES "
+            . "(1, 1, FROM_BASE64('%s'), FROM_BASE64('%s')), "
+            . "(2, 1, FROM_BASE64('%s'), FROM_BASE64('%s'));\n",
+            base64_encode('_edit_lock'),
+            base64_encode('1781114164:51814349'),
+            base64_encode('_thumbnail_id'),
+            base64_encode('42'),
+        );
+
+        file_put_contents($this->stateDir . '/db.sql', $sql);
+        $this->writeState([]);
+        $this->runDbApply();
+
+        $polyfills = resolve_sqlite_integration_path("/php-polyfills.php");
+        $driver = resolve_sqlite_integration_path("/wp-pdo-mysql-on-sqlite.php");
+        require_once $polyfills;
+        require_once $driver;
+        $dsn = "mysql-on-sqlite:path={$this->tempDir}/database/wordpress.sqlite;dbname=wp_test";
+        $pdo = new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rows = $pdo->query("SELECT meta_key FROM wp_postmeta ORDER BY meta_id")->fetchAll();
+        $keys = array_column($rows, 'meta_key');
+
+        $this->assertNotContains(
+            '_edit_lock',
+            $keys,
+            'Remote editor locks must not survive the import — they render as phantom "currently editing" badges',
+        );
+        $this->assertContains(
+            '_thumbnail_id',
+            $keys,
+            'Other postmeta must be left intact',
+        );
+    }
+
+    /**
+     * Re-running db-pull on a completed db-pull state resets the DB
+     * state for a full refresh: db.sql, cached domains, and the
+     * .sql-buffer crash-recovery file are deleted, sql_bytes is
+     * cleared, and the run proceeds as a fresh pull.
+     */
+    public function testDbPullRerunResetsForFullRefresh(): void
+    {
+        file_put_contents($this->stateDir . '/db.sql', "-- stale dump\n");
+        file_put_contents($this->stateDir . '/.import-domains.json', '["old.example.com"]');
+        file_put_contents($this->stateDir . '/.sql-buffer', 'INSERT INTO `wp_posts` VAL');
+
+        $this->writeState([
+            "command" => "db-pull",
+            "status" => "complete",
+            "sql_bytes" => 14,
+            "sql_output" => "file",
+        ]);
+
+        $client = new \ImportClient(
+            'http://fake.url/?reprint-api',
+            $this->stateDir,
+            $this->fs_root,
+        );
+        $reflection = new \ReflectionClass($client);
+        $stateProperty = $reflection->getProperty('state');
+        $loadState = $reflection->getMethod('load_state');
+        $stateProperty->setValue($client, $loadState->invoke($client));
+        $reflection->getProperty('is_tty')->setValue($client, false);
+
+        try {
+            $reflection->getMethod('run_db_sync')->invoke($client);
+        } catch (\Exception $e) {
+            // Expected: contacting the fake URL fails after the reset.
+        }
+
+        $this->assertFileDoesNotExist(
+            $this->stateDir . '/db.sql',
+            'Stale db.sql must be deleted so the refresh re-downloads from scratch',
+        );
+        $this->assertFileDoesNotExist(
+            $this->stateDir . '/.import-domains.json',
+            'Cached domains belong to the previous dump and must be cleared',
+        );
+        $this->assertFileDoesNotExist(
+            $this->stateDir . '/.sql-buffer',
+            'A stale crash-recovery buffer must not be replayed into a refresh',
+        );
+
+        $state = $this->readState();
+        $this->assertNotEquals(
+            'complete',
+            $state['status'],
+            'db-pull re-run on a completed state must start a refresh, not throw or no-op',
+        );
+        $this->assertSame('db-pull', $state['command']);
+        $this->assertNull($state['sql_bytes'], 'Stale sql_bytes must be cleared');
+        $this->assertNull($state['cursor'], 'The refresh must start from a null cursor (full re-dump)');
+    }
+
+    /**
+     * Legacy state repair: a --filter=skipped-earlier run that finished
+     * under an older version left status "in_progress" forever. run()
+     * must detect the terminal shape (stage null, skipped list gone)
+     * and mark it complete so re-runs take the delta path instead of
+     * tripping the mid-flight filter guard.
+     */
+    public function testStuckSkippedEarlierStateIsRepairedOnNextRun(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-index.jsonl',
+            json_encode([
+                "path" => base64_encode('/wp-login.php'),
+                "ctime" => 1000,
+                "size" => 100,
+                "type" => "file",
+            ], JSON_UNESCAPED_SLASHES) . "\n",
+        );
+
+        $this->writeState([
+            "command" => "files-pull",
+            "status" => "in_progress",
+            "stage" => null,
+            "filter" => "skipped-earlier",
+        ]);
+
+        $client = new \ImportClient(
+            'http://fake.url/?reprint-api',
+            $this->stateDir,
+            $this->fs_root,
+        );
+
+        // The old behavior threw "Cannot change --filter from
+        // 'skipped-earlier' to 'essential-files' while a sync is in
+        // progress". With the repair, the run proceeds into a delta sync
+        // and only fails when it can't reach the fake URL.
+        try {
+            $client->run([
+                'command' => 'files-pull',
+                'abort' => false,
+                'verbose' => false,
+                'secret' => null,
+                'tuning_config' => [],
+                'filter' => 'essential-files',
+            ]);
+        } catch (\Exception $e) {
+            $this->assertStringNotContainsString(
+                'Cannot change --filter',
+                $e->getMessage(),
+                'The stuck skipped-earlier state must be repaired before the filter guard runs',
+            );
+        }
+
+        $state = $this->readState();
+        $this->assertSame('files-pull', $state['command']);
+        $this->assertSame('essential-files', $state['filter']);
+    }
+}

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -9,7 +9,8 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * Test files-pull state transitions and preserve-local diff behavior.
  *
- * A completed files-pull should refuse to re-run without --abort.
+ * A completed files-pull re-run starts a delta sync (re-index, diff,
+ * fetch changes) instead of no-oping.
  * After --abort, the next run should start fresh (not "already complete").
  * In preserve-local mode, previously-synced files that changed remotely
  * must still be re-downloaded (not skipped).
@@ -153,10 +154,19 @@ class FilesSyncStateTest extends TestCase
     // ---------------------------------------------------------------
 
     /**
-     * A completed files-pull should refuse to re-run.
+     * A completed files-pull re-run starts a delta sync instead of
+     * no-oping, and clears the stale remote index first
+     * (download_remote_index appends when the file already exists).
      */
-    public function testCompletedFilesSyncRefusesToRerun()
+    public function testCompletedFilesSyncRerunsAsDelta()
     {
+        $indexFile = $this->stateDir . '/.import-index.jsonl';
+        file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
+
+        $staleRemoteLine = $this->indexLine('/stale-from-last-run.php', 1000, 100);
+        $remoteIndexFile = $this->stateDir . '/.import-remote-index.jsonl';
+        file_put_contents($remoteIndexFile, $staleRemoteLine);
+
         $this->writeState([
             "command" => "files-pull",
             "status" => "complete",
@@ -164,12 +174,36 @@ class FilesSyncStateTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $method = $reflection->getMethod('run_files_sync');
-        $method->invoke($client);
+        try {
+            $reflection->getMethod('run_files_sync')->invoke($client);
+        } catch (\Exception $e) {
+            // Expected: contacting the fake URL fails after the reset.
+        }
 
         $state = $this->readState();
-        $this->assertEquals("complete", $state["status"]);
+        $this->assertNotEquals(
+            "complete",
+            $state["status"],
+            "A completed files-pull re-run must start a delta sync, not no-op",
+        );
         $this->assertEquals("files-pull", $state["command"]);
+        $this->assertEquals(
+            "in_progress",
+            $state["status"],
+            "The delta re-sync should be in progress after the reset",
+        );
+
+        // The local index must survive (it's what makes the re-run a delta).
+        $this->assertFileExists($indexFile);
+
+        // The stale remote index must have been cleared before re-indexing.
+        if (file_exists($remoteIndexFile)) {
+            $this->assertStringNotContainsString(
+                trim($staleRemoteLine),
+                file_get_contents($remoteIndexFile),
+                "Stale remote index entries must not survive into the delta re-sync",
+            );
+        }
     }
 
     /**

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -71,17 +71,17 @@ describe('Import: Basic File Sync', () => {
         assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
-    it('re-running after completion refuses without --abort', () => {
+    it('re-running after completion performs a delta sync', () => {
+        // A completed files-sync used to refuse re-runs ("use --abort").
+        // It now re-runs as a delta (re-index → diff → fetch changes); with
+        // no remote changes it finishes with status "complete".
         const result = runImporter(importUrl(), tempDir, 'files-sync', {
             secret: getSiteSecret(site),
-            autoResume: false,
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
-        // In non-tty mode, the JSON output shows {"status":"complete"}
-        // confirming the importer detected the completed state and returned early.
         assert.ok(
-            result.stdout.includes('"status":"complete"') || result.stdout.includes('already complete'),
-            `Expected completed status in output, got stdout: ${result.stdout}\nstderr: ${result.stderr}`,
+            result.stdout.includes('"status":"complete"'),
+            `Expected completed status after delta re-sync, got stdout: ${result.stdout}\nstderr: ${result.stderr}`,
         );
     });
 

--- a/tests/e2e/tests/import-02-sql-sync.test.js
+++ b/tests/e2e/tests/import-02-sql-sync.test.js
@@ -93,12 +93,32 @@ describe('Import: SQL Sync', () => {
         }
     });
 
-    it('re-running db-sync without --abort fails with useful message', () => {
+    it('re-running db-sync after completion refreshes instead of failing', () => {
+        // The 'db-sync completes' test above left tempDir in a completed
+        // state. Re-running used to error ("use --abort"); it now performs
+        // a full refresh (re-dump) and succeeds — parity with files-sync
+        // and the composite pull's re-pull behavior.
         const result = runImporter(importUrl(), tempDir, 'db-sync', {
             secret: getSiteSecret(site),
         });
-        assert.notEqual(result.exitCode, 0, 'Expected non-zero exit code');
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0 (refresh), got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
         const output = result.stdout + result.stderr;
-        assert.ok(output.includes('--abort'), `Expected message mentioning --abort, got: ${output}`);
+        assert.ok(!output.includes('--abort'),
+            `Re-run should no longer print the old --abort error, got: ${output}`);
+
+        // The refresh re-produces a complete dump.
+        const sqlFile = join(tempDir, 'db.sql');
+        assert.ok(existsSync(sqlFile), 'Expected db.sql to exist after refresh');
+        const sql = readFileSync(sqlFile, 'utf-8');
+        assert.ok(sql.includes('CREATE TABLE') && sql.includes('INSERT INTO'),
+            'Expected a complete dump after the refresh');
+
+        // The audit log records that the refresh path was taken (not a no-op).
+        const auditLog = join(tempDir, '.import-audit.log');
+        assert.ok(existsSync(auditLog), 'Expected an audit log');
+        assert.match(readFileSync(auditLog, 'utf-8'), /full refresh/,
+            'Expected the audit log to record the db-pull full refresh');
     });
 });

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -11,7 +11,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
@@ -133,9 +133,17 @@ describe('Import: --filter', () => {
             }
         });
 
-        it('skipped download list was cleaned up', () => {
-            assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-                'Expected skipped download list to be cleaned up');
+        it('skipped download list was emptied', () => {
+            // The list is truncated to empty rather than deleted: apply-runtime
+            // mounts this path into the generated runtime, and deleting it would
+            // crash the runtime (ENOENT) on its next rotation. An empty file
+            // means "no remote-only files left" — all has-skipped checks test
+            // for size > 0.
+            const skippedList = join(tempDir, '.import-download-list-skipped.jsonl');
+            assert.ok(existsSync(skippedList),
+                'Expected skipped download list to remain on disk (truncated, not deleted)');
+            assert.equal(statSync(skippedList).size, 0,
+                'Expected skipped download list to be emptied after skipped-earlier');
         });
 
         it('all files match source', () => {


### PR DESCRIPTION
## Problem

Re-pulling a site never propagated **edits or deletions to existing database rows** — the local database stayed frozen at the content captured by the first completed pull. The root cause is an asymmetry in the engine: the composite `pull` orchestrator resets state for a delta re-pull (`Pull::prepare_repull()`), but callers that drive the sub-commands directly (notably Studio's `pull-reprint`) had no refresh path:

| Sub-command | Re-run on completed state (before) |
| --- | --- |
| `files-pull` | Silent no-op ("already complete… use `--abort`") |
| `db-pull` | Throws "already completed … Use --abort flag to start over." |
| `db-apply` | Throws "already completed. Use --abort flag to re-run." |

`--abort` is destructive (re-downloads everything), so there was no clean incremental re-sync.

## Change

Re-invoking a sub-command on a **completed** state now performs a refresh, matching the composite `pull`'s re-pull semantics:

- **`files-pull` → delta sync.** Keeps the local index, re-indexes the remote, diffs, fetches only changes. Stale remote index / download lists are cleared first (`download_remote_index()` appends when the file exists).
- **`db-pull` → full refresh.** New `ImportClient::reset_db_pull_state()` (now also used by `Pull::prepare_repull()`) resets DB state and deletes `db.sql`, `.import-domains.json`, and the `.sql-buffer` crash-recovery file, then re-downloads the entire dump.
- **`db-apply` → re-apply from statement 0.** The dump is idempotent (`DROP TABLE IF EXISTS` + full INSERTs), so edits, inserts, and deletes all land.

In-progress/partial states still resume from their cursors; `--abort` still clears state without running.

## Bugs fixed along the way

1. **`--filter=skipped-earlier` never marked completion** — the branch returned before the `status = "complete"` marking, leaving every successful essential+skipped pull stuck `in_progress` forever. Fixed, plus a legacy-state repair in `run()` for sessions written by older versions.
2. **Deleting the skipped download list broke running runtimes** — `apply-runtime` mounts `state/.import-download-list-skipped.jsonl` into the generated runtime (remote-uploads proxy), and PHP-WASM re-resolves mounts on every runtime rotation. Deleting the file crashed server starts and WP-CLI with ENOENT. It is now truncated to empty instead (all has-skipped checks test `size > 0`, so semantics are unchanged).
3. **Phantom "X is currently editing" badges** — the dump carries the remote's ephemeral `_edit_lock` postmeta, which renders as an editor lock on the imported copy for 150s after the captured timestamp. `db-apply` now strips `_edit_lock` rows after applying (WordPress regenerates them locally; core's WXR exporter skips them too).
4. **Stale `.sql-buffer` replay** — a leftover crash-recovery buffer could be replayed into the target on a refresh (latent `prepare_repull()` gap, fixed via the shared reset helper).

## Known limitation

A table dropped on the remote between pulls lingers in the local target (the new dump no longer mentions it). WP core tables always exist, so this is rare; recreating the SQLite file on refresh is a possible hardening follow-up.

## Testing

- New `tests/Import/DbResyncStateTest.php`: round-trip via the sub-command path proving an **edited**, **inserted**, and **deleted** row all propagate on re-run; db-pull refresh resets state and deletes stale artifacts; the stuck skipped-earlier state is repaired; `_edit_lock` is stripped while other postmeta survives.
- `tests/Import/FilesSyncStateTest.php` updated: completed `files-pull` re-runs as a delta and clears the stale remote index.
- Full `tests/Import/` + `tests/UrlRewriting/` suites green (493 tests).
- Verified live end-to-end against a WP.com Atomic site via Studio: remote post edits, inserts, and deletes propagate on re-pull; site start and WP-CLI work after sync cycles.




---

_Supersedes #257 — moved from a fork to an in-repo branch so CI runs with full token permissions (the Performance Report perf-comment step can post on this PR)._
