### PR TITLE
Clarify files-pull --only path prefix naming

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1140,11 +1140,11 @@ class ImportClient
     private $remap_rules = [];
 
     /**
-     * @var array<int,string> Resolved `--only` scope: a list of real source
-     * absolute path prefixes the pull is restricted to. Empty = full sync
+     * @var array<int,string> Resolved `--only` file paths: a list of real source
+     * absolute path prefixes the files-pull command is restricted to. Empty = full sync
      * (every detected root).
      */
-    private $scope = [];
+    private $pull_only_files_with_path_prefixes = [];
 
     /** @var AdaptiveTuner|null Adjusts request pacing based on server response times and errors. */
     private $tuner = null;
@@ -1820,13 +1820,13 @@ class ImportClient
             $this->remap_rules = $this->resolve_remap($remap_raw);
         }
 
-        // Resolve the `--only` scope (also requires preflight).
+        // Resolve the `--only` file path prefixes (also requires preflight).
         $only_raw = $options["only"] ?? [];
         if (is_string($only_raw)) {
             $only_raw = [$only_raw];
         }
         if (!empty($only_raw)) {
-            $this->scope = $this->resolve_scope($only_raw);
+            $this->pull_only_files_with_path_prefixes = $this->resolve_pull_only_files_with_path_prefixes($only_raw);
         }
 
         // Handle --abort: clear state for the command and exit immediately.
@@ -6091,9 +6091,13 @@ class ImportClient
 
         if ($cursor === null) {
             $start = $roots[0];
-            if (!empty($this->scope)) {
-                // When in scoped mode (--only), we need to start at the first export dir
-                // to appease the exporter's constraint of list_dir falling within directory[].
+            if (!empty($this->pull_only_files_with_path_prefixes)) {
+                // With --only, get_export_directories() returns only the resolved
+                // file path prefixes, and those become the request's directory[]
+                // allowlist. The exporter rejects list_dir unless it is inside
+                // that allowlist, so $roots[0] may no longer be valid. Start from
+                // the first --only file path prefix; the exporter still traverses
+                // the remaining directory[] entries.
                 $start = $export_dirs[0] ?? $roots[0];
             }
 
@@ -6375,9 +6379,9 @@ class ImportClient
                 $local !== null &&
                 strcmp($local["path"], $remote["path"]) < 0
             ) {
-                // When in scoped mode (--only), we will only delete local files when they fall under our scope.
-                // The local files index ends up being a union across scoped runs.
-                if ($this->in_scope($local["path"])) {
+                // When --only file prefixes are active, only delete local files that fall under those prefixes.
+                // The local files index ends up being a union across files-pull --only runs.
+                if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
                     $this->delete_local_file_path($local["path"]);
                     $this->delete_index_entry($local["path"]);
                 }
@@ -6433,7 +6437,7 @@ class ImportClient
         }
 
         while ($local !== null) {
-            if ($this->in_scope($local["path"])) {
+            if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
                 $this->delete_local_file_path($local["path"]);
                 $this->delete_index_entry($local["path"]);
             }
@@ -8424,7 +8428,7 @@ class ImportClient
      * Build the remap rules from the raw remap pairs + preflight data.
      *
      * Each argument is a template string of `:token:` substitutions and/or a raw absolute path.
-     * Source arguments resolve against the remote site's component locations.
+     * Source arguments resolve against the remote site's WordPress path tokens.
      * Target arguments resolve under --fs-root and must stay within it.
      * Each rule is a full source path => full local target path (both absolute).
      *
@@ -8435,7 +8439,7 @@ class ImportClient
     {
         $fs_root = rtrim($this->get_filesystem_root_path(), "/");
 
-        $source_tokens = $this->wp_component_source_paths();
+        $source_tokens = $this->wp_source_path_tokens();
         $target_tokens = ["fs-root" => $fs_root];
 
         $rules = [];
@@ -8457,10 +8461,11 @@ class ImportClient
             }
         }
 
-        // Whole-tree remap of the wp-content components detached from content_dir,
-        // unless an explicit rule has already placed them somewhere else.
+        // When remapping wp-content, also remap plugins, mu-plugins, and uploads
+        // directories that live outside WP_CONTENT_DIR. Skip any directory that already
+        // has its own explicit --remap rule.
         if ($wp_content_target !== null) {
-            foreach ($this->detached_content_component_sources($source_tokens) as $name => $source) {
+            foreach ($this->content_directories_outside_wp_content($source_tokens) as $name => $source) {
                 if (!isset($rules[$source])) {
                     $rules[$source] = wp_join_unix_paths($wp_content_target, $name);
                 }
@@ -8471,46 +8476,49 @@ class ImportClient
     }
 
     /**
-     * The wp-content components (plugins, mu-plugins, uploads) whose real source
-     * dir is detached from content_dir — i.e. relocated outside it, so a
-     * scope/remap of "wp-content" wouldn't cover them via content_dir alone.
-     * Components with an unknown (null) source, or an unknown content_dir, are
-     * omitted — detachment can't be determined without both.
+     * Find plugins, mu-plugins, and uploads directories that WordPress reports
+     * outside WP_CONTENT_DIR.
      *
-     * @param array<string,string|null> $source_tokens From wp_component_source_paths().
-     * @return array<string,string> dir name => real source path, detached ones only.
+     * When wp-content is selected with --only or --remap, these directories are not
+     * covered by WP_CONTENT_DIR itself, so callers need to handle them separately.
+     * Unknown paths are omitted because both WP_CONTENT_DIR and the directory path
+     * are needed to decide whether the directory lives outside WP_CONTENT_DIR.
+     *
+     * @param array<string,string|null> $source_tokens From wp_source_path_tokens().
+     * @return array<string,string> Directory name => real source path, for
+     *                              directories outside WP_CONTENT_DIR only.
      */
-    private function detached_content_component_sources(array $source_tokens): array
+    private function content_directories_outside_wp_content(array $source_tokens): array
     {
         $content = $source_tokens["wp-content"];
         if ($content === null) {
             return [];
         }
 
-        $detached = [];
+        $directories = [];
         foreach (["wp-plugins" => "plugins", "wp-mu-plugins" => "mu-plugins", "wp-uploads" => "uploads"] as $token => $name) {
             $source = $source_tokens[$token];
             if ($source !== null && !path_is_within_root($source, $content)) {
-                $detached[$name] = $source;
+                $directories[$name] = $source;
             }
         }
 
-        return $detached;
+        return $directories;
     }
 
     /**
      * Resolve raw `--only` sources into a deduped list of real source absolute
-     * prefixes the pull is scoped to. Each source is a `:token:` template (e.g.
+     * prefixes selected for files-pull. Each source is a `:token:` template (e.g.
      * `:wp-content:`, `:wp-uploads:`) or a raw absolute path,
-     * resolved through the same source token table (wp_component_source_paths)
+     * resolved through the same source token table (wp_source_path_tokens)
      * as --remap.
      *
      * @param array<int,string> $only_raw Raw SOURCE values from the CLI.
      * @return array<int,string> Real source prefixes (deduped).
      */
-    private function resolve_scope(array $only_raw): array
+    private function resolve_pull_only_files_with_path_prefixes(array $only_raw): array
     {
-        $source_tokens = $this->wp_component_source_paths();
+        $source_tokens = $this->wp_source_path_tokens();
 
         $prefixes = [];
         foreach ($only_raw as $src) {
@@ -8521,24 +8529,24 @@ class ImportClient
             $resolved = $this->resolve_token_path($src, $source_tokens);
             $prefixes[$resolved] = true;
 
-            // Scoping content_dir also pulls in any detached component (e.g. a
-            // moved uploads dir) so it's enumerated under scope.
+            // Selecting content_dir with --only also pulls in any plugins, mu-plugins,
+            // or uploads directory outside WP_CONTENT_DIR so files-pull enumerates it too.
             if ($resolved === $source_tokens["wp-content"]) {
-                foreach ($this->detached_content_component_sources($source_tokens) as $source) {
+                foreach ($this->content_directories_outside_wp_content($source_tokens) as $source) {
                     $prefixes[$source] = true;
                 }
             }
         }
 
         // Drop any prefix already covered by a broader one (e.g. wp-content and wp-content/plugins)
-        // A scoped pull doesn't need to walk the same subtree twice.
+        // A files-pull --only run doesn't need to walk the same subtree twice.
         $sources = array_keys($prefixes);
         $minimal = [];
         foreach ($sources as $path) {
             $covered = false;
 
             foreach ($sources as $other) {
-                if ($other !== $path && self::path_remainder_under($path, $other) !== null) {
+                if ($other !== $path && path_is_within_root($path, $other)) {
                     $covered = true;
                     break;
                 }
@@ -8553,18 +8561,18 @@ class ImportClient
     }
 
     /**
-     * Whether $path is within the active --only scope. With no --only flag
-     * the pull is unscoped, so everything is in scope (returns true) — this
-     * keeps the diff's delete drains at their default behavior. When scoped,
-     * true only when $path falls under one of the scope prefixes.
+     * Whether $path is selected by the active --only file path prefixes. With no
+     * --only flag, every file path is selected (returns true) — this keeps
+     * the diff's delete drains at their default behavior. When --only is set,
+     * true only when $path falls under one of those file path prefixes.
      */
-    private function in_scope(string $path): bool
+    private function is_file_path_selected_by_pull_only_files(string $path): bool
     {
-        if (empty($this->scope)) {
+        if (empty($this->pull_only_files_with_path_prefixes)) {
             return true;
         }
 
-        foreach ($this->scope as $prefix) {
+        foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
             if (self::path_remainder_under($path, $prefix) !== null) {
                 return true;
             }
@@ -8574,15 +8582,16 @@ class ImportClient
     }
 
     /**
-     * The source site's real component locations from preflight data, as remap
-     * token name => absolute path (wp-content, wp-plugins, wp-mu-plugins,
-     * wp-uploads, abspath).
+     * The source site's real paths from preflight data, as remap/--only token
+     * name => absolute path (wp-content, wp-plugins, wp-mu-plugins, wp-uploads,
+     * abspath).
      *
-     * A wp-content component falls back to its conventional spot under
-     * content_dir when that is known. This is a pure data-gatherer: any entry
-     * may be null when preflight lacks it (no content_dir, abspath undetermined).
+     * Plugins, mu-plugins, and uploads fall back to their conventional locations
+     * under WP_CONTENT_DIR when WP_CONTENT_DIR is known. This is a pure
+     * data-gatherer: any entry may be null when preflight lacks it (no
+     * content_dir, abspath undetermined).
      */
-    private function wp_component_source_paths(): array
+    private function wp_source_path_tokens(): array
     {
         $preflight = $this->state["preflight"]["data"] ?? [];
         $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
@@ -8598,7 +8607,7 @@ class ImportClient
         $mu_plugins_dir = $this->clean_preflight_path( $paths["mu_plugins_dir"] ?? null);
         $uploads_dir = $this->clean_preflight_path( $paths["uploads"]["basedir"] ?? null);
 
-        // If preflight did not report a component path, use its conventional
+        // If preflight did not report a directory path, use its conventional
         // location under WP_CONTENT_DIR when WP_CONTENT_DIR is known.
         if ($content_dir !== null) {
             $plugins_dir = $plugins_dir ?? wp_join_unix_paths( $content_dir, "plugins" );
@@ -8618,11 +8627,12 @@ class ImportClient
     /**
      * Resolve a --remap/--only path argument into an absolute path.
      *
-     * Substitutes a known leading `:token:` (see the token tables in resolve_remap
-     * and resolve_scope) with its value, then trims trailing slashes. The
-     * result must be a valid absolute path with no `.`/`..` segments; a relative
-     * path or an unknown token (left unsubstituted) fails that check. Referencing
-     * a token whose value is unavailable in preflight is a distinct, clear error.
+     * Substitutes a known leading `:token:` (see the token tables in
+     * resolve_remap and resolve_pull_only_files_with_path_prefixes) with its
+     * value, then trims trailing slashes. The result must be a valid absolute
+     * path with no `.`/`..` segments; a relative path or an unknown token (left
+     * unsubstituted) fails that check. Referencing a token whose value is
+     * unavailable in preflight is a distinct, clear error.
      *
      * @param string $raw The raw argument.
      * @param array<string,string|null> $tokens Token name => value (null = unavailable).
@@ -8691,7 +8701,7 @@ class ImportClient
      * checks to prevent directory traversal attacks that could write files
      * outside the import root.
      *
-     * With --remap active, an in-scope source path is first routed to its
+     * With --remap active, a source path matched by a remap rule is first routed to its
      * target (e.g. "/var/www/html/wp-content/x" -> "<docroot>/wp-content/x");
      * paths under no remap rule are still written under --fs-root using their
      * remote absolute path, exactly as a plain pull.
@@ -8708,6 +8718,7 @@ class ImportClient
         }
         return $this->get_filesystem_root_path() . $path;
     }
+
 
     /**
      * Returns the remainder of $path underneath $prefix,
@@ -9531,11 +9542,11 @@ class ImportClient
      */
     private function get_export_directories(): array
     {
-        // --only is a *replace*: the export roots ARE the resolved scope
-        // prefixes, so core/abspath/document_root, remap sources, and the
-        // auto-prepend/append dirs below are not walked by default — only the scope is.
-        if (!empty($this->scope)) {
-            return $this->scope;
+        // With --only, files-pull should enumerate only the selected source path
+        // prefixes. Do not add the default roots, remap sources, document root, or
+        // auto-prepend/append directories below.
+        if (!empty($this->pull_only_files_with_path_prefixes)) {
+            return $this->pull_only_files_with_path_prefixes;
         }
 
         $dirs = $this->get_root_directories_from_preflight();
@@ -9555,9 +9566,9 @@ class ImportClient
             $extra_paths["extra_directory"] = rtrim($this->extra_directory, "/");
         }
 
-        // Ensure every --remap source is enumerated — including a detached
-        // component (relocated uploads/plugins dir) that lives outside the
-        // WordPress roots and so wouldn't be discovered by traversal alone.
+        // Ensure every --remap source is enumerated — including plugins or
+        // uploads directories that live outside the WordPress roots and so
+        // wouldn't be discovered by traversal alone.
         $remap_index = 0;
         foreach (array_keys($this->remap_rules) as $source) {
             $extra_paths["remap_source_{$remap_index}"] = $source;
@@ -11723,7 +11734,7 @@ if (
             'target' => 'only',
             'placeholder' => 'SOURCE',
             'repeatable' => true,
-            'help' => 'Scope the pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
+            'help' => 'Restrict the files-pull command to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
                 'repeat for several. Default pulls everything',
             'commands' => ['files-pull'],
         ],

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -7,13 +7,13 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --only: the diff must reconcile ONLY within scope. A scoped remote index
- * lists in-scope paths only, so the delete drains in
+ * --only: the diff must reconcile only within the --only file path prefixes. A remote index built
+ * with --only lists selected paths only, so the delete drains in
  * diff_indexes_and_build_fetch_list() would otherwise wrongly delete every
- * out-of-scope local entry. Guard both drains so out-of-scope local files +
- * index entries survive, while in-scope orphans are still deleted (delta).
+ * unselected local entry. Guard both drains so unselected local files +
+ * index entries survive, while selected orphans are still deleted (delta).
  */
-class OnlyScopedDiffTest extends TestCase
+class OnlyFilesPathPrefixDiffTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
@@ -98,8 +98,8 @@ class OnlyScopedDiffTest extends TestCase
         return $paths;
     }
 
-    /** Mirror FilesSyncStateTest: load state + preserve-local, then set scope. */
-    private function prepareClient(array $scope): array
+    /** Mirror FilesSyncStateTest: load state + preserve-local, then set the --only file path prefixes. */
+    private function prepareClient(array $pull_only_files_with_path_prefixes): array
     {
         $defaults = [
             "command" => "files-pull",
@@ -119,36 +119,36 @@ class OnlyScopedDiffTest extends TestCase
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
         $r->getProperty('is_tty')->setValue($client, false);
         $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
-        $r->getProperty('scope')->setValue($client, $scope);
+        $r->getProperty('pull_only_files_with_path_prefixes')->setValue($client, $pull_only_files_with_path_prefixes);
         return [$client, $r];
     }
 
-    public function testScopedDiffKeepsOutOfScopeAndDeletesInScopeOrphan(): void
+    public function testOnlyFilesPrefixDiffKeepsUnselectedAndDeletesSelectedOrphan(): void
     {
-        // Local index (sorted): an out-of-scope entry, a matched in-scope file,
-        // and an in-scope orphan absent from the (scoped) remote index. The
-        // delete drains must reconcile only within scope, so the local index
-        // accumulates as a union across scoped runs.
+        // Local index (sorted): an unselected entry, a matched selected file,
+        // and a selected orphan absent from the --only remote index. The
+        // delete drains must reconcile only within the --only file prefixes, so the local index
+        // accumulates as a union across files-pull --only runs.
         $this->writeIndex('.import-index.jsonl',
-            $this->indexLine('/wp-config.php', 1000, 10)               // out of scope
+            $this->indexLine('/wp-config.php', 1000, 10)               // unselected
             . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
-            . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // in-scope orphan
+            . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // selected orphan
         );
         $this->writeIndex('.import-remote-index.jsonl',
             $this->indexLine('/wp-content/keep.txt', 1000, 10)
         );
 
-        $outOfScope = $this->seedLocalFile('/wp-config.php');
+        $unselected = $this->seedLocalFile('/wp-config.php');
         $this->seedLocalFile('/wp-content/keep.txt');
         $orphan = $this->seedLocalFile('/wp-content/old/orphan.txt');
 
         [$client, $r] = $this->prepareClient(['/wp-content']);
         $r->getMethod('diff_indexes_and_build_fetch_list')->invoke($client);
 
-        // Out-of-scope file AND its index entry survive.
-        $this->assertFileExists($outOfScope);
+        // Unselected file AND its index entry survive.
+        $this->assertFileExists($unselected);
         $this->assertContains('/wp-config.php', $this->readLocalIndexPaths());
-        // In-scope orphan file AND its index entry are deleted.
+        // Selected orphan file AND its index entry are deleted.
         $this->assertFileDoesNotExist($orphan);
         $this->assertNotContains('/wp-content/old/orphan.txt', $this->readLocalIndexPaths());
     }

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -7,15 +7,15 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --only scope resolution and enumeration (pure, preflight-injected):
- *   - resolve_scope(): :token: templates / absolute paths → real source
- *     prefixes (sharing --remap's source token table), with detached-component
- *     expansion for wp-content and covered-prefix collapse.
- *   - in_scope(): per-path membership (unscoped ⇒ everything in scope).
- *   - get_export_directories(): under scope, a *replace* of the export roots.
- * Orthogonal to --remap (scope = what gets pulled, not where it lands).
+ * --only file-prefix resolution and enumeration (pure, preflight-injected):
+ *   - resolve_pull_only_files_with_path_prefixes(): :token: templates / absolute paths → real source
+ *     prefixes (sharing --remap's WordPress path token table), with expansion for plugins, mu-plugins, and uploads
+ *     directories outside WP_CONTENT_DIR and covered-prefix collapse.
+ *   - is_file_path_selected_by_pull_only_files(): per-path membership (no --only ⇒ every file path).
+ *   - get_export_directories(): with --only, a *replace* of the export roots.
+ * Orthogonal to --remap (--only file prefixes decide what gets pulled, not where it lands).
  */
-class OnlyScopeTest extends TestCase
+class OnlyFilesPathPrefixTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
@@ -24,7 +24,7 @@ class OnlyScopeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/only-scope-' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/only-files-prefix-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/srv/htdocs';
         mkdir($this->stateDir, 0755, true);
@@ -61,101 +61,102 @@ class OnlyScopeTest extends TestCase
         return $c;
     }
 
-    /** Preflight carrying only the wp paths_urls (for resolve_scope/in_scope). */
+    /** Preflight carrying only the wp paths_urls needed by the --only file-prefix helpers. */
     private function withPaths(array $pathsUrls): \ImportClient
     {
         return $this->client(array('database' => array('wp' => array('paths_urls' => $pathsUrls))));
     }
 
-    public function testResolveScopeAddsDetachedComponentsForWpContent(): void
+    public function testResolvePullOnlyFilesPrefixAddsDirectoriesOutsideWpContent(): void
     {
-        // Scoping :wp-content: yields content_dir plus any component detached
-        // from it (uploads here); a nested component is already covered.
+        // Selecting :wp-content: with --only yields WP_CONTENT_DIR plus any plugins,
+        // mu-plugins, or uploads directory outside it (uploads here); a nested
+        // directory is already covered.
         $c = $this->withPaths(array(
             'content_dir' => '/var/www/html/wp-content',
             'plugins_dir' => '/var/www/html/wp-content/plugins', // nested → not added
-            'uploads' => array('basedir' => '/mnt/uploads'),     // detached → added
+            'uploads' => array('basedir' => '/mnt/uploads'),     // outside WP_CONTENT_DIR → added
         ));
-        $scope = $this->call($c, 'resolve_scope', array(array(':wp-content:')));
-        sort($scope);
-        $this->assertSame(array('/mnt/uploads', '/var/www/html/wp-content'), $scope);
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-content:')));
+        sort($pull_only_files_with_path_prefixes);
+        $this->assertSame(array('/mnt/uploads', '/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
 
-    public function testResolveScopeCollapsesNestedPrefixes(): void
+    public function testResolvePullOnlyFilesPrefixCollapsesNestedPrefixes(): void
     {
         // :wp-content:/plugins is nested under :wp-content: → dropped, so the
         // exporter never walks the subtree twice.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        $scope = $this->call($c, 'resolve_scope', array(array(':wp-content:', ':wp-content:/plugins')));
-        $this->assertSame(array('/var/www/html/wp-content'), $scope);
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-content:', ':wp-content:/plugins')));
+        $this->assertSame(array('/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
 
     public function testResolveMapsTokensToTheirRealRelocatedLocations(): void
     {
         // A token resolves to its real (possibly relocated) location: the moved
-        // plugins dir via :wp-plugins:. A component token narrower than
-        // wp-content does not expand detached components (no /detached/uploads
+        // plugins dir via :wp-plugins:. A token narrower than wp-content does
+        // not add sibling directories outside WP_CONTENT_DIR (no /external/uploads
         // pulled in).
         $c = $this->client(array('database' => array('wp' => array(
             'paths_urls' => array(
                 'content_dir' => '/srv/wp-content',
                 'plugins_dir' => '/custom/plugins',
                 'abspath' => '/var/www/html',
-                'uploads' => array('basedir' => '/detached/uploads'),
+                'uploads' => array('basedir' => '/external/uploads'),
             ),
         ))));
         $this->assertSame(
             array('/custom/plugins/woocommerce'),
-            $this->call($c, 'resolve_scope', array(array(':wp-plugins:/woocommerce')))
+            $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-plugins:/woocommerce')))
         );
     }
 
-    public function testResolveScopeAcceptsRawAbsolutePath(): void
+    public function testResolvePullOnlyFilesPrefixAcceptsRawAbsolutePath(): void
     {
         // Like --remap, a raw absolute source is taken literally (no tokens).
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->assertSame(
             array('/var/custom/data'),
-            $this->call($c, 'resolve_scope', array(array('/var/custom/data')))
+            $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array('/var/custom/data')))
         );
     }
 
-    public function testResolveScopeRejectsBlankSource(): void
+    public function testResolvePullOnlyFilesPrefixRejectsBlankSource(): void
     {
-        // Strict input hygiene: a blank source (e.g. from a trailing comma in
-        // `--only=:wp-content:,`) is an error, not silently ignored.
+        // Strict input hygiene: a blank source (e.g. `--only ""`) is an error,
+        // not silently ignored.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
-        $this->call($c, 'resolve_scope', array(array(':wp-content:', '')));
+        $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-content:', '')));
     }
 
-    public function testResolveScopeRejectsUnavailableToken(): void
+    public function testResolvePullOnlyFilesPrefixRejectsUnavailableToken(): void
     {
         // A token preflight didn't determine yields a clear, preflight-naming
         // error (shared with --remap's resolver).
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('preflight');
-        $this->call($c, 'resolve_scope', array(array(':abspath:/wp-admin')));
+        $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':abspath:/wp-admin')));
     }
 
-    public function testInScopeIsUnscopedTrueAndOtherwiseSlashAware(): void
+    public function testPullOnlyFilesPrefixSelectionDefaultsToTrueAndIsSlashAware(): void
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        // No --only: everything is in scope (keeps the diff deleting orphans).
-        $this->assertTrue($this->call($c, 'in_scope', array('/anything/at/all.php')));
+        // No --only: every file path is selected (keeps the diff deleting orphans).
+        $this->assertTrue($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/anything/at/all.php')));
 
-        $this->set($c, 'scope', array('/var/www/html/wp-content'));
-        $this->assertTrue($this->call($c, 'in_scope', array('/var/www/html/wp-content/themes/a.css')));
-        $this->assertFalse($this->call($c, 'in_scope', array('/var/www/html/wp-config.php')));
+        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
+        $this->assertTrue($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-content/themes/a.css')));
+        $this->assertFalse($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-config.php')));
         // Byte-order sibling must not match the prefix.
-        $this->assertFalse($this->call($c, 'in_scope', array('/var/www/html/wp-content.bak/x')));
+        $this->assertFalse($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-content.bak/x')));
     }
 
-    public function testScopedEnumerationReplacesRootsAndIgnoresOutOfScopeRemap(): void
+    public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void
     {
-        // Under scope, export roots ARE the scope: core/abspath/document_root
-        // are dropped, and an out-of-scope --remap source stays inert.
+        // With --only, export roots ARE the selected file prefixes: core/abspath/document_root
+        // are dropped, and an unselected --remap source stays inert.
         $c = $this->client(array(
             'wp_detect' => array('roots' => array(array('path' => '/var/www/html'))),
             'runtime' => array('document_root' => '/var/www/html'),
@@ -163,7 +164,7 @@ class OnlyScopeTest extends TestCase
                 'content_dir' => '/var/www/html/wp-content',
             ))),
         ));
-        $this->set($c, 'scope', array('/var/www/html/wp-content'));
+        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
         $this->set($c, 'remap_rules', array(
             '/var/www/html/wp-admin' => '/srv/htdocs/wp-admin',
         ));


### PR DESCRIPTION
## What it does

Renames the internal `files-pull --only` model from generic “scope” terminology to explicit file path prefix terminology.

Examples:

- `$scope` → `$pull_only_files_with_path_prefixes`
- `resolve_scope()` → `resolve_pull_only_files_with_path_prefixes()`
- `in_scope()` → `is_file_path_selected_by_pull_only_files()`

It also renames the matching tests from `OnlyScope*` to `OnlyFilesPathPrefix*` and clarifies comments around `plugins`, `mu-plugins`, and `uploads` directories that live outside `WP_CONTENT_DIR`.

## Rationale

`--only` is not a general “scope” system. It selects source file path prefixes for `files-pull`.

Using that language in names and comments makes the important behavior visible: these prefixes decide which remote file trees are enumerated and which local indexed paths may be reconciled during a scoped pull.

## Implementation

This is a naming/comment-only cleanup around the existing `--only` behavior:

- stores resolved `--only` prefixes in `$pull_only_files_with_path_prefixes`
- updates helper names and docblocks to say “file path prefixes” instead of “scope”
- renames `detached_content_component_sources()` to `content_directories_outside_wp_content()`
- renames `wp_component_source_paths()` to `wp_source_path_tokens()`
- replaces the nested-prefix check with `is_parent_dir()` where that is the intent

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/OnlyFilesPathPrefixTest.php
php -l tests/Import/OnlyFilesPathPrefixDiffTest.php
phpunit --configuration tests/phpunit.xml --filter 'OnlyCliParse|OnlyFilesPathPrefix'
```
