### PR TITLE
Remove the advanced-cache.php drop-in on WP Cloud pulls

### DIFF
--- a/packages/reprint-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/reprint-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -89,9 +89,9 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         ];
 
         // Production drop-ins and mu-plugins that depend on WP Cloud
-        // infrastructure: object-cache.php talks to a Memcached server
-        // that doesn't exist locally, wpcomsh* mu-plugins depend on
-        // multisite functions and wp.com API endpoints.
+        // infrastructure: object-cache.php and advanced-cache.php talks
+        // to a Memcached server that doesn't exist locally, wpcomsh*
+        // mu-plugins depend on multisite functions and wp.com API endpoints.
         //
         // TODO: Consider removing all drop-ins unconditionally, not just
         // WP Cloud ones. Drop-ins (object-cache.php, advanced-cache.php,
@@ -101,6 +101,7 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         // problem is universal.
         $manifest->paths_to_remove = [
             'wp-content/object-cache.php',
+            'wp-content/advanced-cache.php',
             'wp-content/mu-plugins/wpcomsh',
             'wp-content/mu-plugins/wpcomsh-dev',
             'wp-content/mu-plugins/wpcomsh-loader.php',

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -169,6 +169,9 @@ class ProductionDropInRemovalTest extends TestCase
         mkdir($wpContent, 0755, true);
         file_put_contents($wpContent . '/object-cache.php', "<?php // Memcached object cache\n");
 
+        // advanced-cache.php (file)
+        file_put_contents($wpContent . '/advanced-cache.php', "<?php // Advanced page cache\n");
+
         // wpcomsh directory with files inside
         $muPlugins = $wpContent . '/mu-plugins';
         mkdir($muPlugins . '/wpcomsh', 0755, true);
@@ -196,6 +199,21 @@ class ProductionDropInRemovalTest extends TestCase
         $this->runApplyRuntime($client);
 
         $this->assertFileDoesNotExist($objectCachePath);
+    }
+
+    public function testApplyRuntimeRemovesAdvancedCacheFile(): void
+    {
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $advancedCachePath = $this->fsRoot . '/wp-content/advanced-cache.php';
+        $this->assertFileExists($advancedCachePath);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertFileDoesNotExist($advancedCachePath);
     }
 
     public function testApplyRuntimeRemovesWpcomshDirectory(): void
@@ -291,6 +309,10 @@ class ProductionDropInRemovalTest extends TestCase
             $auditLog,
         );
         $this->assertStringContainsString(
+            'removed wp-content/advanced-cache.php (production-only)',
+            $auditLog,
+        );
+        $this->assertStringContainsString(
             'removed wp-content/mu-plugins/wpcomsh (production-only)',
             $auditLog,
         );
@@ -317,6 +339,7 @@ class ProductionDropInRemovalTest extends TestCase
 
         $this->assertArrayHasKey('remote_paths_removed_from_local_site', $state['apply']);
         $this->assertContains('wp-content/object-cache.php', $state['apply']['remote_paths_removed_from_local_site']);
+        $this->assertContains('wp-content/advanced-cache.php', $state['apply']['remote_paths_removed_from_local_site']);
         $this->assertContains('wp-content/mu-plugins/wpcomsh', $state['apply']['remote_paths_removed_from_local_site']);
         $this->assertContains('wp-content/mu-plugins/wpcomsh-dev', $state['apply']['remote_paths_removed_from_local_site']);
         $this->assertContains('wp-content/mu-plugins/wpcomsh-loader.php', $state['apply']['remote_paths_removed_from_local_site']);


### PR DESCRIPTION
## What it does

Removes the WP Cloud `advanced-cache.php` cache drop-in during the pull.

## Rationale

On WP Cloud the cache drop-ins are symlinks into `wordpress/drop-ins/`, which `files-pull` doesn't download. The analyzer already removed `object-cache.php` but left `advanced-cache.php`, so it dangled after every pull and broke clients that read that _dangled_ symlink from `wp-content` (e.g. Studio's archive step failing with `ENOENT`).

## Implementation

Adds `wp-content/advanced-cache.php` to `WpcloudHostAnalyzer`'s `paths_to_remove` (the removal loop already handles symlinks). Covers the symlink case in `ProductionDropInRemovalTest`.

## Testing instructions

- `cd tests && ../vendor/bin/phpunit --filter ProductionDropInRemoval`
