### PR TITLE
Exclude remote post edit locks from SQL exports

### DIFF
--- a/packages/reprint-exporter/src/class-mysql-dump-producer.php
+++ b/packages/reprint-exporter/src/class-mysql-dump-producer.php
@@ -669,6 +669,9 @@ class MySQLDumpProducer
             }
             $quoted_col = $this->quote_identifier($column);
             $encoded_value = base64_encode($rule["value"]);
+            // Preserve rows with NULL in the filtered column. In SQL, NULL <> value
+            // evaluates to UNKNOWN, so without the explicit IS NULL branch those rows
+            // would be filtered out even though they do not match the excluded value.
             $conditions[] = "{$quoted_col} IS NULL OR {$quoted_col} <> FROM_BASE64('{$encoded_value}')";
         }
         return $conditions;

--- a/packages/reprint-exporter/src/class-mysql-dump-producer.php
+++ b/packages/reprint-exporter/src/class-mysql-dump-producer.php
@@ -142,6 +142,14 @@ class MySQLDumpProducer
     private $query_time_limit_ms = null;
 
     /**
+     * Row exclusion rules keyed by table name. Each rule is an array with
+     * 'column' and 'value' keys.
+     *
+     * @var array<string, list<array{column: string, value: string}>>
+     */
+    private $exclude_rows_by_table = [];
+
+    /**
      * When a row is too large for a single INSERT, its big columns are split
      * into chunks and queued here. Each entry tracks the column name, its
      * data type, the current byte offset into the value, and the total value
@@ -183,6 +191,24 @@ class MySQLDumpProducer
         if (isset($options["query_time_limit_ms"])) {
             $limit = (int) $options["query_time_limit_ms"];
             $this->query_time_limit_ms = $limit > 0 ? $limit : null;
+        }
+
+        if (isset($options["exclude_rows"]) && is_array($options["exclude_rows"])) {
+            foreach ($options["exclude_rows"] as $rule) {
+                if (
+                    !is_array($rule) ||
+                    !isset($rule["table"], $rule["column"], $rule["value"]) ||
+                    !is_string($rule["table"]) ||
+                    !is_string($rule["column"]) ||
+                    !is_string($rule["value"])
+                ) {
+                    continue;
+                }
+                $this->exclude_rows_by_table[$rule["table"]][] = [
+                    "column" => $rule["column"],
+                    "value" => $rule["value"],
+                ];
+            }
         }
 
         if (isset($options["cursor"])) {
@@ -593,10 +619,16 @@ class MySQLDumpProducer
             $query = $select . " * FROM " . $this->quote_identifier($table);
         }
 
+        $where_conditions = $this->build_row_exclusion_where_conditions();
         if ($this->current_pk_columns && count($this->current_pk_columns) > 0) {
             if ($this->last_pk_values) {
-                $where_conditions = $this->build_pk_where_clause();
-                $query .= " WHERE {$where_conditions}";
+                $where_conditions[] = $this->build_pk_where_clause();
+            }
+
+            if ($where_conditions) {
+                $query .= " WHERE " . implode(" AND ", array_map(function ($condition) {
+                    return "({$condition})";
+                }, $where_conditions));
             }
 
             $order_cols = array_map(function ($col) {
@@ -605,6 +637,12 @@ class MySQLDumpProducer
             $query .= " ORDER BY " . implode(", ", $order_cols);
             $query .= " LIMIT {$this->batch_size}";
         } else {
+            if ($where_conditions) {
+                $query .= " WHERE " . implode(" AND ", array_map(function ($condition) {
+                    return "({$condition})";
+                }, $where_conditions));
+            }
+
             // Best effort pagination for tables without a primary key.
             if ($this->current_offset > 0) {
                 $query .= " LIMIT {$this->batch_size} OFFSET {$this->current_offset}";
@@ -614,6 +652,26 @@ class MySQLDumpProducer
         }
 
         return $query;
+    }
+
+    /** Builds WHERE fragments for configured row exclusions on the current table. */
+    private function build_row_exclusion_where_conditions(): array
+    {
+        if (!$this->current_table || empty($this->exclude_rows_by_table[$this->current_table])) {
+            return [];
+        }
+
+        $conditions = [];
+        foreach ($this->exclude_rows_by_table[$this->current_table] as $rule) {
+            $column = $rule["column"];
+            if (!isset($this->current_column_types[$column])) {
+                continue;
+            }
+            $quoted_col = $this->quote_identifier($column);
+            $encoded_value = base64_encode($rule["value"]);
+            $conditions[] = "{$quoted_col} IS NULL OR {$quoted_col} <> FROM_BASE64('{$encoded_value}')";
+        }
+        return $conditions;
     }
 
     /**

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -184,8 +184,15 @@ function resolve_db_credentials(): array
     $db_user = defined("DB_USER") ? DB_USER : getenv("DB_USER");
     $db_password = defined("DB_PASSWORD") ? DB_PASSWORD : getenv("DB_PASSWORD");
 
+    global $wpdb;
+
     $wp_config_path = null;
-    $table_prefix = $GLOBALS['table_prefix'] ?? null;
+    $table_prefix = null;
+    if (isset($GLOBALS['table_prefix']) && is_string($GLOBALS['table_prefix']) && $GLOBALS['table_prefix'] !== '') {
+        $table_prefix = $GLOBALS['table_prefix'];
+    } elseif (isset($wpdb) && is_object($wpdb) && isset($wpdb->prefix) && is_string($wpdb->prefix) && $wpdb->prefix !== '') {
+        $table_prefix = $wpdb->prefix;
+    }
 
     // On SQLite sites, the driver is already loaded by WordPress via the
     // db.php drop-in. We just need to confirm it's available and skip the
@@ -836,6 +843,11 @@ function endpoint_sql_chunk(
         if ($query_time_limit > 0) {
             $producer_options["query_time_limit_ms"] = $query_time_limit;
         }
+    }
+
+    $exclude_rows = sql_exclude_rows_from_config($config, $creds["table_prefix"] ?? null);
+    if ($exclude_rows) {
+        $producer_options["exclude_rows"] = $exclude_rows;
     }
 
     if (isset($config["cursor"])) {
@@ -3607,6 +3619,91 @@ function path_is_default_skipped(string $path): bool
     }
 
     return false;
+}
+
+/**
+ * Maps importer-requested SQL row filters to producer row-exclusion rules.
+ *
+ * Rules are data, not exporter-known tokens. A client may provide:
+ *
+ *   skip_rows[0][table_suffix]=postmeta
+ *   skip_rows[0][column]=meta_key
+ *   skip_rows[0][value_base64]=X2VkaXRfbG9jaw==
+ *
+ * `table_suffix` is appended to the server-side WordPress table prefix. The
+ * prefix must come from WordPress; if it cannot be resolved, clients must use
+ * explicit `table` instead. Values are base64-encoded so raw bytes never travel
+ * as SQL text.
+ *
+ * @return list<array{table: string, column: string, value: string}>
+ */
+function sql_exclude_rows_from_config(array $config, ?string $table_prefix): array
+{
+    if (!isset($config["skip_rows"])) {
+        return [];
+    }
+
+    $requested = $config["skip_rows"];
+    if (is_string($requested)) {
+        $decoded = json_decode($requested, true);
+        if (!is_array($decoded)) {
+            throw new InvalidArgumentException("skip_rows string must be a JSON array");
+        }
+        $requested = $decoded;
+    }
+    if (!is_array($requested)) {
+        throw new InvalidArgumentException("skip_rows must be an array");
+    }
+
+    $rules = [];
+    foreach ($requested as $index => $rule) {
+        if (!is_array($rule)) {
+            throw new InvalidArgumentException("skip_rows[{$index}] must be an object");
+        }
+
+        $has_table = isset($rule["table"]);
+        $has_suffix = isset($rule["table_suffix"]);
+        if ($has_table === $has_suffix) {
+            throw new InvalidArgumentException("skip_rows[{$index}] must include exactly one of table or table_suffix");
+        }
+        if (!isset($rule["column"], $rule["value_base64"])) {
+            throw new InvalidArgumentException("skip_rows[{$index}] must include column and value_base64");
+        }
+        if (!is_string($rule["column"]) || $rule["column"] === "") {
+            throw new InvalidArgumentException("skip_rows[{$index}].column must be a non-empty string");
+        }
+        if (!is_string($rule["value_base64"])) {
+            throw new InvalidArgumentException("skip_rows[{$index}].value_base64 must be a string");
+        }
+
+        if ($has_suffix) {
+            if (!is_string($rule["table_suffix"]) || $rule["table_suffix"] === "") {
+                throw new InvalidArgumentException("skip_rows[{$index}].table_suffix must be a non-empty string");
+            }
+            if ($table_prefix === null || $table_prefix === "") {
+                throw new InvalidArgumentException("skip_rows[{$index}].table_suffix requires a table_prefix");
+            }
+            $table = $table_prefix . $rule["table_suffix"];
+        } else {
+            if (!is_string($rule["table"]) || $rule["table"] === "") {
+                throw new InvalidArgumentException("skip_rows[{$index}].table must be a non-empty string");
+            }
+            $table = $rule["table"];
+        }
+
+        $value = base64_decode($rule["value_base64"], true);
+        if ($value === false) {
+            throw new InvalidArgumentException("skip_rows[{$index}].value_base64 must be valid base64");
+        }
+
+        $rules[] = [
+            "table" => $table,
+            "column" => $rule["column"],
+            "value" => $value,
+        ];
+    }
+
+    return $rules;
 }
 
 /**

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -3626,11 +3626,11 @@ function path_is_default_skipped(string $path): bool
  *
  * Rules are data, not exporter-known tokens. A client may provide:
  *
- *   skip_rows[0][table_suffix]=postmeta
+ *   skip_rows[0][table_name_without_prefix]=postmeta
  *   skip_rows[0][column]=meta_key
  *   skip_rows[0][value_base64]=X2VkaXRfbG9jaw==
  *
- * `table_suffix` is appended to the server-side WordPress table prefix. The
+ * `table_name_without_prefix` is appended to the server-side WordPress table prefix. The
  * prefix must come from WordPress; if it cannot be resolved, clients must use
  * explicit `table` instead. Values are base64-encoded so raw bytes never travel
  * as SQL text.
@@ -3662,9 +3662,9 @@ function sql_exclude_rows_from_config(array $config, ?string $table_prefix): arr
         }
 
         $has_table = isset($rule["table"]);
-        $has_suffix = isset($rule["table_suffix"]);
-        if ($has_table === $has_suffix) {
-            throw new InvalidArgumentException("skip_rows[{$index}] must include exactly one of table or table_suffix");
+        $has_table_name_without_prefix = isset($rule["table_name_without_prefix"]);
+        if ($has_table === $has_table_name_without_prefix) {
+            throw new InvalidArgumentException("skip_rows[{$index}] must include exactly one of table or table_name_without_prefix");
         }
         if (!isset($rule["column"], $rule["value_base64"])) {
             throw new InvalidArgumentException("skip_rows[{$index}] must include column and value_base64");
@@ -3676,14 +3676,14 @@ function sql_exclude_rows_from_config(array $config, ?string $table_prefix): arr
             throw new InvalidArgumentException("skip_rows[{$index}].value_base64 must be a string");
         }
 
-        if ($has_suffix) {
-            if (!is_string($rule["table_suffix"]) || $rule["table_suffix"] === "") {
-                throw new InvalidArgumentException("skip_rows[{$index}].table_suffix must be a non-empty string");
+        if ($has_table_name_without_prefix) {
+            if (!is_string($rule["table_name_without_prefix"]) || $rule["table_name_without_prefix"] === "") {
+                throw new InvalidArgumentException("skip_rows[{$index}].table_name_without_prefix must be a non-empty string");
             }
             if ($table_prefix === null || $table_prefix === "") {
-                throw new InvalidArgumentException("skip_rows[{$index}].table_suffix requires a table_prefix");
+                throw new InvalidArgumentException("skip_rows[{$index}].table_name_without_prefix requires a table_prefix");
             }
-            $table = $table_prefix . $rule["table_suffix"];
+            $table = $table_prefix . $rule["table_name_without_prefix"];
         } else {
             if (!is_string($rule["table"]) || $rule["table"] === "") {
                 throw new InvalidArgumentException("skip_rows[{$index}].table must be a non-empty string");

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2446,10 +2446,30 @@ class ImportClient
             return [];
         }
         $params = $this->tuner->get_request_params($endpoint);
-        // Tell the server about the client's max_allowed_packet so it can
-        // cap SQL statements to a size the client can actually import.
-        if ($endpoint === "sql_chunk" && $this->max_allowed_packet !== null) {
-            $params["max_allowed_packet"] = $this->max_allowed_packet;
+        if ($endpoint === "sql_chunk") {
+            /**
+             * Ask the exporter to omit source rows that should not enter the local clone.
+             *
+             * The protocol is intentionally data-shaped instead of exporter-defined
+             * tokens: table_suffix is resolved against the source site's table prefix,
+             * column is matched against the source table metadata, and value_base64 lets
+             * the exporter compare with FROM_BASE64(...) without interpolating the raw
+             * value into SQL. _edit_lock is ephemeral editor session state and would
+             * otherwise create stale "being edited" notices in the imported site.
+             */
+            $params["skip_rows"] = [
+                [
+                    "table_suffix" => "postmeta",
+                    "column" => "meta_key",
+                    "value_base64" => base64_encode("_edit_lock"),
+                ],
+            ];
+
+            // Tell the server about the client's max_allowed_packet so it can
+            // cap SQL statements to a size the client can actually import.
+            if ($this->max_allowed_packet !== null) {
+                $params["max_allowed_packet"] = $this->max_allowed_packet;
+            }
         }
         if (!empty($params)) {
             $this->audit_log(

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2492,7 +2492,7 @@ class ImportClient
              * Ask the exporter to omit source rows that should not enter the local clone.
              *
              * The protocol is intentionally data-shaped instead of exporter-defined
-             * tokens: table_suffix is resolved against the source site's table prefix,
+             * tokens: table_name_without_prefix is resolved against the source site's table prefix,
              * column is matched against the source table metadata, and value_base64 lets
              * the exporter compare with FROM_BASE64(...) without interpolating the raw
              * value into SQL. _edit_lock is ephemeral editor session state and would
@@ -2500,7 +2500,7 @@ class ImportClient
              */
             $params["skip_rows"] = [
                 [
-                    "table_suffix" => "postmeta",
+                    "table_name_without_prefix" => "postmeta",
                     "column" => "meta_key",
                     "value_base64" => base64_encode("_edit_lock"),
                 ],

--- a/tests/MySQLDumpProducer/BasicDumpTest.php
+++ b/tests/MySQLDumpProducer/BasicDumpTest.php
@@ -143,6 +143,51 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         $this->assertDatabasesEqual($this->pdo, $importPdo, ['employees']);
     }
 
+    public function testCanExcludeRowsByTableColumnAndValue(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE wp_postmeta (
+                meta_id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                post_id BIGINT UNSIGNED NOT NULL,
+                meta_key VARCHAR(255),
+                meta_value LONGTEXT
+            )
+        ");
+
+        $this->pdo->exec("
+            INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES
+            (1, '_edit_lock', '1781114164:51814349'),
+            (1, '_thumbnail_id', '42'),
+            (2, NULL, 'kept')
+        ");
+
+        $sql = $this->getDumpSQL([
+            'exclude_rows' => [
+                [
+                    'table' => 'wp_postmeta',
+                    'column' => 'meta_key',
+                    'value' => '_edit_lock',
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString(base64_encode('_thumbnail_id'), $sql);
+        $this->assertStringNotContainsString(base64_encode('_edit_lock'), $sql);
+
+        $importPdo = $this->executeDumpInNewDatabase($sql);
+        $rows = $importPdo
+            ->query('SELECT meta_key, meta_value FROM wp_postmeta ORDER BY meta_id')
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertSame(
+            [
+                ['meta_key' => '_thumbnail_id', 'meta_value' => '42'],
+                ['meta_key' => null, 'meta_value' => 'kept'],
+            ],
+            $rows
+        );
+    }
+
     public function testBatchSizeRespected(): void
     {
         $this->pdo->exec("

--- a/tests/SqlSkipRowsProtocolTest.php
+++ b/tests/SqlSkipRowsProtocolTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-exporter/src/export.php';
+
+final class SqlSkipRowsProtocolTest extends TestCase
+{
+    public function testMapsPrefixedTableSuffixRuleToRowExclusion(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'table' => 'wp_123_postmeta',
+                    'column' => 'meta_key',
+                    'value' => '_edit_lock',
+                ],
+            ],
+            sql_exclude_rows_from_config(
+                [
+                    'skip_rows' => [
+                        [
+                            'table_suffix' => 'postmeta',
+                            'column' => 'meta_key',
+                            'value_base64' => base64_encode('_edit_lock'),
+                        ],
+                    ],
+                ],
+                'wp_123_'
+            )
+        );
+    }
+
+    public function testMapsExplicitTableRuleToRowExclusion(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'table' => 'custom_table',
+                    'column' => 'cache_key',
+                    'value' => "raw\0bytes",
+                ],
+            ],
+            sql_exclude_rows_from_config(
+                [
+                    'skip_rows' => [
+                        [
+                            'table' => 'custom_table',
+                            'column' => 'cache_key',
+                            'value_base64' => base64_encode("raw\0bytes"),
+                        ],
+                    ],
+                ],
+                null
+            )
+        );
+    }
+
+    public function testAcceptsJsonEncodedSkipRows(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'table' => 'wp_postmeta',
+                    'column' => 'meta_key',
+                    'value' => '_edit_lock',
+                ],
+            ],
+            sql_exclude_rows_from_config(
+                [
+                    'skip_rows' => json_encode([
+                        [
+                            'table_suffix' => 'postmeta',
+                            'column' => 'meta_key',
+                            'value_base64' => base64_encode('_edit_lock'),
+                        ],
+                    ]),
+                ],
+                'wp_'
+            )
+        );
+    }
+
+    public function testRejectsTableSuffixWithoutTablePrefix(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('table_suffix requires a table_prefix');
+
+        sql_exclude_rows_from_config(
+            [
+                'skip_rows' => [
+                    [
+                        'table_suffix' => 'postmeta',
+                        'column' => 'meta_key',
+                        'value_base64' => base64_encode('_edit_lock'),
+                    ],
+                ],
+            ],
+            null
+        );
+    }
+
+    public function testRejectsInvalidBase64Value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('value_base64 must be valid base64');
+
+        sql_exclude_rows_from_config(
+            [
+                'skip_rows' => [
+                    [
+                        'table_suffix' => 'postmeta',
+                        'column' => 'meta_key',
+                        'value_base64' => 'not valid base64!',
+                    ],
+                ],
+            ],
+            'wp_'
+        );
+    }
+}

--- a/tests/SqlSkipRowsProtocolTest.php
+++ b/tests/SqlSkipRowsProtocolTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../packages/reprint-exporter/src/export.php';
 
 final class SqlSkipRowsProtocolTest extends TestCase
 {
-    public function testMapsPrefixedTableSuffixRuleToRowExclusion(): void
+    public function testMapsTableNameWithoutPrefixRuleToRowExclusion(): void
     {
         $this->assertSame(
             [
@@ -22,7 +22,7 @@ final class SqlSkipRowsProtocolTest extends TestCase
                 [
                     'skip_rows' => [
                         [
-                            'table_suffix' => 'postmeta',
+                            'table_name_without_prefix' => 'postmeta',
                             'column' => 'meta_key',
                             'value_base64' => base64_encode('_edit_lock'),
                         ],
@@ -72,7 +72,7 @@ final class SqlSkipRowsProtocolTest extends TestCase
                 [
                     'skip_rows' => json_encode([
                         [
-                            'table_suffix' => 'postmeta',
+                            'table_name_without_prefix' => 'postmeta',
                             'column' => 'meta_key',
                             'value_base64' => base64_encode('_edit_lock'),
                         ],
@@ -83,16 +83,16 @@ final class SqlSkipRowsProtocolTest extends TestCase
         );
     }
 
-    public function testRejectsTableSuffixWithoutTablePrefix(): void
+    public function testRejectsTableNameWithoutPrefixWhenTablePrefixIsMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('table_suffix requires a table_prefix');
+        $this->expectExceptionMessage('table_name_without_prefix requires a table_prefix');
 
         sql_exclude_rows_from_config(
             [
                 'skip_rows' => [
                     [
-                        'table_suffix' => 'postmeta',
+                        'table_name_without_prefix' => 'postmeta',
                         'column' => 'meta_key',
                         'value_base64' => base64_encode('_edit_lock'),
                     ],
@@ -111,7 +111,7 @@ final class SqlSkipRowsProtocolTest extends TestCase
             [
                 'skip_rows' => [
                     [
-                        'table_suffix' => 'postmeta',
+                        'table_name_without_prefix' => 'postmeta',
                         'column' => 'meta_key',
                         'value_base64' => 'not valid base64!',
                     ],

--- a/tests/SqliteDriverPDOTest.php
+++ b/tests/SqliteDriverPDOTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../lib/sqlite-database-integration/packages/mysql-on-sqlite/src/load.php';
+require_once __DIR__ . '/../packages/reprint-exporter/src/class-sqlite-driver-pdo.php';
+
+final class SqliteDriverPDOTest extends TestCase
+{
+    public function testFromBase64WorksThroughAdapterQueryPath(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $connection = new WP_SQLite_Connection(['pdo' => $pdo]);
+        $driver = new WP_SQLite_Driver($connection, 'wp_test');
+        $adapter = new SqliteDriverPDO($driver, $pdo);
+
+        $adapter->query('CREATE TABLE wp_postmeta (meta_id INTEGER, meta_key TEXT)');
+        $adapter->query(
+            "INSERT INTO wp_postmeta (meta_id, meta_key) VALUES " .
+            "(1, '_edit_lock'), (2, '_thumbnail_id'), (3, NULL)"
+        );
+
+        $stmt = $adapter->query(
+            "SELECT meta_id FROM wp_postmeta " .
+            "WHERE meta_key IS NULL OR meta_key <> FROM_BASE64('" . base64_encode('_edit_lock') . "') " .
+            "ORDER BY meta_id"
+        );
+
+        $this->assertSame(
+            [['meta_id' => '2'], ['meta_id' => '3']],
+            $stmt->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
+}

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -84,7 +84,7 @@ export async function ensureWpTemplate() {
  * Write a full wp-config.php that WordPress/WP-CLI can load.
  * Includes wp-settings.php — required by wp core install.
  */
-function writeFullWpConfig(siteDir, dbHost, dbName, dbUser, dbPass) {
+function writeFullWpConfig(siteDir, dbHost, dbName, dbUser, dbPass, tablePrefix = 'wp_') {
     writeFileSync(join(siteDir, 'wp-config.php'), `<?php
 define('DB_HOST', '${dbHost}');
 define('DB_NAME', '${dbName}');
@@ -100,7 +100,7 @@ define('AUTH_SALT',        'e2e-test-salt-1');
 define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
 define('LOGGED_IN_SALT',   'e2e-test-salt-3');
 define('NONCE_SALT',       'e2e-test-salt-4');
-$table_prefix = 'wp_';
+$table_prefix = '${tablePrefix}';
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/' );
 }
@@ -110,15 +110,15 @@ require_once ABSPATH . 'wp-settings.php';
 
 /**
  * Write the minimal wp-config.php used by the export plugin.
- * Does NOT load wp-settings.php — the plugin reads DB creds directly.
+ * Does NOT load wp-settings.php — the plugin reads DB creds and table prefix directly.
  */
-function writeMinimalWpConfig(siteDir, dbHost, dbName, dbUser, dbPass) {
+function writeMinimalWpConfig(siteDir, dbHost, dbName, dbUser, dbPass, tablePrefix = 'wp_') {
     writeFileSync(join(siteDir, 'wp-config.php'), `<?php
 define('DB_HOST', '${dbHost}');
 define('DB_NAME', '${dbName}');
 define('DB_USER', '${dbUser}');
 define('DB_PASSWORD', '${dbPass}');
-$table_prefix = 'wp_';
+$table_prefix = '${tablePrefix}';
 `);
 }
 
@@ -176,6 +176,7 @@ export function createSampleFiles(siteDir) {
  *   files: 'sample' (default) | 'none'
  *   customDb: async (dbName, conn) => {} — adds extra tables on top of real WP tables
  *   wpConfig: { DB_USER: '...', ... } — override wp-config.php creds AFTER install
+ *   tablePrefix: 'wp_' — table prefix to write into wp-config.php before install
  *   afterCreate: async (siteDir, dbName) => {} — post-creation hook (dir is writable)
  *   afterPermissions: async (siteDir) => {} — runs after final chown/chmod (for chmod 000 etc.)
  */
@@ -224,6 +225,7 @@ export async function ensureSite(name, options = {}) {
     const filesOpt = options.files || 'sample';
     const port = REGISTRY.sites[name]?.port;
     const siteUrl = port ? `http://127.0.0.1:${port}` : 'http://127.0.0.1';
+    const tablePrefix = options.tablePrefix || 'wp_';
 
     const log = (msg) => console.log(`  [${name}] ${msg}`);
     log(`Setting up site (db: ${dbName})`);
@@ -242,7 +244,7 @@ export async function ensureSite(name, options = {}) {
     mkdirSync(join(siteDir, 'test-data'), { recursive: true });
 
     // Write full wp-config.php with admin creds (needed for wp core install)
-    writeFullWpConfig(siteDir, DB_HOST, dbName, DB_USER, DB_PASS);
+    writeFullWpConfig(siteDir, DB_HOST, dbName, DB_USER, DB_PASS, tablePrefix);
 
     // Copy the built plugin bundle, including its bundled Composer vendor tree.
     cpSync(
@@ -297,7 +299,7 @@ export async function ensureSite(name, options = {}) {
         const wpDbPass = options.wpConfig.DB_PASSWORD || DB_PASS;
         const wpDbName = options.wpConfig.DB_NAME || dbName;
         const wpDbHost = options.wpConfig.DB_HOST || DB_HOST;
-        writeFullWpConfig(siteDir, wpDbHost, wpDbName, wpDbUser, wpDbPass);
+        writeFullWpConfig(siteDir, wpDbHost, wpDbName, wpDbUser, wpDbPass, tablePrefix);
     }
 
     // Create sample files (pure Node fs)

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -124,6 +124,9 @@
     },
     "file-body-resume": {
       "port": 8120
+    },
+    "edit-locks": {
+      "port": 8121
     }
   }
 }

--- a/tests/e2e/tests/import-51-skip-edit-locks.test.js
+++ b/tests/e2e/tests/import-51-skip-edit-locks.test.js
@@ -1,0 +1,197 @@
+/**
+ * Test 51: SQL row skip protocol — post edit locks
+ *
+ * Pulls SQL from a source WordPress site with a non-default table prefix into
+ * a separate MySQL database. The source data includes rows that exercise the
+ * boundaries of the default _edit_lock exclusion: only rows in the source
+ * site's prefixed postmeta table whose meta_key is exactly _edit_lock should
+ * disappear. Similar rows in other tables, similarly named keys, NULL keys,
+ * and values that merely look like edit locks must survive the transfer.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    createMysqlConnection, getDbName,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const TABLE_PREFIX = 'rp_';
+const TEST_POST_ID = 99001;
+
+function plainRows(rows) {
+    return rows.map(row => ({ ...row }));
+}
+
+describe('Import: skip remote post edit locks', { timeout: 300000 }, () => {
+    const site = 'edit-locks';
+    const importDb = 'e2e_skip_edit_locks_51';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            tablePrefix: TABLE_PREFIX,
+            customDb: async (_dbName, conn) => {
+                await conn.query(
+                    `INSERT INTO ${TABLE_PREFIX}postmeta (post_id, meta_key, meta_value) VALUES
+                    (?, '_edit_lock', '1781114164:51814349'),
+                    (?, '_edit_lock', '1781114165:51814350'),
+                    (?, '_edit_last', '51814349'),
+                    (?, '_edit_lock_extra', 'should-stay'),
+                    (?, '_thumbnail_id', '42'),
+                    (?, NULL, 'null-key-stays'),
+                    (?, 'not_lock', '1781114164:51814349')`,
+                    [
+                        TEST_POST_ID,
+                        TEST_POST_ID + 1,
+                        TEST_POST_ID,
+                        TEST_POST_ID,
+                        TEST_POST_ID,
+                        TEST_POST_ID,
+                        TEST_POST_ID,
+                    ],
+                );
+
+                await conn.query(
+                    `CREATE TABLE wp_postmeta (
+                        meta_id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                        post_id BIGINT UNSIGNED NOT NULL,
+                        meta_key VARCHAR(255),
+                        meta_value LONGTEXT
+                    )`,
+                );
+                await conn.query(
+                    `INSERT INTO wp_postmeta (post_id, meta_key, meta_value)
+                    VALUES (?, '_edit_lock', 'unprefixed-table-stays')`,
+                    [TEST_POST_ID],
+                );
+
+                await conn.query(
+                    `CREATE TABLE ${TABLE_PREFIX}othermeta (
+                        id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                        meta_key VARCHAR(255),
+                        meta_value LONGTEXT
+                    )`,
+                );
+                await conn.query(
+                    `INSERT INTO ${TABLE_PREFIX}othermeta (meta_key, meta_value)
+                    VALUES ('_edit_lock', 'different-table-stays')`,
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-skip-edit-locks');
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
+    });
+
+    afterAll(async () => {
+        cleanupTempDir(tempDir);
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('source fixture has edit locks in the prefixed postmeta table and lookalikes elsewhere', async () => {
+        const conn = await createMysqlConnection(getDbName(site));
+        try {
+            const [[prefixedLocks]] = await conn.query(
+                `SELECT COUNT(*) AS count FROM ${TABLE_PREFIX}postmeta WHERE post_id IN (?, ?) AND meta_key = '_edit_lock'`,
+                [TEST_POST_ID, TEST_POST_ID + 1],
+            );
+            assert.equal(Number(prefixedLocks.count), 2);
+
+            const [[unprefixedLocks]] = await conn.query(
+                `SELECT COUNT(*) AS count FROM wp_postmeta WHERE post_id = ? AND meta_key = '_edit_lock'`,
+                [TEST_POST_ID],
+            );
+            assert.equal(Number(unprefixedLocks.count), 1);
+
+            const [[otherTableLocks]] = await conn.query(
+                `SELECT COUNT(*) AS count FROM ${TABLE_PREFIX}othermeta WHERE meta_key = '_edit_lock'`,
+            );
+            assert.equal(Number(otherTableLocks.count), 1);
+        } finally {
+            await conn.end();
+        }
+    });
+
+    it('db-pull imports everything except prefixed postmeta _edit_lock rows', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            timeout: 120000,
+            wallTimeout: 300000,
+            extraArgs: [
+                '--sql-output=mysql',
+                '--mysql-host=127.0.0.1',
+                '--mysql-user=e2e_admin',
+                '--mysql-password=e2e_password',
+                `--mysql-database=${importDb}`,
+                // Force the dump across multiple sql_chunk requests so every
+                // resumed request must carry the same skip_rows protocol.
+                '--max-exec=1',
+                '--sql-fragments-start=25',
+                '--sql-fragments-max=25',
+            ],
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected db-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    it('omits only the exact _edit_lock rows from the source-prefixed postmeta table', async () => {
+        const conn = await createMysqlConnection(importDb);
+        try {
+            const [postmetaRows] = await conn.query(
+                `SELECT meta_key, meta_value FROM ${TABLE_PREFIX}postmeta
+                WHERE post_id = ?
+                ORDER BY meta_id`,
+                [TEST_POST_ID],
+            );
+            assert.deepEqual(plainRows(postmetaRows), [
+                { meta_key: '_edit_last', meta_value: '51814349' },
+                { meta_key: '_edit_lock_extra', meta_value: 'should-stay' },
+                { meta_key: '_thumbnail_id', meta_value: '42' },
+                { meta_key: null, meta_value: 'null-key-stays' },
+                { meta_key: 'not_lock', meta_value: '1781114164:51814349' },
+            ]);
+
+            const [[remainingPrefixedLocks]] = await conn.query(
+                `SELECT COUNT(*) AS count FROM ${TABLE_PREFIX}postmeta
+                WHERE post_id IN (?, ?) AND meta_key = '_edit_lock'`,
+                [TEST_POST_ID, TEST_POST_ID + 1],
+            );
+            assert.equal(Number(remainingPrefixedLocks.count), 0);
+        } finally {
+            await conn.end();
+        }
+    });
+
+    it('does not apply the postmeta skip rule to unprefixed or non-postmeta tables', async () => {
+        const conn = await createMysqlConnection(importDb);
+        try {
+            const [unprefixedRows] = await conn.query(
+                `SELECT meta_key, meta_value FROM wp_postmeta WHERE post_id = ?`,
+                [TEST_POST_ID],
+            );
+            assert.deepEqual(plainRows(unprefixedRows), [
+                { meta_key: '_edit_lock', meta_value: 'unprefixed-table-stays' },
+            ]);
+
+            const [otherTableRows] = await conn.query(
+                `SELECT meta_key, meta_value FROM ${TABLE_PREFIX}othermeta`,
+            );
+            assert.deepEqual(plainRows(otherTableRows), [
+                { meta_key: '_edit_lock', meta_value: 'different-table-stays' },
+            ]);
+        } finally {
+            await conn.end();
+        }
+    });
+});


### PR DESCRIPTION
## What it does

Excludes remote WordPress post edit locks from SQL exports before they enter the dump.

`db-pull` now sends a generic row-filter rule with `sql_chunk` requests:

```php
skip_rows[0][table_name_without_prefix]=postmeta
skip_rows[0][column]=meta_key
skip_rows[0][value_base64]=X2VkaXRfbG9jaw== // _edit_lock
```

The exporter turns that rule into a `MySQLDumpProducer` row exclusion for the source site's prefixed `postmeta` table.

## Rationale

`_edit_lock` postmeta is ephemeral editor-session state. If a post is open on the source site during export, importing that row locally can show a phantom “currently editing” badge in wp-admin.

Filtering at export time avoids reading, encoding, transferring, parsing, inserting, and later deleting those rows. The protocol is data-driven, so future importers can exclude different table/column/value rows without teaching the exporter new named tokens.

## Implementation

Added `skip_rows` support to `sql_chunk` requests. Each rule identifies:

- a table via `table_name_without_prefix` plus the source site's WordPress table prefix, or explicit `table`
- a `column`
- a `value_base64`

`table_name_without_prefix` now requires a prefix resolved from WordPress (`$table_prefix` / `$wpdb->prefix`) rather than falling back to `wp_`.

`MySQLDumpProducer` checks the configured column against the current table metadata, quotes identifiers, and appends the exclusion to the table SELECT:

```sql
(`meta_key` IS NULL OR `meta_key` <> FROM_BASE64('X2VkaXRfbG9jaw=='))
```

`value_base64` keeps raw values out of SQL text. `SqliteDriverPDOTest` covers the SQLite-source path and confirms `FROM_BASE64()` works through the adapter query path.

## Testing instructions

Run:

```bash
./vendor/bin/phpunit tests/SqlSkipRowsProtocolTest.php tests/SqliteDriverPDOTest.php --testdox --colors=never
./vendor/bin/phpstan analyze packages/reprint-importer/src/import.php packages/reprint-exporter/src/export.php packages/reprint-exporter/src/class-mysql-dump-producer.php packages/reprint-exporter/src/class-sqlite-driver-pdo.php --memory-limit=1G --no-progress
npm --prefix tests/e2e test -- tests/import-51-skip-edit-locks.test.js
```

CI also runs the MySQL-backed producer coverage in `BasicDumpTest::testCanExcludeRowsByTableColumnAndValue()`.

The E2E test provisions a source site with a non-default `rp_` table prefix, pulls into a separate MySQL database, and verifies only exact `_edit_lock` rows in `rp_postmeta` are skipped. It also checks `_edit_last`, `_edit_lock_extra`, `NULL` meta keys, lock-looking values, an unprefixed `wp_postmeta` table, and another prefixed table all survive.

