### PR TITLE
Mark skipped-earlier file tails complete before delta re-pulls

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1608,17 +1608,7 @@ class ImportClient
             }
             $prev = $this->state["filter"] ?? null;
             $status = $this->state["status"] ?? null;
-            // A pull whose previous run already completed is about to delta
-            // re-pull: Pull::run() calls prepare_repull(), which clears the
-            // leftover sub-command state — including the skipped-earlier
-            // tail's lingering "in_progress" status. That stale state must
-            // not block switching the filter back to the pull's own value.
-            $is_repull =
-                $command === "pull" &&
-                (($this->state["pull"]["stage"] ?? null) === "complete");
-            $is_mid_flight =
-                !$is_repull &&
-                $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
+            $is_mid_flight = $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
             if ($is_mid_flight) {
                 throw new RuntimeException(
                     "Cannot change --filter from '{$prev}' to '{$next}' while a sync is in progress. " .
@@ -2625,6 +2615,14 @@ class ImportClient
                 $this->state["stage"] = "fetch-skipped";
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
+                // The deferred tail reopens a completed files-pull. Once the
+                // tail finishes, restore the completed status so later filter
+                // changes are judged against the actual lifecycle state.
+                if (($this->state["status"] ?? null) === "partial") {
+                    return;
+                }
+                $this->state["status"] = "complete";
+                $this->save_state($this->state);
                 return;
             }
 

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -173,6 +173,46 @@ class FilesSyncStateTest extends TestCase
     }
 
     /**
+     * The deferred skipped-files tail reopens a completed files-pull, and a
+     * successful tail must restore the completed status before returning.
+     */
+    public function testSkippedEarlierTailRestoresCompletedStatus()
+    {
+        $this->writeState([
+            "command" => "files-pull",
+            "status" => "complete",
+            "stage" => null,
+            "filter" => "essential-files",
+        ]);
+        file_put_contents(
+            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            json_encode([
+                "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
+            ], JSON_UNESCAPED_SLASHES) . "\n",
+        );
+
+        $client = new CompletedFileFetchClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->fs_root,
+        );
+
+        ob_start();
+        $client->run([
+            "command" => "files-pull",
+            "filter" => "skipped-earlier",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertEquals("complete", $state["status"]);
+        $this->assertEquals("files-pull", $state["command"]);
+        $this->assertNull($state["stage"]);
+        $this->assertEquals("skipped-earlier", $state["filter"]);
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+    }
+
+    /**
      * After --abort, the state should not be "complete".
      */
     public function testAbortClearsCompletedStatus()
@@ -367,5 +407,27 @@ class FilesSyncStateTest extends TestCase
             file_get_contents($localFile),
             "Fetch stage must overwrite existing files that were placed in the download list",
         );
+    }
+}
+
+/**
+ * Test double that completes a file_fetch request without real network I/O.
+ */
+class CompletedFileFetchClient extends \ImportClient
+{
+    protected function fetch_streaming(
+        string $url,
+        ?string $cursor,
+        \StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        ($context->on_chunk)([
+            "headers" => [
+                "x-chunk-type" => "completion",
+                "x-status" => "complete",
+            ],
+            "body" => "",
+        ]);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -260,18 +260,16 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame($flatten_to, $client->apply_runtime_options["flat_document_root"]);
     }
 
-    public function testRepullBypassesTheMidFlightFilterGuard(): void
+    public function testRepullAfterSkippedEarlierTailUsesCompletedFilesPullState(): void
     {
-        // The state a completed pull leaves once its deferred "skipped-earlier"
-        // tail has run: pull.stage=complete, but the sub-command state still
-        // reads filter=skipped-earlier / status=in_progress. A delta re-pull
-        // (filter=essential-files) must not be blocked by the mid-flight filter
-        // guard — Pull::run() calls prepare_repull() to clear that stale state.
+        // The deferred "skipped-earlier" tail belongs to a files-pull that
+        // has finished. Once that lifecycle state is truthful, a completed
+        // pull can delta re-pull without bypassing the mid-flight guard.
         file_put_contents(
             $this->stateDir . '/.import-state.json',
             json_encode([
                 "command" => "files-pull",
-                "status" => "in_progress",
+                "status" => "complete",
                 "stage" => null,
                 "filter" => "skipped-earlier",
                 "pull" => [
@@ -293,7 +291,6 @@ class PullFilterOptionTest extends TestCase
         ]);
         ob_end_clean();
 
-        // The re-pull ran to completion instead of throwing the filter guard.
         $state = $this->readState();
         $this->assertSame('complete', $state["pull"]["stage"]);
         $this->assertSame('essential-files', $state["filter"]);


### PR DESCRIPTION
## What it does

Marks a successful `files-pull --filter=skipped-earlier` tail as `status=complete` before returning.

This lets the existing mid-flight `--filter` guard keep its original shape: later `pull --filter=essential-files` runs see the previous files sync as complete instead of bypassing the guard for completed pull pipelines.

## Rationale

PR #268 correctly identifies that a delta re-pull can be blocked after deferred files are fetched. The root cause is the deferred `skipped-earlier` tail reopening a completed `files-pull` with `status=in_progress` and then returning without restoring the completed status after a successful fetch.

That leaves stale lifecycle state behind. Fixing the state transition keeps one source of truth: completed work is recorded as complete, and the generic filter guard does not need a pull-specific exception.

## Implementation

After `run_files_sync_pipeline()` handles the `fetch-skipped` stage, `run_files_sync()` now:

1. returns unchanged when the pipeline saved `status=partial` for an interrupted fetch;
2. otherwise restores `status=complete` and saves state before returning.

The pull-level test now models the truthful post-tail state, and a new files-sync test drives the `skipped-earlier` tail through a no-network `file_fetch` test double.

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/FilesSyncStateTest.php
php -l tests/Import/PullFilterOptionTest.php
git diff --check
cd tests && ../vendor/bin/phpunit Import/PullFilterOptionTest.php Import/FilesSyncStateTest.php
```
