### PR TITLE
Batch staged artifact chunk writes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,18 +358,20 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-push/staged-artifact-batches",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
+                "reference": "4299e8cbe30ddce21de036bcef579a2e5d40159e"
             },
             "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
                 "php": ">=7.4",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
+            },
+            "suggest": {
+                "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+                "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
             },
             "type": "library",
             "autoload": {
@@ -382,10 +384,13 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
-                    "src/class-sqlite-driver-pdo.php"
+                    "src/class-staged-artifacts.php",
+                    "src/class-sqlite-driver-pdo.php",
+                    "src/class-wpdb-driver-pdo.php"
                 ],
                 "files": [
-                    "src/utils.php"
+                    "src/utils.php",
+                    "src/class-pdo-polyfill.php"
                 ]
             },
             "license": [

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -113,6 +113,11 @@ final class Site_Export_Staged_Artifacts {
      * committed_bytes reports the durable progress made before the bad chunk,
      * and the sender resumes from there.
      *
+     * The iterable is also the pause point: a generator can simply stop
+     * yielding when the endpoint's resource budget runs out, and the
+     * response's committed_bytes tells the sender where the next request
+     * should resume.
+     *
      * @param iterable<int,array{offset:int,length:int,expected_crc32:string,source:resource|string}> $chunks
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -55,7 +55,8 @@
  * - An artifact id is the staging-relative path the artifact will be applied
  *   from, mirroring the target tree — the staging dir reads like the site
  *   and apply is a rename. Ids with absolute, empty, "." or ".." segments
- *   are rejected, same as the importer's fs-root-relative path rule.
+ *   or any backslash are rejected — stricter than the importer's fs-root
+ *   path rule, which tolerates backslashes and empty segments.
  * - Writers hold an exclusive flock on the staging file; a concurrent writer
  *   gets "busy" instead of interleaved writes.
  *
@@ -83,44 +84,60 @@ final class Site_Export_Staged_Artifacts {
      * @param int             $length          Declared chunk length in bytes.
      * @param string          $expected_crc32  Hex CRC-32 (crc32b) of the chunk body.
      * @param resource|string $source          Chunk body, or a readable stream positioned at it.
-     * @return array{status:string,reason:?string,committed_bytes:int}
-     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on "rejected".
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
+     *   "rejected", and detail names the failing operation when the same
+     *   reason can come from more than one place.
      */
     public function write_chunk(string $artifact_id, int $offset, int $length, string $expected_crc32, $source): array {
-        // These parameters arrive verbatim from a remote client's request,
-        // and the sequencing/copy logic below assumes they are well-formed —
-        // a negative offset would misreport as "duplicate" success and a
-        // short string body would never finish copying. Reject malformed
-        // input with typed reasons before taking the lock or touching disk.
-        $expected_crc32 = strtolower($expected_crc32);
+        return $this->write_chunks($artifact_id, [
+            [
+                'offset' => $offset,
+                'length' => $length,
+                'expected_crc32' => $expected_crc32,
+                'source' => $source,
+            ],
+        ]);
+    }
+
+    /**
+     * Stage consecutive chunks from one request while keeping the staging file
+     * open and locked.
+     *
+     * The upload endpoint can pass a generator that yields parsed chunks from
+     * php://input, so a 100- or 1000-chunk request pays the open/flock/tail
+     * cleanup cost once while still committing each chunk independently for
+     * crash-safe resume.
+     *
+     * Because chunks commit one by one, a mid-batch rejection loses nothing:
+     * committed_bytes reports the durable progress made before the bad chunk,
+     * and the sender resumes from there.
+     *
+     * @param iterable<int,array{offset:int,length:int,expected_crc32:string,source:resource|string}> $chunks
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
+     *   "rejected", and detail names the failing operation when the same
+     *   reason can come from more than one place.
+     */
+    public function write_chunks(string $artifact_id, iterable $chunks): array {
         $paths = $this->artifact_paths($artifact_id);
         if ($paths === null) {
             return $this->write_result('rejected', 'invalid_artifact_id', 0);
         }
-        if ($length < 1 || $offset < 0) {
-            return $this->write_result('rejected', 'invalid_length', 0);
-        }
-        if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
-            return $this->write_result('rejected', 'invalid_hash', 0);
-        }
-        if (is_string($source) && strlen($source) !== $length) {
-            return $this->write_result('rejected', 'length_mismatch', 0);
-        }
-        if (!is_string($source) && !is_resource($source)) {
-            return $this->write_result('rejected', 'invalid_source', 0);
-        }
         if (!$this->ensure_parent_dir($paths['part'])) {
-            return $this->write_result('rejected', 'io_error', 0);
+            return $this->write_result('rejected', 'io_error', 0, 'create_staging_dir');
         }
 
+        // Open without truncating: a resumed transfer must keep committed
+        // bytes until the metadata check below decides what tail to discard.
         $part = @fopen($paths['part'], 'c+b');
         if ($part === false) {
-            return $this->write_result('rejected', 'io_error', 0);
+            return $this->write_result('rejected', 'io_error', 0, 'open_staging_file');
         }
 
         try {
             if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->write_result('busy', null, 0);
+                return $this->write_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
             }
 
             $meta = $this->read_meta($paths['meta']);
@@ -128,38 +145,87 @@ final class Site_Export_Staged_Artifacts {
             if ($meta['verified']) {
                 return $this->write_result('rejected', 'already_verified', $committed);
             }
-            if ($offset + $length <= $committed) {
+
+            // Discard any uncommitted tail from an interrupted earlier write,
+            // then append at the only offset the metadata says is committed.
+            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
+                return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
+            }
+
+            $accepted = false;
+            $duplicate = false;
+            foreach ($chunks as $chunk) {
+                // These parameters arrive verbatim from a remote client's
+                // request, and the sequencing/copy logic below assumes they
+                // are well-formed — a negative offset would misreport as
+                // "duplicate" success and a short string body would never
+                // finish copying. Reject malformed input with typed reasons
+                // before writing bytes.
+                $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
+                $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
+                $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
+                $expected_crc32 = strtolower($expected_crc32);
+                $source = $chunk['source'] ?? null;
+
+                if ($length < 1) {
+                    return $this->write_result('rejected', 'invalid_length', $committed);
+                }
+                if ($offset < 0) {
+                    return $this->write_result('rejected', 'invalid_offset', $committed);
+                }
+                if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
+                    return $this->write_result('rejected', 'invalid_hash', $committed);
+                }
+                if (is_string($source) && strlen($source) !== $length) {
+                    return $this->write_result('rejected', 'length_mismatch', $committed);
+                }
+                if (!is_string($source) && !is_resource($source)) {
+                    return $this->write_result('rejected', 'invalid_source', $committed);
+                }
+                if ($offset + $length <= $committed) {
+                    $drain_reason = $this->drain_source($source, $length);
+                    if ($drain_reason !== null) {
+                        return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+                    }
+                    $duplicate = true;
+                    continue;
+                }
+                if ($offset !== $committed) {
+                    return $this->write_result('rejected', 'offset_gap', $committed);
+                }
+
+                $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
+                if ($copy_reason !== null) {
+                    // A failed copy/hash can leave bytes past the committed
+                    // offset; trim them before the caller retries this chunk.
+                    ftruncate($part, $committed);
+                    return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                }
+
+                // The data is flushed before the commit record moves: a crash
+                // between the two leaves a tail that the next write truncates.
+                if (!fflush($part)) {
+                    ftruncate($part, $committed);
+                    return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                }
+
+                $meta['committed_bytes'] = $committed + $length;
+                if (!$this->write_meta($paths['meta'], $meta)) {
+                    ftruncate($part, $committed);
+                    return $this->write_result('rejected', 'io_error', $committed, 'persist_commit_record');
+                }
+
+                $committed = $meta['committed_bytes'];
+                $accepted = true;
+            }
+
+            if ($accepted) {
+                return $this->write_result('accepted', null, $committed);
+            }
+            if ($duplicate) {
                 return $this->write_result('duplicate', null, $committed);
             }
-            if ($offset !== $committed) {
-                return $this->write_result('rejected', 'offset_gap', $committed);
-            }
-
-            // Discard any uncommitted tail from an interrupted earlier write.
-            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
-                return $this->write_result('rejected', 'io_error', $committed);
-            }
-
-            $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
-            if ($copy_reason !== null) {
-                ftruncate($part, $committed);
-                return $this->write_result('rejected', $copy_reason, $committed);
-            }
-
-            // The data is durable before the commit record moves: a crash
-            // between the two leaves a tail that the next write truncates.
-            if (!fflush($part)) {
-                ftruncate($part, $committed);
-                return $this->write_result('rejected', 'io_error', $committed);
-            }
-
-            $meta['committed_bytes'] = $committed + $length;
-            if (!$this->write_meta($paths['meta'], $meta)) {
-                ftruncate($part, $committed);
-                return $this->write_result('rejected', 'io_error', $committed);
-            }
-
-            return $this->write_result('accepted', null, $meta['committed_bytes']);
+            return $this->write_result('rejected', 'empty_batch', $committed);
         } finally {
             flock($part, LOCK_UN);
             fclose($part);
@@ -177,8 +243,10 @@ final class Site_Export_Staged_Artifacts {
      * reading cannot catch a resume that mixed two versions of the source
      * file — it would faithfully hash the mixed bytes.
      *
-     * @return array{status:string,reason:?string,committed_bytes:int,path:?string}
-     *   status "verified"|"busy"|"rejected"; path is set on "verified".
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
+     *   status "verified"|"busy"|"rejected"; path is set on "verified", and
+     *   detail names the failing operation when the same reason can come
+     *   from more than one place.
      */
     public function finalize(string $artifact_id, int $expected_total_bytes, string $expected_crc32): array {
         $expected_crc32 = strtolower($expected_crc32);
@@ -190,25 +258,29 @@ final class Site_Export_Staged_Artifacts {
             return $this->finalize_result('rejected', 'invalid_hash', 0);
         }
         if ($expected_total_bytes < 0) {
-            return $this->finalize_result('rejected', 'size_mismatch', 0);
+            return $this->finalize_result('rejected', 'invalid_total', 0);
         }
 
         $part_path = $paths['part'];
         if (!file_exists($part_path)) {
-            // A zero-byte artifact legitimately has no chunks.
-            if ($expected_total_bytes > 0 || !$this->ensure_parent_dir($part_path) || @touch($part_path) === false) {
+            // A zero-byte artifact legitimately has no chunks; the fopen
+            // below creates its empty part file.
+            if ($expected_total_bytes > 0) {
                 return $this->finalize_result('rejected', 'missing', 0);
+            }
+            if (!$this->ensure_parent_dir($part_path)) {
+                return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
             }
         }
 
         $part = @fopen($part_path, 'c+b');
         if ($part === false) {
-            return $this->finalize_result('rejected', 'io_error', 0);
+            return $this->finalize_result('rejected', 'io_error', 0, 'open_staging_file');
         }
 
         try {
             if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->finalize_result('busy', null, 0);
+                return $this->finalize_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
             }
 
             $meta = $this->read_meta($paths['meta']);
@@ -218,8 +290,8 @@ final class Site_Export_Staged_Artifacts {
                     && is_string($meta['verified_crc32'])
                     && hash_equals($meta['verified_crc32'], $expected_crc32);
                 return $same
-                    ? $this->finalize_result('verified', null, $committed, $part_path)
-                    : $this->finalize_result('rejected', 'hash_mismatch', $committed);
+                    ? $this->finalize_result('verified', null, $committed, null, $part_path)
+                    : $this->finalize_result('rejected', 'hash_mismatch', $committed, 'verified_record');
             }
 
             if ($committed !== $expected_total_bytes) {
@@ -228,25 +300,27 @@ final class Site_Export_Staged_Artifacts {
 
             // Drop any uncommitted tail so the checksum covers committed bytes only.
             if (!ftruncate($part, $committed)) {
-                return $this->finalize_result('rejected', 'io_error', $committed);
+                return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
             }
 
+            // Hash while holding the staging lock. hash_file() uses its own
+            // read handle, but all writers in this store respect this flock.
             $actual_crc32 = hash_file('crc32b', $part_path);
             if ($actual_crc32 === false) {
-                return $this->finalize_result('rejected', 'io_error', $committed);
+                return $this->finalize_result('rejected', 'io_error', $committed, 'artifact_crc32');
             }
             if (!hash_equals($expected_crc32, $actual_crc32)) {
-                return $this->finalize_result('rejected', 'hash_mismatch', $committed);
+                return $this->finalize_result('rejected', 'hash_mismatch', $committed, 'artifact_crc32');
             }
 
             $meta['verified'] = true;
             $meta['verified_total_bytes'] = $expected_total_bytes;
             $meta['verified_crc32'] = $expected_crc32;
             if (!$this->write_meta($paths['meta'], $meta)) {
-                return $this->finalize_result('rejected', 'io_error', $committed);
+                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_commit_record');
             }
 
-            return $this->finalize_result('verified', null, $committed, $part_path);
+            return $this->finalize_result('verified', null, $committed, null, $part_path);
         } finally {
             flock($part, LOCK_UN);
             fclose($part);
@@ -254,6 +328,11 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
+     * Returns the persisted staging state for an artifact.
+     *
+     * This is advisory and intentionally lock-free; writers still enforce the
+     * committed offset under flock before accepting bytes.
+     *
      * @return array{exists:bool,committed_bytes:int,verified:bool}
      */
     public function status(string $artifact_id): array {
@@ -287,21 +366,36 @@ final class Site_Export_Staged_Artifacts {
             return true;
         }
 
-        $part = @fopen($paths['part'], 'r+b');
-        if ($part !== false) {
+        if (!file_exists($paths['part']) && !file_exists($paths['meta'])) {
+            return true;
+        }
+
+        // 'c+b' so the lock exists even when only the meta record does, and
+        // the meta is unlinked before the part while the lock is held — a
+        // writer arriving after the part unlink locks a fresh inode, and
+        // stale meta it could still read would resurrect its committed_bytes
+        // over bytes that are gone.
+        $part = @fopen($paths['part'], 'c+b');
+        if ($part === false) {
+            return false;
+        }
+        try {
             if (!flock($part, LOCK_EX | LOCK_NB)) {
-                fclose($part);
                 return false;
             }
+            @unlink($paths['meta']);
             @unlink($paths['part']);
+            return true;
+        } finally {
             flock($part, LOCK_UN);
             fclose($part);
         }
-        @unlink($paths['meta']);
-        return true;
     }
 
     /**
+     * Copies exactly $length bytes to the staging file while hashing the same
+     * bytes that landed on disk.
+     *
      * @param resource|string $source
      * @return string|null Rejection reason, or null when $length bytes were
      *                     copied and their checksum matched.
@@ -311,6 +405,8 @@ final class Site_Export_Staged_Artifacts {
         $remaining = $length;
 
         while ($remaining > 0) {
+            // Read in bounded buffers so string and stream sources share the
+            // same write path without materializing a large stream body.
             if (is_string($source)) {
                 $buffer = substr($source, $length - $remaining, min($remaining, self::WRITE_BUFFER_BYTES));
             } else {
@@ -329,6 +425,34 @@ final class Site_Export_Staged_Artifacts {
 
         if (!hash_equals($expected_crc32, hash_final($context))) {
             return 'hash_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * Consumes exactly $length bytes from a duplicate chunk stream.
+     *
+     * Duplicate chunks are not written or re-hashed, but a batched upload may
+     * be reading consecutive chunk bodies from one request stream. Draining
+     * keeps the parser aligned for the next chunk.
+     *
+     * @param resource|string $source
+     * @return string|null Rejection reason, or null when there is no stream
+     *                     body left for this store to consume.
+     */
+    private function drain_source($source, int $length): ?string {
+        if (is_string($source)) {
+            return null;
+        }
+
+        $remaining = $length;
+        while ($remaining > 0) {
+            $buffer = fread($source, min($remaining, self::WRITE_BUFFER_BYTES));
+            if ($buffer === false || $buffer === '') {
+                return 'short_body';
+            }
+            $remaining -= strlen($buffer);
         }
 
         return null;
@@ -357,10 +481,16 @@ final class Site_Export_Staged_Artifacts {
 
     private function ensure_parent_dir(string $path): bool {
         $dir = dirname($path);
-        return is_dir($dir) || @mkdir($dir, 0700, true);
+        // A concurrent creator winning the mkdir race is success, not failure.
+        return is_dir($dir) || @mkdir($dir, 0700, true) || is_dir($dir);
     }
 
     /**
+     * Reads the commit record as best-effort state.
+     *
+     * A missing or unreadable record is treated as an empty artifact so the
+     * next writer must restart from offset 0 instead of trusting stale bytes.
+     *
      * @return array{committed_bytes:int,verified:bool,verified_total_bytes:?int,verified_crc32:?string}
      */
     private function read_meta(string $meta_path): array {
@@ -380,6 +510,8 @@ final class Site_Export_Staged_Artifacts {
             return $defaults;
         }
 
+        // Metadata is intentionally not trusted as schema: old/corrupt files
+        // fall back to defaults after keeping only recognized keys.
         $meta = array_merge($defaults, array_intersect_key($meta, $defaults));
         $meta['committed_bytes'] = max(0, (int) $meta['committed_bytes']);
         $meta['verified'] = (bool) $meta['verified'];
@@ -389,9 +521,14 @@ final class Site_Export_Staged_Artifacts {
 
     private function write_meta(string $meta_path, array $meta): bool {
         // Write-then-rename keeps the commit record atomic: readers see the
-        // old record or the new one, never a torn file.
+        // old record or the new one, never a torn file. Keep the temp file
+        // next to the target so rename stays on the same filesystem.
         $tmp_path = $meta_path . '.tmp';
-        if (@file_put_contents($tmp_path, json_encode($meta)) === false) {
+        $json = json_encode($meta);
+        // A short write (disk full) returns a byte count, not false — never
+        // rename a torn record over the good one.
+        if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
+            @unlink($tmp_path);
             return false;
         }
         if (!@rename($tmp_path, $meta_path)) {
@@ -402,23 +539,25 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * @return array{status:string,reason:?string,committed_bytes:int}
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      */
-    private function write_result(string $status, ?string $reason, int $committed_bytes): array {
+    private function write_result(string $status, ?string $reason, int $committed_bytes, ?string $detail = null): array {
         return [
             'status' => $status,
             'reason' => $reason,
+            'detail' => $detail,
             'committed_bytes' => $committed_bytes,
         ];
     }
 
     /**
-     * @return array{status:string,reason:?string,committed_bytes:int,path:?string}
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
      */
-    private function finalize_result(string $status, ?string $reason, int $committed_bytes, ?string $path = null): array {
+    private function finalize_result(string $status, ?string $reason, int $committed_bytes, ?string $detail = null, ?string $path = null): array {
         return [
             'status' => $status,
             'reason' => $reason,
+            'detail' => $detail,
             'committed_bytes' => $committed_bytes,
             'path' => $path,
         ];

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -6,13 +6,13 @@
  * A transfer moves many files plus database changes at network speed and can
  * be interrupted or aborted at any point — the live site must never see that
  * as half-applied state, and partial content must never exist under the
- * web-served tree, where the server would hand out a half-uploaded
- * "plugin.php.part" as plain text. So staging exists for apply atomicity and
- * containment, not for authentication: nothing a transfer receives touches
- * the site directly, the bytes accumulate here while the site keeps running,
- * aborting before apply is free (discard the staged data), and the apply
- * step later moves verified artifacts into place in one short, controlled
- * window instead of mutating the live tree for the duration of the transfer.
+ * web-served tree, where the server would hand out a half-uploaded plugin
+ * file as plain text. So staging exists for apply atomicity and containment,
+ * not for authentication: nothing a transfer receives touches the site
+ * directly, the bytes accumulate here while the site keeps running, aborting
+ * before apply is free (discard the staged data), and the apply step later
+ * moves verified artifacts into place in one short, controlled window
+ * instead of mutating the live tree for the duration of the transfer.
  *
  * The first consumer is push: bounded chunk uploads from an outbound-only
  * local site (see UploadChunkSizer on the importer side). The pull file
@@ -34,12 +34,28 @@
  * moves data with no content hashing at all, nothing keys on content
  * digests, and error detection is the whole job.
  *
- * The sender hashes while reading and write_chunk() hashes while writing,
- * so the only extra pass is finalize() re-reading the artifact. That is
- * deliberate: chunk-time checks cannot see the staging file changing
- * between requests (a shrunken file is zero-filled back to the committed
- * size by the next write's ftruncate), and PHP 7.4 cannot resume a hash
- * context across requests.
+ * The sender hashes while reading and the store hashes while writing, so the
+ * only extra pass is finalize() re-reading the artifact. That is deliberate:
+ * chunk-time checks cannot see the staging file changing between requests
+ * (a shrunken file is zero-filled back to the committed size by the next
+ * write's ftruncate), and PHP 7.4 cannot resume a hash context across
+ * requests.
+ *
+ * Layout and state follow the pull importer's mechanics. Artifact bytes live
+ * at their plain target-relative paths under files/ — no suffixes, so any
+ * name a site can contain stages verbatim — and progress lives outside the
+ * mirror: state.json holds the cursor for the single in-flight artifact,
+ * verified.jsonl appends one line per artifact finalize() accepted, and lock
+ * is the flock target. The lock cannot live on state.json itself: the cursor
+ * is committed by rename, and a rename-replaced file leaves the held lock on
+ * the orphaned inode.
+ *
+ * Transfers are sequential, like pull: one artifact is in flight at a time
+ * and the cursor tracks only it. Writing chunk 0 of another artifact moves
+ * the cursor there; an unfinished predecessor keeps its bytes on disk but
+ * restarts from offset 0 when the sender returns to it. Concurrency is not a
+ * feature — the lock exists so a retry racing its timed-out predecessor gets
+ * "busy" instead of interleaved writes.
  *
  * Contract:
  *
@@ -48,17 +64,17 @@
  *   and every response carries committed_bytes so an out-of-sync uploader can
  *   resume at the right offset.
  * - Bytes become committed only after the chunk's CRC-32 matched. The data
- *   is flushed before the commit record is updated, so a crash mid-chunk
- *   leaves an uncommitted tail that the next write discards.
+ *   is flushed before the cursor record moves, so a crash mid-chunk leaves
+ *   an uncommitted tail that the next write discards.
  * - finalize() re-hashes the assembled artifact and compares size and checksum
- *   before marking it verified; write_chunk() refuses verified artifacts.
- * - An artifact id is the staging-relative path the artifact will be applied
- *   from, mirroring the target tree — the staging dir reads like the site
- *   and apply is a rename. Ids with absolute, empty, "." or ".." segments
- *   or any backslash are rejected — stricter than the importer's fs-root
- *   path rule, which tolerates backslashes and empty segments.
- * - Writers hold an exclusive flock on the staging file; a concurrent writer
- *   gets "busy" instead of interleaved writes.
+ *   before recording it in verified.jsonl; write_chunks() refuses verified
+ *   artifacts.
+ * - An artifact id is the files/-relative path the artifact will be applied
+ *   from, mirroring the target tree — apply resolves artifacts by id, never
+ *   by enumerating the staging directory. Ids with absolute, empty, "." or
+ *   ".." segments or any backslash are rejected — stricter than the
+ *   importer's fs-root path rule, which tolerates backslashes and empty
+ *   segments.
  *
  * The endpoint owns authentication and request-size limits. It must also
  * place the staging directory outside the web-served tree, and preferably on
@@ -70,10 +86,23 @@ final class Site_Export_Staged_Artifacts {
     private const WRITE_BUFFER_BYTES = 262144;
 
     /** @var string */
-    private $staging_dir;
+    private $files_dir;
+
+    /** @var string */
+    private $state_path;
+
+    /** @var string */
+    private $verified_path;
+
+    /** @var string */
+    private $lock_path;
 
     public function __construct(string $staging_dir) {
-        $this->staging_dir = rtrim($staging_dir, '/');
+        $base = rtrim($staging_dir, '/');
+        $this->files_dir = $base . '/files';
+        $this->state_path = $base . '/state.json';
+        $this->verified_path = $base . '/verified.jsonl';
+        $this->lock_path = $base . '/lock';
     }
 
     /**
@@ -101,8 +130,8 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Stage consecutive chunks from one request while keeping the staging file
-     * open and locked.
+     * Stage consecutive chunks from one request while keeping the artifact
+     * file open and the store locked.
      *
      * The upload endpoint can pass a generator that yields parsed chunks from
      * php://input, so a 100- or 1000-chunk request pays the open/flock/tail
@@ -125,120 +154,134 @@ final class Site_Export_Staged_Artifacts {
      *   reason can come from more than one place.
      */
     public function write_chunks(string $artifact_id, iterable $chunks): array {
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return $this->write_result('rejected', 'invalid_artifact_id', 0);
         }
-        if (!$this->ensure_parent_dir($paths['part'])) {
-            return $this->write_result('rejected', 'io_error', 0, 'create_staging_dir');
-        }
 
-        // Open without truncating: a resumed transfer must keep committed
-        // bytes until the metadata check below decides what tail to discard.
-        $part = @fopen($paths['part'], 'c+b');
-        if ($part === false) {
-            return $this->write_result('rejected', 'io_error', 0, 'open_staging_file');
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return $this->write_result('rejected', 'io_error', 0, 'open_lock_file');
         }
 
         try {
-            if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->write_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return $this->write_result('busy', null, $this->status($artifact_id)['committed_bytes']);
             }
 
-            $meta = $this->read_meta($paths['meta']);
-            $committed = $meta['committed_bytes'];
-            if ($meta['verified']) {
-                return $this->write_result('rejected', 'already_verified', $committed);
+            $verified = $this->read_verified();
+            if (isset($verified[$artifact_id])) {
+                return $this->write_result('rejected', 'already_verified', $verified[$artifact_id]['size']);
             }
 
-            // Discard any uncommitted tail from an interrupted earlier write,
-            // then append at the only offset the metadata says is committed.
-            if (!ftruncate($part, $committed) || fseek($part, $committed) !== 0) {
-                return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
+            // Sequential transfers: the cursor tracks one artifact. A write
+            // to any other artifact starts it from scratch.
+            $state = $this->read_state();
+            $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            if (!$this->ensure_parent_dir($file_path)) {
+                return $this->write_result('rejected', 'io_error', $committed, 'create_staging_dir');
             }
 
-            $accepted = false;
-            $duplicate = false;
-            foreach ($chunks as $chunk) {
-                // These parameters arrive verbatim from a remote client's
-                // request, and the sequencing/copy logic below assumes they
-                // are well-formed — a negative offset would misreport as
-                // "duplicate" success and a short string body would never
-                // finish copying. Reject malformed input with typed reasons
-                // before writing bytes.
-                $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
-                $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
-                $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
-                $expected_crc32 = strtolower($expected_crc32);
-                $source = $chunk['source'] ?? null;
+            // Open without truncating: a resumed transfer must keep committed
+            // bytes until the cursor decides what tail to discard.
+            $file = @fopen($file_path, 'c+b');
+            if ($file === false) {
+                return $this->write_result('rejected', 'io_error', $committed, 'open_artifact_file');
+            }
 
-                if ($length < 1) {
-                    return $this->write_result('rejected', 'invalid_length', $committed);
+            try {
+                // Discard any uncommitted tail from an interrupted earlier
+                // write, then append at the only offset the cursor says is
+                // committed.
+                if (!ftruncate($file, $committed) || fseek($file, $committed) !== 0) {
+                    return $this->write_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
                 }
-                if ($offset < 0) {
-                    return $this->write_result('rejected', 'invalid_offset', $committed);
-                }
-                if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
-                    return $this->write_result('rejected', 'invalid_hash', $committed);
-                }
-                if (is_string($source) && strlen($source) !== $length) {
-                    return $this->write_result('rejected', 'length_mismatch', $committed);
-                }
-                if (!is_string($source) && !is_resource($source)) {
-                    return $this->write_result('rejected', 'invalid_source', $committed);
-                }
-                if ($offset + $length <= $committed) {
-                    $drain_reason = $this->drain_source($source, $length);
-                    if ($drain_reason !== null) {
-                        return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+
+                $accepted = false;
+                $duplicate = false;
+                foreach ($chunks as $chunk) {
+                    // These parameters arrive verbatim from a remote client's
+                    // request, and the sequencing/copy logic below assumes they
+                    // are well-formed — a negative offset would misreport as
+                    // "duplicate" success and a short string body would never
+                    // finish copying. Reject malformed input with typed reasons
+                    // before writing bytes.
+                    $offset = isset($chunk['offset']) ? (int) $chunk['offset'] : -1;
+                    $length = isset($chunk['length']) ? (int) $chunk['length'] : 0;
+                    $expected_crc32 = isset($chunk['expected_crc32']) ? (string) $chunk['expected_crc32'] : '';
+                    $expected_crc32 = strtolower($expected_crc32);
+                    $source = $chunk['source'] ?? null;
+
+                    if ($length < 1) {
+                        return $this->write_result('rejected', 'invalid_length', $committed);
                     }
-                    $duplicate = true;
-                    continue;
-                }
-                if ($offset !== $committed) {
-                    return $this->write_result('rejected', 'offset_gap', $committed);
+                    if ($offset < 0) {
+                        return $this->write_result('rejected', 'invalid_offset', $committed);
+                    }
+                    if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
+                        return $this->write_result('rejected', 'invalid_hash', $committed);
+                    }
+                    if (is_string($source) && strlen($source) !== $length) {
+                        return $this->write_result('rejected', 'length_mismatch', $committed);
+                    }
+                    if (!is_string($source) && !is_resource($source)) {
+                        return $this->write_result('rejected', 'invalid_source', $committed);
+                    }
+                    if ($offset + $length <= $committed) {
+                        $drain_reason = $this->drain_source($source, $length);
+                        if ($drain_reason !== null) {
+                            return $this->write_result('rejected', $drain_reason, $committed, 'duplicate_drain');
+                        }
+                        $duplicate = true;
+                        continue;
+                    }
+                    if ($offset !== $committed) {
+                        return $this->write_result('rejected', 'offset_gap', $committed);
+                    }
+
+                    $copy_reason = $this->copy_and_hash($source, $file, $length, $expected_crc32);
+                    if ($copy_reason !== null) {
+                        // A failed copy/hash can leave bytes past the committed
+                        // offset; trim them before the caller retries this chunk.
+                        ftruncate($file, $committed);
+                        return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                    }
+
+                    // The data is flushed before the cursor record moves: a crash
+                    // between the two leaves a tail that the next write truncates.
+                    if (!fflush($file)) {
+                        ftruncate($file, $committed);
+                        return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                    }
+
+                    if (!$this->write_state($artifact_id, $committed + $length)) {
+                        ftruncate($file, $committed);
+                        return $this->write_result('rejected', 'io_error', $committed, 'persist_cursor');
+                    }
+
+                    $committed += $length;
+                    $accepted = true;
                 }
 
-                $copy_reason = $this->copy_and_hash($source, $part, $length, $expected_crc32);
-                if ($copy_reason !== null) {
-                    // A failed copy/hash can leave bytes past the committed
-                    // offset; trim them before the caller retries this chunk.
-                    ftruncate($part, $committed);
-                    return $this->write_result('rejected', $copy_reason, $committed, 'chunk_body');
+                if ($accepted) {
+                    return $this->write_result('accepted', null, $committed);
                 }
-
-                // The data is flushed before the commit record moves: a crash
-                // between the two leaves a tail that the next write truncates.
-                if (!fflush($part)) {
-                    ftruncate($part, $committed);
-                    return $this->write_result('rejected', 'io_error', $committed, 'flush_chunk_body');
+                if ($duplicate) {
+                    return $this->write_result('duplicate', null, $committed);
                 }
-
-                $meta['committed_bytes'] = $committed + $length;
-                if (!$this->write_meta($paths['meta'], $meta)) {
-                    ftruncate($part, $committed);
-                    return $this->write_result('rejected', 'io_error', $committed, 'persist_commit_record');
-                }
-
-                $committed = $meta['committed_bytes'];
-                $accepted = true;
+                return $this->write_result('rejected', 'empty_batch', $committed);
+            } finally {
+                fclose($file);
             }
-
-            if ($accepted) {
-                return $this->write_result('accepted', null, $committed);
-            }
-            if ($duplicate) {
-                return $this->write_result('duplicate', null, $committed);
-            }
-            return $this->write_result('rejected', 'empty_batch', $committed);
         } finally {
-            flock($part, LOCK_UN);
-            fclose($part);
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 
     /**
-     * Verify the assembled artifact and mark it applyable.
+     * Verify the assembled artifact and record it as applyable.
      *
      * Idempotent: finalizing an already-verified artifact with the same size
      * and checksum succeeds again.
@@ -255,8 +298,8 @@ final class Site_Export_Staged_Artifacts {
      */
     public function finalize(string $artifact_id, int $expected_total_bytes, string $expected_crc32): array {
         $expected_crc32 = strtolower($expected_crc32);
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return $this->finalize_result('rejected', 'invalid_artifact_id', 0);
         }
         if (!preg_match('/^[0-9a-f]{8}$/', $expected_crc32)) {
@@ -266,51 +309,56 @@ final class Site_Export_Staged_Artifacts {
             return $this->finalize_result('rejected', 'invalid_total', 0);
         }
 
-        $part_path = $paths['part'];
-        if (!file_exists($part_path)) {
-            // A zero-byte artifact legitimately has no chunks; the fopen
-            // below creates its empty part file.
-            if ($expected_total_bytes > 0) {
-                return $this->finalize_result('rejected', 'missing', 0);
-            }
-            if (!$this->ensure_parent_dir($part_path)) {
-                return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
-            }
-        }
-
-        $part = @fopen($part_path, 'c+b');
-        if ($part === false) {
-            return $this->finalize_result('rejected', 'io_error', 0, 'open_staging_file');
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return $this->finalize_result('rejected', 'io_error', 0, 'open_lock_file');
         }
 
         try {
-            if (!flock($part, LOCK_EX | LOCK_NB)) {
-                return $this->finalize_result('busy', null, $this->read_meta($paths['meta'])['committed_bytes']);
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return $this->finalize_result('busy', null, $this->status($artifact_id)['committed_bytes']);
             }
 
-            $meta = $this->read_meta($paths['meta']);
-            $committed = $meta['committed_bytes'];
-            if ($meta['verified']) {
-                $same = $meta['verified_total_bytes'] === $expected_total_bytes
-                    && is_string($meta['verified_crc32'])
-                    && hash_equals($meta['verified_crc32'], $expected_crc32);
+            $verified = $this->read_verified();
+            if (isset($verified[$artifact_id])) {
+                $record = $verified[$artifact_id];
+                $same = $record['size'] === $expected_total_bytes
+                    && hash_equals($record['crc32'], $expected_crc32);
                 return $same
-                    ? $this->finalize_result('verified', null, $committed, null, $part_path)
-                    : $this->finalize_result('rejected', 'hash_mismatch', $committed, 'verified_record');
+                    ? $this->finalize_result('verified', null, $record['size'], null, $file_path)
+                    : $this->finalize_result('rejected', 'hash_mismatch', $record['size'], 'verified_record');
+            }
+
+            $state = $this->read_state();
+            $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            if (!file_exists($file_path)) {
+                // A zero-byte artifact legitimately has no chunks; the fopen
+                // below creates its empty file.
+                if ($expected_total_bytes > 0) {
+                    return $this->finalize_result('rejected', 'missing', $committed);
+                }
+                if (!$this->ensure_parent_dir($file_path)) {
+                    return $this->finalize_result('rejected', 'io_error', 0, 'create_staging_dir');
+                }
             }
 
             if ($committed !== $expected_total_bytes) {
                 return $this->finalize_result('rejected', 'size_mismatch', $committed);
             }
 
+            $file = @fopen($file_path, 'c+b');
+            if ($file === false) {
+                return $this->finalize_result('rejected', 'io_error', $committed, 'open_artifact_file');
+            }
             // Drop any uncommitted tail so the checksum covers committed bytes only.
-            if (!ftruncate($part, $committed)) {
+            $truncated = ftruncate($file, $committed);
+            fclose($file);
+            if (!$truncated) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'truncate_uncommitted_tail');
             }
 
-            // Hash while holding the staging lock. hash_file() uses its own
-            // read handle, but all writers in this store respect this flock.
-            $actual_crc32 = hash_file('crc32b', $part_path);
+            $actual_crc32 = hash_file('crc32b', $file_path);
             if ($actual_crc32 === false) {
                 return $this->finalize_result('rejected', 'io_error', $committed, 'artifact_crc32');
             }
@@ -318,31 +366,33 @@ final class Site_Export_Staged_Artifacts {
                 return $this->finalize_result('rejected', 'hash_mismatch', $committed, 'artifact_crc32');
             }
 
-            $meta['verified'] = true;
-            $meta['verified_total_bytes'] = $expected_total_bytes;
-            $meta['verified_crc32'] = $expected_crc32;
-            if (!$this->write_meta($paths['meta'], $meta)) {
-                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_commit_record');
+            if (!$this->append_verified($artifact_id, $expected_total_bytes, $expected_crc32)) {
+                return $this->finalize_result('rejected', 'io_error', $committed, 'persist_verified_record');
+            }
+            if ($state['artifact_id'] === $artifact_id) {
+                // Best effort: a stale cursor is harmless once the verified
+                // record exists — already_verified wins on the next write.
+                $this->write_state(null, 0);
             }
 
-            return $this->finalize_result('verified', null, $committed, null, $part_path);
+            return $this->finalize_result('verified', null, $committed, null, $file_path);
         } finally {
-            flock($part, LOCK_UN);
-            fclose($part);
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 
     /**
-     * Returns the persisted staging state for an artifact.
+     * Returns the recorded staging state for an artifact.
      *
      * This is advisory and intentionally lock-free; writers still enforce the
-     * committed offset under flock before accepting bytes.
+     * committed offset under the lock before accepting bytes.
      *
      * @return array{exists:bool,committed_bytes:int,verified:bool}
      */
     public function status(string $artifact_id): array {
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return [
                 'exists' => false,
                 'committed_bytes' => 0,
@@ -350,62 +400,79 @@ final class Site_Export_Staged_Artifacts {
             ];
         }
 
-        $meta = $this->read_meta($paths['meta']);
+        $verified = $this->read_verified();
+        if (isset($verified[$artifact_id])) {
+            return [
+                'exists' => file_exists($file_path),
+                'committed_bytes' => $verified[$artifact_id]['size'],
+                'verified' => true,
+            ];
+        }
+
+        $state = $this->read_state();
         return [
-            'exists' => file_exists($paths['part']) || file_exists($paths['meta']),
-            'committed_bytes' => $meta['committed_bytes'],
-            'verified' => $meta['verified'],
+            'exists' => file_exists($file_path),
+            'committed_bytes' => $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0,
+            'verified' => false,
         ];
     }
 
     /**
-     * Remove all staged data for an artifact. Safe to call for unknown ids.
+     * Remove all staged data and records for an artifact. Safe to call for
+     * unknown ids.
      *
-     * @return bool False when a concurrent writer holds the artifact — an
+     * @return bool False when a concurrent writer holds the store — an
      *              unguarded unlink would let that writer's commit resurrect
-     *              an orphaned record.
+     *              a discarded artifact.
      */
     public function discard(string $artifact_id): bool {
-        $paths = $this->artifact_paths($artifact_id);
-        if ($paths === null) {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
             return true;
         }
 
-        if (!file_exists($paths['part']) && !file_exists($paths['meta'])) {
+        // Discarding an artifact nothing knows about is a no-op and must not
+        // create the staging scaffolding as a side effect.
+        $state = $this->read_state();
+        if (
+            !file_exists($file_path)
+            && $state['artifact_id'] !== $artifact_id
+            && !isset($this->read_verified()[$artifact_id])
+        ) {
             return true;
         }
 
-        // 'c+b' so the lock exists even when only the meta record does, and
-        // the meta is unlinked before the part while the lock is held — a
-        // writer arriving after the part unlink locks a fresh inode, and
-        // stale meta it could still read would resurrect its committed_bytes
-        // over bytes that are gone.
-        $part = @fopen($paths['part'], 'c+b');
-        if ($part === false) {
+        $lock = $this->open_lock();
+        if ($lock === false) {
             return false;
         }
         try {
-            if (!flock($part, LOCK_EX | LOCK_NB)) {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
                 return false;
             }
-            @unlink($paths['meta']);
-            @unlink($paths['part']);
+
+            @unlink($file_path);
+            $state = $this->read_state();
+            if ($state['artifact_id'] === $artifact_id) {
+                $this->write_state(null, 0);
+            }
+            $this->remove_verified($artifact_id);
             return true;
         } finally {
-            flock($part, LOCK_UN);
-            fclose($part);
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 
     /**
-     * Copies exactly $length bytes to the staging file while hashing the same
-     * bytes that landed on disk.
+     * Copies exactly $length bytes to the artifact file while hashing the
+     * same bytes that landed on disk.
      *
      * @param resource|string $source
      * @return string|null Rejection reason, or null when $length bytes were
      *                     copied and their checksum matched.
      */
-    private function copy_and_hash($source, $part, int $length, string $expected_crc32): ?string {
+    private function copy_and_hash($source, $file, int $length, string $expected_crc32): ?string {
         $context = hash_init('crc32b');
         $remaining = $length;
 
@@ -422,7 +489,7 @@ final class Site_Export_Staged_Artifacts {
             }
 
             hash_update($context, $buffer);
-            if (fwrite($part, $buffer) !== strlen($buffer)) {
+            if (fwrite($file, $buffer) !== strlen($buffer)) {
                 return 'io_error';
             }
             $remaining -= strlen($buffer);
@@ -464,10 +531,10 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Resolve an artifact id to its staging file paths, or null when the id
+     * Resolve an artifact id to its path under files/, or null when the id
      * is not a clean staging-relative path.
      */
-    private function artifact_paths(string $artifact_id): ?array {
+    private function artifact_path(string $artifact_id): ?string {
         if ($artifact_id === '' || $artifact_id[0] === '/' || strpos($artifact_id, "\0") !== false || strpos($artifact_id, '\\') !== false) {
             return null;
         }
@@ -477,11 +544,19 @@ final class Site_Export_Staged_Artifacts {
             }
         }
 
-        $base = $this->staging_dir . '/' . $artifact_id;
-        return [
-            'part' => $base . '.part',
-            'meta' => $base . '.meta.json',
-        ];
+        return $this->files_dir . '/' . $artifact_id;
+    }
+
+    /**
+     * Opens the flock target, creating the staging directory on first use.
+     *
+     * @return resource|false
+     */
+    private function open_lock() {
+        if (!$this->ensure_parent_dir($this->lock_path)) {
+            return false;
+        }
+        return @fopen($this->lock_path, 'c+b');
     }
 
     private function ensure_parent_dir(string $path): bool {
@@ -491,56 +566,120 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Reads the commit record as best-effort state.
+     * Reads the cursor as best-effort state.
      *
-     * A missing or unreadable record is treated as an empty artifact so the
-     * next writer must restart from offset 0 instead of trusting stale bytes.
+     * A missing or unreadable record is treated as no artifact in flight, so
+     * the next writer must restart its artifact from offset 0 instead of
+     * trusting stale bytes.
      *
-     * @return array{committed_bytes:int,verified:bool,verified_total_bytes:?int,verified_crc32:?string}
+     * @return array{artifact_id:?string,committed_bytes:int}
      */
-    private function read_meta(string $meta_path): array {
+    private function read_state(): array {
         $defaults = [
+            'artifact_id' => null,
             'committed_bytes' => 0,
-            'verified' => false,
-            'verified_total_bytes' => null,
-            'verified_crc32' => null,
         ];
 
-        $raw = @file_get_contents($meta_path);
+        $raw = @file_get_contents($this->state_path);
         if ($raw === false) {
             return $defaults;
         }
-        $meta = json_decode($raw, true);
-        if (!is_array($meta)) {
+        $state = json_decode($raw, true);
+        if (!is_array($state) || !is_string($state['artifact_id'] ?? null)) {
             return $defaults;
         }
 
-        // Metadata is intentionally not trusted as schema: old/corrupt files
-        // fall back to defaults after keeping only recognized keys.
-        $meta = array_merge($defaults, array_intersect_key($meta, $defaults));
-        $meta['committed_bytes'] = max(0, (int) $meta['committed_bytes']);
-        $meta['verified'] = (bool) $meta['verified'];
-        $meta['verified_total_bytes'] = $meta['verified_total_bytes'] !== null ? (int) $meta['verified_total_bytes'] : null;
-        return $meta;
+        $committed_bytes = isset($state['committed_bytes']) ? (int) $state['committed_bytes'] : 0;
+        return [
+            'artifact_id' => $state['artifact_id'],
+            'committed_bytes' => max(0, $committed_bytes),
+        ];
     }
 
-    private function write_meta(string $meta_path, array $meta): bool {
-        // Write-then-rename keeps the commit record atomic: readers see the
-        // old record or the new one, never a torn file. Keep the temp file
-        // next to the target so rename stays on the same filesystem.
-        $tmp_path = $meta_path . '.tmp';
-        $json = json_encode($meta);
+    private function write_state(?string $artifact_id, int $committed_bytes): bool {
+        // Write-then-rename keeps the cursor atomic: readers see the old
+        // record or the new one, never a torn file. The temp file sits next
+        // to the target so rename stays on the same filesystem.
+        $tmp_path = $this->state_path . '.tmp';
+        $json = json_encode([
+            'artifact_id' => $artifact_id,
+            'committed_bytes' => $committed_bytes,
+        ]);
         // A short write (disk full) returns a byte count, not false — never
         // rename a torn record over the good one.
         if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
             @unlink($tmp_path);
             return false;
         }
-        if (!@rename($tmp_path, $meta_path)) {
+        if (!@rename($tmp_path, $this->state_path)) {
             @unlink($tmp_path);
             return false;
         }
         return true;
+    }
+
+    /**
+     * Reads the verified-artifact records, keyed by artifact id.
+     *
+     * Malformed lines — a tail torn by a crash mid-append — are skipped, so
+     * the worst case is re-verifying an artifact, never trusting a torn record.
+     *
+     * @return array<string,array{size:int,crc32:string}>
+     */
+    private function read_verified(): array {
+        $raw = @file_get_contents($this->verified_path);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+
+        $records = [];
+        foreach (explode("\n", $raw) as $line) {
+            $record = json_decode($line, true);
+            if (
+                !is_array($record)
+                || !is_string($record['artifact_id'] ?? null)
+                || !is_int($record['size'] ?? null)
+                || $record['size'] < 0
+                || !is_string($record['crc32'] ?? null)
+            ) {
+                continue;
+            }
+            $records[$record['artifact_id']] = [
+                'size' => $record['size'],
+                'crc32' => $record['crc32'],
+            ];
+        }
+        return $records;
+    }
+
+    private function append_verified(string $artifact_id, int $size, string $crc32): bool {
+        $line = json_encode([
+            'artifact_id' => $artifact_id,
+            'size' => $size,
+            'crc32' => $crc32,
+        ]) . "\n";
+        return @file_put_contents($this->verified_path, $line, FILE_APPEND) === strlen($line);
+    }
+
+    private function remove_verified(string $artifact_id): void {
+        $records = $this->read_verified();
+        if (!isset($records[$artifact_id])) {
+            return;
+        }
+        unset($records[$artifact_id]);
+
+        $lines = '';
+        foreach ($records as $id => $record) {
+            $lines .= json_encode([
+                'artifact_id' => $id,
+                'size' => $record['size'],
+                'crc32' => $record['crc32'],
+            ]) . "\n";
+        }
+        $tmp_path = $this->verified_path . '.tmp';
+        if (@file_put_contents($tmp_path, $lines) !== strlen($lines) || !@rename($tmp_path, $this->verified_path)) {
+            @unlink($tmp_path);
+        }
     }
 
     /**

--- a/packages/reprint-importer/src/lib/upload/class-upload-chunk-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-upload-chunk-sizer.php
@@ -89,6 +89,8 @@ class UploadChunkSizer
         $config["growth_holdoff_successes"] = max(0, (int) $config["growth_holdoff_successes"]);
         $this->config = $config;
 
+        // Persisted state may come from an older config or version; clamp it
+        // through the current floor, ceiling, and hard cap before resuming.
         $ceiling = $state["ceiling_bytes"] ?? null;
         $this->ceiling_bytes = is_numeric($ceiling) && (int) $ceiling > 0 ? (int) $ceiling : null;
         $this->chunk_bytes = $this->clamp_chunk(
@@ -133,6 +135,8 @@ class UploadChunkSizer
             return $this->decision("steady");
         }
 
+        // Limits only lower the ceiling; a later, higher preflight value
+        // cannot erase a smaller limit learned earlier in the session.
         return $this->lower_ceiling((int) ($smallest * $this->config["limit_safety_ratio"]));
     }
 
@@ -225,6 +229,9 @@ class UploadChunkSizer
     }
 
     /**
+     * Lowers the learned per-session ceiling and shrinks the current chunk
+     * when it no longer fits.
+     *
      * @return array{action:string,chunk_bytes:int}
      */
     private function lower_ceiling(int $ceiling): array
@@ -246,11 +253,18 @@ class UploadChunkSizer
         return $this->decision("shrink");
     }
 
+    /**
+     * Returns the active ceiling after applying the unconditional hard cap.
+     */
     private function effective_ceiling(): int
     {
         return min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]);
     }
 
+    /**
+     * Normalizes restored state without converting an already-impossible
+     * ceiling into an invalid chunk size.
+     */
     private function clamp_chunk(int $chunk_bytes): int
     {
         return max(

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,18 +358,20 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-push/staged-artifact-batches",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
+                "reference": "4299e8cbe30ddce21de036bcef579a2e5d40159e"
             },
             "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
                 "php": ">=7.4",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
+            },
+            "suggest": {
+                "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+                "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
             },
             "type": "library",
             "autoload": {
@@ -382,10 +384,13 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
-                    "src/class-sqlite-driver-pdo.php"
+                    "src/class-staged-artifacts.php",
+                    "src/class-sqlite-driver-pdo.php",
+                    "src/class-wpdb-driver-pdo.php"
                 ],
                 "files": [
-                    "src/utils.php"
+                    "src/utils.php",
+                    "src/class-pdo-polyfill.php"
                 ]
             },
             "license": [

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -37,6 +37,16 @@ final class StagedArtifactsTest extends TestCase
         return $store->write_chunk($id, $offset, strlen($bytes), hash('crc32b', $bytes), $bytes);
     }
 
+    private function chunk(int $offset, string $bytes): array
+    {
+        return [
+            'offset' => $offset,
+            'length' => strlen($bytes),
+            'expected_crc32' => hash('crc32b', $bytes),
+            'source' => $bytes,
+        ];
+    }
+
     // ---------------------------------------------------------------
     // Assembly and finalize
     // ---------------------------------------------------------------
@@ -75,6 +85,48 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('verified', $store->finalize('artifact-1', strlen($body), hash('crc32b', $body))['status']);
     }
 
+    public function testManyChunksCanBeWrittenInOneOpenLockedBatch(): void
+    {
+        $store = $this->makeStore();
+        $chunks = [];
+        $body = '';
+        $offset = 0;
+        for ($i = 0; $i < 1000; $i++) {
+            $bytes = chr(65 + ($i % 26));
+            $chunks[] = $this->chunk($offset, $bytes);
+            $body .= $bytes;
+            $offset++;
+        }
+
+        $result = $store->write_chunks('artifact-1', $chunks);
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(strlen($body), $result['committed_bytes']);
+        $verified = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame($body, file_get_contents($verified['path']));
+    }
+
+    public function testStreamingBatchKeepsTheArtifactLockAcrossChunks(): void
+    {
+        $store = $this->makeStore();
+        $busy_write = null;
+
+        $chunks = (function () use ($store, &$busy_write) {
+            yield $this->chunk(0, 'first');
+            $busy_write = $this->writeString($store, 'artifact-1', 5, 'blocked');
+            yield $this->chunk(5, 'second');
+        })();
+
+        $result = $store->write_chunks('artifact-1', $chunks);
+
+        $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(11, $result['committed_bytes']);
+        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
     public function testZeroByteArtifactVerifiesWithoutChunks(): void
     {
         $store = $this->makeStore();
@@ -96,6 +148,30 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('verified', $again['status']);
     }
 
+    public function testFinalizeOfUnknownArtifactReportsMissing(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->finalize('never-uploaded', 5, hash('crc32b', 'bytes'));
+
+        $this->assertSame(['rejected', 'missing'], [$result['status'], $result['reason']]);
+    }
+
+    public function testRefinalizeWithDifferentChecksumIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7, hash('crc32b', 'payload'));
+
+        $result = $store->finalize('artifact-1', 7, hash('crc32b', 'tampered'));
+
+        $this->assertSame(
+            ['rejected', 'hash_mismatch', 'verified_record'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+        $this->assertTrue($store->status('artifact-1')['verified']);
+    }
+
     // ---------------------------------------------------------------
     // Idempotent retries and resume
     // ---------------------------------------------------------------
@@ -109,6 +185,104 @@ final class StagedArtifactsTest extends TestCase
 
         $this->assertSame('duplicate', $retry['status']);
         $this->assertSame(5, $retry['committed_bytes']);
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+    }
+
+    public function testDuplicateStreamChunkIsDrainedInsideBatch(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $stream = fopen('php://temp', 'r+b');
+        fwrite($stream, 'firstsecond');
+        rewind($stream);
+        $result = $store->write_chunks('artifact-1', [
+            [
+                'offset' => 0,
+                'length' => 5,
+                'expected_crc32' => hash('crc32b', 'first'),
+                'source' => $stream,
+            ],
+            [
+                'offset' => 5,
+                'length' => 6,
+                'expected_crc32' => hash('crc32b', 'second'),
+                'source' => $stream,
+            ],
+        ]);
+        fclose($stream);
+
+        $this->assertSame('accepted', $result['status']);
+        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testMidBatchRejectionKeepsEarlierChunksCommitted(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->write_chunks('artifact-1', [
+            $this->chunk(0, 'first'),
+            [
+                'offset' => 5,
+                'length' => 6,
+                'expected_crc32' => hash('crc32b', 'other!'),
+                'source' => 'second',
+            ],
+        ]);
+
+        $this->assertSame(
+            ['rejected', 'hash_mismatch', 'chunk_body', 5],
+            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
+        );
+
+        // The sender resumes from committed_bytes instead of restarting.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+        $verified = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testDuplicateDrainOfTruncatedStreamIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $stream = fopen('php://temp', 'r+b');
+        fwrite($stream, 'fir'); // Three of the duplicate chunk's five bytes.
+        rewind($stream);
+        $result = $store->write_chunks('artifact-1', [
+            [
+                'offset' => 0,
+                'length' => 5,
+                'expected_crc32' => hash('crc32b', 'first'),
+                'source' => $stream,
+            ],
+        ]);
+        fclose($stream);
+
+        $this->assertSame(
+            ['rejected', 'short_body', 'duplicate_drain', 5],
+            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
+        );
+    }
+
+    public function testGeneratorFailureMidBatchReleasesTheLockAndKeepsProgress(): void
+    {
+        $store = $this->makeStore();
+        $chunks = (function () {
+            yield $this->chunk(0, 'first');
+            throw new DomainException('endpoint failed to parse the next chunk');
+        })();
+
+        try {
+            $store->write_chunks('artifact-1', $chunks);
+            $threw = false;
+        } catch (DomainException $exception) {
+            $threw = true;
+        }
+
+        $this->assertTrue($threw, 'The generator exception should propagate to the endpoint.');
+        $this->assertSame(5, $store->status('artifact-1')['committed_bytes']);
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
     }
 
@@ -163,6 +337,43 @@ final class StagedArtifactsTest extends TestCase
         $result = $store->finalize('artifact-1', strlen($body), hash('crc32b', $body));
         $this->assertSame('verified', $result['status']);
         $this->assertSame($body, file_get_contents($result['path']));
+    }
+
+    public function testExternallyShrunkenStagingFileFailsTheArtifactChecksum(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        // Simulate the staging file drifting between requests: something
+        // shrinks it below the committed size.
+        file_put_contents($this->staging_dir . '/artifact-1.part', 'fi');
+
+        // The next write zero-fills back to the committed size and appends;
+        // only finalize's whole-artifact checksum can see the damage.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
+
+        $result = $store->finalize('artifact-1', 11, hash('crc32b', 'firstsecond'));
+        $this->assertSame(
+            ['rejected', 'hash_mismatch', 'artifact_crc32'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+        $this->assertFalse($store->status('artifact-1')['verified']);
+    }
+
+    public function testCorruptCommitRecordRestartsTheArtifact(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        file_put_contents($this->staging_dir . '/artifact-1.meta.json', 'not json {');
+
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+        $resumed = $this->writeString($store, 'artifact-1', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$resumed['status'], $resumed['reason'], $resumed['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
     }
 
     public function testFinalizeRejectsWrongSizeAndWrongHash(): void
@@ -225,6 +436,39 @@ final class StagedArtifactsTest extends TestCase
 
         $bad_length = $store->write_chunk('artifact-1', 0, 0, hash('crc32b', ''), '');
         $this->assertSame(['rejected', 'invalid_length'], [$bad_length['status'], $bad_length['reason']]);
+
+        $bad_offset = $store->write_chunk('artifact-1', -1, 5, hash('crc32b', 'bytes'), 'bytes');
+        $this->assertSame(['rejected', 'invalid_offset'], [$bad_offset['status'], $bad_offset['reason']]);
+
+        $bad_source = $store->write_chunk('artifact-1', 0, 5, hash('crc32b', 'bytes'), 42);
+        $this->assertSame(['rejected', 'invalid_source'], [$bad_source['status'], $bad_source['reason']]);
+    }
+
+    public function testUppercaseChecksumsAreAccepted(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->write_chunk('artifact-1', 0, 5, strtoupper(hash('crc32b', 'bytes')), 'bytes');
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(
+            'verified',
+            $store->finalize('artifact-1', 5, strtoupper(hash('crc32b', 'bytes')))['status']
+        );
+    }
+
+    public function testEmptyBatchIsRejectedWithoutDisturbingCommittedBytes(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+
+        $result = $store->write_chunks('artifact-1', []);
+
+        $this->assertSame(
+            ['rejected', 'empty_batch', 5],
+            [$result['status'], $result['reason'], $result['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
     }
 
     public function testStagingMirrorsTheArtifactPath(): void
@@ -242,7 +486,7 @@ final class StagedArtifactsTest extends TestCase
     {
         $store = $this->makeStore();
 
-        foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', ''] as $hostile_id) {
+        foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', '', 'a\\b', "a\0b"] as $hostile_id) {
             $result = $this->writeString($store, $hostile_id, 0, 'bytes');
             $this->assertSame(
                 ['rejected', 'invalid_artifact_id'],
@@ -259,7 +503,7 @@ final class StagedArtifactsTest extends TestCase
             $this->assertTrue($store->discard($hostile_id), "id: {$hostile_id}");
         }
 
-        $this->assertDirectoryDoesNotExist(dirname($this->staging_dir) . '/outside');
+        $this->assertDirectoryDoesNotExist(dirname(dirname($this->staging_dir)) . '/outside');
         $this->assertFileDoesNotExist('/etc/passwd.part');
     }
 
@@ -277,8 +521,10 @@ final class StagedArtifactsTest extends TestCase
         $holder = fopen($part_path, 'r+b');
         flock($holder, LOCK_EX);
 
-        $this->assertSame('busy', $this->writeString($store, 'artifact-1', 5, 'second')['status']);
-        $this->assertSame('busy', $store->finalize('artifact-1', 5, hash('crc32b', 'first'))['status']);
+        $busy_write = $this->writeString($store, 'artifact-1', 5, 'second');
+        $this->assertSame(['busy', 5], [$busy_write['status'], $busy_write['committed_bytes']]);
+        $busy_finalize = $store->finalize('artifact-1', 5, hash('crc32b', 'first'));
+        $this->assertSame(['busy', 5], [$busy_finalize['status'], $busy_finalize['committed_bytes']]);
         $this->assertFalse($store->discard('artifact-1'));
 
         flock($holder, LOCK_UN);
@@ -296,6 +542,35 @@ final class StagedArtifactsTest extends TestCase
         $status = $store->status('artifact-1');
         $this->assertSame(['exists' => false, 'committed_bytes' => 0, 'verified' => false], $status);
         $this->assertTrue($store->discard('never-existed'));
+    }
+
+    public function testDiscardedArtifactRestartsFromScratch(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'first');
+        $store->discard('artifact-1');
+
+        $stale = $this->writeString($store, 'artifact-1', 5, 'second');
+
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
+    }
+
+    public function testDiscardCleansUpAMetaOnlyResidue(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-1', 0, 'payload');
+        unlink($this->staging_dir . '/artifact-1.part');
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $store->status('artifact-1')
+        );
     }
 
     public function testStatusOfUnknownArtifact(): void

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -217,6 +217,22 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
     }
 
+    public function testSwitchingArtifactsRestartsTheAbandonedOne(): void
+    {
+        $store = $this->makeStore();
+        $this->writeString($store, 'artifact-a', 0, 'first');
+
+        // Sequential transfers: chunk 0 of another artifact moves the cursor.
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-b', 0, 'bee')['status']);
+
+        $stale = $this->writeString($store, 'artifact-a', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $this->writeString($store, 'artifact-a', 0, 'fresh')['status']);
+    }
+
     public function testMidBatchRejectionKeepsEarlierChunksCommitted(): void
     {
         $store = $this->makeStore();
@@ -327,10 +343,9 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'committed');
 
-        // Simulate a crash after data was written but before the commit
-        // record moved: garbage sits beyond committed_bytes in the file.
-        $part_path = $this->staging_dir . '/artifact-1.part';
-        file_put_contents($part_path, 'GARBAGE', FILE_APPEND);
+        // Simulate a crash after data was written but before the cursor
+        // moved: garbage sits beyond committed_bytes in the file.
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'GARBAGE', FILE_APPEND);
 
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 9, '-tail')['status']);
         $body = 'committed-tail';
@@ -346,7 +361,7 @@ final class StagedArtifactsTest extends TestCase
 
         // Simulate the staging file drifting between requests: something
         // shrinks it below the committed size.
-        file_put_contents($this->staging_dir . '/artifact-1.part', 'fi');
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
 
         // The next write zero-fills back to the committed size and appends;
         // only finalize's whole-artifact checksum can see the damage.
@@ -365,7 +380,7 @@ final class StagedArtifactsTest extends TestCase
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'first');
 
-        file_put_contents($this->staging_dir . '/artifact-1.meta.json', 'not json {');
+        file_put_contents($this->staging_dir . '/state.json', 'not json {');
 
         $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
         $resumed = $this->writeString($store, 'artifact-1', 5, 'second');
@@ -478,8 +493,20 @@ final class StagedArtifactsTest extends TestCase
 
         $this->assertSame('accepted', $this->writeString($store, $id, 0, 'body { }')['status']);
 
-        $this->assertFileExists($this->staging_dir . '/' . $id . '.part');
-        $this->assertFileExists($this->staging_dir . '/' . $id . '.meta.json');
+        $this->assertFileExists($this->staging_dir . '/files/' . $id);
+        $this->assertFileExists($this->staging_dir . '/state.json');
+    }
+
+    public function testSiteFilenamesThatLookLikeStagingRecordsStageVerbatim(): void
+    {
+        $store = $this->makeStore();
+
+        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json'] as $id) {
+            $this->assertSame('accepted', $this->writeString($store, $id, 0, "body of {$id}")['status']);
+            $verified = $store->finalize($id, strlen("body of {$id}"), hash('crc32b', "body of {$id}"));
+            $this->assertSame('verified', $verified['status'], "id: {$id}");
+            $this->assertSame("body of {$id}", file_get_contents($this->staging_dir . '/files/' . $id));
+        }
     }
 
     public function testIdsOutsideTheStagingDirAreRejected(): void
@@ -504,7 +531,7 @@ final class StagedArtifactsTest extends TestCase
         }
 
         $this->assertDirectoryDoesNotExist(dirname(dirname($this->staging_dir)) . '/outside');
-        $this->assertFileDoesNotExist('/etc/passwd.part');
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/etc/passwd');
     }
 
     // ---------------------------------------------------------------
@@ -517,8 +544,7 @@ final class StagedArtifactsTest extends TestCase
         $this->writeString($store, 'artifact-1', 0, 'first');
 
         // Hold the lock the way a concurrent writer would.
-        $part_path = $this->staging_dir . '/artifact-1.part';
-        $holder = fopen($part_path, 'r+b');
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
         flock($holder, LOCK_EX);
 
         $busy_write = $this->writeString($store, 'artifact-1', 5, 'second');
@@ -559,11 +585,11 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $this->writeString($store, 'artifact-1', 0, 'fresh')['status']);
     }
 
-    public function testDiscardCleansUpAMetaOnlyResidue(): void
+    public function testDiscardClearsTheCursorWhenTheArtifactFileIsMissing(): void
     {
         $store = $this->makeStore();
         $this->writeString($store, 'artifact-1', 0, 'payload');
-        unlink($this->staging_dir . '/artifact-1.part');
+        unlink($this->staging_dir . '/files/artifact-1');
 
         $this->assertTrue($store->discard('artifact-1'));
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,7 @@
             <file>FileIndexDedupTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>StagedArtifactsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>


### PR DESCRIPTION
## What it does

Adds batched writes to `Site_Export_Staged_Artifacts` so one upload request can commit many consecutive chunks while holding the staging file lock once.

This stacks on #298. It still has no HTTP endpoint consumer; the next layer can feed parsed request chunks into `write_chunks()`.

## Rationale

The upload protocol should bundle small files/chunks into bounded requests instead of making one HTTP request per chunk. The staging store needs to support that without losing resumability:

- every chunk still commits independently;
- a failed mid-batch chunk preserves the committed offset before it;
- duplicate chunks from a retry are drained so the request parser stays aligned;
- concurrent writers still get `busy` rather than interleaved bytes.

## Implementation

- Keeps `write_chunk()` as the single-chunk wrapper.
- Adds `write_chunks()` for iterable chunk batches, including generator-backed parsing from `php://input`.
- Returns `detail` fields for ambiguous failures such as `chunk_body`, `duplicate_drain`, `artifact_crc32`, and commit-record persistence.
- Reports `committed_bytes` for `busy` writes/finalize attempts so upload workers can resume from the remote state.
- Tightens artifact-id validation for backslashes and NUL bytes.
- Adds `StagedArtifactsTest.php` to the default PHPUnit suite.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit --colors=never StagedArtifactsTest.php
composer analyze
```
