### PR TITLE
Emit a dispatch-free `runtime.prepend.php` from the php-builtin applier

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ wraps it differently:
 
 | Runtime | Output files | How runtime.php loads |
 |---------|-------------|----------------------|
-| `php-builtin` | `runtime.php`, `start.sh` | Used as the router script for `php -S` |
+| `php-builtin` | `runtime.php`, `runtime.prepend.php`, `start.sh` | `runtime.php` is the router script for `php -S`; `runtime.prepend.php` is a routing-free variant for hosts that own request dispatch and inject it via `auto_prepend_file` |
 | `nginx-fpm` | `runtime.php`, `nginx.conf` | Loaded via `auto_prepend_file` in `fastcgi_param PHP_VALUE` |
 
 The architecture separates source host detection from target runtime

--- a/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
@@ -3,14 +3,27 @@
  * Runtime applier for PHP's built-in development server.
  *
  * Writes:
- * 1. {output_dir}/runtime.php — constants, server vars, route handlers,
- *                                and CLI-server routing logic
- * 2. {output_dir}/start.sh    — shell script with the exact php -S command
+ * 1. {output_dir}/runtime.php         — constants, server vars, route
+ *                                        handlers, and CLI-server routing
+ * 2. {output_dir}/runtime.prepend.php — the same base layers WITHOUT the
+ *                                        routing tail, for hosts that own
+ *                                        request dispatch and inject it via
+ *                                        auto_prepend_file
+ * 3. {output_dir}/start.sh            — shell script with the exact php -S
+ *                                        command
  *
  * runtime.php is the router script passed to php -S. It defines constants,
  * runs route handlers, then handles request routing. PHP files are served
  * via require (not return false) so they execute in the same scope where
  * constants are already defined — no auto_prepend_file needed.
+ *
+ * runtime.prepend.php is for the inverse case: a host (an external php -S
+ * router, FPM, etc.) owns routing and only needs reprint's environment
+ * (constants + SQLite $wpdb shim + uploads proxy) injected ahead of each
+ * request via auto_prepend_file. It deliberately omits the routing tail,
+ * which would otherwise dispatch WordPress during the prepend phase and
+ * bypass the SQLite shim, falling back to MySQL ("Error establishing a
+ * database connection").
  *
  * The developer just runs: bash {output_dir}/start.sh
  */
@@ -23,14 +36,29 @@ class PhpBuiltinApplier implements RuntimeApplier
 
         $summary = [];
 
-        // 1. Write runtime.php (base layers + CLI-server routing)
+        // The base layers (constants, server vars, SQLite $wpdb shim,
+        // uploads proxy) are routing-free and safe to inject as an
+        // auto_prepend_file. The CLI-server routing tail is the only part
+        // that dispatches WordPress, so it must NOT appear in the prepend
+        // artifact — see runtime.prepend.php below.
+        $base = generate_runtime_php($manifest, $fs_root);
+
+        // 1. Write runtime.php (base layers + CLI-server routing). This is
+        //    the standalone router passed to `php -S` by start.sh.
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $fs_root);
-        $runtime .= $this->generate_cli_server_routing($options);
-        write_runtime_file($runtime_path, $runtime);
+        write_runtime_file($runtime_path, $base . $this->generate_cli_server_routing($options));
         $summary[] = "Wrote {$runtime_path}";
 
-        // 2. Write start.sh
+        // 2. Write runtime.prepend.php (base layers only, no routing tail).
+        //    For hosts that own request dispatch — an external `php -S`
+        //    router, FPM, etc. — and inject this via auto_prepend_file.
+        //    Dispatching WordPress from the routing tail during the prepend
+        //    phase would bypass the SQLite $wpdb shim and fall back to MySQL.
+        $prepend_path = $output_dir . '/runtime.prepend.php';
+        write_runtime_file($prepend_path, $base);
+        $summary[] = "Wrote {$prepend_path}";
+
+        // 3. Write start.sh
         $start_path = $output_dir . '/start.sh';
         $start_script = $this->generate_start_script($manifest, $fs_root, $runtime_path, $host, $port);
         write_runtime_file($start_path, $start_script);
@@ -51,8 +79,15 @@ class PhpBuiltinApplier implements RuntimeApplier
      * PHP file execution with PATH_INFO support, and WordPress
      * pretty-permalink fallback.
      *
-     * This code only runs under php -S (guarded by php_sapi_name check).
-     * It's appended to runtime.php after the base layers.
+     * This tail dispatches WordPress (require index.php) and runs
+     * unconditionally — there is no SAPI guard, and php_sapi_name() is
+     * 'cli-server' whether reprint owns the `php -S` router or an external
+     * one injects runtime.php as auto_prepend_file, so it could not
+     * distinguish them anyway. It is appended to runtime.php after the base
+     * layers and is correct only when reprint owns the server (start.sh →
+     * `php -S … runtime.php`). When a host owns request dispatch it must
+     * inject runtime.prepend.php (base layers only) instead, never this
+     * combined file.
      */
     private function generate_cli_server_routing(array $options): string
     {

--- a/tests/Import/PhpBuiltinPrependArtifactTest.php
+++ b/tests/Import/PhpBuiltinPrependArtifactTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/host/class-runtime-manifest.php';
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/target-runtime/load.php';
+
+/**
+ * The php-builtin applier writes two runtime artifacts:
+ *
+ *   - runtime.php          — the standalone `php -S` router (base layers +
+ *                            CLI-server routing tail that dispatches WP).
+ *   - runtime.prepend.php  — base layers only (constants + SQLite $wpdb shim
+ *                            + uploads proxy), for hosts that own request
+ *                            dispatch and inject it via auto_prepend_file.
+ *
+ * The routing tail must never leak into the prepend artifact: dispatching
+ * WordPress during the prepend phase bypasses the SQLite shim and falls back
+ * to MySQL ("Error establishing a database connection").
+ */
+class PhpBuiltinPrependArtifactTest extends TestCase
+{
+    /** Marker the routing tail emits as its first line. */
+    private const ROUTING_MARKER = '// CLI-server routing';
+
+    private string $tempDir;
+    private string $docRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempDir = sys_get_temp_dir() . '/php-builtin-prepend-' . uniqid('', true);
+        $this->docRoot = $this->tempDir . '/docroot';
+        mkdir($this->docRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    /**
+     * Apply the php-builtin runtime into a fresh output dir and return it.
+     *
+     * @param array{plugin_source: string, plugin_dir: string, db_dir: string, db_file: string}|null $sqlite
+     */
+    private function applyRuntime(string $subdir, ?array $sqlite = null): string
+    {
+        $outputDir = $this->tempDir . '/' . $subdir;
+
+        $manifest = new \RuntimeManifest('other');
+        $manifest->sqlite = $sqlite;
+
+        $applier = new \PhpBuiltinApplier();
+        $applier->apply($manifest, $this->docRoot, $outputDir, [
+            'wordpress_index' => $this->docRoot . '/index.php',
+        ]);
+
+        return $outputDir;
+    }
+
+    public function testApplyWritesBothRuntimeAndPrependFiles(): void
+    {
+        $outputDir = $this->applyRuntime('runtime');
+
+        $this->assertFileExists($outputDir . '/runtime.php');
+        $this->assertFileExists($outputDir . '/runtime.prepend.php');
+    }
+
+    public function testRuntimePhpEndsWithRoutingTail(): void
+    {
+        $outputDir = $this->applyRuntime('runtime');
+
+        $runtime = file_get_contents($outputDir . '/runtime.php');
+        $this->assertStringContainsString(self::ROUTING_MARKER, $runtime);
+    }
+
+    public function testPrependFileOmitsRoutingTailButKeepsBaseLayers(): void
+    {
+        $outputDir = $this->applyRuntime('runtime');
+
+        $prepend = file_get_contents($outputDir . '/runtime.prepend.php');
+        $runtime = file_get_contents($outputDir . '/runtime.php');
+
+        // No dispatch tail in the prepend artifact.
+        $this->assertStringNotContainsString(self::ROUTING_MARKER, $prepend);
+
+        // The prepend artifact is exactly the base prefix of runtime.php —
+        // runtime.php is the prepend plus the appended routing tail.
+        $this->assertStringStartsWith($prepend, $runtime);
+        $this->assertNotSame($prepend, $runtime);
+    }
+
+    public function testBothArtifactsAreSyntacticallyValid(): void
+    {
+        $outputDir = $this->applyRuntime('runtime', $this->fakeSqliteConfig());
+
+        foreach (['runtime.php', 'runtime.prepend.php'] as $name) {
+            $path = $outputDir . '/' . $name;
+            $output = [];
+            $code = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' -l ' . escapeshellarg($path) . ' 2>&1', $output, $code);
+            $this->assertSame(0, $code, "php -l failed for {$name}:\n" . implode("\n", $output));
+        }
+    }
+
+    /**
+     * The behavioral guarantee: inject runtime.prepend.php as auto_prepend_file
+     * ahead of an external script (exactly how Studio's native php -S router
+     * consumes it). The prepend must install the SQLite $wpdb proxy and must
+     * NOT dispatch WordPress, so $GLOBALS['wpdb'] resolves to the SQLite loader
+     * — WordPress would see $wpdb already set and never reach MySQL.
+     */
+    public function testPrependInstallsSqliteProxyWithoutDispatch(): void
+    {
+        $outputDir = $this->applyRuntime('runtime', $this->fakeSqliteConfig());
+        $prependPath = $outputDir . '/runtime.prepend.php';
+
+        // A trivial "host-owned" script that runs after the prepend and reports
+        // which $wpdb the prepend installed. It never touches the database, so
+        // the lazy SQLite integration plugin is never required.
+        $probe = $outputDir . '/probe.php';
+        file_put_contents(
+            $probe,
+            "<?php\n" .
+            "echo 'WPDB_CLASS=' . (isset(\$GLOBALS['wpdb']) ? get_class(\$GLOBALS['wpdb']) : 'NONE') . \"\\n\";\n",
+        );
+
+        $cmd = escapeshellarg(PHP_BINARY)
+            . ' -d auto_prepend_file=' . escapeshellarg($prependPath)
+            . ' ' . escapeshellarg($probe)
+            . ' 2>&1';
+
+        $output = [];
+        $code = 0;
+        exec($cmd, $output, $code);
+        $joined = implode("\n", $output);
+
+        $this->assertSame(0, $code, "prepend run failed:\n" . $joined);
+        $this->assertStringContainsString('WPDB_CLASS=Streaming_SQLite_Loader', $joined);
+        $this->assertStringNotContainsString('Error establishing a database connection', $joined);
+        $this->assertStringNotContainsString('Fatal error', $joined);
+    }
+
+    /**
+     * SQLite config whose paths are never resolved by these tests — the proxy
+     * loads the integration plugin lazily, only on the first real DB call.
+     *
+     * @return array{plugin_source: string, plugin_dir: string, db_dir: string, db_file: string}
+     */
+    private function fakeSqliteConfig(): array
+    {
+        return [
+            'plugin_source' => $this->tempDir . '/sqlite-source',
+            'plugin_dir' => $this->tempDir . '/sqlite-plugin',
+            'db_dir' => $this->tempDir . '/db',
+            'db_file' => 'wp.sqlite',
+        ];
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## What it does

The `php-builtin` runtime applier now writes a second artifact, `runtime.prepend.php`, alongside `runtime.php`. It contains the same environment setup (DB constants, the lazy SQLite `$wpdb` proxy, the uploads proxy) **without** the CLI-server routing tail that dispatches WordPress.

`runtime.php` and `start.sh` are unchanged, so standalone `php -S` usage is unaffected.

## Rationale

`runtime.php` glues together two unrelated jobs: (1) environment setup and (2) a request router that `require`s WordPress. Both are correct when reprint owns the server (`start.sh` → `php -S … runtime.php`).

But WordPress Studio's native-PHP `pull-reprint` runs its **own** `php -S … router.php` workers and injects reprint's environment via `-d auto_prepend_file=runtime.php`. `auto_prepend_file` is a per-request bootstrap slot, not a dispatch slot — so the routing tail dispatches WordPress during the prepend phase, the SQLite `$wpdb` shim no longer governs the request that actually serves the page, WordPress falls back to the real MySQL `wpdb`, and every pulled site dies at startup with *"Error establishing a database connection"* (the worker exits 1).

Studio currently works around this by string-stripping the router tail off `runtime.php` downstream. This change supplies the clean artifact instead. It mirrors the existing `nginx-fpm` applier, which already ships a routing-free `runtime.php` consumed via `auto_prepend_file`.

## Implementation

- `PhpBuiltinApplier::apply()` computes the routing-free base once, then writes `runtime.php` = base + routing tail (unchanged) and `runtime.prepend.php` = base only.
- Fixes the `generate_cli_server_routing()` docblock, which falsely claimed the routing tail was guarded by a `php_sapi_name` check. It runs unconditionally — and `php_sapi_name()` is `cli-server` in both modes, so it could not distinguish them anyway.
- README runtime-output table lists the new file.

New test `PhpBuiltinPrependArtifactTest` covers:

- both files are written; `runtime.php` keeps the routing tail; `runtime.prepend.php` omits it but is the exact base prefix of `runtime.php`
- both artifacts are `php -l`-clean
- behavioral: running `php -d auto_prepend_file=runtime.prepend.php <probe>` resolves `$GLOBALS['wpdb']` to the SQLite loader with no dispatch and no DB error — exactly Studio's injection path

## Testing instructions
TBD

