### PR TITLE
Add support for --env-mysql-* flags for secure credential passing

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1681,7 +1681,13 @@ class ImportClient
         }
 
         // MySQL connection parameters for --sql-output=mysql.
-        if (isset($options["mysql_host"])) {
+        if (isset($options["env_mysql_host"])) {
+            $env_var_name = $options["env_mysql_host"];
+            $this->mysql_host = getenv($env_var_name) ?: '';
+            if (!empty($this->mysql_host)) {
+                $this->state["mysql_host"] = $this->mysql_host;
+            }
+        } elseif (isset($options["mysql_host"])) {
             $this->mysql_host = $options["mysql_host"];
             $this->state["mysql_host"] = $this->mysql_host;
         } elseif (isset($this->state["mysql_host"])) {
@@ -1695,14 +1701,26 @@ class ImportClient
             $this->mysql_port = (int) $this->state["mysql_port"];
         }
 
-        if (isset($options["mysql_user"])) {
+        if (isset($options["env_mysql_user"])) {
+            $env_var_name = $options["env_mysql_user"];
+            $this->mysql_user = getenv($env_var_name) ?: '';
+            if (!empty($this->mysql_user)) {
+                $this->state["mysql_user"] = $this->mysql_user;
+            }
+        } elseif (isset($options["mysql_user"])) {
             $this->mysql_user = $options["mysql_user"];
             $this->state["mysql_user"] = $this->mysql_user;
         } elseif (isset($this->state["mysql_user"])) {
             $this->mysql_user = $this->state["mysql_user"];
         }
 
-        if (isset($options["mysql_database"])) {
+        if (isset($options["env_mysql_database"])) {
+            $env_var_name = $options["env_mysql_database"];
+            $this->mysql_database = getenv($env_var_name) ?: '';
+            if (!empty($this->mysql_database)) {
+                $this->state["mysql_database"] = $this->mysql_database;
+            }
+        } elseif (isset($options["mysql_database"])) {
             $this->mysql_database = $options["mysql_database"];
             $this->state["mysql_database"] = $this->mysql_database;
         } elseif (isset($this->state["mysql_database"])) {
@@ -1712,7 +1730,10 @@ class ImportClient
         $this->save_state($this->state);
 
         // Password is never persisted — must be supplied each run or via env.
-        if (isset($options["mysql_password"])) {
+        if (isset($options["env_mysql_password"])) {
+            $env_var_name = $options["env_mysql_password"];
+            $this->mysql_password = getenv($env_var_name) ?: '';
+        } elseif (isset($options["mysql_password"])) {
             $this->mysql_password = $options["mysql_password"];
         } elseif (getenv("MYSQL_PASSWORD") !== false) {
             $this->mysql_password = getenv("MYSQL_PASSWORD");
@@ -11684,6 +11705,14 @@ if (
             'commands' => ['db-pull'],
         ],
         [
+            'name' => 'env-mysql-host',
+            'type' => 'value',
+            'target' => 'env_mysql_host',
+            'placeholder' => 'VAR_NAME',
+            'help' => 'Read MySQL host from environment variable (secure alternative to --mysql-host)',
+            'commands' => ['db-pull'],
+        ],
+        [
             'name' => 'mysql-port',
             'type' => 'value',
             'target' => 'mysql_port',
@@ -11700,6 +11729,14 @@ if (
             'commands' => ['db-pull'],
         ],
         [
+            'name' => 'env-mysql-user',
+            'type' => 'value',
+            'target' => 'env_mysql_user',
+            'placeholder' => 'VAR_NAME',
+            'help' => 'Read MySQL user from environment variable (secure alternative to --mysql-user)',
+            'commands' => ['db-pull'],
+        ],
+        [
             'name' => 'mysql-password',
             'type' => 'value',
             'target' => 'mysql_password',
@@ -11708,11 +11745,27 @@ if (
             'commands' => ['db-pull'],
         ],
         [
+            'name' => 'env-mysql-password',
+            'type' => 'value',
+            'target' => 'env_mysql_password',
+            'placeholder' => 'VAR_NAME',
+            'help' => 'Read MySQL password from environment variable (secure alternative to --mysql-password)',
+            'commands' => ['db-pull'],
+        ],
+        [
             'name' => 'mysql-database',
             'type' => 'value',
             'target' => 'mysql_database',
             'placeholder' => 'DB',
             'help' => 'MySQL database (required for --sql-output=mysql)',
+            'commands' => ['db-pull'],
+        ],
+        [
+            'name' => 'env-mysql-database',
+            'type' => 'value',
+            'target' => 'env_mysql_database',
+            'placeholder' => 'VAR_NAME',
+            'help' => 'Read MySQL database from environment variable (secure alternative to --mysql-database)',
             'commands' => ['db-pull'],
         ],
 


### PR DESCRIPTION
Implements feature requested in issue #24:
- Add --env-mysql-password=VAR_NAME support
- Add --env-mysql-user=VAR_NAME support
- Add --env-mysql-host=VAR_NAME support
- Add --env-mysql-database=VAR_NAME support

These flags allow credentials to be sourced from environment variables specified by the user, avoiding password visibility in 'ps aux' output.

Maintains backward compatibility with existing --mysql-* flags. Falls back to hardcoded MYSQL_PASSWORD env var if no flag specified.

Changes:
- Add CLI option definitions for all 4 new flags
- Update credential parsing logic to check env flags first
- Only persist non-password credentials in state

Fixes #24