### PR TITLE
Support repeated `--only` path arguments in `files-pull`

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1821,10 +1821,12 @@ class ImportClient
         }
 
         // Resolve the `--only` scope (also requires preflight).
-        // Comma-separated for multiple source paths.
-        $only_raw = $options["only"] ?? "";
-        if ($only_raw !== "") {
-            $this->scope = $this->resolve_scope(explode(",", $only_raw));
+        $only_raw = $options["only"] ?? [];
+        if (is_string($only_raw)) {
+            $only_raw = [$only_raw];
+        }
+        if (!empty($only_raw)) {
+            $this->scope = $this->resolve_scope($only_raw);
         }
 
         // Handle --abort: clear state for the command and exit immediately.
@@ -11425,6 +11427,7 @@ if (
     //   placeholder    Value placeholder in help, e.g. 'DIR' (value types)
     //   short          Single-char alias, e.g. 'v' for -v (flag types)
     //   aliases        Array of alternative --names (hidden from help)
+    //   repeatable     Append each value to target instead of replacing it
     //   cast           'int' | 'float' | 'size' (default: string)
     //   flag_value     What to store for flag types (default: true)
     //   valid_values   Array of allowed values (enforced at parse time)
@@ -11719,8 +11722,9 @@ if (
             'type' => 'value-or-next',
             'target' => 'only',
             'placeholder' => 'SOURCE',
+            'repeatable' => true,
             'help' => 'Scope the pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
-                'comma-separate for several. Default pulls everything',
+                'repeat for several. Default pulls everything',
             'commands' => ['files-pull'],
         ],
 
@@ -11952,6 +11956,13 @@ if (
         if ($target === 'fs_root')   { $fs_root = $value;   return; }
         if (strpos($target, 'tuning_config.') === 0) {
             $options['tuning_config'][substr($target, strlen('tuning_config.'))] = $value;
+            return;
+        }
+        if (!empty($def['repeatable'])) {
+            if (!isset($options[$target])) {
+                $options[$target] = [];
+            }
+            $options[$target][] = $value;
             return;
         }
         $options[$target] = $value;

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -6,14 +6,18 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * --only reuses the existing `value-or-next` option type (like --new-site-url),
- * taking a single comma-separated value. The parser lives inside the CLI
- * bootstrap guard (not require-able), so this exercises the real binary and
- * asserts `--only` is a recognized option in both `--only=VAL` and `--only VAL`
- * forms.
+ * but is repeatable because commas are valid path bytes. The parser lives
+ * inside the CLI bootstrap guard (not require-able), so this exercises the real
+ * binary and asserts `--only` is recognized in both `--only=VAL` and
+ * `--only VAL` forms.
  */
 class OnlyCliParseTest extends TestCase
 {
     private $tempDir;
+    /** @var resource|null */
+    private $serverProcess = null;
+    /** @var array<int, resource> */
+    private $serverPipes = array();
 
     protected function setUp(): void
     {
@@ -25,6 +29,18 @@ class OnlyCliParseTest extends TestCase
 
     protected function tearDown(): void
     {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+            $this->serverProcess = null;
+            $this->serverPipes = array();
+        }
+
         // The real CLI run may drop state files (.import-state.json, audit log)
         // into the state dir, so a plain rmdir wouldn't clear it — recurse.
         $this->recursiveDelete($this->tempDir);
@@ -56,7 +72,115 @@ class OnlyCliParseTest extends TestCase
         return shell_exec($cmd . ' 2>&1') ?? '';
     }
 
-    public function testOnlyOptionIsRecognizedInBothForms(): void
+
+    private function findUnusedPort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if (!$socket) {
+            $this->fail("Failed to find unused port: {$errstr}");
+        }
+
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        return (int) substr(strrchr($name, ':'), 1);
+    }
+
+    private function startDirectoryCaptureServer(string $requestsLog): string
+    {
+        $router = $this->tempDir . '/capture-directories.php';
+        file_put_contents($router, sprintf(<<<'PHP'
+<?php
+$log = %s;
+file_put_contents($log, json_encode(array(
+    'endpoint' => $_GET['endpoint'] ?? null,
+    'directory' => $_GET['directory'] ?? null,
+), JSON_UNESCAPED_SLASHES) . "\n", FILE_APPEND);
+
+$boundary = 'reprint-test-boundary';
+header('Content-Type: multipart/mixed; boundary=' . $boundary);
+echo "--{$boundary}\r\n";
+echo "X-Chunk-Type: completion\r\n";
+echo "X-Status: complete\r\n";
+echo "X-Total-Entries: 0\r\n";
+echo "Content-Length: 0\r\n\r\n";
+echo "\r\n--{$boundary}--\r\n";
+PHP, var_export($requestsLog, true)));
+
+        $port = $this->findUnusedPort();
+        $descriptors = array(
+            0 => array('pipe', 'r'),
+            1 => array('pipe', 'w'),
+            2 => array('pipe', 'w'),
+        );
+        $command = sprintf(
+            '%s -S 127.0.0.1:%d %s',
+            escapeshellarg(PHP_BINARY),
+            $port,
+            escapeshellarg($router)
+        );
+
+        $this->serverProcess = proc_open($command, $descriptors, $this->serverPipes, $this->tempDir);
+        if (!is_resource($this->serverProcess)) {
+            $this->fail('Failed to start capture server');
+        }
+        fclose($this->serverPipes[0]);
+
+        for ($i = 0; $i < 50; $i++) {
+            $socket = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+            if ($socket) {
+                fclose($socket);
+                return "http://127.0.0.1:{$port}/export.php?site-export-api";
+            }
+            usleep(100000);
+        }
+
+        $this->fail('Capture server did not start');
+    }
+
+    private function capturedRequests(string $requestsLog): array
+    {
+        if (!file_exists($requestsLog)) {
+            return array();
+        }
+
+        $requests = array();
+        foreach (file($requestsLog, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: array() as $line) {
+            $requests[] = json_decode($line, true);
+        }
+        return $requests;
+    }
+
+    private function writePreflightState(bool $includeRoots = false): void
+    {
+        $data = array(
+            'ok' => true,
+            'database' => array(
+                'wp' => array(
+                    'paths_urls' => array(
+                        'content_dir' => '/var/www/html/wp-content',
+                        'uploads' => array('basedir' => '/var/www/html/wp-content/uploads'),
+                    ),
+                ),
+            ),
+        );
+        if ($includeRoots) {
+            $data['wp_detect'] = array(
+                'roots' => array(
+                    array('path' => '/var/www/html'),
+                ),
+            );
+        }
+
+        file_put_contents($this->tempDir . '/state/.import-state.json', json_encode(array(
+            'preflight' => array(
+                'data' => $data,
+                'http_code' => 200,
+            ),
+        ), JSON_PRETTY_PRINT));
+    }
+
+    public function testOnlyOptionIsRecognizedAsRepeatableInBothForms(): void
     {
         $tail = array(
             '--state-dir=' . $this->tempDir . '/state',
@@ -66,15 +190,102 @@ class OnlyCliParseTest extends TestCase
         // Both forms fail later (unreachable host) but must not be rejected as
         // an unknown option.
         $equals = $this->runCli(array_merge(
-            array('files-pull', 'http://fake.invalid/?site-export-api', '--only=:wp-content:,:wp-uploads:'),
+            array('files-pull', 'http://fake.invalid/?site-export-api', '--only=:wp-content:', '--only=:wp-uploads:/2025'),
             $tail
         ));
         $this->assertStringNotContainsString('Unknown option', $equals);
 
         $space = $this->runCli(array_merge(
-            array('files-pull', 'http://fake.invalid/?site-export-api', '--only', ':wp-content:'),
+            array('files-pull', 'http://fake.invalid/?site-export-api', '--only', ':wp-content:', '--only', ':wp-uploads:/2025'),
             $tail
         ));
         $this->assertStringNotContainsString('Unknown option', $space);
+    }
+
+
+    public function testRepeatedOnlyOptionsAreAllPreserved(): void
+    {
+        // If repeated --only values are collapsed to the last one, this would
+        // succeed because :wp-content: is resolvable. Preserving both values
+        // forces resolution of :abspath:, which this preflight intentionally
+        // omits.
+        $this->writePreflightState();
+
+        $output = $this->runCli(array(
+            'files-pull',
+            'http://fake.invalid/?site-export-api',
+            '--only',
+            ':abspath:/wp-admin',
+            '--only',
+            ':wp-content:',
+            '--abort',
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+        ));
+
+        $result = json_decode($output, true);
+        $this->assertSame(
+            'Cannot resolve token ":abspath:": not available in preflight data. Run preflight first.',
+            $result['error'] ?? null
+        );
+        $this->assertStringNotContainsString('"status":"aborted"', $output);
+    }
+
+    public function testRepeatedOnlyOptionsAreUsedByFilesPull(): void
+    {
+        $this->writePreflightState(true);
+
+        $requestsLog = $this->tempDir . '/requests.jsonl';
+        $remoteUrl = $this->startDirectoryCaptureServer($requestsLog);
+
+        $output = $this->runCli(array(
+            'files-pull',
+            $remoteUrl,
+            '--only',
+            ':wp-content:/plugins',
+            '--only',
+            ':wp-uploads:/2025',
+            '--only',
+            ':wp-content:/themes',
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+        ));
+
+        $this->assertStringNotContainsString('"status":"error"', $output);
+
+        $fileIndexRequest = null;
+        foreach ($this->capturedRequests($requestsLog) as $request) {
+            if (($request['endpoint'] ?? null) === 'file_index') {
+                $fileIndexRequest = $request;
+                break;
+            }
+        }
+
+        $this->assertNotNull($fileIndexRequest, "files-pull should request file_index. Output:\n{$output}");
+        $this->assertSame(array(
+            '/var/www/html/wp-content/plugins',
+            '/var/www/html/wp-content/uploads/2025',
+            '/var/www/html/wp-content/themes',
+        ), $fileIndexRequest['directory'] ?? null);
+    }
+
+    public function testOnlyOptionKeepsCommaInsideSourcePath(): void
+    {
+        // --abort runs after --only resolution, avoiding a network request while
+        // still proving the CLI did not split the SOURCE at the comma.
+        $this->writePreflightState();
+
+        $output = $this->runCli(array(
+            'files-pull',
+            'http://fake.invalid/?site-export-api',
+            '--only',
+            ':wp-content:/plugins,custom',
+            '--abort',
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+        ));
+
+        $this->assertStringContainsString('"status":"aborted"', $output);
+        $this->assertStringNotContainsString('path "custom"', $output);
     }
 }


### PR DESCRIPTION
## What it does

#263 introduced an `--only` argument to filter which files are getting pulled.

This PR changes how multiple paths are passed to reprint.

**Before:** `--only :wp-content:/plugins,:wp-uploads:/2025`

**After:** `--only :wp-content:/plugins --only :wp-uploads:/2025`

## Rationale

`,` is a valid directory-name byte. Using it for splitting leaves no way of filtering directory names containing a comma.

## Implementation

`--only` stays a `value-or-next` option, but is marked `repeatable`. `_cli_store()` appends repeatable values to an array, and `ImportClient::run()` passes that array through to path-prefix resolution.

The focused CLI parser tests cover both invariants:

- repeated `--only` values are preserved
- commas inside one `--only` path are not split

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/OnlyCliParseTest.php
phpunit --configuration tests/phpunit.xml --filter 'OnlyCliParse'
```
