### PR TITLE
Rename terminal progress pipeline mode API

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2980,7 +2980,7 @@ class ImportClient
 
             // In pull mode, finalize the scanning line with a checkmark
             // and start the download progress on a fresh line.
-            if ($has_downloads && $this->progress->is_quiet_lifecycle()) {
+            if ($has_downloads && $this->progress->is_mode('pipeline')) {
                 $green = "\033[32m";
                 $dim = "\033[2m";
                 $r = "\033[0m";
@@ -4235,7 +4235,7 @@ class ImportClient
             "message" => "apply-runtime complete (runtime: {$runtime})",
         ]);
 
-        if (!$this->progress->is_quiet_lifecycle()) {
+        if (!$this->progress->is_mode('pipeline')) {
             fwrite(STDERR, "\n");
             fwrite(STDERR, "Runtime: {$runtime}\n");
             fwrite(STDERR, "Source host: {$webhost}\n");
@@ -4725,7 +4725,7 @@ class ImportClient
             "refreshed" => $refreshed,
             "force_replaced" => $forced,
         ];
-        if (!$this->progress->is_quiet_lifecycle()) {
+        if (!$this->progress->is_mode('pipeline')) {
             fwrite($this->progress_fd, json_encode($result) . "\n");
         }
         $this->output_progress(array_merge(["type" => "flat_docroot_complete"], $result));
@@ -5572,7 +5572,7 @@ class ImportClient
                     "message" => "db-apply complete ({$statements_executed} statements executed)",
                 ]);
 
-                if (!$this->progress->is_quiet_lifecycle()) {
+                if (!$this->progress->is_mode('pipeline')) {
                     // Clear the progress line before printing the final message
                     $this->progress->clear_progress_line();
                 }

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -101,7 +101,7 @@ class Pull
     public function run(array $options): void
     {
         $this->normalize_url();
-        $this->progress->enable_quiet_lifecycle();
+        $this->progress->set_mode('pipeline');
 
         $options = $this->validate_and_default_pull_options($options);
 
@@ -143,7 +143,7 @@ class Pull
     public function run_pull_files(array $options): void
     {
         $this->normalize_url();
-        $this->progress->enable_quiet_lifecycle();
+        $this->progress->set_mode('pipeline');
 
         if (!isset($options['filter'])) {
             $options['filter'] = $this->client->state['filter'] ?? 'none';
@@ -169,7 +169,7 @@ class Pull
     public function run_pull_db(array $options): void
     {
         $this->normalize_url();
-        $this->progress->enable_quiet_lifecycle();
+        $this->progress->set_mode('pipeline');
 
         $options['sql_output'] = 'file';
         $options = $this->default_pull_db_target_options($options);

--- a/packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php
+++ b/packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php
@@ -5,15 +5,15 @@
  * Two categories of output:
  *
  * - Progress line: a single line that overwrites in place. In default
- *   mode it just shows the message; in "quiet lifecycle" mode it also
+ *   mode it just shows the message; in "pipeline progress" mode it also
  *   prepends an animated Braille spinner and (when a fraction is given)
  *   renders a Unicode progress bar. Use show_progress_line().
  *
  * - Lifecycle line: a regular line that announces a phase transition,
  *   e.g. "Starting db-pull". Use show_lifecycle_line(). When
- *   quiet_lifecycle is enabled (typically by an orchestrator like
- *   `pull`), these are suppressed so the orchestrator can provide its
- *   own framing without sub-command noise.
+ *   pipeline progress is enabled (typically by `pull`), these are
+ *   suppressed so the parent command can provide its own framing
+ *   without sub-command noise.
  *
  * Both methods are no-ops when stdout is not a TTY (so machine
  * consumers reading JSONL don't get progress noise interleaved) or
@@ -34,11 +34,11 @@ class TerminalProgress
     private ?int $terminal_width_cache = null;
 
     /**
-     * @var bool When true, suppress lifecycle messages and decorate the
-     * progress line with a spinner / progress bar. Used by orchestrator
-     * commands (e.g. pull) that want to provide their own framing.
+     * @var string Output mode. Pipeline mode suppresses lifecycle messages
+     * and decorates the progress line with a spinner / progress bar. Used by
+     * parent commands (e.g. pull) that want to provide their own framing.
      */
-    private bool $quiet_lifecycle = false;
+    private string $mode = 'default';
 
     /** @var int Spinner frame counter. */
     private int $spinner_tick = 0;
@@ -88,18 +88,21 @@ class TerminalProgress
     }
 
     /**
-     * Enable rich progress mode: lifecycle messages are suppressed,
-     * the progress line gains a spinner/bar prefix, and tick_spinner()
-     * starts animating.
+     * Set the output mode. Pipeline mode suppresses lifecycle messages,
+     * adds a spinner/bar prefix to progress lines, and lets tick_spinner()
+     * animate the active line.
      */
-    public function enable_quiet_lifecycle(): void
+    public function set_mode(string $mode): void
     {
-        $this->quiet_lifecycle = true;
+        if (!in_array($mode, ['default', 'pipeline'], true)) {
+            throw new InvalidArgumentException("Unknown progress mode: {$mode}");
+        }
+        $this->mode = $mode;
     }
 
-    public function is_quiet_lifecycle(): bool
+    public function is_mode(string $mode): bool
     {
-        return $this->quiet_lifecycle;
+        return $this->mode === $mode;
     }
 
     /**
@@ -116,7 +119,7 @@ class TerminalProgress
     /**
      * Show progress in a single refreshing line.
      *
-     * In quiet_lifecycle mode the message is decorated with either a
+     * In pipeline progress mode the message is decorated with either a
      * progress bar (when $fraction is provided) or a Braille spinner.
      * Rate-limited to ~20fps so the terminal can keep up.
      */
@@ -125,7 +128,7 @@ class TerminalProgress
         if (!$this->is_tty || $this->verbose_mode) {
             return;
         }
-        if ($this->quiet_lifecycle) {
+        if ($this->is_mode('pipeline')) {
             // Rate-limit in pull mode to avoid flooding the terminal.
             // Hundreds of updates per second cause visual artifacts
             // because the terminal can't redraw fast enough — \r writes
@@ -150,20 +153,20 @@ class TerminalProgress
     /**
      * Print a lifecycle message announcing a phase transition.
      *
-     * Suppressed when quiet_lifecycle is enabled, so an orchestrator
+     * Suppressed when pipeline progress is enabled, so the parent command
      * can render its own framing without sub-command noise.
      */
     public function show_lifecycle_line(string $message): void
     {
-        if (!$this->is_tty || $this->verbose_mode || $this->quiet_lifecycle) {
+        if (!$this->is_tty || $this->verbose_mode || $this->is_mode('pipeline')) {
             return;
         }
         fwrite($this->progress_fd, $message);
     }
 
     /**
-     * Always print a line (no quiet_lifecycle suppression). Use for
-     * orchestrator-owned output like stage headers / checkmarks.
+     * Always print a line (no pipeline progress suppression). Use for
+     * parent-command output like stage headers / checkmarks.
      */
     public function print_line(string $message): void
     {
@@ -192,7 +195,7 @@ class TerminalProgress
      */
     public function tick_spinner(): void
     {
-        if (!$this->quiet_lifecycle || !$this->is_tty || $this->verbose_mode) {
+        if (!$this->is_mode('pipeline') || !$this->is_tty || $this->verbose_mode) {
             return;
         }
         if ($this->active_label === null && $this->last_progress_message === null) {


### PR DESCRIPTION
## Summary
- replace the old quiet-lifecycle progress API with `set_mode('pipeline')` / `is_mode('pipeline')`
- update pull, pull-files, and pull-db pipeline entry points to select pipeline mode
- update pipeline-mode checks and comments to use the new terminology

## Why
The old `enable_quiet_lifecycle()` name described one side effect instead of the mode the pull pipeline actually enables. The new API names the mode directly and keeps call sites readable.

## Testing
- `composer analyze`
- `php -l packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php`
- `php -l packages/reprint-importer/src/lib/pull/class-pull.php`
- `php -l packages/reprint-importer/src/import.php`
- `vendor/bin/phpunit --colors=never tests/Import/ProgressLineWidthTest.php tests/Import/PullStartModeTest.php`

Note: local PHP emits an unrelated startup warning for a missing `wasmtime.so` dependency, but the checks above completed successfully.
