### PR TITLE
Strip ephemeral _edit_lock postmeta on db-apply

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5402,6 +5402,11 @@ class ImportClient
                     $this->audit_log("DB-APPLY | deactivated plugin {$basename} (path-incompatible siteurl)");
                 }
 
+                // Drop editor locks captured from the remote. On the imported
+                // copy they only produce phantom "X is currently editing"
+                // badges.
+                $this->strip_ephemeral_edit_locks($pdo);
+
                 // Mark complete
                 $this->state["apply"]["statements_executed"] = $statements_executed;
                 $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
@@ -5492,6 +5497,49 @@ class ImportClient
         }
 
         $pdo->exec($executed_query);
+    }
+
+    /**
+     * Delete ephemeral editor locks from the imported database.
+     *
+     * `_edit_lock` postmeta is runtime state (it records that a user has a
+     * post open in the editor right now) that the SQL dump captures
+     * verbatim. On the imported copy the lock is meaningless: the remote
+     * editing session has no relationship to the local site, but WordPress
+     * still renders it as a "X is currently editing" badge for up to 150
+     * seconds after the captured timestamp whenever the pull ran while a
+     * post was open remotely. WordPress regenerates the meta locally on the
+     * next edit, and core's own WXR exporter skips it too, so deleting it
+     * loses nothing.
+     *
+     * Runs at the end of db-apply while the PDO connection is open. A dump
+     * without a postmeta table is tolerated.
+     */
+    private function strip_ephemeral_edit_locks(PDO $pdo): void
+    {
+        $preflight_data = $this->state["preflight"]["data"] ?? [];
+        $table_prefix = $preflight_data["database"]["wp"]["table_prefix"] ?? 'wp_';
+        // Quote the table name to prevent SQL injection from a crafted prefix.
+        $postmeta_table = '`' . str_replace('`', '``', $table_prefix . 'postmeta') . '`';
+
+        try {
+            $deleted = $pdo->exec(
+                "DELETE FROM {$postmeta_table} WHERE meta_key = '_edit_lock'"
+            );
+            // The SQL dump runs with AUTOCOMMIT=0 and issues a final COMMIT,
+            // but autocommit stays off, so our DELETE needs an explicit COMMIT.
+            $pdo->exec('COMMIT');
+            if ($deleted) {
+                $this->audit_log(
+                    "DB-APPLY | removed {$deleted} _edit_lock meta(s) (ephemeral editor locks)",
+                );
+            }
+        } catch (\Throwable $e) {
+            // A dump without the postmeta table isn't an error.
+            $this->audit_log(
+                "DB-APPLY | skipped _edit_lock cleanup: " . $e->getMessage(),
+            );
+        }
     }
 
     /**

--- a/tests/Import/DbApplyEditLockTest.php
+++ b/tests/Import/DbApplyEditLockTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Integration test for the full db-apply flow: a dump carrying an
+ * `_edit_lock` postmeta row is applied to a SQLite target, and db-apply
+ * must strip the lock (so the local copy shows no phantom "X is currently
+ * editing" badge) while leaving every other postmeta row intact.
+ */
+class DbApplyEditLockTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->tempDir = sys_get_temp_dir() . '/import-edit-lock-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Build a dump with a wp_postmeta table holding an `_edit_lock` row and
+     * a `_thumbnail_id` row, using FROM_BASE64 like the real dump output.
+     */
+    private function buildPostmetaDump(): string
+    {
+        $stmts = [];
+        $stmts[] = "DROP TABLE IF EXISTS `wp_postmeta`;";
+        $stmts[] = "CREATE TABLE `wp_postmeta` ("
+            . "`meta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`post_id` bigint(20) unsigned NOT NULL DEFAULT 0, "
+            . "`meta_key` varchar(255) DEFAULT NULL, "
+            . "`meta_value` longtext, "
+            . "PRIMARY KEY (`meta_id`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $stmts[] = sprintf(
+            "INSERT INTO `wp_postmeta` VALUES "
+            . "(1, 1, FROM_BASE64('%s'), FROM_BASE64('%s')), "
+            . "(2, 1, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('_edit_lock'),
+            base64_encode('1781114164:51814349'),
+            base64_encode('_thumbnail_id'),
+            base64_encode('42'),
+        );
+        return implode("\n", $stmts) . "\n";
+    }
+
+    private function writeState(): void
+    {
+        file_put_contents(
+            $this->tempDir . '/.import-state.json',
+            json_encode(['command' => null, 'status' => null, 'apply' => []], JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function querySqlite(string $dbPath, string $sql, string $dbName): array
+    {
+        $polyfills = resolve_sqlite_integration_path("/php-polyfills.php");
+        $driver = resolve_sqlite_integration_path("/wp-pdo-mysql-on-sqlite.php");
+        require_once $polyfills;
+        require_once $driver;
+
+        $dsn = "mysql-on-sqlite:path={$dbPath};dbname={$dbName}";
+        $pdo = new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        \register_sqlite_function($pdo->get_connection()->get_pdo(), 'FROM_BASE64', function ($data) {
+            return $data === null ? null : base64_decode($data);
+        });
+
+        return $pdo->query($sql)->fetchAll();
+    }
+
+    public function testDbApplyStripsEditLockButKeepsOtherMeta(): void
+    {
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+        file_put_contents($this->tempDir . '/db.sql', $this->buildPostmetaDump());
+        $this->writeState();
+
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+        ]);
+
+        $rows = $this->querySqlite(
+            $sqlitePath,
+            "SELECT meta_key FROM wp_postmeta ORDER BY meta_id",
+            'wp_test',
+        );
+        $keys = array_column($rows, 'meta_key');
+
+        $this->assertNotContains(
+            '_edit_lock',
+            $keys,
+            'Remote editor locks must not survive the import (they render as phantom "currently editing" badges)',
+        );
+        $this->assertContains(
+            '_thumbnail_id',
+            $keys,
+            'Other postmeta must be left intact',
+        );
+    }
+}


### PR DESCRIPTION
## What it does

A site pulled with reprint no longer shows a phantom "**X is currently editing**" badge in wp-admin. `db-apply` now strips the remote site's editor locks before marking the import complete.

## Rationale

A WordPress SQL dump captures `_edit_lock` postmeta verbatim. `_edit_lock` is ephemeral runtime state, recording that an editor had a given post open at the moment of the dump (its value is `timestamp:user_id`). On the imported copy the lock is meaningless, the remote editing session has nothing to do with the local site, but WordPress still renders it as a "currently editing" badge in the posts list for up to ~150 seconds after the captured timestamp whenever the pull ran while a post was open remotely.

## Implementation

Added `strip_ephemeral_edit_locks(PDO $pdo)`, called at the end of `run_db_apply` while the target PDO is still open (right after host-plugin deactivation, before the state is marked complete):

```php
$postmeta_table = '`' . str_replace('`', '``', $table_prefix . 'postmeta') . '`';
$deleted = $pdo->exec("DELETE FROM {$postmeta_table} WHERE meta_key = '_edit_lock'");
// The dump runs with AUTOCOMMIT=0 and leaves it off, so the DELETE needs an explicit COMMIT.
$pdo->exec('COMMIT');
```

- The table prefix comes from preflight data (defaults to `wp_`); the name is backtick-quoted with `` ` `` doubling to prevent injection from a crafted prefix.
- Only `_edit_lock` rows are removed; all other postmeta is untouched. WordPress regenerates the lock locally on the next edit, and core's own WXR exporter skips it too, so nothing is lost.
- A dump without a postmeta table is tolerated: the whole operation is wrapped in `try/catch` and logged to the audit log, never fatal.

## Testing instructions

The easiest way to reproduce the issue is to use Studio code:

- Open the remote site, add a Post and publish it, but don't close the window.
- Navigate to Studio repo root and run:
```
export STUDIO_ENABLE_PULL_REPRINT=true && node ~/github/studio/apps/cli/dist/cli/main.mjs pull-reprint --url <your_wpcom_site>
```
- Reply `Y` to create a new Studio site
- Once the site is created, you can open the URL for the `WP Admin` returned by the Reprint CLI
- Observe that the created post is there with a `Currently being edited` message 
<img width="800" height="285" alt="CleanShot 2026-06-18 at 11 20 10@2x" src="https://github.com/user-attachments/assets/81db1648-7ec6-4cad-9f81-c5bb292ad206" />

- Apply the changes on this branch, run `composer build:phar`, copy that to Studio repo by running `cp reprint.phar <studio_repo>/wp-files/reprint`
- On Studio, run `npm run cli:build` so the phar file is copied to the dist folder
- Delete the site to start from scratch and repeat the first three steps
- Observe that the created post does not have the `Currently being edited` message