### PR TITLE
Preserve local file edits during pull-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ the `--on-fs-root-nonempty` flag controls this behavior. It takes the following 
 - `--on-fs-root-nonempty=error` (default): throw an error and abort.
 - `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
 
+**Local file conflicts**
+
+After a file has been synced once, later delta pulls protect local edits by default. If the remote file changed but the local file no longer matches the last synced fingerprint, Reprint keeps the local file and reports the conflict in `.import-local-conflicts.jsonl`. To replace locally edited files with the remote version, run with `--on-local-conflict=overwrite`.
+
 **Filtering files**
 
 The `--filter` flag controls which files are downloaded. This is useful when the media library is large
@@ -634,7 +638,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 ```
 
 * `pull` — Pull the full site. Runs `preflight`, `files-download`, and `db-download`, then adds `db-apply`, `flat-docroot`, `apply-runtime`, and runtime start stages when their options are set.
-* `pull-files` — Pull only files. Runs `preflight` and `files-download`, looping through partial transfers until the local files match the remote site. Re-running performs a delta pull.
+* `pull-files` — Pull only files. Runs `preflight` and `files-download`, looping through partial transfers until the local files match the remote site. Re-running performs a delta pull and preserves locally edited files unless `--on-local-conflict=overwrite` is set.
 * `pull-db` — Pull only the database. Runs `preflight`, `db-download`, and `db-apply`, looping through partial transfers/applies until the target database is up to date. Use `db-download` directly for `--sql-output=stdout` or `--sql-output=mysql`.
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1045,6 +1045,9 @@ class ImportClient
     /** @var string Path to .import-volatile-files.json — files the server marks as frequently-changing. */
     private $volatile_files_file;
 
+    /** @var string Path to .import-local-conflicts.jsonl — tracked local files preserved during delta sync. */
+    private $local_conflicts_file;
+
     /** @var bool When true, emit detailed operation logs to stdout. Set via --verbose. */
     private $verbose_mode = false;
 
@@ -1116,6 +1119,12 @@ class ImportClient
      * Set via --on-fs-root-nonempty, persisted in state so it survives across invocations.
      */
     private $fs_root_nonempty_behavior = 'error';
+
+    /**
+     * What to do when a tracked local file changed after the last successful sync.
+     * Set via --on-local-conflict.
+     */
+    private $local_conflict_behavior = 'preserve-local';
 
     /**
      * Controls which files are downloaded during files-download.
@@ -1237,6 +1246,7 @@ class ImportClient
             $this->state_dir . "/.import-download-list-skipped.jsonl";
         $this->audit_log = $this->state_dir . "/.import-audit.log";
         $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
+        $this->local_conflicts_file = $this->state_dir . "/.import-local-conflicts.jsonl";
         $this->status_file = $this->state_dir . "/.import-status.json";
 
         // Detect TTY for progress display. In stdout mode this is re-evaluated
@@ -1500,6 +1510,43 @@ class ImportClient
         );
     }
 
+    private function report_local_conflicts(): void
+    {
+        if (!is_file($this->local_conflicts_file) || filesize($this->local_conflicts_file) === 0) {
+            return;
+        }
+
+        $conflicts = [];
+        $handle = fopen($this->local_conflicts_file, "r");
+        if ($handle) {
+            while (($line = fgets($handle)) !== false) {
+                $record = json_decode($line, true);
+                if (is_array($record) && isset($record["path"])) {
+                    $conflicts[] = $record;
+                }
+            }
+            fclose($handle);
+        }
+
+        if (empty($conflicts)) {
+            return;
+        }
+
+        $count = count($conflicts);
+        $this->progress->show_lifecycle_line("{$count} local file(s) changed since the last sync and were preserved:\n");
+        foreach ($conflicts as $conflict) {
+            $this->progress->show_lifecycle_line("  {$conflict["path"]}\n");
+        }
+        $this->progress->show_lifecycle_line("Re-run with --on-local-conflict=overwrite to replace them with the remote version.\n");
+
+        $this->output_progress([
+            "type" => "local_conflicts",
+            "count" => $count,
+            "conflicts" => $conflicts,
+            "message" => "{$count} local file(s) changed since the last sync and were preserved",
+        ], true);
+    }
+
     /**
      * Emit a preserve-local skip event to both TTY progress line and JSONL.
      */
@@ -1534,6 +1581,15 @@ class ImportClient
                 throw new InvalidArgumentException(
                     "Invalid --on-fs-root-nonempty value: {$this->fs_root_nonempty_behavior}. " .
                         "Valid values: error, preserve-local",
+                );
+            }
+        }
+        if (isset($options["local_conflict_behavior"])) {
+            $this->local_conflict_behavior = $options["local_conflict_behavior"];
+            if (!in_array($this->local_conflict_behavior, ['preserve-local', 'overwrite'], true)) {
+                throw new InvalidArgumentException(
+                    "Invalid --on-local-conflict value: {$this->local_conflict_behavior}. " .
+                        "Valid values: preserve-local, overwrite",
                 );
             }
         }
@@ -2908,6 +2964,7 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+        $this->report_local_conflicts();
     }
 
     /**
@@ -6364,6 +6421,9 @@ class ImportClient
         $remote_offset = (int) ($diff["remote_offset"] ?? 0);
         $local_after = $diff["local_after"] ?? null;
         $download_mode = $remote_offset > 0 ? "a" : "w";
+        if ($download_mode === "w" && file_exists($this->local_conflicts_file)) {
+            @unlink($this->local_conflicts_file);
+        }
         if ($download_mode === "w") {
             $this->audit_log(
                 "FILE CREATE | {$this->download_list_file} | building download list",
@@ -6449,6 +6509,11 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-download --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
+                    if ($this->preserve_local_conflict($local, null, 'delete')) {
+                        $local_after = $local["path"];
+                        $local = $this->read_index_line($local_handle);
+                        continue;
+                    }
                     $this->delete_local_file_path($local["path"]);
                     $this->delete_index_entry($local["path"]);
                 }
@@ -6462,10 +6527,11 @@ class ImportClient
                     $local["size"] !== $remote["size"] ||
                     $local["type"] !== $remote["type"]
                 ) {
-                    // File is in both indexes but changed on the remote.
-                    // Always re-download — this file is in our local index,
-                    // meaning we synced it before; preserve-local does not
-                    // protect files we own.
+                    if ($this->preserve_local_conflict($local, $remote, 'overwrite')) {
+                        $local_after = $local["path"];
+                        $local = $this->read_index_line($local_handle);
+                        continue;
+                    }
                     $target_handle = ($skipped_handle !== null && $this->is_uploads_path($remote["path"], $uploads_basedir))
                         ? $skipped_handle
                         : $download_handle;
@@ -6505,6 +6571,11 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
+                if ($this->preserve_local_conflict($local, null, 'delete')) {
+                    $local_after = $local["path"];
+                    $local = $this->read_index_line($local_handle);
+                    continue;
+                }
                 $this->delete_local_file_path($local["path"]);
                 $this->delete_index_entry($local["path"]);
             }
@@ -6849,6 +6920,128 @@ class ImportClient
         }
         // Fallback: match the conventional WordPress uploads path
         return strpos($path, "wp-content/uploads/") !== false;
+    }
+
+    private function preserve_local_conflict(array $local, ?array $remote, string $action): bool
+    {
+        if ($this->local_conflict_behavior === 'overwrite') {
+            return false;
+        }
+        if ($action === 'delete' && !$this->local_index_path_exists($local)) {
+            return false;
+        }
+        if ($this->local_path_matches_index_entry($local)) {
+            return false;
+        }
+
+        $this->record_local_conflict($local, $remote, $action);
+        $this->emit_local_conflict_progress($local["path"]);
+        return true;
+    }
+
+    private function local_index_path_exists(array $entry): bool
+    {
+        $path = $entry["path"] ?? "";
+        if ($path === "") {
+            return false;
+        }
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        } catch (RuntimeException $e) {
+            return false;
+        }
+        return file_exists($local_path) || is_link($local_path);
+    }
+
+    private function local_path_matches_index_entry(array $entry): bool
+    {
+        $path = $entry["path"] ?? "";
+        if ($path === "") {
+            return true;
+        }
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        } catch (RuntimeException $e) {
+            return false;
+        }
+
+        $type = $entry["type"] ?? "file";
+        if ($type === "file") {
+            if (!is_file($local_path) || is_link($local_path)) {
+                return false;
+            }
+            return filesize($local_path) === (int) $entry["size"] &&
+                filemtime($local_path) === (int) $entry["ctime"];
+        }
+
+        if ($type === "dir") {
+            return is_dir($local_path) && !is_link($local_path);
+        }
+
+        if ($type === "link") {
+            return is_link($local_path);
+        }
+
+        return false;
+    }
+
+    private function record_local_conflict(array $local, ?array $remote, string $action): void
+    {
+        $path = $local["path"];
+        $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $record = [
+            "path" => $path,
+            "action" => $action,
+            "resolution" => "preserve-local",
+            "synced" => [
+                "ctime" => (int) ($local["ctime"] ?? 0),
+                "size" => (int) ($local["size"] ?? 0),
+                "type" => (string) ($local["type"] ?? "file"),
+            ],
+            "local" => [
+                "mtime" => (file_exists($local_path) || is_link($local_path)) ? (int) filemtime($local_path) : null,
+                "size" => is_file($local_path) && !is_link($local_path) ? (int) filesize($local_path) : null,
+                "type" => $this->local_path_type($local_path),
+            ],
+        ];
+        if ($remote !== null) {
+            $record["remote"] = [
+                "ctime" => (int) ($remote["ctime"] ?? 0),
+                "size" => (int) ($remote["size"] ?? 0),
+                "type" => (string) ($remote["type"] ?? "file"),
+            ];
+        }
+
+        $line = json_encode($record, JSON_UNESCAPED_SLASHES);
+        if ($line !== false) {
+            file_put_contents($this->local_conflicts_file, $line . "\n", FILE_APPEND);
+        }
+        $this->audit_log("LOCAL CONFLICT | {$action} preserved local path: {$path}", true);
+    }
+
+    private function local_path_type(string $path): ?string
+    {
+        if (is_link($path)) {
+            return "link";
+        }
+        if (is_file($path)) {
+            return "file";
+        }
+        if (is_dir($path)) {
+            return "dir";
+        }
+        return null;
+    }
+
+    private function emit_local_conflict_progress(string $path): void
+    {
+        $this->progress->show_progress_line("[conflict] " . $this->display_path($path));
+        $this->output_progress([
+            "type" => "local_conflict",
+            "path" => $path,
+            "resolution" => "preserve-local",
+            "message" => "Local changes preserved: {$path}",
+        ], true);
     }
 
     /**
@@ -11650,6 +11843,16 @@ if (
             'help_section' => 'global',
             'commands' => ['pull', 'pull-files', 'files-download'],
             'aliases' => ['on-docroot-nonempty'],
+        ],
+        [
+            'name' => 'on-local-conflict',
+            'type' => 'value',
+            'target' => 'local_conflict_behavior',
+            'placeholder' => 'MODE',
+            'valid_values' => ['preserve-local', 'overwrite'],
+            'help' => 'What to do when a tracked local file changed since the last sync (preserve-local|overwrite)',
+            'help_section' => 'global',
+            'commands' => ['pull', 'pull-files', 'files-download'],
         ],
         [
             'name' => 'include-caches',

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -282,8 +282,8 @@ class FilesSyncStateTest extends TestCase
      * In preserve-local mode, a file that is in the local index and changed
      * remotely (different ctime) must be added to the download list.
      *
-     * Preserve-local protects pre-existing local files, not files we
-     * previously synced. A changed file in the local index is ours to update.
+     * Preserve-local protects files changed locally after their last sync.
+     * A clean indexed file is ours to update when the remote version changes.
      */
     public function testDeltaDiffRedownloadsChangedIndexedFile()
     {
@@ -295,10 +295,11 @@ class FilesSyncStateTest extends TestCase
         $remoteIndex = $this->stateDir . '/.import-remote-index.jsonl';
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
-        // The file exists locally (downloaded during the initial sync)
+        // The file exists locally exactly as recorded in the last local index.
         $localFile = $this->fs_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
-        file_put_contents($localFile, 'old content');
+        file_put_contents($localFile, str_repeat('x', 200));
+        touch($localFile, 1000);
 
         $this->writeState([
             "command" => "files-download",

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -67,13 +67,16 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     }
 
     /** Create a local file under fs_root for a (source-absolute) index path. */
-    private function seedLocalFile(string $path, string $contents = "x"): string
+    private function seedLocalFile(string $path, string $contents = "x", ?int $mtime = null): string
     {
         $full = $this->fs_root . $path;
         if (!is_dir(dirname($full))) {
             mkdir(dirname($full), 0755, true);
         }
         file_put_contents($full, $contents);
+        if ($mtime !== null) {
+            touch($full, $mtime);
+        }
         return $full;
     }
 
@@ -138,9 +141,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             $this->indexLine('/wp-content/keep.txt', 1000, 10)
         );
 
-        $unselected = $this->seedLocalFile('/wp-config.php');
-        $this->seedLocalFile('/wp-content/keep.txt');
-        $orphan = $this->seedLocalFile('/wp-content/old/orphan.txt');
+        $unselected = $this->seedLocalFile('/wp-config.php', str_repeat('x', 10), 1000);
+        $this->seedLocalFile('/wp-content/keep.txt', str_repeat('x', 10), 1000);
+        $orphan = $this->seedLocalFile('/wp-content/old/orphan.txt', str_repeat('x', 10), 1000);
 
         [$client, $r] = $this->prepareClient(['/wp-content']);
         $r->getMethod('diff_indexes_and_build_fetch_list')->invoke($client);

--- a/tests/e2e/tests/import-52-pull-files-db-gitlike.test.js
+++ b/tests/e2e/tests/import-52-pull-files-db-gitlike.test.js
@@ -25,6 +25,14 @@ function readJson(path) {
     return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
+function readJsonLines(path) {
+    return readFileSync(path, 'utf-8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+}
+
 describe('Import: pull-files git-pull-like sync', { timeout: 300000 }, () => {
     const site = 'pull-files-gitlike';
     let tempDir;
@@ -77,6 +85,7 @@ describe('Import: pull-files git-pull-like sync', { timeout: 300000 }, () => {
     function resetRemoteFiles(marker) {
         execSync(`sudo rm -rf ${JSON.stringify(remotePath('test-data/pull-files'))}`);
         writeRemoteFile('test-data/pull-files/marker.txt', `${marker}\n`);
+        writeRemoteFile('test-data/pull-files/local-conflict.txt', 'remote conflict original\n');
         writeRemoteFile('test-data/pull-files/removed-after-first.txt', 'present in round 1\n');
     }
 
@@ -98,11 +107,31 @@ describe('Import: pull-files git-pull-like sync', { timeout: 300000 }, () => {
         runPullFiles();
 
         assert.equal(readFileSync(localPath('test-data/pull-files/marker.txt'), 'utf-8'), 'round-1\n');
+        assert.equal(readFileSync(localPath('test-data/pull-files/local-conflict.txt'), 'utf-8'), 'remote conflict original\n');
         assert.equal(readFileSync(localPath('test-data/pull-files/removed-after-first.txt'), 'utf-8'), 'present in round 1\n');
 
         const state = readJson(join(tempDir, '.import-state.json'));
         assert.equal(state.pull_files.stage, 'complete');
         assert.equal(state.pull?.stage ?? null, null, 'pull-files must not advance the full pull cursor');
+    });
+
+    it('preserves tracked files with local edits unless overwrite is requested', () => {
+        writeFileSync(localPath('test-data/pull-files/local-conflict.txt'), 'locally edited content\n');
+        writeRemoteFile('test-data/pull-files/local-conflict.txt', 'remote changed after local edit\n');
+
+        runPullFiles();
+
+        assert.equal(readFileSync(localPath('test-data/pull-files/local-conflict.txt'), 'utf-8'), 'locally edited content\n');
+        const conflicts = readJsonLines(join(tempDir, '.import-local-conflicts.jsonl'));
+        assert.ok(conflicts.some((conflict) => (
+            conflict.path === 'test-data/pull-files/local-conflict.txt' &&
+            conflict.action === 'overwrite' &&
+            conflict.resolution === 'preserve-local'
+        )), 'pull-files should report a structured local conflict');
+
+        runPullFiles(['--on-local-conflict=overwrite']);
+
+        assert.equal(readFileSync(localPath('test-data/pull-files/local-conflict.txt'), 'utf-8'), 'remote changed after local edit\n');
     });
 
     it('re-running pull-files after remote changes updates, adds, and deletes files', () => {

--- a/tests/e2e/tests/import-52-pull-files-db-gitlike.test.js
+++ b/tests/e2e/tests/import-52-pull-files-db-gitlike.test.js
@@ -124,7 +124,7 @@ describe('Import: pull-files git-pull-like sync', { timeout: 300000 }, () => {
         assert.equal(readFileSync(localPath('test-data/pull-files/local-conflict.txt'), 'utf-8'), 'locally edited content\n');
         const conflicts = readJsonLines(join(tempDir, '.import-local-conflicts.jsonl'));
         assert.ok(conflicts.some((conflict) => (
-            conflict.path === 'test-data/pull-files/local-conflict.txt' &&
+            conflict.path === remotePath('test-data/pull-files/local-conflict.txt') &&
             conflict.action === 'overwrite' &&
             conflict.resolution === 'preserve-local'
         )), 'pull-files should report a structured local conflict');


### PR DESCRIPTION
## What changed
- Preserve tracked local file edits during delta file pulls by default.
- Report preserved conflicts as structured JSONL in `.import-local-conflicts.jsonl` and as progress events.
- Add `--on-local-conflict=overwrite` for users who explicitly want the remote version to replace local edits.
- Extend the git-pull-like E2E test to verify default preservation and the overwrite escape hatch.

## Why
`pull-files` should feel safe like `git pull`: remote updates should not silently clobber local edits after the first sync.

## Validation
- `php -l packages/reprint-importer/src/import.php`
- `node --check tests/e2e/tests/import-52-pull-files-db-gitlike.test.js`
- `vendor/bin/phpunit --filter 'PullFilterOptionTest|OnlyCliParseTest' tests/Import`
- `composer analyze`
