### PR TITLE
Allow file indexes to start at a selected file

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -2695,11 +2695,13 @@ function encode_index_batch(array $batch_items): array
 }
 
 /**
- * Streams a directory index as gzipped JSON batches of {path, ctime, size, type}.
+ * Streams a file index as gzipped JSON batches of {path, ctime, size, type}.
  *
  * The client supplies list_dir and drives traversal depth-first by
- * enqueuing directories as they are discovered. Resumption is supported
- * via cursor containing the directory stack and last-seen entry.
+ * enqueuing directories as they are discovered. list_dir may also point at
+ * one explicit file, which lets --only selections reuse the same pull file
+ * skipping flow without indexing the file's parent directory. Resumption is
+ * supported via cursor containing the directory stack and last-seen entry.
  */
 function endpoint_file_index(
     array $config,
@@ -2723,6 +2725,7 @@ function endpoint_file_index(
     $list_dir_real = null;
     $stack = [];
     $ordered = [];
+    $direct_files = [];
     $follow_symlinks = !empty($config["follow_symlinks"]);
     $cursor_provided = isset($config["cursor"]);
     // Default-skip generated caches, VCS metadata, OS junk, and editor
@@ -2780,7 +2783,7 @@ function endpoint_file_index(
 
         clearstatcache(true, $list_dir);
         $list_dir_real = realpath($list_dir);
-        if ($list_dir_real === false || !is_dir($list_dir_real)) {
+        if ($list_dir_real === false || (!is_dir($list_dir_real) && !is_file($list_dir_real))) {
             throw new InvalidArgumentException(
                 "list_dir does not exist or is not accessible: {$list_dir}",
             );
@@ -2796,7 +2799,7 @@ function endpoint_file_index(
                 break;
             }
         }
-        // When follow_symlinks is enabled, allow any directory that the
+        // When follow_symlinks is enabled, allow any path that the
         // authenticated client requests.  The client is already authenticated
         // via HMAC, so there is no untrusted-input risk.
         if (!$allowed && !$follow_symlinks) {
@@ -2832,10 +2835,17 @@ function endpoint_file_index(
         }
 
         for ($i = count($ordered) - 1; $i >= 0; $i--) {
-            $stack[] = [
-                "dir" => $ordered[$i],
-                "after" => null,
-            ];
+            if (is_dir($ordered[$i])) {
+                $stack[] = [
+                    "dir" => $ordered[$i],
+                    "after" => null,
+                ];
+            }
+        }
+        foreach ($ordered as $root) {
+            if (!is_dir($root)) {
+                $direct_files[] = $root;
+            }
         }
     }
 
@@ -2858,6 +2868,13 @@ function endpoint_file_index(
     $status = "partial";
     $aborted = false;
     $abort_payload = null;
+
+    foreach ($direct_files as $path) {
+        if (!$include_caches && path_is_default_skipped($path)) {
+            continue;
+        }
+        $batch_items[] = file_index_item_for_path($path);
+    }
 
     // -- Pre-scan: discover intermediate symlinks --
     // When following symlinks, discover intermediate symlinks along each
@@ -3270,6 +3287,42 @@ function endpoint_file_index(
             "time_elapsed" => microtime(true) - $budget->start_time,
         ],
     ];
+}
+
+/** Builds one file_index entry for an explicitly selected file path. */
+function file_index_item_for_path(string $path): array
+{
+    clearstatcache(true, $path);
+    $stat = @lstat($path);
+    if ($stat === false) {
+        throw new InvalidArgumentException(
+            "list_dir does not exist or is not accessible: {$path}",
+        );
+    }
+
+    $mode = $stat["mode"] & STAT_TYPE_MASK;
+    $type = "file";
+    $link_target = null;
+    if ($mode === STAT_TYPE_LINK) {
+        $type = "link";
+        $resolved = resolve_symlink_target($path);
+        $link_target = $resolved['target'];
+    } elseif ($mode === STAT_TYPE_DIR) {
+        $type = "dir";
+    } elseif ($mode !== STAT_TYPE_FILE) {
+        $type = "other";
+    }
+
+    $item = [
+        "path" => $path,
+        "ctime" => (int) ($stat["ctime"] ?? 0),
+        "size" => $type === "file" ? (int) ($stat["size"] ?? 0) : 0,
+        "type" => $type,
+    ];
+    if ($link_target !== null) {
+        $item["target"] = $link_target;
+    }
+    return $item;
 }
 
 /**

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -205,6 +205,18 @@ final class FileIndexSkipDefaultsTest extends TestCase
         $this->assertContains('wp-content/themes/foo/style.css~', $rel);
     }
 
+    public function testFileIndexCanStartAtSingleFileForOnlySelections(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $selected = $siteDir . '/wp-content/themes/foo/style.css';
+        $entries = $this->runFileIndexEntries($siteDir, false, 5000, $selected, $selected);
+
+        $this->assertSame(
+            ['wp-content/themes/foo/style.css'],
+            $this->relativePaths($entries, $siteDir),
+        );
+    }
+
     public function testFileIndexFilterDoesNotBreakResume(): void
     {
         // The skip is applied AFTER the cursor's "after" pointer is updated,
@@ -276,9 +288,9 @@ final class FileIndexSkipDefaultsTest extends TestCase
     /**
      * @return list<array{path: string, type: string}>
      */
-    private function runFileIndexEntries(string $siteDir, bool $includeCaches, int $batchSize = 5000): array
+    private function runFileIndexEntries(string $siteDir, bool $includeCaches, int $batchSize = 5000, ?string $listDir = null, ?string $directory = null): array
     {
-        $stdout = $this->runFileIndex($siteDir, $includeCaches, $batchSize);
+        $stdout = $this->runFileIndex($siteDir, $includeCaches, $batchSize, $listDir, $directory);
 
         // The response is `multipart/mixed; boundary="…"` containing one or
         // more `index_batch` JSON chunks. Parse out each batch and flatten.
@@ -334,6 +346,7 @@ final class FileIndexSkipDefaultsTest extends TestCase
      */
     private function relativePaths(array $entries, string $siteDir): array
     {
+        $siteDir = realpath($siteDir) ?: $siteDir;
         $prefix = $siteDir . '/';
         $out = [];
         foreach ($entries as $e) {
@@ -346,12 +359,12 @@ final class FileIndexSkipDefaultsTest extends TestCase
         return $out;
     }
 
-    private function runFileIndex(string $siteDir, bool $includeCaches, int $batchSize): string
+    private function runFileIndex(string $siteDir, bool $includeCaches, int $batchSize, ?string $listDir = null, ?string $directory = null): string
     {
         $configPath = $this->tempDir . '/index-config.json';
         file_put_contents($configPath, json_encode([
-            'directory' => $siteDir,
-            'list_dir' => $siteDir,
+            'directory' => $directory ?? $siteDir,
+            'list_dir' => $listDir ?? $siteDir,
             'batch_size' => $batchSize,
             'include_caches' => $includeCaches,
         ], JSON_THROW_ON_ERROR));
@@ -373,7 +386,7 @@ PHP,
             ),
         );
 
-        $command = sprintf('%s %s', escapeshellarg(PHP_BINARY), escapeshellarg($scriptPath));
+        $command = sprintf('%s -d display_startup_errors=0 %s', escapeshellarg(PHP_BINARY), escapeshellarg($scriptPath));
         $descriptorSpec = [
             1 => ['pipe', 'w'],
             2 => ['pipe', 'w'],


### PR DESCRIPTION
## What it does

Allows `endpoint_file_index()` to accept `list_dir` pointing at a single file, not only a directory. The response emits a normal file-index entry for that selected file.

## Rationale

`--only` file selections should be able to reuse the existing file-index / skip-defaults flow without indexing the selected file’s parent directory.

## Implementation

- Accepts readable files in the `list_dir` validation path.
- Keeps directories in the traversal stack and handles explicit files separately.
- Adds `file_index_item_for_path()` so direct-file entries use the same metadata shape as normal traversal.
- Adds unit coverage for a single selected theme file.

## Testing instructions

- `cd tests && ../vendor/bin/phpunit --colors=never FileIndexSkipDefaultsTest.php`
- `composer analyze`
