### PR TITLE
Add new `—remap` flag for files-pull

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8378,8 +8378,8 @@ class ImportClient
     /**
      * Resolve a --remap argument (source or target) into an absolute path.
      *
-     * Substitutes every known `:token:` (see the token tables in resolve_remap)
-     * with its value, wherever it appears, then trims trailing slashes. The
+     * Substitutes a known leading `:token:` (see the token tables in resolve_remap)
+     * with its value, then trims trailing slashes. The
      * result must be a valid absolute path with no `.`/`..` segments; a relative
      * path or an unknown token (left unsubstituted) fails that check. Referencing
      * a token whose value is unavailable in preflight is a distinct, clear error.
@@ -8391,17 +8391,25 @@ class ImportClient
     {
         $resolved = $raw;
         foreach ($tokens as $name => $value) {
-            if (strpos($resolved, ":{$name}:") === false) {
+            $token = ":{$name}:";
+            $token_offset = strpos($resolved, $token);
+            if ($token_offset === false) {
                 continue;
+            }
+
+            if ($token_offset !== 0 || strpos($resolved, $token, strlen($token)) !== false) {
+                throw new InvalidArgumentException(
+                    "--remap token \"{$token}\" must appear only at the beginning of the path"
+                );
             }
 
             if ($value === null) {
                 throw new InvalidArgumentException(
-                    "Cannot resolve --remap token \":{$name}:\": not available in preflight data. Run preflight first."
+                    "Cannot resolve --remap token \"{$token}\": not available in preflight data. Run preflight first."
                 );
             }
 
-            $resolved = str_replace(":{$name}:", $value, $resolved);
+            $resolved = $value . substr($resolved, strlen($token));
         }
 
         $resolved = rtrim($resolved, "/");

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10,6 +10,7 @@
  * - Three-phase import: files, SQL, then file deltas
  */
 
+use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
@@ -1132,9 +1133,9 @@ class ImportClient
     private $extra_directory = null;
 
     /**
-     * @var array<int,array{source:string,target:string}> Resolved remap rules:
-     * a full source path → its full local target path (both absolute). Empty =
-     * no remapping (files land nested based on their source).
+     * @var array<string,string> Resolved remap rules: full source path => its
+     * full local target path (both absolute). Empty = no remapping (files land
+     * nested based on their source).
      */
     private $remap_rules = [];
 
@@ -8289,7 +8290,7 @@ class ImportClient
      * here.
      *
      * @param array<int,array{0:string,1:string}> $remap_raw Raw (SRC, TGT) pairs.
-     * @return array<int,array{source:string,target:string}>
+     * @return array<string,string> Source path => target path (both absolute).
      */
     private function resolve_remap(array $remap_raw): array
     {
@@ -8297,31 +8298,23 @@ class ImportClient
         $docroot = rtrim($this->get_filesystem_root_path(), "/");
 
         $rules = [];
-        $explicit_sources = [];
         $wp_content_target = null;
-        foreach ($remap_raw as $pair) {
-            [$src, $tgt] = $pair;
-
-            $wp_path = trim(trim($src), "/");
+        foreach ($remap_raw as [$source, $target]) {
+            $wp_path = trim(trim($source), "/");
             if ($wp_path === "") {
                 throw new InvalidArgumentException("--remap source cannot be empty");
             }
 
             // Accept a target given as a full absolute path that includes the
             // docroot — strip the docroot prefix so it's treated as relative.
-            $tgt = trim($tgt);
-            $under_docroot = self::path_remainder_under(rtrim($tgt, "/"), $docroot);
-            if ($under_docroot !== null) {
-                $tgt = $under_docroot;
-            }
-
-            $tgt_rel = trim($tgt, "/");
+            $target = trim($target);
+            $target_relative = self::path_remainder_under(rtrim($target, "/"), $docroot) ?? $target;
+            $target_relative = trim($target_relative, "/");
 
             $source = $this->resolve_source_path($wp_path, $source_paths);
-            $target = $tgt_rel === "" ? $docroot : $docroot . "/" . $tgt_rel;
-            $rules[] = ["source" => $source, "target" => $target];
+            $target = wp_join_unix_paths($docroot, $target_relative);
+            $rules[$source] = $target;
 
-            $explicit_sources[$source] = true;
             if ($wp_path === "wp-content") {
                 $wp_content_target = $target;
             }
@@ -8331,9 +8324,9 @@ class ImportClient
         if ($wp_content_target !== null) {
             foreach (["plugins", "mu-plugins", "uploads"] as $name) {
                 $source = $source_paths[$name];
-                $detached = self::path_remainder_under($source, $source_paths["content"]) === null;
-                if ($detached && !isset($explicit_sources[$source])) {
-                    $rules[] = ["source" => $source, "target" => $wp_content_target . "/" . $name];
+                $is_outside_content_dir = self::path_remainder_under($source, $source_paths["content"]) === null;
+                if ($is_outside_content_dir && !isset($rules[$source])) {
+                    $rules[$source] = wp_join_unix_paths($wp_content_target, $name);
                 }
             }
         }
@@ -8345,8 +8338,9 @@ class ImportClient
      * The source site's real component locations from preflight data, as
      * name => absolute path (abspath, content, plugins, mu-plugins, uploads).
      * Each wp-content component falls back to its conventional spot under
-     * content_dir; one resolving outside content_dir is "detached". abspath
-     * anchors any path outside wp-content and may be null if undetermined.
+     * content_dir; one resolving outside content_dir is relocated and routed
+     * separately. abspath anchors any path outside wp-content and may be null
+     * if undetermined.
      */
     private function wp_component_source_paths(): array
     {
@@ -8396,7 +8390,7 @@ class ImportClient
         foreach ($bases as $prefix => $base) {
             $rest = self::path_remainder_under($wp_path, $prefix);
             if ($rest !== null) {
-                return $base . $rest;
+                return wp_join_unix_paths($base, $rest);
             }
         }
         // Anything outside wp-content (wp-admin, core, a root file, ...) is
@@ -8407,7 +8401,7 @@ class ImportClient
             );
         }
 
-        return $source_paths["abspath"] . "/" . $wp_path;
+        return wp_join_unix_paths($source_paths["abspath"], $wp_path);
     }
 
     /**
@@ -8422,13 +8416,13 @@ class ImportClient
     private function remap_source_path_to_target(string $source_path): ?string
     {
         $best = null;
-        $best_source_len = -1;
+        $best_source_length = -1;
 
-        foreach ($this->remap_rules as $rule) {
-            $rest = self::path_remainder_under($source_path, $rule["source"]);
-            if ($rest !== null && strlen($rule["source"]) > $best_source_len) {
-                $best = $rule["target"] . $rest;
-                $best_source_len = strlen($rule["source"]);
+        foreach ($this->remap_rules as $source => $target) {
+            $rest = self::path_remainder_under($source_path, $source);
+            if ($rest !== null && strlen($source) > $best_source_length) {
+                $best = wp_join_unix_paths($target, $rest);
+                $best_source_length = strlen($source);
             }
         }
 
@@ -9300,8 +9294,10 @@ class ImportClient
         // Ensure every --remap source is enumerated — including a detached
         // component (relocated uploads/plugins dir) that lives outside the
         // WordPress roots and so wouldn't be discovered by traversal alone.
-        foreach ($this->remap_rules as $i => $rule) {
-            $extra_paths["remap_src_{$i}"] = $rule["source"];
+        $remap_index = 0;
+        foreach (array_keys($this->remap_rules) as $source) {
+            $extra_paths["remap_source_{$remap_index}"] = $source;
+            $remap_index++;
         }
 
         // auto_prepend_file / auto_append_file may point to directories

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8325,7 +8325,7 @@ class ImportClient
         if ($wp_content_target !== null) {
             foreach (["wp-plugins" => "plugins", "wp-mu-plugins" => "mu-plugins", "wp-uploads" => "uploads"] as $token => $name) {
                 $source = $source_tokens[$token];
-                $is_outside_content_dir = self::path_remainder_under($source, $source_tokens["wp-content"]) === null;
+                $is_outside_content_dir = !path_is_within_root($source, $source_tokens["wp-content"]);
                 if ($is_outside_content_dir && !isset($rules[$source])) {
                     $rules[$source] = wp_join_unix_paths($wp_content_target, $name);
                 }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8291,7 +8291,7 @@ class ImportClient
      * Target arguments resolve under --fs-root and must stay within it.
      * Each rule is a full source path => full local target path (both absolute).
      *
-     * @param array<int,array{0:string,1:string}> $remap_raw Raw (SRC, TGT) pairs.
+     * @param array<int,array{0:string,1:string}> $remap_raw Raw (SOURCE, TARGET) pairs.
      * @return array<string,string> Source path => target path (both absolute).
      */
     private function resolve_remap(array $remap_raw): array

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8343,12 +8343,11 @@ class ImportClient
     }
 
     /**
-     * The source site's real component locations from preflight data, as
-     * name => absolute path (abspath, content, plugins, mu-plugins, uploads).
-     * Each wp-content component falls back to its conventional spot under
-     * content_dir; one resolving outside content_dir is relocated and routed
-     * separately. abspath anchors any path outside wp-content and may be null
-     * if undetermined.
+     * The source site's real component locations from preflight data, as name => absolute path.
+     *
+     * A wp-content component falls back to its conventional spot under
+     * content_dir when that is known. This is a pure data-gatherer: any entry
+     * may be null when preflight lacks it (no content_dir, abspath undetermined).
      */
     private function wp_component_source_paths(): array
     {
@@ -8356,23 +8355,23 @@ class ImportClient
         $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
 
         $content_dir = $this->flatten_clean_path($paths["content_dir"] ?? null);
-        if ($content_dir === null) {
-            throw new InvalidArgumentException(
-                "Cannot resolve --remap: preflight has no content_dir. Run preflight first.",
-            );
-        }
 
         $abspath = $this->flatten_clean_path($paths["abspath"] ?? null);
         if ($abspath === null) {
             $abspath = $this->flatten_clean_path($preflight["wp_detect"]["roots"][0]["path"] ?? null);
         }
 
+        // Conventional spot under content_dir, but only when content_dir is known.
+        $maybe_under_content_dir = function (?string $dir, string $name) use ($content_dir): ?string {
+            return $dir ?? ($content_dir === null ? null : $content_dir . "/" . $name);
+        };
+
         return [
             "abspath" => $abspath,
             "content" => $content_dir,
-            "plugins" => $this->flatten_clean_path($paths["plugins_dir"] ?? null) ?? $content_dir . "/plugins",
-            "mu-plugins" => $this->flatten_clean_path($paths["mu_plugins_dir"] ?? null) ?? $content_dir . "/mu-plugins",
-            "uploads" => $this->flatten_clean_path($paths["uploads"]["basedir"] ?? null) ?? $content_dir . "/uploads",
+            "plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["plugins_dir"] ?? null), "plugins"),
+            "mu-plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["mu_plugins_dir"] ?? null), "mu-plugins"),
+            "uploads" => $maybe_under_content_dir($this->flatten_clean_path($paths["uploads"]["basedir"] ?? null), "uploads"),
         ];
     }
 
@@ -8398,8 +8397,7 @@ class ImportClient
 
             if ($value === null) {
                 throw new InvalidArgumentException(
-                    "Cannot resolve --remap token \":{$name}:\": not available in " .
-                        "preflight data. Run preflight first.",
+                    "Cannot resolve --remap token \":{$name}:\": not available in preflight data. Run preflight first."
                 );
             }
 
@@ -8470,6 +8468,9 @@ class ImportClient
      */
     private static function path_remainder_under(string $path, string $prefix): ?string
     {
+        $path = rtrim($path, "/");
+        $prefix = rtrim($prefix, "/");
+
         if ($path === $prefix) {
             return "";
         }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2737,7 +2737,7 @@ class ImportClient
             if ($is_delta) {
                 $this->files_imported = 0;
                 $index_size = $this->index_count();
-    
+
                 $this->audit_log(
                     "START files-pull (delta) | index_files={$index_size}",
                     true,
@@ -3364,7 +3364,7 @@ class ImportClient
             /**
              * base64_decode second parameter is a `strict` flag. It rejects the entire
              * input if it contains any bytes that are not produced by base64_encode().
-             * 
+             *
              * @see https://www.php.net/base64_decode
              */
             $path = base64_decode($path_encoded, true);
@@ -4252,13 +4252,13 @@ class ImportClient
         $uploads_basedir = null;
 
         if (is_array($paths_urls)) {
-            $abspath = $this->flatten_clean_path($paths_urls["abspath"] ?? null);
-            $wp_admin_path = $this->flatten_clean_path($paths_urls["wp_admin_path"] ?? null);
-            $wp_includes_path = $this->flatten_clean_path($paths_urls["wp_includes_path"] ?? null);
-            $content_dir = $this->flatten_clean_path($paths_urls["content_dir"] ?? null);
-            $plugins_dir = $this->flatten_clean_path($paths_urls["plugins_dir"] ?? null);
-            $mu_plugins_dir = $this->flatten_clean_path($paths_urls["mu_plugins_dir"] ?? null);
-            $uploads_basedir = $this->flatten_clean_path(
+            $abspath = $this->clean_preflight_path( $paths_urls["abspath"] ?? null);
+            $wp_admin_path = $this->clean_preflight_path( $paths_urls["wp_admin_path"] ?? null);
+            $wp_includes_path = $this->clean_preflight_path( $paths_urls["wp_includes_path"] ?? null);
+            $content_dir = $this->clean_preflight_path( $paths_urls["content_dir"] ?? null);
+            $plugins_dir = $this->clean_preflight_path( $paths_urls["plugins_dir"] ?? null);
+            $mu_plugins_dir = $this->clean_preflight_path( $paths_urls["mu_plugins_dir"] ?? null);
+            $uploads_basedir = $this->clean_preflight_path(
                 $paths_urls["uploads"]["basedir"] ?? null,
             );
         }
@@ -4267,7 +4267,7 @@ class ImportClient
         if ($abspath === null) {
             $roots = $preflight["wp_detect"]["roots"] ?? [];
             if (!empty($roots)) {
-                $abspath = $this->flatten_clean_path($roots[0]["path"] ?? null);
+                $abspath = $this->clean_preflight_path( $roots[0]["path"] ?? null);
             }
         }
 
@@ -4596,7 +4596,7 @@ class ImportClient
      * Clean a path value from preflight data: trim, strip trailing slash.
      * Returns null if the value is not a non-empty string.
      */
-    private function flatten_clean_path($value): ?string
+    private function clean_preflight_path($value): ?string
     {
         if (!is_string($value) || trim($value) === "") {
             return null;
@@ -8347,11 +8347,11 @@ class ImportClient
         $preflight = $this->state["preflight"]["data"] ?? [];
         $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
 
-        $content_dir = $this->flatten_clean_path($paths["content_dir"] ?? null);
+        $content_dir = $this->clean_preflight_path( $paths["content_dir"] ?? null);
 
-        $abspath = $this->flatten_clean_path($paths["abspath"] ?? null);
+        $abspath = $this->clean_preflight_path( $paths["abspath"] ?? null);
         if ($abspath === null) {
-            $abspath = $this->flatten_clean_path($preflight["wp_detect"]["roots"][0]["path"] ?? null);
+            $abspath = $this->clean_preflight_path( $preflight["wp_detect"]["roots"][0]["path"] ?? null);
         }
 
         // Conventional spot under content_dir, but only when content_dir is known.
@@ -8362,9 +8362,9 @@ class ImportClient
         return [
             "abspath" => $abspath,
             "wp-content" => $content_dir,
-            "wp-plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["plugins_dir"] ?? null), "plugins"),
-            "wp-mu-plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["mu_plugins_dir"] ?? null), "mu-plugins"),
-            "wp-uploads" => $maybe_under_content_dir($this->flatten_clean_path($paths["uploads"]["basedir"] ?? null), "uploads"),
+            "wp-plugins" => $maybe_under_content_dir($this->clean_preflight_path( $paths["plugins_dir"] ?? null), "plugins"),
+            "wp-mu-plugins" => $maybe_under_content_dir($this->clean_preflight_path( $paths["mu_plugins_dir"] ?? null), "mu-plugins"),
+            "wp-uploads" => $maybe_under_content_dir($this->clean_preflight_path( $paths["uploads"]["basedir"] ?? null), "uploads"),
         ];
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1816,6 +1816,10 @@ class ImportClient
             return;
         }
 
+        if ($command === "files-pull") {
+            $this->assert_files_remap_consistent();
+        }
+
         // Dispatch to appropriate command handler
         try {
             switch ($command) {
@@ -8284,6 +8288,52 @@ class ImportClient
     }
 
     /**
+     * Refuse to reuse a files index with different --remap rules.
+     *
+     * The files index stores remote paths. Local writes/deletes derive their
+     * targets from the current remap rules, so changing those rules while the
+     * same index is still in use can point future updates at the wrong path.
+     */
+    private function assert_files_remap_consistent(): void
+    {
+        $fingerprint = $this->files_remap_fingerprint();
+        $previous = $this->state["files_remap_fingerprint"] ?? null;
+
+        $has_existing_index = file_exists($this->index_file) && filesize($this->index_file) > 0;
+        if ($previous === null && $has_existing_index && !empty($this->remap_rules)) {
+            throw new RuntimeException(
+                "Cannot use --remap with an existing files index that was created before remap tracking. " .
+                    "Use a new --state-dir or clear the existing files index first.",
+            );
+        }
+
+        if ($previous !== null && $previous !== $fingerprint) {
+            throw new RuntimeException(
+                "Cannot change --remap rules while reusing the same files index. " .
+                    "Use the original --remap rules, or use a new --state-dir for a fresh files-pull.",
+            );
+        }
+
+        if ($previous === null) {
+            $this->state["files_remap_fingerprint"] = $fingerprint;
+            $this->save_state($this->state);
+        }
+    }
+
+    /**
+     * Stable fingerprint for the resolved remap rule set.
+     *
+     * Rule order does not matter: remap matching chooses the deepest source
+     * path, not the first matching rule.
+     */
+    private function files_remap_fingerprint(): string
+    {
+        $rules = $this->remap_rules;
+        ksort($rules, SORT_STRING);
+        return hash("sha256", json_encode($rules, JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
      * Build the remap rules from the raw remap pairs + preflight data.
      *
      * Each argument is a template string of `:token:` substitutions and/or a raw absolute path.
@@ -10410,6 +10460,7 @@ class ImportClient
         $follow = $this->state["follow_symlinks"] ?? false;
         $nonempty = $this->state["fs_root_nonempty_behavior"] ?? "error";
         $max_packet = $this->state["max_allowed_packet"] ?? null;
+        $files_remap_fingerprint = $this->state["files_remap_fingerprint"] ?? null;
         $pull = $this->state["pull"] ?? null;
         $this->state = $this->default_state();
         $this->state["preflight"] = $preflight;
@@ -10418,6 +10469,7 @@ class ImportClient
         $this->state["follow_symlinks"] = $follow;
         $this->state["fs_root_nonempty_behavior"] = $nonempty;
         $this->state["max_allowed_packet"] = $max_packet;
+        $this->state["files_remap_fingerprint"] = $files_remap_fingerprint;
         if ($pull !== null) {
             $this->state["pull"] = $pull;
         }
@@ -10439,6 +10491,7 @@ class ImportClient
             "fs_root_nonempty_behavior" => "error",
             "filter" => "none",
             "max_allowed_packet" => null,
+            "files_remap_fingerprint" => null,
             "db_index" => [
                 "file" => null,
                 "tables" => 0,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8354,17 +8354,24 @@ class ImportClient
             $abspath = $this->clean_preflight_path( $preflight["wp_detect"]["roots"][0]["path"] ?? null);
         }
 
-        // Conventional spot under content_dir, but only when content_dir is known.
-        $maybe_under_content_dir = function (?string $dir, string $name) use ($content_dir): ?string {
-            return $dir ?? ($content_dir === null ? null : $content_dir . "/" . $name);
-        };
+        $plugins_dir = $this->clean_preflight_path( $paths["plugins_dir"] ?? null);
+        $mu_plugins_dir = $this->clean_preflight_path( $paths["mu_plugins_dir"] ?? null);
+        $uploads_dir = $this->clean_preflight_path( $paths["uploads"]["basedir"] ?? null);
+
+        // If preflight did not report a component path, use its conventional
+        // location under WP_CONTENT_DIR when WP_CONTENT_DIR is known.
+        if ($content_dir !== null) {
+            $plugins_dir = $plugins_dir ?? wp_join_unix_paths( $content_dir, "plugins" );
+            $mu_plugins_dir = $mu_plugins_dir ?? wp_join_unix_paths( $content_dir, "mu-plugins" );
+            $uploads_dir = $uploads_dir ?? wp_join_unix_paths( $content_dir, "uploads" );
+        }
 
         return [
             "abspath" => $abspath,
             "wp-content" => $content_dir,
-            "wp-plugins" => $maybe_under_content_dir($this->clean_preflight_path( $paths["plugins_dir"] ?? null), "plugins"),
-            "wp-mu-plugins" => $maybe_under_content_dir($this->clean_preflight_path( $paths["mu_plugins_dir"] ?? null), "mu-plugins"),
-            "wp-uploads" => $maybe_under_content_dir($this->clean_preflight_path( $paths["uploads"]["basedir"] ?? null), "uploads"),
+            "wp-plugins" => $plugins_dir,
+            "wp-mu-plugins" => $mu_plugins_dir,
+            "wp-uploads" => $uploads_dir,
         ];
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8296,16 +8296,9 @@ class ImportClient
      */
     private function resolve_remap(array $remap_raw): array
     {
-        $source_paths = $this->wp_component_source_paths();
         $fs_root = rtrim($this->get_filesystem_root_path(), "/");
 
-        $source_tokens = [
-            "wp-content" => $source_paths["content"],
-            "wp-plugins" => $source_paths["plugins"],
-            "wp-mu-plugins" => $source_paths["mu-plugins"],
-            "wp-uploads" => $source_paths["uploads"],
-            "abspath" => $source_paths["abspath"],
-        ];
+        $source_tokens = $this->wp_component_source_paths();
         $target_tokens = ["fs-root" => $fs_root];
 
         $rules = [];
@@ -8322,7 +8315,7 @@ class ImportClient
             }
 
             $rules[$source] = $target;
-            if ($source === $source_paths["content"]) {
+            if ($source === $source_tokens["wp-content"]) {
                 $wp_content_target = $target;
             }
         }
@@ -8330,9 +8323,9 @@ class ImportClient
         // Whole-tree remap of the wp-content components that can live outside the content_dir,
         // unless an explicit rule has already placed them somewhere else.
         if ($wp_content_target !== null) {
-            foreach (["plugins", "mu-plugins", "uploads"] as $name) {
-                $source = $source_paths[$name];
-                $is_outside_content_dir = self::path_remainder_under($source, $source_paths["content"]) === null;
+            foreach (["wp-plugins" => "plugins", "wp-mu-plugins" => "mu-plugins", "wp-uploads" => "uploads"] as $token => $name) {
+                $source = $source_tokens[$token];
+                $is_outside_content_dir = self::path_remainder_under($source, $source_tokens["wp-content"]) === null;
                 if ($is_outside_content_dir && !isset($rules[$source])) {
                     $rules[$source] = wp_join_unix_paths($wp_content_target, $name);
                 }
@@ -8343,7 +8336,7 @@ class ImportClient
     }
 
     /**
-     * The source site's real component locations from preflight data, as name => absolute path.
+     * The source site's real component locations from preflight data, as remap token name => absolute path.
      *
      * A wp-content component falls back to its conventional spot under
      * content_dir when that is known. This is a pure data-gatherer: any entry
@@ -8368,10 +8361,10 @@ class ImportClient
 
         return [
             "abspath" => $abspath,
-            "content" => $content_dir,
-            "plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["plugins_dir"] ?? null), "plugins"),
-            "mu-plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["mu_plugins_dir"] ?? null), "mu-plugins"),
-            "uploads" => $maybe_under_content_dir($this->flatten_clean_path($paths["uploads"]["basedir"] ?? null), "uploads"),
+            "wp-content" => $content_dir,
+            "wp-plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["plugins_dir"] ?? null), "plugins"),
+            "wp-mu-plugins" => $maybe_under_content_dir($this->flatten_clean_path($paths["mu_plugins_dir"] ?? null), "mu-plugins"),
+            "wp-uploads" => $maybe_under_content_dir($this->flatten_clean_path($paths["uploads"]["basedir"] ?? null), "uploads"),
         ];
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8284,10 +8284,12 @@ class ImportClient
     }
 
     /**
-     * Build and return the remap rules from the raw remap pairs + preflight
-     * data. Each rule is a full source path → full local target path (both
-     * absolute); the caller's docroot-relative TGT is rooted under the docroot
-     * here.
+     * Build the remap rules from the raw remap pairs + preflight data.
+     *
+     * Each argument is a template string of `:token:` substitutions and/or a raw absolute path.
+     * Source arguments resolve against the remote site's component locations.
+     * Target arguments resolve under --fs-root and must stay within it.
+     * Each rule is a full source path => full local target path (both absolute).
      *
      * @param array<int,array{0:string,1:string}> $remap_raw Raw (SRC, TGT) pairs.
      * @return array<string,string> Source path => target path (both absolute).
@@ -8295,32 +8297,38 @@ class ImportClient
     private function resolve_remap(array $remap_raw): array
     {
         $source_paths = $this->wp_component_source_paths();
-        $docroot = rtrim($this->get_filesystem_root_path(), "/");
+        $fs_root = rtrim($this->get_filesystem_root_path(), "/");
+
+        $source_tokens = [
+            "wp-content" => $source_paths["content"],
+            "wp-plugins" => $source_paths["plugins"],
+            "wp-mu-plugins" => $source_paths["mu-plugins"],
+            "wp-uploads" => $source_paths["uploads"],
+            "abspath" => $source_paths["abspath"],
+        ];
+        $target_tokens = ["fs-root" => $fs_root];
 
         $rules = [];
         $wp_content_target = null;
-        foreach ($remap_raw as [$source, $target]) {
-            $wp_path = trim(trim($source), "/");
-            if ($wp_path === "") {
-                throw new InvalidArgumentException("--remap source cannot be empty");
+        foreach ($remap_raw as [$source_raw, $target_raw]) {
+            $source = $this->resolve_remap_path($source_raw, $source_tokens);
+            $target = $this->resolve_remap_path($target_raw, $target_tokens);
+
+            if (!path_is_within_root($target, $fs_root)) {
+                throw new InvalidArgumentException(
+                    "--remap target \"{$target}\" resolves outside --fs-root ({$fs_root}); " .
+                        "targets must stay within the destination root",
+                );
             }
 
-            // Accept a target given as a full absolute path that includes the
-            // docroot — strip the docroot prefix so it's treated as relative.
-            $target = trim($target);
-            $target_relative = self::path_remainder_under(rtrim($target, "/"), $docroot) ?? $target;
-            $target_relative = trim($target_relative, "/");
-
-            $source = $this->resolve_source_path($wp_path, $source_paths);
-            $target = wp_join_unix_paths($docroot, $target_relative);
             $rules[$source] = $target;
-
-            if ($wp_path === "wp-content") {
+            if ($source === $source_paths["content"]) {
                 $wp_content_target = $target;
             }
         }
 
-        // Pass 2: Do a whole tree remap for wp-content's components if needed.
+        // Whole-tree remap of the wp-content components that can live outside the content_dir,
+        // unless an explicit rule has already placed them somewhere else.
         if ($wp_content_target !== null) {
             foreach (["plugins", "mu-plugins", "uploads"] as $name) {
                 $source = $source_paths[$name];
@@ -8369,39 +8377,39 @@ class ImportClient
     }
 
     /**
-     * Resolve a WordPress-layout path (e.g. "wp-content/plugins/woocommerce",
-     * "wp-admin", "wp-config.php") to the source site's real absolute path.
-     * wp-content and its components resolve via their (possibly relocated) real
-     * dirs; anything else is taken relative to ABSPATH.
+     * Resolve a --remap argument (source or target) into an absolute path.
      *
-     * @param string $wp_path The WordPress-layout path to resolve.
-     * @param array<string,string|null> $source_paths From wp_component_source_paths().
+     * Substitutes every known `:token:` (see the token tables in resolve_remap)
+     * with its value, wherever it appears, then trims trailing slashes. The
+     * result must be a valid absolute path with no `.`/`..` segments; a relative
+     * path or an unknown token (left unsubstituted) fails that check. Referencing
+     * a token whose value is unavailable in preflight is a distinct, clear error.
+     *
+     * @param string $raw The raw remap argument.
+     * @param array<string,string|null> $tokens Token name => value (null = unavailable).
      */
-    private function resolve_source_path(string $wp_path, array $source_paths): string
+    private function resolve_remap_path(string $raw, array $tokens): string
     {
-        // Longest WP-path prefix first, each mapped to its real source location.
-        $bases = [
-            "wp-content/plugins" => $source_paths["plugins"],
-            "wp-content/mu-plugins" => $source_paths["mu-plugins"],
-            "wp-content/uploads" => $source_paths["uploads"],
-            "wp-content" => $source_paths["content"],
-        ];
-
-        foreach ($bases as $prefix => $base) {
-            $rest = self::path_remainder_under($wp_path, $prefix);
-            if ($rest !== null) {
-                return wp_join_unix_paths($base, $rest);
+        $resolved = $raw;
+        foreach ($tokens as $name => $value) {
+            if (strpos($resolved, ":{$name}:") === false) {
+                continue;
             }
-        }
-        // Anything outside wp-content (wp-admin, core, a root file, ...) is
-        // taken relative to ABSPATH.
-        if ($source_paths["abspath"] === null) {
-            throw new InvalidArgumentException(
-                "Cannot resolve --remap {$wp_path}: preflight has no ABSPATH. Run preflight first.",
-            );
+
+            if ($value === null) {
+                throw new InvalidArgumentException(
+                    "Cannot resolve --remap token \":{$name}:\": not available in " .
+                        "preflight data. Run preflight first.",
+                );
+            }
+
+            $resolved = str_replace(":{$name}:", $value, $resolved);
         }
 
-        return wp_join_unix_paths($source_paths["abspath"], $wp_path);
+        $resolved = rtrim($resolved, "/");
+        assert_valid_path($resolved, "--remap path \"{$raw}\"");
+
+        return $resolved;
     }
 
     /**
@@ -11443,8 +11451,9 @@ if (
             'name' => 'remap',
             'type' => 'pair',
             'target' => 'remap',
-            'pair_args' => 'SRC TGT',
-            'help' => 'Place SRC (e.g. wp-content) at TGT, relative to --docroot (repeatable)',
+            'pair_args' => 'SOURCE TARGET',
+            'help' => 'Place SOURCE (a :token: like :wp-uploads: or an absolute path) at TARGET ' .
+                '(a :fs-root: path or an absolute path within --fs-root); repeatable',
             'commands' => ['files-pull'],
         ],
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1131,6 +1131,13 @@ class ImportClient
     /** @var string|null Extra remote directory to include in the export (--extra-directory). */
     private $extra_directory = null;
 
+    /**
+     * @var array<int,array{source:string,target:string}> Resolved remap rules:
+     * a full source path → its full local target path (both absolute). Empty =
+     * no remapping (files land nested based on their source).
+     */
+    private $remap_rules = [];
+
     /** @var AdaptiveTuner|null Adjusts request pacing based on server response times and errors. */
     private $tuner = null;
 
@@ -1791,6 +1798,12 @@ class ImportClient
 
         // All other commands require a prior preflight run.
         $this->require_preflight();
+
+        // Resolve the `--remap` rules (requires preflight to be available first)
+        $remap_raw = $options["remap"] ?? [];
+        if (!empty($remap_raw)) {
+            $this->remap_rules = $this->resolve_remap($remap_raw);
+        }
 
         // Handle --abort: clear state for the command and exit immediately.
         // To abort a sync, run `<command> --abort` (clears state), then
@@ -8269,6 +8282,158 @@ class ImportClient
         return $real;
     }
 
+    /**
+     * Build and return the remap rules from the raw remap pairs + preflight
+     * data. Each rule is a full source path → full local target path (both
+     * absolute); the caller's docroot-relative TGT is rooted under the docroot
+     * here.
+     *
+     * @param array<int,array{0:string,1:string}> $remap_raw Raw (SRC, TGT) pairs.
+     * @return array<int,array{source:string,target:string}>
+     */
+    private function resolve_remap(array $remap_raw): array
+    {
+        $source_paths = $this->wp_component_source_paths();
+        $docroot = rtrim($this->get_filesystem_root_path(), "/");
+
+        $rules = [];
+        $explicit_sources = [];
+        $wp_content_target = null;
+        foreach ($remap_raw as $pair) {
+            [$src, $tgt] = $pair;
+
+            $wp_path = trim(trim($src), "/");
+            if ($wp_path === "") {
+                throw new InvalidArgumentException("--remap source cannot be empty");
+            }
+
+            // Accept a target given as a full absolute path that includes the
+            // docroot — strip the docroot prefix so it's treated as relative.
+            $tgt = trim($tgt);
+            $under_docroot = self::path_remainder_under(rtrim($tgt, "/"), $docroot);
+            if ($under_docroot !== null) {
+                $tgt = $under_docroot;
+            }
+
+            $tgt_rel = trim($tgt, "/");
+
+            $source = $this->resolve_source_path($wp_path, $source_paths);
+            $target = $tgt_rel === "" ? $docroot : $docroot . "/" . $tgt_rel;
+            $rules[] = ["source" => $source, "target" => $target];
+
+            $explicit_sources[$source] = true;
+            if ($wp_path === "wp-content") {
+                $wp_content_target = $target;
+            }
+        }
+
+        // Pass 2: Do a whole tree remap for wp-content's components if needed.
+        if ($wp_content_target !== null) {
+            foreach (["plugins", "mu-plugins", "uploads"] as $name) {
+                $source = $source_paths[$name];
+                $detached = self::path_remainder_under($source, $source_paths["content"]) === null;
+                if ($detached && !isset($explicit_sources[$source])) {
+                    $rules[] = ["source" => $source, "target" => $wp_content_target . "/" . $name];
+                }
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * The source site's real component locations from preflight data, as
+     * name => absolute path (abspath, content, plugins, mu-plugins, uploads).
+     * Each wp-content component falls back to its conventional spot under
+     * content_dir; one resolving outside content_dir is "detached". abspath
+     * anchors any path outside wp-content and may be null if undetermined.
+     */
+    private function wp_component_source_paths(): array
+    {
+        $preflight = $this->state["preflight"]["data"] ?? [];
+        $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
+
+        $content_dir = $this->flatten_clean_path($paths["content_dir"] ?? null);
+        if ($content_dir === null) {
+            throw new InvalidArgumentException(
+                "Cannot resolve --remap: preflight has no content_dir. Run preflight first.",
+            );
+        }
+
+        $abspath = $this->flatten_clean_path($paths["abspath"] ?? null);
+        if ($abspath === null) {
+            $abspath = $this->flatten_clean_path($preflight["wp_detect"]["roots"][0]["path"] ?? null);
+        }
+
+        return [
+            "abspath" => $abspath,
+            "content" => $content_dir,
+            "plugins" => $this->flatten_clean_path($paths["plugins_dir"] ?? null) ?? $content_dir . "/plugins",
+            "mu-plugins" => $this->flatten_clean_path($paths["mu_plugins_dir"] ?? null) ?? $content_dir . "/mu-plugins",
+            "uploads" => $this->flatten_clean_path($paths["uploads"]["basedir"] ?? null) ?? $content_dir . "/uploads",
+        ];
+    }
+
+    /**
+     * Resolve a WordPress-layout path (e.g. "wp-content/plugins/woocommerce",
+     * "wp-admin", "wp-config.php") to the source site's real absolute path.
+     * wp-content and its components resolve via their (possibly relocated) real
+     * dirs; anything else is taken relative to ABSPATH.
+     *
+     * @param string $wp_path The WordPress-layout path to resolve.
+     * @param array<string,string|null> $source_paths From wp_component_source_paths().
+     */
+    private function resolve_source_path(string $wp_path, array $source_paths): string
+    {
+        // Longest WP-path prefix first, each mapped to its real source location.
+        $bases = [
+            "wp-content/plugins" => $source_paths["plugins"],
+            "wp-content/mu-plugins" => $source_paths["mu-plugins"],
+            "wp-content/uploads" => $source_paths["uploads"],
+            "wp-content" => $source_paths["content"],
+        ];
+
+        foreach ($bases as $prefix => $base) {
+            $rest = self::path_remainder_under($wp_path, $prefix);
+            if ($rest !== null) {
+                return $base . $rest;
+            }
+        }
+        // Anything outside wp-content (wp-admin, core, a root file, ...) is
+        // taken relative to ABSPATH.
+        if ($source_paths["abspath"] === null) {
+            throw new InvalidArgumentException(
+                "Cannot resolve --remap {$wp_path}: preflight has no ABSPATH. Run preflight first.",
+            );
+        }
+
+        return $source_paths["abspath"] . "/" . $wp_path;
+    }
+
+    /**
+     * Map a source absolute path to its absolute local target via the remap
+     * rules (most specific source wins), or null when no rule applies.
+     *
+     * Any rules that match the same path are nested (each is a path-prefix of
+     * it, and prefixes of one string are ordered by length), so the longest
+     * matching source is the deepest — i.e. the most specific — match. Ranking
+     * by source, not target: a rule applies based purely on its source side.
+     */
+    private function remap_source_path_to_target(string $source_path): ?string
+    {
+        $best = null;
+        $best_source_len = -1;
+
+        foreach ($this->remap_rules as $rule) {
+            $rest = self::path_remainder_under($source_path, $rule["source"]);
+            if ($rest !== null && strlen($rule["source"]) > $best_source_len) {
+                $best = $rule["target"] . $rest;
+                $best_source_len = strlen($rule["source"]);
+            }
+        }
+
+        return $best;
+    }
 
     /**
      * Resolve a remote absolute path into a local path under the fs root.
@@ -8277,12 +8442,41 @@ class ImportClient
      * local path under the import fs root. Performs symlink traversal security
      * checks to prevent directory traversal attacks that could write files
      * outside the import root.
+     *
+     * With --remap active, an in-scope source path is first routed to its
+     * target (e.g. "/var/www/html/wp-content/x" -> "<docroot>/wp-content/x");
+     * paths under no remap rule fall through to the legacy nested mapping,
+     * exactly as a plain pull.
      */
     private function remote_path_to_local_path_within_import_root(
         string $path
     ): string {
         assert_valid_path($path, "remote path");
+        if (!empty($this->remap_rules)) {
+            $target = $this->remap_source_path_to_target($path);
+            if ($target !== null) {
+                return $target;
+            }
+        }
         return $this->get_filesystem_root_path() . $path;
+    }
+
+    /**
+     * Returns the remainder of $path underneath $prefix,
+     * empty string if $path === $prefix,
+     * or null if $path is not under $prefix.
+     */
+    private static function path_remainder_under(string $path, string $prefix): ?string
+    {
+        if ($path === $prefix) {
+            return "";
+        }
+
+        if (str_starts_with($path, $prefix . "/")) {
+            return substr($path, strlen($prefix));
+        }
+
+        return null;
     }
 
     /**
@@ -9101,6 +9295,13 @@ class ImportClient
 
         if ($this->extra_directory !== null && $this->extra_directory !== "") {
             $extra_paths["extra_directory"] = rtrim($this->extra_directory, "/");
+        }
+
+        // Ensure every --remap source is enumerated — including a detached
+        // component (relocated uploads/plugins dir) that lives outside the
+        // WordPress roots and so wouldn't be discovered by traversal alone.
+        foreach ($this->remap_rules as $i => $rule) {
+            $extra_paths["remap_src_{$i}"] = $rule["source"];
         }
 
         // auto_prepend_file / auto_append_file may point to directories
@@ -11241,6 +11442,14 @@ if (
             'placeholder' => 'URL',
             'help' => 'New site URL (auto-creates --rewrite-url from export URL origin)',
             'commands' => ['pull', 'db-apply'],
+        ],
+        [
+            'name' => 'remap',
+            'type' => 'pair',
+            'target' => 'remap',
+            'pair_args' => 'SRC TGT',
+            'help' => 'Place SRC (e.g. wp-content) at TGT, relative to --docroot (repeatable)',
+            'commands' => ['files-pull'],
         ],
 
         // ── flat-docroot options ────────────────────────────────

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8453,8 +8453,8 @@ class ImportClient
      *
      * With --remap active, an in-scope source path is first routed to its
      * target (e.g. "/var/www/html/wp-content/x" -> "<docroot>/wp-content/x");
-     * paths under no remap rule fall through to the legacy nested mapping,
-     * exactly as a plain pull.
+     * paths under no remap rule are still written under --fs-root using their
+     * remote absolute path, exactly as a plain pull.
      */
     private function remote_path_to_local_path_within_import_root(
         string $path

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -78,8 +78,10 @@ class RemapResolveTest extends TestCase
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
         $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', 'wp-content'))));
         $this->assertCount(1, $rules);
-        $this->assertSame('/var/www/html/wp-content', $rules[0]['source']);
-        $this->assertSame($this->root . '/wp-content', $rules[0]['target']);
+        $this->assertSame(
+            $this->root . '/wp-content',
+            $rules['/var/www/html/wp-content']
+        );
     }
 
     public function testAbsoluteTargetContainingDocrootIsTreatedAsRelative(): void
@@ -90,7 +92,10 @@ class RemapResolveTest extends TestCase
         $rules = $this->call($c, 'resolve_remap', array(array(
             array('wp-content', $this->root . '/some/where'),
         )));
-        $this->assertSame($this->root . '/some/where', $rules[0]['target']);
+        $this->assertSame(
+            $this->root . '/some/where',
+            $rules['/var/www/html/wp-content']
+        );
     }
 
     public function testSurroundingSlashesOnSourceAndTargetAreIgnored(): void
@@ -100,8 +105,10 @@ class RemapResolveTest extends TestCase
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
         $rules = $this->call($c, 'resolve_remap', array(array(array('/wp-content/plugins/', '/wp-content/plugins/'))));
         $this->assertCount(1, $rules);
-        $this->assertSame('/var/www/html/wp-content/plugins', $rules[0]['source']);
-        $this->assertSame($this->root . '/wp-content/plugins', $rules[0]['target']);
+        $this->assertSame(
+            $this->root . '/wp-content/plugins',
+            $rules['/var/www/html/wp-content/plugins']
+        );
     }
 
     public function testDetachedComponentsExpandUnderTarget(): void
@@ -115,10 +122,7 @@ class RemapResolveTest extends TestCase
             'uploads' => array('basedir' => '/mnt/blogs/uploads'),
         ));
         $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', 'wp-content'))));
-        $byTarget = array();
-        foreach ($rules as $r) {
-            $byTarget[$r['target']] = $r['source'];
-        }
+        $byTarget = array_flip($rules);
         $this->assertCount(3, $rules);
         $this->assertSame('/var/www/html/wp-content', $byTarget[$this->root . '/wp-content']);
         $this->assertSame('/mnt/blogs/uploads', $byTarget[$this->root . '/wp-content/uploads']);
@@ -137,7 +141,7 @@ class RemapResolveTest extends TestCase
             array('wp-content/plugins/woocommerce', 'wp-content/plugins/woocommerce'),
         )));
         $this->assertCount(1, $rules);
-        $this->assertSame('/custom/plugins/woocommerce', $rules[0]['source']);
+        $this->assertArrayHasKey('/custom/plugins/woocommerce', $rules);
     }
 
     public function testManualComponentRemapOverridesWholeTreeExpansion(): void
@@ -153,11 +157,10 @@ class RemapResolveTest extends TestCase
             array('wp-content/plugins', 'special-plugins'),
             array('wp-content', 'wp-content'),
         )));
-        $pluginRules = array_values(array_filter($rules, function ($r) {
-            return $r['source'] === '/detached/plugins';
-        }));
-        $this->assertCount(1, $pluginRules, 'exactly one rule for the detached plugins source');
-        $this->assertSame($this->root . '/special-plugins', $pluginRules[0]['target']);
+        // The detached plugins source maps once — to the manual target, not the
+        // whole-tree expansion (a single key per source guarantees no double-route).
+        $this->assertArrayHasKey('/detached/plugins', $rules);
+        $this->assertSame($this->root . '/special-plugins', $rules['/detached/plugins']);
     }
 
     public function testNonWpContentSrcResolvesRelativeToAbspath(): void
@@ -170,8 +173,10 @@ class RemapResolveTest extends TestCase
         ));
         $rules = $this->call($c, 'resolve_remap', array(array(array('wp-admin', 'wp-admin'))));
         $this->assertCount(1, $rules);
-        $this->assertSame('/var/www/html/wp-admin', $rules[0]['source']);
-        $this->assertSame($this->root . '/wp-admin', $rules[0]['target']);
+        $this->assertSame(
+            $this->root . '/wp-admin',
+            $rules['/var/www/html/wp-admin']
+        );
     }
 
     public function testDocrootTargetPlacesAtDocrootRoot(): void
@@ -181,9 +186,9 @@ class RemapResolveTest extends TestCase
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
 
         $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', $this->root))));
-        $this->assertSame($this->root, $rules[0]['target']);
+        $this->assertSame($this->root, $rules['/var/www/html/wp-content']);
 
         $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', ''))));
-        $this->assertSame($this->root, $rules[0]['target']);
+        $this->assertSame($this->root, $rules['/var/www/html/wp-content']);
     }
 }

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -77,6 +77,16 @@ class RemapResolveTest extends TestCase
         return $this->call($c, 'resolve_remap', array($pairs));
     }
 
+    private function assertRemapConsistent($c): void
+    {
+        $this->call($c, 'assert_files_remap_consistent');
+    }
+
+    private function writeLocalIndex(): void
+    {
+        file_put_contents($this->stateDir . '/.import-index.jsonl', "{}\n");
+    }
+
     // --- resolution: SOURCE TARGET → one source => target rule -------------
 
     /**
@@ -193,6 +203,37 @@ class RemapResolveTest extends TestCase
             array(':wp-content:', ':fs-root:/wp-content')
         );
         $this->assertSame($this->root . '/special-plugins', $rules['/detached/plugins']);
+    }
+
+    // --- state consistency -------------------------------------------------
+
+    public function testRejectsChangedRemapRulesForSameState(): void
+    {
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $this->set($c, 'remap_rules', array(
+            '/var/www/html/wp-content' => $this->root . '/wp-content',
+        ));
+        $this->assertRemapConsistent($c);
+
+        $this->set($c, 'remap_rules', array(
+            '/var/www/html/wp-content' => $this->root . '/content',
+        ));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot change --remap rules');
+        $this->assertRemapConsistent($c);
+    }
+
+    public function testRejectsRemapWithUntrackedExistingFilesIndex(): void
+    {
+        $this->writeLocalIndex();
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $this->set($c, 'remap_rules', array(
+            '/var/www/html/wp-content' => $this->root . '/wp-content',
+        ));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('existing files index');
+        $this->assertRemapConsistent($c);
     }
 
     // --- errors ------------------------------------------------------------

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -7,8 +7,12 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --remap: resolving SRC TGT pairs into remap rules, with detached-component
- * expansion driven by the source's preflight paths_urls.
+ * --remap: resolving template-string SOURCE TARGET pairs into remap rules.
+ *
+ * Each argument has its known `:token:`s substituted wherever they appear, then
+ * must resolve to an absolute path. Source tokens are remote WP-layout locations
+ * (:wp-uploads:, :abspath:, …); the target token is :fs-root:. Targets must stay
+ * within --fs-root. Anything that doesn't resolve to an absolute path is an error.
  */
 class RemapResolveTest extends TestCase
 {
@@ -59,11 +63,6 @@ class RemapResolveTest extends TestCase
         (new \ReflectionClass($c))->getProperty($p)->setValue($c, $v);
     }
 
-    private function get($c, string $p)
-    {
-        return (new \ReflectionClass($c))->getProperty($p)->getValue($c);
-    }
-
     private function client(array $pathsUrls): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
@@ -73,122 +72,166 @@ class RemapResolveTest extends TestCase
         return $c;
     }
 
-    public function testWpContentRemapsToFullTargetUnderDocroot(): void
+    private function resolve($c, array ...$pairs): array
     {
-        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', 'wp-content'))));
-        $this->assertCount(1, $rules);
-        $this->assertSame(
-            $this->root . '/wp-content',
-            $rules['/var/www/html/wp-content']
+        return $this->call($c, 'resolve_remap', array($pairs));
+    }
+
+    // --- resolution: SOURCE TARGET → one source => target rule -------------
+
+    /**
+     * Each case resolves a single --remap pair and asserts the resulting rule.
+     * The expected target is given as a suffix appended to the (per-test) fs root.
+     *
+     * @dataProvider provideResolutionCases
+     */
+    public function testResolvesRuleToExpectedSourceAndTarget(
+        array $pathsUrls,
+        string $source,
+        string $target,
+        string $expectedSource,
+        string $expectedTargetSuffix
+    ): void {
+        $rules = $this->resolve($this->client($pathsUrls), array($source, $target));
+        $this->assertSame($this->root . $expectedTargetSuffix, $rules[$expectedSource]);
+    }
+
+    public static function provideResolutionCases(): array
+    {
+        return array(
+            'wp-content token → content dir' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                ':wp-content:', ':fs-root:/wp-content',
+                '/var/www/html/wp-content', '/wp-content',
+            ),
+            'component token + subpath resolves via preflight' => array(
+                array('content_dir' => '/srv/wp-content', 'plugins_dir' => '/custom/plugins'),
+                ':wp-plugins:/woocommerce', ':fs-root:/wp-content/plugins/woocommerce',
+                '/custom/plugins/woocommerce', '/wp-content/plugins/woocommerce',
+            ),
+            'abspath token resolves non-content paths' => array(
+                array('abspath' => '/var/www/html', 'content_dir' => '/var/www/html/wp-content'),
+                ':abspath:/wp-admin', ':fs-root:/wp-admin',
+                '/var/www/html/wp-admin', '/wp-admin',
+            ),
+            'raw absolute source used literally' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                '/var/log/site', ':fs-root:/logs',
+                '/var/log/site', '/logs',
+            ),
+            'fs-root token + subpath' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                ':wp-content:', ':fs-root:/media',
+                '/var/www/html/wp-content', '/media',
+            ),
+            'bare fs-root token is the root itself' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                ':wp-content:', ':fs-root:',
+                '/var/www/html/wp-content', '',
+            ),
+            'trailing slashes trimmed (leading kept)' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                ':wp-content:/', ':fs-root:/media/',
+                '/var/www/html/wp-content', '/media',
+            ),
+            'substitution is literal — no separator enforced' => array(
+                array('content_dir' => '/var/www/html/wp-content', 'plugins_dir' => '/p'),
+                ':wp-plugins:jetpack', ':fs-root:/x',
+                '/pjetpack', '/x',
+            ),
+            'whitespace in a raw path is preserved' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                '/var/data/odd ', ':fs-root:/odd',
+                '/var/data/odd ', '/odd',
+            ),
         );
     }
 
-    public function testAbsoluteTargetContainingDocrootIsTreatedAsRelative(): void
+    public function testRawAbsoluteTargetWithinRootUsedLiterally(): void
     {
-        // A target pasted as a full absolute path under the docroot resolves
-        // the same as the docroot-relative form (no double-nesting).
+        // An absolute target already inside --fs-root is used verbatim (the
+        // :fs-root: token is sugar for exactly this).
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-        $rules = $this->call($c, 'resolve_remap', array(array(
-            array('wp-content', $this->root . '/some/where'),
-        )));
-        $this->assertSame(
-            $this->root . '/some/where',
-            $rules['/var/www/html/wp-content']
-        );
+        $rules = $this->resolve($c, array(':wp-content:', $this->root . '/wp-content'));
+        $this->assertSame($this->root . '/wp-content', $rules['/var/www/html/wp-content']);
     }
 
-    public function testSurroundingSlashesOnSourceAndTargetAreIgnored(): void
-    {
-        // Leading/trailing slashes on either endpoint are trimmed — no rsync-style
-        // folder-vs-contents distinction; both endpoints are explicitly named.
-        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-        $rules = $this->call($c, 'resolve_remap', array(array(array('/wp-content/plugins/', '/wp-content/plugins/'))));
-        $this->assertCount(1, $rules);
-        $this->assertSame(
-            $this->root . '/wp-content/plugins',
-            $rules['/var/www/html/wp-content/plugins']
-        );
-    }
+    // --- detached-component expansion --------------------------------------
 
     public function testDetachedComponentsExpandUnderTarget(): void
     {
-        // Source keeps plugins inside wp-content (nested → no extra rule), but
-        // uploads and mu-plugins outside it (detached → routed under TGT).
+        // Remapping wp-content auto-follows components that live OUTSIDE
+        // content_dir (uploads, mu-plugins here); a nested one (plugins) is
+        // already covered by the wp-content rule and gets no separate rule.
         $c = $this->client(array(
             'content_dir' => '/var/www/html/wp-content',
-            'plugins_dir' => '/var/www/html/wp-content/plugins',
-            'mu_plugins_dir' => '/opt/muplugins',
-            'uploads' => array('basedir' => '/mnt/blogs/uploads'),
+            'plugins_dir' => '/var/www/html/wp-content/plugins', // nested
+            'mu_plugins_dir' => '/opt/muplugins',                // detached
+            'uploads' => array('basedir' => '/mnt/blogs/uploads'), // detached
         ));
-        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', 'wp-content'))));
+        $rules = $this->resolve($c, array(':wp-content:', ':fs-root:/wp-content'));
         $byTarget = array_flip($rules);
         $this->assertCount(3, $rules);
         $this->assertSame('/var/www/html/wp-content', $byTarget[$this->root . '/wp-content']);
         $this->assertSame('/mnt/blogs/uploads', $byTarget[$this->root . '/wp-content/uploads']);
         $this->assertSame('/opt/muplugins', $byTarget[$this->root . '/wp-content/mu-plugins']);
-        // plugins is nested under content_dir → covered by the wp-content rule.
         $this->assertArrayNotHasKey($this->root . '/wp-content/plugins', $byTarget);
     }
 
-    public function testComponentSrcResolvesViaPreflight(): void
+    public function testExplicitComponentOverridesExpansion(): void
     {
-        $c = $this->client(array(
-            'content_dir' => '/srv/wp-content',
-            'plugins_dir' => '/custom/plugins',
-        ));
-        $rules = $this->call($c, 'resolve_remap', array(array(
-            array('wp-content/plugins/woocommerce', 'wp-content/plugins/woocommerce'),
-        )));
-        $this->assertCount(1, $rules);
-        $this->assertArrayHasKey('/custom/plugins/woocommerce', $rules);
-    }
-
-    public function testManualComponentRemapOverridesWholeTreeExpansion(): void
-    {
-        // Detached plugins explicitly sent elsewhere; a whole wp-content remap
-        // must NOT also route them under its own target. Manual flag listed
-        // FIRST to prove order independence.
+        // A detached component sent somewhere explicitly wins over the
+        // whole-wp-content expansion. Explicit rule listed FIRST to prove the
+        // override is order-independent.
         $c = $this->client(array(
             'content_dir' => '/var/www/html/wp-content',
-            'plugins_dir' => '/detached/plugins', // detached → would otherwise expand
+            'plugins_dir' => '/detached/plugins',
         ));
-        $rules = $this->call($c, 'resolve_remap', array(array(
-            array('wp-content/plugins', 'special-plugins'),
-            array('wp-content', 'wp-content'),
-        )));
-        // The detached plugins source maps once — to the manual target, not the
-        // whole-tree expansion (a single key per source guarantees no double-route).
-        $this->assertArrayHasKey('/detached/plugins', $rules);
+        $rules = $this->resolve(
+            $c,
+            array(':wp-plugins:', ':fs-root:/special-plugins'),
+            array(':wp-content:', ':fs-root:/wp-content')
+        );
         $this->assertSame($this->root . '/special-plugins', $rules['/detached/plugins']);
     }
 
-    public function testNonWpContentSrcResolvesRelativeToAbspath(): void
+    // --- errors ------------------------------------------------------------
+
+    /**
+     * Every case must resolve to a valid absolute path; these don't, so each is
+     * rejected with InvalidArgumentException.
+     *
+     * @dataProvider provideInvalidArguments
+     */
+    public function testRejectsInvalidArgument(string $source, string $target): void
     {
-        // wp-admin / core / arbitrary paths are not restricted — they resolve
-        // relative to the source's ABSPATH.
-        $c = $this->client(array(
-            'abspath' => '/var/www/html',
-            'content_dir' => '/var/www/html/wp-content',
-        ));
-        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-admin', 'wp-admin'))));
-        $this->assertCount(1, $rules);
-        $this->assertSame(
-            $this->root . '/wp-admin',
-            $rules['/var/www/html/wp-admin']
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->resolve($c, array($source, $target));
+    }
+
+    public static function provideInvalidArguments(): array
+    {
+        return array(
+            'bare relative source' => array('wp-content/uploads', ':fs-root:/uploads'),
+            'bare relative target' => array(':wp-content:', 'media'),
+            'unclosed token (not substituted)' => array(':wp-plugins', ':fs-root:/p'),
+            'unknown source token' => array(':bogus:', ':fs-root:/x'),
+            'fs-root token invalid as source' => array(':fs-root:/x', ':fs-root:/x'),
+            'remote token invalid as target' => array(':wp-content:', ':wp-content:/x'),
+            'absolute target outside fs-root' => array(':wp-content:', '/media'),
+            'target climbs out via ".."' => array(':wp-content:', ':fs-root:/safe/../../../etc'),
+            'empty source' => array('', ':fs-root:/x'),
         );
     }
 
-    public function testDocrootTargetPlacesAtDocrootRoot(): void
+    public function testAbspathTokenWithoutPreflightThrows(): void
     {
-        // Target == the docroot (whether given absolutely or as an empty
-        // relative) means: place the source at the docroot root itself.
+        // :abspath: present but unavailable (no abspath, no wp_detect roots) gets
+        // a clear message naming preflight, not the generic path error.
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-
-        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', $this->root))));
-        $this->assertSame($this->root, $rules['/var/www/html/wp-content']);
-
-        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', ''))));
-        $this->assertSame($this->root, $rules['/var/www/html/wp-content']);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('preflight');
+        $this->resolve($c, array(':abspath:/wp-admin', ':fs-root:/wp-admin'));
     }
 }

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * --remap: resolving SRC TGT pairs into remap rules, with detached-component
+ * expansion driven by the source's preflight paths_urls.
+ */
+class RemapResolveTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+    private $root; // realpath of fsRoot (targets are rooted under it)
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/remap-resolve-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/srv/htdocs';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+        $this->root = realpath($this->fsRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrm($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function rrm(string $d): void
+    {
+        if (!is_dir($d)) {
+            return;
+        }
+        foreach (scandir($d) as $i) {
+            if ($i === '.' || $i === '..') {
+                continue;
+            }
+            $p = "$d/$i";
+            (is_dir($p) && !is_link($p)) ? $this->rrm($p) : unlink($p);
+        }
+        rmdir($d);
+    }
+
+    private function call($c, string $m, array $a = array())
+    {
+        return (new \ReflectionClass($c))->getMethod($m)->invoke($c, ...$a);
+    }
+
+    private function set($c, string $p, $v): void
+    {
+        (new \ReflectionClass($c))->getProperty($p)->setValue($c, $v);
+    }
+
+    private function get($c, string $p)
+    {
+        return (new \ReflectionClass($c))->getProperty($p)->getValue($c);
+    }
+
+    private function client(array $pathsUrls): \ImportClient
+    {
+        $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
+        $this->set($c, 'state', array('preflight' => array('data' => array(
+            'database' => array('wp' => array('paths_urls' => $pathsUrls)),
+        ))));
+        return $c;
+    }
+
+    public function testWpContentRemapsToFullTargetUnderDocroot(): void
+    {
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', 'wp-content'))));
+        $this->assertCount(1, $rules);
+        $this->assertSame('/var/www/html/wp-content', $rules[0]['source']);
+        $this->assertSame($this->root . '/wp-content', $rules[0]['target']);
+    }
+
+    public function testAbsoluteTargetContainingDocrootIsTreatedAsRelative(): void
+    {
+        // A target pasted as a full absolute path under the docroot resolves
+        // the same as the docroot-relative form (no double-nesting).
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $rules = $this->call($c, 'resolve_remap', array(array(
+            array('wp-content', $this->root . '/some/where'),
+        )));
+        $this->assertSame($this->root . '/some/where', $rules[0]['target']);
+    }
+
+    public function testSurroundingSlashesOnSourceAndTargetAreIgnored(): void
+    {
+        // Leading/trailing slashes on either endpoint are trimmed — no rsync-style
+        // folder-vs-contents distinction; both endpoints are explicitly named.
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $rules = $this->call($c, 'resolve_remap', array(array(array('/wp-content/plugins/', '/wp-content/plugins/'))));
+        $this->assertCount(1, $rules);
+        $this->assertSame('/var/www/html/wp-content/plugins', $rules[0]['source']);
+        $this->assertSame($this->root . '/wp-content/plugins', $rules[0]['target']);
+    }
+
+    public function testDetachedComponentsExpandUnderTarget(): void
+    {
+        // Source keeps plugins inside wp-content (nested → no extra rule), but
+        // uploads and mu-plugins outside it (detached → routed under TGT).
+        $c = $this->client(array(
+            'content_dir' => '/var/www/html/wp-content',
+            'plugins_dir' => '/var/www/html/wp-content/plugins',
+            'mu_plugins_dir' => '/opt/muplugins',
+            'uploads' => array('basedir' => '/mnt/blogs/uploads'),
+        ));
+        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', 'wp-content'))));
+        $byTarget = array();
+        foreach ($rules as $r) {
+            $byTarget[$r['target']] = $r['source'];
+        }
+        $this->assertCount(3, $rules);
+        $this->assertSame('/var/www/html/wp-content', $byTarget[$this->root . '/wp-content']);
+        $this->assertSame('/mnt/blogs/uploads', $byTarget[$this->root . '/wp-content/uploads']);
+        $this->assertSame('/opt/muplugins', $byTarget[$this->root . '/wp-content/mu-plugins']);
+        // plugins is nested under content_dir → covered by the wp-content rule.
+        $this->assertArrayNotHasKey($this->root . '/wp-content/plugins', $byTarget);
+    }
+
+    public function testComponentSrcResolvesViaPreflight(): void
+    {
+        $c = $this->client(array(
+            'content_dir' => '/srv/wp-content',
+            'plugins_dir' => '/custom/plugins',
+        ));
+        $rules = $this->call($c, 'resolve_remap', array(array(
+            array('wp-content/plugins/woocommerce', 'wp-content/plugins/woocommerce'),
+        )));
+        $this->assertCount(1, $rules);
+        $this->assertSame('/custom/plugins/woocommerce', $rules[0]['source']);
+    }
+
+    public function testManualComponentRemapOverridesWholeTreeExpansion(): void
+    {
+        // Detached plugins explicitly sent elsewhere; a whole wp-content remap
+        // must NOT also route them under its own target. Manual flag listed
+        // FIRST to prove order independence.
+        $c = $this->client(array(
+            'content_dir' => '/var/www/html/wp-content',
+            'plugins_dir' => '/detached/plugins', // detached → would otherwise expand
+        ));
+        $rules = $this->call($c, 'resolve_remap', array(array(
+            array('wp-content/plugins', 'special-plugins'),
+            array('wp-content', 'wp-content'),
+        )));
+        $pluginRules = array_values(array_filter($rules, function ($r) {
+            return $r['source'] === '/detached/plugins';
+        }));
+        $this->assertCount(1, $pluginRules, 'exactly one rule for the detached plugins source');
+        $this->assertSame($this->root . '/special-plugins', $pluginRules[0]['target']);
+    }
+
+    public function testNonWpContentSrcResolvesRelativeToAbspath(): void
+    {
+        // wp-admin / core / arbitrary paths are not restricted — they resolve
+        // relative to the source's ABSPATH.
+        $c = $this->client(array(
+            'abspath' => '/var/www/html',
+            'content_dir' => '/var/www/html/wp-content',
+        ));
+        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-admin', 'wp-admin'))));
+        $this->assertCount(1, $rules);
+        $this->assertSame('/var/www/html/wp-admin', $rules[0]['source']);
+        $this->assertSame($this->root . '/wp-admin', $rules[0]['target']);
+    }
+
+    public function testDocrootTargetPlacesAtDocrootRoot(): void
+    {
+        // Target == the docroot (whether given absolutely or as an empty
+        // relative) means: place the source at the docroot root itself.
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+
+        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', $this->root))));
+        $this->assertSame($this->root, $rules[0]['target']);
+
+        $rules = $this->call($c, 'resolve_remap', array(array(array('wp-content', ''))));
+        $this->assertSame($this->root, $rules[0]['target']);
+    }
+}

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -225,13 +225,41 @@ class RemapResolveTest extends TestCase
         );
     }
 
-    public function testAbspathTokenWithoutPreflightThrows(): void
+    /**
+     * A token whose value preflight didn't determine yields a clear,
+     * preflight-naming error — from the single place that resolves tokens,
+     * regardless of which token it is.
+     *
+     * @dataProvider provideUnavailableTokens
+     */
+    public function testUnavailableTokenNamesPreflight(array $pathsUrls, string $source): void
     {
-        // :abspath: present but unavailable (no abspath, no wp_detect roots) gets
-        // a clear message naming preflight, not the generic path error.
-        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $c = $this->client($pathsUrls);
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('preflight');
-        $this->resolve($c, array(':abspath:/wp-admin', ':fs-root:/wp-admin'));
+        $this->resolve($c, array($source, ':fs-root:/x'));
+    }
+
+    public static function provideUnavailableTokens(): array
+    {
+        return array(
+            ':abspath: with no abspath in preflight' => array(
+                array('content_dir' => '/var/www/html/wp-content'),
+                ':abspath:/wp-admin',
+            ),
+            ':wp-content: with no content_dir in preflight' => array(
+                array(),
+                ':wp-content:',
+            ),
+        );
+    }
+
+    public function testRawOnlyRemapNeedsNoPreflightComponents(): void
+    {
+        // Raw absolute source + target reference no tokens, so they resolve even
+        // when preflight provided no component locations at all.
+        $c = $this->client(array());
+        $rules = $this->resolve($c, array('/var/www/site', $this->root . '/site'));
+        $this->assertSame($this->root . '/site', $rules['/var/www/site']);
     }
 }

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -217,12 +217,21 @@ class RemapResolveTest extends TestCase
             'bare relative target' => array(':wp-content:', 'media'),
             'unclosed token (not substituted)' => array(':wp-plugins', ':fs-root:/p'),
             'unknown source token' => array(':bogus:', ':fs-root:/x'),
+            'source token not at beginning' => array('/tmp/:wp-content:', ':fs-root:/x'),
+            'same source token repeated after beginning' => array(':wp-content:/:wp-content:', ':fs-root:/x'),
             'fs-root token invalid as source' => array(':fs-root:/x', ':fs-root:/x'),
             'remote token invalid as target' => array(':wp-content:', ':wp-content:/x'),
             'absolute target outside fs-root' => array(':wp-content:', '/media'),
             'target climbs out via ".."' => array(':wp-content:', ':fs-root:/safe/../../../etc'),
             'empty source' => array('', ':fs-root:/x'),
         );
+    }
+
+    public function testRejectsTargetTokenNotAtBeginning(): void
+    {
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->resolve($c, array(':wp-content:', $this->root . '/:fs-root:'));
     }
 
     /**

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * --remap: the single write seam (remote_path_to_local_path_within_import_root)
+ * routes in-scope source paths to their target and leaves the rest nested.
+ */
+class RemapSeamTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+    private $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/remap-seam-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/srv/htdocs';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+        $this->root = realpath($this->fsRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrm($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function rrm(string $d): void
+    {
+        if (!is_dir($d)) {
+            return;
+        }
+        foreach (scandir($d) as $i) {
+            if ($i === '.' || $i === '..') {
+                continue;
+            }
+            $p = "$d/$i";
+            (is_dir($p) && !is_link($p)) ? $this->rrm($p) : unlink($p);
+        }
+        rmdir($d);
+    }
+
+    private function call($c, string $m, array $a = array())
+    {
+        return (new \ReflectionClass($c))->getMethod($m)->invoke($c, ...$a);
+    }
+
+    private function set($c, string $p, $v): void
+    {
+        (new \ReflectionClass($c))->getProperty($p)->setValue($c, $v);
+    }
+
+    private function clientWithRules(array $rules): \ImportClient
+    {
+        $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
+        $this->set($c, 'remap_rules', $rules);
+        return $c;
+    }
+
+    public function testInScopePathMapsToDest(): void
+    {
+        $c = $this->clientWithRules(array(
+            array('source' => '/var/www/html/wp-content', 'target' => $this->root . '/wp-content'),
+        ));
+        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+            '/var/www/html/wp-content/plugins/woo/woo.php',
+        ));
+        $this->assertSame($this->root . '/wp-content/plugins/woo/woo.php', $local);
+    }
+
+    public function testDeeperSourceWinsRegardlessOfTargetLength(): void
+    {
+        // Two nested sources; the deeper (more specific) one has the SHORTER
+        // target. It must still win — specificity is ranked by source, not by
+        // target length.
+        $c = $this->clientWithRules(array(
+            array('source' => '/srv/wp-content', 'target' => $this->root . '/archive-of-everything'),
+            array('source' => '/srv/wp-content/plugins', 'target' => $this->root . '/p'),
+        ));
+        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+            '/srv/wp-content/plugins/woo/woo.php',
+        ));
+        $this->assertSame($this->root . '/p/woo/woo.php', $local);
+    }
+
+    public function testDocrootRootTargetPlacesFilesAtDocrootRoot(): void
+    {
+        // A target that is the docroot itself: files land directly at the root,
+        // no double slash.
+        $c = $this->clientWithRules(array(
+            array('source' => '/var/www/html/wp-content', 'target' => $this->root),
+        ));
+        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+            '/var/www/html/wp-content/plugins/woo/woo.php',
+        ));
+        $this->assertSame($this->root . '/plugins/woo/woo.php', $local);
+    }
+
+    public function testOutOfScopePathFallsBackToNestedIdentity(): void
+    {
+        $c = $this->clientWithRules(array(
+            array('source' => '/var/www/html/wp-content', 'target' => $this->root . '/wp-content'),
+        ));
+        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+            '/var/www/html/wp-admin/index.php',
+        ));
+        $this->assertSame($this->root . '/var/www/html/wp-admin/index.php', $local);
+    }
+
+    public function testNoRulesIsLegacyMapping(): void
+    {
+        $c = $this->clientWithRules(array());
+        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+            '/var/www/html/wp-content/x.txt',
+        ));
+        $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local);
+    }
+}

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -69,7 +69,7 @@ class RemapSeamTest extends TestCase
     public function testInScopePathMapsToDest(): void
     {
         $c = $this->clientWithRules(array(
-            array('source' => '/var/www/html/wp-content', 'target' => $this->root . '/wp-content'),
+            '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
         $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
             '/var/www/html/wp-content/plugins/woo/woo.php',
@@ -83,8 +83,8 @@ class RemapSeamTest extends TestCase
         // target. It must still win — specificity is ranked by source, not by
         // target length.
         $c = $this->clientWithRules(array(
-            array('source' => '/srv/wp-content', 'target' => $this->root . '/archive-of-everything'),
-            array('source' => '/srv/wp-content/plugins', 'target' => $this->root . '/p'),
+            '/srv/wp-content' => $this->root . '/archive-of-everything',
+            '/srv/wp-content/plugins' => $this->root . '/p',
         ));
         $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
             '/srv/wp-content/plugins/woo/woo.php',
@@ -97,7 +97,7 @@ class RemapSeamTest extends TestCase
         // A target that is the docroot itself: files land directly at the root,
         // no double slash.
         $c = $this->clientWithRules(array(
-            array('source' => '/var/www/html/wp-content', 'target' => $this->root),
+            '/var/www/html/wp-content' => $this->root,
         ));
         $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
             '/var/www/html/wp-content/plugins/woo/woo.php',
@@ -108,7 +108,7 @@ class RemapSeamTest extends TestCase
     public function testOutOfScopePathFallsBackToNestedIdentity(): void
     {
         $c = $this->clientWithRules(array(
-            array('source' => '/var/www/html/wp-content', 'target' => $this->root . '/wp-content'),
+            '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
         $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
             '/var/www/html/wp-admin/index.php',

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -124,4 +124,29 @@ class RemapSeamTest extends TestCase
         ));
         $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local);
     }
+
+    /**
+     * The path-prefix helper underpinning rule matching. A trailing slash on
+     * either argument is path-equivalent and must be ignored.
+     *
+     * @dataProvider providePathRemainderCases
+     */
+    public function testPathRemainderUnder(?string $expected, string $path, string $prefix): void
+    {
+        $c = $this->clientWithRules(array());
+        $this->assertSame($expected, $this->call($c, 'path_remainder_under', array($path, $prefix)));
+    }
+
+    public static function providePathRemainderCases(): array
+    {
+        return array(
+            'exact match' => array('', '/a/b', '/a/b'),
+            'under prefix' => array('/c', '/a/b/c', '/a/b'),
+            'not under (prefix is not a path boundary)' => array(null, '/a/bc', '/a/b'),
+            'trailing slash on prefix' => array('', '/home/adam', '/home/adam/'),
+            'trailing slash on path' => array('', '/home/adam/', '/home/adam'),
+            'trailing slash on both' => array('', '/home/adam/', '/home/adam/'),
+            'under, prefix has trailing slash' => array('/c', '/a/b/c', '/a/b/'),
+        );
+    }
 }

--- a/tests/e2e/setup.sh
+++ b/tests/e2e/setup.sh
@@ -11,5 +11,6 @@ if command -v composer &>/dev/null && [ -f "$PROJECT_ROOT/reprint-exporter-wp/co
     composer install --no-dev --no-interaction --prefer-dist --working-dir="$PROJECT_ROOT/reprint-exporter-wp"
 fi
 
-cd "$(dirname "$0")"
-npm install --silent
+# JavaScript dependencies are installed by the dedicated workflow step after
+# setup. Keep this script focused on PHP/runtime dependencies so npm failures
+# are reported by that explicit install step instead of being hidden here.

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -7,7 +7,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import {
@@ -136,6 +136,18 @@ describe('Import: SQLite Export', () => {
                     allowRoot,
                     { timeout: 60000, stdio: 'pipe' },
                 );
+
+                // Finish any pending DB upgrade before the site is served.
+                // On the Playground CLI job, the first PHP-FPM request can otherwise
+                // race WordPress's upgrade flow and briefly leave the fresh SQLite
+                // site in maintenance mode.
+                execSync(
+                    `php /tmp/wp-cli.phar core update-db` +
+                    ` --path=${JSON.stringify(siteDir)}` +
+                    allowRoot,
+                    { timeout: 60000, stdio: 'pipe' },
+                );
+                rmSync(join(siteDir, '.maintenance'), { force: true });
 
                 // Activate the site-export plugin.
                 execSync(


### PR DESCRIPTION
Tell the importer where to place certain files during `files-pull` via a new `--remap SOURCE TARGET` flag:

It places a source subtree at a chosen path under `--fs-root` instead of nesting it under the source's full absolute path — so instead of content landing at `/srv/htdocs/var/www/html/wp-content/…`, it lands at `/srv/htdocs/wp-content`.

```
--remap :wp-content: :fs-root:/wp-content
--remap :wp-content: /srv/htdocs/wp-content   # same thing as above

# Most-specific source wins
--remap :wp-content: :fs-root:/wp-content --remap :wp-uploads: :fs-root:/media
```

The SOURCE and TARGET are template strings, known `:token:`s are substituted with real paths, and the result must be an absolute path.

  - **SOURCE** — a remote WP-layout token, or a raw absolute remote path:
    - `:wp-content:` `:wp-plugins:` `:wp-mu-plugins:` `:wp-uploads:` — the source site's real component locations, discovered during preflight (so they're correct even when relocated, e.g. uploads under `/user/site-media-files`).
    - `:abspath:` — the source's WP core root, for things outside wp-content (`:abspath:/wp-admin`).
    - a raw absolute path (`/var/www/…`) — pulled verbatim.
  - **TARGET** — a `:fs-root:`-anchored path or a raw absolute path:
    - it must resolve **within `--fs-root`** (otherwise it's an error). `:fs-root:` expands to the `--fs-root` you passed.
 
## Testing

You'll need a source site with the reprint exporter installed.

```
  DOCROOT=/tmp/remap-test  STATE=/tmp/remap-state
  URL="https://YOUR-SITE.com/?reprint-api"  SECRET="<migration secret>"

  rm -rf "$DOCROOT" "$STATE"; mkdir -p "$DOCROOT" "$STATE"

  php importer/import.php preflight  "$URL" --state-dir="$STATE" --fs-root="$DOCROOT" --secret="$SECRET"

  # re-run until it prints "complete" (resumable; exits non-zero while partial)
  php importer/import.php files-pull "$URL" --state-dir="$STATE" --fs-root="$DOCROOT" --secret="$SECRET" \
    --remap :wp-content: :fs-root:/custom/wp-content --no-follow-symlinks
  ```
  
  Then confirm placement:
  - `ls "$DOCROOT/custom/wp-content"` — plugins/ themes/ uploads/ … (landed here via `--remap`)
  - `ls "$DOCROOT"` — `custom/` and `var/` (core falls through, nested under `var/www/html`)