### PR TITLE
Expose pull completion metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,14 @@ still running, completed, or needs resuming. The `command` + `status` fields
 tell you where the pipeline is. The `stage` field gives finer granularity
 (e.g., `"scanning"`, `"sorting"`, `"streaming"` for file sync).
 
+For pull-level lifecycle checks, prefer `import-metadata` over reading
+`.import-state.json` directly. It exposes Reprint-owned pull state as a small,
+stable JSON contract for host integrations:
+
+```bash
+php reprint.phar import-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
+```
+
 #### `.import-volatile-files.json` — files that changed during sync
 
 During `files-pull`, a file on the source may be modified while the importer is
@@ -633,6 +641,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
+* `import-metadata` — Prints local pull lifecycle metadata as JSON, including `hasCompletedOnce`. Requires only `--state-dir`; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1348,6 +1348,7 @@ class ImportClient
     public function mark_pull_complete(): void
     {
         $this->state['pull']['stage'] = 'complete';
+        $this->state['pull']['has_completed_once'] = true;
         $this->state['status'] = 'complete';
         $this->save_state($this->state);
     }
@@ -1538,34 +1539,40 @@ class ImportClient
         $this->pipeline_step = $options["pipeline_step"] ?? null;
         $this->pipeline_steps = $options["pipeline_steps"] ?? null;
 
+        $valid_commands = [
+            "pull",
+            "files-pull",
+            "files-index",
+            "files-stats",
+            "db-pull",
+            "db-index",
+            "db-domains",
+            "db-apply",
+            "import-metadata",
+            "preflight",
+            "preflight-assert",
+            "flat-docroot",
+            "apply-runtime",
+        ];
+
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: pull, files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
+                "Command is required. Valid commands: " . implode(", ", $valid_commands),
             );
         }
 
-        if (
-            !in_array($command, [
-                "pull",
-                "files-pull",
-                "files-index",
-                "db-pull",
-                "db-index",
-                "db-domains",
-                "db-apply",
-                "files-stats",
-                "preflight",
-                "preflight-assert",
-                "flat-docroot",
-                "apply-runtime",
-            ])
-        ) {
+        if (!in_array($command, $valid_commands, true)) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: pull, files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
+                "Invalid command: {$command}. Valid commands: " . implode(", ", $valid_commands),
             );
         }
 
         $this->state = $this->load_state();
+
+        if ($command === "import-metadata") {
+            $this->run_import_metadata();
+            return;
+        }
 
         // Persist follow_symlinks in state so it survives across invocations.
         // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
@@ -3802,6 +3809,42 @@ class ImportClient
         echo json_encode($result, JSON_PRETTY_PRINT) . "\n";
     }
 
+    /**
+     * Prints host-facing import lifecycle metadata without mutating state.
+     */
+    private function run_import_metadata(): void
+    {
+        echo json_encode(
+            $this->build_import_metadata(),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+        ) . "\n";
+    }
+
+    /**
+     * Builds the small metadata contract exposed to host integrations.
+     *
+     * `hasCompletedOnce` is derived from Reprint-owned pull state so
+     * callers do not need to persist a parallel flag that could drift.
+     *
+     * @return array{hasCompletedOnce: bool, pullStage: mixed}
+     */
+    private function build_import_metadata(): array
+    {
+        $pull = $this->state["pull"] ?? [];
+        if (!is_array($pull)) {
+            $pull = [];
+        }
+
+        $pull_stage = $pull["stage"] ?? null;
+        $has_completed_once =
+            !empty($pull["has_completed_once"]) ||
+            $pull_stage === "complete";
+
+        return [
+            "hasCompletedOnce" => $has_completed_once,
+            "pullStage" => $pull_stage,
+        ];
+    }
 
     /**
      * Format a byte count into a human-readable string.
@@ -10302,6 +10345,7 @@ class ImportClient
                 "stage" => null,
                 "files_filter" => null,
                 "skipped_pending" => false,
+                "has_completed_once" => false,
             ],
         ];
     }
@@ -11557,7 +11601,8 @@ if (
         }
 
         $info = $command_info[$command];
-        echo "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
+        $usage = $info["usage"] ?? "reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]";
+        echo "Usage: {$usage}\n";
         echo "\n";
         echo $info["description"];
 
@@ -11907,6 +11952,17 @@ if (
                 "  reprint db-domains - --state-dir=/path/to/state\n",
             "extra" => null,
         ],
+        "import-metadata" => [
+            "level" => "low",
+            "short" => "Print local import lifecycle metadata as JSON",
+            "usage" => "reprint import-metadata --state-dir=DIR",
+            "description" =>
+                "Reads --state-dir/.import-state.json and prints metadata for\n" .
+                "host integrations. No network calls are made.\n",
+            "extra" =>
+                "Example:\n" .
+                "  reprint import-metadata --state-dir=./state | jq '.hasCompletedOnce'\n",
+        ],
         "db-apply" => [
             "level" => "low",
             "short" => "Import the SQL dump into a local MySQL or SQLite database",
@@ -12034,10 +12090,10 @@ if (
         exit(0);
     }
 
-    // Only apply-runtime truly doesn't need a remote URL. Other local-only
-    // commands (db-domains, db-apply, etc.) still accept it for CLI
-    // consistency and backward compatibility with existing callers.
-    $local_only_commands = ["apply-runtime"];
+    // apply-runtime and import-metadata don't need a remote URL. Other
+    // local-only commands (db-domains, db-apply, etc.) still accept it for
+    // CLI consistency and backward compatibility with existing callers.
+    $local_only_commands = ["apply-runtime", "import-metadata"];
     $is_local_only = in_array($command, $local_only_commands, true);
 
     if ($is_local_only) {
@@ -12071,7 +12127,7 @@ if (
         fwrite(STDERR, "Use --fs-root for the raw download directory, or --flat-document-root for a flattened layout.\n");
         exit(1);
     }
-    if (!$fs_root && !$flat_document_root) {
+    if (!$fs_root && !$flat_document_root && $command !== "import-metadata") {
         fwrite(STDERR, "Error: --fs-root=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
@@ -12079,7 +12135,10 @@ if (
     if (!$fs_root) {
         // For commands that need an fs root in the constructor, use the
         // flattened fs root. run_apply_runtime will resolve it properly.
-        $fs_root = $flat_document_root;
+        // import-metadata reads only state, but ImportClient still expects
+        // an fs root path. Point it at state-dir rather than requiring an
+        // otherwise-unused CLI option.
+        $fs_root = $flat_document_root ?: $state_dir;
     }
 
     try {

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -402,6 +402,7 @@ class Pull
             $state['pull']['stage'] = null;
             $state['pull']['files_filter'] = null;
             $state['pull']['skipped_pending'] = false;
+            $state['pull']['has_completed_once'] = true;
             $state['command'] = null;
             $state['status'] = null;
             $state['cursor'] = null;

--- a/tests/Import/ImportMetadataTest.php
+++ b/tests/Import/ImportMetadataTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class ImportMetadataTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+
+    /**
+     * Creates an isolated state directory for each metadata scenario.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/reprint-import-metadata-' . uniqid('', true);
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    /**
+     * Removes the temporary state and filesystem roots created for the test.
+     */
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    /**
+     * Deletes a directory tree while preserving symlink boundaries.
+     */
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Writes importer state directly so each test can model one lifecycle shape.
+     */
+    private function writeState(array $state): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
+     * Runs the metadata command and returns its decoded JSON response.
+     */
+    private function readMetadata(): array
+    {
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+
+        ob_start();
+        $client->run(['command' => 'import-metadata']);
+        $output = ob_get_clean();
+
+        $metadata = json_decode($output, true);
+        $this->assertIsArray($metadata, $output);
+
+        return $metadata;
+    }
+
+    /**
+     * Verifies a missing state file is reported as a never-completed pull.
+     */
+    public function testImportMetadataReportsNoCompletedPullForFreshState(): void
+    {
+        $metadata = $this->readMetadata();
+
+        $this->assertFalse($metadata['hasCompletedOnce']);
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+        $this->assertNull($metadata['pullStage']);
+    }
+
+    /**
+     * Verifies completed low-level commands do not imply a completed pull.
+     */
+    public function testImportMetadataDoesNotTreatCompletedSubcommandAsCompletedPull(): void
+    {
+        $this->writeState([
+            'command' => 'files-pull',
+            'status' => 'complete',
+        ]);
+
+        $metadata = $this->readMetadata();
+
+        $this->assertFalse($metadata['hasCompletedOnce']);
+        $this->assertNull($metadata['pullStage']);
+    }
+
+    /**
+     * Verifies old state files with pull.stage=complete still report completion.
+     */
+    public function testImportMetadataReportsCompletedLegacyState(): void
+    {
+        $this->writeState([
+            'status' => 'complete',
+            'pull' => [
+                'stage' => 'complete',
+                'files_filter' => 'essential-files',
+                'skipped_pending' => true,
+            ],
+        ]);
+
+        $metadata = $this->readMetadata();
+
+        $this->assertTrue($metadata['hasCompletedOnce']);
+        $this->assertSame('complete', $metadata['pullStage']);
+    }
+
+    /**
+     * Verifies delta re-pull state preserves that a pull completed previously.
+     */
+    public function testImportMetadataReportsPriorCompletionDuringRepull(): void
+    {
+        $this->writeState([
+            'status' => null,
+            'pull' => [
+                'stage' => null,
+                'files_filter' => null,
+                'skipped_pending' => false,
+                'has_completed_once' => true,
+            ],
+        ]);
+
+        $metadata = $this->readMetadata();
+
+        $this->assertTrue($metadata['hasCompletedOnce']);
+        $this->assertNull($metadata['pullStage']);
+    }
+}

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -196,6 +196,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('complete', $state["pull"]["stage"]);
         $this->assertSame('essential-files', $state["pull"]["files_filter"]);
         $this->assertTrue($state["pull"]["skipped_pending"]);
+        $this->assertTrue($state["pull"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
         $this->assertFileExists($this->stateDir . '/.import-download-list-skipped.jsonl');
     }
@@ -215,6 +216,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('complete', $state["pull"]["stage"]);
         $this->assertSame('none', $state["pull"]["files_filter"]);
         $this->assertFalse($state["pull"]["skipped_pending"]);
+        $this->assertTrue($state["pull"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
         $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
     }


### PR DESCRIPTION
## What changed

- Added `reprint import-metadata --state-dir=DIR` to print local import lifecycle metadata as JSON.
- Recorded `pull.has_completed_once` when a pull completes and preserved it when a completed pull is reset for a delta re-pull.
- Added focused tests for fresh state, completed pull state, completed subcommand state, and in-progress re-pull state.

## Why

Host integrations need to know whether Reprint has ever completed a pull without duplicating Reprint-owned lifecycle state. Exposing this through Reprint keeps one source of truth and avoids separate metadata in callers drifting out of sync.

## Validation

- `php -l packages/reprint-importer/src/import.php`
- `php -l packages/reprint-importer/src/lib/pull/class-pull.php`
- `php -l tests/Import/ImportMetadataTest.php`
- `./vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/ImportMetadataTest.php tests/Import/PullFilterOptionTest.php`
