### PR TITLE
Extract reusable shared pipeline runner from the `pull` command

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -53,7 +53,7 @@ require_once __DIR__ . '/lib/external-merge-sort.php';
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
 require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
 
-// Pull command — orchestrates the lower-level commands into a pipeline
+// Pull command — orchestrates lower-level commands into a pipeline
 require_once __DIR__ . '/lib/pull/class-pull.php';
 
 /**
@@ -1353,15 +1353,17 @@ class ImportClient
     }
 
     /** Mark a pull pipeline stage as completed in state. */
-    public function mark_pull_stage_complete(string $stage): void
+    public function mark_pull_stage_complete(string $stage, string $pipeline = 'pull'): void
     {
+        $this->state['pull']['pipeline'] = $pipeline;
         $this->state['pull']['stage'] = $stage;
         $this->save_state($this->state);
     }
 
     /** Mark the pull pipeline as fully complete in state. */
-    public function mark_pull_complete(): void
+    public function mark_pull_complete(string $pipeline = 'pull'): void
     {
+        $this->state['pull']['pipeline'] = $pipeline;
         $this->state['pull']['stage'] = 'complete';
         $this->state['pull']['has_completed_once'] = true;
         $this->state['status'] = 'complete';
@@ -1374,6 +1376,29 @@ class ImportClient
         $this->state['pull']['files_filter'] = $filter;
         $this->state['pull']['skipped_pending'] = $skipped_pending;
         $this->save_state($this->state);
+    }
+
+    /**
+     * Resolve file-selection options after preflight is available.
+     */
+    public function prepare_files_pull_options(array $options, bool $assert_remap = true): void
+    {
+        $remap_raw = $options["remap"] ?? [];
+        if (!empty($remap_raw)) {
+            $this->remap_rules = $this->resolve_remap($remap_raw);
+        }
+
+        $only_raw = $options["only"] ?? [];
+        if (is_string($only_raw)) {
+            $only_raw = [$only_raw];
+        }
+        if (!empty($only_raw)) {
+            $this->pull_only_files_with_path_prefixes = $this->resolve_pull_only_files_with_path_prefixes($only_raw);
+        }
+
+        if ($assert_remap) {
+            $this->assert_files_remap_consistent();
+        }
     }
 
     /** True when the skipped-download list exists and still has entries. */
@@ -1517,7 +1542,7 @@ class ImportClient
      * Run the import process with explicit command validation.
      *
      * @param array $options Options:
-     *   - command: Required. One of: files-pull, files-index, db-pull, db-index, preflight, preflight-assert
+     *   - command: Required. One of the entries in $valid_commands below.
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
      */
@@ -1582,6 +1607,13 @@ class ImportClient
             );
         }
 
+        // High-level pulls persist resume state before they enter the stage
+        // runner. Reject invalid options first so a typo does not leave behind
+        // state that looks like an interrupted pull.
+        if ($command === "pull") {
+            $this->pull->assert_options_valid_before_state_write($command, $options);
+        }
+
         $this->state = $this->load_state();
 
         if ($command === "import-metadata") {
@@ -1624,7 +1656,7 @@ class ImportClient
                 !in_array($next, ["none", "essential-files"], true)
             ) {
                 throw new InvalidArgumentException(
-                    "Invalid --filter value for pull: {$next}. " .
+                    "Invalid --filter value for {$command}: {$next}. " .
                         "Valid values: none, essential-files",
                 );
             }
@@ -1653,6 +1685,10 @@ class ImportClient
             $this->save_state($this->state);
         } elseif (isset($this->state["max_allowed_packet"])) {
             $this->max_allowed_packet = (int) $this->state["max_allowed_packet"];
+        }
+
+        if ($command === "pull") {
+            $options["sql_output"] = "file";
         }
 
         // Persist sql_output_mode in state so it survives across resume invocations.
@@ -1740,8 +1776,8 @@ class ImportClient
             $this->hmac_client = new \Site_Export_HMAC_Client($options["secret"]);
         }
 
-        // pull orchestrates the full pipeline (preflight → files → db → apply)
-        // internally, so it must run before the normal command dispatch.
+        // pull orchestrates preflight and lower-level stages internally,
+        // so it runs before the normal command dispatch.
         if ($command === "pull") {
             if ($abort) {
                 $this->pull->abort();
@@ -1750,6 +1786,13 @@ class ImportClient
             try {
                 $this->pull->run($options);
             } catch (\Exception $e) {
+                if ($e instanceof \PullFailureReportedException) {
+                    $previous = $e->getPrevious();
+                    if ($previous instanceof \Exception) {
+                        throw $previous;
+                    }
+                    throw $e;
+                }
                 $this->output_progress([
                     "status" => "error",
                     "error" => $e->getMessage(),
@@ -1814,19 +1857,8 @@ class ImportClient
         // All other commands require a prior preflight run.
         $this->require_preflight();
 
-        // Resolve the `--remap` rules (requires preflight to be available first)
-        $remap_raw = $options["remap"] ?? [];
-        if (!empty($remap_raw)) {
-            $this->remap_rules = $this->resolve_remap($remap_raw);
-        }
-
-        // Resolve the `--only` file path prefixes (also requires preflight).
-        $only_raw = $options["only"] ?? [];
-        if (is_string($only_raw)) {
-            $only_raw = [$only_raw];
-        }
-        if (!empty($only_raw)) {
-            $this->pull_only_files_with_path_prefixes = $this->resolve_pull_only_files_with_path_prefixes($only_raw);
+        if (in_array($command, ["files-pull", "files-index"], true)) {
+            $this->prepare_files_pull_options($options, $command === "files-pull" && !$abort);
         }
 
         // Handle --abort: clear state for the command and exit immediately.
@@ -1837,10 +1869,6 @@ class ImportClient
             //        for that command.
             $this->handle_abort($command);
             return;
-        }
-
-        if ($command === "files-pull") {
-            $this->assert_files_remap_consistent();
         }
 
         // Dispatch to appropriate command handler
@@ -10838,8 +10866,11 @@ class ImportClient
             ],
             // Pull pipeline state — tracks progress through the composite
             // preflight → files-pull → db-pull → db-apply → ... pipeline.
-            // "stage" is the last completed stage name, or "complete".
+            // "pipeline" is the high-level command that owns "stage";
+            // top-level "command" still tracks the active atomic command.
+            // "stage" is the last completed high-level stage, or "complete".
             "pull" => [
+                "pipeline" => null,
                 "stage" => null,
                 "files_filter" => null,
                 "skipped_pending" => false,
@@ -10905,6 +10936,9 @@ class ImportClient
             $pull = [];
         }
         $pull = array_intersect_key($pull, $defaults["pull"]);
+        if (($pull["pipeline"] ?? null) === null && ($pull["stage"] ?? null) !== null) {
+            $pull["pipeline"] = "pull";
+        }
         $state["pull"] = array_merge($defaults["pull"], $pull);
         return $state;
     }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1353,28 +1353,30 @@ class ImportClient
     }
 
     /** Mark a pull pipeline stage as completed in state. */
-    public function mark_pull_stage_complete(string $stage, string $pipeline = 'pull'): void
+    public function mark_pull_stage_complete(string $stage, string $pipeline = 'pull', array $stage_sequence = []): void
     {
-        $this->state['pull']['pipeline'] = $pipeline;
-        $this->state['pull']['stage'] = $stage;
+        $this->state['pull_pipeline']['started_by_command'] = $pipeline;
+        $this->state['pull_pipeline']['last_completed_stage'] = $stage;
+        if ($stage_sequence !== []) {
+            $this->state['pull_pipeline']['stage_sequence'] = $stage_sequence;
+        }
         $this->save_state($this->state);
     }
 
     /** Mark the pull pipeline as fully complete in state. */
     public function mark_pull_complete(string $pipeline = 'pull'): void
     {
-        $this->state['pull']['pipeline'] = $pipeline;
-        $this->state['pull']['stage'] = 'complete';
-        $this->state['pull']['has_completed_once'] = true;
-        $this->state['status'] = 'complete';
+        $this->state['pull_pipeline']['started_by_command'] = $pipeline;
+        $this->state['pull_pipeline']['has_completed_once'] = true;
+        $this->state['active_resumable_command']['completion_state'] = 'complete';
         $this->save_state($this->state);
     }
 
     /** Record the pull's file filter and whether deferred files remain. */
     public function set_pull_files_state(string $filter, bool $skipped_pending): void
     {
-        $this->state['pull']['files_filter'] = $filter;
-        $this->state['pull']['skipped_pending'] = $skipped_pending;
+        $this->state['pull_pipeline']['files_filter'] = $filter;
+        $this->state['pull_pipeline']['skipped_pending'] = $skipped_pending;
         $this->save_state($this->state);
     }
 
@@ -1661,7 +1663,7 @@ class ImportClient
                 );
             }
             $prev = $this->state["filter"] ?? null;
-            $status = $this->state["status"] ?? null;
+            $status = $this->state["active_resumable_command"]["completion_state"] ?? null;
             $is_mid_flight = $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
             if ($is_mid_flight) {
                 throw new RuntimeException(
@@ -1836,7 +1838,7 @@ class ImportClient
             }
             try {
                 $this->run_db_apply($options);
-                $final_status = $this->state["status"] ?? "complete";
+                $final_status = $this->state["active_resumable_command"]["completion_state"] ?? "complete";
                 $this->output_progress(["status" => $final_status, "message" => "db-apply {$final_status}"]);
                 if ($final_status === "partial") {
                     $this->exit_code = 2;
@@ -1894,7 +1896,7 @@ class ImportClient
                     break;
             }
 
-            $final_status = $this->state["status"] ?? "complete";
+            $final_status = $this->state["active_resumable_command"]["completion_state"] ?? "complete";
             $this->output_progress(["status" => $final_status, "message" => "{$command} {$final_status}"]);
 
             // Exit code 2 signals "partial progress, call me again" so
@@ -1977,9 +1979,9 @@ class ImportClient
                     "RESTART | Clearing files-index state",
                     true,
                 );
-                $this->state["command"] = "files-index";
-                $this->state["status"] = null;
-                $this->state["stage"] = null;
+                $this->state["active_resumable_command"]["command_name"] = "files-index";
+                $this->state["active_resumable_command"]["completion_state"] = null;
+                $this->state["active_resumable_command"]["current_stage"] = null;
                 $this->state["index"] = $this->default_state()["index"];
                 if (file_exists($this->remote_index_file)) {
                     @unlink($this->remote_index_file);
@@ -2660,10 +2662,10 @@ class ImportClient
      */
     public function run_files_sync(): void
     {
-        $state_command = $this->state["command"] ?? null;
+        $state_command = $this->state["active_resumable_command"]["command_name"] ?? null;
         $current_status =
             $state_command === "files-pull"
-                ? $this->state["status"] ?? null
+                ? $this->state["active_resumable_command"]["completion_state"] ?? null
                 : null;
         $has_progress =
             $state_command === "files-pull" &&
@@ -2701,18 +2703,18 @@ class ImportClient
                     "stage" => "fetch-skipped",
                     "message" => "Downloading previously skipped files",
                 ], true);
-                $this->state["status"] = "in_progress";
-                $this->state["stage"] = "fetch-skipped";
+                $this->state["active_resumable_command"]["completion_state"] = "in_progress";
+                $this->state["active_resumable_command"]["current_stage"] = "fetch-skipped";
                 $this->state["files_pull_only_fingerprint"] = $this->files_pull_only_fingerprint();
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
                 // tail finishes, restore the completed status so later filter
                 // changes are judged against the actual lifecycle state.
-                if (($this->state["status"] ?? null) === "partial") {
+                if (($this->state["active_resumable_command"]["completion_state"] ?? null) === "partial") {
                     return;
                 }
-                $this->state["status"] = "complete";
+                $this->state["active_resumable_command"]["completion_state"] = "complete";
                 $this->save_state($this->state);
                 return;
             }
@@ -2778,7 +2780,7 @@ class ImportClient
             $index_size = $this->index_count();
 
 
-            $stage = $this->state["stage"] ?? "index";
+            $stage = $this->state["active_resumable_command"]["current_stage"] ?? "index";
             $this->audit_log(
                 sprintf(
                     "RESUME files-pull | stage=%s | indexed_files=%d",
@@ -2810,9 +2812,9 @@ class ImportClient
                 );
             }
 
-            $this->state["command"] = "files-pull";
-            $this->state["status"] = "in_progress";
-            $this->state["stage"] = "index";
+            $this->state["active_resumable_command"]["command_name"] = "files-pull";
+            $this->state["active_resumable_command"]["completion_state"] = "in_progress";
+            $this->state["active_resumable_command"]["current_stage"] = "index";
             $this->state["files_pull_only_fingerprint"] = $this->files_pull_only_fingerprint();
             $this->state["diff"] = $this->default_state()["diff"];
             $this->state["index"] = $this->default_state()["index"];
@@ -2856,18 +2858,18 @@ class ImportClient
             }
         }
 
-        $this->state["command"] = "files-pull";
-        $this->state["status"] = "in_progress";
+        $this->state["active_resumable_command"]["command_name"] = "files-pull";
+        $this->state["active_resumable_command"]["completion_state"] = "in_progress";
         $this->save_state($this->state);
 
         $this->run_files_sync_pipeline();
 
         // Pipeline returns early with partial status if interrupted
-        if (($this->state["status"] ?? null) === "partial") {
+        if (($this->state["active_resumable_command"]["completion_state"] ?? null) === "partial") {
             return;
         }
 
-        $this->state["status"] = "complete";
+        $this->state["active_resumable_command"]["completion_state"] = "complete";
         $this->save_state($this->state);
 
         $this->progress->clear_progress_line();
@@ -2902,25 +2904,25 @@ class ImportClient
      */
     private function run_files_sync_pipeline(): void
     {
-        $stage = $this->state["stage"] ?? "index";
+        $stage = $this->state["active_resumable_command"]["current_stage"] ?? "index";
 
         if ($stage === "index") {
             $complete = $this->download_remote_index();
             if (!$complete) {
-                $this->state["status"] = "partial";
+                $this->state["active_resumable_command"]["completion_state"] = "partial";
                 $this->save_state($this->state);
                 return;
             }
             if ($this->follow_symlinks) {
                 $this->discover_symlink_targets();
                 if ($this->shutdown_requested) {
-                    $this->state["status"] = "partial";
+                    $this->state["active_resumable_command"]["completion_state"] = "partial";
                     $this->save_state($this->state);
                     return;
                 }
             }
             $this->sort_index_file($this->remote_index_file);
-            $this->state["stage"] = "diff";
+            $this->state["active_resumable_command"]["current_stage"] = "diff";
             $this->state["diff"] = $this->default_state()["diff"];
             if (file_exists($this->download_list_file)) {
                 @unlink($this->download_list_file);
@@ -2941,7 +2943,7 @@ class ImportClient
         if ($stage === "diff") {
             $complete = $this->diff_indexes_and_build_fetch_list();
             if (!$complete) {
-                $this->state["status"] = "partial";
+                $this->state["active_resumable_command"]["completion_state"] = "partial";
                 $this->save_state($this->state);
                 return;
             }
@@ -2961,7 +2963,7 @@ class ImportClient
             } else {
                 $stage = null;
             }
-            $this->state["stage"] = $stage;
+            $this->state["active_resumable_command"]["current_stage"] = $stage;
             $this->save_state($this->state);
 
             // In pull mode, finalize the scanning line with a checkmark
@@ -3001,7 +3003,7 @@ class ImportClient
                 "fetch",
             );
             if (!$complete) {
-                $this->state["status"] = "partial";
+                $this->state["active_resumable_command"]["completion_state"] = "partial";
                 $this->save_state($this->state);
                 return;
             }
@@ -3022,7 +3024,7 @@ class ImportClient
                 // Essential files are done — mark the sync as complete.
                 // The skipped list stays on disk for a later
                 // --filter=skipped-earlier run.
-                $this->state["stage"] = null;
+                $this->state["active_resumable_command"]["current_stage"] = null;
                 $this->save_state($this->state);
                 $this->audit_log(
                     "ESSENTIAL FILES COMPLETE | skipped files listed in {$this->skipped_download_list_file} — run with --filter=skipped-earlier to download them",
@@ -3031,7 +3033,7 @@ class ImportClient
                 $stage = null;
             } elseif ($has_skipped) {
                 // Skipped list exists but filter is "none" — download now.
-                $this->state["stage"] = "fetch-skipped";
+                $this->state["active_resumable_command"]["current_stage"] = "fetch-skipped";
                 $this->save_state($this->state);
                 $stage = "fetch-skipped";
                 $this->audit_log(
@@ -3040,7 +3042,7 @@ class ImportClient
                 );
                 $this->write_status_file();
             } else {
-                $this->state["stage"] = null;
+                $this->state["active_resumable_command"]["current_stage"] = null;
                 $this->save_state($this->state);
                 $stage = null;
             }
@@ -3052,11 +3054,11 @@ class ImportClient
                 "fetch_skipped",
             );
             if (!$complete) {
-                $this->state["status"] = "partial";
+                $this->state["active_resumable_command"]["completion_state"] = "partial";
                 $this->save_state($this->state);
                 return;
             }
-            $this->state["stage"] = null;
+            $this->state["active_resumable_command"]["current_stage"] = null;
             $this->state["fetch_skipped"] = $this->default_state()["fetch_skipped"];
             $this->save_state($this->state);
 
@@ -3086,10 +3088,10 @@ class ImportClient
      */
     private function run_files_index(): void
     {
-        $state_command = $this->state["command"] ?? null;
+        $state_command = $this->state["active_resumable_command"]["command_name"] ?? null;
         $current_status =
             $state_command === "files-index"
-                ? $this->state["status"] ?? null
+                ? $this->state["active_resumable_command"]["completion_state"] ?? null
                 : null;
 
         if ($current_status === "complete") {
@@ -3099,9 +3101,9 @@ class ImportClient
         }
 
         if ($current_status === null) {
-            $this->state["command"] = "files-index";
-            $this->state["status"] = "in_progress";
-            $this->state["stage"] = "index";
+            $this->state["active_resumable_command"]["command_name"] = "files-index";
+            $this->state["active_resumable_command"]["completion_state"] = "in_progress";
+            $this->state["active_resumable_command"]["current_stage"] = "index";
             $this->save_state($this->state);
             $this->audit_log("START files-index", true);
             $this->progress->show_lifecycle_line("Starting files-index\n");
@@ -3129,7 +3131,7 @@ class ImportClient
             ], true);
         }
 
-        $this->state["command"] = "files-index";
+        $this->state["active_resumable_command"]["command_name"] = "files-index";
         $this->save_state($this->state);
 
         $attempts = 0;
@@ -3141,7 +3143,7 @@ class ImportClient
             }
 
             if ($this->shutdown_requested) {
-                $this->state["status"] = "partial";
+                $this->state["active_resumable_command"]["completion_state"] = "partial";
                 $this->save_state($this->state);
                 return;
             }
@@ -3170,8 +3172,8 @@ class ImportClient
         }
 
         $this->sort_index_file($this->remote_index_file);
-        $this->state["status"] = "complete";
-        $this->state["stage"] = null;
+        $this->state["active_resumable_command"]["completion_state"] = "complete";
+        $this->state["active_resumable_command"]["current_stage"] = null;
         $this->save_state($this->state);
 
         $count = 0;
@@ -3555,15 +3557,15 @@ class ImportClient
      */
     public function run_db_sync(): void
     {
-        $state_command = $this->state["command"] ?? null;
+        $state_command = $this->state["active_resumable_command"]["command_name"] ?? null;
         $sql_file = $this->state_dir . "/db.sql";
 
         $has_progress =
             $state_command === "db-pull" &&
-            ($this->state["status"] ?? null) === "in_progress";
+            ($this->state["active_resumable_command"]["completion_state"] ?? null) === "in_progress";
         $current_status =
             $state_command === "db-pull"
-                ? $this->state["status"] ?? null
+                ? $this->state["active_resumable_command"]["completion_state"] ?? null
                 : null;
 
         // Check if already completed
@@ -3587,13 +3589,13 @@ class ImportClient
         }
 
         if ($has_progress) {
-            $stage = $this->state["stage"] ?? "db-index";
+            $stage = $this->state["active_resumable_command"]["current_stage"] ?? "db-index";
             $this->audit_log(
                 sprintf(
                     "RESUME db-pull | stage=%s | cursor=%s",
                     $stage,
-                    !empty($this->state["cursor"])
-                        ? substr($this->state["cursor"], 0, 20) . "..."
+                    !empty($this->state["active_resumable_command"]["remote_cursor"])
+                        ? substr($this->state["active_resumable_command"]["remote_cursor"], 0, 20) . "..."
                         : "none",
                 ),
                 true,
@@ -3609,10 +3611,10 @@ class ImportClient
             ], true);
         } else {
             // Starting fresh
-            $this->state["command"] = "db-pull";
-            $this->state["status"] = "in_progress";
-            $this->state["cursor"] = null;
-            $this->state["stage"] = "db-index";
+            $this->state["active_resumable_command"]["command_name"] = "db-pull";
+            $this->state["active_resumable_command"]["completion_state"] = "in_progress";
+            $this->state["active_resumable_command"]["remote_cursor"] = null;
+            $this->state["active_resumable_command"]["current_stage"] = "db-index";
             $this->state["diff"] = $this->default_state()["diff"];
             $this->state["db_index"] = $this->default_state()["db_index"];
             $this->save_state($this->state);
@@ -3628,11 +3630,11 @@ class ImportClient
             ], true);
         }
 
-        $this->state["command"] = "db-pull";
+        $this->state["active_resumable_command"]["command_name"] = "db-pull";
         $this->save_state($this->state);
 
         // Stage 1: db-index (table metadata for progress estimation)
-        $stage = $this->state["stage"] ?? "db-index";
+        $stage = $this->state["active_resumable_command"]["current_stage"] ?? "db-index";
         if ($stage === "db-index") {
             $this->output_progress([
                 "status" => "starting",
@@ -3643,7 +3645,7 @@ class ImportClient
             $this->download_db_index();
 
             // Timeout during db-index — state already saved, exit partial.
-            if (($this->state["status"] ?? null) === "partial") {
+            if (($this->state["active_resumable_command"]["completion_state"] ?? null) === "partial") {
                 return;
             }
 
@@ -3653,8 +3655,8 @@ class ImportClient
             );
 
             // Transition to sql stage
-            $this->state["stage"] = "sql";
-            $this->state["cursor"] = null;
+            $this->state["active_resumable_command"]["current_stage"] = "sql";
+            $this->state["active_resumable_command"]["remote_cursor"] = null;
             $this->save_state($this->state);
         }
 
@@ -3668,12 +3670,12 @@ class ImportClient
         $this->download_sql();
 
         // Timeout during SQL download — state already saved, exit partial.
-        if (($this->state["status"] ?? null) === "partial") {
+        if (($this->state["active_resumable_command"]["completion_state"] ?? null) === "partial") {
             return;
         }
 
         // Mark as complete
-        $this->state["status"] = "complete";
+        $this->state["active_resumable_command"]["completion_state"] = "complete";
         $this->save_state($this->state);
 
         $this->audit_log("db-pull complete", true);
@@ -3923,15 +3925,13 @@ class ImportClient
      */
     private function build_import_metadata(): array
     {
-        $pull = $this->state["pull"] ?? [];
+        $pull = $this->state["pull_pipeline"] ?? [];
         if (!is_array($pull)) {
             $pull = [];
         }
 
-        $pull_stage = $pull["stage"] ?? null;
-        $has_completed_once =
-            !empty($pull["has_completed_once"]) ||
-            $pull_stage === "complete";
+        $pull_stage = $pull["last_completed_stage"] ?? null;
+        $has_completed_once = !empty($pull["has_completed_once"]);
 
         return [
             "hasCompletedOnce" => $has_completed_once,
@@ -4293,11 +4293,11 @@ class ImportClient
             return true;
         }
 
-        if (($this->state["command"] ?? null) !== "files-pull") {
+        if (($this->state["active_resumable_command"]["command_name"] ?? null) !== "files-pull") {
             return false;
         }
 
-        $status = $this->state["status"] ?? null;
+        $status = $this->state["active_resumable_command"]["completion_state"] ?? null;
         return $status !== null && $status !== "complete";
     }
 
@@ -5179,8 +5179,8 @@ class ImportClient
         }
 
         // Check state for resume
-        $state_command = $this->state["command"] ?? null;
-        $current_status = $state_command === "db-apply" ? ($this->state["status"] ?? null) : null;
+        $state_command = $this->state["active_resumable_command"]["command_name"] ?? null;
+        $current_status = $state_command === "db-apply" ? ($this->state["active_resumable_command"]["completion_state"] ?? null) : null;
 
         if ($current_status === "complete") {
             throw new RuntimeException(
@@ -5212,8 +5212,8 @@ class ImportClient
                 "message" => "Resuming db-apply (executed: {$statements_executed} statements)",
             ], true);
         } else {
-            $this->state["command"] = "db-apply";
-            $this->state["status"] = "in_progress";
+            $this->state["active_resumable_command"]["command_name"] = "db-apply";
+            $this->state["active_resumable_command"]["completion_state"] = "in_progress";
             $this->state["apply"] = $this->default_state()["apply"];
             if (!empty($url_mapping)) {
                 $this->state["apply"]["rewrite_url"] = $url_mapping;
@@ -5496,7 +5496,7 @@ class ImportClient
                 // Save partial progress
                 $this->state["apply"]["statements_executed"] = $statements_executed;
                 $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
-                $this->state["status"] = "partial";
+                $this->state["active_resumable_command"]["completion_state"] = "partial";
                 $this->save_state($this->state);
                 $this->audit_log(
                     sprintf(
@@ -5541,7 +5541,7 @@ class ImportClient
                 // Mark complete
                 $this->state["apply"]["statements_executed"] = $statements_executed;
                 $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
-                $this->state["status"] = "complete";
+                $this->state["active_resumable_command"]["completion_state"] = "complete";
                 $this->save_state($this->state);
 
                 $this->audit_log(
@@ -5783,15 +5783,15 @@ class ImportClient
      */
     private function run_db_index(): void
     {
-        $state_command = $this->state["command"] ?? null;
+        $state_command = $this->state["active_resumable_command"]["command_name"] ?? null;
         $tables_file = $this->state_dir . "/db-tables.jsonl";
 
         $has_cursor =
             $state_command === "db-index" &&
-            !empty($this->state["cursor"] ?? null);
+            !empty($this->state["active_resumable_command"]["remote_cursor"] ?? null);
         $current_status =
             $state_command === "db-index"
-                ? $this->state["status"] ?? null
+                ? $this->state["active_resumable_command"]["completion_state"] ?? null
                 : null;
         $tables_exists = file_exists($tables_file);
 
@@ -5808,10 +5808,10 @@ class ImportClient
         }
 
         if (!$has_cursor) {
-            $this->state["command"] = "db-index";
-            $this->state["status"] = "in_progress";
-            $this->state["cursor"] = null;
-            $this->state["stage"] = null;
+            $this->state["active_resumable_command"]["command_name"] = "db-index";
+            $this->state["active_resumable_command"]["completion_state"] = "in_progress";
+            $this->state["active_resumable_command"]["remote_cursor"] = null;
+            $this->state["active_resumable_command"]["current_stage"] = null;
             $this->state["diff"] = $this->default_state()["diff"];
             $this->state["db_index"] = $this->default_state()["db_index"];
             $this->save_state($this->state);
@@ -5828,7 +5828,7 @@ class ImportClient
             $this->audit_log(
                 sprintf(
                     "RESUME db-index | cursor=%s",
-                    substr($this->state["cursor"], 0, 20) . "...",
+                    substr($this->state["active_resumable_command"]["remote_cursor"], 0, 20) . "...",
                 ),
                 true,
             );
@@ -5841,12 +5841,12 @@ class ImportClient
             ], true);
         }
 
-        $this->state["command"] = "db-index";
+        $this->state["active_resumable_command"]["command_name"] = "db-index";
         $this->save_state($this->state);
 
         $this->download_db_index();
 
-        $this->state["status"] = "complete";
+        $this->state["active_resumable_command"]["completion_state"] = "complete";
         $this->save_state($this->state);
 
         $tables = (int) ($this->state["db_index"]["tables"] ?? 0);
@@ -6070,7 +6070,7 @@ class ImportClient
                 $this->state["current_file"] = $context->file_path;
                 $this->state["current_file_bytes"] = $context->file_bytes_written;
             }
-            $this->state["status"] = "partial";
+            $this->state["active_resumable_command"]["completion_state"] = "partial";
             $this->save_state($this->state);
             return false;
         }
@@ -6314,7 +6314,7 @@ class ImportClient
             $this->assert_can_retry_consecutive_timeout("file_index", $cursor_before, $cursor);
             fclose($handle);
             $this->state["index"] = ["cursor" => $cursor];
-            $this->state["status"] = "partial";
+            $this->state["active_resumable_command"]["completion_state"] = "partial";
             $this->save_state($this->state);
             return false;
         }
@@ -7303,7 +7303,7 @@ class ImportClient
      */
     private function download_sql(): void
     {
-        $cursor = $this->state["cursor"] ?? null;
+        $cursor = $this->state["active_resumable_command"]["remote_cursor"] ?? null;
         $complete = false;
         $mode = $this->sql_output_mode;
 
@@ -7500,7 +7500,7 @@ class ImportClient
                         if ($sql_handle) {
                             fflush($sql_handle);
                         }
-                        $this->state["cursor"] = $cursor;
+                        $this->state["active_resumable_command"]["remote_cursor"] = $cursor;
                         $this->state["sql_bytes"] = $sql_bytes_written;
                         $this->state["sql_statements_counted"] = $sql_statements_counted;
                         $this->save_state($this->state);
@@ -7667,10 +7667,10 @@ class ImportClient
                     if ($sql_handle) {
                         fflush($sql_handle);
                     }
-                    $this->state["cursor"] = $cursor;
+                    $this->state["active_resumable_command"]["remote_cursor"] = $cursor;
                     $this->state["sql_bytes"] = $sql_bytes_written;
                     $this->state["sql_statements_counted"] = $sql_statements_counted;
-                    $this->state["status"] = "partial";
+                    $this->state["active_resumable_command"]["completion_state"] = "partial";
                     $this->save_state($this->state);
                     // Discard any pending SQL buffer — it's incomplete and
                     // will be re-fetched on the next invocation. Setting
@@ -7718,10 +7718,10 @@ class ImportClient
                         if ($sql_handle) {
                             fflush($sql_handle);
                         }
-                        $this->state["cursor"] = $cursor;
+                        $this->state["active_resumable_command"]["remote_cursor"] = $cursor;
                         $this->state["sql_bytes"] = $sql_bytes_written;
                         $this->state["sql_statements_counted"] = $sql_statements_counted;
-                        $this->state["status"] = "partial";
+                        $this->state["active_resumable_command"]["completion_state"] = "partial";
                         $this->save_state($this->state);
                         $curl_timed_out = true;
                         break;
@@ -7741,7 +7741,7 @@ class ImportClient
                     fflush($sql_handle);
                 }
 
-                $this->state["cursor"] = $cursor;
+                $this->state["active_resumable_command"]["remote_cursor"] = $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
                 $this->state["sql_bytes"] = $complete ? null : $sql_bytes_written;
                 $this->save_state($this->state);
@@ -8075,7 +8075,7 @@ class ImportClient
      */
     private function download_db_index(): void
     {
-        $cursor = $this->state["cursor"] ?? null;
+        $cursor = $this->state["active_resumable_command"]["remote_cursor"] ?? null;
         $complete = false;
         $tables_file = $this->state_dir . "/db-tables.jsonl";
 
@@ -8219,7 +8219,7 @@ class ImportClient
                     // with no progress, so we don't retry forever.
                     $this->assert_can_retry_consecutive_timeout("db_index", $cursor_before, $cursor);
                     fflush($handle);
-                    $this->state["cursor"] = $cursor;
+                    $this->state["active_resumable_command"]["remote_cursor"] = $cursor;
                     $this->state["db_index"] = [
                         "file" => $tables_file,
                         "tables" => $tables_written,
@@ -8227,7 +8227,7 @@ class ImportClient
                         "bytes" => $bytes_written,
                         "updated_at" => time(),
                     ];
-                    $this->state["status"] = "partial";
+                    $this->state["active_resumable_command"]["completion_state"] = "partial";
                     $this->save_state($this->state);
                     return;
                 }
@@ -8240,7 +8240,7 @@ class ImportClient
                 );
 
                 fflush($handle);
-                $this->state["cursor"] = $cursor;
+                $this->state["active_resumable_command"]["remote_cursor"] = $cursor;
                 $this->state["db_index"] = [
                     "file" => $tables_file,
                     "tables" => $tables_written,
@@ -10767,7 +10767,7 @@ class ImportClient
         $nonempty = $this->state["fs_root_nonempty_behavior"] ?? "error";
         $max_packet = $this->state["max_allowed_packet"] ?? null;
         $files_remap_fingerprint = $this->state["files_remap_fingerprint"] ?? null;
-        $pull = $this->state["pull"] ?? null;
+        $pull = $this->state["pull_pipeline"] ?? null;
         $this->state = $this->default_state();
         $this->state["preflight"] = $preflight;
         $this->state["version"] = $version;
@@ -10777,17 +10777,21 @@ class ImportClient
         $this->state["max_allowed_packet"] = $max_packet;
         $this->state["files_remap_fingerprint"] = $files_remap_fingerprint;
         if ($pull !== null) {
-            $this->state["pull"] = $pull;
+            $this->state["pull_pipeline"] = $pull;
         }
     }
 
     public function default_state(): array
     {
         return [
-            "command" => null,
-            "status" => null,
-            "cursor" => null,
-            "stage" => null,
+            // Resume checkpoint for the lower-level command currently being
+            // run directly or as a stage inside a pull pipeline.
+            "active_resumable_command" => [
+                "command_name" => null,
+                "completion_state" => null,
+                "current_stage" => null,
+                "remote_cursor" => null,
+            ],
             "preflight" => null,
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
@@ -10864,14 +10868,12 @@ class ImportClient
                 "config" => [],
                 "state" => [],
             ],
-            // Pull pipeline state — tracks progress through the composite
-            // preflight → files-pull → db-pull → db-apply → ... pipeline.
-            // "pipeline" is the high-level command that owns "stage";
-            // top-level "command" still tracks the active atomic command.
-            // "stage" is the last completed high-level stage, or "complete".
-            "pull" => [
-                "pipeline" => null,
-                "stage" => null,
+            // Resume checkpoint for the user-facing pull pipeline command
+            // being orchestrated.
+            "pull_pipeline" => [
+                "started_by_command" => null,
+                "stage_sequence" => [],
+                "last_completed_stage" => null,
                 "files_filter" => null,
                 "skipped_pending" => false,
                 "has_completed_once" => false,
@@ -10887,6 +10889,18 @@ class ImportClient
         $defaults = $this->default_state();
         $state = array_intersect_key($state, $defaults);
         $state = array_merge($defaults, $state);
+        $active_resumable_command = $state["active_resumable_command"] ?? [];
+        if (!is_array($active_resumable_command)) {
+            $active_resumable_command = [];
+        }
+        $active_resumable_command = array_intersect_key(
+            $active_resumable_command,
+            $defaults["active_resumable_command"],
+        );
+        $state["active_resumable_command"] = array_merge(
+            $defaults["active_resumable_command"],
+            $active_resumable_command,
+        );
         $diff = $state["diff"];
         if (!is_array($diff)) {
             $diff = [];
@@ -10931,15 +10945,15 @@ class ImportClient
         }
         $apply = array_intersect_key($apply, $defaults["apply"]);
         $state["apply"] = array_merge($defaults["apply"], $apply);
-        $pull = $state["pull"] ?? [];
+        $pull = $state["pull_pipeline"] ?? [];
         if (!is_array($pull)) {
             $pull = [];
         }
-        $pull = array_intersect_key($pull, $defaults["pull"]);
-        if (($pull["pipeline"] ?? null) === null && ($pull["stage"] ?? null) !== null) {
-            $pull["pipeline"] = "pull";
+        $pull = array_intersect_key($pull, $defaults["pull_pipeline"]);
+        $state["pull_pipeline"] = array_merge($defaults["pull_pipeline"], $pull);
+        if (!is_array($state["pull_pipeline"]["stage_sequence"])) {
+            $state["pull_pipeline"]["stage_sequence"] = [];
         }
-        $state["pull"] = array_merge($defaults["pull"], $pull);
         return $state;
     }
 
@@ -11205,17 +11219,6 @@ class ImportClient
         $state = $this->normalize_state($state);
         $state = $this->decode_state_paths($state);
 
-        // Migrate legacy command names from older state files.
-        static $legacy_commands = [
-            "files-sync" => "files-pull",
-            "db-sync" => "db-pull",
-            "flat-document-root" => "flat-docroot",
-        ];
-        $state_cmd = $state["command"] ?? null;
-        if ($state_cmd && isset($legacy_commands[$state_cmd])) {
-            $state["command"] = $legacy_commands[$state_cmd];
-        }
-
         return $state;
     }
 
@@ -11258,7 +11261,7 @@ class ImportClient
         $indexed = $this->index_count();
         $files_imported = $this->files_imported; // Completed in this run
         $has_cursor =
-            !empty($state["cursor"] ?? null) ||
+            !empty($state["active_resumable_command"]["remote_cursor"] ?? null) ||
             !empty($state["index"]["cursor"] ?? null) ||
             !empty($state["fetch"]["cursor"] ?? null);
         $cursor_info = $has_cursor ? "cursor=saved" : "cursor=none";
@@ -11286,11 +11289,11 @@ class ImportClient
     public function write_status_file(?string $error = null): void
     {
         $state = $this->state ?? [];
-        $command = $state["command"] ?? null;
-        $status = $error !== null ? "error" : ($state["status"] ?? "in_progress");
+        $command = $state["active_resumable_command"]["command_name"] ?? null;
+        $status = $error !== null ? "error" : ($state["active_resumable_command"]["completion_state"] ?? "in_progress");
 
         // Derive phase from the state's stage field
-        $phase = $state["stage"] ?? null;
+        $phase = $state["active_resumable_command"]["current_stage"] ?? null;
 
         $payload = [
             "step" => $this->pipeline_step,
@@ -11350,7 +11353,7 @@ class ImportClient
         // Log final progress before exit
         $indexed = $this->index_count();
         $files_imported = $this->files_imported; // Files completed in this run
-        $current_command = $this->state["command"] ?? "unknown";
+        $current_command = $this->state["active_resumable_command"]["command_name"] ?? "unknown";
 
         $this->audit_log(
             sprintf(

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -1,7 +1,14 @@
 <?php
 /**
- * The `pull` command — orchestrates the lower-level commands into a
- * single resumable site clone pipeline.
+ * Signals that Pull already emitted the stage-specific error/status output.
+ */
+class PullFailureReportedException extends RuntimeException
+{
+}
+
+/**
+ * The `pull` command — orchestrates lower-level commands into a
+ * resumable pipeline.
  *
  * Each step retries automatically on server timeouts (exit code 2). If
  * the process is interrupted, re-running pull resumes from the last
@@ -86,14 +93,101 @@ class Pull
         $this->normalize_url();
         $this->progress->enable_quiet_lifecycle();
 
-        $options = $this->validate_and_default_options($options);
+        $options = $this->validate_and_default_pull_options($options);
 
-        $stages = $this->stages($options);
-        $total = count($stages);
+        $this->run_pipeline('pull', $this->stages($options), $options, 'Pulling');
+    }
+
+    /**
+     * Handle --abort for the pull command: clear pipeline state but
+     * leave downloaded files in place.
+     */
+    public function abort(): void
+    {
+        $this->prepare_repull();
+        $message = "Pull state cleared. Downloaded files are preserved.";
+        $this->progress->show_lifecycle_line("{$message}\n");
+        $this->client->output_progress([
+            "type" => "lifecycle",
+            "event" => "aborted",
+            "command" => "pull",
+            "message" => $message,
+        ], true);
+    }
+
+    private function run_pipeline(string $command, array $stages, array $options, string $title): void
+    {
+        $this->assert_no_conflicting_pull($command, $stages);
+
         $state = $this->client->state;
-        $completed_stage = $state['pull']['stage'] ?? null;
+        $pull_pipeline = $state['pull']['pipeline'] ?? null;
+        $pull_stage = $state['pull']['stage'] ?? null;
+        // Atomic commands leave state["command"] marked complete. Reuse that
+        // marker only while resuming the same high-level pipeline; otherwise a
+        // prior standalone files-pull/db-pull would make pull skip
+        // the fresh delta it was asked to compute.
+        $can_reuse_atomic_state =
+            $pull_pipeline === $command &&
+            $pull_stage !== null &&
+            $pull_stage !== 'complete';
+        $completed_current_pipeline = $pull_pipeline === $command && $pull_stage === 'complete';
+        if (!$completed_current_pipeline && !$can_reuse_atomic_state && ($state['status'] ?? null) === 'complete') {
+            $state_dir = $this->client->state_dir;
+            $defaults = $this->client->default_state();
 
-        // If the prior pull completed, prepare for a delta re-pull.
+            if (($state['command'] ?? null) === 'files-pull' && in_array('files-pull', $stages, true)) {
+                $this->client->mutate_state(function (array $state) use ($defaults) {
+                    $state['command'] = null;
+                    $state['status'] = null;
+                    $state['cursor'] = null;
+                    $state['stage'] = null;
+                    $state['consecutive_timeouts'] = 0;
+                    $state['current_file'] = null;
+                    $state['current_file_bytes'] = null;
+                    $state['diff'] = $defaults['diff'];
+                    $state['index'] = $defaults['index'];
+                    $state['fetch'] = $defaults['fetch'];
+                    $state['fetch_skipped'] = $defaults['fetch_skipped'];
+                    $state['files_pull_only_fingerprint'] = null;
+                    return $state;
+                });
+                foreach ([
+                    "{$state_dir}/.import-remote-index.jsonl",
+                    "{$state_dir}/.import-download-list.jsonl",
+                    "{$state_dir}/.import-download-list-skipped.jsonl",
+                ] as $path) {
+                    if (file_exists($path)) {
+                        @unlink($path);
+                    }
+                }
+                $state = $this->client->state;
+            } elseif (($state['command'] ?? null) === 'db-pull' && in_array('db-pull', $stages, true)) {
+                $this->client->mutate_state(function (array $state) use ($defaults) {
+                    $state['command'] = null;
+                    $state['status'] = null;
+                    $state['cursor'] = null;
+                    $state['stage'] = null;
+                    $state['consecutive_timeouts'] = 0;
+                    $state['sql_bytes'] = null;
+                    $state['db_index'] = $defaults['db_index'];
+                    return $state;
+                });
+                foreach ([
+                    "{$state_dir}/db.sql",
+                    "{$state_dir}/db-tables.jsonl",
+                    "{$state_dir}/.import-domains.json",
+                ] as $path) {
+                    if (file_exists($path)) {
+                        @unlink($path);
+                    }
+                }
+                $state = $this->client->state;
+            }
+        }
+
+        $total = count($stages);
+        $completed_stage = $pull_pipeline === $command ? $pull_stage : null;
+
         if ($completed_stage === 'complete') {
             $this->prepare_repull();
             $completed_stage = null;
@@ -101,7 +195,7 @@ class Pull
 
         $start_index = 0;
         if ($completed_stage !== null) {
-            $idx = array_search($completed_stage, $stages);
+            $idx = array_search($completed_stage, $stages, true);
             if ($idx !== false) {
                 $start_index = $idx + 1;
             }
@@ -110,19 +204,19 @@ class Pull
         $host = parse_url($this->client->remote_url, PHP_URL_HOST) ?? $this->client->remote_url;
         $bold = "\033[1m";
         $r = "\033[0m";
-        $this->progress->print_line("\n{$bold}Pulling {$host}{$r}\n");
+        $this->progress->print_line("\n{$bold}{$title} {$host}{$r}\n");
 
         $this->client->output_progress([
             "type" => "lifecycle",
             "event" => "starting",
-            "command" => "pull",
+            "command" => $command,
             "stages" => $stages,
             "resume_from" => $start_index,
-            "message" => "Starting pull",
+            "message" => "Starting {$command}",
         ], true);
 
         $this->client->audit_log(
-            sprintf("PULL | stages=%s | resume_from=%d", implode(",", $stages), $start_index),
+            sprintf("%s | stages=%s | resume_from=%d", strtoupper($command), implode(",", $stages), $start_index),
             true,
         );
 
@@ -139,43 +233,56 @@ class Pull
             try {
                 $this->run_stage($stage, $options, $step, $total);
             } catch (\Exception $e) {
-                $this->report_failure($stage, $stages, $i, $e);
-                throw $e;
+                $this->report_failure($command, $stage, $stages, $i, $e);
+                throw new PullFailureReportedException($e->getMessage(), 0, $e);
             }
 
-            $this->client->mark_pull_stage_complete($stage);
+            $this->client->mark_pull_stage_complete($stage, $command);
         }
 
         // The 'start' stage handles its own completion (it needs to save
         // state before blocking on the server process).
         if (!in_array('start', $stages, true)) {
-            $this->client->mark_pull_complete();
+            $this->client->mark_pull_complete($command);
             $this->print_summary();
         }
 
+        $complete_message = $command === 'pull' ? 'Pull complete' : "{$command} complete";
         $this->client->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
-            "command" => "pull",
+            "command" => $command,
             "stages" => $stages,
-            "message" => "Pull complete",
+            "message" => $complete_message,
         ], true);
     }
 
-    /**
-     * Handle --abort for the pull command: clear pipeline state but
-     * leave downloaded files in place.
-     */
-    public function abort(): void
+    private function assert_no_conflicting_pull(string $command, array $stages): void
     {
-        $this->prepare_repull();
-        $this->progress->show_lifecycle_line("Pull state cleared. Downloaded files are preserved.\n");
-        $this->client->output_progress([
-            "type" => "lifecycle",
-            "event" => "aborted",
-            "command" => "pull",
-            "message" => "Pull state cleared",
-        ], true);
+        $pull = $this->client->state['pull'] ?? [];
+        $pull_pipeline = $pull['pipeline'] ?? 'pull';
+        $pull_stage = $pull['stage'] ?? null;
+
+        if ($pull_stage !== null && $pull_stage !== 'complete' && $pull_pipeline !== $command) {
+            throw new RuntimeException(
+                "A {$pull_pipeline} command is already in progress. " .
+                "Finish it, rerun {$pull_pipeline}, or use --abort before running {$command}."
+            );
+        }
+
+        $state_command = $this->client->state['command'] ?? null;
+        $state_status = $this->client->state['status'] ?? null;
+        if (
+            $state_status !== null &&
+            $state_status !== 'complete' &&
+            in_array($state_command, ['files-pull', 'db-pull', 'db-apply'], true) &&
+            !in_array($state_command, $stages, true)
+        ) {
+            throw new RuntimeException(
+                "A {$state_command} command is already in progress. " .
+                "Finish it, rerun {$state_command}, or use --abort before running {$command}."
+            );
+        }
     }
 
     private function run_stage(string $stage, array $options, int $step, int $total): void
@@ -183,15 +290,18 @@ class Pull
         switch ($stage) {
             case 'preflight':
                 $this->client->run_preflight();
-                if ($this->check_plugin_installed()) {
+                $preflight = $this->client->state["preflight"] ?? null;
+                $ok = ($preflight["http_code"] ?? 0) === 200 && !empty($preflight["data"]["ok"]);
+                if (!$ok) {
                     $this->client->exit_code = 1;
-                    return;
+                    throw new RuntimeException($preflight["error"] ?? "Preflight check failed");
                 }
                 $this->print_done($stage, $this->preflight_summary());
                 break;
 
             case 'files-pull':
-                $this->run_until_complete(function () {
+                $this->client->prepare_files_pull_options($options);
+                $this->run_until_complete('files-pull', function () {
                     $this->client->run_files_sync();
                 });
                 $skipped_pending =
@@ -209,18 +319,29 @@ class Pull
                 break;
 
             case 'db-pull':
-                $this->run_until_complete(function () {
-                    $this->client->run_db_sync();
-                });
+                if (
+                    ($this->client->state['command'] ?? null) !== 'db-pull' ||
+                    ($this->client->state['status'] ?? null) !== 'complete' ||
+                    !file_exists($this->client->state_dir . '/db.sql')
+                ) {
+                    $this->run_until_complete('db-pull', function () {
+                        $this->client->run_db_sync();
+                    });
+                }
                 $sql_file = $this->client->state_dir . "/db.sql";
                 $size = file_exists($sql_file) ? $this->format_bytes(filesize($sql_file)) : null;
                 $this->print_done($stage, $size);
                 break;
 
             case 'db-apply':
-                $this->run_until_complete(function () use ($options) {
-                    $this->client->run_db_apply($options);
-                });
+                if (
+                    ($this->client->state['command'] ?? null) !== 'db-apply' ||
+                    ($this->client->state['status'] ?? null) !== 'complete'
+                ) {
+                    $this->run_until_complete('db-apply', function () use ($options) {
+                        $this->client->run_db_apply($options);
+                    });
+                }
                 $state = $this->client->state;
                 $stmts = (int) ($state["apply"]["statements_executed"] ?? 0);
                 $this->print_done($stage, $stmts > 0 ? number_format($stmts) . " statements" : null);
@@ -243,53 +364,39 @@ class Pull
     }
 
     /**
-     * Validate user-provided options and apply defaults.
+     * Reject invalid high-level pull options before ImportClient persists
+     * resume-related state.
      */
-    private function validate_and_default_options(array $options): array
+    public function assert_options_valid_before_state_write(string $command, array $options): void
     {
-        // --runtime and --start-runtime values are validated at CLI parse
-        // time from VALID_TARGET_RUNTIMES. Re-check here for programmatic
-        // callers (e.g. ImportClient::run invoked directly) that bypass
-        // the CLI parser.
-        foreach (['runtime', 'start_runtime'] as $key) {
-            if (!empty($options[$key]) && !in_array($options[$key], VALID_TARGET_RUNTIMES, true)) {
-                $flag = str_replace('_', '-', $key);
-                throw new InvalidArgumentException(
-                    "Invalid --{$flag} value: {$options[$key]}. " .
-                    "Valid runtimes: " . implode(', ', VALID_TARGET_RUNTIMES)
-                );
-            }
+        $sql_output = $options["sql_output"] ?? "file";
+        if ($sql_output !== "file") {
+            throw new InvalidArgumentException(
+                "{$command} downloads SQL to the local state directory before applying it. " .
+                "Use db-pull directly for --sql-output={$sql_output}."
+            );
         }
 
+        $this->assert_runtime_options_valid($options);
+        $options = $this->default_pull_runtime_options($options);
+        if ($options['runtime'] === 'none') {
+            unset($options['runtime']);
+        }
+        $options = $this->default_pull_target_options($options);
+        $this->validate_database_target_options($options);
+    }
+
+    /**
+     * Validate user-provided pull options and apply defaults without saving state.
+     */
+    private function validate_and_default_pull_options(array $options): array
+    {
+        $this->assert_runtime_options_valid($options);
         // Default --runtime to php-builtin so pull always ends with a
         // running local server. Users can override with --runtime=nginx-fpm,
         // --runtime=playground-cli, or --runtime=none to skip runtime
         // generation entirely.
-        if (empty($options['runtime'])) {
-            if (!empty($options['start_runtime']) && $options['start_runtime'] !== 'none') {
-                $options['runtime'] = $options['start_runtime'];
-            } else {
-                $options['runtime'] = 'php-builtin';
-            }
-        }
-
-        if (empty($options['start_runtime'])) {
-            $options['start_runtime'] = $this->default_start_runtime($options['runtime']);
-        }
-        if ($options['start_runtime'] !== 'none') {
-            if (!$this->can_start_runtime($options['start_runtime'])) {
-                throw new InvalidArgumentException(
-                    "Starting runtime {$options['start_runtime']} is not supported yet. " .
-                    "Supported start runtimes: php-builtin, playground-cli, none"
-                );
-            }
-            if ($options['start_runtime'] !== $options['runtime']) {
-                throw new InvalidArgumentException(
-                    "--start-runtime={$options['start_runtime']} requires matching --runtime={$options['start_runtime']}, " .
-                    "or omit --runtime to use {$options['start_runtime']} for both."
-                );
-            }
-        }
+        $options = $this->default_pull_runtime_options($options);
 
         if ($options['runtime'] === 'none') {
             unset($options['runtime']);
@@ -298,35 +405,8 @@ class Pull
         // Default --target-engine to sqlite for php-builtin and
         // playground-cli (no MySQL server needed). nginx-fpm users
         // probably have a server stack — require explicit DB config.
-        if (empty($options['target_engine']) && empty($options['target_user']) && empty($options['target_db'])) {
-            if (($options['runtime'] ?? null) !== 'nginx-fpm') {
-                $options['target_engine'] = 'sqlite';
-            }
-        }
-
-        if (!empty($options['target_engine'])) {
-            $engine = strtolower($options['target_engine']);
-            if (!in_array($engine, ['mysql', 'sqlite'], true)) {
-                throw new InvalidArgumentException(
-                    "Invalid --target-engine value: {$options['target_engine']}. " .
-                    "Valid engines: mysql, sqlite"
-                );
-            }
-        }
-
-        $engine = strtolower($options['target_engine'] ?? '');
-        if ($engine === 'mysql') {
-            if (empty($options['target_user'])) {
-                throw new InvalidArgumentException(
-                    "--target-user is required for MySQL database import."
-                );
-            }
-            if (empty($options['target_db'])) {
-                throw new InvalidArgumentException(
-                    "--target-db is required for MySQL database import."
-                );
-            }
-        }
+        $options = $this->default_pull_target_options($options);
+        $options = $this->validate_database_target_options($options);
 
         if (empty($options['output_dir'])) {
             $options['output_dir'] = $this->client->state_dir . '/runtime';
@@ -350,6 +430,97 @@ class Pull
         // the flattened layout.
         if (!empty($options['flatten_to']) && empty($options['flat_document_root'])) {
             $options['flat_document_root'] = $options['flatten_to'];
+        }
+
+        return $options;
+    }
+
+    private function assert_runtime_options_valid(array $options): void
+    {
+        // --runtime and --start-runtime values are validated at CLI parse
+        // time from VALID_TARGET_RUNTIMES. Re-check here for programmatic
+        // callers (e.g. ImportClient::run invoked directly) that bypass
+        // the CLI parser.
+        foreach (['runtime', 'start_runtime'] as $key) {
+            if (!empty($options[$key]) && !in_array($options[$key], VALID_TARGET_RUNTIMES, true)) {
+                $flag = str_replace('_', '-', $key);
+                throw new InvalidArgumentException(
+                    "Invalid --{$flag} value: {$options[$key]}. " .
+                    "Valid runtimes: " . implode(', ', VALID_TARGET_RUNTIMES)
+                );
+            }
+        }
+
+        $options = $this->default_pull_runtime_options($options);
+        if ($options['start_runtime'] === 'none') {
+            return;
+        }
+        if (!$this->can_start_runtime($options['start_runtime'])) {
+            throw new InvalidArgumentException(
+                "Starting runtime {$options['start_runtime']} is not supported yet. " .
+                "Supported start runtimes: php-builtin, playground-cli, none"
+            );
+        }
+        if ($options['start_runtime'] !== $options['runtime']) {
+            throw new InvalidArgumentException(
+                "--start-runtime={$options['start_runtime']} requires matching --runtime={$options['start_runtime']}, " .
+                "or omit --runtime to use {$options['start_runtime']} for both."
+            );
+        }
+    }
+
+    private function default_pull_runtime_options(array $options): array
+    {
+        if (empty($options['runtime'])) {
+            if (!empty($options['start_runtime']) && $options['start_runtime'] !== 'none') {
+                $options['runtime'] = $options['start_runtime'];
+            } else {
+                $options['runtime'] = 'php-builtin';
+            }
+        }
+
+        if (empty($options['start_runtime'])) {
+            $options['start_runtime'] = $this->default_start_runtime($options['runtime']);
+        }
+
+        return $options;
+    }
+
+    private function default_pull_target_options(array $options): array
+    {
+        if (empty($options['target_engine']) && empty($options['target_user']) && empty($options['target_db'])) {
+            if (($options['runtime'] ?? null) !== 'nginx-fpm') {
+                $options['target_engine'] = 'sqlite';
+            }
+        }
+
+        return $options;
+    }
+
+    private function validate_database_target_options(array $options): array
+    {
+        if (!empty($options['target_engine'])) {
+            $engine = strtolower($options['target_engine']);
+            if (!in_array($engine, ['mysql', 'sqlite'], true)) {
+                throw new InvalidArgumentException(
+                    "Invalid --target-engine value: {$options['target_engine']}. " .
+                    "Valid engines: mysql, sqlite"
+                );
+            }
+            $options['target_engine'] = $engine;
+        }
+
+        if (($options['target_engine'] ?? 'mysql') === 'mysql') {
+            if (empty($options['target_user'])) {
+                throw new InvalidArgumentException(
+                    "--target-user is required for MySQL database import."
+                );
+            }
+            if (empty($options['target_db'])) {
+                throw new InvalidArgumentException(
+                    "--target-db is required for MySQL database import."
+                );
+            }
         }
 
         return $options;
@@ -409,6 +580,7 @@ class Pull
         $state_dir = $this->client->state_dir;
         $defaults = $this->client->default_state();
         $this->client->mutate_state(function (array $state) use ($defaults) {
+            $state['pull']['pipeline'] = 'pull';
             $state['pull']['stage'] = null;
             $state['pull']['files_filter'] = null;
             $state['pull']['skipped_pending'] = false;
@@ -451,13 +623,16 @@ class Pull
      * resetting the status to "in_progress" so the handler enters its
      * resume path (it specifically checks for that value).
      */
-    private function run_until_complete(callable $handler): void
+    private function run_until_complete(string $stage, callable $handler): void
     {
         for ($attempt = 0; $attempt < 1000; $attempt++) {
             $handler();
             $state = $this->client->state;
+            if (($state['status'] ?? null) === 'complete') {
+                return;
+            }
             if (($state['status'] ?? null) !== 'partial') {
-                break;
+                throw new RuntimeException("Stage {$stage} stopped before completing.");
             }
             $this->client->mutate_state(function (array $state) {
                 $state['status'] = 'in_progress';
@@ -466,58 +641,8 @@ class Pull
             $this->client->exit_code = 0;
             $this->progress->tick_spinner();
         }
-    }
 
-    /**
-     * Check whether preflight detected that the exporter plugin is not
-     * installed. Returns true if so (caller should abort the pipeline).
-     */
-    private function check_plugin_installed(): bool
-    {
-        $state = $this->client->state;
-        $preflight = $state["preflight"] ?? null;
-        $ok = ($preflight["http_code"] ?? 0) === 200 && !empty($preflight["data"]["ok"]);
-        if ($ok) {
-            return false;
-        }
-
-        $error = $preflight["error"] ?? null;
-        $error_code = $this->client->last_error_code;
-        $is_not_installed =
-            $error_code === 'NOT_FOUND' ||
-            $error_code === 'HTML_RESPONSE';
-
-        if ($is_not_installed) {
-            $red = "\033[31m";
-            $bold = "\033[1m";
-            $dim = "\033[2m";
-            $cyan = "\033[36m";
-            $r = "\033[0m";
-            $this->progress->print_line("\n{$red}  ✗ The exporter plugin is not installed on this site.{$r}\n\n");
-            $this->progress->print_line("  To set it up, run:\n\n");
-            $this->progress->print_line("    {$cyan}php reprint.phar install-exporter{$r}\n\n");
-            $this->progress->print_line("  {$dim}This will show the download URL and step-by-step instructions.{$r}\n");
-        } else {
-            $red = "\033[31m";
-            $dim = "\033[2m";
-            $r = "\033[0m";
-            $this->progress->print_line("\n{$red}  ✗ Preflight failed{$r}\n");
-            if ($error) {
-                $indented = implode("\n  ", explode("\n", $error));
-                $this->progress->print_line("  {$indented}\n");
-            }
-        }
-
-        $this->client->output_progress([
-            "status" => "error",
-            "command" => "pull",
-            "failed_stage" => "preflight",
-            "error_code" => $error_code,
-            "error" => $error ?? "Preflight check failed",
-            "message" => $error ?? "Preflight check failed",
-        ]);
-
-        return true;
+        throw new RuntimeException("Stage {$stage} kept reporting partial progress after 1000 retry attempts; aborting.");
     }
 
     /**
@@ -641,23 +766,47 @@ class Pull
         }
     }
 
-    private function report_failure(string $stage, array $stages, int $i, \Exception $e): void
+    private function report_failure(string $command, string $stage, array $stages, int $i, \Exception $e): void
     {
+        $message = $stage === 'preflight'
+            ? $e->getMessage()
+            : "Pull failed at {$stage}: " . $e->getMessage();
+
         $this->client->output_progress([
             "status" => "error",
-            "command" => "pull",
+            "command" => $command,
             "failed_stage" => $stage,
             "completed_stages" => array_slice($stages, 0, $i),
             "error_code" => $this->client->last_error_code,
             "error" => $e->getMessage(),
-            "message" => "Pull failed at {$stage}: " . $e->getMessage(),
+            "message" => $message,
         ]);
-        $this->client->write_status_file("Pull failed at {$stage}: " . $e->getMessage());
+        $this->client->write_status_file($message);
 
         $red = "\033[31m";
         $dim = "\033[2m";
         $r = "\033[0m";
         $this->progress->clear_progress_line();
+
+        if ($stage === 'preflight') {
+            $error_code = $this->client->last_error_code;
+            $is_not_installed =
+                $error_code === 'NOT_FOUND' ||
+                $error_code === 'HTML_RESPONSE';
+
+            if ($is_not_installed) {
+                $cyan = "\033[36m";
+                $this->progress->print_line("\n{$red}  ✗ The exporter plugin is not installed on this site.{$r}\n\n");
+                $this->progress->print_line("  To set it up, run:\n\n");
+                $this->progress->print_line("    {$cyan}php reprint.phar install-exporter{$r}\n\n");
+                $this->progress->print_line("  {$dim}This will show the download URL and step-by-step instructions.{$r}\n");
+            } else {
+                $this->progress->print_line("\n{$red}  ✗ Preflight failed{$r}\n");
+                $this->progress->print_line("  " . implode("\n  ", explode("\n", $e->getMessage())) . "\n");
+            }
+            return;
+        }
+
         $this->progress->print_line("  {$red}✗ " . $this->stage_label($stage) . "{$r}\n");
         $this->progress->print_line("    {$dim}" . $e->getMessage() . "{$r}\n\n");
         $this->progress->print_line("  Re-run the same command to resume.\n");

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -115,32 +115,96 @@ class Pull
         ], true);
     }
 
+    /**
+     * Runs a named pull pipeline from the first unfinished stage.
+     *
+     * `state['pull_pipeline']` records orchestration progress: which
+     * user-facing command started the pipeline and which whole stage was last
+     * completed. `state['active_resumable_command']` records the resumable
+     * lower-level command, whether it was invoked directly or as a stage in
+     * this pipeline, including its completion status, internal state, and
+     * remote cursor.
+     *
+     * Keeping those checkpoints separate lets a rerun resume safely when a
+     * lower-level command completed but the pipeline checkpoint was not saved
+     * yet.
+     */
     private function run_pipeline(string $command, array $stages, array $options, string $title): void
     {
-        $this->assert_no_conflicting_pull($command, $stages);
-
         $state = $this->client->state;
-        $pull_pipeline = $state['pull']['pipeline'] ?? null;
-        $pull_stage = $state['pull']['stage'] ?? null;
-        // Atomic commands leave state["command"] marked complete. Reuse that
-        // marker only while resuming the same high-level pipeline; otherwise a
-        // prior standalone files-pull/db-pull would make pull skip
-        // the fresh delta it was asked to compute.
-        $can_reuse_atomic_state =
-            $pull_pipeline === $command &&
-            $pull_stage !== null &&
-            $pull_stage !== 'complete';
-        $completed_current_pipeline = $pull_pipeline === $command && $pull_stage === 'complete';
-        if (!$completed_current_pipeline && !$can_reuse_atomic_state && ($state['status'] ?? null) === 'complete') {
+        $pull_pipeline = $state['pull_pipeline']['started_by_command'] ?? null;
+        $pull_stage = $state['pull_pipeline']['last_completed_stage'] ?? null;
+        $stage_sequence = $state['pull_pipeline']['stage_sequence'] ?? [];
+        if (!is_array($stage_sequence) || $stage_sequence === []) {
+            $stage_sequence = $stages;
+        }
+        $pipeline_final_stage = $stage_sequence[count($stage_sequence) - 1] ?? null;
+        $state_command = $state['active_resumable_command']['command_name'] ?? null;
+        $state_status = $state['active_resumable_command']['completion_state'] ?? null;
+        $completed_stage = $pull_pipeline === $command ? $pull_stage : null;
+        $completed_current_pipeline =
+            $completed_stage !== null &&
+            $pipeline_final_stage !== null &&
+            $completed_stage === $pipeline_final_stage;
+
+        if ($completed_current_pipeline) {
+            $this->prepare_repull();
+            $completed_stage = null;
+            $pull_stage = null;
+            $state_command = null;
+            $state_status = null;
+        }
+
+        $pipeline_has_resume_state =
+            $pull_pipeline !== null &&
+            (
+                $pull_stage !== null ||
+                $state_command !== null ||
+                $state_status !== null
+            );
+
+        if ($pipeline_has_resume_state && $pull_pipeline !== $command) {
+            throw new RuntimeException(
+                "Another command is already in progress: {$pull_pipeline}. " .
+                "Rerun {$pull_pipeline} to resume it. Only use --abort if you want to discard " .
+                "that pipeline's resume state before running {$command}."
+            );
+        }
+
+        $has_direct_command_state = !$pipeline_has_resume_state && $state_status !== null;
+        if (
+            $has_direct_command_state &&
+            $state_status !== 'complete' &&
+            in_array($state_command, ['files-pull', 'db-pull', 'db-apply'], true) &&
+            !in_array($state_command, $stages, true)
+        ) {
+            throw new RuntimeException(
+                "Another command is already in progress: {$state_command}. " .
+                "Rerun {$state_command} to resume it. Only use --abort if you want to discard " .
+                "that command's resume state before running {$command}."
+            );
+        }
+
+        if ($has_direct_command_state && $state_status === 'complete') {
+            // Users can run lower-level commands directly, e.g.
+            // `reprint files-pull` or `reprint db-pull`, without going through
+            // this pull pipeline. Those commands save their own completion
+            // state in active_resumable_command. That state must not make
+            // `reprint pull` skip its files or database stage: the pipeline
+            // has not recorded that stage as complete. Clear the direct
+            // command checkpoint first so the stage computes a fresh delta.
             $state_dir = $this->client->state_dir;
             $defaults = $this->client->default_state();
 
-            if (($state['command'] ?? null) === 'files-pull' && in_array('files-pull', $stages, true)) {
+            if ($state_command === 'files-pull' && in_array('files-pull', $stages, true)) {
+                // Keep the local file index, but clear transient files-pull
+                // download state so this pipeline computes a fresh
+                // remote-vs-local delta.
                 $this->client->mutate_state(function (array $state) use ($defaults) {
-                    $state['command'] = null;
-                    $state['status'] = null;
-                    $state['cursor'] = null;
-                    $state['stage'] = null;
+                    $state['active_resumable_command']['command_name'] = null;
+                    $state['active_resumable_command']['completion_state'] = null;
+                    $state['active_resumable_command']['remote_cursor'] = null;
+                    $state['active_resumable_command']['current_stage'] = null;
                     $state['consecutive_timeouts'] = 0;
                     $state['current_file'] = null;
                     $state['current_file_bytes'] = null;
@@ -160,13 +224,13 @@ class Pull
                         @unlink($path);
                     }
                 }
-                $state = $this->client->state;
-            } elseif (($state['command'] ?? null) === 'db-pull' && in_array('db-pull', $stages, true)) {
+            } elseif ($state_command === 'db-pull' && in_array('db-pull', $stages, true)) {
+                // Discard database dump artifacts from any previous runs.
                 $this->client->mutate_state(function (array $state) use ($defaults) {
-                    $state['command'] = null;
-                    $state['status'] = null;
-                    $state['cursor'] = null;
-                    $state['stage'] = null;
+                    $state['active_resumable_command']['command_name'] = null;
+                    $state['active_resumable_command']['completion_state'] = null;
+                    $state['active_resumable_command']['remote_cursor'] = null;
+                    $state['active_resumable_command']['current_stage'] = null;
                     $state['consecutive_timeouts'] = 0;
                     $state['sql_bytes'] = null;
                     $state['db_index'] = $defaults['db_index'];
@@ -181,18 +245,10 @@ class Pull
                         @unlink($path);
                     }
                 }
-                $state = $this->client->state;
             }
         }
 
         $total = count($stages);
-        $completed_stage = $pull_pipeline === $command ? $pull_stage : null;
-
-        if ($completed_stage === 'complete') {
-            $this->prepare_repull();
-            $completed_stage = null;
-        }
-
         $start_index = 0;
         if ($completed_stage !== null) {
             $idx = array_search($completed_stage, $stages, true);
@@ -237,7 +293,7 @@ class Pull
                 throw new PullFailureReportedException($e->getMessage(), 0, $e);
             }
 
-            $this->client->mark_pull_stage_complete($stage, $command);
+            $this->client->mark_pull_stage_complete($stage, $command, $stages);
         }
 
         // The 'start' stage handles its own completion (it needs to save
@@ -257,34 +313,14 @@ class Pull
         ], true);
     }
 
-    private function assert_no_conflicting_pull(string $command, array $stages): void
-    {
-        $pull = $this->client->state['pull'] ?? [];
-        $pull_pipeline = $pull['pipeline'] ?? 'pull';
-        $pull_stage = $pull['stage'] ?? null;
-
-        if ($pull_stage !== null && $pull_stage !== 'complete' && $pull_pipeline !== $command) {
-            throw new RuntimeException(
-                "A {$pull_pipeline} command is already in progress. " .
-                "Finish it, rerun {$pull_pipeline}, or use --abort before running {$command}."
-            );
-        }
-
-        $state_command = $this->client->state['command'] ?? null;
-        $state_status = $this->client->state['status'] ?? null;
-        if (
-            $state_status !== null &&
-            $state_status !== 'complete' &&
-            in_array($state_command, ['files-pull', 'db-pull', 'db-apply'], true) &&
-            !in_array($state_command, $stages, true)
-        ) {
-            throw new RuntimeException(
-                "A {$state_command} command is already in progress. " .
-                "Finish it, rerun {$state_command}, or use --abort before running {$command}."
-            );
-        }
-    }
-
+    /**
+     * Runs one pipeline stage and prints its completion summary.
+     *
+     * Stages that delegate to lower-level commands rely on those commands for
+     * their own resume state. The pipeline checkpoint is saved by the caller
+     * after this method returns, so a thrown exception leaves the stage
+     * unfinished at the orchestration level.
+     */
     private function run_stage(string $stage, array $options, int $step, int $total): void
     {
         switch ($stage) {
@@ -319,9 +355,12 @@ class Pull
                 break;
 
             case 'db-pull':
+                // A completed db-pull is useful only when the downloaded SQL
+                // dump is still present. Without the dump, the following
+                // db-apply stage would have nothing safe to import.
                 if (
-                    ($this->client->state['command'] ?? null) !== 'db-pull' ||
-                    ($this->client->state['status'] ?? null) !== 'complete' ||
+                    ($this->client->state['active_resumable_command']['command_name'] ?? null) !== 'db-pull' ||
+                    ($this->client->state['active_resumable_command']['completion_state'] ?? null) !== 'complete' ||
                     !file_exists($this->client->state_dir . '/db.sql')
                 ) {
                     $this->run_until_complete('db-pull', function () {
@@ -334,9 +373,12 @@ class Pull
                 break;
 
             case 'db-apply':
+                // Database import is not safe to run twice. If db-apply
+                // already reached lower-level completion, accept that result even
+                // when the pipeline checkpoint still needs to be advanced.
                 if (
-                    ($this->client->state['command'] ?? null) !== 'db-apply' ||
-                    ($this->client->state['status'] ?? null) !== 'complete'
+                    ($this->client->state['active_resumable_command']['command_name'] ?? null) !== 'db-apply' ||
+                    ($this->client->state['active_resumable_command']['completion_state'] ?? null) !== 'complete'
                 ) {
                     $this->run_until_complete('db-apply', function () use ($options) {
                         $this->client->run_db_apply($options);
@@ -435,12 +477,15 @@ class Pull
         return $options;
     }
 
+    /**
+     * Validates runtime options for both CLI and programmatic callers.
+     *
+     * Programmatic callers can invoke ImportClient without the CLI parser, so
+     * pull validates runtime names and start/runtime combinations here before
+     * any resume state is written.
+     */
     private function assert_runtime_options_valid(array $options): void
     {
-        // --runtime and --start-runtime values are validated at CLI parse
-        // time from VALID_TARGET_RUNTIMES. Re-check here for programmatic
-        // callers (e.g. ImportClient::run invoked directly) that bypass
-        // the CLI parser.
         foreach (['runtime', 'start_runtime'] as $key) {
             if (!empty($options[$key]) && !in_array($options[$key], VALID_TARGET_RUNTIMES, true)) {
                 $flag = str_replace('_', '-', $key);
@@ -469,6 +514,13 @@ class Pull
         }
     }
 
+    /**
+     * Applies runtime defaults without mutating persisted state.
+     *
+     * `pull` should produce a runnable local site by default, so it generates
+     * php-builtin runtime files unless the caller selects a runtime, selects a
+     * start runtime, or disables runtime generation explicitly.
+     */
     private function default_pull_runtime_options(array $options): array
     {
         if (empty($options['runtime'])) {
@@ -486,6 +538,14 @@ class Pull
         return $options;
     }
 
+    /**
+     * Applies the database target defaults for generated runtimes.
+     *
+     * php-builtin and playground-cli can run without a local MySQL server, so
+     * pull imports into SQLite by default for those runtimes. nginx-fpm does
+     * not imply a database target because it is normally paired with an
+     * externally managed server.
+     */
     private function default_pull_target_options(array $options): array
     {
         if (empty($options['target_engine']) && empty($options['target_user']) && empty($options['target_db'])) {
@@ -497,6 +557,13 @@ class Pull
         return $options;
     }
 
+    /**
+     * Validates database import target options.
+     *
+     * MySQL imports need a user and database name because Reprint connects to
+     * an existing server. SQLite imports can use the generated default path
+     * when no explicit target path is supplied.
+     */
     private function validate_database_target_options(array $options): array
     {
         if (!empty($options['target_engine'])) {
@@ -526,6 +593,12 @@ class Pull
         return $options;
     }
 
+    /**
+     * Selects the runtime that should receive generated runtime files.
+     *
+     * A requested start runtime also implies runtime generation because there
+     * is no generated server to start otherwise.
+     */
     private function resolve_runtime(array $options): ?string
     {
         if (!empty($options['runtime'])) {
@@ -537,6 +610,12 @@ class Pull
         return null;
     }
 
+    /**
+     * Selects the runtime, if any, to launch after generation.
+     *
+     * Without an explicit start option, pull starts only runtimes that this
+     * process knows how to launch directly.
+     */
     private function resolve_start_runtime(array $options, ?string $runtime): string
     {
         if (!empty($options['start_runtime'])) {
@@ -545,11 +624,17 @@ class Pull
         return $this->default_start_runtime($runtime);
     }
 
+    /**
+     * Returns the implicit start mode for a generated runtime.
+     */
     private function default_start_runtime(?string $runtime): string
     {
         return $this->can_start_runtime($runtime) ? $runtime : 'none';
     }
 
+    /**
+     * Indicates whether pull can launch the generated runtime directly.
+     */
     private function can_start_runtime(?string $runtime): bool
     {
         return in_array($runtime, ['php-builtin', 'playground-cli'], true);
@@ -580,15 +665,16 @@ class Pull
         $state_dir = $this->client->state_dir;
         $defaults = $this->client->default_state();
         $this->client->mutate_state(function (array $state) use ($defaults) {
-            $state['pull']['pipeline'] = 'pull';
-            $state['pull']['stage'] = null;
-            $state['pull']['files_filter'] = null;
-            $state['pull']['skipped_pending'] = false;
-            $state['pull']['has_completed_once'] = true;
-            $state['command'] = null;
-            $state['status'] = null;
-            $state['cursor'] = null;
-            $state['stage'] = null;
+            $state['pull_pipeline']['started_by_command'] = 'pull';
+            $state['pull_pipeline']['stage_sequence'] = [];
+            $state['pull_pipeline']['last_completed_stage'] = null;
+            $state['pull_pipeline']['files_filter'] = null;
+            $state['pull_pipeline']['skipped_pending'] = false;
+            $state['pull_pipeline']['has_completed_once'] = true;
+            $state['active_resumable_command']['command_name'] = null;
+            $state['active_resumable_command']['completion_state'] = null;
+            $state['active_resumable_command']['remote_cursor'] = null;
+            $state['active_resumable_command']['current_stage'] = null;
             $state['consecutive_timeouts'] = 0;
             $state['sql_bytes'] = null;
             $state['current_file'] = null;
@@ -618,24 +704,24 @@ class Pull
     }
 
     /**
-     * Sub-commands return with state["status"]="partial" when a server
-     * timeout drops the connection. This loop retries automatically,
-     * resetting the status to "in_progress" so the handler enters its
-     * resume path (it specifically checks for that value).
+     * Lower-level commands return with completion_state="partial" when a
+     * server timeout drops the connection. This loop retries automatically,
+     * resetting the completion state to "in_progress" so the handler enters
+     * its resume path on the next call.
      */
     private function run_until_complete(string $stage, callable $handler): void
     {
         for ($attempt = 0; $attempt < 1000; $attempt++) {
             $handler();
             $state = $this->client->state;
-            if (($state['status'] ?? null) === 'complete') {
+            if (($state['active_resumable_command']['completion_state'] ?? null) === 'complete') {
                 return;
             }
-            if (($state['status'] ?? null) !== 'partial') {
+            if (($state['active_resumable_command']['completion_state'] ?? null) !== 'partial') {
                 throw new RuntimeException("Stage {$stage} stopped before completing.");
             }
             $this->client->mutate_state(function (array $state) {
-                $state['status'] = 'in_progress';
+                $state['active_resumable_command']['completion_state'] = 'in_progress';
                 return $state;
             });
             $this->client->exit_code = 0;
@@ -690,8 +776,9 @@ class Pull
         // Mark pull complete BEFORE the server blocks so killing the
         // server (Ctrl-C) doesn't leave the pipeline mid-flight.
         $this->client->mutate_state(function (array $state) {
-            $state['pull']['stage'] = 'start';
-            $state['status'] = 'complete';
+            $state['pull_pipeline']['last_completed_stage'] = 'start';
+            $state['pull_pipeline']['has_completed_once'] = true;
+            $state['active_resumable_command']['completion_state'] = 'complete';
             return $state;
         });
 
@@ -717,6 +804,9 @@ class Pull
         $this->client->exit_code = $exit_code;
     }
 
+    /**
+     * Starts a progress line that stage commands can update in place.
+     */
     private function print_stage_header(string $stage): void
     {
         $this->progress->clear_progress_line();
@@ -729,6 +819,9 @@ class Pull
         $this->progress->print_line("\n\r\033[K  {$cyan}⠋{$r} {$label}");
     }
 
+    /**
+     * Finishes the active progress line with the stage result.
+     */
     private function print_done(string $stage, ?string $summary = null): void
     {
         $this->progress->clear_progress_line();
@@ -741,6 +834,9 @@ class Pull
         $this->progress->set_active_label(null);
     }
 
+    /**
+     * Shows a completed stage that is being skipped during resume.
+     */
     private function print_skipped(string $stage): void
     {
         $dim = "\033[2m";
@@ -749,6 +845,9 @@ class Pull
         $this->progress->print_line("  {$dim}✓ {$label}{$r}\n");
     }
 
+    /**
+     * Prints the final summary for pipelines that return to the shell.
+     */
     private function print_summary(): void
     {
         $green = "\033[32m";
@@ -759,13 +858,19 @@ class Pull
         $this->progress->print_line(
             "\n{$green}{$bold}Done.{$r} {$dim}Files in {$fs_root}{$r}\n"
         );
-        if (!empty($this->client->state['pull']['skipped_pending'])) {
+        if (!empty($this->client->state['pull_pipeline']['skipped_pending'])) {
             $this->progress->print_line(
                 "{$dim}Deferred files remain. The skipped download list was preserved on disk for a follow-up sync.{$r}\n"
             );
         }
     }
 
+    /**
+     * Reports a failed stage once before the caller rethrows.
+     *
+     * Preflight failures are formatted separately because a missing exporter
+     * plugin is an actionable setup problem, not a resumable transfer failure.
+     */
     private function report_failure(string $command, string $stage, array $stages, int $i, \Exception $e): void
     {
         $message = $stage === 'preflight'
@@ -812,6 +917,9 @@ class Pull
         $this->progress->print_line("  Re-run the same command to resume.\n");
     }
 
+    /**
+     * Formats a byte count for human-readable stage summaries.
+     */
     private function format_bytes(int $bytes): string
     {
         if ($bytes >= 1073741824) {

--- a/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -39,10 +39,10 @@ function remote_upload_proxy_code(): string
 		) {
 			$state = json_decode((string) file_get_contents($state_file), true);
 			if (is_array($state)) {
-				$command = $state['command'] ?? null;
-				$status = $state['status'] ?? null;
+				$command = $state['active_resumable_command']['command_name'] ?? null;
+				$status = $state['active_resumable_command']['completion_state'] ?? null;
 				$proxy_enabled =
-					($command === 'files-pull' || $command === 'files-sync') &&
+					$command === 'files-pull' &&
 					$status !== null &&
 					$status !== 'complete';
 			}

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -7,8 +7,9 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Verify that cURL timeouts during download save state and set status to
- * "partial" instead of crashing with a fatal RuntimeException.
+ * Verify that cURL timeouts during download save state and set the
+ * resumable command completion state to "partial" instead of crashing with
+ * a fatal RuntimeException.
  *
  * Each download method (download_sql, download_file_fetch, download_remote_index,
  * download_db_index) is tested by injecting a CurlTimeoutException via a
@@ -64,10 +65,12 @@ class CurlTimeoutRecoveryTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            "command" => null,
-            "status" => null,
-            "cursor" => null,
-            "stage" => null,
+            "active_resumable_command" => [
+                "command_name" => null,
+                "completion_state" => null,
+                "current_stage" => null,
+                "remote_cursor" => null,
+            ],
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
@@ -146,10 +149,12 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testSqlDownloadTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
-            "stage" => "sql",
-            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "sql",
+                "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            ],
             "sql_bytes" => 1024,
         ]);
 
@@ -167,11 +172,11 @@ class CurlTimeoutRecoveryTest extends TestCase
         $state = $this->readState();
         $this->assertEquals(
             "partial",
-            $state["status"],
-            "After cURL timeout, status should be 'partial' not an exception"
+            $state["active_resumable_command"]["completion_state"],
+            "After cURL timeout, resumable command completion state should be 'partial' not an exception"
         );
         $this->assertNotNull(
-            $state["cursor"],
+            $state["active_resumable_command"]["remote_cursor"],
             "Cursor should be preserved for resumption"
         );
         $this->assertNotNull(
@@ -187,9 +192,11 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testFileFetchTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => [
                 "offset" => 0,
                 "next_offset" => 100,
@@ -216,8 +223,8 @@ class CurlTimeoutRecoveryTest extends TestCase
         $state = $this->readState();
         $this->assertEquals(
             "partial",
-            $state["status"],
-            "After cURL timeout during file fetch, status should be 'partial'"
+            $state["active_resumable_command"]["completion_state"],
+            "After cURL timeout during file fetch, resumable command completion state should be 'partial'"
         );
     }
 
@@ -228,9 +235,11 @@ class CurlTimeoutRecoveryTest extends TestCase
         file_put_contents($trackedPath, str_repeat('a', 256));
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => [
                 "offset" => 0,
                 "next_offset" => 100,
@@ -288,9 +297,11 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testRemoteIndexTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "index",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "index",
+            ],
             "index" => [
                 "cursor" => base64_encode('{"dir":"/wp-content","offset":500}'),
             ],
@@ -320,8 +331,8 @@ class CurlTimeoutRecoveryTest extends TestCase
         $state = $this->readState();
         $this->assertEquals(
             "partial",
-            $state["status"],
-            "After cURL timeout during index download, status should be 'partial'"
+            $state["active_resumable_command"]["completion_state"],
+            "After cURL timeout during index download, resumable command completion state should be 'partial'"
         );
         $this->assertNotNull(
             $state["index"]["cursor"] ?? null,
@@ -336,10 +347,12 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testDbIndexTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
-            "stage" => "db-index",
-            "cursor" => base64_encode('{"table_offset":5}'),
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "db-index",
+                "remote_cursor" => base64_encode('{"table_offset":5}'),
+            ],
             "db_index" => [
                 "file" => null,
                 "tables" => 3,
@@ -357,8 +370,8 @@ class CurlTimeoutRecoveryTest extends TestCase
         $state = $this->readState();
         $this->assertEquals(
             "partial",
-            $state["status"],
-            "After cURL timeout during db-index, status should be 'partial'"
+            $state["active_resumable_command"]["completion_state"],
+            "After cURL timeout during db-index, resumable command completion state should be 'partial'"
         );
     }
 
@@ -369,10 +382,12 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testRunDbSyncExitsPartialOnSqlTimeout()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
-            "stage" => "sql",
-            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "sql",
+                "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            ],
             "sql_bytes" => 0,
             "db_index" => [
                 "file" => $this->stateDir . "/db-tables.jsonl",
@@ -395,8 +410,8 @@ class CurlTimeoutRecoveryTest extends TestCase
         $state = $this->readState();
         $this->assertEquals(
             "partial",
-            $state["status"],
-            "run_db_sync should set status to 'partial' on timeout, not throw"
+            $state["active_resumable_command"]["completion_state"],
+            "run_db_sync should set resumable command completion state to 'partial' on timeout, not throw"
         );
     }
 
@@ -421,8 +436,10 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testTrackConsecutiveTimeoutIncrementsOnNoProgress()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+            ],
             "consecutive_timeouts" => 0,
         ]);
 
@@ -443,8 +460,10 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testTrackConsecutiveTimeoutResetsOnProgress()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+            ],
             "consecutive_timeouts" => 2,
         ]);
 
@@ -461,8 +480,10 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testTrackConsecutiveTimeoutThrowsAtMax()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+            ],
             "consecutive_timeouts" => 2,
         ]);
 
@@ -484,10 +505,12 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testSqlDownloadGivesUpAfterMaxConsecutiveTimeouts()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
-            "stage" => "sql",
-            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "sql",
+                "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            ],
             "sql_bytes" => 1024,
             "consecutive_timeouts" => 2,
         ]);
@@ -510,10 +533,12 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testFirstTimeoutIncrementsCounterInState()
     {
         $this->writeState([
-            "command" => "db-pull",
-            "status" => "in_progress",
-            "stage" => "sql",
-            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "sql",
+                "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            ],
             "sql_bytes" => 1024,
             "consecutive_timeouts" => 0,
         ]);
@@ -530,7 +555,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         $downloadSql->invoke($client);
 
         $state = $this->readState();
-        $this->assertEquals("partial", $state["status"]);
+        $this->assertEquals("partial", $state["active_resumable_command"]["completion_state"]);
         $this->assertEquals(
             1,
             $state["consecutive_timeouts"],
@@ -541,9 +566,11 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testSuccessfulRequestResetsCounter()
     {
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "index",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "index",
+            ],
             "index" => [
                 "cursor" => base64_encode('{"dir":"/wp-content","offset":500}'),
             ],

--- a/tests/Import/DownloadListProgressTest.php
+++ b/tests/Import/DownloadListProgressTest.php
@@ -77,10 +77,12 @@ class DownloadListProgressTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            "command" => null,
-            "status" => null,
-            "cursor" => null,
-            "stage" => null,
+            "active_resumable_command" => [
+                "command_name" => null,
+                "completion_state" => null,
+                "current_stage" => null,
+                "remote_cursor" => null,
+            ],
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
@@ -143,9 +145,11 @@ class DownloadListProgressTest extends TestCase
         $listFile = $this->writeDownloadList(100);
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();
@@ -168,9 +172,11 @@ class DownloadListProgressTest extends TestCase
         $offset = $this->byteOffsetAfterLines($listFile, 40);
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => [
                 "offset" => $offset,
                 "next_offset" => $offset,
@@ -202,9 +208,11 @@ class DownloadListProgressTest extends TestCase
         $pastEnd = filesize($listFile) + 1000;
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => [
                 "offset" => $pastEnd,
                 "next_offset" => $pastEnd,
@@ -236,9 +244,11 @@ class DownloadListProgressTest extends TestCase
 
         // First invocation at offset 30
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => ["offset" => $offset30, "next_offset" => $offset30, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
         ]);
 
@@ -253,9 +263,11 @@ class DownloadListProgressTest extends TestCase
 
         // Second invocation at offset 60
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => ["offset" => $offset60, "next_offset" => $offset60, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
         ]);
 
@@ -280,9 +292,11 @@ class DownloadListProgressTest extends TestCase
         $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch-skipped",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch-skipped",
+            ],
             "fetch_skipped" => ["offset" => $offset20, "next_offset" => $offset20, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
         ]);
 
@@ -316,9 +330,11 @@ class DownloadListProgressTest extends TestCase
         $listFile = $this->writeDownloadList(10);
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();
@@ -341,9 +357,11 @@ class DownloadListProgressTest extends TestCase
         $offset40 = $this->byteOffsetAfterLines($listFile, 40);
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
             "fetch" => ["offset" => $offset40, "next_offset" => $offset40, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
         ]);
 

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -68,10 +68,12 @@ class FilesSyncStateTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            "command" => null,
-            "status" => null,
-            "cursor" => null,
-            "stage" => null,
+            "active_resumable_command" => [
+                "command_name" => null,
+                "completion_state" => null,
+                "current_stage" => null,
+                "remote_cursor" => null,
+            ],
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
@@ -158,8 +160,10 @@ class FilesSyncStateTest extends TestCase
     public function testCompletedFilesSyncRefusesToRerun()
     {
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "complete",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();
@@ -168,8 +172,8 @@ class FilesSyncStateTest extends TestCase
         $method->invoke($client);
 
         $state = $this->readState();
-        $this->assertEquals("complete", $state["status"]);
-        $this->assertEquals("files-pull", $state["command"]);
+        $this->assertEquals("complete", $state["active_resumable_command"]["completion_state"]);
+        $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
     }
 
     /**
@@ -179,9 +183,11 @@ class FilesSyncStateTest extends TestCase
     public function testSkippedEarlierTailRestoresCompletedStatus()
     {
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "complete",
-            "stage" => null,
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
             "filter" => "essential-files",
         ]);
         file_put_contents(
@@ -205,9 +211,9 @@ class FilesSyncStateTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertEquals("complete", $state["status"]);
-        $this->assertEquals("files-pull", $state["command"]);
-        $this->assertNull($state["stage"]);
+        $this->assertEquals("complete", $state["active_resumable_command"]["completion_state"]);
+        $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
+        $this->assertNull($state["active_resumable_command"]["current_stage"]);
         $this->assertEquals("skipped-earlier", $state["filter"]);
         $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
     }
@@ -221,8 +227,10 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "complete",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();
@@ -233,8 +241,9 @@ class FilesSyncStateTest extends TestCase
         $state = $this->readState();
         $this->assertNotEquals(
             "complete",
-            $state["status"] ?? null,
-            "After abort, status must not be 'complete' — the next run should start fresh",
+            $state["active_resumable_command"]["completion_state"] ?? null,
+            "After abort, resumable command completion state must not be 'complete' — " .
+            "the next run should start fresh",
         );
     }
 
@@ -248,8 +257,10 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "complete",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+            ],
         ]);
 
         // Step 1: abort
@@ -268,10 +279,10 @@ class FilesSyncStateTest extends TestCase
         $state = $this->readState();
         $this->assertNotEquals(
             "complete",
-            $state["status"],
+            $state["active_resumable_command"]["completion_state"],
             "After abort + re-run, the sync should start fresh, not report 'already complete'",
         );
-        $this->assertEquals("files-pull", $state["command"]);
+        $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
     }
 
     // ---------------------------------------------------------------
@@ -301,9 +312,11 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($localFile, 'old content');
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "diff",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "diff",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();
@@ -339,9 +352,11 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($localFile, 'local drop-in');
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "diff",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "diff",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();
@@ -375,9 +390,11 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($localFile, 'old content');
 
         $this->writeState([
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "fetch",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
         ]);
 
         [$client, $reflection] = $this->prepareClient();

--- a/tests/Import/ImportMetadataTest.php
+++ b/tests/Import/ImportMetadataTest.php
@@ -104,8 +104,10 @@ class ImportMetadataTest extends TestCase
     public function testImportMetadataDoesNotTreatCompletedSubcommandAsCompletedPull(): void
     {
         $this->writeState([
-            'command' => 'files-pull',
-            'status' => 'complete',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'complete',
+            ],
         ]);
 
         $metadata = $this->readMetadata();
@@ -115,23 +117,27 @@ class ImportMetadataTest extends TestCase
     }
 
     /**
-     * Verifies old state files with pull.stage=complete still report completion.
+     * Verifies a completed pull pipeline reports completion.
      */
-    public function testImportMetadataReportsCompletedLegacyState(): void
+    public function testImportMetadataReportsCompletedPullState(): void
     {
         $this->writeState([
-            'status' => 'complete',
-            'pull' => [
-                'stage' => 'complete',
+            'active_resumable_command' => [
+                'completion_state' => 'complete',
+            ],
+            'pull_pipeline' => [
+                'stage_sequence' => ['preflight', 'files-pull', 'db-pull', 'db-apply'],
+                'last_completed_stage' => 'db-apply',
                 'files_filter' => 'essential-files',
                 'skipped_pending' => true,
+                'has_completed_once' => true,
             ],
         ]);
 
         $metadata = $this->readMetadata();
 
         $this->assertTrue($metadata['hasCompletedOnce']);
-        $this->assertSame('complete', $metadata['pullStage']);
+        $this->assertSame('db-apply', $metadata['pullStage']);
     }
 
     /**
@@ -140,9 +146,11 @@ class ImportMetadataTest extends TestCase
     public function testImportMetadataReportsPriorCompletionDuringRepull(): void
     {
         $this->writeState([
-            'status' => null,
-            'pull' => [
-                'stage' => null,
+            'active_resumable_command' => [
+                'completion_state' => null,
+            ],
+            'pull_pipeline' => [
+                'last_completed_stage' => null,
                 'files_filter' => null,
                 'skipped_pending' => false,
                 'has_completed_once' => true,

--- a/tests/Import/LegacyCommandAliasTest.php
+++ b/tests/Import/LegacyCommandAliasTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../../importer/import.php';
 
 /**
  * Smoke test: old command names (files-sync, db-sync, flat-document-root)
- * must continue to work via the alias table and state migration.
+ * must continue to work via the alias table.
  */
 class LegacyCommandAliasTest extends TestCase
 {
@@ -99,17 +99,20 @@ class LegacyCommandAliasTest extends TestCase
         ];
     }
 
-    /**
-     * State files written with old command names must be migrated
-     * to new names when loaded.
-     *
-     * @dataProvider legacyStateProvider
-     */
-    public function testStateMigrationFromLegacyCommandName(string $old_name, string $new_name): void
+    public function testLegacyStateFieldsAreIgnored(): void
     {
         file_put_contents(
             $this->stateDir . '/.import-state.json',
-            json_encode(["command" => $old_name, "status" => "in_progress"]),
+            json_encode([
+                "command" => "files-pull",
+                "status" => "in_progress",
+                "cursor" => "legacy-cursor",
+                "stage" => "fetch",
+                "pull" => [
+                    "pipeline" => "pull",
+                    "stage" => "files-pull",
+                ],
+            ]),
         );
 
         $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->fs_root);
@@ -117,19 +120,25 @@ class LegacyCommandAliasTest extends TestCase
         $loadState = $reflection->getMethod('load_state');
         $state = $loadState->invoke($client);
 
-        $this->assertEquals(
-            $new_name,
-            $state["command"],
-            "State with command '{$old_name}' should be migrated to '{$new_name}'",
-        );
+        $this->assertArrayNotHasKey('command', $state);
+        $this->assertArrayNotHasKey('status', $state);
+        $this->assertArrayNotHasKey('cursor', $state);
+        $this->assertArrayNotHasKey('stage', $state);
+        $this->assertArrayNotHasKey('pull', $state);
+        $this->assertSame([
+            "command_name" => null,
+            "completion_state" => null,
+            "current_stage" => null,
+            "remote_cursor" => null,
+        ], $state["active_resumable_command"]);
+        $this->assertSame([
+            "started_by_command" => null,
+            "stage_sequence" => [],
+            "last_completed_stage" => null,
+            "files_filter" => null,
+            "skipped_pending" => false,
+            "has_completed_once" => false,
+        ], $state["pull_pipeline"]);
     }
 
-    public static function legacyStateProvider(): array
-    {
-        return [
-            'files-sync → files-pull' => ['files-sync', 'files-pull'],
-            'db-sync → db-pull' => ['db-sync', 'db-pull'],
-            'flat-document-root → flat-docroot' => ['flat-document-root', 'flat-docroot'],
-        ];
-    }
 }

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -410,7 +410,7 @@ class NewSiteUrlSqliteTest extends TestCase
         ]);
 
         $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
-        $this->assertSame('complete', $state['status']);
+        $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
         $this->assertSame(3, $state['apply']['statements_executed']);
         $this->assertSame(strlen($sql), $state['apply']['bytes_read']);
     }

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -223,12 +223,49 @@ PHP, var_export($requestsLog, true)));
             '--fs-root=' . $this->tempDir . '/fs',
         ));
 
-        $result = json_decode($output, true);
+        $result = null;
+        foreach (array_reverse(preg_split('/\R/', trim($output)) ?: []) as $line) {
+            if ($line === '' || $line[0] !== '{') {
+                continue;
+            }
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                $result = $decoded;
+                break;
+            }
+        }
         $this->assertSame(
             'Cannot resolve token ":abspath:": not available in preflight data. Run preflight first.',
             $result['error'] ?? null
         );
         $this->assertStringNotContainsString('"status":"aborted"', $output);
+    }
+
+    public function testPullPreflightFailureReportsOriginalExceptionInCliJson(): void
+    {
+        $output = $this->runCli(array(
+            'pull',
+            'http://fake.invalid/?site-export-api',
+            '--runtime=none',
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+        ));
+
+        $error = null;
+        foreach (array_reverse(preg_split('/\R/', trim($output)) ?: array()) as $line) {
+            if ($line === '' || $line[0] !== '{') {
+                continue;
+            }
+            $decoded = json_decode($line, true);
+            if (is_array($decoded) && isset($decoded['exception'])) {
+                $error = $decoded;
+                break;
+            }
+        }
+
+        $this->assertSame(\RuntimeException::class, $error['exception'] ?? null, "Output:
+{$output}");
+        $this->assertStringNotContainsString('PullFailureReportedException', $output);
     }
 
     public function testRepeatedOnlyOptionsAreUsedByFilesPull(): void

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -102,9 +102,11 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     private function prepareClient(array $pull_only_files_with_path_prefixes): array
     {
         $defaults = [
-            "command" => "files-pull",
-            "status" => "in_progress",
-            "stage" => "diff",
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "diff",
+            ],
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -84,9 +84,12 @@ class OnlyFilesPathPrefixTest extends TestCase
     private function writeFilesPullState(array $state): void
     {
         $defaults = array(
-            'command' => 'files-pull',
-            'status' => 'in_progress',
-            'stage' => 'diff',
+            'active_resumable_command' => array(
+                'command_name' => 'files-pull',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'diff',
+                'remote_cursor' => null,
+            ),
             'preflight' => array(
                 'data' => array(
                     'database' => array(
@@ -272,14 +275,14 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->runFilesPullWithOnly(array(':wp-content:/plugins'));
 
         $state = $this->readState();
-        $this->assertSame('complete', $state['status'] ?? null);
+        $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
         $this->assertSame(
             $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
             $state['files_pull_only_fingerprint'] ?? null
         );
     }
 
-    public function testRunRecordsOnlyFingerprintForLegacyInProgressFilesPullState(): void
+    public function testRunRecordsOnlyFingerprintForInProgressFilesPullState(): void
     {
         file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
         $this->writeFilesPullState(array(
@@ -298,15 +301,17 @@ class OnlyFilesPathPrefixTest extends TestCase
     public function testRunAllowsChangingOnlyPrefixesAfterCompletedFilesPull(): void
     {
         $this->writeFilesPullState(array(
-            'status' => 'complete',
-            'stage' => null,
+            'active_resumable_command' => array(
+                'completion_state' => 'complete',
+                'current_stage' => null,
+            ),
             'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
         $this->runFilesPullWithOnly(array(':wp-uploads:'));
 
         $state = $this->readState();
-        $this->assertSame('complete', $state['status'] ?? null);
+        $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
     }
 
     public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -9,6 +9,12 @@ require_once __DIR__ . '/../../importer/import.php';
 class PullFilterFakeClient extends \ImportClient
 {
     private bool $create_skipped_list;
+    public int $preflight_runs = 0;
+    public int $files_sync_runs = 0;
+    public int $db_sync_runs = 0;
+    public int $db_apply_runs = 0;
+    public array $progress_events = [];
+    public array $status_errors = [];
 
     public function __construct(string $state_dir, string $fs_root, bool $create_skipped_list)
     {
@@ -22,10 +28,12 @@ class PullFilterFakeClient extends \ImportClient
 
     public function output_progress(array $data, bool $force = false): void
     {
+        $this->progress_events[] = $data;
     }
 
     public function write_status_file(?string $error = null): void
     {
+        $this->status_errors[] = $error;
     }
 
     public function index_count(): int
@@ -35,6 +43,7 @@ class PullFilterFakeClient extends \ImportClient
 
     public function run_preflight(): void
     {
+        $this->preflight_runs++;
         $this->mutate_state(function (array $state) {
             $state["preflight"] = [
                 "http_code" => 200,
@@ -57,6 +66,14 @@ class PullFilterFakeClient extends \ImportClient
 
     public function run_files_sync(): void
     {
+        if (
+            ($this->state["command"] ?? null) === "files-pull" &&
+            ($this->state["status"] ?? null) === "complete"
+        ) {
+            return;
+        }
+
+        $this->files_sync_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
                 $this->state_dir . '/.import-download-list-skipped.jsonl',
@@ -76,6 +93,7 @@ class PullFilterFakeClient extends \ImportClient
 
     public function run_db_sync(): void
     {
+        $this->db_sync_runs++;
         file_put_contents($this->state_dir . '/db.sql', "SELECT 1;\n");
         $this->mutate_state(function (array $state) {
             $state["command"] = "db-pull";
@@ -87,11 +105,29 @@ class PullFilterFakeClient extends \ImportClient
 
     public function run_db_apply(array $options): void
     {
+        $this->db_apply_runs++;
         $this->mutate_state(function (array $state) {
             $state["command"] = "db-apply";
             $state["status"] = "complete";
             $state["stage"] = null;
             $state["apply"]["statements_executed"] = 42;
+            return $state;
+        });
+    }
+}
+
+class PullFailingPreflightFakeClient extends PullFilterFakeClient
+{
+    public function run_preflight(): void
+    {
+        $this->preflight_runs++;
+        $this->last_error_code = 'HTTP_ERROR';
+        $this->mutate_state(function (array $state) {
+            $state["preflight"] = [
+                "http_code" => 500,
+                "error" => "Exporter unavailable",
+            ];
+            $state["status"] = "complete";
             return $state;
         });
     }
@@ -199,6 +235,93 @@ class PullFilterOptionTest extends TestCase
         $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
     }
 
+    public function testPullDoesNotAdvancePastFailedPreflight(): void
+    {
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->fs_root, false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "runtime" => "none",
+            ]);
+            $this->fail('Expected pull to stop on failed preflight');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Exporter unavailable', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->preflight_runs);
+        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertNull($state["pull"]["stage"]);
+
+        $error_events = array_values(array_filter(
+            $client->progress_events,
+            static fn (array $event): bool => ($event["status"] ?? null) === "error",
+        ));
+        $this->assertCount(1, $error_events);
+        $this->assertSame("preflight", $error_events[0]["failed_stage"]);
+        $this->assertSame("Exporter unavailable", $error_events[0]["message"]);
+        $status_errors = array_values(array_filter(
+            $client->status_errors,
+            static fn ($error): bool => $error !== null,
+        ));
+        $this->assertSame(["Exporter unavailable"], $status_errors);
+    }
+
+    public function testPullResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "command" => "files-pull",
+                "status" => "complete",
+                "stage" => null,
+                "pull" => [
+                    "stage" => "preflight",
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(1, $client->db_sync_runs);
+        $this->assertSame('pull', $state["pull"]["pipeline"]);
+        $this->assertSame('complete', $state["pull"]["stage"]);
+    }
+
+    public function testInvalidPullOptionsFailBeforeStateIsPersisted(): void
+    {
+        $client = $this->makeClient(false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "runtime" => "not-a-runtime",
+            ]);
+            $this->fail('Expected pull to reject an invalid runtime');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('Invalid --runtime value', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+    }
+
     public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
     {
         $client = $this->makeClient(true);
@@ -275,6 +398,7 @@ class PullFilterOptionTest extends TestCase
                 "stage" => null,
                 "filter" => "skipped-earlier",
                 "pull" => [
+                    "pipeline" => "pull",
                     "stage" => "complete",
                     "files_filter" => "essential-files",
                     "skipped_pending" => true,

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -59,7 +59,7 @@ class PullFilterFakeClient extends \ImportClient
                     ],
                 ],
             ];
-            $state["status"] = "complete";
+            $state["active_resumable_command"]["completion_state"] = "complete";
             return $state;
         });
     }
@@ -67,8 +67,8 @@ class PullFilterFakeClient extends \ImportClient
     public function run_files_sync(): void
     {
         if (
-            ($this->state["command"] ?? null) === "files-pull" &&
-            ($this->state["status"] ?? null) === "complete"
+            ($this->state["active_resumable_command"]["command_name"] ?? null) === "files-pull" &&
+            ($this->state["active_resumable_command"]["completion_state"] ?? null) === "complete"
         ) {
             return;
         }
@@ -84,9 +84,9 @@ class PullFilterFakeClient extends \ImportClient
         }
 
         $this->mutate_state(function (array $state) {
-            $state["command"] = "files-pull";
-            $state["status"] = "complete";
-            $state["stage"] = null;
+            $state["active_resumable_command"]["command_name"] = "files-pull";
+            $state["active_resumable_command"]["completion_state"] = "complete";
+            $state["active_resumable_command"]["current_stage"] = null;
             return $state;
         });
     }
@@ -96,9 +96,9 @@ class PullFilterFakeClient extends \ImportClient
         $this->db_sync_runs++;
         file_put_contents($this->state_dir . '/db.sql', "SELECT 1;\n");
         $this->mutate_state(function (array $state) {
-            $state["command"] = "db-pull";
-            $state["status"] = "complete";
-            $state["stage"] = null;
+            $state["active_resumable_command"]["command_name"] = "db-pull";
+            $state["active_resumable_command"]["completion_state"] = "complete";
+            $state["active_resumable_command"]["current_stage"] = null;
             return $state;
         });
     }
@@ -107,9 +107,9 @@ class PullFilterFakeClient extends \ImportClient
     {
         $this->db_apply_runs++;
         $this->mutate_state(function (array $state) {
-            $state["command"] = "db-apply";
-            $state["status"] = "complete";
-            $state["stage"] = null;
+            $state["active_resumable_command"]["command_name"] = "db-apply";
+            $state["active_resumable_command"]["completion_state"] = "complete";
+            $state["active_resumable_command"]["current_stage"] = null;
             $state["apply"]["statements_executed"] = 42;
             return $state;
         });
@@ -127,7 +127,7 @@ class PullFailingPreflightFakeClient extends PullFilterFakeClient
                 "http_code" => 500,
                 "error" => "Exporter unavailable",
             ];
-            $state["status"] = "complete";
+            $state["active_resumable_command"]["completion_state"] = "complete";
             return $state;
         });
     }
@@ -255,7 +255,7 @@ class PullFilterOptionTest extends TestCase
         $state = $this->readState();
         $this->assertSame(1, $client->preflight_runs);
         $this->assertSame(0, $client->files_sync_runs);
-        $this->assertNull($state["pull"]["stage"]);
+        $this->assertNull($state["pull_pipeline"]["last_completed_stage"]);
 
         $error_events = array_values(array_filter(
             $client->progress_events,
@@ -276,11 +276,14 @@ class PullFilterOptionTest extends TestCase
         file_put_contents(
             $this->stateDir . '/.import-state.json',
             json_encode([
-                "command" => "files-pull",
-                "status" => "complete",
-                "stage" => null,
-                "pull" => [
-                    "stage" => "preflight",
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull",
+                    "last_completed_stage" => "preflight",
                 ],
                 "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
             ]),
@@ -298,8 +301,85 @@ class PullFilterOptionTest extends TestCase
         $state = $this->readState();
         $this->assertSame(0, $client->files_sync_runs);
         $this->assertSame(1, $client->db_sync_runs);
-        $this->assertSame('pull', $state["pull"]["pipeline"]);
-        $this->assertSame('complete', $state["pull"]["stage"]);
+        $this->assertSame('pull', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+    }
+
+    public function testPullResumesSameUnfinishedPipelineWithoutConflict(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "in_progress",
+                    "current_stage" => "fetch",
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull",
+                    "last_completed_stage" => "preflight",
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->files_sync_runs);
+        $this->assertSame('pull', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+    }
+
+    public function testPullRefusesToClearCompletedCommandOwnedByDifferentUnfinishedPipeline(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "db-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull-db",
+                    "last_completed_stage" => null,
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+        file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
+
+        $client = $this->makeClient(false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "runtime" => "none",
+            ]);
+            $this->fail('Expected pull to refuse a different unfinished pipeline');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Another command is already in progress: pull-db', $e->getMessage());
+            $this->assertStringContainsString('Rerun pull-db to resume it', $e->getMessage());
+            $this->assertStringContainsString('Only use --abort if you want to discard', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $state = $this->readState();
+        $this->assertSame('pull-db', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertNull($state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('db-pull', $state["active_resumable_command"]["command_name"]);
+        $this->assertSame('complete', $state["active_resumable_command"]["completion_state"]);
+        $this->assertFileExists($this->stateDir . '/db.sql');
     }
 
     public function testInvalidPullOptionsFailBeforeStateIsPersisted(): void
@@ -335,10 +415,10 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame('complete', $state["pull"]["stage"]);
-        $this->assertSame('essential-files', $state["pull"]["files_filter"]);
-        $this->assertTrue($state["pull"]["skipped_pending"]);
-        $this->assertTrue($state["pull"]["has_completed_once"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('essential-files', $state["pull_pipeline"]["files_filter"]);
+        $this->assertTrue($state["pull_pipeline"]["skipped_pending"]);
+        $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
         $this->assertFileExists($this->stateDir . '/.import-download-list-skipped.jsonl');
     }
@@ -355,10 +435,10 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame('complete', $state["pull"]["stage"]);
-        $this->assertSame('none', $state["pull"]["files_filter"]);
-        $this->assertFalse($state["pull"]["skipped_pending"]);
-        $this->assertTrue($state["pull"]["has_completed_once"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('none', $state["pull_pipeline"]["files_filter"]);
+        $this->assertFalse($state["pull_pipeline"]["skipped_pending"]);
+        $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
         $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
     }
@@ -393,13 +473,16 @@ class PullFilterOptionTest extends TestCase
         file_put_contents(
             $this->stateDir . '/.import-state.json',
             json_encode([
-                "command" => "files-pull",
-                "status" => "complete",
-                "stage" => null,
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
                 "filter" => "skipped-earlier",
-                "pull" => [
-                    "pipeline" => "pull",
-                    "stage" => "complete",
+                "pull_pipeline" => [
+                    "started_by_command" => "pull",
+                    "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
+                    "last_completed_stage" => "db-apply",
                     "files_filter" => "essential-files",
                     "skipped_pending" => true,
                 ],
@@ -418,7 +501,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame('complete', $state["pull"]["stage"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
         $this->assertSame('essential-files', $state["filter"]);
     }
 }

--- a/tests/Import/PullStartModeTest.php
+++ b/tests/Import/PullStartModeTest.php
@@ -103,7 +103,7 @@ class PullStartModeTest extends TestCase
     {
         $pull = $this->makePull();
         $reflection = new \ReflectionClass($pull);
-        $method = $reflection->getMethod('validate_and_default_options');
+        $method = $reflection->getMethod('validate_and_default_pull_options');
         $method->setAccessible(true);
 
         $options = $method->invoke($pull, [

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -60,10 +60,12 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            'command' => null,
-            'status' => null,
-            'cursor' => null,
-            'stage' => null,
+            'active_resumable_command' => [
+                'command_name' => null,
+                'completion_state' => null,
+                'current_stage' => null,
+                'remote_cursor' => null,
+            ],
             'preflight' => [
                 'http_code' => 200,
                 'data' => [
@@ -143,8 +145,10 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     public function testApplyRuntimeAddsProxyWhenSkippedUploadsRemain(): void
     {
         $this->writeState([
-            'command' => 'db-apply',
-            'status' => 'complete',
+            'active_resumable_command' => [
+                'command_name' => 'db-apply',
+                'completion_state' => 'complete',
+            ],
             'filter' => 'essential-files',
         ]);
         file_put_contents(
@@ -181,9 +185,11 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     public function testApplyRuntimeAddsProxyWhileFilesSyncIsIncomplete(): void
     {
         $this->writeState([
-            'command' => 'files-pull',
-            'status' => 'partial',
-            'stage' => 'fetch',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'partial',
+                'current_stage' => 'fetch',
+            ],
         ]);
 
         $client = $this->makeClient();
@@ -207,8 +213,10 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     public function testApplyRuntimeOmitsProxyAfterFilesSyncCompletes(): void
     {
         $this->writeState([
-            'command' => 'files-pull',
-            'status' => 'complete',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'complete',
+            ],
             'filter' => 'none',
         ]);
 

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -69,10 +69,12 @@ class RuntimeFilesTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            "command" => null,
-            "status" => null,
-            "cursor" => null,
-            "stage" => null,
+            "active_resumable_command" => [
+                "command_name" => null,
+                "completion_state" => null,
+                "current_stage" => null,
+                "remote_cursor" => null,
+            ],
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -752,5 +752,23 @@ export function assertTreesMatch(sourceDir, importedDir, options = {}) {
     assert.equal(problems.length, 0, `Trees differ: ${problems.join('; ')}`);
 }
 
+/**
+ * Assert that a high-level pull pipeline finished all stages it recorded.
+ */
+export function assertPullPipelineComplete(state, command = 'pull') {
+    const pipeline = state.pull_pipeline;
+    assert.ok(pipeline, 'Expected pull_pipeline state to exist');
+    assert.equal(pipeline.started_by_command, command);
+    assert.equal(pipeline.has_completed_once, true);
+    assert.ok(Array.isArray(pipeline.stage_sequence),
+        'Expected pull_pipeline.stage_sequence to be an array');
+    assert.ok(pipeline.stage_sequence.length > 0,
+        'Expected pull_pipeline.stage_sequence to record at least one stage');
+    assert.equal(
+        pipeline.last_completed_stage,
+        pipeline.stage_sequence[pipeline.stage_sequence.length - 1],
+    );
+}
+
 // Re-export constants
 export { SITE_ROOT, PROJECT_ROOT, IMPORTER_PATH, PHP_BINARY, DB_HOST, DB_USER, DB_PASS };

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -43,8 +43,8 @@ describe('Import: Basic File Sync', () => {
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.command, 'files-pull');
-        assert.equal(state.status, 'complete');
+        assert.equal(state.active_resumable_command.command_name, 'files-pull');
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 
     it('fs-root file hashes match source site directory', () => {
@@ -109,6 +109,6 @@ describe('Import: Basic File Sync', () => {
 
         const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf8'));
-        assert.equal(state.status, 'complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 });

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -69,7 +69,7 @@ describe('Import: Symlinks', () => {
             const stateFile = join(tempDir, '.import-state.json');
             assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.status, 'complete', 'Expected status to be complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
         });
     });
 

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -118,7 +118,7 @@ INSERT INTO wp_secret_table VALUES (1, 'top secret');
         it('state shows complete', () => {
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
 
         it('SQL dump contains both tables', () => {

--- a/tests/e2e/tests/import-09-resume-sql.test.js
+++ b/tests/e2e/tests/import-09-resume-sql.test.js
@@ -49,7 +49,7 @@ describe('Import: Resume SQL', { timeout: 120000 }, () => {
 
         const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.status, 'complete', 'Expected status to be complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
     });
 
     it('db.sql is valid', () => {

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -60,7 +60,7 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
         assert.ok(existsSync(stateFile), 'Expected state file to exist');
 
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.status, 'complete', 'Expected status to be complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
     });
 
     it('indexed at least 3000 files from remote', () => {

--- a/tests/e2e/tests/import-12-gzip-corruption.test.js
+++ b/tests/e2e/tests/import-12-gzip-corruption.test.js
@@ -91,8 +91,8 @@ describe('Import: Gzip Corruption', () => {
                 if (existsSync(stateFile)) {
                     const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
                     assert.ok(
-                        state.status === 'complete' || state.status === 'in_progress',
-                        `Expected valid status, got: ${state.status}`
+                        state.active_resumable_command.completion_state === 'complete' || state.active_resumable_command.completion_state === 'in_progress',
+                        `Expected valid status, got: ${state.active_resumable_command.completion_state}`
                     );
                 }
             } else {

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -156,7 +156,7 @@ describe('Import: Volatile Files', () => {
 
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
 
         it('readable files are still downloaded', () => {

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -55,7 +55,7 @@ describe('Import: Full Round-Trip', () => {
 
         const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.status, 'complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 
     it('db-sync completes', () => {

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -83,7 +83,7 @@ describe('Import: Request Cutoff', () => {
 
         const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.status, 'complete', `Expected complete status, got ${state.status}`);
+        assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected complete status, got ${state.active_resumable_command.completion_state}`);
     });
 
     it('all file hashes match source after resume', () => {

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -96,6 +96,6 @@ describe('Import: Delta Sync with Deletions', () => {
     it('state shows complete after delta', () => {
         const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.status, 'complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -48,7 +48,7 @@ describe('Import: State Corruption', () => {
 
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
 
         it('audit log records corruption warning', () => {
@@ -78,8 +78,10 @@ describe('Import: State Corruption', () => {
             tempDir = createTempDir('e2e-state-wrong-cmd');
             // Write valid state but for a different command
             writeFileSync(join(tempDir, '.import-state.json'), JSON.stringify({
-                command: 'db-sync',
-                status: 'complete',
+                active_resumable_command: {
+                    command_name: 'db-pull',
+                    completion_state: 'complete',
+                },
             }));
         });
 
@@ -96,8 +98,8 @@ describe('Import: State Corruption', () => {
 
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.command, 'files-pull', 'Expected command to be updated');
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.command_name, 'files-pull', 'Expected command to be updated');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
     });
 
@@ -108,9 +110,11 @@ describe('Import: State Corruption', () => {
             tempDir = createTempDir('e2e-state-restart');
             // Write a partial state to simulate interrupted transfer
             writeFileSync(join(tempDir, '.import-state.json'), JSON.stringify({
-                command: 'files-sync',
-                status: 'in_progress',
-                cursor: 'some-old-cursor',
+                active_resumable_command: {
+                    command_name: 'files-pull',
+                    completion_state: 'in_progress',
+                    remote_cursor: 'some-old-cursor',
+                },
             }));
         });
 
@@ -127,8 +131,8 @@ describe('Import: State Corruption', () => {
 
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.notEqual(state.status, 'in_progress', 'Expected status to be cleared');
-            assert.ok(!state.cursor, 'Expected cursor to be cleared');
+            assert.notEqual(state.active_resumable_command.completion_state, 'in_progress', 'Expected status to be cleared');
+            assert.ok(!state.active_resumable_command.remote_cursor, 'Expected cursor to be cleared');
         });
 
         it('running after --abort completes fresh sync', () => {
@@ -139,7 +143,7 @@ describe('Import: State Corruption', () => {
 
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
 
         it('files match source after restart', () => {

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -214,7 +214,7 @@ describe('Import: Follow Symlinks', () => {
 
     it('state shows complete', () => {
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.status, 'complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
         assert.equal(state.follow_symlinks, true, 'follow_symlinks should be persisted in state');
     });
 

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -163,7 +163,7 @@ describe('Import: --preserve-local', () => {
         it('state shows complete with preserve_local persisted', () => {
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
 

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -81,8 +81,8 @@ describe('Import: --filter', () => {
 
         it('state shows complete with filter persisted', () => {
             const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-            assert.equal(state.command, 'files-pull');
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.command_name, 'files-pull');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.filter, 'essential-files');
         });
 
@@ -171,7 +171,7 @@ describe('Import: --filter', () => {
         it('state preserves filter across resume cycles', () => {
             const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
             assert.equal(state.filter, 'essential-files');
-            assert.equal(state.status, 'complete');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
 
         it('uploads were NOT downloaded', () => {

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -72,7 +72,7 @@ describe('Import: Playground CLI runtime', () => {
             `files-sync failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
 
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.status, 'complete');
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 
     it('db-sync downloads the SQL dump', () => {

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -133,8 +133,8 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 120000 }, () => {
             const stateFile = join(tempDir, '.import-state.json');
             assert.ok(existsSync(stateFile), 'Expected state file to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf8'));
-            assert.equal(state.status, 'partial',
-                `Expected status=partial, got ${state.status}`);
+            assert.equal(state.active_resumable_command.completion_state, 'partial',
+                `Expected status=partial, got ${state.active_resumable_command.completion_state}`);
         });
 
         it('audit log records the incomplete response', () => {

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -14,7 +14,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, assertSiteMirror,
-    fsRootDir, compareDatabases, createMysqlConnection, getDbName,
+    fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -67,7 +67,7 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
+        assertPullPipelineComplete(state);
     });
 
     it('files match source', () => {
@@ -99,6 +99,6 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
             `Expected exit 0 on re-pull, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
+        assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-47-pull-multi-request.test.js
+++ b/tests/e2e/tests/import-47-pull-multi-request.test.js
@@ -15,7 +15,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
@@ -75,7 +75,7 @@ describe('Import: Pull Multi-Request', { timeout: 300000 }, () => {
 
     it('state shows pull complete', () => {
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
+        assertPullPipelineComplete(state);
     });
 
     it('file download counter never decreases across requests', () => {

--- a/tests/e2e/tests/import-48-pull-crash-resume.test.js
+++ b/tests/e2e/tests/import-48-pull-crash-resume.test.js
@@ -21,7 +21,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
@@ -71,7 +71,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
             `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
+        assertPullPipelineComplete(state);
     });
 
     it('--abort clears pull pipeline state', () => {
@@ -83,10 +83,10 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected abort exit 0, got ${result.exitCode}`);
 
-        // Pull stage should be cleared
+        // The completed-stage marker should be cleared.
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, null,
-            'Expected pull.stage to be null after abort');
+        assert.equal(state.pull_pipeline.last_completed_stage, null,
+            'Expected pull_pipeline.last_completed_stage to be null after abort');
 
         // Local index should be preserved (for delta sync)
         assert.ok(existsSync(join(tempDir, '.import-index.jsonl')),
@@ -105,7 +105,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
             `Expected re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
+        assertPullPipelineComplete(state);
     });
 
     it('files still match source after re-pull', () => {
@@ -126,8 +126,8 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
     });
 
     it('second re-pull without abort also works (auto delta)', () => {
-        // Running pull again when pull.stage=complete should auto-reset
-        // and perform another delta sync.
+        // Running pull again after it completed all recorded stages should
+        // auto-reset and perform another delta sync.
         const result = runImporter(importUrl(), tempDir, 'pull', {
             secret: getSiteSecret(site),
             skipPreflight: true,
@@ -139,6 +139,6 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
             `Expected auto re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
+        assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -13,7 +13,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir, compareDatabases, createMysqlConnection, getDbName,
+    fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -87,9 +87,9 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
-        assert.equal(state.pull.files_filter, 'essential-files');
-        assert.equal(state.pull.skipped_pending, true);
+        assertPullPipelineComplete(state);
+        assert.equal(state.pull_pipeline.files_filter, 'essential-files');
+        assert.equal(state.pull_pipeline.skipped_pending, true);
     });
 
     it('skipped download list remains on disk', () => {

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -159,7 +159,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
 
         const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.status, 'complete', `Expected status=complete after resume, got ${state.status}`);
+        assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected status=complete after resume, got ${state.active_resumable_command.completion_state}`);
     });
 
     it('resumed file matches source byte-for-byte (no gap, no duplication)', () => {

--- a/tests/e2e/tests/import-50-pull-manual-start.test.js
+++ b/tests/e2e/tests/import-50-pull-manual-start.test.js
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
+    assertPullPipelineComplete,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -61,8 +62,8 @@ describe('Import: Pull start-runtime none', { timeout: 180000 }, () => {
 
     it('marks the pull complete and generates playground runtime files', () => {
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        assert.equal(state.pull.stage, 'complete');
-        assert.equal(state.status, 'complete');
+        assertPullPipelineComplete(state);
+        assert.equal(state.active_resumable_command.completion_state, 'complete');
 
         assert.ok(existsSync(join(runtimeDir, 'runtime.php')), 'runtime.php should exist');
         assert.ok(existsSync(join(runtimeDir, 'blueprint.json')), 'blueprint.json should exist');


### PR DESCRIPTION
## What it does

Extracts the existing `pull` flow into a reusable, resumable stage runner without adding the new `pull-files` / `pull-db` commands yet.

The `pull` command still runs the same high-level stages, but the orchestration now lives in `Pull::run_pipeline()` / `Pull::run_stage()` so later PRs can reuse the same machinery for narrower pipelines.

## Rationale

`pull-files` and `pull-db` will behave like smaller `git pull`-style pipelines, not like wrappers around one atomic command. Therefore, they need the same guarantees as `pull`:

- do not advance the pipeline stage until the lower-level command was re-run enough times it successfully completed
- resume safely after a crash between lower-level completion and high-level stage completion
- reject conflicting unfinished pipeline state instead of silently discarding it

This PR isolates those invariants first so the command additions can be reviewed separately.

## Testing instructions

GitHub CI is green for PHPUnit, PHPStan, E2E PHP 7.4–8.5, Playground CLI E2E, and the pull pipeline benchmark.
