### PR TITLE
pull: fix the flattened runtime root and delta re-pull after deferred files

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1608,17 +1608,7 @@ class ImportClient
             }
             $prev = $this->state["filter"] ?? null;
             $status = $this->state["status"] ?? null;
-            // A pull whose previous run already completed is about to delta
-            // re-pull: Pull::run() calls prepare_repull(), which clears the
-            // leftover sub-command state — including the skipped-earlier
-            // tail's lingering "in_progress" status. That stale state must
-            // not block switching the filter back to the pull's own value.
-            $is_repull =
-                $command === "pull" &&
-                (($this->state["pull"]["stage"] ?? null) === "complete");
-            $is_mid_flight =
-                !$is_repull &&
-                $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
+            $is_mid_flight = $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
             if ($is_mid_flight) {
                 throw new RuntimeException(
                     "Cannot change --filter from '{$prev}' to '{$next}' while a sync is in progress. " .
@@ -2625,6 +2615,14 @@ class ImportClient
                 $this->state["stage"] = "fetch-skipped";
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
+                // The deferred tail reopens a completed files-pull. Once the
+                // tail finishes, restore the completed status so later filter
+                // changes are judged against the actual lifecycle state.
+                if (($this->state["status"] ?? null) === "partial") {
+                    return;
+                }
+                $this->state["status"] = "complete";
+                $this->save_state($this->state);
                 return;
             }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1608,7 +1608,17 @@ class ImportClient
             }
             $prev = $this->state["filter"] ?? null;
             $status = $this->state["status"] ?? null;
-            $is_mid_flight = $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
+            // A pull whose previous run already completed is about to delta
+            // re-pull: Pull::run() calls prepare_repull(), which clears the
+            // leftover sub-command state — including the skipped-earlier
+            // tail's lingering "in_progress" status. That stale state must
+            // not block switching the filter back to the pull's own value.
+            $is_repull =
+                $command === "pull" &&
+                (($this->state["pull"]["stage"] ?? null) === "complete");
+            $is_mid_flight =
+                !$is_repull &&
+                $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
             if ($is_mid_flight) {
                 throw new RuntimeException(
                     "Cannot change --filter from '{$prev}' to '{$next}' while a sync is in progress. " .

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -342,6 +342,16 @@ class Pull
             );
         }
 
+        // When --flatten-to produces a flattened document root, the
+        // apply-runtime stage must target that flattened directory rather
+        // than its default (the raw download tree + remote document_root).
+        // Derive flat_document_root from flatten_to so a single
+        // `pull --flatten-to=X --runtime=...` generates a runtime rooted at
+        // the flattened layout.
+        if (!empty($options['flatten_to']) && empty($options['flat_document_root'])) {
+            $options['flat_document_root'] = $options['flatten_to'];
+        }
+
         return $options;
     }
 

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -173,6 +173,46 @@ class FilesSyncStateTest extends TestCase
     }
 
     /**
+     * The deferred skipped-files tail reopens a completed files-pull, and a
+     * successful tail must restore the completed status before returning.
+     */
+    public function testSkippedEarlierTailRestoresCompletedStatus()
+    {
+        $this->writeState([
+            "command" => "files-pull",
+            "status" => "complete",
+            "stage" => null,
+            "filter" => "essential-files",
+        ]);
+        file_put_contents(
+            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            json_encode([
+                "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
+            ], JSON_UNESCAPED_SLASHES) . "\n",
+        );
+
+        $client = new CompletedFileFetchClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->fs_root,
+        );
+
+        ob_start();
+        $client->run([
+            "command" => "files-pull",
+            "filter" => "skipped-earlier",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertEquals("complete", $state["status"]);
+        $this->assertEquals("files-pull", $state["command"]);
+        $this->assertNull($state["stage"]);
+        $this->assertEquals("skipped-earlier", $state["filter"]);
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+    }
+
+    /**
      * After --abort, the state should not be "complete".
      */
     public function testAbortClearsCompletedStatus()
@@ -367,5 +407,27 @@ class FilesSyncStateTest extends TestCase
             file_get_contents($localFile),
             "Fetch stage must overwrite existing files that were placed in the download list",
         );
+    }
+}
+
+/**
+ * Test double that completes a file_fetch request without real network I/O.
+ */
+class CompletedFileFetchClient extends \ImportClient
+{
+    protected function fetch_streaming(
+        string $url,
+        ?string $cursor,
+        \StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        ($context->on_chunk)([
+            "headers" => [
+                "x-chunk-type" => "completion",
+                "x-status" => "complete",
+            ],
+            "body" => "",
+        ]);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -98,6 +98,25 @@ class PullFilterFakeClient extends \ImportClient
 }
 
 /**
+ * Fake client that records the options the pull pipeline hands to
+ * apply-runtime, so we can assert the flatten_to -> flat_document_root
+ * bridge. flat-docroot is stubbed to a no-op.
+ */
+class PullBridgeFakeClient extends PullFilterFakeClient
+{
+    public ?array $apply_runtime_options = null;
+
+    public function run_flat_document_root(array $options): void
+    {
+    }
+
+    public function run_apply_runtime(array $options): void
+    {
+        $this->apply_runtime_options = $options;
+    }
+}
+
+/**
  * Tests for pull-level file filtering.
  */
 class PullFilterOptionTest extends TestCase
@@ -217,5 +236,66 @@ class PullFilterOptionTest extends TestCase
         $this->assertFalse($state["pull"]["skipped_pending"]);
         $this->assertSame('none', $state["filter"]);
         $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+    }
+
+    public function testPullDerivesFlatDocumentRootFromFlattenTo(): void
+    {
+        $client = new PullBridgeFakeClient($this->stateDir, $this->fs_root, false);
+        $flatten_to = $this->tempDir . '/flattened-site';
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "filter" => "essential-files",
+            "flatten_to" => $flatten_to,
+            "runtime" => "playground-cli",
+            "start_runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        // The pull pipeline must hand apply-runtime a flat_document_root
+        // derived from --flatten-to, so the generated runtime targets the
+        // flattened layout instead of the raw download tree.
+        $this->assertIsArray($client->apply_runtime_options);
+        $this->assertSame($flatten_to, $client->apply_runtime_options["flat_document_root"]);
+    }
+
+    public function testRepullBypassesTheMidFlightFilterGuard(): void
+    {
+        // The state a completed pull leaves once its deferred "skipped-earlier"
+        // tail has run: pull.stage=complete, but the sub-command state still
+        // reads filter=skipped-earlier / status=in_progress. A delta re-pull
+        // (filter=essential-files) must not be blocked by the mid-flight filter
+        // guard — Pull::run() calls prepare_repull() to clear that stale state.
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "command" => "files-pull",
+                "status" => "in_progress",
+                "stage" => null,
+                "filter" => "skipped-earlier",
+                "pull" => [
+                    "stage" => "complete",
+                    "files_filter" => "essential-files",
+                    "skipped_pending" => true,
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "filter" => "essential-files",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        // The re-pull ran to completion instead of throwing the filter guard.
+        $state = $this->readState();
+        $this->assertSame('complete', $state["pull"]["stage"]);
+        $this->assertSame('essential-files', $state["filter"]);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -260,18 +260,16 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame($flatten_to, $client->apply_runtime_options["flat_document_root"]);
     }
 
-    public function testRepullBypassesTheMidFlightFilterGuard(): void
+    public function testRepullAfterSkippedEarlierTailUsesCompletedFilesPullState(): void
     {
-        // The state a completed pull leaves once its deferred "skipped-earlier"
-        // tail has run: pull.stage=complete, but the sub-command state still
-        // reads filter=skipped-earlier / status=in_progress. A delta re-pull
-        // (filter=essential-files) must not be blocked by the mid-flight filter
-        // guard — Pull::run() calls prepare_repull() to clear that stale state.
+        // The deferred "skipped-earlier" tail belongs to a files-pull that
+        // has finished. Once that lifecycle state is truthful, a completed
+        // pull can delta re-pull without bypassing the mid-flight guard.
         file_put_contents(
             $this->stateDir . '/.import-state.json',
             json_encode([
                 "command" => "files-pull",
-                "status" => "in_progress",
+                "status" => "complete",
                 "stage" => null,
                 "filter" => "skipped-earlier",
                 "pull" => [
@@ -293,7 +291,6 @@ class PullFilterOptionTest extends TestCase
         ]);
         ob_end_clean();
 
-        // The re-pull ran to completion instead of throwing the filter guard.
         $state = $this->readState();
         $this->assertSame('complete', $state["pull"]["stage"]);
         $this->assertSame('essential-files', $state["filter"]);


### PR DESCRIPTION
## What it does

Two fixes to the composite `pull` command so it correctly runs, and re-runs, the full preflight -> files-pull -> db-pull -> db-apply -> flat-docroot -> apply-runtime pipeline from a single invocation:

1. **`pull --flatten-to=DIR --runtime=...` now generates a runtime rooted at the flattened layout** (`DIR`) instead of the raw download tree. The two options now compose: `--flatten-to` builds the flattened docroot and `--runtime` targets it.
2. **A completed pull can be re-pulled after its deferred-files tail ran.** Once `skipped-earlier` files have been fetched, the files sub-command records a truthful `status=complete`, so the next `pull --filter=essential-files` proceeds as a delta re-pull without weakening the mid-flight `--filter` guard.

## Rationale

**`--flatten-to` did not reach apply-runtime.** `pull` forwards `--flatten-to` to the flat-docroot stage as `flatten_to`, but `run_apply_runtime()` reads a different key, `flat_document_root`, and otherwise falls back to `fs_root + remote document_root` (the raw tree). So a pull that both flattens and generates a runtime produced a runtime pointing at the wrong root: the flatten and runtime stages did not compose.

**Delta re-pull was blocked after a deferred-files tail.** `pull` supports delta re-pull: re-running a completed pull resets its own state via `prepare_repull()` and re-syncs. But after an `--filter=essential-files` pull fetched its deferred `skipped-earlier` files, the state still read `filter=skipped-earlier`, `status=in_progress`. The next `pull --filter=essential-files` loaded that stale state in `ImportClient::run()` and the mid-flight guard threw:

```text
Cannot change --filter from 'skipped-earlier' to 'essential-files' while a sync is in progress.
```

That guard is correct for real in-progress syncs. The bug was the stale lifecycle state: a successful `skipped-earlier` tail had finished, but did not restore the files sub-command to `status=complete` before returning.

## Implementation

`validate_and_default_options()` derives the missing runtime key:

```php
if (!empty($options['flatten_to']) && empty($options['flat_document_root'])) {
    $options['flat_document_root'] = $options['flatten_to'];
}
```

`run_files_sync()` now restores `status=complete` after a successful deferred `fetch-skipped` tail. If the pipeline saves `status=partial`, it still returns early so the next invocation can resume.

```php
$this->run_files_sync_pipeline();
if (($this->state["status"] ?? null) === "partial") {
    return;
}
$this->state["status"] = "complete";
$this->save_state($this->state);
```

The filter guard remains generic: it blocks real mid-flight filter changes, and completed skipped-file tails no longer look mid-flight.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/PullFilterOptionTest.php Import/FilesSyncStateTest.php
```

Tests cover:

- `testPullDerivesFlatDocumentRootFromFlattenTo`: a pull with `--flatten-to` plus `--runtime` hands apply-runtime a matching `flat_document_root`.
- `testSkippedEarlierTailRestoresCompletedStatus`: a successful `files-pull --filter=skipped-earlier` tail restores `status=complete` and clears the skipped list.
- `testRepullAfterSkippedEarlierTailUsesCompletedFilesPullState`: a completed pull can delta re-pull after the skipped-files tail because the files sub-command state is complete.

#### Testing using Studio

- Use a remote site that has uploads.
- Using the `trunk` branch of reprint, build reprint and move it to Studio repo:

```bash
composer build:phar && cp reprint.phar <studio-repo>/apps/cli/dist/cli/wp-files/reprint/reprint.phar
```

- Open a terminal on the root of the Studio repo and run:

```bash
node apps/cli/dist/cli/main.mjs pull-reprint --url <remote-site-url> --name g1 --yes
```

- Run the command again so a delta-pull is done:

```bash
node apps/cli/dist/cli/main.mjs pull-reprint --url <remote-site-url> --name g1 --yes
```

- Check there is an error `Failed to pull site: {"error":"Cannot change --filter from 'skipped-earlier' to 'essential-files' while a sync is in progress`.
- Repeat the steps using this branch and verify the site can be re-pulled without errors.
