### PR TITLE
Reject changed --only values while resuming files-pull

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2623,6 +2623,7 @@ class ImportClient
             $current_status !== "complete";
 
         $this->recover_index_updates();
+        $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
 
         // Already completed.
         if ($current_status === "complete") {
@@ -2654,6 +2655,7 @@ class ImportClient
                 ], true);
                 $this->state["status"] = "in_progress";
                 $this->state["stage"] = "fetch-skipped";
+                $this->state["files_pull_only_fingerprint"] = $this->files_pull_only_fingerprint();
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
@@ -2763,6 +2765,7 @@ class ImportClient
             $this->state["command"] = "files-pull";
             $this->state["status"] = "in_progress";
             $this->state["stage"] = "index";
+            $this->state["files_pull_only_fingerprint"] = $this->files_pull_only_fingerprint();
             $this->state["diff"] = $this->default_state()["diff"];
             $this->state["index"] = $this->default_state()["index"];
             $this->state["fetch"] = $this->default_state()["fetch"];
@@ -8425,6 +8428,53 @@ class ImportClient
     }
 
     /**
+     * Refuse to resume a files-pull after changing --only.
+     *
+     * The in-progress remote index cursor/file was built from one directory[]
+     * allowlist. Switching the selected source path prefixes mid-resume would
+     * mix indexes from different traversals. Completed runs are allowed to use
+     * different --only prefixes because the local index is intentionally a union
+     * across files-pull --only runs.
+     */
+    private function assert_files_pull_only_unchanged_while_resuming(bool $has_progress): void
+    {
+        if (!$has_progress) {
+            return;
+        }
+
+        $fingerprint = $this->files_pull_only_fingerprint();
+        $previous = $this->state["files_pull_only_fingerprint"] ?? null;
+
+        if ($previous !== null && $previous !== $fingerprint) {
+            throw new RuntimeException(
+                "Cannot change --only while resuming files-pull. " .
+                    "Use the original --only values, or use --abort to start a new files-pull.",
+            );
+        }
+
+        // Older in-progress state may not have this guard persisted yet. Record
+        // the current value so subsequent resumes cannot drift.
+        if ($previous === null) {
+            $this->state["files_pull_only_fingerprint"] = $fingerprint;
+            $this->save_state($this->state);
+        }
+    }
+
+    /**
+     * Stable fingerprint for the resolved --only file path prefixes.
+     *
+     * Prefix order is part of the fingerprint because it determines the first
+     * list_dir used to start the traversal.
+     */
+    private function files_pull_only_fingerprint(): string
+    {
+        return hash(
+            "sha256",
+            json_encode($this->pull_only_files_with_path_prefixes, JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
      * Build the remap rules from the raw remap pairs + preflight data.
      *
      * Each argument is a template string of `:token:` substitutions and/or a raw absolute path.
@@ -10700,6 +10750,7 @@ class ImportClient
             "filter" => "none",
             "max_allowed_packet" => null,
             "files_remap_fingerprint" => null,
+            "files_pull_only_fingerprint" => null,
             "db_index" => [
                 "file" => null,
                 "tables" => 0,

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -33,14 +33,23 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     protected function tearDown(): void
     {
-        foreach (array_reverse(glob($this->tempDir . '/*') ?: array()) as $p) {
-            is_dir($p) ? @rmdir($p) : @unlink($p);
-        }
-        @rmdir($this->stateDir);
-        @rmdir($this->fsRoot);
-        @rmdir($this->tempDir . '/srv');
-        @rmdir($this->tempDir);
+        $this->recursiveDelete($this->tempDir);
         parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            (is_dir($path) && !is_link($path)) ? $this->recursiveDelete($path) : unlink($path);
+        }
+        rmdir($dir);
     }
 
     private function call($c, string $m, array $a = array())
@@ -65,6 +74,68 @@ class OnlyFilesPathPrefixTest extends TestCase
     private function withPaths(array $pathsUrls): \ImportClient
     {
         return $this->client(array('database' => array('wp' => array('paths_urls' => $pathsUrls))));
+    }
+
+    private function onlyFingerprint(array $prefixes): string
+    {
+        return hash('sha256', json_encode($prefixes, JSON_UNESCAPED_SLASHES));
+    }
+
+    private function writeFilesPullState(array $state): void
+    {
+        $defaults = array(
+            'command' => 'files-pull',
+            'status' => 'in_progress',
+            'stage' => 'diff',
+            'preflight' => array(
+                'data' => array(
+                    'database' => array(
+                        'wp' => array(
+                            'paths_urls' => array(
+                                'content_dir' => '/var/www/html/wp-content',
+                                'uploads' => array('basedir' => '/var/www/html/wp-content/uploads'),
+                            ),
+                        ),
+                    ),
+                    'wp_detect' => array(
+                        'roots' => array(array('path' => '/var/www/html')),
+                    ),
+                ),
+                'http_code' => 200,
+            ),
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+            'filter' => 'none',
+        );
+
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function runFilesPullWithOnly(array $only): void
+    {
+        $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
+        $output = fopen('php://temp', 'w');
+        $clientReflection = new \ReflectionClass($c);
+        $clientReflection->getProperty('progress_fd')->setValue($c, $output);
+        $progress = $clientReflection->getProperty('progress')->getValue($c);
+        (new \ReflectionClass($progress))->getProperty('progress_fd')->setValue($progress, $output);
+
+        try {
+            $c->run(array(
+                'command' => 'files-pull',
+                'only' => $only,
+            ));
+        } finally {
+            fclose($output);
+        }
+    }
+
+    private function readState(): array
+    {
+        return json_decode(file_get_contents($this->stateDir . '/.import-state.json'), true);
     }
 
     public function testResolvePullOnlyFilesPrefixAddsDirectoriesOutsideWpContent(): void
@@ -151,6 +222,91 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->assertFalse($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-config.php')));
         // Byte-order sibling must not match the prefix.
         $this->assertFalse($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-content.bak/x')));
+    }
+
+    public function testChangingOnlyPrefixesWhileResumingFilesPullIsRejected(): void
+    {
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+
+        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
+        $original_fingerprint = $this->call($c, 'files_pull_only_fingerprint');
+
+        $this->set($c, 'state', array('files_pull_only_fingerprint' => $original_fingerprint));
+        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot change --only while resuming files-pull');
+        $this->call($c, 'assert_files_pull_only_unchanged_while_resuming', array(true));
+    }
+
+    public function testChangingOnlyPrefixesAfterCompletedFilesPullIsAllowed(): void
+    {
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+
+        $this->set($c, 'state', array('files_pull_only_fingerprint' => 'different'));
+        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
+
+        $this->call($c, 'assert_files_pull_only_unchanged_while_resuming', array(false));
+        $this->addToAssertionCount(1);
+    }
+
+
+    public function testRunRejectsChangingOnlyPrefixesWhileFilesPullIsInProgress(): void
+    {
+        $this->writeFilesPullState(array(
+            'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+        ));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot change --only while resuming files-pull');
+        $this->runFilesPullWithOnly(array(':wp-uploads:'));
+    }
+
+    public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
+    {
+        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
+        $this->writeFilesPullState(array(
+            'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+        ));
+
+        $this->runFilesPullWithOnly(array(':wp-content:/plugins'));
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status'] ?? null);
+        $this->assertSame(
+            $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            $state['files_pull_only_fingerprint'] ?? null
+        );
+    }
+
+    public function testRunRecordsOnlyFingerprintForLegacyInProgressFilesPullState(): void
+    {
+        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
+        $this->writeFilesPullState(array(
+            'files_pull_only_fingerprint' => null,
+        ));
+
+        $this->runFilesPullWithOnly(array(':wp-content:/plugins'));
+
+        $state = $this->readState();
+        $this->assertSame(
+            $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            $state['files_pull_only_fingerprint'] ?? null
+        );
+    }
+
+    public function testRunAllowsChangingOnlyPrefixesAfterCompletedFilesPull(): void
+    {
+        $this->writeFilesPullState(array(
+            'status' => 'complete',
+            'stage' => null,
+            'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+        ));
+
+        $this->runFilesPullWithOnly(array(':wp-uploads:'));
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status'] ?? null);
     }
 
     public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void


### PR DESCRIPTION
## What it does

Rejects changed `--only` values while resuming an incomplete `files-pull`.

Completed `files-pull` runs can still use different `--only` values later, so scoped pulls can build a union in the local file index over time.

## Rationale

An in-progress remote index cursor/file is tied to one `directory[]` allowlist. If `--only` changes mid-resume, the importer can mix index data from different traversals.

That guard should apply only while a `files-pull` is incomplete. Once the run is complete, changing `--only` is safe and expected.

## Implementation

Stores `files_pull_only_fingerprint`, a stable fingerprint of the resolved `--only` file path prefixes, when a fresh `files-pull` starts.

On resume:

- matching fingerprint: continue
- missing fingerprint from older in-progress state: record the current one
- different fingerprint: fail with a clear `Cannot change --only while resuming files-pull` error

The tests cover both the helper-level invariant and the real `run()` path:

- changing `--only` during an in-progress `files-pull` is rejected
- resuming with the same `--only` succeeds
- older in-progress state without a fingerprint gets one recorded
- completed `files-pull` state can use different `--only` values later

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/OnlyFilesPathPrefixTest.php
phpunit --configuration tests/phpunit.xml --filter 'OnlyCliParse|OnlyFilesPathPrefixTest'
```
