### PR TITLE
Add resumable pull-db pipeline command

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,26 @@ php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
     --only=:wp-content: --only=:wp-plugins:
 ```
 
+#### Pull only the database.
+
+`pull-db` runs the database side of the high-level pull pipeline:
+
+1. `preflight`
+2. `db-pull`
+3. `db-apply`
+
+Use it when you want the local database to catch up with the remote site without
+touching files or runtime configuration:
+
+```bash
+php reprint.phar pull-db "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --target-engine=sqlite
+```
+
+If a different pull-like command is already in progress, finish or abort that
+command first. This avoids reusing partially written state for a different
+pipeline.
+
 #### Step 3 — Download the database.
 
 By default, this streams a SQL dump into `$STATE_DIR/db.sql`:
@@ -659,6 +679,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
+* `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1584,6 +1584,7 @@ class ImportClient
         $valid_commands = [
             "pull",
             "pull-files",
+            "pull-db",
             "files-pull",
             "files-index",
             "files-stats",
@@ -1613,7 +1614,7 @@ class ImportClient
         // High-level pulls persist resume state before they enter the stage
         // runner. Reject invalid options first so a typo does not leave behind
         // state that looks like an interrupted pull.
-        if ($command === "pull") {
+        if (in_array($command, ["pull", "pull-db"], true)) {
             $this->pull->assert_options_valid_before_state_write($command, $options);
         }
 
@@ -1690,7 +1691,7 @@ class ImportClient
             $this->max_allowed_packet = (int) $this->state["max_allowed_packet"];
         }
 
-        if ($command === "pull") {
+        if (in_array($command, ["pull", "pull-db"], true)) {
             $options["sql_output"] = "file";
         }
 
@@ -1781,7 +1782,7 @@ class ImportClient
 
         // Pull-like commands orchestrate preflight and lower-level stages
         // internally, so they run before the normal command dispatch.
-        if (in_array($command, ["pull", "pull-files"], true)) {
+        if (in_array($command, ["pull", "pull-files", "pull-db"], true)) {
             if ($abort) {
                 $this->pull->abort($command);
                 return;
@@ -1793,6 +1794,9 @@ class ImportClient
                         break;
                     case "pull-files":
                         $this->pull->run_pull_files($options);
+                        break;
+                    case "pull-db":
+                        $this->pull->run_pull_db($options);
                         break;
                 }
             } catch (\Exception $e) {
@@ -11590,7 +11594,7 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
         ],
         [
             'name' => 'abort',
@@ -11598,7 +11602,7 @@ if (
             'target' => 'abort',
             'help' => 'Abort current sync and exit (preserves downloaded files)',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
         ],
         [
             'name' => 'verbose',
@@ -11607,7 +11611,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -11710,7 +11714,7 @@ if (
             'placeholder' => 'SIZE',
             'cast' => 'size',
             'help' => 'Client max_allowed_packet (e.g. 16M, 64M)',
-            'commands' => ['db-pull'],
+            'commands' => ['pull-db', 'db-pull'],
         ],
         [
             'name' => 'sql-output',
@@ -11768,7 +11772,7 @@ if (
             'target' => 'target_engine',
             'placeholder' => 'ENGINE',
             'help' => 'Target database engine: mysql (default) or sqlite',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'target-host',
@@ -11776,7 +11780,7 @@ if (
             'target' => 'target_host',
             'placeholder' => 'HOST',
             'help' => 'Target MySQL host (default: 127.0.0.1)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'target-port',
@@ -11785,7 +11789,7 @@ if (
             'placeholder' => 'PORT',
             'cast' => 'int',
             'help' => 'Target MySQL port (default: 3306)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'target-user',
@@ -11793,7 +11797,7 @@ if (
             'target' => 'target_user',
             'placeholder' => 'USER',
             'help' => 'Target MySQL user (required for mysql)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'target-pass',
@@ -11801,7 +11805,7 @@ if (
             'target' => 'target_pass',
             'placeholder' => 'PASS',
             'help' => 'Target MySQL password',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'target-db',
@@ -11809,7 +11813,7 @@ if (
             'target' => 'target_db',
             'placeholder' => 'NAME',
             'help' => 'Target DB name (required for mysql, optional for sqlite)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'target-sqlite-path',
@@ -11817,7 +11821,7 @@ if (
             'target' => 'target_sqlite_path',
             'placeholder' => 'PATH',
             'help' => 'Target SQLite database file (default: <wp-content>/database/.ht.sqlite)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'rewrite-url',
@@ -11825,7 +11829,7 @@ if (
             'target' => 'rewrite_url',
             'pair_args' => 'FROM TO',
             'help' => 'Rewrite FROM to TO (repeatable)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'new-site-url',
@@ -11833,7 +11837,7 @@ if (
             'target' => 'new_site_url',
             'placeholder' => 'URL',
             'help' => 'New site URL (auto-creates --rewrite-url from export URL origin)',
-            'commands' => ['pull', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
             'name' => 'remap',
@@ -12397,12 +12401,35 @@ if (
                 "without running the database stages.\n",
             "extra" =>
                 "Examples:\n" .
-                "  reprint pull-files https://example.com \\n" .
+                "  reprint pull-files https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files\n" .
                 "\n" .
-                "  reprint pull-files https://example.com \\n" .
-                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\n" .
+                "  reprint pull-files https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --only=:wp-content: --only=:wp-plugins:\n",
+        ],
+        "pull-db" => [
+            "level" => "high",
+            "short" => "Pull and apply the database through the high-level pull pipeline",
+            "description" =>
+                "Runs the database side of the pull pipeline:\n" .
+                "\n" .
+                "  1. Preflight — probe the remote site environment\n" .
+                "  2. db-pull — download the SQL dump into --state-dir/db.sql\n" .
+                "  3. db-apply — import the dump into a local database\n" .
+                "\n" .
+                "This gives the database the same retry and resume behavior as pull,\n" .
+                "without running the file or runtime stages.\n",
+            "extra" =>
+                "Examples:\n" .
+                "  reprint pull-db https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --target-engine=sqlite\n" .
+                "\n" .
+                "  reprint pull-db https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --target-user=root --target-db=wp_local \\\n" .
+                "    --new-site-url=http://localhost:8881\n",
         ],
         "install-exporter" => [
             "level" => "high",

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -7,15 +7,15 @@ class PullFailureReportedException extends RuntimeException
 }
 
 /**
- * The `pull` command — orchestrates lower-level commands into a
- * resumable pipeline.
+ * High-level pull commands — orchestrate lower-level commands into
+ * resumable pipelines.
  *
  * Each step retries automatically on server timeouts (exit code 2). If
- * the process is interrupted, re-running pull resumes from the last
- * completed step. Like `git pull` composes fetch + merge, `pull`
- * composes preflight → files-pull → db-pull → db-apply →
+ * the process is interrupted, re-running the same high-level command
+ * resumes from the last completed step. Like `git pull` composes fetch +
+ * merge, `pull` composes preflight → files-pull → db-pull → db-apply →
  * flat-docroot → apply-runtime → start. `pull-files` runs the file
- * subset.
+ * subset, and `pull-db` runs the database subset.
  *
  * The class holds a reference to ImportClient because each stage
  * delegates to an ImportClient method (run_preflight, run_files_sync,
@@ -96,20 +96,58 @@ class Pull
 
         $options = $this->validate_and_default_pull_options($options);
 
-        $this->run_pipeline('pull', $this->stages($options), $options, 'Pulling');
+        $this->run_pipeline(
+            'pull',
+            $this->stages($options),
+            $options,
+            'Pulling',
+            [
+                'reset_file_transfer_state' => true,
+                'reset_file_selection_state' => false,
+                'reset_db_state' => true,
+            ]
+        );
     }
 
     /**
-     * Handle --abort for high-level file pull commands.
+     * Handle --abort for high-level pull commands.
      *
-     * Downloaded site files stay in place; the next run refreshes the
-     * file indexes and fetches a fresh delta.
+     * File pipelines keep downloaded site files in place. The database
+     * pipeline removes stale database artifacts so the next pull-db fetches
+     * and applies a fresh dump.
      */
     public function abort(string $command = 'pull'): void
     {
-        $this->prepare_repull($command);
+        switch ($command) {
+            case 'pull-files':
+                $this->prepare_repull($command, [
+                    'reset_file_transfer_state' => true,
+                    'reset_file_selection_state' => true,
+                    'reset_db_state' => false,
+                ]);
+                break;
+
+            case 'pull-db':
+                $this->prepare_repull($command, [
+                    'reset_file_transfer_state' => false,
+                    'reset_file_selection_state' => false,
+                    'reset_db_state' => true,
+                ]);
+                break;
+
+            default:
+                $this->prepare_repull($command, [
+                    'reset_file_transfer_state' => true,
+                    'reset_file_selection_state' => false,
+                    'reset_db_state' => true,
+                ]);
+                break;
+        }
         $label = $command === 'pull' ? 'Pull' : $command;
-        $message = "{$label} state cleared. Downloaded files are preserved.";
+        $message = "{$label} state cleared.";
+        $message .= $command === 'pull-db'
+            ? " Database artifacts will be downloaded again."
+            : " Downloaded files are preserved.";
         $this->progress->show_lifecycle_line("{$message}\n");
         $this->client->output_progress([
             "type" => "lifecycle",
@@ -129,7 +167,40 @@ class Pull
 
         $options = $this->validate_and_default_pull_files_options($options, 'pull-files');
 
-        $this->run_pipeline('pull-files', ['preflight', 'files-pull'], $options, 'Pulling files from');
+        $this->run_pipeline(
+            'pull-files',
+            ['preflight', 'files-pull'],
+            $options,
+            'Pulling files from',
+            [
+                'reset_file_transfer_state' => true,
+                'reset_file_selection_state' => true,
+                'reset_db_state' => false,
+            ]
+        );
+    }
+
+    /**
+     * Run only the database stages from the pull pipeline.
+     */
+    public function run_pull_db(array $options): void
+    {
+        $this->normalize_url();
+        $this->progress->enable_quiet_lifecycle();
+
+        $options = $this->validate_and_default_pull_db_options($options);
+
+        $this->run_pipeline(
+            'pull-db',
+            ['preflight', 'db-pull', 'db-apply'],
+            $options,
+            'Pulling database from',
+            [
+                'reset_file_transfer_state' => false,
+                'reset_file_selection_state' => false,
+                'reset_db_state' => true,
+            ]
+        );
     }
 
     /**
@@ -146,8 +217,13 @@ class Pull
      * lower-level command completed but the pipeline checkpoint was not saved
      * yet.
      */
-    private function run_pipeline(string $command, array $stages, array $options, string $title): void
-    {
+    private function run_pipeline(
+        string $command,
+        array $stages,
+        array $options,
+        string $title,
+        array $repull_reset_state
+    ): void {
         $state = $this->client->state;
         $pull_pipeline = $state['pull_pipeline']['started_by_command'] ?? null;
         $pull_stage = $state['pull_pipeline']['last_completed_stage'] ?? null;
@@ -166,7 +242,10 @@ class Pull
             $pull_stage === $pipeline_final_stage;
 
         if ($completed_pipeline) {
-            $this->prepare_repull($command);
+            $this->prepare_repull(
+                $command,
+                $repull_reset_state,
+            );
             $completed_stage = null;
             $pull_pipeline = null;
             $pull_stage = null;
@@ -208,10 +287,10 @@ class Pull
             // Users can run lower-level commands directly, e.g.
             // `reprint files-pull` or `reprint db-pull`, without going through
             // this pull pipeline. Those commands save their own completion
-            // state in active_resumable_command. That state must not make
-            // `reprint pull` skip its files or database stage: the pipeline
-            // has not recorded that stage as complete. Clear the direct
-            // command checkpoint first so the stage computes a fresh delta.
+            // state in active_resumable_command. That state must not make a
+            // high-level command skip its matching stage: the pipeline has not
+            // recorded that stage as complete. Clear the direct command
+            // checkpoint first so the stage computes a fresh delta.
             $state_dir = $this->client->state_dir;
             $defaults = $this->client->default_state();
 
@@ -440,13 +519,21 @@ class Pull
             );
         }
 
-        $this->assert_runtime_options_valid($options);
-        $options = $this->default_pull_runtime_options($options);
-        if ($options['runtime'] === 'none') {
-            unset($options['runtime']);
+        if ($command === 'pull') {
+            $this->assert_runtime_options_valid($options);
+            $options = $this->default_pull_runtime_options($options);
+            if ($options['runtime'] === 'none') {
+                unset($options['runtime']);
+            }
+            $options = $this->default_pull_target_options($options);
+            $this->validate_database_target_options($options);
+            return;
         }
-        $options = $this->default_pull_target_options($options);
-        $this->validate_database_target_options($options);
+
+        if ($command === 'pull-db') {
+            $options = $this->default_pull_db_target_options($options);
+            $this->validate_database_target_options($options);
+        }
     }
 
     /**
@@ -579,6 +666,26 @@ class Pull
     }
 
     /**
+     * Applies database target defaults for the database-only pull command.
+     */
+    private function default_pull_db_target_options(array $options): array
+    {
+        if (empty($options['target_engine'])) {
+            $has_mysql_target =
+                !empty($options['target_host']) ||
+                !empty($options['target_port']) ||
+                !empty($options['target_user']) ||
+                !empty($options['target_pass']);
+            $has_sqlite_target = !empty($options['target_sqlite_path']);
+            if ($has_sqlite_target || (!$has_mysql_target && empty($options['target_db']))) {
+                $options['target_engine'] = 'sqlite';
+            }
+        }
+
+        return $options;
+    }
+
+    /**
      * Validates database import target options.
      *
      * MySQL imports need a user and database name because Reprint connects to
@@ -629,6 +736,17 @@ class Pull
             );
         }
         return $options;
+    }
+
+    /**
+     * Validate user-provided pull-db options and apply defaults without saving state.
+     */
+    private function validate_and_default_pull_db_options(array $options): array
+    {
+        $options['sql_output'] = 'file';
+        $options = $this->default_pull_db_target_options($options);
+
+        return $this->validate_database_target_options($options);
     }
 
     /**
@@ -694,21 +812,21 @@ class Pull
     /**
      * Reset sub-command state for a delta re-pull.
      *
-     * Keeps preflight data and downloaded files in place. `pull` keeps the
-     * local file index so files-pull runs in delta mode, while `pull-files`
-     * clears the in-progress index cursor and --only fingerprint so a new
-     * selection starts from a fresh remote traversal. Database artifacts are
-     * cleared only for the full pull pipeline because pull-files never creates
-     * or consumes them.
+     * Keeps preflight data and downloaded files in place. The caller chooses
+     * which checkpoint groups to clear because each high-level command owns a
+     * different subset of the full pull pipeline.
      */
-    private function prepare_repull(string $command = 'pull'): void
-    {
+    private function prepare_repull(
+        string $command,
+        array $repull_reset_state
+    ): void {
         $state_dir = $this->client->state_dir;
         $defaults = $this->client->default_state();
-        $reset_db_state = $command === 'pull';
-        $reset_file_selection_state = $command !== 'pull';
+        $reset_file_transfer_state = !empty($repull_reset_state['reset_file_transfer_state']);
+        $reset_file_selection_state = !empty($repull_reset_state['reset_file_selection_state']);
+        $reset_db_state = !empty($repull_reset_state['reset_db_state']);
 
-        $this->client->mutate_state(function (array $state) use ($command, $defaults, $reset_db_state, $reset_file_selection_state) {
+        $this->client->mutate_state(function (array $state) use ($command, $defaults, $reset_file_transfer_state, $reset_file_selection_state, $reset_db_state) {
             $state['pull_pipeline']['started_by_command'] = $command;
             $state['pull_pipeline']['stage_sequence'] = [];
             $state['pull_pipeline']['last_completed_stage'] = null;
@@ -720,11 +838,13 @@ class Pull
             $state['active_resumable_command']['remote_cursor'] = null;
             $state['active_resumable_command']['current_stage'] = null;
             $state['consecutive_timeouts'] = 0;
-            $state['current_file'] = null;
-            $state['current_file_bytes'] = null;
-            $state['diff'] = $defaults['diff'];
-            $state['fetch'] = $defaults['fetch'];
-            $state['fetch_skipped'] = $defaults['fetch_skipped'];
+            if ($reset_file_transfer_state) {
+                $state['current_file'] = null;
+                $state['current_file_bytes'] = null;
+                $state['diff'] = $defaults['diff'];
+                $state['fetch'] = $defaults['fetch'];
+                $state['fetch_skipped'] = $defaults['fetch_skipped'];
+            }
             if ($reset_file_selection_state) {
                 $state['index'] = $defaults['index'];
                 $state['files_pull_only_fingerprint'] = null;
@@ -738,13 +858,15 @@ class Pull
             return $state;
         });
 
-        $paths = [
-            $state_dir . "/.import-remote-index.jsonl",
-            $state_dir . "/.import-download-list.jsonl",
-            $state_dir . "/.import-download-list-skipped.jsonl",
-        ];
+        $paths = [];
+        if ($reset_file_transfer_state) {
+            $paths[] = $state_dir . "/.import-remote-index.jsonl";
+            $paths[] = $state_dir . "/.import-download-list.jsonl";
+            $paths[] = $state_dir . "/.import-download-list-skipped.jsonl";
+        }
         if ($reset_db_state) {
             $paths[] = $state_dir . "/db.sql";
+            $paths[] = $state_dir . "/db-tables.jsonl";
             $paths[] = $state_dir . "/.import-domains.json";
         }
 

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -580,6 +580,154 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
     }
 
+    public function testPullDbRunsPreflightDownloadAndApplyStages(): void
+    {
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->preflight_runs);
+        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(1, $client->db_sync_runs);
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame('pull-db', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
+        $this->assertSame(42, $state["apply"]["statements_executed"]);
+    }
+
+    public function testPullDbRejectsConflictingInProgressPullFiles(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "partial",
+                    "current_stage" => "fetch",
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull-files",
+                    "stage_sequence" => ["preflight", "files-pull"],
+                    "last_completed_stage" => "preflight",
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull-db",
+                "target_engine" => "sqlite",
+            ]);
+            $this->fail('Expected pull-db to reject an in-progress pull-files command');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Another command is already in progress: pull-files', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertSame(0, $client->db_sync_runs);
+        $this->assertSame(0, $client->db_apply_runs);
+    }
+
+    public function testPullDbResumesAfterDbPullCompletedBeforePipelineStageWasMarked(): void
+    {
+        file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "db-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "pull_pipeline" => [
+                    "started_by_command" => "pull-db",
+                    "stage_sequence" => ["preflight", "db-pull", "db-apply"],
+                    "last_completed_stage" => "preflight",
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(0, $client->db_sync_runs);
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
+    }
+
+    public function testPullDbAfterStandaloneDbPullDownloadsFreshDump(): void
+    {
+        file_put_contents($this->stateDir . '/db.sql', "SELECT stale;\n");
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "db-pull",
+                    "completion_state" => "complete",
+                    "current_stage" => null,
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->db_sync_runs);
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame("SELECT 1;\n", file_get_contents($this->stateDir . '/db.sql'));
+        $this->assertSame('pull-db', $state["pull_pipeline"]["started_by_command"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
+    }
+
+    public function testInvalidPullDbOptionsFailBeforeStateIsPersisted(): void
+    {
+        $client = $this->makeClient(false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull-db",
+                "target_engine" => "not-a-database",
+            ]);
+            $this->fail('Expected pull-db to reject an invalid target engine');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('Invalid --target-engine value', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+    }
+
     public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
     {
         $client = $this->makeClient(true);


### PR DESCRIPTION
## What it does

Adds `pull-db`, the database-only counterpart to `pull-files`. It runs this high-level pipeline:

1. `preflight`
2. `db-pull`
3. `db-apply`

The command updates the local database from the remote site without pulling files or generating runtime files.

## Testing instructions

CI