### PR TITLE
Add `—only` flag for files-pull, limiting scope

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1139,6 +1139,13 @@ class ImportClient
      */
     private $remap_rules = [];
 
+    /**
+     * @var array<int,string> Resolved `--only` scope: a list of real source
+     * absolute path prefixes the pull is restricted to. Empty = full sync
+     * (every detected root).
+     */
+    private $scope = [];
+
     /** @var AdaptiveTuner|null Adjusts request pacing based on server response times and errors. */
     private $tuner = null;
 
@@ -1811,6 +1818,13 @@ class ImportClient
         $remap_raw = $options["remap"] ?? [];
         if (!empty($remap_raw)) {
             $this->remap_rules = $this->resolve_remap($remap_raw);
+        }
+
+        // Resolve the `--only` scope (also requires preflight).
+        // Comma-separated for multiple source paths.
+        $only_raw = $options["only"] ?? "";
+        if ($only_raw !== "") {
+            $this->scope = $this->resolve_scope(explode(",", $only_raw));
         }
 
         // Handle --abort: clear state for the command and exit immediately.
@@ -6069,9 +6083,19 @@ class ImportClient
 
         $complete = false;
         $chunks_since_save = 0;
+
+        $export_dirs = $this->get_export_directories();
         $params = $this->get_tuned_params("file_index");
+
         if ($cursor === null) {
-            $params["list_dir"] = $list_dir_override ?? $roots[0];
+            $start = $roots[0];
+            if (!empty($this->scope)) {
+                // When in scoped mode (--only), we need to start at the first export dir
+                // to appease the exporter's constraint of list_dir falling within directory[].
+                $start = $export_dirs[0] ?? $roots[0];
+            }
+
+            $params["list_dir"] = $list_dir_override ?? $start;
         }
         if ($this->follow_symlinks) {
             $params["follow_symlinks"] = "1";
@@ -6087,7 +6111,6 @@ class ImportClient
         // a shared WordPress core directory (e.g. /wordpress/core/6.9.4/)
         // rather than the site's document root, so the scan would miss
         // wp-content entirely (no plugins, themes, or uploads).
-        $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
         }
@@ -6350,8 +6373,12 @@ class ImportClient
                 $local !== null &&
                 strcmp($local["path"], $remote["path"]) < 0
             ) {
-                $this->delete_local_file_path($local["path"]);
-                $this->delete_index_entry($local["path"]);
+                // When in scoped mode (--only), we will only delete local files when they fall under our scope.
+                // The local files index ends up being a union across scoped runs.
+                if ($this->in_scope($local["path"])) {
+                    $this->delete_local_file_path($local["path"]);
+                    $this->delete_index_entry($local["path"]);
+                }
                 $local_after = $local["path"];
                 $local = $this->read_index_line($local_handle);
             }
@@ -6404,8 +6431,10 @@ class ImportClient
         }
 
         while ($local !== null) {
-            $this->delete_local_file_path($local["path"]);
-            $this->delete_index_entry($local["path"]);
+            if ($this->in_scope($local["path"])) {
+                $this->delete_local_file_path($local["path"]);
+                $this->delete_index_entry($local["path"]);
+            }
             $local_after = $local["path"];
             $local = $this->read_index_line($local_handle);
         }
@@ -8410,8 +8439,8 @@ class ImportClient
         $rules = [];
         $wp_content_target = null;
         foreach ($remap_raw as [$source_raw, $target_raw]) {
-            $source = $this->resolve_remap_path($source_raw, $source_tokens);
-            $target = $this->resolve_remap_path($target_raw, $target_tokens);
+            $source = $this->resolve_token_path($source_raw, $source_tokens);
+            $target = $this->resolve_token_path($target_raw, $target_tokens);
 
             if (!path_is_within_root($target, $fs_root)) {
                 throw new InvalidArgumentException(
@@ -8426,13 +8455,11 @@ class ImportClient
             }
         }
 
-        // Whole-tree remap of the wp-content components that can live outside the content_dir,
+        // Whole-tree remap of the wp-content components detached from content_dir,
         // unless an explicit rule has already placed them somewhere else.
         if ($wp_content_target !== null) {
-            foreach (["wp-plugins" => "plugins", "wp-mu-plugins" => "mu-plugins", "wp-uploads" => "uploads"] as $token => $name) {
-                $source = $source_tokens[$token];
-                $is_outside_content_dir = !path_is_within_root($source, $source_tokens["wp-content"]);
-                if ($is_outside_content_dir && !isset($rules[$source])) {
+            foreach ($this->detached_content_component_sources($source_tokens) as $name => $source) {
+                if (!isset($rules[$source])) {
                     $rules[$source] = wp_join_unix_paths($wp_content_target, $name);
                 }
             }
@@ -8442,7 +8469,112 @@ class ImportClient
     }
 
     /**
-     * The source site's real component locations from preflight data, as remap token name => absolute path.
+     * The wp-content components (plugins, mu-plugins, uploads) whose real source
+     * dir is detached from content_dir — i.e. relocated outside it, so a
+     * scope/remap of "wp-content" wouldn't cover them via content_dir alone.
+     * Components with an unknown (null) source, or an unknown content_dir, are
+     * omitted — detachment can't be determined without both.
+     *
+     * @param array<string,string|null> $source_tokens From wp_component_source_paths().
+     * @return array<string,string> dir name => real source path, detached ones only.
+     */
+    private function detached_content_component_sources(array $source_tokens): array
+    {
+        $content = $source_tokens["wp-content"];
+        if ($content === null) {
+            return [];
+        }
+
+        $detached = [];
+        foreach (["wp-plugins" => "plugins", "wp-mu-plugins" => "mu-plugins", "wp-uploads" => "uploads"] as $token => $name) {
+            $source = $source_tokens[$token];
+            if ($source !== null && !path_is_within_root($source, $content)) {
+                $detached[$name] = $source;
+            }
+        }
+
+        return $detached;
+    }
+
+    /**
+     * Resolve raw `--only` sources into a deduped list of real source absolute
+     * prefixes the pull is scoped to. Each source is a `:token:` template (e.g.
+     * `:wp-content:`, `:wp-uploads:`) or a raw absolute path,
+     * resolved through the same source token table (wp_component_source_paths)
+     * as --remap.
+     *
+     * @param array<int,string> $only_raw Raw SOURCE values from the CLI.
+     * @return array<int,string> Real source prefixes (deduped).
+     */
+    private function resolve_scope(array $only_raw): array
+    {
+        $source_tokens = $this->wp_component_source_paths();
+
+        $prefixes = [];
+        foreach ($only_raw as $src) {
+            if ($src === "") {
+                throw new InvalidArgumentException("--only source cannot be empty");
+            }
+
+            $resolved = $this->resolve_token_path($src, $source_tokens);
+            $prefixes[$resolved] = true;
+
+            // Scoping content_dir also pulls in any detached component (e.g. a
+            // moved uploads dir) so it's enumerated under scope.
+            if ($resolved === $source_tokens["wp-content"]) {
+                foreach ($this->detached_content_component_sources($source_tokens) as $source) {
+                    $prefixes[$source] = true;
+                }
+            }
+        }
+
+        // Drop any prefix already covered by a broader one (e.g. wp-content and wp-content/plugins)
+        // A scoped pull doesn't need to walk the same subtree twice.
+        $sources = array_keys($prefixes);
+        $minimal = [];
+        foreach ($sources as $path) {
+            $covered = false;
+
+            foreach ($sources as $other) {
+                if ($other !== $path && self::path_remainder_under($path, $other) !== null) {
+                    $covered = true;
+                    break;
+                }
+            }
+
+            if (!$covered) {
+                $minimal[] = $path;
+            }
+        }
+
+        return $minimal;
+    }
+
+    /**
+     * Whether $path is within the active --only scope. With no --only flag
+     * the pull is unscoped, so everything is in scope (returns true) — this
+     * keeps the diff's delete drains at their default behavior. When scoped,
+     * true only when $path falls under one of the scope prefixes.
+     */
+    private function in_scope(string $path): bool
+    {
+        if (empty($this->scope)) {
+            return true;
+        }
+
+        foreach ($this->scope as $prefix) {
+            if (self::path_remainder_under($path, $prefix) !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The source site's real component locations from preflight data, as remap
+     * token name => absolute path (wp-content, wp-plugins, wp-mu-plugins,
+     * wp-uploads, abspath).
      *
      * A wp-content component falls back to its conventional spot under
      * content_dir when that is known. This is a pure data-gatherer: any entry
@@ -8482,18 +8614,18 @@ class ImportClient
     }
 
     /**
-     * Resolve a --remap argument (source or target) into an absolute path.
+     * Resolve a --remap/--only path argument into an absolute path.
      *
-     * Substitutes a known leading `:token:` (see the token tables in resolve_remap)
-     * with its value, then trims trailing slashes. The
+     * Substitutes a known leading `:token:` (see the token tables in resolve_remap
+     * and resolve_scope) with its value, then trims trailing slashes. The
      * result must be a valid absolute path with no `.`/`..` segments; a relative
      * path or an unknown token (left unsubstituted) fails that check. Referencing
      * a token whose value is unavailable in preflight is a distinct, clear error.
      *
-     * @param string $raw The raw remap argument.
+     * @param string $raw The raw argument.
      * @param array<string,string|null> $tokens Token name => value (null = unavailable).
      */
-    private function resolve_remap_path(string $raw, array $tokens): string
+    private function resolve_token_path(string $raw, array $tokens): string
     {
         $resolved = $raw;
         foreach ($tokens as $name => $value) {
@@ -8505,13 +8637,13 @@ class ImportClient
 
             if ($token_offset !== 0 || strpos($resolved, $token, strlen($token)) !== false) {
                 throw new InvalidArgumentException(
-                    "--remap token \"{$token}\" must appear only at the beginning of the path"
+                    "token \"{$token}\" must appear only at the beginning of the path"
                 );
             }
 
             if ($value === null) {
                 throw new InvalidArgumentException(
-                    "Cannot resolve --remap token \"{$token}\": not available in preflight data. Run preflight first."
+                    "Cannot resolve token \"{$token}\": not available in preflight data. Run preflight first."
                 );
             }
 
@@ -8519,7 +8651,7 @@ class ImportClient
         }
 
         $resolved = rtrim($resolved, "/");
-        assert_valid_path($resolved, "--remap path \"{$raw}\"");
+        assert_valid_path($resolved, "path \"{$raw}\"");
 
         return $resolved;
     }
@@ -9397,6 +9529,13 @@ class ImportClient
      */
     private function get_export_directories(): array
     {
+        // --only is a *replace*: the export roots ARE the resolved scope
+        // prefixes, so core/abspath/document_root, remap sources, and the
+        // auto-prepend/append dirs below are not walked by default — only the scope is.
+        if (!empty($this->scope)) {
+            return $this->scope;
+        }
+
         $dirs = $this->get_root_directories_from_preflight();
         if (empty($dirs)) {
             return [];
@@ -11573,6 +11712,15 @@ if (
             'pair_args' => 'SOURCE TARGET',
             'help' => 'Place SOURCE (a :token: like :wp-uploads: or an absolute path) at TARGET ' .
                 '(a :fs-root: path or an absolute path within --fs-root); repeatable',
+            'commands' => ['files-pull'],
+        ],
+        [
+            'name' => 'only',
+            'type' => 'value-or-next',
+            'target' => 'only',
+            'placeholder' => 'SOURCE',
+            'help' => 'Scope the pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
+                'comma-separate for several. Default pulls everything',
             'commands' => ['files-pull'],
         ],
 

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * --only reuses the existing `value-or-next` option type (like --new-site-url),
+ * taking a single comma-separated value. The parser lives inside the CLI
+ * bootstrap guard (not require-able), so this exercises the real binary and
+ * asserts `--only` is a recognized option in both `--only=VAL` and `--only VAL`
+ * forms.
+ */
+class OnlyCliParseTest extends TestCase
+{
+    private $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/only-cli-' . uniqid();
+        mkdir($this->tempDir . '/state', 0755, true);
+        mkdir($this->tempDir . '/fs', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // The real CLI run may drop state files (.import-state.json, audit log)
+        // into the state dir, so a plain rmdir wouldn't clear it — recurse.
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            (is_dir($path) && !is_link($path)) ? $this->recursiveDelete($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    private function runCli(array $args): string
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $cmd = 'php ' . escapeshellarg($entry);
+        foreach ($args as $a) {
+            $cmd .= ' ' . escapeshellarg($a);
+        }
+        return shell_exec($cmd . ' 2>&1') ?? '';
+    }
+
+    public function testOnlyOptionIsRecognizedInBothForms(): void
+    {
+        $tail = array(
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+            '--secret=x',
+        );
+        // Both forms fail later (unreachable host) but must not be rejected as
+        // an unknown option.
+        $equals = $this->runCli(array_merge(
+            array('files-pull', 'http://fake.invalid/?site-export-api', '--only=:wp-content:,:wp-uploads:'),
+            $tail
+        ));
+        $this->assertStringNotContainsString('Unknown option', $equals);
+
+        $space = $this->runCli(array_merge(
+            array('files-pull', 'http://fake.invalid/?site-export-api', '--only', ':wp-content:'),
+            $tail
+        ));
+        $this->assertStringNotContainsString('Unknown option', $space);
+    }
+}

--- a/tests/Import/OnlyScopeTest.php
+++ b/tests/Import/OnlyScopeTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * --only scope resolution and enumeration (pure, preflight-injected):
+ *   - resolve_scope(): :token: templates / absolute paths → real source
+ *     prefixes (sharing --remap's source token table), with detached-component
+ *     expansion for wp-content and covered-prefix collapse.
+ *   - in_scope(): per-path membership (unscoped ⇒ everything in scope).
+ *   - get_export_directories(): under scope, a *replace* of the export roots.
+ * Orthogonal to --remap (scope = what gets pulled, not where it lands).
+ */
+class OnlyScopeTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/only-scope-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/srv/htdocs';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse(glob($this->tempDir . '/*') ?: array()) as $p) {
+            is_dir($p) ? @rmdir($p) : @unlink($p);
+        }
+        @rmdir($this->stateDir);
+        @rmdir($this->fsRoot);
+        @rmdir($this->tempDir . '/srv');
+        @rmdir($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function call($c, string $m, array $a = array())
+    {
+        return (new \ReflectionClass($c))->getMethod($m)->invoke($c, ...$a);
+    }
+
+    private function set($c, string $p, $v): void
+    {
+        (new \ReflectionClass($c))->getProperty($p)->setValue($c, $v);
+    }
+
+    private function client(array $preflightData): \ImportClient
+    {
+        $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
+        $this->set($c, 'state', array('preflight' => array('data' => $preflightData)));
+        $this->set($c, 'audit_log', $this->tempDir . '/audit.log');
+        return $c;
+    }
+
+    /** Preflight carrying only the wp paths_urls (for resolve_scope/in_scope). */
+    private function withPaths(array $pathsUrls): \ImportClient
+    {
+        return $this->client(array('database' => array('wp' => array('paths_urls' => $pathsUrls))));
+    }
+
+    public function testResolveScopeAddsDetachedComponentsForWpContent(): void
+    {
+        // Scoping :wp-content: yields content_dir plus any component detached
+        // from it (uploads here); a nested component is already covered.
+        $c = $this->withPaths(array(
+            'content_dir' => '/var/www/html/wp-content',
+            'plugins_dir' => '/var/www/html/wp-content/plugins', // nested → not added
+            'uploads' => array('basedir' => '/mnt/uploads'),     // detached → added
+        ));
+        $scope = $this->call($c, 'resolve_scope', array(array(':wp-content:')));
+        sort($scope);
+        $this->assertSame(array('/mnt/uploads', '/var/www/html/wp-content'), $scope);
+    }
+
+    public function testResolveScopeCollapsesNestedPrefixes(): void
+    {
+        // :wp-content:/plugins is nested under :wp-content: → dropped, so the
+        // exporter never walks the subtree twice.
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+        $scope = $this->call($c, 'resolve_scope', array(array(':wp-content:', ':wp-content:/plugins')));
+        $this->assertSame(array('/var/www/html/wp-content'), $scope);
+    }
+
+    public function testResolveMapsTokensToTheirRealRelocatedLocations(): void
+    {
+        // A token resolves to its real (possibly relocated) location: the moved
+        // plugins dir via :wp-plugins:. A component token narrower than
+        // wp-content does not expand detached components (no /detached/uploads
+        // pulled in).
+        $c = $this->client(array('database' => array('wp' => array(
+            'paths_urls' => array(
+                'content_dir' => '/srv/wp-content',
+                'plugins_dir' => '/custom/plugins',
+                'abspath' => '/var/www/html',
+                'uploads' => array('basedir' => '/detached/uploads'),
+            ),
+        ))));
+        $this->assertSame(
+            array('/custom/plugins/woocommerce'),
+            $this->call($c, 'resolve_scope', array(array(':wp-plugins:/woocommerce')))
+        );
+    }
+
+    public function testResolveScopeAcceptsRawAbsolutePath(): void
+    {
+        // Like --remap, a raw absolute source is taken literally (no tokens).
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+        $this->assertSame(
+            array('/var/custom/data'),
+            $this->call($c, 'resolve_scope', array(array('/var/custom/data')))
+        );
+    }
+
+    public function testResolveScopeRejectsBlankSource(): void
+    {
+        // Strict input hygiene: a blank source (e.g. from a trailing comma in
+        // `--only=:wp-content:,`) is an error, not silently ignored.
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->call($c, 'resolve_scope', array(array(':wp-content:', '')));
+    }
+
+    public function testResolveScopeRejectsUnavailableToken(): void
+    {
+        // A token preflight didn't determine yields a clear, preflight-naming
+        // error (shared with --remap's resolver).
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('preflight');
+        $this->call($c, 'resolve_scope', array(array(':abspath:/wp-admin')));
+    }
+
+    public function testInScopeIsUnscopedTrueAndOtherwiseSlashAware(): void
+    {
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+        // No --only: everything is in scope (keeps the diff deleting orphans).
+        $this->assertTrue($this->call($c, 'in_scope', array('/anything/at/all.php')));
+
+        $this->set($c, 'scope', array('/var/www/html/wp-content'));
+        $this->assertTrue($this->call($c, 'in_scope', array('/var/www/html/wp-content/themes/a.css')));
+        $this->assertFalse($this->call($c, 'in_scope', array('/var/www/html/wp-config.php')));
+        // Byte-order sibling must not match the prefix.
+        $this->assertFalse($this->call($c, 'in_scope', array('/var/www/html/wp-content.bak/x')));
+    }
+
+    public function testScopedEnumerationReplacesRootsAndIgnoresOutOfScopeRemap(): void
+    {
+        // Under scope, export roots ARE the scope: core/abspath/document_root
+        // are dropped, and an out-of-scope --remap source stays inert.
+        $c = $this->client(array(
+            'wp_detect' => array('roots' => array(array('path' => '/var/www/html'))),
+            'runtime' => array('document_root' => '/var/www/html'),
+            'database' => array('wp' => array('paths_urls' => array(
+                'content_dir' => '/var/www/html/wp-content',
+            ))),
+        ));
+        $this->set($c, 'scope', array('/var/www/html/wp-content'));
+        $this->set($c, 'remap_rules', array(
+            '/var/www/html/wp-admin' => '/srv/htdocs/wp-admin',
+        ));
+        $dirs = $this->call($c, 'get_export_directories');
+        $this->assertSame(array('/var/www/html/wp-content'), $dirs);
+    }
+}

--- a/tests/Import/OnlyScopedDiffTest.php
+++ b/tests/Import/OnlyScopedDiffTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * --only: the diff must reconcile ONLY within scope. A scoped remote index
+ * lists in-scope paths only, so the delete drains in
+ * diff_indexes_and_build_fetch_list() would otherwise wrongly delete every
+ * out-of-scope local entry. Guard both drains so out-of-scope local files +
+ * index entries survive, while in-scope orphans are still deleted (delta).
+ */
+class OnlyScopedDiffTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fs_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/only-diff-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fs_root = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fs_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function indexLine(string $path, int $ctime, int $size, string $type = "file"): string
+    {
+        return json_encode([
+            "path" => base64_encode($path),
+            "ctime" => $ctime,
+            "size" => $size,
+            "type" => $type,
+        ], JSON_UNESCAPED_SLASHES) . "\n";
+    }
+
+    /** Create a local file under fs_root for a (source-absolute) index path. */
+    private function seedLocalFile(string $path, string $contents = "x"): string
+    {
+        $full = $this->fs_root . $path;
+        if (!is_dir(dirname($full))) {
+            mkdir(dirname($full), 0755, true);
+        }
+        file_put_contents($full, $contents);
+        return $full;
+    }
+
+    private function writeIndex(string $name, string $contents): void
+    {
+        file_put_contents($this->stateDir . '/' . $name, $contents);
+    }
+
+    private function readLocalIndexPaths(): array
+    {
+        $file = $this->stateDir . '/.import-index.jsonl';
+        if (!file_exists($file)) {
+            return [];
+        }
+        $paths = [];
+        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $data = json_decode($line, true);
+            if (isset($data["path"])) {
+                $paths[] = base64_decode($data["path"]);
+            }
+        }
+        return $paths;
+    }
+
+    /** Mirror FilesSyncStateTest: load state + preserve-local, then set scope. */
+    private function prepareClient(array $scope): array
+    {
+        $defaults = [
+            "command" => "files-pull",
+            "status" => "in_progress",
+            "stage" => "diff",
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "follow_symlinks" => false,
+            "fs_root_nonempty_behavior" => "preserve-local",
+        ];
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode($defaults, JSON_PRETTY_PRINT),
+        );
+
+        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
+        $r = new \ReflectionClass($client);
+        $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
+        $r->getProperty('is_tty')->setValue($client, false);
+        $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
+        $r->getProperty('scope')->setValue($client, $scope);
+        return [$client, $r];
+    }
+
+    public function testScopedDiffKeepsOutOfScopeAndDeletesInScopeOrphan(): void
+    {
+        // Local index (sorted): an out-of-scope entry, a matched in-scope file,
+        // and an in-scope orphan absent from the (scoped) remote index. The
+        // delete drains must reconcile only within scope, so the local index
+        // accumulates as a union across scoped runs.
+        $this->writeIndex('.import-index.jsonl',
+            $this->indexLine('/wp-config.php', 1000, 10)               // out of scope
+            . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
+            . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // in-scope orphan
+        );
+        $this->writeIndex('.import-remote-index.jsonl',
+            $this->indexLine('/wp-content/keep.txt', 1000, 10)
+        );
+
+        $outOfScope = $this->seedLocalFile('/wp-config.php');
+        $this->seedLocalFile('/wp-content/keep.txt');
+        $orphan = $this->seedLocalFile('/wp-content/old/orphan.txt');
+
+        [$client, $r] = $this->prepareClient(['/wp-content']);
+        $r->getMethod('diff_indexes_and_build_fetch_list')->invoke($client);
+
+        // Out-of-scope file AND its index entry survive.
+        $this->assertFileExists($outOfScope);
+        $this->assertContains('/wp-config.php', $this->readLocalIndexPaths());
+        // In-scope orphan file AND its index entry are deleted.
+        $this->assertFileDoesNotExist($orphan);
+        $this->assertNotContains('/wp-content/old/orphan.txt', $this->readLocalIndexPaths());
+    }
+}

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -147,7 +147,10 @@ nginx
 
 echo "=== All services running ==="
 
-# Run tests
+# Run tests. Any args passed to the container are forwarded to vitest, so you
+# can target specific files, e.g.:
+#   docker run --rm reprint-e2e tests/import-51-only-remap-managed-composition.test.js
+# With no args, the full suite runs (CI default).
 cd /app/tests/e2e
 echo "=== Running E2E tests ==="
-npx vitest run
+npx vitest run "$@"

--- a/tests/e2e/lib/atomic-hosting-fixture.js
+++ b/tests/e2e/lib/atomic-hosting-fixture.js
@@ -1,0 +1,136 @@
+/**
+ * Shared fixture: a realistic WP.com Atomic / managed-hosting layout where WP
+ * core, plugins, themes, drop-ins, and mu-plugins live in a shared, read-only
+ * directory and are symlinked into the site root.
+ *
+ * Used by the preserve-local tests (import-37) and the --only/--remap managed
+ * composition test (import-51).
+ *
+ * Layout produced (relative to `siteRoot`):
+ *
+ *   <siteRoot>/
+ *     __wp__                     -> ../wordpress/core/latest
+ *     wp-load.php                -> __wp__/wp-load.php
+ *     wp-content/
+ *       object-cache.php         -> ../../wordpress/drop-ins/object-cache.php
+ *       advanced-cache.php       -> ../../wordpress/drop-ins/advanced-cache.php
+ *       mu-plugins/
+ *         wpcomsh               -> ../../../wordpress/plugins/wpcomsh/latest
+ *         wpcomsh-loader.php    -> ../../../wordpress/plugins/wpcomsh/latest/wpcomsh-loader.php
+ *       plugins/
+ *         akismet               -> ../../../wordpress/plugins/akismet/latest
+ *         jetpack               -> ../../../wordpress/plugins/jetpack/latest
+ *       themes/
+ *         twentyseventeen       -> ../../../wordpress/themes/twentyseventeen/latest
+ *
+ * The shared `wordpress/` tree is created as a sibling of `siteRoot` (so the
+ * hardcoded relative symlinks resolve regardless of how deep `siteRoot` is) and
+ * locked to 0555 to mirror real hosting's read-only managed layer.
+ */
+import { existsSync, writeFileSync, mkdirSync, symlinkSync, chmodSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+/**
+ * Build the managed hosting structure at an absolute `siteRoot`.
+ *
+ * @param {string} siteRoot Absolute path the site root lives at (the docroot).
+ * @returns {{ siteRoot: string, wpShared: string }}
+ */
+export function buildAtomicHostingFixture(siteRoot) {
+    // Shared tree is a sibling of the site root — keeps the relative symlinks
+    // below valid no matter how deep siteRoot is.
+    const wpShared = join(dirname(siteRoot), 'wordpress');
+
+    // -- shared wordpress directory (read-only after setup) --------
+    const dirs = [
+        'core/latest/wp-includes',
+        'drop-ins',
+        'plugins/akismet/latest',
+        'plugins/jetpack/latest',
+        'plugins/wpcomsh/latest',
+        'themes/twentyseventeen/latest',
+    ];
+    for (const d of dirs) {
+        mkdirSync(join(wpShared, d), { recursive: true });
+    }
+    writeFileSync(join(wpShared, 'core/latest/wp-load.php'),
+        '<?php // shared WP core loader');
+    writeFileSync(join(wpShared, 'core/latest/wp-includes/version.php'),
+        '<?php $wp_version = "6.7";');
+    writeFileSync(join(wpShared, 'drop-ins/object-cache.php'),
+        '<?php // shared object cache drop-in');
+    writeFileSync(join(wpShared, 'drop-ins/advanced-cache.php'),
+        '<?php // shared advanced cache drop-in');
+    writeFileSync(join(wpShared, 'plugins/akismet/latest/akismet.php'),
+        '<?php // shared akismet');
+    writeFileSync(join(wpShared, 'plugins/jetpack/latest/jetpack.php'),
+        '<?php // shared jetpack');
+    writeFileSync(join(wpShared, 'plugins/wpcomsh/latest/wpcomsh-loader.php'),
+        '<?php // shared wpcomsh loader');
+    writeFileSync(join(wpShared, 'themes/twentyseventeen/latest/style.css'),
+        '/* shared twentyseventeen */');
+
+    // -- site root with hosting symlinks ---------------------------
+    mkdirSync(join(siteRoot, 'wp-content', 'mu-plugins'), { recursive: true });
+    mkdirSync(join(siteRoot, 'wp-content', 'plugins'), { recursive: true });
+    mkdirSync(join(siteRoot, 'wp-content', 'themes'), { recursive: true });
+
+    // Directory symlink to WP core
+    symlinkSync('../wordpress/core/latest',
+        join(siteRoot, '__wp__'));
+
+    // File symlink through __wp__
+    symlinkSync('__wp__/wp-load.php',
+        join(siteRoot, 'wp-load.php'));
+
+    // Drop-in file symlinks (2 levels up from wp-content/ to site parent)
+    symlinkSync('../../wordpress/drop-ins/object-cache.php',
+        join(siteRoot, 'wp-content', 'object-cache.php'));
+    symlinkSync('../../wordpress/drop-ins/advanced-cache.php',
+        join(siteRoot, 'wp-content', 'advanced-cache.php'));
+
+    // mu-plugins: directory symlink + file symlink (3 levels up)
+    symlinkSync('../../../wordpress/plugins/wpcomsh/latest',
+        join(siteRoot, 'wp-content', 'mu-plugins', 'wpcomsh'));
+    symlinkSync('../../../wordpress/plugins/wpcomsh/latest/wpcomsh-loader.php',
+        join(siteRoot, 'wp-content', 'mu-plugins', 'wpcomsh-loader.php'));
+
+    // Plugin directory symlinks (3 levels up)
+    symlinkSync('../../../wordpress/plugins/akismet/latest',
+        join(siteRoot, 'wp-content', 'plugins', 'akismet'));
+    symlinkSync('../../../wordpress/plugins/jetpack/latest',
+        join(siteRoot, 'wp-content', 'plugins', 'jetpack'));
+
+    // Theme directory symlink (3 levels up)
+    symlinkSync('../../../wordpress/themes/twentyseventeen/latest',
+        join(siteRoot, 'wp-content', 'themes', 'twentyseventeen'));
+
+    // Lock down the shared directory — hosting infra is read-only
+    chmodSync(join(wpShared, 'core/latest/wp-includes'), 0o555);
+    chmodSync(join(wpShared, 'core/latest'), 0o555);
+    chmodSync(join(wpShared, 'drop-ins'), 0o555);
+    chmodSync(join(wpShared, 'plugins/akismet/latest'), 0o555);
+    chmodSync(join(wpShared, 'plugins/jetpack/latest'), 0o555);
+    chmodSync(join(wpShared, 'plugins/wpcomsh/latest'), 0o555);
+    chmodSync(join(wpShared, 'themes/twentyseventeen/latest'), 0o555);
+
+    return { siteRoot, wpShared };
+}
+
+// Restore write permissions so cleanup can remove the tree.
+export function unlockSharedDir(wpShared) {
+    if (!existsSync(wpShared)) return;
+    const unlock = [
+        'core/latest/wp-includes',
+        'core/latest',
+        'drop-ins',
+        'plugins/akismet/latest',
+        'plugins/jetpack/latest',
+        'plugins/wpcomsh/latest',
+        'themes/twentyseventeen/latest',
+    ];
+    for (const d of unlock) {
+        const p = join(wpShared, d);
+        if (existsSync(p)) chmodSync(p, 0o755);
+    }
+}

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -124,6 +124,9 @@
     },
     "file-body-resume": {
       "port": 8120
+    },
+    "only-remap-managed": {
+      "port": 8121
     }
   }
 }

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -33,7 +33,7 @@ import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     existsSync, readFileSync, writeFileSync, mkdirSync,
-    symlinkSync, chmodSync, lstatSync, readlinkSync,
+    symlinkSync, lstatSync, readlinkSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import {
@@ -43,6 +43,7 @@ import {
     fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
+import { buildAtomicHostingFixture, unlockSharedDir } from '../lib/atomic-hosting-fixture.js';
 
 describe('Import: --preserve-local', () => {
     const site = 'preserve-local';
@@ -78,114 +79,21 @@ describe('Import: --preserve-local', () => {
     // ----------------------------------------------------------------
     // Helper: build the realistic hosting structure inside a fs-root.
     //
-    // Places a shared "wordpress/" directory as a sibling of the site
-    // directory (both under fs-root/srv/e2e-sites/), then creates all
-    // the hosting symlinks inside the site root.  The shared directory
-    // is made read-only (chmod 555) so that files under symlinked dirs
-    // cannot be written — matching real hosting constraints.
+    // The managed Atomic structure (shared read-only wordpress/ tree +
+    // hosting symlinks) lives in the shared buildAtomicHostingFixture helper.
+    // Here we place it at fs-root/<siteDir> (where this test's source content
+    // reconstructs, since it runs without --remap) and add the test-specific
+    // conflicting regular file.
     // ----------------------------------------------------------------
     function buildHostingStructureInLocalFsRoot(fsRoot) {
-        const siteRoot = join(fsRoot, siteDir);
-        const wpShared = join(fsRoot, dirname(siteDir), 'wordpress');
+        const { siteRoot, wpShared } = buildAtomicHostingFixture(join(fsRoot, siteDir));
 
-        // -- shared wordpress directory (read-only after setup) --------
-        const dirs = [
-            'core/latest/wp-includes',
-            'drop-ins',
-            'plugins/akismet/latest',
-            'plugins/jetpack/latest',
-            'plugins/wpcomsh/latest',
-            'themes/twentyseventeen/latest',
-        ];
-        for (const d of dirs) {
-            mkdirSync(join(wpShared, d), { recursive: true });
-        }
-        writeFileSync(join(wpShared, 'core/latest/wp-load.php'),
-            '<?php // shared WP core loader');
-        writeFileSync(join(wpShared, 'core/latest/wp-includes/version.php'),
-            '<?php $wp_version = "6.7";');
-        writeFileSync(join(wpShared, 'drop-ins/object-cache.php'),
-            '<?php // shared object cache drop-in');
-        writeFileSync(join(wpShared, 'drop-ins/advanced-cache.php'),
-            '<?php // shared advanced cache drop-in');
-        writeFileSync(join(wpShared, 'plugins/akismet/latest/akismet.php'),
-            '<?php // shared akismet');
-        writeFileSync(join(wpShared, 'plugins/jetpack/latest/jetpack.php'),
-            '<?php // shared jetpack');
-        writeFileSync(join(wpShared, 'plugins/wpcomsh/latest/wpcomsh-loader.php'),
-            '<?php // shared wpcomsh loader');
-        writeFileSync(join(wpShared, 'themes/twentyseventeen/latest/style.css'),
-            '/* shared twentyseventeen */');
-
-        // -- site root with hosting symlinks ---------------------------
-        mkdirSync(join(siteRoot, 'wp-content', 'mu-plugins'), { recursive: true });
-        mkdirSync(join(siteRoot, 'wp-content', 'plugins'), { recursive: true });
-        mkdirSync(join(siteRoot, 'wp-content', 'themes'), { recursive: true });
-
-        // Directory symlink to WP core
-        symlinkSync('../wordpress/core/latest',
-            join(siteRoot, '__wp__'));
-
-        // File symlink through __wp__
-        symlinkSync('__wp__/wp-load.php',
-            join(siteRoot, 'wp-load.php'));
-
-        // Drop-in file symlinks (2 levels up from wp-content/ to site parent)
-        symlinkSync('../../wordpress/drop-ins/object-cache.php',
-            join(siteRoot, 'wp-content', 'object-cache.php'));
-        symlinkSync('../../wordpress/drop-ins/advanced-cache.php',
-            join(siteRoot, 'wp-content', 'advanced-cache.php'));
-
-        // mu-plugins: directory symlink + file symlink (3 levels up)
-        symlinkSync('../../../wordpress/plugins/wpcomsh/latest',
-            join(siteRoot, 'wp-content', 'mu-plugins', 'wpcomsh'));
-        symlinkSync('../../../wordpress/plugins/wpcomsh/latest/wpcomsh-loader.php',
-            join(siteRoot, 'wp-content', 'mu-plugins', 'wpcomsh-loader.php'));
-
-        // Plugin directory symlinks (3 levels up)
-        symlinkSync('../../../wordpress/plugins/akismet/latest',
-            join(siteRoot, 'wp-content', 'plugins', 'akismet'));
-        symlinkSync('../../../wordpress/plugins/jetpack/latest',
-            join(siteRoot, 'wp-content', 'plugins', 'jetpack'));
-
-        // Theme directory symlink (3 levels up)
-        symlinkSync('../../../wordpress/themes/twentyseventeen/latest',
-            join(siteRoot, 'wp-content', 'themes', 'twentyseventeen'));
-
-        // -- local regular files that conflict with remote paths --------
-        // These are plain files (not symlinks) that also exist on the
-        // remote site.  preserve-local should keep the local version.
+        // A plain local file that also exists on the remote with different
+        // content — preserve-local should keep the local version.
         writeFileSync(join(siteRoot, 'wp-content', 'maintenance.php'),
             '<?php // LOCAL maintenance – should be preserved');
 
-        // Lock down the shared directory — hosting infra is read-only
-        chmodSync(join(wpShared, 'core/latest/wp-includes'), 0o555);
-        chmodSync(join(wpShared, 'core/latest'), 0o555);
-        chmodSync(join(wpShared, 'drop-ins'), 0o555);
-        chmodSync(join(wpShared, 'plugins/akismet/latest'), 0o555);
-        chmodSync(join(wpShared, 'plugins/jetpack/latest'), 0o555);
-        chmodSync(join(wpShared, 'plugins/wpcomsh/latest'), 0o555);
-        chmodSync(join(wpShared, 'themes/twentyseventeen/latest'), 0o555);
-
         return { siteRoot, wpShared };
-    }
-
-    // Restore write permissions so cleanup can remove the tree.
-    function unlockSharedDir(wpShared) {
-        if (!existsSync(wpShared)) return;
-        const unlock = [
-            'core/latest/wp-includes',
-            'core/latest',
-            'drop-ins',
-            'plugins/akismet/latest',
-            'plugins/jetpack/latest',
-            'plugins/wpcomsh/latest',
-            'themes/twentyseventeen/latest',
-        ];
-        for (const d of unlock) {
-            const p = join(wpShared, d);
-            if (existsSync(p)) chmodSync(p, 0o755);
-        }
     }
 
     // ------------------------------------------------------------------

--- a/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
+++ b/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
@@ -1,0 +1,266 @@
+/**
+ * Test 51: --only + --remap onto a managed Atomic docroot (v1 composition)
+ *
+ * The committed Docker twin of the real "first migration onto a managed Atomic
+ * site" flow, plus the scoped re-sync that follows it. It exercises the v1
+ * invocation —
+ *
+ *   files-sync --only :wp-content: --remap :wp-content: :fs-root:/wp-content \
+ *     --on-fs-root-nonempty=preserve-local --no-follow-symlinks
+ *
+ * — against a fs-root pre-populated with the realistic managed hosting layout
+ * (shared read-only wordpress/ tree + hosting symlinks; see
+ * lib/atomic-hosting-fixture.js), then a second, narrower scoped run on the
+ * same target.
+ *
+ * Topology note: the e2e source ABSPATH is /srv/e2e-sites/<site>, so without
+ * --remap the source's wp-content would reconstruct at
+ * fs-root/srv/e2e-sites/<site>/wp-content (nested). `--remap :wp-content:
+ * :fs-root:/wp-content` flattens it to fs-root/wp-content — which is why the
+ * managed fixture here lives at the fs-root ROOT (the docroot), unlike test 37.
+ *
+ * Phase 1 — first migration (--only :wp-content:). Verifies the four contracts
+ * of the composition:
+ *   1. Core excluded (--only)        — no wp-admin/wp-includes pulled.
+ *   2. Direct placement (--remap)    — wp-content at fs-root/wp-content, no nesting.
+ *   3. Managed layer preserved       — hosting symlinks intact, read-only dirs
+ *                                      don't crash, shared content untouched.
+ *   4. New userland lands + collisions skip — custom content written; source
+ *                                      files colliding with the managed layer
+ *                                      are skipped (target wins).
+ *
+ * Phase 2 — scoped delta re-sync (--only :wp-content:/plugins). Verifies the
+ * re-sync behavior against the same managed target:
+ *   A. Delta-delete   — a file the SOURCE removed that is IN the current scope
+ *                       and was previously synced is deleted on the target.
+ *   B. Scope-survival — content synced by the earlier, broader run but OUTSIDE
+ *                       the current scope is NOT deleted (the delete-drain is
+ *                       guarded by in_scope(); the local index is a union across
+ *                       scoped runs).
+ *   plus a control: an in-scope file the source still has is retained.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, writeFileSync, mkdirSync, lstatSync, readlinkSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    readAuditLog, fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+import { buildAtomicHostingFixture, unlockSharedDir } from '../lib/atomic-hosting-fixture.js';
+
+describe('Import: --only + --remap onto a managed Atomic docroot', () => {
+    const site = 'only-remap-managed';
+    let siteDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (remoteSiteDir) => {
+                const wpContent = join(remoteSiteDir, 'wp-content');
+
+                // custom-plugin — imported in phase 1, then REMOVED from the
+                // source before the phase 2 delta (in-scope deletion).
+                const pluginDir = join(wpContent, 'plugins', 'custom-plugin');
+                mkdirSync(pluginDir, { recursive: true });
+                writeFileSync(join(pluginDir, 'custom-plugin.php'),
+                    '<?php /* REMOTE custom plugin – imported, then removed from source */');
+
+                // keep-plugin — in scope on both runs, stays on the source;
+                // must be retained through the delta (control).
+                const keepDir = join(wpContent, 'plugins', 'keep-plugin');
+                mkdirSync(keepDir, { recursive: true });
+                writeFileSync(join(keepDir, 'keep-plugin.php'),
+                    '<?php /* REMOTE keep plugin – stays on source */');
+
+                // custom-theme — imported in phase 1, OUT of scope in phase 2;
+                // must survive the narrower re-sync.
+                const themeDir = join(wpContent, 'themes', 'custom-theme');
+                mkdirSync(themeDir, { recursive: true });
+                writeFileSync(join(themeDir, 'style.css'),
+                    '/* REMOTE custom theme – imported, out of scope on the delta run */');
+
+                const uploadsDir = join(wpContent, 'uploads', '2025', '06');
+                mkdirSync(uploadsDir, { recursive: true });
+                writeFileSync(join(uploadsDir, 'new.jpg'),
+                    'REMOTE upload – should be imported');
+
+                // Collision with the managed akismet symlink: the remote ships
+                // its own akismet (with a readme the shared copy lacks). Neither
+                // should overwrite or write through the managed symlink.
+                const akismetDir = join(wpContent, 'plugins', 'akismet');
+                mkdirSync(akismetDir, { recursive: true });
+                writeFileSync(join(akismetDir, 'akismet.php'),
+                    '<?php /* REMOTE akismet – should NOT appear locally */');
+                writeFileSync(join(akismetDir, 'readme.txt'),
+                    'Remote Akismet readme – should NOT appear locally');
+            },
+        });
+        siteDir = getSiteDir(site);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${siteDir}`;
+    }
+
+    // Shared remap + preserve flags; the --only scope varies per run.
+    const remap = ['--remap', ':wp-content:', ':fs-root:/wp-content'];
+    const preserve = ['--on-fs-root-nonempty=preserve-local', '--no-follow-symlinks'];
+
+    let tempDir;
+    let fsRoot;
+    let wpShared;
+
+    beforeAll(() => {
+        tempDir = createTempDir('e2e-only-remap-managed');
+        fsRoot = fsRootDir(tempDir);
+        // Managed layer lives at the fs-root ROOT — that's where
+        // `--remap :wp-content: :fs-root:/wp-content` places the pulled content.
+        ({ wpShared } = buildAtomicHostingFixture(fsRoot));
+    });
+
+    afterAll(() => {
+        unlockSharedDir(wpShared);
+        cleanupTempDir(tempDir);
+    });
+
+    const tgtPlugin = (name) => join(fsRoot, 'wp-content', 'plugins', name);
+    const tgtTheme = (name) => join(fsRoot, 'wp-content', 'themes', name);
+
+    // ================================================================
+    // Phase 1 — first migration: --only :wp-content:
+    // ================================================================
+    it('files-sync completes with --only + --remap + preserve-local', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--only', ':wp-content:', ...remap, ...preserve],
+        });
+        assert.equal(
+            result.exitCode, 0,
+            `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+    });
+
+    // -- 1. Core excluded (--only) --------------------------------
+    it('source WP core is never pulled', () => {
+        assert.ok(!existsSync(join(fsRoot, 'wp-admin')),
+            'wp-admin should not be pulled (--only :wp-content:)');
+        assert.ok(!existsSync(join(fsRoot, 'wp-includes')),
+            'wp-includes should not be pulled (--only :wp-content:)');
+    });
+
+    // -- 2. Direct placement (--remap) ----------------------------
+    it('wp-content lands at fs-root/wp-content, not nested', () => {
+        assert.ok(existsSync(join(fsRoot, 'wp-content')),
+            'wp-content should exist at the fs-root root');
+        // No source-abspath nesting: nothing reconstructed under /srv/...
+        assert.ok(!existsSync(join(fsRoot, 'srv')),
+            'content should be remapped, not nested under srv/e2e-sites/...');
+    });
+
+    it('new userland content is written under the remapped wp-content', () => {
+        assert.ok(existsSync(join(tgtPlugin('custom-plugin'), 'custom-plugin.php')),
+            'custom plugin should be imported');
+        assert.ok(existsSync(join(tgtPlugin('keep-plugin'), 'keep-plugin.php')),
+            'keep plugin should be imported');
+        assert.ok(existsSync(join(tgtTheme('custom-theme'), 'style.css')),
+            'custom theme should be imported');
+        assert.ok(existsSync(join(fsRoot, 'wp-content', 'uploads', '2025', '06', 'new.jpg')),
+            'uploaded media should be imported');
+    });
+
+    // -- 3. Managed layer preserved -------------------------------
+    it('managed hosting symlinks stay intact', () => {
+        assert.ok(lstatSync(join(fsRoot, '__wp__')).isSymbolicLink(), '__wp__ symlink preserved');
+        assert.equal(readlinkSync(join(fsRoot, '__wp__')), '../wordpress/core/latest');
+        assert.ok(lstatSync(join(fsRoot, 'wp-load.php')).isSymbolicLink(), 'wp-load.php symlink preserved');
+        assert.ok(lstatSync(join(fsRoot, 'wp-content', 'plugins', 'jetpack')).isSymbolicLink(),
+            'jetpack symlink preserved');
+        assert.ok(lstatSync(join(fsRoot, 'wp-content', 'object-cache.php')).isSymbolicLink(),
+            'object-cache.php drop-in symlink preserved');
+    });
+
+    it('shared read-only managed content is not modified', () => {
+        assert.equal(
+            readFileSync(join(wpShared, 'plugins/akismet/latest/akismet.php'), 'utf-8'),
+            '<?php // shared akismet',
+        );
+    });
+
+    // -- 4. Collisions skip (target wins) -------------------------
+    it('source files colliding with the managed layer are skipped', () => {
+        // akismet is a managed symlink; the remote's akismet.php must not win.
+        assert.equal(
+            readFileSync(join(fsRoot, 'wp-content', 'plugins', 'akismet', 'akismet.php'), 'utf-8'),
+            '<?php // shared akismet',
+            'managed akismet.php should win over the remote version',
+        );
+        // The remote's readme.txt must not be written through the symlink into
+        // the shared (read-only) pool.
+        assert.ok(!existsSync(join(wpShared, 'plugins/akismet/latest/readme.txt')),
+            'remote readme.txt must not leak into the shared akismet dir');
+    });
+
+    it('audit log records PRESERVE-LOCAL skips', () => {
+        const audit = readAuditLog(tempDir);
+        assert.ok(audit.includes('PRESERVE-LOCAL'),
+            'expected PRESERVE-LOCAL skip entries in the audit log');
+    });
+
+    // ================================================================
+    // Phase 2 — scoped delta re-sync: --only :wp-content:/plugins
+    // ================================================================
+    it('removes custom-plugin from source, then aborts to force a fresh delta', () => {
+        // The source tree is owned by nginx:nginx (site-setup chowns it), so
+        // mutate it via sudo — matching the delta pattern in import-03.
+        execSync(`sudo rm -rf ${JSON.stringify(join(siteDir, 'wp-content', 'plugins', 'custom-plugin'))}`);
+        assert.ok(!existsSync(join(siteDir, 'wp-content', 'plugins', 'custom-plugin')),
+            'precondition: source custom-plugin removed');
+        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--abort'],
+            autoResume: false,
+        });
+        assert.equal(abort.exitCode, 0, `abort expected exit 0\nstderr: ${abort.stderr}`);
+    });
+
+    it('scoped delta re-sync completes (--only :wp-content:/plugins)', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--only', ':wp-content:/plugins', ...remap, ...preserve],
+        });
+        assert.equal(
+            result.exitCode, 0,
+            `delta re-sync expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+    });
+
+    // A — delta delete
+    it('delta-deletes the in-scope plugin the source removed', () => {
+        assert.ok(!existsSync(tgtPlugin('custom-plugin')),
+            'custom-plugin should be deleted (in scope, removed from source)');
+    });
+
+    // control — in-scope, still on source
+    it('retains the in-scope plugin the source still has', () => {
+        assert.ok(existsSync(join(tgtPlugin('keep-plugin'), 'keep-plugin.php')),
+            'keep-plugin should be retained (in scope, still on source)');
+    });
+
+    // B — scope survival
+    it('preserves the out-of-scope theme synced by the earlier broader run', () => {
+        assert.ok(existsSync(join(tgtTheme('custom-theme'), 'style.css')),
+            'custom-theme should survive (out of scope in the delta run — delete-drain skips it)');
+    });
+
+    it('managed layer stays intact through the delta', () => {
+        assert.ok(lstatSync(join(fsRoot, '__wp__')).isSymbolicLink(), '__wp__ symlink intact');
+        assert.ok(lstatSync(tgtPlugin('akismet')).isSymbolicLink(), 'akismet managed symlink intact');
+        assert.ok(lstatSync(join(fsRoot, 'wp-content', 'object-cache.php')).isSymbolicLink(),
+            'object-cache.php drop-in symlink intact');
+    });
+});


### PR DESCRIPTION
The PR adds a new `--only SOURCE` flag, allowing for specifying which folders should be imported, allowing you to limit an import:

```
# just userland, no core
--only :wp-content:

# multiple subtrees (comma-separated)
--only :wp-plugins:,:wp-content:/themes

# scope + placement together: only wp-content, landed un-nested
--only :wp-content: --remap :wp-content: /srv/htdocs/wp-content
  ```

- SOURCE uses the same `:token:` convention as `--remap` (or a raw absolute path). Each token auto-resolves to the real source location from preflight.
- Available source tokens: `:wp-content:`, `:wp-plugins:`, `:wp-mu-plugins:`, `:wp-uploads:`, `:abspath:`. Can append a sub-path after any token (e.g. `:wp-content:/themes`).
- Scoped pulls only delete within scope, so the local index accumulates as a union across scoped runs.

## Testing

You'll need a source site with the reprint exporter installed.

```
DOCROOT=/tmp/remap-test  STATE=/tmp/remap-state
URL="https://YOUR-SITE.com/?site-export-api"  SECRET="<migration secret>"

php importer/import.php preflight  "$URL" --state-dir="$STATE" --fs-root="$DOCROOT" --secret="$SECRET"

# resumes; exits non-zero while partial
php importer/import.php files-pull "$URL" --state-dir="$STATE" --fs-root="$DOCROOT" --secret="$SECRET" --only :wp-content:
```

Confirm the scope was respected. Try again with `--only :wp-plugins:`, and note that the prev-imported themes/uploads aren't deleted.