### PR TITLE
Add resumable pull-files pipeline command

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,29 @@ The three filter values:
 The uploads directory is detected from preflight data (`uploads.basedir`), falling back to
 `wp-content/uploads/` if unavailable.
 
+#### Pull only files.
+
+`pull-files` runs the file side of the high-level pull pipeline:
+
+1. `preflight`
+2. `files-pull`
+
+Use it when you want a `git pull`-style file update without running any
+database stages:
+
+```bash
+php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+```
+
+It accepts the `pull` file filters (`--filter=none` and
+`--filter=essential-files`) plus the same path selection options as
+`files-pull`, including repeated `--only` values:
+
+```bash
+php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --only=:wp-content: --only=:wp-plugins:
+```
+
 #### Step 3 — Download the database.
 
 By default, this streams a SQL dump into `$STATE_DIR/db.sql`:
@@ -635,6 +658,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
+* `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -53,7 +53,7 @@ require_once __DIR__ . '/lib/external-merge-sort.php';
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
 require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
 
-// Pull command — orchestrates lower-level commands into a pipeline
+// High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';
 
 /**
@@ -1170,7 +1170,7 @@ class ImportClient
     /** @var TerminalProgress Renders progress and lifecycle output to the terminal. */
     private TerminalProgress $progress;
 
-    /** @var Pull Orchestrates the pull command pipeline. */
+    /** @var Pull Orchestrates high-level pull pipelines. */
     private Pull $pull;
 
     /** @var int Cumulative count of index entries written (survives retries). */
@@ -1583,6 +1583,7 @@ class ImportClient
 
         $valid_commands = [
             "pull",
+            "pull-files",
             "files-pull",
             "files-index",
             "files-stats",
@@ -1654,7 +1655,7 @@ class ImportClient
         if (isset($options["filter"])) {
             $next = $options["filter"];
             if (
-                $command === "pull" &&
+                in_array($command, ["pull", "pull-files"], true) &&
                 !in_array($next, ["none", "essential-files"], true)
             ) {
                 throw new InvalidArgumentException(
@@ -1778,15 +1779,22 @@ class ImportClient
             $this->hmac_client = new \Site_Export_HMAC_Client($options["secret"]);
         }
 
-        // pull orchestrates preflight and lower-level stages internally,
-        // so it runs before the normal command dispatch.
-        if ($command === "pull") {
+        // Pull-like commands orchestrate preflight and lower-level stages
+        // internally, so they run before the normal command dispatch.
+        if (in_array($command, ["pull", "pull-files"], true)) {
             if ($abort) {
-                $this->pull->abort();
+                $this->pull->abort($command);
                 return;
             }
             try {
-                $this->pull->run($options);
+                switch ($command) {
+                    case "pull":
+                        $this->pull->run($options);
+                        break;
+                    case "pull-files":
+                        $this->pull->run_pull_files($options);
+                        break;
+                }
             } catch (\Exception $e) {
                 if ($e instanceof \PullFailureReportedException) {
                     $previous = $e->getPrevious();
@@ -11582,7 +11590,7 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
         ],
         [
             'name' => 'abort',
@@ -11590,7 +11598,7 @@ if (
             'target' => 'abort',
             'help' => 'Abort current sync and exit (preserves downloaded files)',
             'help_section' => 'global',
-            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
+            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
         ],
         [
             'name' => 'verbose',
@@ -11599,7 +11607,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -11608,7 +11616,7 @@ if (
             'flag_value' => false,
             'help' => 'Do not follow symlinks pointing outside root directories',
             'help_section' => 'global',
-            'commands' => ['pull', 'files-pull'],
+            'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
         [
             'name' => 'follow-symlinks',
@@ -11625,7 +11633,7 @@ if (
             'placeholder' => 'MODE',
             'help' => 'What to do when fs root is non-empty (error|preserve-local)',
             'help_section' => 'global',
-            'commands' => ['pull', 'files-pull'],
+            'commands' => ['pull', 'pull-files', 'files-pull'],
             'aliases' => ['on-docroot-nonempty'],
         ],
         [
@@ -11635,7 +11643,7 @@ if (
             'flag_value' => true,
             'help' => 'Include generated caches, VCS metadata, OS junk and editor scratch files (skipped by default)',
             'help_section' => 'global',
-            'commands' => ['pull', 'files-pull', 'files-index'],
+            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index'],
         ],
         [
             'name' => 'adaptive',
@@ -11682,8 +11690,8 @@ if (
             'target' => 'filter',
             'placeholder' => 'MODE',
             'valid_values' => ['none', 'essential-files', 'skipped-earlier'],
-            'help' => 'Filter which files to download (pull: none|essential-files; files-pull also supports skipped-earlier)',
-            'commands' => ['pull', 'files-pull'],
+            'help' => 'Filter which files to download (pull/pull-files: none|essential-files; files-pull also supports skipped-earlier)',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
         [
             'name' => 'extra-directory',
@@ -11691,7 +11699,7 @@ if (
             'target' => 'extra_directory',
             'placeholder' => 'DIR',
             'help' => 'Additional remote directory to include in the export',
-            'commands' => ['files-pull', 'files-index'],
+            'commands' => ['pull-files', 'files-pull', 'files-index'],
         ],
 
         // ── db-pull options ──────────────────────────────────────
@@ -11834,7 +11842,7 @@ if (
             'pair_args' => 'SOURCE TARGET',
             'help' => 'Place SOURCE (a :token: like :wp-uploads: or an absolute path) at TARGET ' .
                 '(a :fs-root: path or an absolute path within --fs-root); repeatable',
-            'commands' => ['files-pull'],
+            'commands' => ['pull-files', 'files-pull'],
         ],
         [
             'name' => 'only',
@@ -11844,7 +11852,7 @@ if (
             'repeatable' => true,
             'help' => 'Restrict the files-pull command to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
                 'repeat for several. Default pulls everything',
-            'commands' => ['files-pull'],
+            'commands' => ['pull-files', 'files-pull'],
         ],
 
         // ── flat-docroot options ────────────────────────────────
@@ -12375,6 +12383,26 @@ if (
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --runtime=playground-cli --start-runtime=none --output-dir=./runtime\n",
+        ],
+        "pull-files" => [
+            "level" => "high",
+            "short" => "Pull files through the high-level pull pipeline",
+            "description" =>
+                "Runs the file side of the pull pipeline:\n" .
+                "\n" .
+                "  1. Preflight — probe the remote site environment\n" .
+                "  2. files-pull — download all files, or a selected subset\n" .
+                "\n" .
+                "This gives files the same retry and resume behavior as pull,\n" .
+                "without running the database stages.\n",
+            "extra" =>
+                "Examples:\n" .
+                "  reprint pull-files https://example.com \\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files\n" .
+                "\n" .
+                "  reprint pull-files https://example.com \\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\n" .
+                "    --only=:wp-content: --only=:wp-plugins:\n",
         ],
         "install-exporter" => [
             "level" => "high",

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -12,9 +12,10 @@ class PullFailureReportedException extends RuntimeException
  *
  * Each step retries automatically on server timeouts (exit code 2). If
  * the process is interrupted, re-running pull resumes from the last
- * completed step. Like `git pull` composes fetch + merge, this composes
- * preflight → files-pull → db-pull → db-apply → flat-docroot →
- * apply-runtime → start.
+ * completed step. Like `git pull` composes fetch + merge, `pull`
+ * composes preflight → files-pull → db-pull → db-apply →
+ * flat-docroot → apply-runtime → start. `pull-files` runs the file
+ * subset.
  *
  * The class holds a reference to ImportClient because each stage
  * delegates to an ImportClient method (run_preflight, run_files_sync,
@@ -99,20 +100,36 @@ class Pull
     }
 
     /**
-     * Handle --abort for the pull command: clear pipeline state but
-     * leave downloaded files in place.
+     * Handle --abort for high-level file pull commands.
+     *
+     * Downloaded site files stay in place; the next run refreshes the
+     * file indexes and fetches a fresh delta.
      */
-    public function abort(): void
+    public function abort(string $command = 'pull'): void
     {
-        $this->prepare_repull();
-        $message = "Pull state cleared. Downloaded files are preserved.";
+        $this->prepare_repull($command);
+        $label = $command === 'pull' ? 'Pull' : $command;
+        $message = "{$label} state cleared. Downloaded files are preserved.";
         $this->progress->show_lifecycle_line("{$message}\n");
         $this->client->output_progress([
             "type" => "lifecycle",
             "event" => "aborted",
-            "command" => "pull",
+            "command" => $command,
             "message" => $message,
         ], true);
+    }
+
+    /**
+     * Run only the file stages from the pull pipeline.
+     */
+    public function run_pull_files(array $options): void
+    {
+        $this->normalize_url();
+        $this->progress->enable_quiet_lifecycle();
+
+        $options = $this->validate_and_default_pull_files_options($options, 'pull-files');
+
+        $this->run_pipeline('pull-files', ['preflight', 'files-pull'], $options, 'Pulling files from');
     }
 
     /**
@@ -142,14 +159,16 @@ class Pull
         $state_command = $state['active_resumable_command']['command_name'] ?? null;
         $state_status = $state['active_resumable_command']['completion_state'] ?? null;
         $completed_stage = $pull_pipeline === $command ? $pull_stage : null;
-        $completed_current_pipeline =
-            $completed_stage !== null &&
+        $completed_pipeline =
+            $pull_pipeline !== null &&
+            $pull_stage !== null &&
             $pipeline_final_stage !== null &&
-            $completed_stage === $pipeline_final_stage;
+            $pull_stage === $pipeline_final_stage;
 
-        if ($completed_current_pipeline) {
-            $this->prepare_repull();
+        if ($completed_pipeline) {
+            $this->prepare_repull($command);
             $completed_stage = null;
+            $pull_pipeline = null;
             $pull_stage = null;
             $state_command = null;
             $state_status = null;
@@ -300,7 +319,9 @@ class Pull
         // state before blocking on the server process).
         if (!in_array('start', $stages, true)) {
             $this->client->mark_pull_complete($command);
-            $this->print_summary();
+            if ($command === 'pull') {
+                $this->print_summary();
+            }
         }
 
         $complete_message = $command === 'pull' ? 'Pull complete' : "{$command} complete";
@@ -594,6 +615,23 @@ class Pull
     }
 
     /**
+     * Validate user-provided pull-files options and apply defaults without saving state.
+     */
+    private function validate_and_default_pull_files_options(array $options, string $command): array
+    {
+        if (!isset($options['filter'])) {
+            $options['filter'] = $this->client->state['filter'] ?? 'none';
+        }
+        if (!in_array($options['filter'], ['none', 'essential-files'], true)) {
+            throw new InvalidArgumentException(
+                "Invalid --filter value for {$command}: {$options['filter']}. " .
+                "Valid values: none, essential-files"
+            );
+        }
+        return $options;
+    }
+
+    /**
      * Selects the runtime that should receive generated runtime files.
      *
      * A requested start runtime also implies runtime generation because there
@@ -656,16 +694,22 @@ class Pull
     /**
      * Reset sub-command state for a delta re-pull.
      *
-     * Keeps the local file index (so files-pull runs in delta mode) and
-     * preflight data, but clears everything else and deletes db.sql /
-     * the remote index so the next pull re-fetches them.
+     * Keeps preflight data and downloaded files in place. `pull` keeps the
+     * local file index so files-pull runs in delta mode, while `pull-files`
+     * clears the in-progress index cursor and --only fingerprint so a new
+     * selection starts from a fresh remote traversal. Database artifacts are
+     * cleared only for the full pull pipeline because pull-files never creates
+     * or consumes them.
      */
-    private function prepare_repull(): void
+    private function prepare_repull(string $command = 'pull'): void
     {
         $state_dir = $this->client->state_dir;
         $defaults = $this->client->default_state();
-        $this->client->mutate_state(function (array $state) use ($defaults) {
-            $state['pull_pipeline']['started_by_command'] = 'pull';
+        $reset_db_state = $command === 'pull';
+        $reset_file_selection_state = $command !== 'pull';
+
+        $this->client->mutate_state(function (array $state) use ($command, $defaults, $reset_db_state, $reset_file_selection_state) {
+            $state['pull_pipeline']['started_by_command'] = $command;
             $state['pull_pipeline']['stage_sequence'] = [];
             $state['pull_pipeline']['last_completed_stage'] = null;
             $state['pull_pipeline']['files_filter'] = null;
@@ -676,31 +720,41 @@ class Pull
             $state['active_resumable_command']['remote_cursor'] = null;
             $state['active_resumable_command']['current_stage'] = null;
             $state['consecutive_timeouts'] = 0;
-            $state['sql_bytes'] = null;
             $state['current_file'] = null;
             $state['current_file_bytes'] = null;
-            $state['db_index'] = $defaults['db_index'];
             $state['diff'] = $defaults['diff'];
             $state['fetch'] = $defaults['fetch'];
             $state['fetch_skipped'] = $defaults['fetch_skipped'];
-            $state['apply'] = $defaults['apply'];
-            $state['sql_output'] = null;
+            if ($reset_file_selection_state) {
+                $state['index'] = $defaults['index'];
+                $state['files_pull_only_fingerprint'] = null;
+            }
+            if ($reset_db_state) {
+                $state['sql_bytes'] = null;
+                $state['db_index'] = $defaults['db_index'];
+                $state['apply'] = $defaults['apply'];
+                $state['sql_output'] = null;
+            }
             return $state;
         });
 
-        foreach ([
-            $state_dir . "/db.sql",
-            $state_dir . "/.import-domains.json",
+        $paths = [
             $state_dir . "/.import-remote-index.jsonl",
             $state_dir . "/.import-download-list.jsonl",
             $state_dir . "/.import-download-list-skipped.jsonl",
-        ] as $path) {
+        ];
+        if ($reset_db_state) {
+            $paths[] = $state_dir . "/db.sql";
+            $paths[] = $state_dir . "/.import-domains.json";
+        }
+
+        foreach ($paths as $path) {
             if (file_exists($path)) {
                 @unlink($path);
             }
         }
 
-        $this->client->audit_log("PULL | prepared for delta re-pull", true);
+        $this->client->audit_log(strtoupper($command) . " | prepared for delta re-pull", true);
     }
 
     /**

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -268,6 +268,32 @@ PHP, var_export($requestsLog, true)));
         $this->assertStringNotContainsString('PullFailureReportedException', $output);
     }
 
+    public function testPullFilesPreflightFailureReportsOriginalExceptionInCliJson(): void
+    {
+        $output = $this->runCli(array(
+            'pull-files',
+            'http://fake.invalid/?site-export-api',
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+        ));
+
+        $error = null;
+        foreach (array_reverse(preg_split('/\R/', trim($output)) ?: array()) as $line) {
+            if ($line === '' || $line[0] !== '{') {
+                continue;
+            }
+            $decoded = json_decode($line, true);
+            if (is_array($decoded) && isset($decoded['exception'])) {
+                $error = $decoded;
+                break;
+            }
+        }
+
+        $this->assertSame(\RuntimeException::class, $error['exception'] ?? null, "Output:
+{$output}");
+        $this->assertStringNotContainsString('PullFailureReportedException', $output);
+    }
+
     public function testRepeatedOnlyOptionsAreUsedByFilesPull(): void
     {
         $this->writePreflightState(true);

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -402,6 +402,184 @@ class PullFilterOptionTest extends TestCase
         $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
     }
 
+    public function testPullFilesRunsOnlyPreflightAndFilesStages(): void
+    {
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull-files",
+            "filter" => "essential-files",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->preflight_runs);
+        $this->assertSame(1, $client->files_sync_runs);
+        $this->assertSame(0, $client->db_sync_runs);
+        $this->assertSame(0, $client->db_apply_runs);
+        $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('essential-files', $state["pull_pipeline"]["files_filter"]);
+    }
+
+    public function testPullFilesDoesNotAdvancePastFailedPreflight(): void
+    {
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->fs_root, false);
+
+        try {
+            ob_start();
+            $client->run(["command" => "pull-files"]);
+            $this->fail('Expected pull-files to stop on failed preflight');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Exporter unavailable', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->preflight_runs);
+        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertNull($state["pull_pipeline"]["last_completed_stage"]);
+
+        $error_events = array_values(array_filter(
+            $client->progress_events,
+            static fn (array $event): bool => ($event["status"] ?? null) === "error",
+        ));
+        $this->assertCount(1, $error_events);
+        $this->assertSame("preflight", $error_events[0]["failed_stage"]);
+        $this->assertSame("Exporter unavailable", $error_events[0]["message"]);
+    }
+
+    public function testPullFilesResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull-files",
+                    "stage_sequence" => ["preflight", "files-pull"],
+                    "last_completed_stage" => "preflight",
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run(["command" => "pull-files"]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('files-pull', $state["active_resumable_command"]["command_name"]);
+    }
+
+    public function testPullFilesAfterStandaloneFilesPullStartsFreshDelta(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run(["command" => "pull-files"]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->files_sync_runs);
+        $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
+    }
+
+    public function testPullAfterFilesPullCompletedBeforePipelineStageWasMarkedDoesNotStealIt(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull-files",
+                    "stage_sequence" => ["preflight", "files-pull"],
+                    "last_completed_stage" => "preflight",
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "runtime" => "none",
+            ]);
+            $this->fail('Expected pull to reject an in-progress pull-files pipeline');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Another command is already in progress: pull-files', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->db_sync_runs);
+    }
+
+    public function testRerunningCompletedPullFilesStartsFreshFilesDelta(): void
+    {
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run(["command" => "pull-files"]);
+        $client->run(["command" => "pull-files"]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(2, $client->files_sync_runs);
+        $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
+    }
+
+    public function testPullAfterCompletedPullFilesStartsFreshFilesDelta(): void
+    {
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run(["command" => "pull-files"]);
+        $client->run([
+            "command" => "pull",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(2, $client->files_sync_runs);
+        $this->assertSame(1, $client->db_sync_runs);
+        $this->assertSame('pull', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+    }
+
     public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
     {
         $client = $this->makeClient(true);


### PR DESCRIPTION
## What it does

Adds `pull-files`, a high-level file-only pull command. It runs:

1. `preflight`
2. `files-pull`

That gives file pulls the same high-level retry/resume behavior as `pull` without running any database stages.

## Rationale

Studio needs to pull selected files without forcing a database pull. Calling atomic `files-pull` directly would skip the shared high-level pipeline lifecycle and resume checks.

## Implementation

- Registers `pull-files` as a high-level command.
- Routes it through `Pull::run_pull_files()` and the shared `run_pipeline()` runner.
- Allows `--filter=none|essential-files`, repeated `--only`, `--remap`, and related file-selection options on `pull-files`.
- Resets only file-transfer state when rerunning a completed `pull-files` pipeline so the next run computes a fresh file delta.
- Documents `pull-files` in the README and CLI help.

## Testing instructions

```bash
php -d display_startup_errors=0 vendor/bin/phpunit --colors=never \
  tests/Import/PullFilterOptionTest.php \
  tests/Import/OnlyCliParseTest.php \
  tests/Import/PullStartModeTest.php

php -d display_startup_errors=0 vendor/bin/phpunit --colors=never \
  tests/Import/PullFilterOptionTest.php \
  tests/Import/OnlyCliParseTest.php \
  tests/Import/PullStartModeTest.php \
  tests/Import/FilesSyncStateTest.php \
  tests/Import/CurlTimeoutRecoveryTest.php \
  tests/Import/OnlyFilesPathPrefixTest.php \
  tests/Import/NewSiteUrlSqliteTest.php \
  tests/Import/DownloadListProgressTest.php \
  tests/Import/OnlyFilesPathPrefixDiffTest.php \
  tests/Import/ImportMetadataTest.php \
  tests/Import/RemoteUploadProxyRuntimeTest.php \
  tests/Import/RuntimeFilesTest.php \
  tests/Import/LegacyCommandAliasTest.php

php -d display_startup_errors=0 /Users/cloudnik/.local/bin/composer analyze

git diff --check
```
