### PR TITLE
Truncate the skipped-download list instead of deleting it

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10171,9 +10171,6 @@ class ImportClient
     }
 
     /**
-     * Return the default compact state structure.
-     */
-    /**
      * Empty the skipped-files download list by truncating it in place
      * rather than deleting it.
      *
@@ -10221,6 +10218,9 @@ class ImportClient
         }
     }
 
+    /**
+     * Return the default compact state structure.
+     */
     public function default_state(): array
     {
         return [

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1888,10 +1888,7 @@ class ImportClient
                     @unlink($this->download_list_file);
                     $this->audit_log("FILE DELETE | {$this->download_list_file}");
                 }
-                if (file_exists($this->skipped_download_list_file)) {
-                    @unlink($this->skipped_download_list_file);
-                    $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
-                }
+                $this->clear_skipped_download_list("abort files-pull");
                 if (file_exists($this->volatile_files_file)) {
                     @unlink($this->volatile_files_file);
                     $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
@@ -2828,12 +2825,7 @@ class ImportClient
                     "FILE DELETE | {$this->download_list_file} | clearing before diff stage",
                 );
             }
-            if (file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | clearing before diff stage",
-                );
-            }
+            $this->clear_skipped_download_list("clearing before diff stage");
             $this->save_state($this->state);
             $stage = "diff";
         }
@@ -2887,11 +2879,8 @@ class ImportClient
                     "FILE DELETE | {$this->download_list_file} | no files to fetch",
                 );
             }
-            if (!$has_skipped && file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | no skipped files to fetch",
-                );
+            if (!$has_skipped) {
+                $this->clear_skipped_download_list("no skipped files to fetch");
             }
         }
 
@@ -2960,12 +2949,7 @@ class ImportClient
             $this->state["fetch_skipped"] = $this->default_state()["fetch_skipped"];
             $this->save_state($this->state);
 
-            if (file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | skipped files fetch complete",
-                );
-            }
+            $this->clear_skipped_download_list("skipped files fetch complete");
         }
 
         // Recreate intermediate path symlinks so the full symlink chain
@@ -10189,6 +10173,29 @@ class ImportClient
     /**
      * Return the default compact state structure.
      */
+    /**
+     * Empty the skipped-files download list by truncating it in place
+     * rather than deleting it.
+     *
+     * apply-runtime mounts this file into the generated runtime (the
+     * temporary remote-uploads proxy reads it to decide which paths are
+     * still remote-only). A running server re-resolves its mounts on every
+     * PHP runtime rotation, and on restart from a persisted config, so
+     * deleting the file breaks the mount with ENOENT. An empty file means
+     * "no remote-only files left", which is what every caller wants, since
+     * all has-skipped checks test for size > 0.
+     */
+    public function clear_skipped_download_list(string $reason): void
+    {
+        if (!file_exists($this->skipped_download_list_file)) {
+            return;
+        }
+        file_put_contents($this->skipped_download_list_file, "");
+        $this->audit_log(
+            "FILE TRUNCATE | {$this->skipped_download_list_file} | {$reason}",
+        );
+    }
+
     /**
      * Reset state to defaults while preserving cross-command data like
      * preflight results, version, and follow_symlinks.

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -424,12 +424,14 @@ class Pull
             $state_dir . "/.import-domains.json",
             $state_dir . "/.import-remote-index.jsonl",
             $state_dir . "/.import-download-list.jsonl",
-            $state_dir . "/.import-download-list-skipped.jsonl",
         ] as $path) {
             if (file_exists($path)) {
                 @unlink($path);
             }
         }
+        // Truncated, not deleted: the generated runtime may hold a mount
+        // of this file for the remote-uploads proxy.
+        $this->client->clear_skipped_download_list("prepared for delta re-pull");
 
         $this->client->audit_log("PULL | prepared for delta re-pull", true);
     }

--- a/tests/Import/ClearSkippedDownloadListTest.php
+++ b/tests/Import/ClearSkippedDownloadListTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Test that clear_skipped_download_list() truncates the skipped-files
+ * download list in place rather than deleting it.
+ *
+ * apply-runtime mounts this file into the generated runtime, so deleting
+ * it crashes the running site with ENOENT on the next runtime rotation.
+ * Truncating to empty keeps the mount valid while signalling "no
+ * remote-only files left" (every has-skipped check tests for size > 0).
+ */
+class ClearSkippedDownloadListTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $skippedListFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/import-clear-skipped-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
+        $this->skippedListFile = $this->stateDir . '/.import-download-list-skipped.jsonl';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->stateDir . '/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->stateDir);
+        @rmdir($this->tempDir . '/fs-root');
+        @rmdir($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->tempDir . '/fs-root');
+    }
+
+    public function testTruncatesExistingListToEmptyWithoutDeleting(): void
+    {
+        file_put_contents(
+            $this->skippedListFile,
+            json_encode(['path' => base64_encode('/wp-content/uploads/2024/photo.jpg')]) . "\n",
+        );
+        $this->assertGreaterThan(0, filesize($this->skippedListFile));
+
+        $this->makeClient()->clear_skipped_download_list('test reason');
+
+        $this->assertFileExists(
+            $this->skippedListFile,
+            'The list must remain on disk (truncated, not deleted) so the runtime mount stays valid',
+        );
+        $this->assertSame(
+            0,
+            filesize($this->skippedListFile),
+            'The list must be truncated to empty',
+        );
+    }
+
+    public function testNoOpWhenListIsAbsent(): void
+    {
+        $this->assertFileDoesNotExist($this->skippedListFile);
+
+        // Must not throw and must not create the file.
+        $this->makeClient()->clear_skipped_download_list('test reason');
+
+        $this->assertFileDoesNotExist(
+            $this->skippedListFile,
+            'A missing list must stay missing (no file is created)',
+        );
+    }
+}

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -11,7 +11,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
@@ -133,9 +133,17 @@ describe('Import: --filter', () => {
             }
         });
 
-        it('skipped download list was cleaned up', () => {
-            assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-                'Expected skipped download list to be cleaned up');
+        it('skipped download list was emptied', () => {
+            // The list is truncated to empty rather than deleted: apply-runtime
+            // mounts this path into the generated runtime, and deleting it would
+            // crash the runtime (ENOENT) on its next rotation. An empty file
+            // means "no remote-only files left" (all has-skipped checks test
+            // for size > 0).
+            const skippedList = join(tempDir, '.import-download-list-skipped.jsonl');
+            assert.ok(existsSync(skippedList),
+                'Expected skipped download list to remain on disk (truncated, not deleted)');
+            assert.equal(statSync(skippedList).size, 0,
+                'Expected skipped download list to be emptied after skipped-earlier');
         });
 
         it('all files match source', () => {


### PR DESCRIPTION
## What it does

A pulled site no longer crashes with `ENOENT` after the deferred uploads (`--filter=skipped-earlier`) tail finishes downloading. The importer now empties the skipped-download list by truncating it in place instead of deleting it.

## Rationale

`apply-runtime` mounts the skipped-download list (`.import-download-list-skipped.jsonl`) into the generated runtime — the temporary remote-uploads proxy reads it to decide which `wp-content/uploads` paths are still remote-only. Several cleanup paths in the importer deleted that file with `unlink()`.

PHP-WASM re-resolves its mounts on every runtime rotation (and on restart from a persisted config). Once the file was gone, the mount resolved to a missing path and the running site crashed with `ENOENT` — both the server start and WP-CLI failed. The crash surfaced right after the uploads tail completed, which is where the list was being deleted.

## Implementation

Replaced every deletion of the list with a new `ImportClient::clear_skipped_download_list()` that truncates the file to empty in place:

```php
public function clear_skipped_download_list(string $reason): void
{
    if (!file_exists($this->skipped_download_list_file)) {
        return;
    }
    file_put_contents($this->skipped_download_list_file, "");
    $this->audit_log("FILE TRUNCATE | {$this->skipped_download_list_file} | {$reason}");
}
```

An empty file means "no remote-only files left", which is exactly what every `has_skipped` check already wants — they all test `filesize(...) > 0`. So the runtime mount stays valid and no caller behavior changes. Updated the four call sites in `import.php` (abort files-pull, clearing before diff stage, no skipped files to fetch, skipped files fetch complete) and the one in `Pull::prepare_repull()`.

## Testing instructions

The easiest way to reproduce the issue is to use Studio code:
1. Navigate to Studio repo root and run:
```
export STUDIO_ENABLE_PULL_REPRINT=true && node ~/github/studio/apps/cli/dist/cli/main.mjs pull-reprint --url <your_wpcom_site>
```
2. Reply `Y` to create a new Studio site
3. Wait for the site to be created, then open Studio and stop and start the created site
4. Observe that there is an error <img width="303" height="233" alt="CleanShot 2026-06-17 at 18 32 13@2x" src="https://github.com/user-attachments/assets/fd2116e7-f32d-40ae-9dc5-3ccaa257891f" />
5. Apply the changes on this branch and compile them by running `composer build:phar` on this repo
6. Copy the `reprint.phar` to the following folder on Studio `cp reprint.phar <studio_repo>/wp-files/reprint`
7. On Studio, run `npm run cli:build` so the `phar` file is copied to the dist folder
8. Delete the previously created Studio site so you can start from scratch and previous pulls are deleted
9. Repeat steps 1-3 and verify that the site starts successfully

