### PR TITLE
Report changed files in pull-files summary

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2724,6 +2724,7 @@ class ImportClient
                 $this->import_state()->active_resumable_command->completion_state = "in_progress";
                 $this->import_state()->active_resumable_command->current_stage = "fetch-skipped";
                 $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
+                $this->import_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state($this->state);
                 $this->run_files_sync_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
@@ -2838,6 +2839,7 @@ class ImportClient
             $this->import_state()->index = new RemoteFileIndexCursorState();
             $this->import_state()->fetch = new DownloadListFetchProgressState();
             $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+            $this->import_state()->files_pull_summary = new FilesPullSummaryState();
             $this->save_state($this->state);
 
             if ($is_delta) {
@@ -6634,6 +6636,7 @@ class ImportClient
         if ($this->download_list_done !== null) {
             $this->download_list_done += $batch_entries;
         }
+        $this->import_state()->files_pull_summary->files_pulled += $batch_entries;
         $this->files_imported = 0;
 
         $this->set_download_list_fetch_state($state_key, DownloadListFetchProgressState::from_array([
@@ -10828,6 +10831,9 @@ class ImportClient
             "max_allowed_packet" => null,
             "files_remap_fingerprint" => null,
             "files_pull_only_fingerprint" => null,
+            "files_pull_summary" => [
+                "files_pulled" => 0,
+            ],
             "db_index" => [
                 "file" => null,
                 "tables" => 0,
@@ -10967,6 +10973,18 @@ class ImportClient
         }
         $fetch = array_intersect_key($fetch, $defaults["fetch"]);
         $state["fetch"] = array_merge($defaults["fetch"], $fetch);
+        $files_pull_summary = $state["files_pull_summary"] ?? [];
+        if (!is_array($files_pull_summary)) {
+            $files_pull_summary = [];
+        }
+        $files_pull_summary = array_intersect_key(
+            $files_pull_summary,
+            $defaults["files_pull_summary"],
+        );
+        $state["files_pull_summary"] = array_merge(
+            $defaults["files_pull_summary"],
+            $files_pull_summary,
+        );
         $tuning = $state["tuning"] ?? [];
         if (!is_array($tuning)) {
             $tuning = [];

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -284,6 +284,7 @@ class Pull
                     $state->index = new RemoteFileIndexCursorState();
                     $state->fetch = new DownloadListFetchProgressState();
                     $state->fetch_skipped = new DownloadListFetchProgressState();
+                    $state->files_pull_summary = new FilesPullSummaryState();
                     $state->files_pull_only_fingerprint = null;
                     return $state;
                 });
@@ -432,12 +433,15 @@ class Pull
                     $options['filter'] === 'essential-files' &&
                     $this->client->has_skipped_files_pending();
                 $this->client->set_pull_files_state($options['filter'], $skipped_pending);
-                $count = $this->client->index_count();
-                $summary = $count > 0 ? number_format($count) . " files" : null;
+                $files_pulled = $this->client->state->files_pull_summary->files_pulled;
+                $pulled_label = $files_pulled === 1 ? 'file' : 'files';
+                $summary = sprintf(
+                    '%s changed %s pulled',
+                    number_format($files_pulled),
+                    $pulled_label,
+                );
                 if ($skipped_pending) {
-                    $summary = $summary !== null
-                        ? $summary . ", deferred files pending"
-                        : "deferred files pending";
+                    $summary .= ", deferred files pending";
                 }
                 $this->print_done($stage, $summary);
                 break;
@@ -797,6 +801,7 @@ class Pull
                 $state->diff = new FileDiffProgressState();
                 $state->fetch = new DownloadListFetchProgressState();
                 $state->fetch_skipped = new DownloadListFetchProgressState();
+                $state->files_pull_summary = new FilesPullSummaryState();
             }
             if ($reset_file_selection_state) {
                 $state->index = new RemoteFileIndexCursorState();

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -165,6 +165,24 @@ class DownloadListFetchProgressState
     }
 }
 
+class FilesPullSummaryState
+{
+    /** @var int Number of changed files pulled in the current files-pull run. */
+    public int $files_pulled = 0;
+
+    public static function from_array(array $data): self
+    {
+        $state = new self();
+        $state->files_pulled = (int) ($data['files_pulled'] ?? 0);
+        return $state;
+    }
+
+    public function to_array(): array
+    {
+        return ['files_pulled' => $this->files_pulled];
+    }
+}
+
 class DatabaseApplyCommandState
 {
     /** @var int SQL statements successfully executed. */
@@ -335,6 +353,7 @@ class ImportState
     public ?int $max_allowed_packet = null;
     public ?string $files_remap_fingerprint = null;
     public ?string $files_pull_only_fingerprint = null;
+    public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;
     public FileDiffProgressState $diff;
     public RemoteFileIndexCursorState $index;
@@ -363,6 +382,7 @@ class ImportState
         $this->index = new RemoteFileIndexCursorState();
         $this->fetch = new DownloadListFetchProgressState();
         $this->fetch_skipped = new DownloadListFetchProgressState();
+        $this->files_pull_summary = new FilesPullSummaryState();
         $this->apply = new DatabaseApplyCommandState();
         $this->tuning = new AdaptiveTuningState();
         $this->pull_pipeline = new PullPipelineCheckpointState();
@@ -384,6 +404,7 @@ class ImportState
         $state->max_allowed_packet = isset($data['max_allowed_packet']) ? (int) $data['max_allowed_packet'] : null;
         $state->files_remap_fingerprint = isset($data['files_remap_fingerprint']) ? (string) $data['files_remap_fingerprint'] : null;
         $state->files_pull_only_fingerprint = isset($data['files_pull_only_fingerprint']) ? (string) $data['files_pull_only_fingerprint'] : null;
+        $state->files_pull_summary = self::files_pull_summary_from($data['files_pull_summary'] ?? []);
         $state->db_index = self::database_table_index_from($data['db_index'] ?? []);
         $state->diff = self::file_diff_progress_from($data['diff'] ?? []);
         $state->index = self::remote_file_index_cursor_from($data['index'] ?? []);
@@ -421,6 +442,7 @@ class ImportState
             'max_allowed_packet' => $this->max_allowed_packet,
             'files_remap_fingerprint' => $this->files_remap_fingerprint,
             'files_pull_only_fingerprint' => $this->files_pull_only_fingerprint,
+            'files_pull_summary' => $this->files_pull_summary->to_array(),
             'db_index' => $this->db_index->to_array(),
             'diff' => $this->diff->to_array(),
             'index' => $this->index->to_array(),
@@ -445,6 +467,11 @@ class ImportState
     private static function resumable_command_checkpoint_from($value): ResumableCommandCheckpointState
     {
         return $value instanceof ResumableCommandCheckpointState ? $value : ResumableCommandCheckpointState::from_array(is_array($value) ? $value : []);
+    }
+
+    private static function files_pull_summary_from($value): FilesPullSummaryState
+    {
+        return $value instanceof FilesPullSummaryState ? $value : FilesPullSummaryState::from_array(is_array($value) ? $value : []);
     }
 
     private static function database_table_index_from($value): DatabaseTableIndexState

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -9,12 +9,16 @@ require_once __DIR__ . '/../../importer/import.php';
 class PullFilterFakeClient extends \ImportClient
 {
     private bool $create_skipped_list;
+    public int $files_pulled = 0;
     public int $preflight_runs = 0;
     public int $files_sync_runs = 0;
     public int $db_sync_runs = 0;
     public int $db_apply_runs = 0;
     public array $progress_events = [];
     public array $status_errors = [];
+
+    /** @var resource|null */
+    private $terminal_progress_stream = null;
 
     public function __construct(string $state_dir, string $fs_root, bool $create_skipped_list)
     {
@@ -34,6 +38,29 @@ class PullFilterFakeClient extends \ImportClient
     public function write_status_file(?string $error = null): void
     {
         $this->status_errors[] = $error;
+    }
+
+    public function captureTerminalProgress(): void
+    {
+        $ref = new \ReflectionClass(\ImportClient::class);
+        $property = $ref->getProperty('progress');
+        $property->setAccessible(true);
+        $progress = $property->getValue($this);
+
+        $this->terminal_progress_stream = fopen('php://temp', 'w+');
+        $progress->set_is_tty(true);
+        $progress->set_progress_fd($this->terminal_progress_stream);
+    }
+
+    public function terminalProgressOutput(): string
+    {
+        if ($this->terminal_progress_stream === null) {
+            return '';
+        }
+
+        rewind($this->terminal_progress_stream);
+        $output = stream_get_contents($this->terminal_progress_stream);
+        return $output === false ? '' : $output;
     }
 
     public function index_count(): int
@@ -87,6 +114,7 @@ class PullFilterFakeClient extends \ImportClient
             $state->active_resumable_command->command_name = "files-pull";
             $state->active_resumable_command->completion_state = "complete";
             $state->active_resumable_command->current_stage = null;
+            $state->files_pull_summary->files_pulled = $this->files_pulled;
             return $state;
         });
     }
@@ -400,6 +428,53 @@ class PullFilterOptionTest extends TestCase
         }
 
         $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+    }
+
+    public function testPullFilesSummaryReportsNoChangedFilesPulled(): void
+    {
+        $client = $this->makeClient(false);
+        $client->captureTerminalProgress();
+
+        $client->run([
+            "command" => "pull-files",
+        ]);
+
+        $output = $client->terminalProgressOutput();
+        $this->assertStringContainsString('0 changed files pulled', $output);
+        $this->assertStringNotContainsString('pull scope compared', $output);
+    }
+
+    public function testPullFilesSummaryReportsChangedFilePulled(): void
+    {
+        $client = $this->makeClient(false);
+        $client->files_pulled = 1;
+        $client->captureTerminalProgress();
+
+        $client->run([
+            "command" => "pull-files",
+            "only" => ["/var/www/html/wp-content/uploads/reprint-demo"],
+        ]);
+
+        $this->assertStringContainsString(
+            '1 changed file pulled',
+            $client->terminalProgressOutput(),
+        );
+    }
+
+    public function testPullFilesSummaryReportsDeferredFilesPending(): void
+    {
+        $client = $this->makeClient(true);
+        $client->captureTerminalProgress();
+
+        $client->run([
+            "command" => "pull-files",
+            "filter" => "essential-files",
+        ]);
+
+        $this->assertStringContainsString(
+            '0 changed files pulled, deferred files pending',
+            $client->terminalProgressOutput(),
+        );
     }
 
     public function testPullFilesRunsOnlyPreflightAndFilesStages(): void


### PR DESCRIPTION
## What it does

Changes the high-level `pull-files` stage summary from an index-size count to the number of changed files actually pulled:

```text
✓ Pulling files — 0 changed files pulled
```

If an `essential-files` run leaves skipped uploads for later, the summary still calls that out:

```text
✓ Pulling files — 0 changed files pulled, deferred files pending
```

## Rationale

The previous summary printed `index_count()`, so a no-op selective pull could say `1 files` every time. That read like Reprint had pulled a file on every rerun, even when it only compared the remote index and found nothing to download.

## Implementation

Adds a small `files_pull_summary` state entry with `files_pulled`. It resets when a fresh `files-pull` starts and increments after each completed download batch.

The high-level pull pipeline now formats that value instead of reusing the local index count. This keeps the user-facing summary tied to transferred changed files, not the size of the indexed scope.

Also updates `CliHelpTest` to run help commands with the configured PHP binary instead of `PHP_BINARY -n`, matching CI's loaded extensions.

## Testing instructions

```bash
php -d display_startup_errors=0 -l packages/reprint-importer/src/import.php
php -d display_startup_errors=0 -l packages/reprint-importer/src/lib/pull/class-pull.php
php -d display_startup_errors=0 -l tests/Import/PullFilterOptionTest.php
php -d display_startup_errors=0 -l tests/Import/CliHelpTest.php
php -d display_startup_errors=0 vendor/bin/phpunit --colors=never tests/Import/CliHelpTest.php tests/Import/PullFilterOptionTest.php tests/Import/OnlyCliParseTest.php tests/Import/PullStartModeTest.php tests/Import/FilesSyncStateTest.php tests/Import/DownloadListProgressTest.php tests/Import/OnlyFilesPathPrefixTest.php tests/Import/OnlyFilesPathPrefixDiffTest.php
git diff --check
```

Also smoke-tested against a local Docker WordPress site; a no-op selective rerun prints `0 changed files pulled`.
