### PR TITLE
Use configured PHP binary in CLI parsing tests

### DIFF
--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -65,7 +65,7 @@ class OnlyCliParseTest extends TestCase
     private function runCli(array $args): string
     {
         $entry = __DIR__ . '/../../importer/import.php';
-        $cmd = 'php ' . escapeshellarg($entry);
+        $cmd = escapeshellarg(PHP_BINARY) . ' -d display_startup_errors=0 ' . escapeshellarg($entry);
         foreach ($args as $a) {
             $cmd .= ' ' . escapeshellarg($a);
         }


### PR DESCRIPTION
## What it does

Makes `OnlyCliParseTest` invoke the importer with `PHP_BINARY` instead of a hard-coded `php`.

## Rationale

The test should exercise the same PHP executable as PHPUnit. This avoids surprises on systems where `php` on `PATH` differs from the runtime running the test suite.

## Implementation

The CLI helper now builds commands from `PHP_BINARY` and suppresses startup-warning output with `-d display_startup_errors=0`.

## Testing instructions

- `cd tests && ../vendor/bin/phpunit --colors=never Import/OnlyCliParseTest.php`
