### PR TITLE
Clear .sql-buffer on delta re-pull

### DIFF
--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -421,6 +421,9 @@ class Pull
 
         foreach ([
             $state_dir . "/db.sql",
+            // The --sql-output=mysql crash-recovery buffer; a stale one would
+            // otherwise be replayed into the target on the next db-pull.
+            $state_dir . "/.sql-buffer",
             $state_dir . "/.import-domains.json",
             $state_dir . "/.import-remote-index.jsonl",
             $state_dir . "/.import-download-list.jsonl",

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -218,4 +218,35 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('none', $state["filter"]);
         $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
     }
+
+    public function testRepullClearsStaleSqlBuffer(): void
+    {
+        // Complete an initial pull so the next run takes the delta re-pull path.
+        ob_start();
+        $this->makeClient(false)->run([
+            "command" => "pull",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        // Simulate a leftover --sql-output=mysql crash-recovery buffer from the
+        // prior run. Replaying it into the target on a re-pull would corrupt
+        // the freshly re-downloaded database.
+        $sqlBuffer = $this->stateDir . '/.sql-buffer';
+        file_put_contents($sqlBuffer, "INSERT INTO wp_posts VALUES (1);\n");
+        $this->assertFileExists($sqlBuffer);
+
+        // Re-pull: prepare_repull() must delete the stale buffer.
+        ob_start();
+        $this->makeClient(false)->run([
+            "command" => "pull",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $this->assertFileDoesNotExist(
+            $sqlBuffer,
+            'A delta re-pull must clear the stale .sql-buffer crash-recovery file',
+        );
+    }
 }


### PR DESCRIPTION
## What it does

A delta re-pull (re-running the composite `pull` after it completed) now removes the stale `.sql-buffer` crash-recovery file along with the rest of the database state it resets.

## Rationale

`Pull::prepare_repull()` resets state so a re-pull re-downloads and re-applies the database from scratch: it deletes `db.sql`, the domains file, the remote index, and the download lists. It did **not** delete `.sql-buffer` — the crash-recovery buffer written by `--sql-output=mysql` mode (where db-pull streams straight into MySQL).

A `.sql-buffer` left over from a previously interrupted run would be reloaded on the next db-pull and replayed into the target **on top of** the freshly re-downloaded dump.

(Only `--sql-output=mysql` writes this buffer; the default `--sql-output=file` path never does, so this is a latent-gap fix.)

## Implementation

One line added to the existing deletion list in `prepare_repull()`:

```php
$state_dir . "/db.sql",
// The --sql-output=mysql crash-recovery buffer; a stale one would
// otherwise be replayed into the target on the next db-pull.
$state_dir . "/.sql-buffer",
```

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/PullFilterOptionTest.php
```

New test `testRepullClearsStaleSqlBuffer` completes a pull, drops a `.sql-buffer` file, runs `pull` again (the delta re-pull path), and asserts the buffer is gone. The full `Import/` suite is green (265 tests) and WPCS reports no new violations.
