### PR TITLE
Mark --filter=skipped-earlier runs complete

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2615,6 +2615,35 @@ class ImportClient
                 $this->state["stage"] = "fetch-skipped";
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
+
+                // The skipped-files fetch can span several invocations: each
+                // files-sync run yields when it hits its execution budget
+                // (--max-exec) or a server timeout, saving its cursor and
+                // returning status "partial" (exit code 2) so the caller
+                // re-invokes it to continue. On a partial return the fetch
+                // isn't finished, so return without marking it complete and
+                // let the next run resume.
+                $pipeline_status = $this->state["status"] ?? null;
+                if ($pipeline_status === "partial") {
+                    return;
+                }
+
+                // Mark the run complete. Without this, the state stays
+                // "in_progress" forever after a successful skipped-files
+                // fetch, and later runs take the resume path instead of
+                // the complete path.
+                $this->state["status"] = "complete";
+                $this->save_state($this->state);
+
+                $this->audit_log("files-pull (skipped files) complete", true);
+                $this->progress->show_lifecycle_line("files-pull (skipped files) complete\n");
+                $this->output_progress([
+                    "type" => "lifecycle",
+                    "event" => "complete",
+                    "command" => "files-pull",
+                    "stage" => "fetch-skipped",
+                    "message" => "files-pull (skipped files) complete",
+                ], true);
                 return;
             }
 

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -125,6 +125,12 @@ describe('Import: --filter', () => {
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
         });
 
+        it('state is marked complete after skipped-earlier', () => {
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            assert.equal(state.status, 'complete',
+                'Expected the skipped-earlier run to be marked complete (not left in_progress)');
+        });
+
         it('upload files now exist in the fs-root', () => {
             const importedRoot = join(fsRootDir(tempDir), siteDir);
             for (const f of UPLOAD_FILES) {


### PR DESCRIPTION
## What it does

A completed `files-sync --filter=skipped-earlier` run (the second phase that downloads the deferred uploads) is now recorded as `complete` in the state file. Previously it was left at `in_progress` forever, so a later `files-sync` saw a non-complete state and took the resume path instead of treating the sync as done.

## Rationale

In `ImportClient::run_files_sync`, the `--filter=skipped-earlier` branch sets `status = "in_progress"`, runs the fetch pipeline, and then `return`s — short-circuiting before the code path that marks the run `complete`:

```php
$this->state["status"] = "in_progress";
$this->state["stage"]  = "fetch-skipped";
$this->save_state($this->state);
$this->run_files_sync_pipeline();
return;   // <- never reaches the "complete" marking
```

So even after a fully successful skipped-earlier fetch, the state stayed `in_progress`.

## Implementation

After the pipeline returns, mark the run complete. The partial case is guarded first: if the pipeline yielded mid-fetch (it hit its `--max-exec` budget or a server timeout and returned `status = "partial"`, exit code 2), it returns without marking complete so the next invocation resumes from the cursor.

```php
$this->run_files_sync_pipeline();

$pipeline_status = $this->state["status"] ?? null;
if ($pipeline_status === "partial") {
    return; // yielded mid-fetch; resume on the next run
}

$this->state["status"] = "complete";
$this->save_state($this->state);
// ... emit the "complete" lifecycle event (command files-pull, stage fetch-skipped)
```

## Testing instructions

The E2E `import-40-defer-uploads` test now asserts that after the `--filter=skipped-earlier` run the persisted state `status` is `complete` (it was `in_progress` before this fix):

```bash
cd tests/e2e && npm run test -- tests/import-40-defer-uploads.test.js
```

The full `Import/` PHPUnit suite is green (264 tests) and WPCS reports no new violations.
