### PR TITLE
Document accepted pull-files and pull-db CLI options

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -11771,7 +11771,7 @@ if (
             'type' => 'value',
             'target' => 'target_engine',
             'placeholder' => 'ENGINE',
-            'help' => 'Target database engine: mysql (default) or sqlite',
+            'help' => 'Target database engine: mysql or sqlite',
             'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
         [
@@ -11854,7 +11854,7 @@ if (
             'target' => 'only',
             'placeholder' => 'SOURCE',
             'repeatable' => true,
-            'help' => 'Restrict the files-pull command to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
+            'help' => 'Restrict the file pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
                 'repeat for several. Default pulls everything',
             'commands' => ['pull-files', 'files-pull'],
         ],
@@ -12180,12 +12180,20 @@ if (
         echo "\n";
         echo $info["description"];
 
-        // Collect options tagged for this command.
-        $cmd_options = array_filter($option_defs, function ($d) use ($command) {
+        // Collect options tagged for this command. Required options are also
+        // shown when the command usage names them, so command-specific help
+        // matches what the CLI requires without duplicating every command name
+        // in the option definition.
+        $cmd_options = array_filter($option_defs, function ($d) use ($command, $usage) {
             if (($d['help'] ?? null) === null) {
                 return false;
             }
-            return isset($d['commands']) && in_array($command, $d['commands'], true);
+            if (isset($d['commands']) && in_array($command, $d['commands'], true)) {
+                return true;
+            }
+            return
+                ($d['help_section'] ?? null) === 'required' &&
+                strpos($usage, "--{$d['name']}") !== false;
         });
 
         // Show command-specific options first, then global ones.
@@ -12419,7 +12427,8 @@ if (
                 "  3. db-apply — import the dump into a local database\n" .
                 "\n" .
                 "This gives the database the same retry and resume behavior as pull,\n" .
-                "without running the file or runtime stages.\n",
+                "without running the file or runtime stages. With no MySQL target\n" .
+                "options, pull-db imports into SQLite by default.\n",
             "extra" =>
                 "Examples:\n" .
                 "  reprint pull-db https://example.com \\\n" .

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+class CliHelpTest extends TestCase
+{
+    private function runHelp(string $command): string
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $cmd = escapeshellarg(PHP_BINARY) . ' -n ' . escapeshellarg($entry) . ' ' . escapeshellarg($command) . ' --help';
+        return shell_exec($cmd . ' 2>&1') ?? '';
+    }
+
+    public function testPullFilesHelpShowsRequiredAndFileSelectionOptions(): void
+    {
+        $output = $this->runHelp('pull-files');
+
+        $this->assertStringContainsString('--state-dir=DIR', $output);
+        $this->assertStringContainsString('--fs-root=DIR', $output);
+        $this->assertStringContainsString('--filter=MODE', $output);
+        $this->assertStringContainsString('--remap SOURCE TARGET', $output);
+        $this->assertStringContainsString('--only=SOURCE', $output);
+    }
+
+    public function testPullDbHelpShowsRequiredAndDatabaseOptions(): void
+    {
+        $output = $this->runHelp('pull-db');
+
+        $this->assertStringContainsString('--state-dir=DIR', $output);
+        $this->assertStringContainsString('--fs-root=DIR', $output);
+        $this->assertStringContainsString('--max-allowed-packet=SIZE', $output);
+        $this->assertStringContainsString('--target-engine=ENGINE', $output);
+        $this->assertStringContainsString('--new-site-url=URL', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- show required options in command-specific help when the command usage requires them
- document accepted pull-files selection options, including repeated --only
- clarify pull-db target engine help and SQLite default behavior

## Tests
- php -n -l packages/reprint-importer/src/import.php
- php -n -l tests/Import/CliHelpTest.php
- phpunit --colors=never tests/Import/CliHelpTest.php