### PR TITLE
Add staged storage for chunked artifact transfers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,18 +358,20 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-push/staged-artifact-batches",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
+                "reference": "4299e8cbe30ddce21de036bcef579a2e5d40159e"
             },
             "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
                 "php": ">=7.4",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
+            },
+            "suggest": {
+                "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+                "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
             },
             "type": "library",
             "autoload": {
@@ -382,10 +384,13 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
-                    "src/class-sqlite-driver-pdo.php"
+                    "src/class-staged-artifacts.php",
+                    "src/class-sqlite-driver-pdo.php",
+                    "src/class-wpdb-driver-pdo.php"
                 ],
                 "files": [
-                    "src/utils.php"
+                    "src/utils.php",
+                    "src/class-pdo-polyfill.php"
                 ]
             },
             "license": [

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -22,6 +22,7 @@
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
             "src/class-http-server.php",
+            "src/class-staged-artifacts.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"
         ],

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -155,22 +155,42 @@ final class Site_Export_Staged_Artifacts {
     public function write_chunks(string $artifact_id, iterable $chunks): array {
         $file_path = $this->artifact_path($artifact_id);
         if ($file_path === null) {
-            return $this->write_result('rejected', 'invalid_artifact_id', 0);
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_artifact_id',
+                'detail' => null,
+                'committed_bytes' => 0,
+            ];
         }
 
         $lock = $this->open_lock();
         if ($lock === false) {
-            return $this->write_result('rejected', 'io_error', 0, 'open_lock_file');
+            return [
+                'status' => 'rejected',
+                'reason' => 'io_error',
+                'detail' => 'open_lock_file',
+                'committed_bytes' => 0,
+            ];
         }
 
         try {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
-                return $this->write_result('busy', null, $this->status($artifact_id)['committed_bytes']);
+                return [
+                    'status' => 'busy',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $this->status($artifact_id)['committed_bytes'],
+                ];
             }
 
             $verified = $this->read_verified();
             if (isset($verified[$artifact_id])) {
-                return $this->write_result('rejected', 'already_verified', $verified[$artifact_id]);
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'already_verified',
+                    'detail' => null,
+                    'committed_bytes' => $verified[$artifact_id],
+                ];
             }
 
             // Sequential transfers: the cursor tracks one artifact. A write
@@ -179,14 +199,24 @@ final class Site_Export_Staged_Artifacts {
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
 
             if (!$this->ensure_parent_dir($file_path)) {
-                return $this->write_result('rejected', 'io_error', $committed, 'create_staging_dir');
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'create_staging_dir',
+                    'committed_bytes' => $committed,
+                ];
             }
 
             // Open without truncating: a resumed transfer must keep committed
             // bytes until the cursor decides what tail to discard.
             $file = @fopen($file_path, 'c+b');
             if ($file === false) {
-                return $this->write_result('rejected', 'io_error', $committed, 'open_artifact_file');
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'open_artifact_file',
+                    'committed_bytes' => $committed,
+                ];
             }
 
             try {
@@ -194,7 +224,12 @@ final class Site_Export_Staged_Artifacts {
                 // write, then append at the only offset the cursor says is
                 // committed.
                 if (!ftruncate($file, $committed) || fseek($file, $committed) !== 0) {
-                    return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'truncate_uncommitted_tail',
+                        'committed_bytes' => $committed,
+                    ];
                 }
 
                 $accepted = false;
@@ -211,27 +246,57 @@ final class Site_Export_Staged_Artifacts {
                     $source = $chunk['source'] ?? null;
 
                     if ($length < 1) {
-                        return $this->write_result('rejected', 'invalid_length', $committed);
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'invalid_length',
+                            'detail' => null,
+                            'committed_bytes' => $committed,
+                        ];
                     }
                     if ($offset < 0) {
-                        return $this->write_result('rejected', 'invalid_offset', $committed);
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'invalid_offset',
+                            'detail' => null,
+                            'committed_bytes' => $committed,
+                        ];
                     }
                     if (is_string($source) && strlen($source) !== $length) {
-                        return $this->write_result('rejected', 'length_mismatch', $committed);
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'length_mismatch',
+                            'detail' => null,
+                            'committed_bytes' => $committed,
+                        ];
                     }
                     if (!is_string($source) && !is_resource($source)) {
-                        return $this->write_result('rejected', 'invalid_source', $committed);
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'invalid_source',
+                            'detail' => null,
+                            'committed_bytes' => $committed,
+                        ];
                     }
                     if ($offset + $length <= $committed) {
                         $drain_reason = $this->drain_source($source, $length);
                         if ($drain_reason !== null) {
-                            return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+                            return [
+                                'status' => 'rejected',
+                                'reason' => $drain_reason,
+                                'detail' => 'duplicate_drain',
+                                'committed_bytes' => $committed,
+                            ];
                         }
                         $duplicate = true;
                         continue;
                     }
                     if ($offset !== $committed) {
-                        return $this->write_result('rejected', 'offset_gap', $committed);
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'offset_gap',
+                            'detail' => null,
+                            'committed_bytes' => $committed,
+                        ];
                     }
 
                     $copy_reason = $this->copy_source($source, $file, $length);
@@ -239,19 +304,34 @@ final class Site_Export_Staged_Artifacts {
                         // A failed copy can leave bytes past the committed
                         // offset; trim them before the caller retries this chunk.
                         ftruncate($file, $committed);
-                        return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                        return [
+                            'status' => 'rejected',
+                            'reason' => $copy_reason,
+                            'detail' => 'chunk_body',
+                            'committed_bytes' => $committed,
+                        ];
                     }
 
                     // The data is flushed before the cursor record moves: a crash
                     // between the two leaves a tail that the next write truncates.
                     if (!fflush($file)) {
                         ftruncate($file, $committed);
-                        return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'io_error',
+                            'detail' => 'flush_chunk_body',
+                            'committed_bytes' => $committed,
+                        ];
                     }
 
                     if (!$this->write_state($artifact_id, $committed + $length)) {
                         ftruncate($file, $committed);
-                        return $this->write_result('rejected', 'io_error', $committed, 'persist_cursor');
+                        return [
+                            'status' => 'rejected',
+                            'reason' => 'io_error',
+                            'detail' => 'persist_cursor',
+                            'committed_bytes' => $committed,
+                        ];
                     }
 
                     $committed += $length;
@@ -259,12 +339,27 @@ final class Site_Export_Staged_Artifacts {
                 }
 
                 if ($accepted) {
-                    return $this->write_result('accepted', null, $committed);
+                    return [
+                        'status' => 'accepted',
+                        'reason' => null,
+                        'detail' => null,
+                        'committed_bytes' => $committed,
+                    ];
                 }
                 if ($duplicate) {
-                    return $this->write_result('duplicate', null, $committed);
+                    return [
+                        'status' => 'duplicate',
+                        'reason' => null,
+                        'detail' => null,
+                        'committed_bytes' => $committed,
+                    ];
                 }
-                return $this->write_result('rejected', 'empty_batch', $committed);
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'empty_batch',
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                ];
             } finally {
                 fclose($file);
             }
@@ -293,27 +388,64 @@ final class Site_Export_Staged_Artifacts {
     public function finalize(string $artifact_id, int $expected_total_bytes): array {
         $file_path = $this->artifact_path($artifact_id);
         if ($file_path === null) {
-            return $this->finalize_result('rejected', 'invalid_artifact_id', 0);
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_artifact_id',
+                'detail' => null,
+                'committed_bytes' => 0,
+                'path' => null,
+            ];
         }
         if ($expected_total_bytes < 0) {
-            return $this->finalize_result('rejected', 'invalid_total', 0);
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_total',
+                'detail' => null,
+                'committed_bytes' => 0,
+                'path' => null,
+            ];
         }
 
         $lock = $this->open_lock();
         if ($lock === false) {
-            return $this->finalize_result('rejected', 'io_error', 0, 'open_lock_file');
+            return [
+                'status' => 'rejected',
+                'reason' => 'io_error',
+                'detail' => 'open_lock_file',
+                'committed_bytes' => 0,
+                'path' => null,
+            ];
         }
 
         try {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
-                return $this->finalize_result('busy', null, $this->status($artifact_id)['committed_bytes']);
+                return [
+                    'status' => 'busy',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $this->status($artifact_id)['committed_bytes'],
+                    'path' => null,
+                ];
             }
 
             $verified = $this->read_verified();
             if (isset($verified[$artifact_id])) {
-                return $verified[$artifact_id] === $expected_total_bytes
-                    ? $this->finalize_result('verified', null, $verified[$artifact_id], null, $file_path)
-                    : $this->finalize_result('rejected', 'size_mismatch', $verified[$artifact_id], 'verified_record');
+                if ($verified[$artifact_id] === $expected_total_bytes) {
+                    return [
+                        'status' => 'verified',
+                        'reason' => null,
+                        'detail' => null,
+                        'committed_bytes' => $verified[$artifact_id],
+                        'path' => $file_path,
+                    ];
+                }
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'size_mismatch',
+                    'detail' => 'verified_record',
+                    'committed_bytes' => $verified[$artifact_id],
+                    'path' => null,
+                ];
             }
 
             $state = $this->read_state();
@@ -323,30 +455,66 @@ final class Site_Export_Staged_Artifacts {
                 // A zero-byte artifact legitimately has no chunks; the fopen
                 // below creates its empty file.
                 if ($expected_total_bytes > 0) {
-                    return $this->finalize_result('rejected', 'missing', $committed);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'missing',
+                        'detail' => null,
+                        'committed_bytes' => $committed,
+                        'path' => null,
+                    ];
                 }
                 if (!$this->ensure_parent_dir($file_path)) {
-                    return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'create_staging_dir',
+                        'committed_bytes' => 0,
+                        'path' => null,
+                    ];
                 }
             }
 
             if ($committed !== $expected_total_bytes) {
-                return $this->finalize_result('rejected', 'size_mismatch', $committed);
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'size_mismatch',
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
             }
 
             $file = @fopen($file_path, 'c+b');
             if ($file === false) {
-                return $this->finalize_result('rejected', 'io_error', $committed, 'open_artifact_file');
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'open_artifact_file',
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
             }
             // Drop any uncommitted tail so the artifact holds committed bytes only.
             $truncated = ftruncate($file, $committed);
             fclose($file);
             if (!$truncated) {
-                return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'truncate_uncommitted_tail',
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
             }
 
             if (!$this->append_verified($artifact_id, $expected_total_bytes)) {
-                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_verified_record');
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'persist_verified_record',
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
             }
             if ($state['artifact_id'] === $artifact_id) {
                 // Best effort: a stale cursor is harmless once the verified
@@ -354,7 +522,13 @@ final class Site_Export_Staged_Artifacts {
                 $this->write_state(null, 0);
             }
 
-            return $this->finalize_result('verified', null, $committed, null, $file_path);
+            return [
+                'status' => 'verified',
+                'reason' => null,
+                'detail' => null,
+                'committed_bytes' => $committed,
+                'path' => $file_path,
+            ];
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -653,28 +827,5 @@ final class Site_Export_Staged_Artifacts {
         }
     }
 
-    /**
-     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
-     */
-    private function write_result(string $status, ?string $reason, int $committed_bytes, ?string $detail = null): array {
-        return [
-            'status' => $status,
-            'reason' => $reason,
-            'detail' => $detail,
-            'committed_bytes' => $committed_bytes,
-        ];
-    }
 
-    /**
-     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
-     */
-    private function finalize_result(string $status, ?string $reason, int $committed_bytes, ?string $detail = null, ?string $path = null): array {
-        return [
-            'status' => $status,
-            'reason' => $reason,
-            'detail' => $detail,
-            'committed_bytes' => $committed_bytes,
-            'path' => $path,
-        ];
-    }
 }

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -113,6 +113,11 @@ final class Site_Export_Staged_Artifacts {
      * committed_bytes reports the durable progress made before the bad chunk,
      * and the sender resumes from there.
      *
+     * The iterable is also the pause point: a generator can simply stop
+     * yielding when the endpoint's resource budget runs out, and the
+     * response's committed_bytes tells the sender where the next request
+     * should resume.
+     *
      * @param iterable<int,array{offset:int,length:int,expected_crc32:string,source:resource|string}> $chunks
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -47,10 +47,13 @@
  * mirror: state.json holds the cursor for the single in-flight artifact and
  * verified.jsonl appends one line per artifact finalize() accepted.
  *
- * Transfers are sequential, like pull: one artifact is in flight at a time
- * and the cursor tracks only it. Writing chunk 0 of another artifact moves
- * the cursor there; an unfinished predecessor keeps its bytes on disk but
- * restarts from offset 0 when the sender returns to it.
+ * Transfers are sequential, like pull: progress is tracked for one artifact
+ * at a time — the one currently being uploaded. That artifact can be
+ * interrupted and resumed freely, because the cursor survives across
+ * requests. Starting a different artifact forgets the unfinished one's
+ * progress: its partial bytes stay under files/, but returning to it means
+ * re-uploading from offset 0. Senders must finish or discard one artifact
+ * before starting the next; interleaving two uploads is not supported.
  *
  * Locking: every mutator — write_chunks(), finalize(), discard() — holds one
  * exclusive non-blocking flock on the lock file for its whole call, so a

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -55,7 +55,8 @@
  * - An artifact id is the staging-relative path the artifact will be applied
  *   from, mirroring the target tree — the staging dir reads like the site
  *   and apply is a rename. Ids with absolute, empty, "." or ".." segments
- *   are rejected, same as the importer's fs-root-relative path rule.
+ *   or any backslash are rejected — stricter than the importer's fs-root
+ *   path rule, which tolerates backslashes and empty segments.
  * - Writers hold an exclusive flock on the staging file; a concurrent writer
  *   gets "busy" instead of interleaved writes.
  *
@@ -83,44 +84,60 @@ final class Site_Export_Staged_Artifacts {
      * @param int             $length          Declared chunk length in bytes.
      * @param string          $expected_crc32  Hex CRC-32 (crc32b) of the chunk body.
      * @param resource|string $source          Chunk body, or a readable stream positioned at it.
-     * @return array{status:string,reason:?string,committed_bytes:int}
-     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on "rejected".
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
+     *   "rejected", and detail names the failing operation when the same
+     *   reason can come from more than one place.
      */
     public function write_chunk(string $artifact_id, int $offset, int $length, string $expected_crc32, $source): array {
-        // These parameters arrive verbatim from a remote client's request,
-        // and the sequencing/copy logic below assumes they are well-formed —
-        // a negative offset would misreport as "duplicate" success and a
-        // short string body would never finish copying. Reject malformed
-        // input with typed reasons before taking the lock or touching disk.
-        $expected_crc32 = strtolower($expected_crc32);
+        return $this->write_chunks($artifact_id, [
+            [
+                'offset' => $offset,
+                'length' => $length,
+                'expected_crc32' => $expected_crc32,
+                'source' => $source,
+            ],
+        ]);
+    }
+
+    /**
+     * Stage consecutive chunks from one request while keeping the staging file
+     * open and locked.
+     *
+     * The upload endpoint can pass a generator that yields parsed chunks from
+     * php://input, so a 100- or 1000-chunk request pays the open/flock/tail
+     * cleanup cost once while still committing each chunk independently for
+     * crash-safe resume.
+     *
+     * Because chunks commit one by one, a mid-batch rejection loses nothing:
+     * committed_bytes reports the durable progress made before the bad chunk,
+     * and the sender resumes from there.
+     *
+     * @param iterable<int,array{offset:int,length:int,expected_crc32:string,source:resource|string}> $chunks
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
+     *   "rejected", and detail names the failing operation when the same
+     *   reason can come from more than one place.
+     */
+    public function write_chunks(string $artifact_id, iterable $chunks): array {
         $paths = $this->artifact_paths($artifact_id);
         if ($paths === null) {
             return $this->write_result('rejected', 'invalid_artifact_id', 0);
         }
-        if ($length < 1 || $offset < 0) {
-            return $this->write_result('rejected', 'invalid_length', 0);
-        }
-        if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
-            return $this->write_result('rejected', 'invalid_hash', 0);
-        }
-        if (is_string($source) && strlen($source) !== $length) {
-            return $this->write_result('rejected', 'length_mismatch', 0);
-        }
-        if (!is_string($source) && !is_resource($source)) {
-            return $this->write_result('rejected', 'invalid_source', 0);
-        }
         if (!$this->ensure_parent_dir($paths['part'])) {
-            return $this->write_result('rejected', 'io_error', 0);
+            return $this->write_result('rejected', 'io_error', 0, 'create_staging_dir');
         }
 
+        // Open without truncating: a resumed transfer must keep committed
+        // bytes until the metadata check below decides what tail to discard.
         $part = @fopen($paths['part'], 'c+b');
         if ($part === false) {
-            return $this->write_result('rejected', 'io_error', 0);
+            return $this->write_result('rejected', 'io_error', 0, 'open_staging_file');
         }
 
         try {
             if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->write_result('busy', null, 0);
+                return $this->write_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
             }
 
             $meta = $this->read_meta($paths['meta']);
@@ -128,38 +145,87 @@ final class Site_Export_Staged_Artifacts {
             if ($meta['verified']) {
                 return $this->write_result('rejected', 'already_verified', $committed);
             }
-            if ($offset + $length <= $committed) {
+
+            // Discard any uncommitted tail from an interrupted earlier write,
+            // then append at the only offset the metadata says is committed.
+            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
+                return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
+            }
+
+            $accepted = false;
+            $duplicate = false;
+            foreach ($chunks as $chunk) {
+                // These parameters arrive verbatim from a remote client's
+                // request, and the sequencing/copy logic below assumes they
+                // are well-formed — a negative offset would misreport as
+                // "duplicate" success and a short string body would never
+                // finish copying. Reject malformed input with typed reasons
+                // before writing bytes.
+                $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
+                $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
+                $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
+                $expected_crc32 = strtolower($expected_crc32);
+                $source = $chunk['source'] ?? null;
+
+                if ($length < 1) {
+                    return $this->write_result('rejected', 'invalid_length', $committed);
+                }
+                if ($offset < 0) {
+                    return $this->write_result('rejected', 'invalid_offset', $committed);
+                }
+                if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
+                    return $this->write_result('rejected', 'invalid_hash', $committed);
+                }
+                if (is_string($source) && strlen($source) !== $length) {
+                    return $this->write_result('rejected', 'length_mismatch', $committed);
+                }
+                if (!is_string($source) && !is_resource($source)) {
+                    return $this->write_result('rejected', 'invalid_source', $committed);
+                }
+                if ($offset + $length <= $committed) {
+                    $drain_reason = $this->drain_source($source, $length);
+                    if ($drain_reason !== null) {
+                        return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+                    }
+                    $duplicate = true;
+                    continue;
+                }
+                if ($offset !== $committed) {
+                    return $this->write_result('rejected', 'offset_gap', $committed);
+                }
+
+                $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
+                if ($copy_reason !== null) {
+                    // A failed copy/hash can leave bytes past the committed
+                    // offset; trim them before the caller retries this chunk.
+                    ftruncate($part, $committed);
+                    return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                }
+
+                // The data is flushed before the commit record moves: a crash
+                // between the two leaves a tail that the next write truncates.
+                if (!fflush($part)) {
+                    ftruncate($part, $committed);
+                    return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                }
+
+                $meta['committed_bytes'] = $committed + $length;
+                if (!$this->write_meta($paths['meta'], $meta)) {
+                    ftruncate($part, $committed);
+                    return $this->write_result('rejected', 'io_error', $committed, 'persist_commit_record');
+                }
+
+                $committed = $meta['committed_bytes'];
+                $accepted = true;
+            }
+
+            if ($accepted) {
+                return $this->write_result('accepted', null, $committed);
+            }
+            if ($duplicate) {
                 return $this->write_result('duplicate', null, $committed);
             }
-            if ($offset !== $committed) {
-                return $this->write_result('rejected', 'offset_gap', $committed);
-            }
-
-            // Discard any uncommitted tail from an interrupted earlier write.
-            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
-                return $this->write_result('rejected', 'io_error', $committed);
-            }
-
-            $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
-            if ($copy_reason !== null) {
-                ftruncate($part, $committed);
-                return $this->write_result('rejected', $copy_reason, $committed);
-            }
-
-            // The data is durable before the commit record moves: a crash
-            // between the two leaves a tail that the next write truncates.
-            if (!fflush($part)) {
-                ftruncate($part, $committed);
-                return $this->write_result('rejected', 'io_error', $committed);
-            }
-
-            $meta['committed_bytes'] = $committed + $length;
-            if (!$this->write_meta($paths['meta'], $meta)) {
-                ftruncate($part, $committed);
-                return $this->write_result('rejected', 'io_error', $committed);
-            }
-
-            return $this->write_result('accepted', null, $meta['committed_bytes']);
+            return $this->write_result('rejected', 'empty_batch', $committed);
         } finally {
             flock($part, LOCK_UN);
             fclose($part);
@@ -177,8 +243,10 @@ final class Site_Export_Staged_Artifacts {
      * reading cannot catch a resume that mixed two versions of the source
      * file — it would faithfully hash the mixed bytes.
      *
-     * @return array{status:string,reason:?string,committed_bytes:int,path:?string}
-     *   status "verified"|"busy"|"rejected"; path is set on "verified".
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
+     *   status "verified"|"busy"|"rejected"; path is set on "verified", and
+     *   detail names the failing operation when the same reason can come
+     *   from more than one place.
      */
     public function finalize(string $artifact_id, int $expected_total_bytes, string $expected_crc32): array {
         $expected_crc32 = strtolower($expected_crc32);
@@ -190,25 +258,29 @@ final class Site_Export_Staged_Artifacts {
             return $this->finalize_result('rejected', 'invalid_hash', 0);
         }
         if ($expected_total_bytes < 0) {
-            return $this->finalize_result('rejected', 'size_mismatch', 0);
+            return $this->finalize_result('rejected', 'invalid_total', 0);
         }
 
         $part_path = $paths['part'];
         if (!file_exists($part_path)) {
-            // A zero-byte artifact legitimately has no chunks.
-            if ($expected_total_bytes > 0 || !$this->ensure_parent_dir($part_path) || @touch($part_path) === false) {
+            // A zero-byte artifact legitimately has no chunks; the fopen
+            // below creates its empty part file.
+            if ($expected_total_bytes > 0) {
                 return $this->finalize_result('rejected', 'missing', 0);
+            }
+            if (!$this->ensure_parent_dir($part_path)) {
+                return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
             }
         }
 
         $part = @fopen($part_path, 'c+b');
         if ($part === false) {
-            return $this->finalize_result('rejected', 'io_error', 0);
+            return $this->finalize_result('rejected', 'io_error', 0, 'open_staging_file');
         }
 
         try {
             if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->finalize_result('busy', null, 0);
+                return $this->finalize_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
             }
 
             $meta = $this->read_meta($paths['meta']);
@@ -218,8 +290,8 @@ final class Site_Export_Staged_Artifacts {
                     && is_string($meta['verified_crc32'])
                     && hash_equals($meta['verified_crc32'], $expected_crc32);
                 return $same
-                    ? $this->finalize_result('verified', null, $committed, $part_path)
-                    : $this->finalize_result('rejected', 'hash_mismatch', $committed);
+                    ? $this->finalize_result('verified', null, $committed, null, $part_path)
+                    : $this->finalize_result('rejected', 'hash_mismatch', $committed, 'verified_record');
             }
 
             if ($committed !== $expected_total_bytes) {
@@ -228,25 +300,27 @@ final class Site_Export_Staged_Artifacts {
 
             // Drop any uncommitted tail so the checksum covers committed bytes only.
             if (!ftruncate($part, $committed)) {
-                return $this->finalize_result('rejected', 'io_error', $committed);
+                return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
             }
 
+            // Hash while holding the staging lock. hash_file() uses its own
+            // read handle, but all writers in this store respect this flock.
             $actual_crc32 = hash_file('crc32b', $part_path);
             if ($actual_crc32 === false) {
-                return $this->finalize_result('rejected', 'io_error', $committed);
+                return $this->finalize_result('rejected', 'io_error', $committed, 'artifact_crc32');
             }
             if (!hash_equals($expected_crc32, $actual_crc32)) {
-                return $this->finalize_result('rejected', 'hash_mismatch', $committed);
+                return $this->finalize_result('rejected', 'hash_mismatch', $committed, 'artifact_crc32');
             }
 
             $meta['verified'] = true;
             $meta['verified_total_bytes'] = $expected_total_bytes;
             $meta['verified_crc32'] = $expected_crc32;
             if (!$this->write_meta($paths['meta'], $meta)) {
-                return $this->finalize_result('rejected', 'io_error', $committed);
+                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_commit_record');
             }
 
-            return $this->finalize_result('verified', null, $committed, $part_path);
+            return $this->finalize_result('verified', null, $committed, null, $part_path);
         } finally {
             flock($part, LOCK_UN);
             fclose($part);
@@ -254,6 +328,11 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
+     * Returns the persisted staging state for an artifact.
+     *
+     * This is advisory and intentionally lock-free; writers still enforce the
+     * committed offset under flock before accepting bytes.
+     *
      * @return array{exists:bool,committed_bytes:int,verified:bool}
      */
     public function status(string $artifact_id): array {
@@ -287,21 +366,36 @@ final class Site_Export_Staged_Artifacts {
             return true;
         }
 
-        $part = @fopen($paths['part'], 'r+b');
-        if ($part !== false) {
+        if (!file_exists($paths['part']) && !file_exists($paths['meta'])) {
+            return true;
+        }
+
+        // 'c+b' so the lock exists even when only the meta record does, and
+        // the meta is unlinked before the part while the lock is held — a
+        // writer arriving after the part unlink locks a fresh inode, and
+        // stale meta it could still read would resurrect its committed_bytes
+        // over bytes that are gone.
+        $part = @fopen($paths['part'], 'c+b');
+        if ($part === false) {
+            return false;
+        }
+        try {
             if (!flock($part, LOCK_EX | LOCK_NB)) {
-                fclose($part);
                 return false;
             }
+            @unlink($paths['meta']);
             @unlink($paths['part']);
+            return true;
+        } finally {
             flock($part, LOCK_UN);
             fclose($part);
         }
-        @unlink($paths['meta']);
-        return true;
     }
 
     /**
+     * Copies exactly $length bytes to the staging file while hashing the same
+     * bytes that landed on disk.
+     *
      * @param resource|string $source
      * @return string|null Rejection reason, or null when $length bytes were
      *                     copied and their checksum matched.
@@ -311,6 +405,8 @@ final class Site_Export_Staged_Artifacts {
         $remaining = $length;
 
         while ($remaining > 0) {
+            // Read in bounded buffers so string and stream sources share the
+            // same write path without materializing a large stream body.
             if (is_string($source)) {
                 $buffer = substr($source, $length - $remaining, min($remaining, self::WRITE_BUFFER_BYTES));
             } else {
@@ -329,6 +425,34 @@ final class Site_Export_Staged_Artifacts {
 
         if (!hash_equals($expected_crc32, hash_final($context))) {
             return 'hash_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * Consumes exactly $length bytes from a duplicate chunk stream.
+     *
+     * Duplicate chunks are not written or re-hashed, but a batched upload may
+     * be reading consecutive chunk bodies from one request stream. Draining
+     * keeps the parser aligned for the next chunk.
+     *
+     * @param resource|string $source
+     * @return string|null Rejection reason, or null when there is no stream
+     *                     body left for this store to consume.
+     */
+    private function drain_source($source, int $length): ?string {
+        if (is_string($source)) {
+            return null;
+        }
+
+        $remaining = $length;
+        while ($remaining > 0) {
+            $buffer = fread($source, min($remaining, self::WRITE_BUFFER_BYTES));
+            if ($buffer === false || $buffer === '') {
+                return 'short_body';
+            }
+            $remaining -= strlen($buffer);
         }
 
         return null;
@@ -357,10 +481,16 @@ final class Site_Export_Staged_Artifacts {
 
     private function ensure_parent_dir(string $path): bool {
         $dir = dirname($path);
-        return is_dir($dir) || @mkdir($dir, 0700, true);
+        // A concurrent creator winning the mkdir race is success, not failure.
+        return is_dir($dir) || @mkdir($dir, 0700, true) || is_dir($dir);
     }
 
     /**
+     * Reads the commit record as best-effort state.
+     *
+     * A missing or unreadable record is treated as an empty artifact so the
+     * next writer must restart from offset 0 instead of trusting stale bytes.
+     *
      * @return array{committed_bytes:int,verified:bool,verified_total_bytes:?int,verified_crc32:?string}
      */
     private function read_meta(string $meta_path): array {
@@ -380,6 +510,8 @@ final class Site_Export_Staged_Artifacts {
             return $defaults;
         }
 
+        // Metadata is intentionally not trusted as schema: old/corrupt files
+        // fall back to defaults after keeping only recognized keys.
         $meta = array_merge($defaults, array_intersect_key($meta, $defaults));
         $meta['committed_bytes'] = max(0, (int) $meta['committed_bytes']);
         $meta['verified'] = (bool) $meta['verified'];
@@ -389,9 +521,14 @@ final class Site_Export_Staged_Artifacts {
 
     private function write_meta(string $meta_path, array $meta): bool {
         // Write-then-rename keeps the commit record atomic: readers see the
-        // old record or the new one, never a torn file.
+        // old record or the new one, never a torn file. Keep the temp file
+        // next to the target so rename stays on the same filesystem.
         $tmp_path = $meta_path . '.tmp';
-        if (@file_put_contents($tmp_path, json_encode($meta)) === false) {
+        $json = json_encode($meta);
+        // A short write (disk full) returns a byte count, not false — never
+        // rename a torn record over the good one.
+        if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
+            @unlink($tmp_path);
             return false;
         }
         if (!@rename($tmp_path, $meta_path)) {
@@ -402,23 +539,25 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * @return array{status:string,reason:?string,committed_bytes:int}
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      */
-    private function write_result(string $status, ?string $reason, int $committed_bytes): array {
+    private function write_result(string $status, ?string $reason, int $committed_bytes, ?string $detail = null): array {
         return [
             'status' => $status,
             'reason' => $reason,
+            'detail' => $detail,
             'committed_bytes' => $committed_bytes,
         ];
     }
 
     /**
-     * @return array{status:string,reason:?string,committed_bytes:int,path:?string}
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
      */
-    private function finalize_result(string $status, ?string $reason, int $committed_bytes, ?string $path = null): array {
+    private function finalize_result(string $status, ?string $reason, int $committed_bytes, ?string $detail = null, ?string $path = null): array {
         return [
             'status' => $status,
             'reason' => $reason,
+            'detail' => $detail,
             'committed_bytes' => $committed_bytes,
             'path' => $path,
         ];

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -6,13 +6,13 @@
  * A transfer moves many files plus database changes at network speed and can
  * be interrupted or aborted at any point — the live site must never see that
  * as half-applied state, and partial content must never exist under the
- * web-served tree, where the server would hand out a half-uploaded
- * "plugin.php.part" as plain text. So staging exists for apply atomicity and
- * containment, not for authentication: nothing a transfer receives touches
- * the site directly, the bytes accumulate here while the site keeps running,
- * aborting before apply is free (discard the staged data), and the apply
- * step later moves verified artifacts into place in one short, controlled
- * window instead of mutating the live tree for the duration of the transfer.
+ * web-served tree, where the server would hand out a half-uploaded plugin
+ * file as plain text. So staging exists for apply atomicity and containment,
+ * not for authentication: nothing a transfer receives touches the site
+ * directly, the bytes accumulate here while the site keeps running, aborting
+ * before apply is free (discard the staged data), and the apply step later
+ * moves verified artifacts into place in one short, controlled window
+ * instead of mutating the live tree for the duration of the transfer.
  *
  * The first consumer is push: bounded chunk uploads from an outbound-only
  * local site (see UploadChunkSizer on the importer side). The pull file
@@ -34,12 +34,28 @@
  * moves data with no content hashing at all, nothing keys on content
  * digests, and error detection is the whole job.
  *
- * The sender hashes while reading and write_chunk() hashes while writing,
- * so the only extra pass is finalize() re-reading the artifact. That is
- * deliberate: chunk-time checks cannot see the staging file changing
- * between requests (a shrunken file is zero-filled back to the committed
- * size by the next write's ftruncate), and PHP 7.4 cannot resume a hash
- * context across requests.
+ * The sender hashes while reading and the store hashes while writing, so the
+ * only extra pass is finalize() re-reading the artifact. That is deliberate:
+ * chunk-time checks cannot see the staging file changing between requests
+ * (a shrunken file is zero-filled back to the committed size by the next
+ * write's ftruncate), and PHP 7.4 cannot resume a hash context across
+ * requests.
+ *
+ * Layout and state follow the pull importer's mechanics. Artifact bytes live
+ * at their plain target-relative paths under files/ — no suffixes, so any
+ * name a site can contain stages verbatim — and progress lives outside the
+ * mirror: state.json holds the cursor for the single in-flight artifact,
+ * verified.jsonl appends one line per artifact finalize() accepted, and lock
+ * is the flock target. The lock cannot live on state.json itself: the cursor
+ * is committed by rename, and a rename-replaced file leaves the held lock on
+ * the orphaned inode.
+ *
+ * Transfers are sequential, like pull: one artifact is in flight at a time
+ * and the cursor tracks only it. Writing chunk 0 of another artifact moves
+ * the cursor there; an unfinished predecessor keeps its bytes on disk but
+ * restarts from offset 0 when the sender returns to it. Concurrency is not a
+ * feature — the lock exists so a retry racing its timed-out predecessor gets
+ * "busy" instead of interleaved writes.
  *
  * Contract:
  *
@@ -48,17 +64,17 @@
  *   and every response carries committed_bytes so an out-of-sync uploader can
  *   resume at the right offset.
  * - Bytes become committed only after the chunk's CRC-32 matched. The data
- *   is flushed before the commit record is updated, so a crash mid-chunk
- *   leaves an uncommitted tail that the next write discards.
+ *   is flushed before the cursor record moves, so a crash mid-chunk leaves
+ *   an uncommitted tail that the next write discards.
  * - finalize() re-hashes the assembled artifact and compares size and checksum
- *   before marking it verified; write_chunk() refuses verified artifacts.
- * - An artifact id is the staging-relative path the artifact will be applied
- *   from, mirroring the target tree — the staging dir reads like the site
- *   and apply is a rename. Ids with absolute, empty, "." or ".." segments
- *   or any backslash are rejected — stricter than the importer's fs-root
- *   path rule, which tolerates backslashes and empty segments.
- * - Writers hold an exclusive flock on the staging file; a concurrent writer
- *   gets "busy" instead of interleaved writes.
+ *   before recording it in verified.jsonl; write_chunks() refuses verified
+ *   artifacts.
+ * - An artifact id is the files/-relative path the artifact will be applied
+ *   from, mirroring the target tree — apply resolves artifacts by id, never
+ *   by enumerating the staging directory. Ids with absolute, empty, "." or
+ *   ".." segments or any backslash are rejected — stricter than the
+ *   importer's fs-root path rule, which tolerates backslashes and empty
+ *   segments.
  *
  * The endpoint owns authentication and request-size limits. It must also
  * place the staging directory outside the web-served tree, and preferably on
@@ -70,10 +86,23 @@ final class Site_Export_Staged_Artifacts {
     private const WRITE_BUFFER_BYTES = 262144;
 
     /** @var string */
-    private $staging_dir;
+    private $files_dir;
+
+    /** @var string */
+    private $state_path;
+
+    /** @var string */
+    private $verified_path;
+
+    /** @var string */
+    private $lock_path;
 
     public function __construct(string $staging_dir) {
-        $this->staging_dir = rtrim($staging_dir, '/');
+        $base = rtrim($staging_dir, '/');
+        $this->files_dir = $base . '/files';
+        $this->state_path = $base . '/state.json';
+        $this->verified_path = $base . '/verified.jsonl';
+        $this->lock_path = $base . '/lock';
     }
 
     /**
@@ -101,8 +130,8 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Stage consecutive chunks from one request while keeping the staging file
-     * open and locked.
+     * Stage consecutive chunks from one request while keeping the artifact
+     * file open and the store locked.
      *
      * The upload endpoint can pass a generator that yields parsed chunks from
      * php://input, so a 100- or 1000-chunk request pays the open/flock/tail
@@ -125,120 +154,134 @@ final class Site_Export_Staged_Artifacts {
      *   reason can come from more than one place.
      */
     public function write_chunks(string $artifact_id, iterable $chunks): array {
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return $this->write_result('rejected', 'invalid_artifact_id', 0);
         }
-        if (!$this->ensure_parent_dir($paths['part'])) {
-            return $this->write_result('rejected', 'io_error', 0, 'create_staging_dir');
-        }
 
-        // Open without truncating: a resumed transfer must keep committed
-        // bytes until the metadata check below decides what tail to discard.
-        $part = @fopen($paths['part'], 'c+b');
-        if ($part === false) {
-            return $this->write_result('rejected', 'io_error', 0, 'open_staging_file');
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return $this->write_result('rejected', 'io_error', 0, 'open_lock_file');
         }
 
         try {
-            if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->write_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return $this->write_result('busy', null, $this->status($artifact_id)['committed_bytes']);
             }
 
-            $meta = $this->read_meta($paths['meta']);
-            $committed = $meta['committed_bytes'];
-            if ($meta['verified']) {
-                return $this->write_result('rejected', 'already_verified', $committed);
+            $verified = $this->read_verified();
+            if (isset($verified[$artifact_id])) {
+                return $this->write_result('rejected', 'already_verified', $verified[$artifact_id]['size']);
             }
 
-            // Discard any uncommitted tail from an interrupted earlier write,
-            // then append at the only offset the metadata says is committed.
-            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
-                return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
+            // Sequential transfers: the cursor tracks one artifact. A write
+            // to any other artifact starts it from scratch.
+            $state = $this->read_state();
+            $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            if (!$this->ensure_parent_dir($file_path)) {
+                return $this->write_result('rejected', 'io_error', $committed, 'create_staging_dir');
             }
 
-            $accepted = false;
-            $duplicate = false;
-            foreach ($chunks as $chunk) {
-                // These parameters arrive verbatim from a remote client's
-                // request, and the sequencing/copy logic below assumes they
-                // are well-formed — a negative offset would misreport as
-                // "duplicate" success and a short string body would never
-                // finish copying. Reject malformed input with typed reasons
-                // before writing bytes.
-                $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
-                $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
-                $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
-                $expected_crc32 = strtolower($expected_crc32);
-                $source = $chunk['source'] ?? null;
+            // Open without truncating: a resumed transfer must keep committed
+            // bytes until the cursor decides what tail to discard.
+            $file = @fopen($file_path, 'c+b');
+            if ($file === false) {
+                return $this->write_result('rejected', 'io_error', $committed, 'open_artifact_file');
+            }
 
-                if ($length < 1) {
-                    return $this->write_result('rejected', 'invalid_length', $committed);
+            try {
+                // Discard any uncommitted tail from an interrupted earlier
+                // write, then append at the only offset the cursor says is
+                // committed.
+                if (!ftruncate($file, $committed) || fseek($file, $committed) !== 0) {
+                    return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
                 }
-                if ($offset < 0) {
-                    return $this->write_result('rejected', 'invalid_offset', $committed);
-                }
-                if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
-                    return $this->write_result('rejected', 'invalid_hash', $committed);
-                }
-                if (is_string($source) && strlen($source) !== $length) {
-                    return $this->write_result('rejected', 'length_mismatch', $committed);
-                }
-                if (!is_string($source) && !is_resource($source)) {
-                    return $this->write_result('rejected', 'invalid_source', $committed);
-                }
-                if ($offset + $length <= $committed) {
-                    $drain_reason = $this->drain_source($source, $length);
-                    if ($drain_reason !== null) {
-                        return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+
+                $accepted = false;
+                $duplicate = false;
+                foreach ($chunks as $chunk) {
+                    // These parameters arrive verbatim from a remote client's
+                    // request, and the sequencing/copy logic below assumes they
+                    // are well-formed — a negative offset would misreport as
+                    // "duplicate" success and a short string body would never
+                    // finish copying. Reject malformed input with typed reasons
+                    // before writing bytes.
+                    $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
+                    $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
+                    $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
+                    $expected_crc32 = strtolower($expected_crc32);
+                    $source = $chunk['source'] ?? null;
+
+                    if ($length < 1) {
+                        return $this->write_result('rejected', 'invalid_length', $committed);
                     }
-                    $duplicate = true;
-                    continue;
-                }
-                if ($offset !== $committed) {
-                    return $this->write_result('rejected', 'offset_gap', $committed);
+                    if ($offset < 0) {
+                        return $this->write_result('rejected', 'invalid_offset', $committed);
+                    }
+                    if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
+                        return $this->write_result('rejected', 'invalid_hash', $committed);
+                    }
+                    if (is_string($source) && strlen($source) !== $length) {
+                        return $this->write_result('rejected', 'length_mismatch', $committed);
+                    }
+                    if (!is_string($source) && !is_resource($source)) {
+                        return $this->write_result('rejected', 'invalid_source', $committed);
+                    }
+                    if ($offset + $length <= $committed) {
+                        $drain_reason = $this->drain_source($source, $length);
+                        if ($drain_reason !== null) {
+                            return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+                        }
+                        $duplicate = true;
+                        continue;
+                    }
+                    if ($offset !== $committed) {
+                        return $this->write_result('rejected', 'offset_gap', $committed);
+                    }
+
+                    $copy_reason = $this->copy_and_hash($source, $file, $length, $expected_crc32);
+                    if ($copy_reason !== null) {
+                        // A failed copy/hash can leave bytes past the committed
+                        // offset; trim them before the caller retries this chunk.
+                        ftruncate($file, $committed);
+                        return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                    }
+
+                    // The data is flushed before the cursor record moves: a crash
+                    // between the two leaves a tail that the next write truncates.
+                    if (!fflush($file)) {
+                        ftruncate($file, $committed);
+                        return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                    }
+
+                    if (!$this->write_state($artifact_id, $committed + $length)) {
+                        ftruncate($file, $committed);
+                        return $this->write_result('rejected', 'io_error', $committed, 'persist_cursor');
+                    }
+
+                    $committed += $length;
+                    $accepted = true;
                 }
 
-                $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
-                if ($copy_reason !== null) {
-                    // A failed copy/hash can leave bytes past the committed
-                    // offset; trim them before the caller retries this chunk.
-                    ftruncate($part, $committed);
-                    return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                if ($accepted) {
+                    return $this->write_result('accepted', null, $committed);
                 }
-
-                // The data is flushed before the commit record moves: a crash
-                // between the two leaves a tail that the next write truncates.
-                if (!fflush($part)) {
-                    ftruncate($part, $committed);
-                    return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                if ($duplicate) {
+                    return $this->write_result('duplicate', null, $committed);
                 }
-
-                $meta['committed_bytes'] = $committed + $length;
-                if (!$this->write_meta($paths['meta'], $meta)) {
-                    ftruncate($part, $committed);
-                    return $this->write_result('rejected', 'io_error', $committed, 'persist_commit_record');
-                }
-
-                $committed = $meta['committed_bytes'];
-                $accepted = true;
+                return $this->write_result('rejected', 'empty_batch', $committed);
+            } finally {
+                fclose($file);
             }
-
-            if ($accepted) {
-                return $this->write_result('accepted', null, $committed);
-            }
-            if ($duplicate) {
-                return $this->write_result('duplicate', null, $committed);
-            }
-            return $this->write_result('rejected', 'empty_batch', $committed);
         } finally {
-            flock($part, LOCK_UN);
-            fclose($part);
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 
     /**
-     * Verify the assembled artifact and mark it applyable.
+     * Verify the assembled artifact and record it as applyable.
      *
      * Idempotent: finalizing an already-verified artifact with the same size
      * and checksum succeeds again.
@@ -255,8 +298,8 @@ final class Site_Export_Staged_Artifacts {
      */
     public function finalize(string $artifact_id, int $expected_total_bytes, string $expected_crc32): array {
         $expected_crc32 = strtolower($expected_crc32);
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return $this->finalize_result('rejected', 'invalid_artifact_id', 0);
         }
         if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
@@ -266,51 +309,56 @@ final class Site_Export_Staged_Artifacts {
             return $this->finalize_result('rejected', 'invalid_total', 0);
         }
 
-        $part_path = $paths['part'];
-        if (!file_exists($part_path)) {
-            // A zero-byte artifact legitimately has no chunks; the fopen
-            // below creates its empty part file.
-            if ($expected_total_bytes > 0) {
-                return $this->finalize_result('rejected', 'missing', 0);
-            }
-            if (!$this->ensure_parent_dir($part_path)) {
-                return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
-            }
-        }
-
-        $part = @fopen($part_path, 'c+b');
-        if ($part === false) {
-            return $this->finalize_result('rejected', 'io_error', 0, 'open_staging_file');
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return $this->finalize_result('rejected', 'io_error', 0, 'open_lock_file');
         }
 
         try {
-            if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->finalize_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return $this->finalize_result('busy', null, $this->status($artifact_id)['committed_bytes']);
             }
 
-            $meta = $this->read_meta($paths['meta']);
-            $committed = $meta['committed_bytes'];
-            if ($meta['verified']) {
-                $same = $meta['verified_total_bytes'] === $expected_total_bytes
-                    && is_string($meta['verified_crc32'])
-                    && hash_equals($meta['verified_crc32'], $expected_crc32);
+            $verified = $this->read_verified();
+            if (isset($verified[$artifact_id])) {
+                $record = $verified[$artifact_id];
+                $same = $record['size'] === $expected_total_bytes
+                    && hash_equals($record['crc32'], $expected_crc32);
                 return $same
-                    ? $this->finalize_result('verified', null, $committed, null, $part_path)
-                    : $this->finalize_result('rejected', 'hash_mismatch', $committed, 'verified_record');
+                    ? $this->finalize_result('verified', null, $record['size'], null, $file_path)
+                    : $this->finalize_result('rejected', 'hash_mismatch', $record['size'], 'verified_record');
+            }
+
+            $state = $this->read_state();
+            $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            if (!file_exists($file_path)) {
+                // A zero-byte artifact legitimately has no chunks; the fopen
+                // below creates its empty file.
+                if ($expected_total_bytes > 0) {
+                    return $this->finalize_result('rejected', 'missing', $committed);
+                }
+                if (!$this->ensure_parent_dir($file_path)) {
+                    return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
+                }
             }
 
             if ($committed !== $expected_total_bytes) {
                 return $this->finalize_result('rejected', 'size_mismatch', $committed);
             }
 
+            $file = @fopen($file_path, 'c+b');
+            if ($file === false) {
+                return $this->finalize_result('rejected', 'io_error', $committed, 'open_artifact_file');
+            }
             // Drop any uncommitted tail so the checksum covers committed bytes only.
-            if (!ftruncate($part, $committed)) {
+            $truncated = ftruncate($file, $committed);
+            fclose($file);
+            if (!$truncated) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
             }
 
-            // Hash while holding the staging lock. hash_file() uses its own
-            // read handle, but all writers in this store respect this flock.
-            $actual_crc32 = hash_file('crc32b', $part_path);
+            $actual_crc32 = hash_file('crc32b', $file_path);
             if ($actual_crc32 === false) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'artifact_crc32');
             }
@@ -318,31 +366,33 @@ final class Site_Export_Staged_Artifacts {
                 return $this->finalize_result('rejected', 'hash_mismatch', $committed, 'artifact_crc32');
             }
 
-            $meta['verified'] = true;
-            $meta['verified_total_bytes'] = $expected_total_bytes;
-            $meta['verified_crc32'] = $expected_crc32;
-            if (!$this->write_meta($paths['meta'], $meta)) {
-                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_commit_record');
+            if (!$this->append_verified($artifact_id, $expected_total_bytes, $expected_crc32)) {
+                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_verified_record');
+            }
+            if ($state['artifact_id'] === $artifact_id) {
+                // Best effort: a stale cursor is harmless once the verified
+                // record exists — already_verified wins on the next write.
+                $this->write_state(null, 0);
             }
 
-            return $this->finalize_result('verified', null, $committed, null, $part_path);
+            return $this->finalize_result('verified', null, $committed, null, $file_path);
         } finally {
-            flock($part, LOCK_UN);
-            fclose($part);
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 
     /**
-     * Returns the persisted staging state for an artifact.
+     * Returns the recorded staging state for an artifact.
      *
      * This is advisory and intentionally lock-free; writers still enforce the
-     * committed offset under flock before accepting bytes.
+     * committed offset under the lock before accepting bytes.
      *
      * @return array{exists:bool,committed_bytes:int,verified:bool}
      */
     public function status(string $artifact_id): array {
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return [
                 'exists' => false,
                 'committed_bytes' => 0,
@@ -350,62 +400,79 @@ final class Site_Export_Staged_Artifacts {
             ];
         }
 
-        $meta = $this->read_meta($paths['meta']);
+        $verified = $this->read_verified();
+        if (isset($verified[$artifact_id])) {
+            return [
+                'exists' => file_exists($file_path),
+                'committed_bytes' => $verified[$artifact_id]['size'],
+                'verified' => true,
+            ];
+        }
+
+        $state = $this->read_state();
         return [
-            'exists' => file_exists($paths['part']) || file_exists($paths['meta']),
-            'committed_bytes' => $meta['committed_bytes'],
-            'verified' => $meta['verified'],
+            'exists' => file_exists($file_path),
+            'committed_bytes' => $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0,
+            'verified' => false,
         ];
     }
 
     /**
-     * Remove all staged data for an artifact. Safe to call for unknown ids.
+     * Remove all staged data and records for an artifact. Safe to call for
+     * unknown ids.
      *
-     * @return bool False when a concurrent writer holds the artifact — an
+     * @return bool False when a concurrent writer holds the store — an
      *              unguarded unlink would let that writer's commit resurrect
-     *              an orphaned record.
+     *              a discarded artifact.
      */
     public function discard(string $artifact_id): bool {
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return true;
         }
 
-        if (!file_exists($paths['part']) && !file_exists($paths['meta'])) {
+        // Discarding an artifact nothing knows about is a no-op and must not
+        // create the staging scaffolding as a side effect.
+        $state = $this->read_state();
+        if (
+            !file_exists($file_path)
+            && $state['artifact_id'] !== $artifact_id
+            && !isset($this->read_verified()[$artifact_id])
+        ) {
             return true;
         }
 
-        // 'c+b' so the lock exists even when only the meta record does, and
-        // the meta is unlinked before the part while the lock is held — a
-        // writer arriving after the part unlink locks a fresh inode, and
-        // stale meta it could still read would resurrect its committed_bytes
-        // over bytes that are gone.
-        $part = @fopen($paths['part'], 'c+b');
-        if ($part === false) {
+        $lock = $this->open_lock();
+        if ($lock === false) {
             return false;
         }
         try {
-            if (!flock($part, LOCK_EX | LOCK_NB)) {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
                 return false;
             }
-            @unlink($paths['meta']);
-            @unlink($paths['part']);
+
+            @unlink($file_path);
+            $state = $this->read_state();
+            if ($state['artifact_id'] === $artifact_id) {
+                $this->write_state(null, 0);
+            }
+            $this->remove_verified($artifact_id);
             return true;
         } finally {
-            flock($part, LOCK_UN);
-            fclose($part);
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 
     /**
-     * Copies exactly $length bytes to the staging file while hashing the same
-     * bytes that landed on disk.
+     * Copies exactly $length bytes to the artifact file while hashing the
+     * same bytes that landed on disk.
      *
      * @param resource|string $source
      * @return string|null Rejection reason, or null when $length bytes were
      *                     copied and their checksum matched.
      */
-    private function copy_and_hash($source, $part, int $length, string $expected_crc32): ?string {
+    private function copy_and_hash($source, $file, int $length, string $expected_crc32): ?string {
         $context = hash_init('crc32b');
         $remaining = $length;
 
@@ -422,7 +489,7 @@ final class Site_Export_Staged_Artifacts {
             }
 
             hash_update($context, $buffer);
-            if (fwrite($part, $buffer) !== strlen($buffer)) {
+            if (fwrite($file, $buffer) !== strlen($buffer)) {
                 return 'io_error';
             }
             $remaining -= strlen($buffer);
@@ -464,10 +531,10 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Resolve an artifact id to its staging file paths, or null when the id
+     * Resolve an artifact id to its path under files/, or null when the id
      * is not a clean staging-relative path.
      */
-    private function artifact_paths(string $artifact_id): ?array {
+    private function artifact_path(string $artifact_id): ?string {
         if ($artifact_id === '' || $artifact_id[0] === '/' || strpos($artifact_id, "\0") !== false || strpos($artifact_id, '\\') !== false) {
             return null;
         }
@@ -477,11 +544,19 @@ final class Site_Export_Staged_Artifacts {
             }
         }
 
-        $base = $this->staging_dir . '/' . $artifact_id;
-        return [
-            'part' => $base . '.part',
-            'meta' => $base . '.meta.json',
-        ];
+        return $this->files_dir . '/' . $artifact_id;
+    }
+
+    /**
+     * Opens the flock target, creating the staging directory on first use.
+     *
+     * @return resource|false
+     */
+    private function open_lock() {
+        if (!$this->ensure_parent_dir($this->lock_path)) {
+            return false;
+        }
+        return @fopen($this->lock_path, 'c+b');
     }
 
     private function ensure_parent_dir(string $path): bool {
@@ -491,56 +566,120 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Reads the commit record as best-effort state.
+     * Reads the cursor as best-effort state.
      *
-     * A missing or unreadable record is treated as an empty artifact so the
-     * next writer must restart from offset 0 instead of trusting stale bytes.
+     * A missing or unreadable record is treated as no artifact in flight, so
+     * the next writer must restart its artifact from offset 0 instead of
+     * trusting stale bytes.
      *
-     * @return array{committed_bytes:int,verified:bool,verified_total_bytes:?int,verified_crc32:?string}
+     * @return array{artifact_id:?string,committed_bytes:int}
      */
-    private function read_meta(string $meta_path): array {
+    private function read_state(): array {
         $defaults = [
+            'artifact_id' => null,
             'committed_bytes' => 0,
-            'verified' => false,
-            'verified_total_bytes' => null,
-            'verified_crc32' => null,
         ];
 
-        $raw = @file_get_contents($meta_path);
+        $raw = @file_get_contents($this->state_path);
         if ($raw === false) {
             return $defaults;
         }
-        $meta = json_decode($raw, true);
-        if (!is_array($meta)) {
+        $state = json_decode($raw, true);
+        if (!is_array($state) || !is_string($state['artifact_id'] ?? null)) {
             return $defaults;
         }
 
-        // Metadata is intentionally not trusted as schema: old/corrupt files
-        // fall back to defaults after keeping only recognized keys.
-        $meta = array_merge($defaults, array_intersect_key($meta, $defaults));
-        $meta['committed_bytes'] = max(0, (int) $meta['committed_bytes']);
-        $meta['verified'] = (bool) $meta['verified'];
-        $meta['verified_total_bytes'] = $meta['verified_total_bytes'] !== null ? (int) $meta['verified_total_bytes'] : null;
-        return $meta;
+        $committed_bytes = isset($state['committed_bytes']) ? (int) $state['committed_bytes'] : 0;
+        return [
+            'artifact_id' => $state['artifact_id'],
+            'committed_bytes' => max(0, $committed_bytes),
+        ];
     }
 
-    private function write_meta(string $meta_path, array $meta): bool {
-        // Write-then-rename keeps the commit record atomic: readers see the
-        // old record or the new one, never a torn file. Keep the temp file
-        // next to the target so rename stays on the same filesystem.
-        $tmp_path = $meta_path . '.tmp';
-        $json = json_encode($meta);
+    private function write_state(?string $artifact_id, int $committed_bytes): bool {
+        // Write-then-rename keeps the cursor atomic: readers see the old
+        // record or the new one, never a torn file. The temp file sits next
+        // to the target so rename stays on the same filesystem.
+        $tmp_path = $this->state_path . '.tmp';
+        $json = json_encode([
+            'artifact_id' => $artifact_id,
+            'committed_bytes' => $committed_bytes,
+        ]);
         // A short write (disk full) returns a byte count, not false — never
         // rename a torn record over the good one.
         if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
             @unlink($tmp_path);
             return false;
         }
-        if (!@rename($tmp_path, $meta_path)) {
+        if (!@rename($tmp_path, $this->state_path)) {
             @unlink($tmp_path);
             return false;
         }
         return true;
+    }
+
+    /**
+     * Reads the verified-artifact records, keyed by artifact id.
+     *
+     * Malformed lines — a tail torn by a crash mid-append — are skipped, so
+     * the worst case is re-verifying an artifact, never trusting a torn record.
+     *
+     * @return array<string,array{size:int,crc32:string}>
+     */
+    private function read_verified(): array {
+        $raw = @file_get_contents($this->verified_path);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+
+        $records = [];
+        foreach (explode("\n", $raw) as $line) {
+            $record = json_decode($line, true);
+            if (
+                !is_array($record)
+                || !is_string($record['artifact_id'] ?? null)
+                || !is_int($record['size'] ?? null)
+                || $record['size'] < 0
+                || !is_string($record['crc32'] ?? null)
+            ) {
+                continue;
+            }
+            $records[$record['artifact_id']] = [
+                'size' => $record['size'],
+                'crc32' => $record['crc32'],
+            ];
+        }
+        return $records;
+    }
+
+    private function append_verified(string $artifact_id, int $size, string $crc32): bool {
+        $line = json_encode([
+            'artifact_id' => $artifact_id,
+            'size' => $size,
+            'crc32' => $crc32,
+        ]) . "\n";
+        return @file_put_contents($this->verified_path, $line, FILE_APPEND) === strlen($line);
+    }
+
+    private function remove_verified(string $artifact_id): void {
+        $records = $this->read_verified();
+        if (!isset($records[$artifact_id])) {
+            return;
+        }
+        unset($records[$artifact_id]);
+
+        $lines = '';
+        foreach ($records as $id => $record) {
+            $lines .= json_encode([
+                'artifact_id' => $id,
+                'size' => $record['size'],
+                'crc32' => $record['crc32'],
+            ]) . "\n";
+        }
+        $tmp_path = $this->verified_path . '.tmp';
+        if (@file_put_contents($tmp_path, $lines) !== strlen($lines) || !@rename($tmp_path, $this->verified_path)) {
+            @unlink($tmp_path);
+        }
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -44,18 +44,24 @@
  * Layout and state follow the pull importer's mechanics. Artifact bytes live
  * at their plain target-relative paths under files/ — no suffixes, so any
  * name a site can contain stages verbatim — and progress lives outside the
- * mirror: state.json holds the cursor for the single in-flight artifact,
- * verified.jsonl appends one line per artifact finalize() accepted, and lock
- * is the flock target. The lock cannot live on state.json itself: the cursor
- * is committed by rename, and a rename-replaced file leaves the held lock on
- * the orphaned inode.
+ * mirror: state.json holds the cursor for the single in-flight artifact and
+ * verified.jsonl appends one line per artifact finalize() accepted.
  *
  * Transfers are sequential, like pull: one artifact is in flight at a time
  * and the cursor tracks only it. Writing chunk 0 of another artifact moves
  * the cursor there; an unfinished predecessor keeps its bytes on disk but
- * restarts from offset 0 when the sender returns to it. Concurrency is not a
- * feature — the lock exists so a retry racing its timed-out predecessor gets
- * "busy" instead of interleaved writes.
+ * restarts from offset 0 when the sender returns to it.
+ *
+ * Locking: every mutator — write_chunks(), finalize(), discard() — holds one
+ * exclusive non-blocking flock on the lock file for its whole call, so a
+ * batch keeps the store to itself from its first chunk to its last. This is
+ * not for parallelism (transfers are sequential); it exists so a retry
+ * racing its timed-out predecessor gets "busy" instead of interleaving
+ * writes. The lock needs its own never-replaced file: state.json commits by
+ * rename, and renaming a locked file strands the held flock on the orphaned
+ * inode while the next opener locks the fresh one. Readers stay lock-free —
+ * state.json is rename-atomic, verified.jsonl is append-only, and
+ * committed_bytes only grows — so status() always reads a safe resume hint.
  *
  * Contract:
  *
@@ -358,6 +364,9 @@ final class Site_Export_Staged_Artifacts {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
             }
 
+            // Reading through a second handle without locking the artifact
+            // file is safe: every writer serializes on the store lock held
+            // here.
             $actual_crc32 = hash_file('crc32b', $file_path);
             if ($actual_crc32 === false) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'artifact_crc32');
@@ -549,6 +558,10 @@ final class Site_Export_Staged_Artifacts {
 
     /**
      * Opens the flock target, creating the staging directory on first use.
+     *
+     * The lock file must never be written or rename-replaced: a rename
+     * strands a held flock on the orphaned inode and lets the next opener
+     * lock the store concurrently.
      *
      * @return resource|false
      */

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -1,0 +1,426 @@
+<?php
+
+/**
+ * Staged storage for chunked artifact transfers.
+ *
+ * A transfer moves many files plus database changes at network speed and can
+ * be interrupted or aborted at any point — the live site must never see that
+ * as half-applied state, and partial content must never exist under the
+ * web-served tree, where the server would hand out a half-uploaded
+ * "plugin.php.part" as plain text. So staging exists for apply atomicity and
+ * containment, not for authentication: nothing a transfer receives touches
+ * the site directly, the bytes accumulate here while the site keeps running,
+ * aborting before apply is free (discard the staged data), and the apply
+ * step later moves verified artifacts into place in one short, controlled
+ * window instead of mutating the live tree for the duration of the transfer.
+ *
+ * The first consumer is push: bounded chunk uploads from an outbound-only
+ * local site (see UploadChunkSizer on the importer side). The pull file
+ * writer has the same needs whenever its target is a live site — today it
+ * streams downloads straight to their final paths, which is fine for a fresh
+ * local directory but not for a web-served tree — so nothing here is
+ * upload-specific: sequential offsets match pull's byte-offset resume model,
+ * and adopting this store there mainly needs source-declared checksums in the
+ * file index/fetch protocol.
+ *
+ * The checksums gate the apply step; they are not an auth scheme (the
+ * control plane's HMAC owns authorization) and they do not guard the wire
+ * (TLS does). They catch accidents neither can see: a sender reading the
+ * wrong bytes (offset bugs, a live source file changing mid-transfer),
+ * truncation in buffering layers behind the TLS edge, and the staging file
+ * drifting between requests. finalize()'s whole-artifact checksum defines
+ * "complete and correct"; the per-chunk checksum just localizes a bad chunk
+ * to a one-chunk retry. CRC-32 is enough for that: the rest of the pipeline
+ * moves data with no content hashing at all, nothing keys on content
+ * digests, and error detection is the whole job.
+ *
+ * The sender hashes while reading and write_chunk() hashes while writing,
+ * so the only extra pass is finalize() re-reading the artifact. That is
+ * deliberate: chunk-time checks cannot see the staging file changing
+ * between requests (a shrunken file is zero-filled back to the committed
+ * size by the next write's ftruncate), and PHP 7.4 cannot resume a hash
+ * context across requests.
+ *
+ * Contract:
+ *
+ * - Chunks are sequential. A chunk is accepted only at the committed offset.
+ *   Retrying an already-committed chunk is an idempotent no-op ("duplicate"),
+ *   and every response carries committed_bytes so an out-of-sync uploader can
+ *   resume at the right offset.
+ * - Bytes become committed only after the chunk's CRC-32 matched. The data
+ *   is flushed before the commit record is updated, so a crash mid-chunk
+ *   leaves an uncommitted tail that the next write discards.
+ * - finalize() re-hashes the assembled artifact and compares size and checksum
+ *   before marking it verified; write_chunk() refuses verified artifacts.
+ * - An artifact id is the staging-relative path the artifact will be applied
+ *   from, mirroring the target tree — the staging dir reads like the site
+ *   and apply is a rename. Ids with absolute, empty, "." or ".." segments
+ *   are rejected, same as the importer's fs-root-relative path rule.
+ * - Writers hold an exclusive flock on the staging file; a concurrent writer
+ *   gets "busy" instead of interleaved writes.
+ *
+ * The endpoint owns authentication and request-size limits. It must also
+ * place the staging directory outside the web-served tree, and preferably on
+ * the same filesystem as the apply target so the apply step can move
+ * verified artifacts with an atomic rename().
+ */
+final class Site_Export_Staged_Artifacts {
+
+    private const WRITE_BUFFER_BYTES = 262144;
+
+    /** @var string */
+    private $staging_dir;
+
+    public function __construct(string $staging_dir) {
+        $this->staging_dir = rtrim($staging_dir, '/');
+    }
+
+    /**
+     * Stage one chunk of an artifact at the given offset.
+     *
+     * @param string          $artifact_id     Opaque artifact identifier.
+     * @param int             $offset          Byte offset this chunk starts at.
+     * @param int             $length          Declared chunk length in bytes.
+     * @param string          $expected_crc32  Hex CRC-32 (crc32b) of the chunk body.
+     * @param resource|string $source          Chunk body, or a readable stream positioned at it.
+     * @return array{status:string,reason:?string,committed_bytes:int}
+     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on "rejected".
+     */
+    public function write_chunk(string $artifact_id, int $offset, int $length, string $expected_crc32, $source): array {
+        // These parameters arrive verbatim from a remote client's request,
+        // and the sequencing/copy logic below assumes they are well-formed —
+        // a negative offset would misreport as "duplicate" success and a
+        // short string body would never finish copying. Reject malformed
+        // input with typed reasons before taking the lock or touching disk.
+        $expected_crc32 = strtolower($expected_crc32);
+        $paths = $this->artifact_paths($artifact_id);
+        if ($paths === null) {
+            return $this->write_result('rejected', 'invalid_artifact_id', 0);
+        }
+        if ($length < 1 || $offset < 0) {
+            return $this->write_result('rejected', 'invalid_length', 0);
+        }
+        if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
+            return $this->write_result('rejected', 'invalid_hash', 0);
+        }
+        if (is_string($source) && strlen($source) !== $length) {
+            return $this->write_result('rejected', 'length_mismatch', 0);
+        }
+        if (!is_string($source) && !is_resource($source)) {
+            return $this->write_result('rejected', 'invalid_source', 0);
+        }
+        if (!$this->ensure_parent_dir($paths['part'])) {
+            return $this->write_result('rejected', 'io_error', 0);
+        }
+
+        $part = @fopen($paths['part'], 'c+b');
+        if ($part === false) {
+            return $this->write_result('rejected', 'io_error', 0);
+        }
+
+        try {
+            if (!flock($part, LOCK_EX | LOCK_NB)) {
+                return $this->write_result('busy', null, 0);
+            }
+
+            $meta = $this->read_meta($paths['meta']);
+            $committed = $meta['committed_bytes'];
+            if ($meta['verified']) {
+                return $this->write_result('rejected', 'already_verified', $committed);
+            }
+            if ($offset + $length <= $committed) {
+                return $this->write_result('duplicate', null, $committed);
+            }
+            if ($offset !== $committed) {
+                return $this->write_result('rejected', 'offset_gap', $committed);
+            }
+
+            // Discard any uncommitted tail from an interrupted earlier write.
+            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
+                return $this->write_result('rejected', 'io_error', $committed);
+            }
+
+            $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
+            if ($copy_reason !== null) {
+                ftruncate($part, $committed);
+                return $this->write_result('rejected', $copy_reason, $committed);
+            }
+
+            // The data is durable before the commit record moves: a crash
+            // between the two leaves a tail that the next write truncates.
+            if (!fflush($part)) {
+                ftruncate($part, $committed);
+                return $this->write_result('rejected', 'io_error', $committed);
+            }
+
+            $meta['committed_bytes'] = $committed + $length;
+            if (!$this->write_meta($paths['meta'], $meta)) {
+                ftruncate($part, $committed);
+                return $this->write_result('rejected', 'io_error', $committed);
+            }
+
+            return $this->write_result('accepted', null, $meta['committed_bytes']);
+        } finally {
+            flock($part, LOCK_UN);
+            fclose($part);
+        }
+    }
+
+    /**
+     * Verify the assembled artifact and mark it applyable.
+     *
+     * Idempotent: finalizing an already-verified artifact with the same size
+     * and checksum succeeds again.
+     *
+     * $expected_crc32 must be the checksum declared when the transfer was
+     * planned, before any bytes moved. A checksum the sender computes while
+     * reading cannot catch a resume that mixed two versions of the source
+     * file — it would faithfully hash the mixed bytes.
+     *
+     * @return array{status:string,reason:?string,committed_bytes:int,path:?string}
+     *   status "verified"|"busy"|"rejected"; path is set on "verified".
+     */
+    public function finalize(string $artifact_id, int $expected_total_bytes, string $expected_crc32): array {
+        $expected_crc32 = strtolower($expected_crc32);
+        $paths = $this->artifact_paths($artifact_id);
+        if ($paths === null) {
+            return $this->finalize_result('rejected', 'invalid_artifact_id', 0);
+        }
+        if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
+            return $this->finalize_result('rejected', 'invalid_hash', 0);
+        }
+        if ($expected_total_bytes < 0) {
+            return $this->finalize_result('rejected', 'size_mismatch', 0);
+        }
+
+        $part_path = $paths['part'];
+        if (!file_exists($part_path)) {
+            // A zero-byte artifact legitimately has no chunks.
+            if ($expected_total_bytes > 0 || !$this->ensure_parent_dir($part_path) || @touch($part_path) === false) {
+                return $this->finalize_result('rejected', 'missing', 0);
+            }
+        }
+
+        $part = @fopen($part_path, 'c+b');
+        if ($part === false) {
+            return $this->finalize_result('rejected', 'io_error', 0);
+        }
+
+        try {
+            if (!flock($part, LOCK_EX | LOCK_NB)) {
+                return $this->finalize_result('busy', null, 0);
+            }
+
+            $meta = $this->read_meta($paths['meta']);
+            $committed = $meta['committed_bytes'];
+            if ($meta['verified']) {
+                $same = $meta['verified_total_bytes'] === $expected_total_bytes
+                    && is_string($meta['verified_crc32'])
+                    && hash_equals($meta['verified_crc32'], $expected_crc32);
+                return $same
+                    ? $this->finalize_result('verified', null, $committed, $part_path)
+                    : $this->finalize_result('rejected', 'hash_mismatch', $committed);
+            }
+
+            if ($committed !== $expected_total_bytes) {
+                return $this->finalize_result('rejected', 'size_mismatch', $committed);
+            }
+
+            // Drop any uncommitted tail so the checksum covers committed bytes only.
+            if (!ftruncate($part, $committed)) {
+                return $this->finalize_result('rejected', 'io_error', $committed);
+            }
+
+            $actual_crc32 = hash_file('crc32b', $part_path);
+            if ($actual_crc32 === false) {
+                return $this->finalize_result('rejected', 'io_error', $committed);
+            }
+            if (!hash_equals($expected_crc32, $actual_crc32)) {
+                return $this->finalize_result('rejected', 'hash_mismatch', $committed);
+            }
+
+            $meta['verified'] = true;
+            $meta['verified_total_bytes'] = $expected_total_bytes;
+            $meta['verified_crc32'] = $expected_crc32;
+            if (!$this->write_meta($paths['meta'], $meta)) {
+                return $this->finalize_result('rejected', 'io_error', $committed);
+            }
+
+            return $this->finalize_result('verified', null, $committed, $part_path);
+        } finally {
+            flock($part, LOCK_UN);
+            fclose($part);
+        }
+    }
+
+    /**
+     * @return array{exists:bool,committed_bytes:int,verified:bool}
+     */
+    public function status(string $artifact_id): array {
+        $paths = $this->artifact_paths($artifact_id);
+        if ($paths === null) {
+            return [
+                'exists' => false,
+                'committed_bytes' => 0,
+                'verified' => false,
+            ];
+        }
+
+        $meta = $this->read_meta($paths['meta']);
+        return [
+            'exists' => file_exists($paths['part']) || file_exists($paths['meta']),
+            'committed_bytes' => $meta['committed_bytes'],
+            'verified' => $meta['verified'],
+        ];
+    }
+
+    /**
+     * Remove all staged data for an artifact. Safe to call for unknown ids.
+     *
+     * @return bool False when a concurrent writer holds the artifact — an
+     *              unguarded unlink would let that writer's commit resurrect
+     *              an orphaned record.
+     */
+    public function discard(string $artifact_id): bool {
+        $paths = $this->artifact_paths($artifact_id);
+        if ($paths === null) {
+            return true;
+        }
+
+        $part = @fopen($paths['part'], 'r+b');
+        if ($part !== false) {
+            if (!flock($part, LOCK_EX | LOCK_NB)) {
+                fclose($part);
+                return false;
+            }
+            @unlink($paths['part']);
+            flock($part, LOCK_UN);
+            fclose($part);
+        }
+        @unlink($paths['meta']);
+        return true;
+    }
+
+    /**
+     * @param resource|string $source
+     * @return string|null Rejection reason, or null when $length bytes were
+     *                     copied and their checksum matched.
+     */
+    private function copy_and_hash($source, $part, int $length, string $expected_crc32): ?string {
+        $context = hash_init('crc32b');
+        $remaining = $length;
+
+        while ($remaining > 0) {
+            if (is_string($source)) {
+                $buffer = substr($source, $length - $remaining, min($remaining, self::WRITE_BUFFER_BYTES));
+            } else {
+                $buffer = fread($source, min($remaining, self::WRITE_BUFFER_BYTES));
+                if ($buffer === false || $buffer === '') {
+                    return 'short_body';
+                }
+            }
+
+            hash_update($context, $buffer);
+            if (fwrite($part, $buffer) !== strlen($buffer)) {
+                return 'io_error';
+            }
+            $remaining -= strlen($buffer);
+        }
+
+        if (!hash_equals($expected_crc32, hash_final($context))) {
+            return 'hash_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve an artifact id to its staging file paths, or null when the id
+     * is not a clean staging-relative path.
+     */
+    private function artifact_paths(string $artifact_id): ?array {
+        if ($artifact_id === '' || $artifact_id[0] === '/' || strpos($artifact_id, "\0") !== false || strpos($artifact_id, '\\') !== false) {
+            return null;
+        }
+        foreach (explode('/', $artifact_id) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return null;
+            }
+        }
+
+        $base = $this->staging_dir . '/' . $artifact_id;
+        return [
+            'part' => $base . '.part',
+            'meta' => $base . '.meta.json',
+        ];
+    }
+
+    private function ensure_parent_dir(string $path): bool {
+        $dir = dirname($path);
+        return is_dir($dir) || @mkdir($dir, 0700, true);
+    }
+
+    /**
+     * @return array{committed_bytes:int,verified:bool,verified_total_bytes:?int,verified_crc32:?string}
+     */
+    private function read_meta(string $meta_path): array {
+        $defaults = [
+            'committed_bytes' => 0,
+            'verified' => false,
+            'verified_total_bytes' => null,
+            'verified_crc32' => null,
+        ];
+
+        $raw = @file_get_contents($meta_path);
+        if ($raw === false) {
+            return $defaults;
+        }
+        $meta = json_decode($raw, true);
+        if (!is_array($meta)) {
+            return $defaults;
+        }
+
+        $meta = array_merge($defaults, array_intersect_key($meta, $defaults));
+        $meta['committed_bytes'] = max(0, (int) $meta['committed_bytes']);
+        $meta['verified'] = (bool) $meta['verified'];
+        $meta['verified_total_bytes'] = $meta['verified_total_bytes'] !== null ? (int) $meta['verified_total_bytes'] : null;
+        return $meta;
+    }
+
+    private function write_meta(string $meta_path, array $meta): bool {
+        // Write-then-rename keeps the commit record atomic: readers see the
+        // old record or the new one, never a torn file.
+        $tmp_path = $meta_path . '.tmp';
+        if (@file_put_contents($tmp_path, json_encode($meta)) === false) {
+            return false;
+        }
+        if (!@rename($tmp_path, $meta_path)) {
+            @unlink($tmp_path);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return array{status:string,reason:?string,committed_bytes:int}
+     */
+    private function write_result(string $status, ?string $reason, int $committed_bytes): array {
+        return [
+            'status' => $status,
+            'reason' => $reason,
+            'committed_bytes' => $committed_bytes,
+        ];
+    }
+
+    /**
+     * @return array{status:string,reason:?string,committed_bytes:int,path:?string}
+     */
+    private function finalize_result(string $status, ?string $reason, int $committed_bytes, ?string $path = null): array {
+        return [
+            'status' => $status,
+            'reason' => $reason,
+            'committed_bytes' => $committed_bytes,
+            'path' => $path,
+        ];
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -19,27 +19,18 @@
  * writer has the same needs whenever its target is a live site — today it
  * streams downloads straight to their final paths, which is fine for a fresh
  * local directory but not for a web-served tree — so nothing here is
- * upload-specific: sequential offsets match pull's byte-offset resume model,
- * and adopting this store there mainly needs source-declared checksums in the
- * file index/fetch protocol.
+ * upload-specific: sequential offsets match pull's byte-offset resume model.
  *
- * The checksums gate the apply step; they are not an auth scheme (the
- * control plane's HMAC owns authorization) and they do not guard the wire
- * (TLS does). They catch accidents neither can see: a sender reading the
- * wrong bytes (offset bugs, a live source file changing mid-transfer),
- * truncation in buffering layers behind the TLS edge, and the staging file
- * drifting between requests. finalize()'s whole-artifact checksum defines
- * "complete and correct"; the per-chunk checksum just localizes a bad chunk
- * to a one-chunk retry. CRC-32 is enough for that: the rest of the pipeline
- * moves data with no content hashing at all, nothing keys on content
- * digests, and error detection is the whole job.
- *
- * The sender hashes while reading and the store hashes while writing, so the
- * only extra pass is finalize() re-reading the artifact. That is deliberate:
- * chunk-time checks cannot see the staging file changing between requests
- * (a shrunken file is zero-filled back to the committed size by the next
- * write's ftruncate), and PHP 7.4 cannot resume a hash context across
- * requests.
+ * Integrity checks are byte counts, the same discipline pull uses: every
+ * chunk must supply exactly its declared length, and finalize() compares the
+ * assembled size against the total declared at plan time. That catches
+ * truncation, missing chunks, and resume-offset bugs; it does not read the
+ * artifact back, so finalize() costs the same for a 1 KB file and a 50 GB
+ * dump. Corruption that preserves length — including a staging file that
+ * shrank between requests and was zero-filled back to the committed size by
+ * the next write's ftruncate — is not detected, the same trust pull's
+ * writer places in its local disk. The wire belongs to TLS and request
+ * authorization to the control plane's HMAC.
  *
  * Layout and state follow the pull importer's mechanics. Artifact bytes live
  * at their plain target-relative paths under files/ — no suffixes, so any
@@ -72,12 +63,13 @@
  *   Retrying an already-committed chunk is an idempotent no-op ("duplicate"),
  *   and every response carries committed_bytes so an out-of-sync uploader can
  *   resume at the right offset.
- * - Bytes become committed only after the chunk's CRC-32 matched. The data
- *   is flushed before the cursor record moves, so a crash mid-chunk leaves
- *   an uncommitted tail that the next write discards.
- * - finalize() re-hashes the assembled artifact and compares size and checksum
- *   before recording it in verified.jsonl; write_chunks() refuses verified
- *   artifacts.
+ * - Bytes become committed only after the chunk arrived at exactly its
+ *   declared length. The data is flushed before the cursor record moves, so
+ *   a crash mid-chunk leaves an uncommitted tail that the next write
+ *   discards.
+ * - finalize() compares the assembled size against the plan-declared total
+ *   before recording the artifact in verified.jsonl; write_chunks() refuses
+ *   verified artifacts.
  * - An artifact id is the files/-relative path the artifact will be applied
  *   from, mirroring the target tree — apply resolves artifacts by id, never
  *   by enumerating the staging directory. Ids with absolute, empty, "." or
@@ -117,22 +109,20 @@ final class Site_Export_Staged_Artifacts {
     /**
      * Stage one chunk of an artifact at the given offset.
      *
-     * @param string          $artifact_id     Opaque artifact identifier.
-     * @param int             $offset          Byte offset this chunk starts at.
-     * @param int             $length          Declared chunk length in bytes.
-     * @param string          $expected_crc32  Hex CRC-32 (crc32b) of the chunk body.
-     * @param resource|string $source          Chunk body, or a readable stream positioned at it.
+     * @param string          $artifact_id Opaque artifact identifier.
+     * @param int             $offset      Byte offset this chunk starts at.
+     * @param int             $length      Declared chunk length in bytes.
+     * @param resource|string $source      Chunk body, or a readable stream positioned at it.
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
      *   "rejected", and detail names the failing operation when the same
      *   reason can come from more than one place.
      */
-    public function write_chunk(string $artifact_id, int $offset, int $length, string $expected_crc32, $source): array {
+    public function write_chunk(string $artifact_id, int $offset, int $length, $source): array {
         return $this->write_chunks($artifact_id, [
             [
                 'offset' => $offset,
                 'length' => $length,
-                'expected_crc32' => $expected_crc32,
                 'source' => $source,
             ],
         ]);
@@ -156,7 +146,7 @@ final class Site_Export_Staged_Artifacts {
      * response's committed_bytes tells the sender where the next request
      * should resume.
      *
-     * @param iterable<int,array{offset:int,length:int,expected_crc32:string,source:resource|string}> $chunks
+     * @param iterable<int,array{offset:int,length:int,source:resource|string}> $chunks
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
      *   "rejected", and detail names the failing operation when the same
@@ -180,7 +170,7 @@ final class Site_Export_Staged_Artifacts {
 
             $verified = $this->read_verified();
             if (isset($verified[$artifact_id])) {
-                return $this->write_result('rejected', 'already_verified', $verified[$artifact_id]['size']);
+                return $this->write_result('rejected', 'already_verified', $verified[$artifact_id]);
             }
 
             // Sequential transfers: the cursor tracks one artifact. A write
@@ -218,8 +208,6 @@ final class Site_Export_Staged_Artifacts {
                     // before writing bytes.
                     $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
                     $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
-                    $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
-                    $expected_crc32 = strtolower($expected_crc32);
                     $source = $chunk['source'] ?? null;
 
                     if ($length < 1) {
@@ -227,9 +215,6 @@ final class Site_Export_Staged_Artifacts {
                     }
                     if ($offset < 0) {
                         return $this->write_result('rejected', 'invalid_offset', $committed);
-                    }
-                    if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
-                        return $this->write_result('rejected', 'invalid_hash', $committed);
                     }
                     if (is_string($source) && strlen($source) !== $length) {
                         return $this->write_result('rejected', 'length_mismatch', $committed);
@@ -249,9 +234,9 @@ final class Site_Export_Staged_Artifacts {
                         return $this->write_result('rejected', 'offset_gap', $committed);
                     }
 
-                    $copy_reason = $this->copy_and_hash($source, $file, $length, $expected_crc32);
+                    $copy_reason = $this->copy_source($source, $file, $length);
                     if ($copy_reason !== null) {
-                        // A failed copy/hash can leave bytes past the committed
+                        // A failed copy can leave bytes past the committed
                         // offset; trim them before the caller retries this chunk.
                         ftruncate($file, $committed);
                         return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
@@ -290,29 +275,25 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Verify the assembled artifact and record it as applyable.
+     * Confirm the assembled artifact against its declared size and record it
+     * as applyable.
      *
      * Idempotent: finalizing an already-verified artifact with the same size
-     * and checksum succeeds again.
+     * succeeds again.
      *
-     * $expected_crc32 must be the checksum declared when the transfer was
-     * planned, before any bytes moved. A checksum the sender computes while
-     * reading cannot catch a resume that mixed two versions of the source
-     * file — it would faithfully hash the mixed bytes.
+     * $expected_total_bytes is the size declared when the transfer was
+     * planned. The check never reads the artifact back, so it costs the same
+     * regardless of artifact size.
      *
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
      *   status "verified"|"busy"|"rejected"; path is set on "verified", and
      *   detail names the failing operation when the same reason can come
      *   from more than one place.
      */
-    public function finalize(string $artifact_id, int $expected_total_bytes, string $expected_crc32): array {
-        $expected_crc32 = strtolower($expected_crc32);
+    public function finalize(string $artifact_id, int $expected_total_bytes): array {
         $file_path = $this->artifact_path($artifact_id);
         if ($file_path === null) {
             return $this->finalize_result('rejected', 'invalid_artifact_id', 0);
-        }
-        if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
-            return $this->finalize_result('rejected', 'invalid_hash', 0);
         }
         if ($expected_total_bytes < 0) {
             return $this->finalize_result('rejected', 'invalid_total', 0);
@@ -330,12 +311,9 @@ final class Site_Export_Staged_Artifacts {
 
             $verified = $this->read_verified();
             if (isset($verified[$artifact_id])) {
-                $record = $verified[$artifact_id];
-                $same = $record['size'] === $expected_total_bytes
-                    && hash_equals($record['crc32'], $expected_crc32);
-                return $same
-                    ? $this->finalize_result('verified', null, $record['size'], null, $file_path)
-                    : $this->finalize_result('rejected', 'hash_mismatch', $record['size'], 'verified_record');
+                return $verified[$artifact_id] === $expected_total_bytes
+                    ? $this->finalize_result('verified', null, $verified[$artifact_id], null, $file_path)
+                    : $this->finalize_result('rejected', 'size_mismatch', $verified[$artifact_id], 'verified_record');
             }
 
             $state = $this->read_state();
@@ -360,25 +338,14 @@ final class Site_Export_Staged_Artifacts {
             if ($file === false) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'open_artifact_file');
             }
-            // Drop any uncommitted tail so the checksum covers committed bytes only.
+            // Drop any uncommitted tail so the artifact holds committed bytes only.
             $truncated = ftruncate($file, $committed);
             fclose($file);
             if (!$truncated) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
             }
 
-            // Reading through a second handle without locking the artifact
-            // file is safe: every writer serializes on the store lock held
-            // here.
-            $actual_crc32 = hash_file('crc32b', $file_path);
-            if ($actual_crc32 === false) {
-                return $this->finalize_result('rejected', 'io_error', $committed, 'artifact_crc32');
-            }
-            if (!hash_equals($expected_crc32, $actual_crc32)) {
-                return $this->finalize_result('rejected', 'hash_mismatch', $committed, 'artifact_crc32');
-            }
-
-            if (!$this->append_verified($artifact_id, $expected_total_bytes, $expected_crc32)) {
+            if (!$this->append_verified($artifact_id, $expected_total_bytes)) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'persist_verified_record');
             }
             if ($state['artifact_id'] === $artifact_id) {
@@ -416,7 +383,7 @@ final class Site_Export_Staged_Artifacts {
         if (isset($verified[$artifact_id])) {
             return [
                 'exists' => file_exists($file_path),
-                'committed_bytes' => $verified[$artifact_id]['size'],
+                'committed_bytes' => $verified[$artifact_id],
                 'verified' => true,
             ];
         }
@@ -477,15 +444,13 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Copies exactly $length bytes to the artifact file while hashing the
-     * same bytes that landed on disk.
+     * Copies exactly $length bytes from the source to the artifact file.
      *
      * @param resource|string $source
      * @return string|null Rejection reason, or null when $length bytes were
-     *                     copied and their checksum matched.
+     *                     copied.
      */
-    private function copy_and_hash($source, $file, int $length, string $expected_crc32): ?string {
-        $context = hash_init('crc32b');
+    private function copy_source($source, $file, int $length): ?string {
         $remaining = $length;
 
         while ($remaining > 0) {
@@ -500,15 +465,10 @@ final class Site_Export_Staged_Artifacts {
                 }
             }
 
-            hash_update($context, $buffer);
             if (fwrite($file, $buffer) !== strlen($buffer)) {
                 return 'io_error';
             }
             $remaining -= strlen($buffer);
-        }
-
-        if (!hash_equals($expected_crc32, hash_final($context))) {
-            return 'hash_mismatch';
         }
 
         return null;
@@ -517,8 +477,8 @@ final class Site_Export_Staged_Artifacts {
     /**
      * Consumes exactly $length bytes from a duplicate chunk stream.
      *
-     * Duplicate chunks are not written or re-hashed, but a batched upload may
-     * be reading consecutive chunk bodies from one request stream. Draining
+     * Duplicate chunks are not re-written, but a batched upload may be
+     * reading consecutive chunk bodies from one request stream. Draining
      * keeps the parser aligned for the next chunk.
      *
      * @param resource|string $source
@@ -635,12 +595,13 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Reads the verified-artifact records, keyed by artifact id.
+     * Reads the verified-artifact records: artifact id to verified size.
      *
      * Malformed lines — a tail torn by a crash mid-append — are skipped, so
-     * the worst case is re-verifying an artifact, never trusting a torn record.
+     * the worst case is re-finalizing an artifact, never trusting a torn
+     * record.
      *
-     * @return array<string,array{size:int,crc32:string}>
+     * @return array<string,int>
      */
     private function read_verified(): array {
         $raw = @file_get_contents($this->verified_path);
@@ -656,23 +617,18 @@ final class Site_Export_Staged_Artifacts {
                 || !is_string($record['artifact_id'] ?? null)
                 || !is_int($record['size'] ?? null)
                 || $record['size'] < 0
-                || !is_string($record['crc32'] ?? null)
             ) {
                 continue;
             }
-            $records[$record['artifact_id']] = [
-                'size' => $record['size'],
-                'crc32' => $record['crc32'],
-            ];
+            $records[$record['artifact_id']] = $record['size'];
         }
         return $records;
     }
 
-    private function append_verified(string $artifact_id, int $size, string $crc32): bool {
+    private function append_verified(string $artifact_id, int $size): bool {
         $line = json_encode([
             'artifact_id' => $artifact_id,
             'size' => $size,
-            'crc32' => $crc32,
         ]) . "\n";
         return @file_put_contents($this->verified_path, $line, FILE_APPEND) === strlen($line);
     }
@@ -685,11 +641,10 @@ final class Site_Export_Staged_Artifacts {
         unset($records[$artifact_id]);
 
         $lines = '';
-        foreach ($records as $id => $record) {
+        foreach ($records as $id => $size) {
             $lines .= json_encode([
                 'artifact_id' => $id,
-                'size' => $record['size'],
-                'crc32' => $record['crc32'],
+                'size' => $size,
             ]) . "\n";
         }
         $tmp_path = $this->verified_path . '.tmp';

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -510,13 +510,14 @@ final class Site_Export_Staged_Artifacts {
      * Remove all staged data and records for an artifact. Safe to call for
      * unknown ids.
      *
-     * Retry until true: a discard killed between its unlink and record
-     * updates leaves a partial state that only another discard fully
-     * cleans up. Every partial state is retriable.
+     * Retry until true: a discard killed between its steps — or stopped by
+     * a failing one — leaves a partial state that only another discard
+     * fully cleans up. Every partial state is retriable.
      *
-     * @return bool False when a concurrent writer holds the store — an
+     * @return bool False when a concurrent writer holds the store (an
      *              unguarded unlink would let that writer's commit resurrect
-     *              a discarded artifact.
+     *              a discarded artifact) or when a cleanup step failed and
+     *              staged data remains.
      */
     public function discard(string $artifact_id): bool {
         $file_path = $this->artifact_path($artifact_id);
@@ -524,14 +525,13 @@ final class Site_Export_Staged_Artifacts {
             return true;
         }
 
-        // Discarding an artifact nothing knows about is a no-op and must not
-        // create the staging scaffolding as a side effect.
-        $state = $this->read_state();
-        if (
-            !file_exists($file_path)
-            && $state['artifact_id'] !== $artifact_id
-            && !isset($this->read_verified()[$artifact_id])
-        ) {
+        // A missing staging directory proves nothing is staged and no writer
+        // is mid-step, so this one no-op may skip locking (open_lock() would
+        // create the scaffolding as a side effect). Every other check belongs
+        // under the lock: a first append can be in flight with no trace on
+        // disk yet, and its commit would resurrect an artifact this call just
+        // reported discarded.
+        if (!is_dir(dirname($this->lock_path))) {
             return true;
         }
 
@@ -544,13 +544,14 @@ final class Site_Export_Staged_Artifacts {
                 return false;
             }
 
-            @unlink($file_path);
-            $state = $this->read_state();
-            if ($state['artifact_id'] === $artifact_id) {
-                $this->write_state(null, 0);
+            if (file_exists($file_path) && !@unlink($file_path)) {
+                return false;
             }
-            $this->remove_verified($artifact_id);
-            return true;
+            $state = $this->read_state();
+            if ($state['artifact_id'] === $artifact_id && !$this->write_state(null, 0)) {
+                return false;
+            }
+            return $this->remove_verified($artifact_id);
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -691,10 +692,10 @@ final class Site_Export_Staged_Artifacts {
         return @file_put_contents($this->verified_path, $line, FILE_APPEND) === strlen($line);
     }
 
-    private function remove_verified(string $artifact_id): void {
+    private function remove_verified(string $artifact_id): bool {
         $records = $this->read_verified();
         if (!isset($records[$artifact_id])) {
-            return;
+            return true;
         }
         unset($records[$artifact_id]);
 
@@ -708,6 +709,8 @@ final class Site_Export_Staged_Artifacts {
         $tmp_path = $this->verified_path . '.tmp';
         if (@file_put_contents($tmp_path, $lines) !== strlen($lines) || !@rename($tmp_path, $this->verified_path)) {
             @unlink($tmp_path);
+            return false;
         }
+        return true;
     }
 }

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -826,6 +826,4 @@ final class Site_Export_Staged_Artifacts {
             @unlink($tmp_path);
         }
     }
-
-
 }

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -21,16 +21,27 @@
  * local directory but not for a web-served tree — so nothing here is
  * upload-specific: sequential offsets match pull's byte-offset resume model.
  *
- * Integrity checks are byte counts, the same discipline pull uses: every
- * chunk must supply exactly its declared length, and finalize() compares the
- * assembled size against the total declared at plan time. That catches
- * truncation, missing chunks, and resume-offset bugs; it does not read the
- * artifact back, so finalize() costs the same for a 1 KB file and a 50 GB
- * dump. Corruption that preserves length — including a staging file that
- * shrank between requests and was zero-filled back to the committed size by
- * the next write's ftruncate — is not detected, the same trust pull's
- * writer places in its local disk. The wire belongs to TLS and request
- * authorization to the control plane's HMAC.
+ * The caller drives the loop, matching the streaming producers: where a
+ * reader calls next_chunk() until the producer is done, a sender calls
+ * append() once per buffer it read, and the store performs exactly one
+ * bounded, individually-committed step per call. Nothing is held between
+ * calls, so the transfer can stop after any step and resume from
+ * committed_bytes — in the next request, the next process, or a test that
+ * stops the loop at a chosen iteration. Stopping inside a step leaves an
+ * uncommitted tail the next append truncates away. Reading the request
+ * body, sizing buffers, and skipping bytes the store reports as duplicate
+ * all belong to the caller's loop.
+ *
+ * Integrity checks are byte counts, the same discipline pull uses: an
+ * append is accepted only at the committed offset and only whole, and
+ * finalize() compares the assembled size against the total declared at plan
+ * time. That catches truncation, missing bytes, and resume-offset bugs; it
+ * does not read the artifact back, so finalize() costs the same for a 1 KB
+ * file and a 50 GB dump. Corruption that preserves length — including a
+ * staging file that shrank between requests and was zero-filled back to the
+ * committed size by the next append's ftruncate — is not detected, the same
+ * trust pull's writer places in its local disk. The wire belongs to TLS and
+ * request authorization to the control plane's HMAC.
  *
  * Layout and state follow the pull importer's mechanics. Artifact bytes live
  * at their plain target-relative paths under files/ — no suffixes, so any
@@ -46,29 +57,28 @@
  * re-uploading from offset 0. Senders must finish or discard one artifact
  * before starting the next; interleaving two uploads is not supported.
  *
- * Locking: every mutator — write_chunks(), finalize(), discard() — holds one
- * exclusive non-blocking flock on the lock file for its whole call, so a
- * batch keeps the store to itself from its first chunk to its last. This is
- * not for parallelism (transfers are sequential); it exists so a retry
- * racing its timed-out predecessor gets "busy" instead of interleaving
- * writes. The lock needs its own never-replaced file: state.json commits by
- * rename, and renaming a locked file strands the held flock on the orphaned
- * inode while the next opener locks the fresh one. Readers stay lock-free —
- * state.json is rename-atomic, verified.jsonl is append-only, and
- * committed_bytes only grows — so status() always reads a safe resume hint.
+ * Locking: every mutator — append(), finalize(), discard() — holds one
+ * exclusive non-blocking flock on the lock file for its single step and
+ * releases it before returning. This is not for parallelism (transfers are
+ * sequential); it exists so a retry racing its timed-out predecessor gets
+ * "busy" instead of interleaving writes. The lock needs its own
+ * never-replaced file: state.json commits by rename, and renaming a locked
+ * file strands the held flock on the orphaned inode while the next opener
+ * locks the fresh one. Readers stay lock-free — state.json is rename-atomic,
+ * verified.jsonl is append-only, and committed_bytes only grows — so
+ * status() always reads a safe resume hint.
  *
  * Contract:
  *
- * - Chunks are sequential. A chunk is accepted only at the committed offset.
- *   Retrying an already-committed chunk is an idempotent no-op ("duplicate"),
- *   and every response carries committed_bytes so an out-of-sync uploader can
- *   resume at the right offset.
- * - Bytes become committed only after the chunk arrived at exactly its
- *   declared length. The data is flushed before the cursor record moves, so
- *   a crash mid-chunk leaves an uncommitted tail that the next write
- *   discards.
+ * - Appends are sequential: a buffer is accepted only at the committed
+ *   offset, whole or not at all. Re-sending already-committed bytes is an
+ *   idempotent no-op ("duplicate"), and every response carries
+ *   committed_bytes so an out-of-sync sender can resume at the right offset.
+ * - Bytes become committed only after they are flushed and the cursor
+ *   record moved, in that order — a crash mid-step leaves an uncommitted
+ *   tail that the next append discards.
  * - finalize() compares the assembled size against the plan-declared total
- *   before recording the artifact in verified.jsonl; write_chunks() refuses
+ *   before recording the artifact in verified.jsonl; append() refuses
  *   verified artifacts.
  * - An artifact id is the files/-relative path the artifact will be applied
  *   from, mirroring the target tree — apply resolves artifacts by id, never
@@ -77,14 +87,12 @@
  *   importer's fs-root path rule, which tolerates backslashes and empty
  *   segments.
  *
- * The endpoint owns authentication and request-size limits. It must also
- * place the staging directory outside the web-served tree, and preferably on
- * the same filesystem as the apply target so the apply step can move
- * verified artifacts with an atomic rename().
+ * The endpoint owns authentication, request-size limits, and buffer sizing.
+ * It must also place the staging directory outside the web-served tree, and
+ * preferably on the same filesystem as the apply target so the apply step
+ * can move verified artifacts with an atomic rename().
  */
 final class Site_Export_Staged_Artifacts {
-
-    private const WRITE_BUFFER_BYTES = 262144;
 
     /** @var string */
     private $files_dir;
@@ -107,57 +115,44 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Stage one chunk of an artifact at the given offset.
+     * Append one caller-provided buffer at the committed offset.
      *
-     * @param string          $artifact_id Opaque artifact identifier.
-     * @param int             $offset      Byte offset this chunk starts at.
-     * @param int             $length      Declared chunk length in bytes.
-     * @param resource|string $source      Chunk body, or a readable stream positioned at it.
+     * One call is one reentrant step: validate, lock, write the whole
+     * buffer, flush, move the cursor, unlock. The caller's loop reads its
+     * source and sizes the buffers; a "duplicate" response means these
+     * bytes are already committed and the caller should skip forward in
+     * its own source and continue from committed_bytes.
+     *
+     * @param string $artifact_id Opaque artifact identifier.
+     * @param int    $offset      Byte offset this buffer starts at.
+     * @param string $bytes       The buffer to append.
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
      *   "rejected", and detail names the failing operation when the same
      *   reason can come from more than one place.
      */
-    public function write_chunk(string $artifact_id, int $offset, int $length, $source): array {
-        return $this->write_chunks($artifact_id, [
-            [
-                'offset' => $offset,
-                'length' => $length,
-                'source' => $source,
-            ],
-        ]);
-    }
-
-    /**
-     * Stage consecutive chunks from one request while keeping the artifact
-     * file open and the store locked.
-     *
-     * The upload endpoint can pass a generator that yields parsed chunks from
-     * php://input, so a 100- or 1000-chunk request pays the open/flock/tail
-     * cleanup cost once while still committing each chunk independently for
-     * crash-safe resume.
-     *
-     * Because chunks commit one by one, a mid-batch rejection loses nothing:
-     * committed_bytes reports the durable progress made before the bad chunk,
-     * and the sender resumes from there.
-     *
-     * The iterable is also the pause point: a generator can simply stop
-     * yielding when the endpoint's resource budget runs out, and the
-     * response's committed_bytes tells the sender where the next request
-     * should resume.
-     *
-     * @param iterable<int,array{offset:int,length:int,source:resource|string}> $chunks
-     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
-     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
-     *   "rejected", and detail names the failing operation when the same
-     *   reason can come from more than one place.
-     */
-    public function write_chunks(string $artifact_id, iterable $chunks): array {
+    public function append(string $artifact_id, int $offset, string $bytes): array {
         $file_path = $this->artifact_path($artifact_id);
         if ($file_path === null) {
             return [
                 'status' => 'rejected',
                 'reason' => 'invalid_artifact_id',
+                'detail' => null,
+                'committed_bytes' => 0,
+            ];
+        }
+        if ($offset < 0) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_offset',
+                'detail' => null,
+                'committed_bytes' => 0,
+            ];
+        }
+        if ($bytes === '') {
+            return [
+                'status' => 'rejected',
+                'reason' => 'empty_body',
                 'detail' => null,
                 'committed_bytes' => 0,
             ];
@@ -193,10 +188,27 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            // Sequential transfers: the cursor tracks one artifact. A write
-            // to any other artifact starts it from scratch.
+            // Sequential transfers: the cursor tracks one artifact. An
+            // append to any other artifact starts it from scratch.
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            if ($offset + strlen($bytes) <= $committed) {
+                return [
+                    'status' => 'duplicate',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                ];
+            }
+            if ($offset !== $committed) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'offset_gap',
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                ];
+            }
 
             if (!$this->ensure_parent_dir($file_path)) {
                 return [
@@ -221,7 +233,7 @@ final class Site_Export_Staged_Artifacts {
 
             try {
                 // Discard any uncommitted tail from an interrupted earlier
-                // write, then append at the only offset the cursor says is
+                // step, then append at the only offset the cursor says is
                 // committed.
                 if (!ftruncate($file, $committed) || fseek($file, $committed) !== 0) {
                     return [
@@ -232,133 +244,45 @@ final class Site_Export_Staged_Artifacts {
                     ];
                 }
 
-                $accepted = false;
-                $duplicate = false;
-                foreach ($chunks as $chunk) {
-                    // These parameters arrive verbatim from a remote client's
-                    // request, and the sequencing/copy logic below assumes they
-                    // are well-formed — a negative offset would misreport as
-                    // "duplicate" success and a short string body would never
-                    // finish copying. Reject malformed input with typed reasons
-                    // before writing bytes.
-                    $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
-                    $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
-                    $source = $chunk['source'] ?? null;
-
-                    if ($length < 1) {
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'invalid_length',
-                            'detail' => null,
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-                    if ($offset < 0) {
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'invalid_offset',
-                            'detail' => null,
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-                    if (is_string($source) && strlen($source) !== $length) {
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'length_mismatch',
-                            'detail' => null,
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-                    if (!is_string($source) && !is_resource($source)) {
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'invalid_source',
-                            'detail' => null,
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-                    if ($offset + $length <= $committed) {
-                        $drain_reason = $this->drain_source($source, $length);
-                        if ($drain_reason !== null) {
-                            return [
-                                'status' => 'rejected',
-                                'reason' => $drain_reason,
-                                'detail' => 'duplicate_drain',
-                                'committed_bytes' => $committed,
-                            ];
-                        }
-                        $duplicate = true;
-                        continue;
-                    }
-                    if ($offset !== $committed) {
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'offset_gap',
-                            'detail' => null,
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-
-                    $copy_reason = $this->copy_source($source, $file, $length);
-                    if ($copy_reason !== null) {
-                        // A failed copy can leave bytes past the committed
-                        // offset; trim them before the caller retries this chunk.
-                        ftruncate($file, $committed);
-                        return [
-                            'status' => 'rejected',
-                            'reason' => $copy_reason,
-                            'detail' => 'chunk_body',
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-
-                    // The data is flushed before the cursor record moves: a crash
-                    // between the two leaves a tail that the next write truncates.
-                    if (!fflush($file)) {
-                        ftruncate($file, $committed);
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'io_error',
-                            'detail' => 'flush_chunk_body',
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-
-                    if (!$this->write_state($artifact_id, $committed + $length)) {
-                        ftruncate($file, $committed);
-                        return [
-                            'status' => 'rejected',
-                            'reason' => 'io_error',
-                            'detail' => 'persist_cursor',
-                            'committed_bytes' => $committed,
-                        ];
-                    }
-
-                    $committed += $length;
-                    $accepted = true;
-                }
-
-                if ($accepted) {
+                if (fwrite($file, $bytes) !== strlen($bytes)) {
+                    // A partial write leaves bytes past the committed offset;
+                    // trim them before the caller retries this step.
+                    ftruncate($file, $committed);
                     return [
-                        'status' => 'accepted',
-                        'reason' => null,
-                        'detail' => null,
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'write_body',
                         'committed_bytes' => $committed,
                     ];
                 }
-                if ($duplicate) {
+
+                // The data is flushed before the cursor record moves: a crash
+                // between the two leaves a tail that the next append truncates.
+                if (!fflush($file)) {
+                    ftruncate($file, $committed);
                     return [
-                        'status' => 'duplicate',
-                        'reason' => null,
-                        'detail' => null,
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'flush_body',
                         'committed_bytes' => $committed,
                     ];
                 }
+
+                if (!$this->write_state($artifact_id, $committed + strlen($bytes))) {
+                    ftruncate($file, $committed);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'persist_cursor',
+                        'committed_bytes' => $committed,
+                    ];
+                }
+
                 return [
-                    'status' => 'rejected',
-                    'reason' => 'empty_batch',
+                    'status' => 'accepted',
+                    'reason' => null,
                     'detail' => null,
-                    'committed_bytes' => $committed,
+                    'committed_bytes' => $committed + strlen($bytes),
                 ];
             } finally {
                 fclose($file);
@@ -452,7 +376,7 @@ final class Site_Export_Staged_Artifacts {
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
 
             if (!file_exists($file_path)) {
-                // A zero-byte artifact legitimately has no chunks; the fopen
+                // A zero-byte artifact legitimately has no appends; the fopen
                 // below creates its empty file.
                 if ($expected_total_bytes > 0) {
                     return [
@@ -518,7 +442,7 @@ final class Site_Export_Staged_Artifacts {
             }
             if ($state['artifact_id'] === $artifact_id) {
                 // Best effort: a stale cursor is harmless once the verified
-                // record exists — already_verified wins on the next write.
+                // record exists — already_verified wins on the next append.
                 $this->write_state(null, 0);
             }
 
@@ -615,65 +539,6 @@ final class Site_Export_Staged_Artifacts {
             flock($lock, LOCK_UN);
             fclose($lock);
         }
-    }
-
-    /**
-     * Copies exactly $length bytes from the source to the artifact file.
-     *
-     * @param resource|string $source
-     * @return string|null Rejection reason, or null when $length bytes were
-     *                     copied.
-     */
-    private function copy_source($source, $file, int $length): ?string {
-        $remaining = $length;
-
-        while ($remaining > 0) {
-            // Read in bounded buffers so string and stream sources share the
-            // same write path without materializing a large stream body.
-            if (is_string($source)) {
-                $buffer = substr($source, $length - $remaining, min($remaining, self::WRITE_BUFFER_BYTES));
-            } else {
-                $buffer = fread($source, min($remaining, self::WRITE_BUFFER_BYTES));
-                if ($buffer === false || $buffer === '') {
-                    return 'short_body';
-                }
-            }
-
-            if (fwrite($file, $buffer) !== strlen($buffer)) {
-                return 'io_error';
-            }
-            $remaining -= strlen($buffer);
-        }
-
-        return null;
-    }
-
-    /**
-     * Consumes exactly $length bytes from a duplicate chunk stream.
-     *
-     * Duplicate chunks are not re-written, but a batched upload may be
-     * reading consecutive chunk bodies from one request stream. Draining
-     * keeps the parser aligned for the next chunk.
-     *
-     * @param resource|string $source
-     * @return string|null Rejection reason, or null when there is no stream
-     *                     body left for this store to consume.
-     */
-    private function drain_source($source, int $length): ?string {
-        if (is_string($source)) {
-            return null;
-        }
-
-        $remaining = $length;
-        while ($remaining > 0) {
-            $buffer = fread($source, min($remaining, self::WRITE_BUFFER_BYTES));
-            if ($buffer === false || $buffer === '') {
-                return 'short_body';
-            }
-            $remaining -= strlen($buffer);
-        }
-
-        return null;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -354,6 +354,18 @@ final class Site_Export_Staged_Artifacts {
 
             $verified = $this->read_verified();
             if (isset($verified[$artifact_id])) {
+                // The record can outlive the file — a discard killed between
+                // its steps, or external cleanup. There is nothing left to
+                // apply, so verified must not be re-affirmed.
+                if (!file_exists($file_path)) {
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'missing',
+                        'detail' => 'verified_record',
+                        'committed_bytes' => $verified[$artifact_id],
+                        'path' => null,
+                    ];
+                }
                 if ($verified[$artifact_id] === $expected_total_bytes) {
                     return [
                         'status' => 'verified',
@@ -497,6 +509,10 @@ final class Site_Export_Staged_Artifacts {
     /**
      * Remove all staged data and records for an artifact. Safe to call for
      * unknown ids.
+     *
+     * Retry until true: a discard killed between its unlink and record
+     * updates leaves a partial state that only another discard fully
+     * cleans up. Every partial state is retriable.
      *
      * @return bool False when a concurrent writer holds the store — an
      *              unguarded unlink would let that writer's commit resurrect
@@ -665,7 +681,10 @@ final class Site_Export_Staged_Artifacts {
     }
 
     private function append_verified(string $artifact_id, int $size): bool {
-        $line = json_encode([
+        // The leading newline seals any torn tail a killed writer left
+        // behind onto its own (skipped) line, so this record stays
+        // parseable. Blank lines between records are skipped on read.
+        $line = "\n" . json_encode([
             'artifact_id' => $artifact_id,
             'size' => $size,
         ]) . "\n";

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -46,8 +46,13 @@
  * Layout and state follow the pull importer's mechanics. Artifact bytes live
  * at their plain target-relative paths under files/ — no suffixes, so any
  * name a site can contain stages verbatim — and progress lives outside the
- * mirror: state.json holds the cursor for the single in-flight artifact and
- * verified.jsonl appends one line per artifact finalize() accepted.
+ * mirror: state.json holds the cursor for the single in-flight artifact,
+ * and each artifact finalize() accepted has a marker at the same relative
+ * path under verified/, holding the verified size. Markers, not a shared
+ * log, because the already-verified check runs on every append: one stat
+ * per call no matter how many artifacts a transfer has finished, where a
+ * log would be re-read and re-parsed in full each time and a 50k-file
+ * push would spend its appends parsing it.
  *
  * Transfers are sequential, like pull: progress is tracked for one artifact
  * at a time — the one currently being uploaded. That artifact can be
@@ -64,9 +69,9 @@
  * "busy" instead of interleaving writes. The lock needs its own
  * never-replaced file: state.json commits by rename, and renaming a locked
  * file strands the held flock on the orphaned inode while the next opener
- * locks the fresh one. Readers stay lock-free — state.json is rename-atomic,
- * verified.jsonl is append-only, and committed_bytes only grows — so
- * status() always reads a safe resume hint.
+ * locks the fresh one. Readers stay lock-free — state.json and verified
+ * markers appear whole or not at all (both commit by rename), and
+ * committed_bytes only grows — so status() always reads a safe resume hint.
  *
  * Contract:
  *
@@ -78,7 +83,7 @@
  *   record moved, in that order — a crash mid-step leaves an uncommitted
  *   tail that the next append discards.
  * - finalize() compares the assembled size against the plan-declared total
- *   before recording the artifact in verified.jsonl; append() refuses
+ *   before writing the artifact's verified marker; append() refuses
  *   verified artifacts.
  * - An artifact id is the files/-relative path the artifact will be applied
  *   from, mirroring the target tree — apply resolves artifacts by id, never
@@ -101,7 +106,10 @@ final class Site_Export_Staged_Artifacts {
     private $state_path;
 
     /** @var string */
-    private $verified_path;
+    private $verified_dir;
+
+    /** @var string */
+    private $verified_tmp_path;
 
     /** @var string */
     private $lock_path;
@@ -110,7 +118,12 @@ final class Site_Export_Staged_Artifacts {
         $base = rtrim($staging_dir, '/');
         $this->files_dir = $base . '/files';
         $this->state_path = $base . '/state.json';
-        $this->verified_path = $base . '/verified.jsonl';
+        $this->verified_dir = $base . '/verified';
+        // One reusable temp file, outside verified/: a marker's own ".tmp"
+        // sibling would collide with the marker of an artifact actually
+        // named that way. Marker writes happen under the lock, so a single
+        // temp path cannot race itself.
+        $this->verified_tmp_path = $base . '/verified.tmp';
         $this->lock_path = $base . '/lock';
     }
 
@@ -178,13 +191,13 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            $verified = $this->read_verified();
-            if (isset($verified[$artifact_id])) {
+            $verified_size = $this->read_verified_size($artifact_id);
+            if ($verified_size !== null) {
                 return [
                     'status' => 'rejected',
                     'reason' => 'already_verified',
                     'detail' => null,
-                    'committed_bytes' => $verified[$artifact_id],
+                    'committed_bytes' => $verified_size,
                 ];
             }
 
@@ -352,8 +365,8 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            $verified = $this->read_verified();
-            if (isset($verified[$artifact_id])) {
+            $verified_size = $this->read_verified_size($artifact_id);
+            if ($verified_size !== null) {
                 // The record can outlive the file — a discard killed between
                 // its steps, or external cleanup. There is nothing left to
                 // apply, so verified must not be re-affirmed.
@@ -362,16 +375,16 @@ final class Site_Export_Staged_Artifacts {
                         'status' => 'rejected',
                         'reason' => 'missing',
                         'detail' => 'verified_record',
-                        'committed_bytes' => $verified[$artifact_id],
+                        'committed_bytes' => $verified_size,
                         'path' => null,
                     ];
                 }
-                if ($verified[$artifact_id] === $expected_total_bytes) {
+                if ($verified_size === $expected_total_bytes) {
                     return [
                         'status' => 'verified',
                         'reason' => null,
                         'detail' => null,
-                        'committed_bytes' => $verified[$artifact_id],
+                        'committed_bytes' => $verified_size,
                         'path' => $file_path,
                     ];
                 }
@@ -379,7 +392,7 @@ final class Site_Export_Staged_Artifacts {
                     'status' => 'rejected',
                     'reason' => 'size_mismatch',
                     'detail' => 'verified_record',
-                    'committed_bytes' => $verified[$artifact_id],
+                    'committed_bytes' => $verified_size,
                     'path' => null,
                 ];
             }
@@ -443,7 +456,7 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            if (!$this->append_verified($artifact_id, $expected_total_bytes)) {
+            if (!$this->write_verified_marker($artifact_id, $expected_total_bytes)) {
                 return [
                     'status' => 'rejected',
                     'reason' => 'io_error',
@@ -489,11 +502,11 @@ final class Site_Export_Staged_Artifacts {
             ];
         }
 
-        $verified = $this->read_verified();
-        if (isset($verified[$artifact_id])) {
+        $verified_size = $this->read_verified_size($artifact_id);
+        if ($verified_size !== null) {
             return [
                 'exists' => file_exists($file_path),
-                'committed_bytes' => $verified[$artifact_id],
+                'committed_bytes' => $verified_size,
                 'verified' => true,
             ];
         }
@@ -551,7 +564,7 @@ final class Site_Export_Staged_Artifacts {
             if ($state['artifact_id'] === $artifact_id && !$this->write_state(null, 0)) {
                 return false;
             }
-            return $this->remove_verified($artifact_id);
+            return $this->remove_verified_marker($artifact_id);
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -651,66 +664,53 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Reads the verified-artifact records: artifact id to verified size.
-     *
-     * Malformed lines — a tail torn by a crash mid-append — are skipped, so
-     * the worst case is re-finalizing an artifact, never trusting a torn
-     * record.
-     *
-     * @return array<string,int>
+     * The verified marker mirrors the artifact's relative path under
+     * verified/, so lookup is one stat regardless of transfer size.
      */
-    private function read_verified(): array {
-        $raw = @file_get_contents($this->verified_path);
-        if ($raw === false || $raw === '') {
-            return [];
-        }
-
-        $records = [];
-        foreach (explode("\n", $raw) as $line) {
-            $record = json_decode($line, true);
-            if (
-                !is_array($record)
-                || !is_string($record['artifact_id'] ?? null)
-                || !is_int($record['size'] ?? null)
-                || $record['size'] < 0
-            ) {
-                continue;
-            }
-            $records[$record['artifact_id']] = $record['size'];
-        }
-        return $records;
+    private function verified_marker_path(string $artifact_id): string {
+        return $this->verified_dir . '/' . $artifact_id;
     }
 
-    private function append_verified(string $artifact_id, int $size): bool {
-        // The leading newline seals any torn tail a killed writer left
-        // behind onto its own (skipped) line, so this record stays
-        // parseable. Blank lines between records are skipped on read.
-        $line = "\n" . json_encode([
-            'artifact_id' => $artifact_id,
-            'size' => $size,
-        ]) . "\n";
-        return @file_put_contents($this->verified_path, $line, FILE_APPEND) === strlen($line);
+    /**
+     * Reads an artifact's verified size, or null when it is not verified.
+     *
+     * A malformed marker — torn by a crash, since markers commit by rename
+     * this means external interference — reads as not verified, so the
+     * worst case is re-finalizing an artifact, never trusting a torn record.
+     */
+    private function read_verified_size(string $artifact_id): ?int {
+        $raw = @file_get_contents($this->verified_marker_path($artifact_id));
+        if ($raw === false) {
+            return null;
+        }
+        $record = json_decode($raw, true);
+        if (!is_array($record) || !is_int($record['size'] ?? null) || $record['size'] < 0) {
+            return null;
+        }
+        return $record['size'];
     }
 
-    private function remove_verified(string $artifact_id): bool {
-        $records = $this->read_verified();
-        if (!isset($records[$artifact_id])) {
-            return true;
+    private function write_verified_marker(string $artifact_id, int $size): bool {
+        $marker_path = $this->verified_marker_path($artifact_id);
+        if (!$this->ensure_parent_dir($marker_path)) {
+            return false;
         }
-        unset($records[$artifact_id]);
-
-        $lines = '';
-        foreach ($records as $id => $size) {
-            $lines .= json_encode([
-                'artifact_id' => $id,
-                'size' => $size,
-            ]) . "\n";
+        $json = json_encode(['size' => $size]);
+        // Same discipline as the cursor: a short write (disk full) must
+        // never become a marker, so write whole to the temp file and rename.
+        if (@file_put_contents($this->verified_tmp_path, $json) !== strlen($json)) {
+            @unlink($this->verified_tmp_path);
+            return false;
         }
-        $tmp_path = $this->verified_path . '.tmp';
-        if (@file_put_contents($tmp_path, $lines) !== strlen($lines) || !@rename($tmp_path, $this->verified_path)) {
-            @unlink($tmp_path);
+        if (!@rename($this->verified_tmp_path, $marker_path)) {
+            @unlink($this->verified_tmp_path);
             return false;
         }
         return true;
+    }
+
+    private function remove_verified_marker(string $artifact_id): bool {
+        $marker_path = $this->verified_marker_path($artifact_id);
+        return !file_exists($marker_path) || @unlink($marker_path);
     }
 }

--- a/packages/reprint-importer/src/lib/upload/class-upload-chunk-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-upload-chunk-sizer.php
@@ -89,6 +89,8 @@ class UploadChunkSizer
         $config["growth_holdoff_successes"] = max(0, (int) $config["growth_holdoff_successes"]);
         $this->config = $config;
 
+        // Persisted state may come from an older config or version; clamp it
+        // through the current floor, ceiling, and hard cap before resuming.
         $ceiling = $state["ceiling_bytes"] ?? null;
         $this->ceiling_bytes = is_numeric($ceiling) && (int) $ceiling > 0 ? (int) $ceiling : null;
         $this->chunk_bytes = $this->clamp_chunk(
@@ -133,6 +135,8 @@ class UploadChunkSizer
             return $this->decision("steady");
         }
 
+        // Limits only lower the ceiling; a later, higher preflight value
+        // cannot erase a smaller limit learned earlier in the session.
         return $this->lower_ceiling((int) ($smallest * $this->config["limit_safety_ratio"]));
     }
 
@@ -225,6 +229,9 @@ class UploadChunkSizer
     }
 
     /**
+     * Lowers the learned per-session ceiling and shrinks the current chunk
+     * when it no longer fits.
+     *
      * @return array{action:string,chunk_bytes:int}
      */
     private function lower_ceiling(int $ceiling): array
@@ -246,11 +253,18 @@ class UploadChunkSizer
         return $this->decision("shrink");
     }
 
+    /**
+     * Returns the active ceiling after applying the unconditional hard cap.
+     */
     private function effective_ceiling(): int
     {
         return min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]);
     }
 
+    /**
+     * Normalizes restored state without converting an already-impossible
+     * ceiling into an invalid chunk size.
+     */
     private function clamp_chunk(int $chunk_bytes): int
     {
         return max(

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,18 +358,20 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-push/staged-artifact-batches",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
+                "reference": "4299e8cbe30ddce21de036bcef579a2e5d40159e"
             },
             "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
                 "php": ">=7.4",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
+            },
+            "suggest": {
+                "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+                "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
             },
             "type": "library",
             "autoload": {
@@ -382,10 +384,13 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
-                    "src/class-sqlite-driver-pdo.php"
+                    "src/class-staged-artifacts.php",
+                    "src/class-sqlite-driver-pdo.php",
+                    "src/class-wpdb-driver-pdo.php"
                 ],
                 "files": [
-                    "src/utils.php"
+                    "src/utils.php",
+                    "src/class-pdo-polyfill.php"
                 ]
             },
             "license": [

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -520,6 +520,25 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
     }
 
+    public function testDiscardOfAnUntracedArtifactRespectsTheWriterLock(): void
+    {
+        $store = $this->makeStore();
+        $store->append('other-artifact', 0, 'xx');
+
+        // The first append for artifact-1 is in flight: it holds the lock
+        // but has not yet created the file or moved the cursor. A discard
+        // that answered true here would be contradicted by that append's
+        // commit a moment later.
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+
+        $this->assertFalse($store->discard('artifact-1'));
+
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertTrue($store->discard('artifact-1'));
+    }
+
     public function testDiscardRemovesAllStagedData(): void
     {
         $store = $this->makeStore();
@@ -530,6 +549,15 @@ final class StagedArtifactsTest extends TestCase
         $status = $store->status('artifact-1');
         $this->assertSame(['exists' => false, 'committed_bytes' => 0, 'verified' => false], $status);
         $this->assertTrue($store->discard('never-existed'));
+    }
+
+    public function testDiscardBeforeAnyStagingExistsCreatesNothing(): void
+    {
+        $store = $this->makeStore();
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $this->assertDirectoryDoesNotExist($this->staging_dir);
     }
 
     public function testDiscardedArtifactRestartsFromScratch(): void
@@ -559,6 +587,66 @@ final class StagedArtifactsTest extends TestCase
             ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
             $store->status('artifact-1')
         );
+    }
+
+    public function testDiscardReportsFailureWhenTheArtifactFileCannotBeRemoved(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        // Unlinking needs write permission on files/, not on the file.
+        chmod($this->staging_dir . '/files', 0500);
+        $this->assertFalse($store->discard('artifact-1'));
+        $this->assertFileExists($this->staging_dir . '/files/artifact-1');
+
+        // Retry until true: the next attempt finishes the cleanup.
+        chmod($this->staging_dir . '/files', 0700);
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+    }
+
+    public function testDiscardReportsFailureWhenTheCursorCannotBeCleared(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        // Clearing the cursor writes state.json.tmp into the staging dir;
+        // the artifact unlink itself only needs write on files/.
+        chmod($this->staging_dir, 0500);
+        $this->assertFalse($store->discard('artifact-1'));
+        $this->assertSame(7, $store->status('artifact-1')['committed_bytes']);
+
+        chmod($this->staging_dir, 0700);
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+    }
+
+    public function testDiscardReportsFailureWhenTheVerifiedRecordCannotBeRemoved(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+
+        // Rewriting verified.jsonl needs its temp file in the staging dir.
+        chmod($this->staging_dir, 0500);
+        $this->assertFalse($store->discard('artifact-1'));
+        $this->assertTrue($store->status('artifact-1')['verified']);
+
+        chmod($this->staging_dir, 0700);
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertFalse($store->status('artifact-1')['verified']);
     }
 
     public function testStatusOfUnknownArtifact(): void

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -250,6 +250,168 @@ final class StagedArtifactsTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // Crash recovery: partial states a kill can leave behind
+    // ---------------------------------------------------------------
+
+    public function testEveryCallCanRunInItsOwnProcess(): void
+    {
+        // Each call constructs its own store instance — no shared in-memory
+        // state, as if every step ran in a separate PHP request.
+        $step = fn() => new Site_Export_Staged_Artifacts($this->staging_dir);
+
+        $this->assertSame('accepted', $step()->append('a.txt', 0, 'aaa')['status']);
+        $this->assertSame('accepted', $step()->append('a.txt', 3, 'AAA')['status']);
+        $this->assertSame('verified', $step()->finalize('a.txt', 6)['status']);
+        $this->assertSame('accepted', $step()->append('b.txt', 0, 'bb')['status']);
+        $this->assertSame('verified', $step()->finalize('b.txt', 2)['status']);
+        $this->assertSame('verified', $step()->finalize('empty.txt', 0)['status']);
+
+        $this->assertSame('aaaAAA', file_get_contents($this->staging_dir . '/files/a.txt'));
+        $this->assertSame('bb', file_get_contents($this->staging_dir . '/files/b.txt'));
+        $this->assertTrue($step()->status('a.txt')['verified']);
+    }
+
+    public function testKilledCursorWriteLeavesRecoverableState(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        // Simulate a kill inside write_state: the temp record was written,
+        // the rename never happened, and the appended bytes sit beyond the
+        // still-old cursor.
+        file_put_contents($this->staging_dir . '/state.json.tmp', '{"artifact_id":"artifact-1"');
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'second', FILE_APPEND);
+
+        $this->assertSame(5, $store->status('artifact-1')['committed_bytes']);
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testTornVerifiedRecordIsIgnoredAndRefinalizeRecovers(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-a', 0, 'aaa');
+        $store->finalize('artifact-a', 3);
+        $store->append('artifact-b', 0, 'bbbb');
+
+        // Simulate a kill halfway through recording artifact-b as verified:
+        // the record file ends in a torn line.
+        file_put_contents(
+            $this->staging_dir . '/verified.jsonl',
+            '{"artifact_id":"artifact-b","si',
+            FILE_APPEND
+        );
+
+        $this->assertFalse($store->status('artifact-b')['verified']);
+        $this->assertTrue($store->status('artifact-a')['verified']);
+        $this->assertSame('verified', $store->finalize('artifact-b', 4)['status']);
+        $this->assertTrue($store->status('artifact-b')['verified']);
+    }
+
+    public function testFinalizeKilledBeforeClearingCursorStaysConsistent(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        // Simulate a kill after the verified record landed but before the
+        // cursor was cleared.
+        file_put_contents(
+            $this->staging_dir . '/verified.jsonl',
+            "\n" . json_encode(['artifact_id' => 'artifact-1', 'size' => 7]) . "\n",
+            FILE_APPEND
+        );
+
+        $stale = $store->append('artifact-1', 7, 'more');
+        $this->assertSame(['rejected', 'already_verified'], [$stale['status'], $stale['reason']]);
+        $this->assertSame('verified', $store->finalize('artifact-1', 7)['status']);
+        $this->assertSame('accepted', $store->append('artifact-2', 0, 'next')['status']);
+    }
+
+    public function testVerifiedRecordWithoutTheArtifactFileReportsMissing(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $refinalized = $store->finalize('artifact-1', 7);
+
+        $this->assertSame(
+            ['rejected', 'missing', 'verified_record'],
+            [$refinalized['status'], $refinalized['reason'], $refinalized['detail']]
+        );
+
+        // Recovery: discard the orphaned record, then upload from scratch.
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'payload')['status']);
+        $this->assertSame('verified', $store->finalize('artifact-1', 7)['status']);
+    }
+
+    public function testDiscardKilledMidwayIsRetriable(): void
+    {
+        // Window 1: the artifact file was unlinked, the cursor survived.
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
+
+        // Window 2: the cursor was cleared, the verified record survived.
+        $store->finalize('artifact-1', 5);
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertFalse($store->status('artifact-1')['verified']);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'again')['status']);
+    }
+
+    public function testArtifactPathBlockedByAnotherEntryIsATypedError(): void
+    {
+        $store = $this->makeStore();
+
+        // A directory sits where the artifact file should go.
+        $store->append('theme/style.css', 0, 'body{}');
+        $blocked_by_dir = $store->append('theme', 0, 'zip');
+        $this->assertSame(
+            ['rejected', 'io_error', 'open_artifact_file'],
+            [$blocked_by_dir['status'], $blocked_by_dir['reason'], $blocked_by_dir['detail']]
+        );
+
+        // A file sits where a parent directory should go.
+        $store->append('plugin.php', 0, '<?php');
+        $blocked_by_file = $store->append('plugin.php/readme.txt', 0, 'hi');
+        $this->assertSame(
+            ['rejected', 'io_error', 'create_staging_dir'],
+            [$blocked_by_file['status'], $blocked_by_file['reason'], $blocked_by_file['detail']]
+        );
+    }
+
+    public function testUnwritableStagingDirectoryIsATypedError(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        mkdir($this->staging_dir, 0700, true);
+        chmod($this->staging_dir, 0500);
+        $store = $this->makeStore();
+
+        $result = $store->append('artifact-1', 0, 'bytes');
+        $this->assertSame(
+            ['rejected', 'io_error', 'open_lock_file'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+
+        // The next run recovers once the environment does.
+        chmod($this->staging_dir, 0700);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'bytes')['status']);
+    }
+
+    // ---------------------------------------------------------------
     // Input validation
     // ---------------------------------------------------------------
 

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -37,6 +37,16 @@ final class StagedArtifactsTest extends TestCase
         return $store->write_chunk($id, $offset, strlen($bytes), hash('crc32b', $bytes), $bytes);
     }
 
+    private function chunk(int $offset, string $bytes): array
+    {
+        return [
+            'offset' => $offset,
+            'length' => strlen($bytes),
+            'expected_crc32' => hash('crc32b', $bytes),
+            'source' => $bytes,
+        ];
+    }
+
     // ---------------------------------------------------------------
     // Assembly and finalize
     // ---------------------------------------------------------------
@@ -75,6 +85,48 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('verified', $store->finalize('artifact-1', strlen($body), hash('crc32b', $body))['status']);
     }
 
+    public function testManyChunksCanBeWrittenInOneOpenLockedBatch(): void
+    {
+        $store = $this->makeStore();
+        $chunks = [];
+        $body = '';
+        $offset = 0;
+        for ($i = 0; $i < 1000; $i++) {
+            $bytes = chr(65 + ($i % 26));
+            $chunks[] = $this->chunk($offset, $bytes);
+            $body .= $bytes;
+            $offset++;
+        }
+
+        $result = $store->write_chunks('artifact-1', $chunks);
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(strlen($body), $result['committed_bytes']);
+        $verified = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame($body, file_get_contents($verified['path']));
+    }
+
+    public function testStreamingBatchKeepsTheArtifactLockAcrossChunks(): void
+    {
+        $store = $this->makeStore();
+        $busy_write = null;
+
+        $chunks = (function () use ($store, &$busy_write) {
+            yield $this->chunk(0, 'first');
+            $busy_write = $this->writeString($store, 'artifact-1', 5, 'blocked');
+            yield $this->chunk(5, 'second');
+        })();
+
+        $result = $store->write_chunks('artifact-1', $chunks);
+
+        $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(11, $result['committed_bytes']);
+        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
     public function testZeroByteArtifactVerifiesWithoutChunks(): void
     {
         $store = $this->makeStore();
@@ -96,6 +148,30 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('verified', $again['status']);
     }
 
+    public function testFinalizeOfUnknownArtifactReportsMissing(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->finalize('never-uploaded', 5, hash('crc32b', 'bytes'));
+
+        $this->assertSame(['rejected', 'missing'], [$result['status'], $result['reason']]);
+    }
+
+    public function testRefinalizeWithDifferentChecksumIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+
+        $result = $store->finalize('artifact-1', 7, hash('crc32b', 'tampered'));
+
+        $this->assertSame(
+            ['rejected', 'hash_mismatch', 'verified_record'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+        $this->assertTrue($store->status('artifact-1')['verified']);
+    }
+
     // ---------------------------------------------------------------
     // Idempotent retries and resume
     // ---------------------------------------------------------------
@@ -109,6 +185,104 @@ final class StagedArtifactsTest extends TestCase
 
         $this->assertSame('duplicate', $retry['status']);
         $this->assertSame(5, $retry['committed_bytes']);
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+    }
+
+    public function testDuplicateStreamChunkIsDrainedInsideBatch(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $stream = fopen('php://temp', 'r+b');
+        fwrite($stream, 'firstsecond');
+        rewind($stream);
+        $result = $store->write_chunks('artifact-1', [
+            [
+                'offset' => 0,
+                'length' => 5,
+                'expected_crc32' => hash('crc32b', 'first'),
+                'source' => $stream,
+            ],
+            [
+                'offset' => 5,
+                'length' => 6,
+                'expected_crc32' => hash('crc32b', 'second'),
+                'source' => $stream,
+            ],
+        ]);
+        fclose($stream);
+
+        $this->assertSame('accepted', $result['status']);
+        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testMidBatchRejectionKeepsEarlierChunksCommitted(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->write_chunks('artifact-1', [
+            $this->chunk(0, 'first'),
+            [
+                'offset' => 5,
+                'length' => 6,
+                'expected_crc32' => hash('crc32b', 'other!'),
+                'source' => 'second',
+            ],
+        ]);
+
+        $this->assertSame(
+            ['rejected', 'hash_mismatch', 'chunk_body', 5],
+            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
+        );
+
+        // The sender resumes from committed_bytes instead of restarting.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testDuplicateDrainOfTruncatedStreamIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $stream = fopen('php://temp', 'r+b');
+        fwrite($stream, 'fir'); // Three of the duplicate chunk's five bytes.
+        rewind($stream);
+        $result = $store->write_chunks('artifact-1', [
+            [
+                'offset' => 0,
+                'length' => 5,
+                'expected_crc32' => hash('crc32b', 'first'),
+                'source' => $stream,
+            ],
+        ]);
+        fclose($stream);
+
+        $this->assertSame(
+            ['rejected', 'short_body', 'duplicate_drain', 5],
+            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
+        );
+    }
+
+    public function testGeneratorFailureMidBatchReleasesTheLockAndKeepsProgress(): void
+    {
+        $store = $this->makeStore();
+        $chunks = (function () {
+            yield $this->chunk(0, 'first');
+            throw new DomainException('endpoint failed to parse the next chunk');
+        })();
+
+        try {
+            $store->write_chunks('artifact-1', $chunks);
+            $threw = false;
+        } catch (DomainException $exception) {
+            $threw = true;
+        }
+
+        $this->assertTrue($threw, 'The generator exception should propagate to the endpoint.');
+        $this->assertSame(5, $store->status('artifact-1')['committed_bytes']);
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
     }
 
@@ -163,6 +337,43 @@ final class StagedArtifactsTest extends TestCase
         $result = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
         $this->assertSame('verified', $result['status']);
         $this->assertSame($body, file_get_contents($result['path']));
+    }
+
+    public function testExternallyShrunkenStagingFileFailsTheArtifactChecksum(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        // Simulate the staging file drifting between requests: something
+        // shrinks it below the committed size.
+        file_put_contents($this->staging_dir . '/artifact-1.part', 'fi');
+
+        // The next write zero-fills back to the committed size and appends;
+        // only finalize's whole-artifact checksum can see the damage.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+
+        $result = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame(
+            ['rejected', 'hash_mismatch', 'artifact_crc32'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+        $this->assertFalse($store->status('artifact-1')['verified']);
+    }
+
+    public function testCorruptCommitRecordRestartsTheArtifact(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        file_put_contents($this->staging_dir . '/artifact-1.meta.json', 'not json {');
+
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+        $resumed = $this->writeString($store, 'artifact-1', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$resumed['status'], $resumed['reason'], $resumed['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
     }
 
     public function testFinalizeRejectsWrongSizeAndWrongHash(): void
@@ -225,6 +436,39 @@ final class StagedArtifactsTest extends TestCase
 
         $bad_length = $store->write_chunk('artifact-1', 0, 0, hash('crc32b', ''), '');
         $this->assertSame(['rejected', 'invalid_length'], [$bad_length['status'], $bad_length['reason']]);
+
+        $bad_offset = $store->write_chunk('artifact-1', -1, 5, hash('crc32b', 'bytes'), 'bytes');
+        $this->assertSame(['rejected', 'invalid_offset'], [$bad_offset['status'], $bad_offset['reason']]);
+
+        $bad_source = $store->write_chunk('artifact-1', 0, 5, hash('crc32b', 'bytes'), 42);
+        $this->assertSame(['rejected', 'invalid_source'], [$bad_source['status'], $bad_source['reason']]);
+    }
+
+    public function testUppercaseChecksumsAreAccepted(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->write_chunk('artifact-1', 0, 5, strtoupper(hash('crc32b', 'bytes')), 'bytes');
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(
+            'verified',
+            $store->finalize('artifact-1', 5, strtoupper(hash('crc32b', 'bytes')))['status']
+        );
+    }
+
+    public function testEmptyBatchIsRejectedWithoutDisturbingCommittedBytes(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $result = $store->write_chunks('artifact-1', []);
+
+        $this->assertSame(
+            ['rejected', 'empty_batch', 5],
+            [$result['status'], $result['reason'], $result['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
     }
 
     public function testStagingMirrorsTheArtifactPath(): void
@@ -242,7 +486,7 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', ''] as $hostile_id) {
+        foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', '', 'a\\b', "a\0b"] as $hostile_id) {
             $result = $this->writeString($store, $hostile_id, 0, 'bytes');
             $this->assertSame(
                 ['rejected', 'invalid_artifact_id'],
@@ -259,7 +503,7 @@ final class StagedArtifactsTest extends TestCase
             $this->assertTrue($store->discard($hostile_id), "id: {$hostile_id}");
         }
 
-        $this->assertDirectoryDoesNotExist(dirname($this->staging_dir) . '/outside');
+        $this->assertDirectoryDoesNotExist(dirname(dirname($this->staging_dir)) . '/outside');
         $this->assertFileDoesNotExist('/etc/passwd.part');
     }
 
@@ -277,8 +521,10 @@ final class StagedArtifactsTest extends TestCase
         $holder = fopen($part_path, 'r+b');
         flock($holder, LOCK_EX);
 
-        $this->assertSame('busy', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-        $this->assertSame('busy', $store->finalize('artifact-1', 5, hash('crc32b', 'first'))['status']);
+        $busy_write = $this->writeString($store, 'artifact-1', 5, 'second');
+        $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
+        $busy_finalize = $store->finalize('artifact-1', 5, hash('crc32b', 'first'));
+        $this->assertSame(['busy', 5], [$busy_finalize['status'], $busy_finalize['committed_bytes']]);
         $this->assertFalse($store->discard('artifact-1'));
 
         flock($holder, LOCK_UN);
@@ -296,6 +542,35 @@ final class StagedArtifactsTest extends TestCase
         $status = $store->status('artifact-1');
         $this->assertSame(['exists' => false, 'committed_bytes' => 0, 'verified' => false], $status);
         $this->assertTrue($store->discard('never-existed'));
+    }
+
+    public function testDiscardedArtifactRestartsFromScratch(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->discard('artifact-1');
+
+        $stale = $this->writeString($store, 'artifact-1', 5, 'second');
+
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
+    }
+
+    public function testDiscardCleansUpAMetaOnlyResidue(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+        unlink($this->staging_dir . '/artifact-1.part');
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $store->status('artifact-1')
+        );
     }
 
     public function testStatusOfUnknownArtifact(): void

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -34,7 +34,7 @@ final class StagedArtifactsTest extends TestCase
 
     private function writeString(Site_Export_Staged_Artifacts $store, string $id, int $offset, string $bytes): array
     {
-        return $store->write_chunk($id, $offset, strlen($bytes), hash('crc32b', $bytes), $bytes);
+        return $store->write_chunk($id, $offset, strlen($bytes), $bytes);
     }
 
     private function chunk(int $offset, string $bytes): array
@@ -42,7 +42,6 @@ final class StagedArtifactsTest extends TestCase
         return [
             'offset' => $offset,
             'length' => strlen($bytes),
-            'expected_crc32' => hash('crc32b', $bytes),
             'source' => $bytes,
         ];
     }
@@ -64,7 +63,7 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $second['status']);
         $this->assertSame(strlen($body), $second['committed_bytes']);
 
-        $result = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $result = $store->finalize('artifact-1', strlen($body));
         $this->assertSame('verified', $result['status']);
         $this->assertSame($body, file_get_contents($result['path']));
         $this->assertTrue($store->status('artifact-1')['verified']);
@@ -78,11 +77,11 @@ final class StagedArtifactsTest extends TestCase
         $stream = fopen('php://temp', 'r+b');
         fwrite($stream, $body);
         rewind($stream);
-        $result = $store->write_chunk('artifact-1', 0, strlen($body), hash('crc32b', $body), $stream);
+        $result = $store->write_chunk('artifact-1', 0, strlen($body), $stream);
         fclose($stream);
 
         $this->assertSame('accepted', $result['status']);
-        $this->assertSame('verified', $store->finalize('artifact-1', strlen($body), hash('crc32b', $body))['status']);
+        $this->assertSame('verified', $store->finalize('artifact-1', strlen($body))['status']);
     }
 
     public function testManyChunksCanBeWrittenInOneOpenLockedBatch(): void
@@ -102,7 +101,7 @@ final class StagedArtifactsTest extends TestCase
 
         $this->assertSame('accepted', $result['status']);
         $this->assertSame(strlen($body), $result['committed_bytes']);
-        $verified = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $verified = $store->finalize('artifact-1', strlen($body));
         $this->assertSame('verified', $verified['status']);
         $this->assertSame($body, file_get_contents($verified['path']));
     }
@@ -123,7 +122,7 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
         $this->assertSame('accepted', $result['status']);
         $this->assertSame(11, $result['committed_bytes']);
-        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $verified = $store->finalize('artifact-1', 11);
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
     }
 
@@ -131,7 +130,7 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        $result = $store->finalize('empty-artifact', 0, hash('crc32b', ''));
+        $result = $store->finalize('empty-artifact', 0);
 
         $this->assertSame('verified', $result['status']);
         $this->assertSame('', file_get_contents($result['path']));
@@ -141,9 +140,9 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'payload');
-        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+        $store->finalize('artifact-1', 7);
 
-        $again = $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+        $again = $store->finalize('artifact-1', 7);
 
         $this->assertSame('verified', $again['status']);
     }
@@ -152,21 +151,21 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        $result = $store->finalize('never-uploaded', 5, hash('crc32b', 'bytes'));
+        $result = $store->finalize('never-uploaded', 5);
 
         $this->assertSame(['rejected', 'missing'], [$result['status'], $result['reason']]);
     }
 
-    public function testRefinalizeWithDifferentChecksumIsRejected(): void
+    public function testRefinalizeWithDifferentSizeIsRejected(): void
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'payload');
-        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+        $store->finalize('artifact-1', 7);
 
-        $result = $store->finalize('artifact-1', 7, hash('crc32b', 'tampered'));
+        $result = $store->finalize('artifact-1', 9);
 
         $this->assertSame(
-            ['rejected', 'hash_mismatch', 'verified_record'],
+            ['rejected', 'size_mismatch', 'verified_record'],
             [$result['status'], $result['reason'], $result['detail']]
         );
         $this->assertTrue($store->status('artifact-1')['verified']);
@@ -200,20 +199,18 @@ final class StagedArtifactsTest extends TestCase
             [
                 'offset' => 0,
                 'length' => 5,
-                'expected_crc32' => hash('crc32b', 'first'),
                 'source' => $stream,
             ],
             [
                 'offset' => 5,
                 'length' => 6,
-                'expected_crc32' => hash('crc32b', 'second'),
                 'source' => $stream,
             ],
         ]);
         fclose($stream);
 
         $this->assertSame('accepted', $result['status']);
-        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $verified = $store->finalize('artifact-1', 11);
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
     }
 
@@ -237,24 +234,29 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
+        // The second chunk's stream ends three bytes short of its declared
+        // length, failing the batch after the first chunk committed.
+        $short_stream = fopen('php://temp', 'r+b');
+        fwrite($short_stream, 'sec');
+        rewind($short_stream);
         $result = $store->write_chunks('artifact-1', [
             $this->chunk(0, 'first'),
             [
                 'offset' => 5,
                 'length' => 6,
-                'expected_crc32' => hash('crc32b', 'other!'),
-                'source' => 'second',
+                'source' => $short_stream,
             ],
         ]);
+        fclose($short_stream);
 
         $this->assertSame(
-            ['rejected', 'hash_mismatch', 'chunk_body', 5],
+            ['rejected', 'short_body', 'chunk_body', 5],
             [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
         );
 
         // The sender resumes from committed_bytes instead of restarting.
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $verified = $store->finalize('artifact-1', 11);
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
     }
 
@@ -270,7 +272,6 @@ final class StagedArtifactsTest extends TestCase
             [
                 'offset' => 0,
                 'length' => 5,
-                'expected_crc32' => hash('crc32b', 'first'),
                 'source' => $stream,
             ],
         ]);
@@ -318,26 +319,6 @@ final class StagedArtifactsTest extends TestCase
     // Integrity
     // ---------------------------------------------------------------
 
-    public function testChunkHashMismatchLeavesCommittedBytesUntouched(): void
-    {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
-
-        $result = $store->write_chunk('artifact-1', 5, 6, hash('crc32b', 'other!'), 'second');
-
-        $this->assertSame('rejected', $result['status']);
-        $this->assertSame('hash_mismatch', $result['reason']);
-        $this->assertSame(5, $result['committed_bytes']);
-
-        // The correct retry still lands at the same offset.
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-        $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
-        $this->assertSame(
-            'firstsecond',
-            file_get_contents($store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'))['path'])
-        );
-    }
-
     public function testUncommittedTailFromACrashedWriteIsDiscarded(): void
     {
         $store = $this->makeStore();
@@ -349,30 +330,25 @@ final class StagedArtifactsTest extends TestCase
 
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 9, '-tail')['status']);
         $body = 'committed-tail';
-        $result = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $result = $store->finalize('artifact-1', strlen($body));
         $this->assertSame('verified', $result['status']);
         $this->assertSame($body, file_get_contents($result['path']));
     }
 
-    public function testExternallyShrunkenStagingFileFailsTheArtifactChecksum(): void
+    public function testShrunkenStagingFileIsZeroFilledBackToTheCursor(): void
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'first');
 
-        // Simulate the staging file drifting between requests: something
-        // shrinks it below the committed size.
+        // The staging file drifts between requests: something shrinks it
+        // below the committed size. The cursor, not the file, is the
+        // authority — the next write zero-fills back to the committed size.
         file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
 
-        // The next write zero-fills back to the committed size and appends;
-        // only finalize's whole-artifact checksum can see the damage.
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-
-        $result = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
-        $this->assertSame(
-            ['rejected', 'hash_mismatch', 'artifact_crc32'],
-            [$result['status'], $result['reason'], $result['detail']]
-        );
-        $this->assertFalse($store->status('artifact-1')['verified']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame("fi\0\0\0second", file_get_contents($verified['path']));
     }
 
     public function testCorruptCommitRecordRestartsTheArtifact(): void
@@ -391,17 +367,14 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
     }
 
-    public function testFinalizeRejectsWrongSizeAndWrongHash(): void
+    public function testFinalizeRejectsWrongSize(): void
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'payload');
 
-        $wrong_size = $store->finalize('artifact-1', 99, hash('crc32b', 'payload'));
+        $wrong_size = $store->finalize('artifact-1', 99);
+
         $this->assertSame(['rejected', 'size_mismatch'], [$wrong_size['status'], $wrong_size['reason']]);
-
-        $wrong_hash = $store->finalize('artifact-1', 7, hash('crc32b', 'tampered'));
-        $this->assertSame(['rejected', 'hash_mismatch'], [$wrong_hash['status'], $wrong_hash['reason']]);
-
         $this->assertFalse($store->status('artifact-1')['verified']);
     }
 
@@ -412,7 +385,7 @@ final class StagedArtifactsTest extends TestCase
         $stream = fopen('php://temp', 'r+b');
         fwrite($stream, 'only-9b!!');
         rewind($stream);
-        $result = $store->write_chunk('artifact-1', 0, 100, hash('crc32b', 'whatever'), $stream);
+        $result = $store->write_chunk('artifact-1', 0, 100, $stream);
         fclose($stream);
 
         $this->assertSame(['rejected', 'short_body', 0], [$result['status'], $result['reason'], $result['committed_bytes']]);
@@ -422,7 +395,7 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        $result = $store->write_chunk('artifact-1', 0, 3, hash('crc32b', 'abcdef'), 'abcdef');
+        $result = $store->write_chunk('artifact-1', 0, 3, 'abcdef');
 
         $this->assertSame(['rejected', 'length_mismatch'], [$result['status'], $result['reason']]);
     }
@@ -431,7 +404,7 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'payload');
-        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+        $store->finalize('artifact-1', 7);
 
         $result = $this->writeString($store, 'artifact-1', 7, 'more');
 
@@ -442,34 +415,18 @@ final class StagedArtifactsTest extends TestCase
     // Input validation
     // ---------------------------------------------------------------
 
-    public function testMalformedHashAndLengthAreRejected(): void
+    public function testMalformedLengthOffsetAndSourceAreRejected(): void
     {
         $store = $this->makeStore();
 
-        $bad_hash = $store->write_chunk('artifact-1', 0, 5, 'not-a-crc32', 'bytes');
-        $this->assertSame(['rejected', 'invalid_hash'], [$bad_hash['status'], $bad_hash['reason']]);
-
-        $bad_length = $store->write_chunk('artifact-1', 0, 0, hash('crc32b', ''), '');
+        $bad_length = $store->write_chunk('artifact-1', 0, 0, '');
         $this->assertSame(['rejected', 'invalid_length'], [$bad_length['status'], $bad_length['reason']]);
 
-        $bad_offset = $store->write_chunk('artifact-1', -1, 5, hash('crc32b', 'bytes'), 'bytes');
+        $bad_offset = $store->write_chunk('artifact-1', -1, 5, 'bytes');
         $this->assertSame(['rejected', 'invalid_offset'], [$bad_offset['status'], $bad_offset['reason']]);
 
-        $bad_source = $store->write_chunk('artifact-1', 0, 5, hash('crc32b', 'bytes'), 42);
+        $bad_source = $store->write_chunk('artifact-1', 0, 5, 42);
         $this->assertSame(['rejected', 'invalid_source'], [$bad_source['status'], $bad_source['reason']]);
-    }
-
-    public function testUppercaseChecksumsAreAccepted(): void
-    {
-        $store = $this->makeStore();
-
-        $result = $store->write_chunk('artifact-1', 0, 5, strtoupper(hash('crc32b', 'bytes')), 'bytes');
-
-        $this->assertSame('accepted', $result['status']);
-        $this->assertSame(
-            'verified',
-            $store->finalize('artifact-1', 5, strtoupper(hash('crc32b', 'bytes')))['status']
-        );
     }
 
     public function testEmptyBatchIsRejectedWithoutDisturbingCommittedBytes(): void
@@ -503,7 +460,7 @@ final class StagedArtifactsTest extends TestCase
 
         foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json'] as $id) {
             $this->assertSame('accepted', $this->writeString($store, $id, 0, "body of {$id}")['status']);
-            $verified = $store->finalize($id, strlen("body of {$id}"), hash('crc32b', "body of {$id}"));
+            $verified = $store->finalize($id, strlen("body of {$id}"));
             $this->assertSame('verified', $verified['status'], "id: {$id}");
             $this->assertSame("body of {$id}", file_get_contents($this->staging_dir . '/files/' . $id));
         }
@@ -520,7 +477,7 @@ final class StagedArtifactsTest extends TestCase
                 [$result['status'], $result['reason']],
                 "id: {$hostile_id}"
             );
-            $finalized = $store->finalize($hostile_id, 5, hash('crc32b', 'bytes'));
+            $finalized = $store->finalize($hostile_id, 5);
             $this->assertSame(
                 ['rejected', 'invalid_artifact_id'],
                 [$finalized['status'], $finalized['reason']],
@@ -549,7 +506,7 @@ final class StagedArtifactsTest extends TestCase
 
         $busy_write = $this->writeString($store, 'artifact-1', 5, 'second');
         $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
-        $busy_finalize = $store->finalize('artifact-1', 5, hash('crc32b', 'first'));
+        $busy_finalize = $store->finalize('artifact-1', 5);
         $this->assertSame(['busy', 5], [$busy_finalize['status'], $busy_finalize['committed_bytes']]);
         $this->assertFalse($store->discard('artifact-1'));
 

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -462,12 +462,41 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json', 'verified', 'verified.tmp'] as $id) {
+        // 'lock' and 'files' shadow the store's own scaffolding names;
+        // they must stage under files/ without touching the real lock
+        // file or the artifact tree root.
+        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json', 'verified', 'verified.tmp', 'lock', 'files'] as $id) {
             $this->assertSame('accepted', $store->append($id, 0, "body of {$id}")['status']);
             $verified = $store->finalize($id, strlen("body of {$id}"));
             $this->assertSame('verified', $verified['status'], "id: {$id}");
             $this->assertSame("body of {$id}", file_get_contents($this->staging_dir . '/files/' . $id));
         }
+
+        // The store's own lock file must still be the lock, not an
+        // artifact: concurrency still excludes after staging id 'lock'.
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        $this->assertTrue(flock($holder, LOCK_EX | LOCK_NB), 'the base lock file survives as a lock');
+        $busy = $store->append('another.txt', 0, 'x');
+        $this->assertSame('busy', $busy['status']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+    }
+
+    public function testDeeplyNestedIdsStageAndDiscardCleanly(): void
+    {
+        // Hosting trees nest far deeper than fixtures; the files/ mirror,
+        // the verified/ marker tree, and discard must all handle it.
+        $store = $this->makeStore();
+        $id = implode('/', array_fill(0, 12, 'd')) . '/deep.txt';
+
+        $this->assertSame('accepted', $store->append($id, 0, 'deep bytes')['status']);
+        $this->assertSame('verified', $store->finalize($id, 10)['status']);
+        $this->assertFileExists($this->staging_dir . '/files/' . $id);
+        $this->assertTrue($store->status($id)['verified']);
+
+        $this->assertTrue($store->discard($id));
+        $this->assertFalse($store->status($id)['exists']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/' . $id);
     }
 
     public function testIdsOutsideTheStagingDirAreRejected(): void

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -296,12 +296,11 @@ final class StagedArtifactsTest extends TestCase
         $store->finalize('artifact-a', 3);
         $store->append('artifact-b', 0, 'bbbb');
 
-        // Simulate a kill halfway through recording artifact-b as verified:
-        // the record file ends in a torn line.
+        // A malformed marker (markers commit by rename, so this means
+        // external interference) must read as not verified.
         file_put_contents(
-            $this->staging_dir . '/verified.jsonl',
-            '{"artifact_id":"artifact-b","si',
-            FILE_APPEND
+            $this->staging_dir . '/verified/artifact-b',
+            '{"si'
         );
 
         $this->assertFalse($store->status('artifact-b')['verified']);
@@ -315,12 +314,12 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
         $store->append('artifact-1', 0, 'payload');
 
-        // Simulate a kill after the verified record landed but before the
+        // Simulate a kill after the verified marker landed but before the
         // cursor was cleared.
+        mkdir($this->staging_dir . '/verified', 0700, true);
         file_put_contents(
-            $this->staging_dir . '/verified.jsonl',
-            "\n" . json_encode(['artifact_id' => 'artifact-1', 'size' => 7]) . "\n",
-            FILE_APPEND
+            $this->staging_dir . '/verified/artifact-1',
+            json_encode(['size' => 7])
         );
 
         $stale = $store->append('artifact-1', 7, 'more');
@@ -463,7 +462,7 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json'] as $id) {
+        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json', 'verified', 'verified.tmp'] as $id) {
             $this->assertSame('accepted', $store->append($id, 0, "body of {$id}")['status']);
             $verified = $store->finalize($id, strlen("body of {$id}"));
             $this->assertSame('verified', $verified['status'], "id: {$id}");
@@ -639,12 +638,12 @@ final class StagedArtifactsTest extends TestCase
         $store->append('artifact-1', 0, 'payload');
         $store->finalize('artifact-1', 7);
 
-        // Rewriting verified.jsonl needs its temp file in the staging dir.
-        chmod($this->staging_dir, 0500);
+        // Unlinking the marker needs write permission on verified/.
+        chmod($this->staging_dir . '/verified', 0500);
         $this->assertFalse($store->discard('artifact-1'));
         $this->assertTrue($store->status('artifact-1')['verified']);
 
-        chmod($this->staging_dir, 0700);
+        chmod($this->staging_dir . '/verified', 0700);
         $this->assertTrue($store->discard('artifact-1'));
         $this->assertFalse($store->status('artifact-1')['verified']);
     }

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -32,31 +32,17 @@ final class StagedArtifactsTest extends TestCase
         return new Site_Export_Staged_Artifacts($this->staging_dir);
     }
 
-    private function writeString(Site_Export_Staged_Artifacts $store, string $id, int $offset, string $bytes): array
-    {
-        return $store->write_chunk($id, $offset, strlen($bytes), $bytes);
-    }
-
-    private function chunk(int $offset, string $bytes): array
-    {
-        return [
-            'offset' => $offset,
-            'length' => strlen($bytes),
-            'source' => $bytes,
-        ];
-    }
-
     // ---------------------------------------------------------------
     // Assembly and finalize
     // ---------------------------------------------------------------
 
-    public function testSequentialChunksAssembleAndVerify(): void
+    public function testSequentialAppendsAssembleAndVerify(): void
     {
         $store = $this->makeStore();
         $body = 'hello staged upload world';
 
-        $first = $this->writeString($store, 'artifact-1', 0, substr($body, 0, 10));
-        $second = $this->writeString($store, 'artifact-1', 10, substr($body, 10));
+        $first = $store->append('artifact-1', 0, substr($body, 0, 10));
+        $second = $store->append('artifact-1', 10, substr($body, 10));
 
         $this->assertSame('accepted', $first['status']);
         $this->assertSame(10, $first['committed_bytes']);
@@ -69,64 +55,30 @@ final class StagedArtifactsTest extends TestCase
         $this->assertTrue($store->status('artifact-1')['verified']);
     }
 
-    public function testChunkBodyCanBeAStream(): void
+    public function testCallerDrivenLoopStreamsASourceInBoundedBuffers(): void
     {
         $store = $this->makeStore();
-        $body = str_repeat('streamed!', 100000); // ~900 KB, spans several copy buffers
+        $body = str_repeat('streamed!', 100000); // ~900 KB, many buffers
 
-        $stream = fopen('php://temp', 'r+b');
-        fwrite($stream, $body);
-        rewind($stream);
-        $result = $store->write_chunk('artifact-1', 0, strlen($body), $stream);
-        fclose($stream);
-
-        $this->assertSame('accepted', $result['status']);
-        $this->assertSame('verified', $store->finalize('artifact-1', strlen($body))['status']);
-    }
-
-    public function testManyChunksCanBeWrittenInOneOpenLockedBatch(): void
-    {
-        $store = $this->makeStore();
-        $chunks = [];
-        $body = '';
-        $offset = 0;
-        for ($i = 0; $i < 1000; $i++) {
-            $bytes = chr(65 + ($i % 26));
-            $chunks[] = $this->chunk($offset, $bytes);
-            $body .= $bytes;
-            $offset++;
+        // The endpoint's loop: read the source in bounded buffers, one
+        // append per buffer.
+        $source = fopen('php://temp', 'r+b');
+        fwrite($source, $body);
+        rewind($source);
+        $committed = 0;
+        while (($buffer = fread($source, 65536)) !== false && $buffer !== '') {
+            $result = $store->append('artifact-1', $committed, $buffer);
+            $this->assertSame('accepted', $result['status']);
+            $committed = $result['committed_bytes'];
         }
+        fclose($source);
 
-        $result = $store->write_chunks('artifact-1', $chunks);
-
-        $this->assertSame('accepted', $result['status']);
-        $this->assertSame(strlen($body), $result['committed_bytes']);
+        $this->assertSame(strlen($body), $committed);
         $verified = $store->finalize('artifact-1', strlen($body));
-        $this->assertSame('verified', $verified['status']);
         $this->assertSame($body, file_get_contents($verified['path']));
     }
 
-    public function testStreamingBatchKeepsTheArtifactLockAcrossChunks(): void
-    {
-        $store = $this->makeStore();
-        $busy_write = null;
-
-        $chunks = (function () use ($store, &$busy_write) {
-            yield $this->chunk(0, 'first');
-            $busy_write = $this->writeString($store, 'artifact-1', 5, 'blocked');
-            yield $this->chunk(5, 'second');
-        })();
-
-        $result = $store->write_chunks('artifact-1', $chunks);
-
-        $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
-        $this->assertSame('accepted', $result['status']);
-        $this->assertSame(11, $result['committed_bytes']);
-        $verified = $store->finalize('artifact-1', 11);
-        $this->assertSame('firstsecond', file_get_contents($verified['path']));
-    }
-
-    public function testZeroByteArtifactVerifiesWithoutChunks(): void
+    public function testZeroByteArtifactVerifiesWithoutAppends(): void
     {
         $store = $this->makeStore();
 
@@ -139,7 +91,7 @@ final class StagedArtifactsTest extends TestCase
     public function testFinalizeIsIdempotent(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->append('artifact-1', 0, 'payload');
         $store->finalize('artifact-1', 7);
 
         $again = $store->finalize('artifact-1', 7);
@@ -159,7 +111,7 @@ final class StagedArtifactsTest extends TestCase
     public function testRefinalizeWithDifferentSizeIsRejected(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->append('artifact-1', 0, 'payload');
         $store->finalize('artifact-1', 7);
 
         $result = $store->finalize('artifact-1', 9);
@@ -172,205 +124,139 @@ final class StagedArtifactsTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // Idempotent retries and resume
+    // Reentrancy and resume
     // ---------------------------------------------------------------
 
-    public function testRetryingACommittedChunkIsADuplicateNoOp(): void
+    public function testLoopCanStopAfterAnyStepAndResumeInAFreshProcess(): void
     {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
+        $buffers = ['aa', 'bb', 'cc', 'dd'];
 
-        $retry = $this->writeString($store, 'artifact-1', 0, 'first');
+        foreach ([0, 1, 2, 3, 4] as $stop_after) {
+            $staging = $this->staging_dir . "/stop-after-{$stop_after}";
+            $first_run = new Site_Export_Staged_Artifacts($staging);
+            for ($i = 0; $i < $stop_after; $i++) {
+                $this->assertSame(
+                    'accepted',
+                    $first_run->append('artifact-1', $i * 2, $buffers[$i])['status']
+                );
+            }
+            unset($first_run); // The driving loop stops; nothing is held.
 
-        $this->assertSame('duplicate', $retry['status']);
-        $this->assertSame(5, $retry['committed_bytes']);
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-    }
-
-    public function testDuplicateStreamChunkIsDrainedInsideBatch(): void
-    {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
-
-        $stream = fopen('php://temp', 'r+b');
-        fwrite($stream, 'firstsecond');
-        rewind($stream);
-        $result = $store->write_chunks('artifact-1', [
-            [
-                'offset' => 0,
-                'length' => 5,
-                'source' => $stream,
-            ],
-            [
-                'offset' => 5,
-                'length' => 6,
-                'source' => $stream,
-            ],
-        ]);
-        fclose($stream);
-
-        $this->assertSame('accepted', $result['status']);
-        $verified = $store->finalize('artifact-1', 11);
-        $this->assertSame('firstsecond', file_get_contents($verified['path']));
-    }
-
-    public function testSwitchingArtifactsRestartsTheAbandonedOne(): void
-    {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-a', 0, 'first');
-
-        // Sequential transfers: chunk 0 of another artifact moves the cursor.
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-b', 0, 'bee')['status']);
-
-        $stale = $this->writeString($store, 'artifact-a', 5, 'second');
-        $this->assertSame(
-            ['rejected', 'offset_gap', 0],
-            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
-        );
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-a', 0, 'fresh')['status']);
-    }
-
-    public function testMidBatchRejectionKeepsEarlierChunksCommitted(): void
-    {
-        $store = $this->makeStore();
-
-        // The second chunk's stream ends three bytes short of its declared
-        // length, failing the batch after the first chunk committed.
-        $short_stream = fopen('php://temp', 'r+b');
-        fwrite($short_stream, 'sec');
-        rewind($short_stream);
-        $result = $store->write_chunks('artifact-1', [
-            $this->chunk(0, 'first'),
-            [
-                'offset' => 5,
-                'length' => 6,
-                'source' => $short_stream,
-            ],
-        ]);
-        fclose($short_stream);
-
-        $this->assertSame(
-            ['rejected', 'short_body', 'chunk_body', 5],
-            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
-        );
-
-        // The sender resumes from committed_bytes instead of restarting.
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-        $verified = $store->finalize('artifact-1', 11);
-        $this->assertSame('firstsecond', file_get_contents($verified['path']));
-    }
-
-    public function testDuplicateDrainOfTruncatedStreamIsRejected(): void
-    {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
-
-        $stream = fopen('php://temp', 'r+b');
-        fwrite($stream, 'fir'); // Three of the duplicate chunk's five bytes.
-        rewind($stream);
-        $result = $store->write_chunks('artifact-1', [
-            [
-                'offset' => 0,
-                'length' => 5,
-                'source' => $stream,
-            ],
-        ]);
-        fclose($stream);
-
-        $this->assertSame(
-            ['rejected', 'short_body', 'duplicate_drain', 5],
-            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
-        );
-    }
-
-    public function testGeneratorFailureMidBatchReleasesTheLockAndKeepsProgress(): void
-    {
-        $store = $this->makeStore();
-        $chunks = (function () {
-            yield $this->chunk(0, 'first');
-            throw new DomainException('endpoint failed to parse the next chunk');
-        })();
-
-        try {
-            $store->write_chunks('artifact-1', $chunks);
-            $threw = false;
-        } catch (DomainException $exception) {
-            $threw = true;
+            // A fresh instance — the next request — resumes from the cursor.
+            $resumed = new Site_Export_Staged_Artifacts($staging);
+            $this->assertSame(
+                $stop_after * 2,
+                $resumed->status('artifact-1')['committed_bytes'],
+                "stopped after {$stop_after} steps"
+            );
+            for ($i = $stop_after; $i < 4; $i++) {
+                $this->assertSame(
+                    'accepted',
+                    $resumed->append('artifact-1', $i * 2, $buffers[$i])['status']
+                );
+            }
+            $verified = $resumed->finalize('artifact-1', 8);
+            $this->assertSame('verified', $verified['status'], "stopped after {$stop_after} steps");
+            $this->assertSame('aabbccdd', file_get_contents($verified['path']));
         }
-
-        $this->assertTrue($threw, 'The generator exception should propagate to the endpoint.');
-        $this->assertSame(5, $store->status('artifact-1')['committed_bytes']);
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
     }
 
-    public function testOffsetGapIsRejectedWithCommittedBytesForResync(): void
+    public function testStoppingInsideAStepDiscardsTheUncommittedTail(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->append('artifact-1', 0, 'committed');
 
-        $result = $this->writeString($store, 'artifact-1', 20, 'too-far');
-
-        $this->assertSame('rejected', $result['status']);
-        $this->assertSame('offset_gap', $result['reason']);
-        $this->assertSame(5, $result['committed_bytes']);
-    }
-
-    // ---------------------------------------------------------------
-    // Integrity
-    // ---------------------------------------------------------------
-
-    public function testUncommittedTailFromACrashedWriteIsDiscarded(): void
-    {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'committed');
-
-        // Simulate a crash after data was written but before the cursor
+        // Simulate a kill after bytes were written but before the cursor
         // moved: garbage sits beyond committed_bytes in the file.
         file_put_contents($this->staging_dir . '/files/artifact-1', 'GARBAGE', FILE_APPEND);
 
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 9, '-tail')['status']);
+        $this->assertSame('accepted', $store->append('artifact-1', 9, '-tail')['status']);
         $body = 'committed-tail';
         $result = $store->finalize('artifact-1', strlen($body));
         $this->assertSame('verified', $result['status']);
         $this->assertSame($body, file_get_contents($result['path']));
     }
 
-    public function testShrunkenStagingFileIsZeroFilledBackToTheCursor(): void
+    public function testResendingCommittedBytesIsADuplicateNoOp(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->append('artifact-1', 0, 'first');
 
-        // The staging file drifts between requests: something shrinks it
-        // below the committed size. The cursor, not the file, is the
-        // authority — the next write zero-fills back to the committed size.
-        file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
+        $retry = $store->append('artifact-1', 0, 'first');
 
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-        $verified = $store->finalize('artifact-1', 11);
-        $this->assertSame('verified', $verified['status']);
-        $this->assertSame("fi\0\0\0second", file_get_contents($verified['path']));
+        $this->assertSame('duplicate', $retry['status']);
+        $this->assertSame(5, $retry['committed_bytes']);
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+    }
+
+    public function testOffsetGapIsRejectedWithCommittedBytesForResync(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        $result = $store->append('artifact-1', 20, 'too-far');
+
+        $this->assertSame('rejected', $result['status']);
+        $this->assertSame('offset_gap', $result['reason']);
+        $this->assertSame(5, $result['committed_bytes']);
+    }
+
+    public function testSwitchingArtifactsRestartsTheAbandonedOne(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-a', 0, 'first');
+
+        // Sequential transfers: an append to another artifact moves the cursor.
+        $this->assertSame('accepted', $store->append('artifact-b', 0, 'bee')['status']);
+
+        $stale = $store->append('artifact-a', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $store->append('artifact-a', 0, 'fresh')['status']);
     }
 
     public function testCorruptCommitRecordRestartsTheArtifact(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->append('artifact-1', 0, 'first');
 
         file_put_contents($this->staging_dir . '/state.json', 'not json {');
 
         $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
-        $resumed = $this->writeString($store, 'artifact-1', 5, 'second');
+        $resumed = $store->append('artifact-1', 5, 'second');
         $this->assertSame(
             ['rejected', 'offset_gap', 0],
             [$resumed['status'], $resumed['reason'], $resumed['committed_bytes']]
         );
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
     }
+
+    public function testShrunkenStagingFileIsZeroFilledBackToTheCursor(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        // The staging file drifts between requests: something shrinks it
+        // below the committed size. The cursor, not the file, is the
+        // authority — the next append zero-fills back to the committed size.
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
+
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame("fi\0\0\0second", file_get_contents($verified['path']));
+    }
+
+    // ---------------------------------------------------------------
+    // Input validation
+    // ---------------------------------------------------------------
 
     public function testFinalizeRejectsWrongSize(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->append('artifact-1', 0, 'payload');
 
         $wrong_size = $store->finalize('artifact-1', 99);
 
@@ -378,69 +264,26 @@ final class StagedArtifactsTest extends TestCase
         $this->assertFalse($store->status('artifact-1')['verified']);
     }
 
-    public function testShortStreamBodyIsRejected(): void
+    public function testMalformedOffsetAndBufferAreRejected(): void
     {
         $store = $this->makeStore();
 
-        $stream = fopen('php://temp', 'r+b');
-        fwrite($stream, 'only-9b!!');
-        rewind($stream);
-        $result = $store->write_chunk('artifact-1', 0, 100, $stream);
-        fclose($stream);
+        $bad_offset = $store->append('artifact-1', -1, 'bytes');
+        $this->assertSame(['rejected', 'invalid_offset'], [$bad_offset['status'], $bad_offset['reason']]);
 
-        $this->assertSame(['rejected', 'short_body', 0], [$result['status'], $result['reason'], $result['committed_bytes']]);
-    }
-
-    public function testStringLengthMismatchIsRejected(): void
-    {
-        $store = $this->makeStore();
-
-        $result = $store->write_chunk('artifact-1', 0, 3, 'abcdef');
-
-        $this->assertSame(['rejected', 'length_mismatch'], [$result['status'], $result['reason']]);
+        $empty = $store->append('artifact-1', 0, '');
+        $this->assertSame(['rejected', 'empty_body'], [$empty['status'], $empty['reason']]);
     }
 
     public function testWritingToAVerifiedArtifactIsRejected(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->append('artifact-1', 0, 'payload');
         $store->finalize('artifact-1', 7);
 
-        $result = $this->writeString($store, 'artifact-1', 7, 'more');
+        $result = $store->append('artifact-1', 7, 'more');
 
         $this->assertSame(['rejected', 'already_verified'], [$result['status'], $result['reason']]);
-    }
-
-    // ---------------------------------------------------------------
-    // Input validation
-    // ---------------------------------------------------------------
-
-    public function testMalformedLengthOffsetAndSourceAreRejected(): void
-    {
-        $store = $this->makeStore();
-
-        $bad_length = $store->write_chunk('artifact-1', 0, 0, '');
-        $this->assertSame(['rejected', 'invalid_length'], [$bad_length['status'], $bad_length['reason']]);
-
-        $bad_offset = $store->write_chunk('artifact-1', -1, 5, 'bytes');
-        $this->assertSame(['rejected', 'invalid_offset'], [$bad_offset['status'], $bad_offset['reason']]);
-
-        $bad_source = $store->write_chunk('artifact-1', 0, 5, 42);
-        $this->assertSame(['rejected', 'invalid_source'], [$bad_source['status'], $bad_source['reason']]);
-    }
-
-    public function testEmptyBatchIsRejectedWithoutDisturbingCommittedBytes(): void
-    {
-        $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
-
-        $result = $store->write_chunks('artifact-1', []);
-
-        $this->assertSame(
-            ['rejected', 'empty_batch', 5],
-            [$result['status'], $result['reason'], $result['committed_bytes']]
-        );
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
     }
 
     public function testStagingMirrorsTheArtifactPath(): void
@@ -448,7 +291,7 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
         $id = 'wp-content/themes/foo/style.css';
 
-        $this->assertSame('accepted', $this->writeString($store, $id, 0, 'body { }')['status']);
+        $this->assertSame('accepted', $store->append($id, 0, 'body { }')['status']);
 
         $this->assertFileExists($this->staging_dir . '/files/' . $id);
         $this->assertFileExists($this->staging_dir . '/state.json');
@@ -459,7 +302,7 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
 
         foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json'] as $id) {
-            $this->assertSame('accepted', $this->writeString($store, $id, 0, "body of {$id}")['status']);
+            $this->assertSame('accepted', $store->append($id, 0, "body of {$id}")['status']);
             $verified = $store->finalize($id, strlen("body of {$id}"));
             $this->assertSame('verified', $verified['status'], "id: {$id}");
             $this->assertSame("body of {$id}", file_get_contents($this->staging_dir . '/files/' . $id));
@@ -471,7 +314,7 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
 
         foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', '', 'a\\b', "a\0b"] as $hostile_id) {
-            $result = $this->writeString($store, $hostile_id, 0, 'bytes');
+            $result = $store->append($hostile_id, 0, 'bytes');
             $this->assertSame(
                 ['rejected', 'invalid_artifact_id'],
                 [$result['status'], $result['reason']],
@@ -498,27 +341,27 @@ final class StagedArtifactsTest extends TestCase
     public function testConcurrentWriterGetsBusy(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->append('artifact-1', 0, 'first');
 
         // Hold the lock the way a concurrent writer would.
         $holder = fopen($this->staging_dir . '/lock', 'r+b');
         flock($holder, LOCK_EX);
 
-        $busy_write = $this->writeString($store, 'artifact-1', 5, 'second');
-        $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
+        $busy_append = $store->append('artifact-1', 5, 'second');
+        $this->assertSame(['busy', 5], [$busy_append['status'], $busy_append['committed_bytes']]);
         $busy_finalize = $store->finalize('artifact-1', 5);
         $this->assertSame(['busy', 5], [$busy_finalize['status'], $busy_finalize['committed_bytes']]);
         $this->assertFalse($store->discard('artifact-1'));
 
         flock($holder, LOCK_UN);
         fclose($holder);
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
     }
 
     public function testDiscardRemovesAllStagedData(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->append('artifact-1', 0, 'payload');
 
         $this->assertTrue($store->discard('artifact-1'));
 
@@ -530,22 +373,22 @@ final class StagedArtifactsTest extends TestCase
     public function testDiscardedArtifactRestartsFromScratch(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->append('artifact-1', 0, 'first');
         $store->discard('artifact-1');
 
-        $stale = $this->writeString($store, 'artifact-1', 5, 'second');
+        $stale = $store->append('artifact-1', 5, 'second');
 
         $this->assertSame(
             ['rejected', 'offset_gap', 0],
             [$stale['status'], $stale['reason'], $stale['committed_bytes']]
         );
-        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
     }
 
     public function testDiscardClearsTheCursorWhenTheArtifactFileIsMissing(): void
     {
         $store = $this->makeStore();
-        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->append('artifact-1', 0, 'payload');
         unlink($this->staging_dir . '/files/artifact-1');
 
         $this->assertTrue($store->discard('artifact-1'));

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -217,6 +217,22 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
     }
 
+    public function testSwitchingArtifactsRestartsTheAbandonedOne(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-a', 0, 'first');
+
+        // Sequential transfers: chunk 0 of another artifact moves the cursor.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-b', 0, 'bee')['status']);
+
+        $stale = $this->writeString($store, 'artifact-a', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-a', 0, 'fresh')['status']);
+    }
+
     public function testMidBatchRejectionKeepsEarlierChunksCommitted(): void
     {
         $store = $this->makeStore();
@@ -327,10 +343,9 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'committed');
 
-        // Simulate a crash after data was written but before the commit
-        // record moved: garbage sits beyond committed_bytes in the file.
-        $part_path = $this->staging_dir . '/artifact-1.part';
-        file_put_contents($part_path, 'GARBAGE', FILE_APPEND);
+        // Simulate a crash after data was written but before the cursor
+        // moved: garbage sits beyond committed_bytes in the file.
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'GARBAGE', FILE_APPEND);
 
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 9, '-tail')['status']);
         $body = 'committed-tail';
@@ -346,7 +361,7 @@ final class StagedArtifactsTest extends TestCase
 
         // Simulate the staging file drifting between requests: something
         // shrinks it below the committed size.
-        file_put_contents($this->staging_dir . '/artifact-1.part', 'fi');
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
 
         // The next write zero-fills back to the committed size and appends;
         // only finalize's whole-artifact checksum can see the damage.
@@ -365,7 +380,7 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'first');
 
-        file_put_contents($this->staging_dir . '/artifact-1.meta.json', 'not json {');
+        file_put_contents($this->staging_dir . '/state.json', 'not json {');
 
         $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
         $resumed = $this->writeString($store, 'artifact-1', 5, 'second');
@@ -478,8 +493,20 @@ final class StagedArtifactsTest extends TestCase
 
         $this->assertSame('accepted', $this->writeString($store, $id, 0, 'body { }')['status']);
 
-        $this->assertFileExists($this->staging_dir . '/' . $id . '.part');
-        $this->assertFileExists($this->staging_dir . '/' . $id . '.meta.json');
+        $this->assertFileExists($this->staging_dir . '/files/' . $id);
+        $this->assertFileExists($this->staging_dir . '/state.json');
+    }
+
+    public function testSiteFilenamesThatLookLikeStagingRecordsStageVerbatim(): void
+    {
+        $store = $this->makeStore();
+
+        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json'] as $id) {
+            $this->assertSame('accepted', $this->writeString($store, $id, 0, "body of {$id}")['status']);
+            $verified = $store->finalize($id, strlen("body of {$id}"), hash('crc32b', "body of {$id}"));
+            $this->assertSame('verified', $verified['status'], "id: {$id}");
+            $this->assertSame("body of {$id}", file_get_contents($this->staging_dir . '/files/' . $id));
+        }
     }
 
     public function testIdsOutsideTheStagingDirAreRejected(): void
@@ -504,7 +531,7 @@ final class StagedArtifactsTest extends TestCase
         }
 
         $this->assertDirectoryDoesNotExist(dirname(dirname($this->staging_dir)) . '/outside');
-        $this->assertFileDoesNotExist('/etc/passwd.part');
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/etc/passwd');
     }
 
     // ---------------------------------------------------------------
@@ -517,8 +544,7 @@ final class StagedArtifactsTest extends TestCase
         $this->writeString($store, 'artifact-1', 0, 'first');
 
         // Hold the lock the way a concurrent writer would.
-        $part_path = $this->staging_dir . '/artifact-1.part';
-        $holder = fopen($part_path, 'r+b');
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
         flock($holder, LOCK_EX);
 
         $busy_write = $this->writeString($store, 'artifact-1', 5, 'second');
@@ -559,11 +585,11 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
     }
 
-    public function testDiscardCleansUpAMetaOnlyResidue(): void
+    public function testDiscardClearsTheCursorWhenTheArtifactFileIsMissing(): void
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'payload');
-        unlink($this->staging_dir . '/artifact-1.part');
+        unlink($this->staging_dir . '/files/artifact-1');
 
         $this->assertTrue($store->discard('artifact-1'));
 

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -1,0 +1,310 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedArtifactsTest extends TestCase
+{
+    private string $staging_dir;
+
+    protected function setUp(): void
+    {
+        $this->staging_dir = sys_get_temp_dir() . '/staged-artifacts-test-' . bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->staging_dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeStore(): Site_Export_Staged_Artifacts
+    {
+        return new Site_Export_Staged_Artifacts($this->staging_dir);
+    }
+
+    private function writeString(Site_Export_Staged_Artifacts $store, string $id, int $offset, string $bytes): array
+    {
+        return $store->write_chunk($id, $offset, strlen($bytes), hash('crc32b', $bytes), $bytes);
+    }
+
+    // ---------------------------------------------------------------
+    // Assembly and finalize
+    // ---------------------------------------------------------------
+
+    public function testSequentialChunksAssembleAndVerify(): void
+    {
+        $store = $this->makeStore();
+        $body = 'hello staged upload world';
+
+        $first = $this->writeString($store, 'artifact-1', 0, substr($body, 0, 10));
+        $second = $this->writeString($store, 'artifact-1', 10, substr($body, 10));
+
+        $this->assertSame('accepted', $first['status']);
+        $this->assertSame(10, $first['committed_bytes']);
+        $this->assertSame('accepted', $second['status']);
+        $this->assertSame(strlen($body), $second['committed_bytes']);
+
+        $result = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($result['path']));
+        $this->assertTrue($store->status('artifact-1')['verified']);
+    }
+
+    public function testChunkBodyCanBeAStream(): void
+    {
+        $store = $this->makeStore();
+        $body = str_repeat('streamed!', 100000); // ~900 KB, spans several copy buffers
+
+        $stream = fopen('php://temp', 'r+b');
+        fwrite($stream, $body);
+        rewind($stream);
+        $result = $store->write_chunk('artifact-1', 0, strlen($body), hash('crc32b', $body), $stream);
+        fclose($stream);
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame('verified', $store->finalize('artifact-1', strlen($body), hash('crc32b', $body))['status']);
+    }
+
+    public function testZeroByteArtifactVerifiesWithoutChunks(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->finalize('empty-artifact', 0, hash('crc32b', ''));
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame('', file_get_contents($result['path']));
+    }
+
+    public function testFinalizeIsIdempotent(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+
+        $again = $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+
+        $this->assertSame('verified', $again['status']);
+    }
+
+    // ---------------------------------------------------------------
+    // Idempotent retries and resume
+    // ---------------------------------------------------------------
+
+    public function testRetryingACommittedChunkIsADuplicateNoOp(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $retry = $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $this->assertSame('duplicate', $retry['status']);
+        $this->assertSame(5, $retry['committed_bytes']);
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+    }
+
+    public function testOffsetGapIsRejectedWithCommittedBytesForResync(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $result = $this->writeString($store, 'artifact-1', 20, 'too-far');
+
+        $this->assertSame('rejected', $result['status']);
+        $this->assertSame('offset_gap', $result['reason']);
+        $this->assertSame(5, $result['committed_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Integrity
+    // ---------------------------------------------------------------
+
+    public function testChunkHashMismatchLeavesCommittedBytesUntouched(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $result = $store->write_chunk('artifact-1', 5, 6, hash('crc32b', 'other!'), 'second');
+
+        $this->assertSame('rejected', $result['status']);
+        $this->assertSame('hash_mismatch', $result['reason']);
+        $this->assertSame(5, $result['committed_bytes']);
+
+        // The correct retry still lands at the same offset.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+        $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame(
+            'firstsecond',
+            file_get_contents($store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'))['path'])
+        );
+    }
+
+    public function testUncommittedTailFromACrashedWriteIsDiscarded(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'committed');
+
+        // Simulate a crash after data was written but before the commit
+        // record moved: garbage sits beyond committed_bytes in the file.
+        $part_path = $this->staging_dir . '/artifact-1.part';
+        file_put_contents($part_path, 'GARBAGE', FILE_APPEND);
+
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 9, '-tail')['status']);
+        $body = 'committed-tail';
+        $result = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($result['path']));
+    }
+
+    public function testFinalizeRejectsWrongSizeAndWrongHash(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+
+        $wrong_size = $store->finalize('artifact-1', 99, hash('crc32b', 'payload'));
+        $this->assertSame(['rejected', 'size_mismatch'], [$wrong_size['status'], $wrong_size['reason']]);
+
+        $wrong_hash = $store->finalize('artifact-1', 7, hash('crc32b', 'tampered'));
+        $this->assertSame(['rejected', 'hash_mismatch'], [$wrong_hash['status'], $wrong_hash['reason']]);
+
+        $this->assertFalse($store->status('artifact-1')['verified']);
+    }
+
+    public function testShortStreamBodyIsRejected(): void
+    {
+        $store = $this->makeStore();
+
+        $stream = fopen('php://temp', 'r+b');
+        fwrite($stream, 'only-9b!!');
+        rewind($stream);
+        $result = $store->write_chunk('artifact-1', 0, 100, hash('crc32b', 'whatever'), $stream);
+        fclose($stream);
+
+        $this->assertSame(['rejected', 'short_body', 0], [$result['status'], $result['reason'], $result['committed_bytes']]);
+    }
+
+    public function testStringLengthMismatchIsRejected(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->write_chunk('artifact-1', 0, 3, hash('crc32b', 'abcdef'), 'abcdef');
+
+        $this->assertSame(['rejected', 'length_mismatch'], [$result['status'], $result['reason']]);
+    }
+
+    public function testWritingToAVerifiedArtifactIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+
+        $result = $this->writeString($store, 'artifact-1', 7, 'more');
+
+        $this->assertSame(['rejected', 'already_verified'], [$result['status'], $result['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Input validation
+    // ---------------------------------------------------------------
+
+    public function testMalformedHashAndLengthAreRejected(): void
+    {
+        $store = $this->makeStore();
+
+        $bad_hash = $store->write_chunk('artifact-1', 0, 5, 'not-a-crc32', 'bytes');
+        $this->assertSame(['rejected', 'invalid_hash'], [$bad_hash['status'], $bad_hash['reason']]);
+
+        $bad_length = $store->write_chunk('artifact-1', 0, 0, hash('crc32b', ''), '');
+        $this->assertSame(['rejected', 'invalid_length'], [$bad_length['status'], $bad_length['reason']]);
+    }
+
+    public function testStagingMirrorsTheArtifactPath(): void
+    {
+        $store = $this->makeStore();
+        $id = 'wp-content/themes/foo/style.css';
+
+        $this->assertSame('accepted', $this->writeString($store, $id, 0, 'body { }')['status']);
+
+        $this->assertFileExists($this->staging_dir . '/' . $id . '.part');
+        $this->assertFileExists($this->staging_dir . '/' . $id . '.meta.json');
+    }
+
+    public function testIdsOutsideTheStagingDirAreRejected(): void
+    {
+        $store = $this->makeStore();
+
+        foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', ''] as $hostile_id) {
+            $result = $this->writeString($store, $hostile_id, 0, 'bytes');
+            $this->assertSame(
+                ['rejected', 'invalid_artifact_id'],
+                [$result['status'], $result['reason']],
+                "id: {$hostile_id}"
+            );
+            $finalized = $store->finalize($hostile_id, 5, hash('crc32b', 'bytes'));
+            $this->assertSame(
+                ['rejected', 'invalid_artifact_id'],
+                [$finalized['status'], $finalized['reason']],
+                "id: {$hostile_id}"
+            );
+            $this->assertFalse($store->status($hostile_id)['exists'], "id: {$hostile_id}");
+            $this->assertTrue($store->discard($hostile_id), "id: {$hostile_id}");
+        }
+
+        $this->assertDirectoryDoesNotExist(dirname($this->staging_dir) . '/outside');
+        $this->assertFileDoesNotExist('/etc/passwd.part');
+    }
+
+    // ---------------------------------------------------------------
+    // Concurrency and lifecycle
+    // ---------------------------------------------------------------
+
+    public function testConcurrentWriterGetsBusy(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        // Hold the lock the way a concurrent writer would.
+        $part_path = $this->staging_dir . '/artifact-1.part';
+        $holder = fopen($part_path, 'r+b');
+        flock($holder, LOCK_EX);
+
+        $this->assertSame('busy', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+        $this->assertSame('busy', $store->finalize('artifact-1', 5, hash('crc32b', 'first'))['status']);
+        $this->assertFalse($store->discard('artifact-1'));
+
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+    }
+
+    public function testDiscardRemovesAllStagedData(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $status = $store->status('artifact-1');
+        $this->assertSame(['exists' => false, 'committed_bytes' => 0, 'verified' => false], $status);
+        $this->assertTrue($store->discard('never-existed'));
+    }
+
+    public function testStatusOfUnknownArtifact(): void
+    {
+        $store = $this->makeStore();
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $store->status('unknown')
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,5 +26,9 @@ if (!class_exists('Site_Export_HTTP_Server', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-http-server.php';
 }
 
+if (!class_exists('Site_Export_Staged_Artifacts', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-artifacts.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,7 @@
             <file>FileIndexDedupTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>StagedArtifactsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>


### PR DESCRIPTION
## What it does

Adds `Site_Export_Staged_Artifacts`, the storage that chunked transfers accumulate in on a live target instead of touching the site. The caller drives the loop: it reads its source in bounded buffers and calls `append()` once per buffer — one reentrant, individually-committed step per call — and an artifact becomes applyable only after `finalize()` confirms the assembled size against the total declared at plan time.

Nothing consumes it yet — #277 (stacked on this) carries the push relay and staged apply, and the chunk-upload endpoint work wires the store to #293's control-plane auth and #297's chunk sizing. Part of the push plan in #276.

## Rationale

Staging exists for **apply atomicity and containment**, not authentication. A transfer moves many files plus database changes and can be interrupted or aborted at any point:

- **The live site must never see half-applied state** — new theme with old DB, half a plugin. With staging, the site runs untouched for the whole transfer, aborting is free (discard the staged data), and apply later moves verified artifacts into place in one short window.
- **Partial content must never exist under the web-served tree.** The staging directory lives outside it.

**The caller owns the loop, matching the streaming producers.** Where a reader drives `MySQLDumpProducer`/`FileTreeProducer` by calling `next_chunk()` until done, a sender drives this store by calling `append()` once per buffer it read. The store holds nothing between calls, so the transfer can stop after any step — next request, next process, or a test that halts at a chosen iteration — and resume from `committed_bytes`. An internal read loop would make exactly those stop points untestable.

**Integrity checks are byte counts, the same discipline pull uses.** An append is accepted only at the committed offset and only whole; `finalize()` compares the assembled size against the plan-declared total and never reads the artifact back, so it costs the same for a 1 KB file and a 50 GB dump (a whole-artifact hash would not fit PHP's execution limit for large artifacts). That catches truncation, missing bytes, and resume-offset bugs; corruption that preserves length is not detected — the same trust pull's writer places in its local disk. The wire belongs to TLS, request authorization to #293's HMAC.

**Layout and state follow pull's mechanics, and transfers are sequential like pull.** Artifact bytes live at their plain target-relative paths under `files/` — no `.part` suffixes and no per-artifact sidecars, so any filename a site can contain stages verbatim (including `index.php.part` or `state.json`). Progress lives outside the mirror: `state.json` is the rename-atomic cursor for the single in-flight artifact, and each finalized artifact has a rename-committed marker under `verified/` holding its size — the already-verified check that runs on every append costs one stat, however many artifacts a transfer has finished. Concurrency is not a feature — the single `lock` file exists only so a retry racing its timed-out predecessor gets `"busy"`.

## Implementation

- **One call, one committed step**: `append()` validates, locks, writes the whole buffer, flushes, moves the cursor by atomic rename, and unlocks. Stopping between calls needs no cleanup; a kill inside a call leaves an uncommitted tail the next append truncates away. Every response carries `committed_bytes`.
- **Resync through typed responses**: re-sent bytes come back as `duplicate` (the caller skips forward in its own source); a wrong offset comes back as `offset_gap` with the committed count to resume from.
- **Progress is tracked for one artifact at a time** — the one currently being uploaded. Starting a different artifact forgets the unfinished one's progress: its partial bytes stay under `files/`, but returning to it means re-uploading from offset 0. (A sender that loses its own state and restarts the whole transfer still works — committed prefixes come back as `duplicate`.)
- **The lock is per step**: each mutator takes an exclusive non-blocking `flock` on the `lock` file and releases it before returning; contenders get `busy` with the current committed offset. The lock needs its own never-replaced file because `state.json` commits by rename, which strands a held flock on the orphaned inode. Readers never lock: the cursor is rename-atomic, `verified.jsonl` append-only, and `committed_bytes` monotonic, so `status()` is safely lock-free.
- **Typed results, no exceptions**: `accepted | duplicate | busy | rejected` with a machine-readable `reason` (`offset_gap`, `empty_body`, `size_mismatch`, `already_verified`, ...) plus a `detail` field naming the exact failing operation when one reason has several sources (`write_body`, `persist_cursor`, `verified_record`, ...).
- An artifact id is the `files/`-relative path the artifact will be applied from; ids with absolute, empty, `.` or `..` segments or any backslash are rejected. Apply resolves artifacts by id, never by enumerating the staging directory.
- The endpoint owns authentication, request-size limits, and buffer sizing, and must place the staging directory outside the web-served tree, preferably on the same filesystem as the apply target so apply can use atomic `rename()`.

```php
$staged = new Site_Export_Staged_Artifacts($staging_dir);

// The endpoint's loop: read the request body in bounded buffers.
while (($buffer = fread($input, 262144)) !== false && $buffer !== '') {
    $result = $staged->append($artifact_id, $offset, $buffer);
    // => ['status' => 'accepted', 'reason' => null, 'detail' => null, 'committed_bytes' => 262144]
    $offset = $result['committed_bytes'];
}

$done = $staged->finalize($artifact_id, $total_bytes);
// => ['status' => 'verified', 'path' => '/staging/files/...', ...] — safe to apply
```

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit StagedArtifactsTest.php
composer analyze
```

37 tests (registered in `tests/phpunit.xml`, so `composer test` and CI run them) cover the caller-driven loop and every kill window: streaming in bounded buffers, stopping the loop after every possible step and resuming in a fresh process, a kill inside a step (uncommitted tail), a kill inside the cursor write (stale `.tmp` + unrecorded bytes), a torn verified record, a finalize killed before clearing the cursor, both discard kill windows (discard is retry-until-true), a verified record orphaned by its missing file, every call running in its own instance, duplicate resend and offset-gap resync, zero-fill of a shrunken staging file, corrupt cursor recovery, paths blocked by a directory or file where the mirror needs the opposite, an unwritable staging dir that recovers with its permissions, artifact-id validation including record-lookalike filenames, lock contention, zero-byte artifacts, a discard denied while an untraced append holds the lock, and each discard cleanup step (file unlink, cursor clear, record rewrite) reporting false for retry when it fails.


