### PR TITLE
Better prior-op understanding for `files-sync --filter=skipped-earlier` calls

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1660,7 +1660,9 @@ class ImportClient
         //
         // Changing the filter mid-flight is not allowed.  The user must either
         // start fresh (--abort) or finish the current sync before switching.
-        // The one valid transition is: essential-files (complete) → skipped-earlier.
+        // Exceptions: essential-files may advance to skipped-earlier once
+        // complete, and skipped-earlier (a terminal tail-fetch) may always give
+        // way to a fresh full sync.
         if (isset($options["filter"])) {
             $next = $options["filter"];
             if (
@@ -1674,7 +1676,14 @@ class ImportClient
             }
             $prev = $this->import_state()->filter ?? null;
             $status = $this->import_state()->active_resumable_command->completion_state ?? null;
-            $is_mid_flight = $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
+            // Leaving a skipped-earlier tail-fetch for another sync is a fresh
+            // cycle, not a mid-flight filter change.
+            $is_mid_flight =
+                $prev !== null &&
+                $prev !== $next &&
+                $prev !== "skipped-earlier" &&
+                $status !== null &&
+                $status !== "complete";
             if ($is_mid_flight) {
                 throw new RuntimeException(
                     "Cannot change --filter from '{$prev}' to '{$next}' while a sync is in progress. " .
@@ -2681,6 +2690,26 @@ class ImportClient
     public function run_files_sync(): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
+
+        // A full `pull` leaves active_resumable_command on its last stage
+        // (db-apply), not files-pull, so a standalone skipped-earlier run can't
+        // tell that files-pull finished with a deferred tail. Recover that from
+        // the pipeline's skipped_pending flag and restore the files-pull
+        // checkpoint. Once the fetch starts it persists command_name=files-pull,
+        // so on the resume passes this recovery is skipped and won't clobber the
+        // checkpoint.
+        if (
+            $this->filter === "skipped-earlier" &&
+            $state_command !== "files-pull" &&
+            $this->import_state()->pull_pipeline->skipped_pending
+        ) {
+            $this->import_state()->active_resumable_command->command_name = "files-pull";
+            $this->import_state()->active_resumable_command->completion_state = "complete";
+            $this->import_state()->active_resumable_command->current_stage = null;
+            $this->save_state($this->state);
+            $state_command = "files-pull";
+        }
+
         $current_status =
             $state_command === "files-pull"
                 ? $this->import_state()->active_resumable_command->completion_state ?? null
@@ -2767,9 +2796,15 @@ class ImportClient
         }
 
         // --filter=skipped-earlier is only valid after a completed
-        // --filter=essential-files run.  It doesn't make sense as a fresh
-        // start or resume of an in-progress sync.
-        if ($this->filter === "skipped-earlier") {
+        // --filter=essential-files run. Reject it as a fresh start, but allow
+        // resuming a skipped-files fetch that is already under way: a
+        // multi-batch fetch returns status="partial" and is re-run, at which
+        // point stage is "fetch-skipped" and the resume flows through the
+        // $has_progress path below (and completes via the shared tail).
+        if (
+            $this->filter === "skipped-earlier" &&
+            ($this->import_state()->active_resumable_command->current_stage ?? null) !== "fetch-skipped"
+        ) {
             throw new RuntimeException(
                 "--filter=skipped-earlier was requested but there is no completed sync with skipped files. " .
                     "Run files-pull with --filter=essential-files first.",
@@ -3080,6 +3115,9 @@ class ImportClient
             }
             $this->import_state()->active_resumable_command->current_stage = null;
             $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+            // Tail fully fetched; clear the flag so a later skipped-earlier run
+            // doesn't treat the now-empty tail as pending.
+            $this->import_state()->pull_pipeline->skipped_pending = false;
             $this->save_state($this->state);
 
             if (file_exists($this->skipped_download_list_file)) {

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -285,6 +285,53 @@ class FilesSyncStateTest extends TestCase
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
     }
 
+    /**
+     * After a full `pull`, active_resumable_command points at the last stage
+     * (db-apply), not files-pull, but pull_pipeline records a deferred tail. A
+     * standalone skipped-earlier run must recover the completed files-pull and
+     * fetch the tail rather than throwing "no completed sync with skipped
+     * files".
+     */
+    public function testSkippedEarlierAfterCompositePullAdoptsFilesPullState(): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->indexLine('/wp-content/uploads/2024/01/photo.jpg', 1000, 100),
+        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "db-apply",
+                "completion_state" => "complete",
+            ],
+            "filter" => "skipped-earlier",
+            "pull_pipeline" => [
+                "files_filter" => "essential-files",
+                "skipped_pending" => true,
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $filterProp = $reflection->getProperty('filter');
+        $filterProp->setValue($client, 'skipped-earlier');
+
+        try {
+            $reflection->getMethod('run_files_sync')->invoke($client);
+        } catch (\Exception $e) {
+            // Expected: the fetch fails against the fake URL. The point is that
+            // it got PAST the "no completed sync with skipped files" guard.
+            $this->assertStringNotContainsString(
+                'no completed sync with skipped files',
+                $e->getMessage(),
+            );
+        }
+
+        // The checkpoint was restored to the completed files-pull and the
+        // deferred-tail fetch started.
+        $state = $this->readState();
+        $this->assertSame('files-pull', $state["active_resumable_command"]["command_name"]);
+        $this->assertSame('fetch-skipped', $state["active_resumable_command"]["current_stage"]);
+    }
+
     // ---------------------------------------------------------------
     // Preserve-local diff tests
     // ---------------------------------------------------------------

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -905,4 +905,44 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
         $this->assertSame('essential-files', $state["filter"]);
     }
+
+    public function testRepullAfterInterruptedSkippedEarlierTailIsNotBlocked(): void
+    {
+        // An interrupted skipped-earlier tail leaves completion_state="partial"
+        // with filter=skipped-earlier. A new essential-files pull must still be
+        // allowed: the filter-change guard must not treat the terminal tail as
+        // a mid-flight sync.
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "active_resumable_command" => [
+                    "command_name" => "files-pull",
+                    "completion_state" => "partial",
+                    "current_stage" => "fetch-skipped",
+                ],
+                "filter" => "skipped-earlier",
+                "pull_pipeline" => [
+                    "started_by_command" => "pull",
+                    "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
+                    "last_completed_stage" => "db-apply",
+                    "files_filter" => "essential-files",
+                    "skipped_pending" => true,
+                ],
+                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            ]),
+        );
+
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "filter" => "essential-files",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame('essential-files', $state["filter"]);
+    }
 }

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -138,6 +138,29 @@ describe('Import: --filter', () => {
                 'Expected skipped download list to be cleaned up');
         });
 
+        it('state shows complete after skipped-earlier (not left in_progress)', () => {
+            // Regression: the skipped-earlier fetch must mark the sync
+            // complete. If it leaves status="in_progress", the filter-change
+            // guard blocks the next delta re-pull below.
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            assert.equal(state.active_resumable_command.completion_state, 'complete',
+                `Expected completion_state=complete after skipped-earlier, got ${state.active_resumable_command?.completion_state}`);
+        });
+
+        it('a subsequent essential-files delta re-pull succeeds', () => {
+            // Regression: switching the filter back to essential-files after a
+            // completed skipped-earlier fetch must be allowed (the guard only
+            // blocks filter changes mid-sync). Previously this threw
+            // "Cannot change --filter from 'skipped-earlier' to
+            // 'essential-files' while a sync is in progress."
+            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+                secret: getSiteSecret(site),
+                extraArgs: ['--filter=essential-files'],
+            });
+            assert.equal(result.exitCode, 0,
+                `Expected exit 0 on delta re-pull\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+        });
+
         it('all files match source', () => {
             const importedRoot = join(fsRootDir(tempDir), siteDir);
             assertTreesMatch(siteDir, importedRoot);


### PR DESCRIPTION
### Background

The `pull-reprint` command in Studio CLI runs Reprint in the "two-phased pull mode", which means a first pass with `pull --filter=essential-files` and a second pass with `files-sync --filter=skipped-earlier`. The entire point of this approach is so that we can start the local WordPress server in between the first and second pass, so the user can get to work sooner. 

This is a nice touch from the user perspective, but the Reprint implementation has flaws related to state handling in the `files-sync --filter=skipped-earlier` pass that are currently taped over in the Studio CLI `pull-reprint` implementation This is the first PR of at least two where my ultimate goal is to update Reprint in a way that lets us drop the logic in the Studio CLI `pull-reprint` command that mutates Reprint's internal state (see [this](https://github.com/Automattic/studio/blob/65f108b39cfd553f0916b7e79fe41bc9d5cab03b/apps/cli/commands/pull-reprint.ts#L821-L856)). 

### Changes in this PR

This PR fixes two issues.

**Firstly**, a `files-sync --filter=skipped-earlier` run that's interrupted leaves `filter: skipped-earlier` and `active_resumable_command.completion_state: partial` in the disk state. The next `pull --filter=essential-files` run then throws:

```
Cannot change --filter from 'skipped-earlier' to 'essential-files' while a sync is in progress.
```

This is because Reprint thinks the previously interrupted `files-sync --filter=skipped-earlier` operation must run to completion before it's safe to run a `--filter=essential-files` pull, but that's not actually true. It is safe to restart the pull in this scenario. Claude added the code that makes Reprint do this.

**Secondly**, there's [logic](https://github.com/Automattic/studio/blob/65f108b39cfd553f0916b7e79fe41bc9d5cab03b/apps/cli/commands/pull-reprint.ts#L821-L856) in the `pull-reprint` command in Studio CLI (the same as I was referencing earlier) that tapes over an issue with running `files-sync --filter=skipped-earlier` after `pull --filter=essential-files`.

If I remove that logic and run a pull, I get this error:

```
--filter=skipped-earlier was requested but there is no completed sync with skipped files.
```

This happens despite the initial pull completing successfully and leaving a skipped list. That's because `run_files_sync()` doesn't properly consider the actual end state that `pull --filter=essential-files` leaves behind. The logic in the Studio CLI `pull-reprint` command clearly illustrates the problem. Claude implemented a fix for this.

Ultimately, we should probably update the `pull-files` command to handle `--filter=skipped-earlier` and move the status rigmarole into `run_pipeline()`. I'll leave that for another PR, though.

### Testing instructions

TBD