### PR TITLE
Serve the staged artifact store over the export API

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-artifact-batches",
+            "version": "dev-push/staged-upload-endpoints",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "4299e8cbe30ddce21de036bcef579a2e5d40159e"
+                "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
             },
             "require": {
                 "php": ">=7.4",
@@ -385,6 +385,7 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-staged-artifacts.php",
+                    "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"
                 ],

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -23,6 +23,7 @@
             "src/class-hmac-server.php",
             "src/class-http-server.php",
             "src/class-staged-artifacts.php",
+            "src/class-staged-endpoints.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"
         ],

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -22,6 +22,9 @@ final class Site_Export_HTTP_Server {
     /** @var string|null */
     private $default_directory;
 
+    /** @var string[] Endpoints dispatched without a resource budget. */
+    private $no_budget_endpoints = ['preflight'];
+
     public function __construct(array $options = []) {
         $this->handlers = $options['handlers'] ?? $this->default_handlers();
         $this->budget_factory = $options['budget_factory'] ?? [$this, 'default_budget_factory'];
@@ -31,11 +34,22 @@ final class Site_Export_HTTP_Server {
         };
         $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
         $this->default_directory = $options['default_directory'] ?? null;
+
+        if (isset($options['staged']) && is_array($options['staged'])) {
+            $this->register_staged_handlers(new Site_Export_Staged_Endpoints($options['staged']));
+        }
     }
 
     public function handle_request(array $request = []): void {
         $server = $request['server'] ?? $_SERVER;
-        $body = array_key_exists('body', $request) ? (string) $request['body'] : call_user_func($this->body_reader);
+        if (array_key_exists('body', $request)) {
+            $body = (string) $request['body'];
+        } else {
+            // Config parsing only consumes JSON bodies. Reading anything
+            // else here would buffer a raw upload body (staged_upload) in
+            // memory before its handler can stream it.
+            $body = $this->is_json_content_type($server) ? call_user_func($this->body_reader) : '';
+        }
         $config = $request['config'] ?? $this->parse_http_config(
             $request['get'] ?? $_GET,
             $request['post'] ?? $_POST,
@@ -262,7 +276,7 @@ final class Site_Export_HTTP_Server {
         }
 
         $handler = $this->handlers[$endpoint];
-        if ($endpoint === 'preflight') {
+        if (in_array($endpoint, $this->no_budget_endpoints, true)) {
             call_user_func($handler, $config);
             return;
         }
@@ -285,6 +299,59 @@ final class Site_Export_HTTP_Server {
             'db_index' => 'endpoint_db_index',
             'preflight' => 'endpoint_preflight',
         ];
+    }
+
+    /**
+     * Wire the staged artifact routes to the shared dispatcher.
+     *
+     * Explicitly-passed handlers win over these, matching how the
+     * handlers option replaces the default map.
+     */
+    private function register_staged_handlers(Site_Export_Staged_Endpoints $endpoints): void {
+        $routes = [
+            'staged_upload' => static function (array $config) use ($endpoints): void {
+                $input = @fopen('php://input', 'rb');
+                try {
+                    self::emit_json_response(
+                        $endpoints->upload($config, $_SERVER, $input === false ? null : $input)
+                    );
+                } finally {
+                    if (is_resource($input)) {
+                        fclose($input);
+                    }
+                }
+            },
+            'staged_finalize' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->finalize($config, $_SERVER));
+            },
+            'staged_status' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->status($config));
+            },
+            'staged_discard' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->discard($config, $_SERVER));
+            },
+        ];
+
+        foreach ($routes as $endpoint => $handler) {
+            if (!isset($this->handlers[$endpoint])) {
+                $this->handlers[$endpoint] = $handler;
+            }
+            $this->no_budget_endpoints[] = $endpoint;
+        }
+    }
+
+    /**
+     * @param array{http_code:int,body:array} $response
+     */
+    private static function emit_json_response(array $response): void {
+        http_response_code($response['http_code']);
+        header('Content-Type: application/json');
+        echo json_encode($response['body']);
+    }
+
+    private function is_json_content_type(array $server): bool {
+        $content_type = (string) ( $server['CONTENT_TYPE'] ?? '' );
+        return strtolower(trim( (string) strtok($content_type, ';'))) === 'application/json';
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -1,0 +1,419 @@
+<?php
+
+use function WordPress\Reprint\Exporter\parse_size;
+
+/**
+ * HTTP endpoints for the staged artifact store.
+ *
+ * This is the target side of a push chunk upload: the sender reads its
+ * source in bounded chunks (sized by UploadChunkSizer on the importer
+ * side) and posts each chunk here, where it accumulates in
+ * Site_Export_Staged_Artifacts instead of touching the live site.
+ *
+ * Four routes share the existing endpoint dispatcher:
+ *
+ * - staged_upload   (POST, data plane): raw chunk bytes in the request
+ *   body, artifact_id and offset in the query string.
+ * - staged_finalize (POST, control plane): confirm the assembled size.
+ * - staged_status   (GET, control plane): resume hint for a sender.
+ * - staged_discard  (POST, control plane): drop an artifact; retry
+ *   until the response says discarded.
+ *
+ * Control-plane routes have small bodies and ride the embedding layer's
+ * existing HMAC verification, like every other endpoint. staged_upload
+ * cannot: that verification buffers the whole request body to hash it,
+ * and a chunk can be as large as the sizer's 1 GiB cap. So the upload
+ * route authenticates inside the handler, in two steps that keep memory
+ * bounded and keep unauthenticated bytes away from the store:
+ *
+ * 1. verify_signed_content_hash() checks the signature, nonce, and
+ *    timestamp headers before a single body byte is read. A caller
+ *    without the shared secret is rejected without costing a body read.
+ * 2. The body streams into a spool (memory up to a small threshold,
+ *    then a temp file) while a SHA-256 digest accumulates. Only when
+ *    the digest matches the signed claim does the spool drain into
+ *    append(), one bounded buffer per call. A mismatched or oversized
+ *    body is discarded with the spool — the store never sees it. The
+ *    spool is one extra sequential disk pass over bytes the host
+ *    already buffered for the request; that is the price of never
+ *    committing an unverified byte.
+ *
+ * A replayed capture of a signed upload within the timestamp tolerance
+ * re-appends bytes the store already committed and comes back
+ * "duplicate" — idempotent, same as a sender retry.
+ *
+ * Chunk retries are the normal case, not an error: a sender that timed
+ * out learns nothing about what landed, retries the same chunk, and may
+ * later resend with shifted boundaries. The upload route therefore
+ * compares the store's committed offset with the chunk's range first,
+ * answers "duplicate" for fully-committed ranges, skips the committed
+ * prefix of a straddling chunk, and answers offset_gap (with
+ * committed_bytes) only when the chunk starts beyond the frontier.
+ *
+ * Rejections the chunk sizer must learn from are typed for it: a body
+ * over the request cap is HTTP 413 with max_request_bytes in the
+ * payload, exactly what record_too_large() consumes. The cap defaults
+ * to post_max_size (falling back to the sizer's own 1 GiB hard cap when
+ * PHP reports none), because a proxy or PHP itself would refuse larger
+ * bodies before this code runs anyway.
+ *
+ * All options are server-owned. Client config never chooses the staging
+ * directory, the secret, or the caps — a request parameter named like
+ * an option is ignored. Methods return ['http_code' => int, 'body' =>
+ * array] and never echo, so tests drive them directly; the dispatcher
+ * wiring in Site_Export_HTTP_Server emits the JSON.
+ */
+final class Site_Export_Staged_Endpoints {
+
+    /** The chunk sizer never sends more than this, so accept up to it. */
+    private const DEFAULT_MAX_REQUEST_BYTES = 1073741824;
+
+    /** One append() step per this many spooled bytes. */
+    private const DEFAULT_APPEND_BUFFER_BYTES = 262144;
+
+    /** Spool bytes held in memory before php://temp spills to disk. */
+    private const SPOOL_MEMORY_BYTES = 2097152;
+
+    /** Request-body read size while spooling. */
+    private const READ_BUFFER_BYTES = 65536;
+
+    /** @var Site_Export_Staged_Artifacts */
+    private $store;
+
+    /** @var string|null */
+    private $secret;
+
+    /** @var int */
+    private $max_request_bytes;
+
+    /** @var int */
+    private $append_buffer_bytes;
+
+    /** @var int */
+    private $timestamp_tolerance;
+
+    /**
+     * @param array $options Server-owned configuration:
+     *   - staging_dir (string, required): passed to the artifact store.
+     *     Must live outside the web-served tree.
+     *   - secret (?string): shared secret for upload authentication.
+     *     Null leaves uploads answering 503 until one is configured.
+     *   - max_request_bytes (int): upload body cap; defaults to
+     *     post_max_size, or 1 GiB when PHP reports no limit.
+     *   - append_buffer_bytes (int): spool-to-store step size.
+     *   - timestamp_tolerance (int): HMAC freshness window in seconds.
+     */
+    public function __construct(array $options) {
+        $staging_dir = $options['staging_dir'] ?? null;
+        if (!is_string($staging_dir) || $staging_dir === '') {
+            throw new InvalidArgumentException('Staged endpoints require a staging_dir option.');
+        }
+        $this->store = new Site_Export_Staged_Artifacts($staging_dir);
+
+        $secret = $options['secret'] ?? null;
+        $this->secret = is_string($secret) && $secret !== '' ? $secret : null;
+
+        $max = $options['max_request_bytes'] ?? null;
+        if (!is_numeric($max) || (int) $max <= 0) {
+            $post_max = ini_get('post_max_size');
+            $max = is_string($post_max) && $post_max !== '' ? parse_size($post_max) : 0;
+            if ($max <= 0) {
+                $max = self::DEFAULT_MAX_REQUEST_BYTES;
+            }
+        }
+        $this->max_request_bytes = (int) $max;
+
+        $buffer = $options['append_buffer_bytes'] ?? null;
+        $this->append_buffer_bytes = is_numeric($buffer) && (int) $buffer > 0
+            ? (int) $buffer
+            : self::DEFAULT_APPEND_BUFFER_BYTES;
+
+        $tolerance = $options['timestamp_tolerance'] ?? null;
+        $this->timestamp_tolerance = is_numeric($tolerance) && (int) $tolerance > 0
+            ? (int) $tolerance
+            : 300;
+    }
+
+    /**
+     * Stage one chunk of an artifact.
+     *
+     * @param array $config Request parameters (artifact_id, offset).
+     * @param array $headers Request headers/server vars ($_SERVER shape).
+     * @param resource|null $input Request body stream (php://input).
+     * @return array{http_code:int,body:array}
+     */
+    public function upload(array $config, array $headers, $input): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+        $offset = $config['offset'] ?? null;
+        if (!is_numeric($offset) || (int) $offset < 0) {
+            return $this->rejected(400, 'invalid_offset');
+        }
+        $offset = (int) $offset;
+
+        if ($this->secret === null) {
+            return $this->rejected(503, 'not_configured', 'shared_secret');
+        }
+
+        // Headers first: nobody without the secret gets a body read.
+        $hmac = new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance);
+        $auth = $hmac->verify_signed_content_hash($headers);
+        if ($auth['error'] !== null) {
+            return $this->rejected(403, 'auth_failed', $auth['error']);
+        }
+
+        $declared_length = $headers['CONTENT_LENGTH'] ?? ( $headers['HTTP_CONTENT_LENGTH'] ?? null );
+        if (is_numeric($declared_length) && (int) $declared_length > $this->max_request_bytes) {
+            return $this->too_large($artifact_id);
+        }
+
+        if (!is_resource($input)) {
+            return $this->rejected(500, 'io_error', 'open_request_body');
+        }
+
+        $spool = fopen('php://temp/maxmemory:' . self::SPOOL_MEMORY_BYTES, 'w+b');
+        if ($spool === false) {
+            return $this->rejected(500, 'io_error', 'open_spool');
+        }
+
+        try {
+            $context = hash_init('sha256');
+            $spooled = 0;
+            while (( $buffer = fread($input, self::READ_BUFFER_BYTES) ) !== false && $buffer !== '') {
+                $spooled += strlen($buffer);
+                if ($spooled > $this->max_request_bytes) {
+                    return $this->too_large($artifact_id);
+                }
+                hash_update($context, $buffer);
+                if (fwrite($spool, $buffer) !== strlen($buffer)) {
+                    return $this->rejected(500, 'io_error', 'write_spool');
+                }
+            }
+            if ($buffer === false && !feof($input)) {
+                return $this->rejected(400, 'body_read_failed');
+            }
+
+            // The signature authenticated the hash claim; this comparison
+            // authenticates the bytes. Nothing reached the store yet.
+            if (!hash_equals( (string) $auth['content_hash'], hash_final($context))) {
+                return $this->rejected(403, 'content_hash_mismatch');
+            }
+
+            if ($spooled === 0) {
+                return $this->rejected(400, 'empty_body');
+            }
+
+            $status = $this->store->status($artifact_id);
+            if ($status['verified']) {
+                return $this->rejected(409, 'already_verified', null, $status['committed_bytes']);
+            }
+            $committed = $status['committed_bytes'];
+            if ($committed >= $offset + $spooled) {
+                // A retried chunk that fully landed before the sender's
+                // timeout. Nothing to write.
+                return [
+                    'http_code' => 200,
+                    'body' => [
+                        'status' => 'duplicate',
+                        'reason' => null,
+                        'detail' => null,
+                        'committed_bytes' => $committed,
+                    ],
+                ];
+            }
+            if ($committed < $offset) {
+                return $this->rejected(409, 'offset_gap', null, $committed);
+            }
+
+            // A resent chunk may straddle the committed frontier; skip the
+            // prefix the store already has so appends line up with it.
+            rewind($spool);
+            if ($committed > $offset && fseek($spool, $committed - $offset) !== 0) {
+                return $this->rejected(500, 'io_error', 'seek_spool');
+            }
+
+            $position = $committed;
+            while (( $buffer = fread($spool, $this->append_buffer_bytes) ) !== false && $buffer !== '') {
+                $result = $this->store->append($artifact_id, $position, $buffer);
+                if ($result['status'] !== 'accepted') {
+                    return $this->from_store_result($result);
+                }
+                $position = $result['committed_bytes'];
+            }
+
+            return [
+                'http_code' => 200,
+                'body' => [
+                    'status' => 'accepted',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $position,
+                ],
+            ];
+        } finally {
+            fclose($spool);
+        }
+    }
+
+    /**
+     * Confirm an assembled artifact against its plan-declared size.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function finalize(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+        $total_bytes = $config['total_bytes'] ?? null;
+        if (!is_numeric($total_bytes) || (int) $total_bytes < 0) {
+            return $this->rejected(400, 'invalid_total');
+        }
+
+        $result = $this->store->finalize($artifact_id, (int) $total_bytes);
+        // The staged path is server-local detail; apply resolves by id.
+        unset($result['path']);
+        return $this->from_store_result($result);
+    }
+
+    /**
+     * Resume hint for a sender: committed offset and verified flag.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function status(array $config): array {
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+
+        return [
+            'http_code' => 200,
+            'body' => $this->store->status($artifact_id),
+        ];
+    }
+
+    /**
+     * Drop an artifact's staged bytes and records.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function discard(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+
+        if (!$this->store->discard($artifact_id)) {
+            // Held by a concurrent writer or a failed cleanup step; both
+            // are the store's retry-until-true contract.
+            return [
+                'http_code' => 423,
+                'body' => ['discarded' => false],
+            ];
+        }
+        return [
+            'http_code' => 200,
+            'body' => ['discarded' => true],
+        ];
+    }
+
+    /**
+     * @return array{http_code:int,body:array}|null Null when the method is POST.
+     */
+    private function require_post(array $headers): ?array {
+        $method = strtoupper( (string) ( $headers['REQUEST_METHOD'] ?? '' ));
+        if ($method === 'POST') {
+            return null;
+        }
+        return $this->rejected(405, 'method_not_allowed');
+    }
+
+    /**
+     * Map a store result onto an HTTP code, passing its typed body through.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    private function from_store_result(array $result): array {
+        switch ($result['status']) {
+            case 'accepted':
+            case 'duplicate':
+            case 'verified':
+                $code = 200;
+                break;
+            case 'busy':
+                $code = 423;
+                break;
+            default:
+                $code = $this->code_for_reason( (string) $result['reason']);
+        }
+
+        return [
+            'http_code' => $code,
+            'body' => $result,
+        ];
+    }
+
+    private function code_for_reason(string $reason): int {
+        switch ($reason) {
+            case 'io_error':
+                return 500;
+            case 'offset_gap':
+            case 'already_verified':
+            case 'size_mismatch':
+            case 'missing':
+                return 409;
+            default:
+                return 400;
+        }
+    }
+
+    /**
+     * @return array{http_code:int,body:array}
+     */
+    private function rejected(int $http_code, string $reason, ?string $detail = null, int $committed_bytes = 0): array {
+        return [
+            'http_code' => $http_code,
+            'body' => [
+                'status' => 'rejected',
+                'reason' => $reason,
+                'detail' => $detail,
+                'committed_bytes' => $committed_bytes,
+            ],
+        ];
+    }
+
+    /**
+     * The structured too-large rejection UploadChunkSizer::record_too_large()
+     * consumes: HTTP 413 plus the cap it must stay under.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    private function too_large(string $artifact_id): array {
+        $response = $this->rejected(
+            413,
+            'request_too_large',
+            null,
+            $this->store->status($artifact_id)['committed_bytes']
+        );
+        $response['body']['max_request_bytes'] = $this->max_request_bytes;
+        return $response;
+    }
+}

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -17,3 +17,19 @@ if (!function_exists('trailingslashit')) {
         return rtrim($value, '/\\') . '/';
     }
 }
+
+if (!function_exists('wp_unslash')) {
+    /**
+     * @param string|array $value
+     * @return string|array
+     */
+    function wp_unslash($value) {
+        return is_array($value) ? array_map('wp_unslash', $value) : stripslashes((string) $value);
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key(string $key): string {
+        return (string) preg_replace('/[^a-z0-9_\-]/', '', strtolower($key));
+    }
+}

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -17,19 +17,3 @@ if (!function_exists('trailingslashit')) {
         return rtrim($value, '/\\') . '/';
     }
 }
-
-if (!function_exists('wp_unslash')) {
-    /**
-     * @param string|array $value
-     * @return string|array
-     */
-    function wp_unslash($value) {
-        return is_array($value) ? array_map('wp_unslash', $value) : stripslashes((string) $value);
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key(string $key): string {
-        return (string) preg_replace('/[^a-z0-9_\-]/', '', strtolower($key));
-    }
-}

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-artifact-batches",
+            "version": "dev-push/staged-upload-endpoints",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "4299e8cbe30ddce21de036bcef579a2e5d40159e"
+                "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
             },
             "require": {
                 "php": ">=7.4",
@@ -385,6 +385,7 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-staged-artifacts.php",
+                    "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"
                 ],

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -180,6 +180,28 @@ function _site_export_default_authenticate(): void {
 }
 
 /**
+ * Server-side options for the staged artifact endpoints.
+ *
+ * The staging directory must live outside the web-served tree, and WordPress
+ * has no guaranteed writable directory there, so the default sits under the
+ * system temp dir, keyed by ABSPATH so co-hosted sites do not share staging
+ * state. A host that cleans its temp dir only costs a transfer its progress —
+ * artifacts re-upload from offset 0. Define SITE_EXPORT_STAGING_DIR to pick a
+ * durable location instead.
+ */
+function _site_export_staged_options(): array {
+    $staging_dir = defined('SITE_EXPORT_STAGING_DIR')
+        ? SITE_EXPORT_STAGING_DIR
+        : rtrim(sys_get_temp_dir(), '/') . '/reprint-staging-' . md5(ABSPATH);
+
+    return [
+        'staging_dir' => $staging_dir,
+        'secret' => _site_export_get_shared_secret(),
+        'timestamp_tolerance' => SITE_EXPORT_TIMESTAMP_TOLERANCE,
+    ];
+}
+
+/**
  * Handle an export API request.
  *
  * WordPress is already loaded at this point — DB credentials, $table_prefix,
@@ -250,8 +272,20 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
-    $authenticate();
+    // staged_upload authenticates inside its handler: the default handler
+    // here buffers the whole request body to hash it, which a chunk upload
+    // cannot afford. The upload route verifies the signed headers first and
+    // hashes the body as it streams. A custom authenticate callable still
+    // runs for every endpoint — its embedder owns that tradeoff.
+    $endpoint = isset($_GET['endpoint']) && is_string($_GET['endpoint'])
+        ? sanitize_key(wp_unslash($_GET['endpoint']))
+        : '';
+    $authenticate = $options['authenticate'] ?? null;
+    if ($authenticate !== null) {
+        $authenticate();
+    } elseif ($endpoint !== 'staged_upload') {
+        _site_export_default_authenticate();
+    }
 
     // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server
     // is resolvable. The class itself will require export.php on demand
@@ -267,6 +301,7 @@ function _site_export_handle_api_request(array $options = []): void {
     try {
         Site_Export_HTTP_Server::serve([
             'default_directory' => ABSPATH,
+            'staged' => _site_export_staged_options(),
         ]);
     } catch (Exception $e) {
         if (!headers_sent()) {

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -277,9 +277,9 @@ function _site_export_handle_api_request(array $options = []): void {
     // cannot afford. The upload route verifies the signed headers first and
     // hashes the body as it streams. A custom authenticate callable still
     // runs for every endpoint — its embedder owns that tradeoff.
-    $endpoint = isset($_GET['endpoint']) && is_string($_GET['endpoint'])
-        ? sanitize_key(wp_unslash($_GET['endpoint']))
-        : '';
+    // filter_input, not WP sanitizers: lib.php also runs without WordPress
+    // bootstrapped (hosts that route the API from their own index.php).
+    $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -1,0 +1,535 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedEndpointsTest extends TestCase {
+
+    private const SECRET = 'staged-endpoints-test-secret';
+
+    private string $staging_dir;
+
+    protected function setUp(): void
+    {
+        $this->staging_dir = sys_get_temp_dir() . '/staged-endpoints-test-' . bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->staging_dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
+    {
+        return new Site_Export_Staged_Endpoints(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+        ], $overrides));
+    }
+
+    /**
+     * Headers the way $_SERVER presents them, signed like the HMAC client:
+     * HMAC-SHA256(nonce . timestamp . SHA256(body), secret).
+     */
+    private function signedHeaders(string $body, array $overrides = []): array
+    {
+        $nonce = $overrides['nonce'] ?? bin2hex(random_bytes(16));
+        $timestamp = $overrides['timestamp'] ?? (string) time();
+        $content_hash = $overrides['content_hash'] ?? hash('sha256', $body);
+        $signature = hash_hmac(
+            'sha256',
+            $nonce . $timestamp . $content_hash,
+            $overrides['secret'] ?? self::SECRET
+        );
+
+        return [
+            'REQUEST_METHOD' => 'POST',
+            'HTTP_X_AUTH_SIGNATURE' => $overrides['signature'] ?? $signature,
+            'HTTP_X_AUTH_NONCE' => $nonce,
+            'HTTP_X_AUTH_TIMESTAMP' => $timestamp,
+            'HTTP_X_AUTH_CONTENT_HASH' => $content_hash,
+        ];
+    }
+
+    /** @return resource */
+    private function bodyStream(string $body)
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, $body);
+        rewind($stream);
+        return $stream;
+    }
+
+    private function upload(
+        Site_Export_Staged_Endpoints $endpoints,
+        string $artifact_id,
+        int $offset,
+        string $body,
+        array $header_overrides = []
+    ): array {
+        $stream = $this->bodyStream($body);
+        try {
+            return $endpoints->upload(
+                ['artifact_id' => $artifact_id, 'offset' => $offset],
+                $this->signedHeaders($body, $header_overrides),
+                $stream
+            );
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    private function finalize(Site_Export_Staged_Endpoints $endpoints, string $artifact_id, int $total): array
+    {
+        return $endpoints->finalize(
+            ['artifact_id' => $artifact_id, 'total_bytes' => $total],
+            ['REQUEST_METHOD' => 'POST']
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Upload data plane
+    // ---------------------------------------------------------------
+
+    public function testChunksStageAndFinalizeVerifies(): void
+    {
+        // A small append buffer forces many store steps per chunk.
+        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
+        $body = 'the quick brown fox jumps over the lazy dog';
+        $split = 20;
+
+        $first = $this->upload($endpoints, 'a/b/dump.sql', 0, substr($body, 0, $split));
+        $this->assertSame(200, $first['http_code']);
+        $this->assertSame('accepted', $first['body']['status']);
+        $this->assertSame($split, $first['body']['committed_bytes']);
+
+        $second = $this->upload($endpoints, 'a/b/dump.sql', $split, substr($body, $split));
+        $this->assertSame(strlen($body), $second['body']['committed_bytes']);
+
+        $verified = $this->finalize($endpoints, 'a/b/dump.sql', strlen($body));
+        $this->assertSame(200, $verified['http_code']);
+        $this->assertSame('verified', $verified['body']['status']);
+        $this->assertArrayNotHasKey('path', $verified['body']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/a/b/dump.sql'));
+    }
+
+    public function testRetriedChunkLandsAsDuplicate(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+
+        // The sender timed out without the response and retries the chunk.
+        $retry = $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+
+        $this->assertSame(200, $retry['http_code']);
+        $this->assertSame('duplicate', $retry['body']['status']);
+        $this->assertSame(10, $retry['body']['committed_bytes']);
+    }
+
+    public function testResentChunkStraddlingTheFrontierAppendsOnlyTheTail(): void
+    {
+        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
+        $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+
+        // After a resync the sender resends from offset 0 with a larger
+        // chunk; only the bytes past the committed frontier may land.
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'abcdefghijKLMNO');
+
+        $this->assertSame(200, $result['http_code']);
+        $this->assertSame('accepted', $result['body']['status']);
+        $this->assertSame(15, $result['body']['committed_bytes']);
+        $this->assertSame(
+            'abcdefghijKLMNO',
+            file_get_contents($this->staging_dir . '/files/artifact-1')
+        );
+    }
+
+    public function testChunkBeyondTheFrontierIsAnOffsetGapWithResumeHint(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'abcde');
+
+        $result = $this->upload($endpoints, 'artifact-1', 50, 'later-bytes');
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('offset_gap', $result['body']['reason']);
+        $this->assertSame(5, $result['body']['committed_bytes']);
+    }
+
+    public function testUploadToAVerifiedArtifactIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $this->finalize($endpoints, 'artifact-1', 7);
+
+        $result = $this->upload($endpoints, 'artifact-1', 7, 'more');
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('already_verified', $result['body']['reason']);
+    }
+
+    public function testEmptyBodyIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, '');
+
+        $this->assertSame(400, $result['http_code']);
+        $this->assertSame('empty_body', $result['body']['reason']);
+    }
+
+    public function testUploadWhileTheStoreIsHeldReportsBusy(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'first');
+
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $result = $this->upload($endpoints, 'artifact-1', 5, 'second');
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertSame(423, $result['http_code']);
+        $this->assertSame('busy', $result['body']['status']);
+        $this->assertSame(5, $result['body']['committed_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Upload authentication: no unverified byte reaches the store
+    // ---------------------------------------------------------------
+
+    public function testUploadWithoutAuthHeadersIsRejectedBeforeTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $stream = $this->bodyStream('payload');
+
+        $result = $endpoints->upload(
+            ['artifact_id' => 'artifact-1', 'offset' => 0],
+            ['REQUEST_METHOD' => 'POST'],
+            $stream
+        );
+        fclose($stream);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('auth_failed', $result['body']['reason']);
+        $this->assertStringContainsString('X-Auth-Signature', $result['body']['detail']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir);
+    }
+
+    public function testUploadWithWrongSignatureIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload', [
+            'signature' => str_repeat('0', 64),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('auth_failed', $result['body']['reason']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir);
+    }
+
+    public function testUploadWithExpiredTimestampIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload', [
+            'timestamp' => (string) ( time() - 3600 ),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('auth_failed', $result['body']['reason']);
+    }
+
+    public function testBodyNotMatchingTheSignedHashNeverReachesTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        // Valid signature over the hash of different bytes: the headers
+        // authenticate, the body does not.
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'actually-sent-bytes', [
+            'content_hash' => hash('sha256', 'the-bytes-that-were-signed'),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('content_hash_mismatch', $result['body']['reason']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
+        $this->assertSame(0, $endpoints->status(['artifact_id' => 'artifact-1'])['body']['committed_bytes']);
+    }
+
+    public function testUploadWithoutAConfiguredSecretIsUnavailable(): void
+    {
+        $endpoints = $this->makeEndpoints(['secret' => null]);
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload');
+
+        $this->assertSame(503, $result['http_code']);
+        $this->assertSame('not_configured', $result['body']['reason']);
+    }
+
+    // ---------------------------------------------------------------
+    // Request-size limits: the chunk sizer's 413 contract
+    // ---------------------------------------------------------------
+
+    public function testBodyOverTheCapIs413WithMaxRequestBytes(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, str_repeat('x', 100));
+
+        $this->assertSame(413, $result['http_code']);
+        $this->assertSame('request_too_large', $result['body']['reason']);
+        $this->assertSame(64, $result['body']['max_request_bytes']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
+    }
+
+    public function testDeclaredContentLengthOverTheCapIs413BeforeReading(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
+
+        // An empty stream stands in for the body: the declared length alone
+        // must trigger the rejection, before any read happens.
+        $stream = $this->bodyStream('');
+        $headers = $this->signedHeaders('');
+        $headers['CONTENT_LENGTH'] = '5000';
+        $result = $endpoints->upload(
+            ['artifact_id' => 'artifact-1', 'offset' => 0],
+            $headers,
+            $stream
+        );
+        fclose($stream);
+
+        $this->assertSame(413, $result['http_code']);
+        $this->assertSame('request_too_large', $result['body']['reason']);
+        $this->assertSame(64, $result['body']['max_request_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Control plane: finalize, status, discard
+    // ---------------------------------------------------------------
+
+    public function testFinalizeWithWrongTotalIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+
+        $result = $this->finalize($endpoints, 'artifact-1', 99);
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('size_mismatch', $result['body']['reason']);
+    }
+
+    public function testFinalizeOfUnknownArtifactReportsMissing(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->finalize($endpoints, 'never-uploaded', 5);
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('missing', $result['body']['reason']);
+    }
+
+    public function testFinalizeIsIdempotentAndZeroByteArtifactsVerify(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $this->finalize($endpoints, 'artifact-1', 7);
+
+        $this->assertSame(200, $this->finalize($endpoints, 'artifact-1', 7)['http_code']);
+        $this->assertSame('verified', $this->finalize($endpoints, 'empty.txt', 0)['body']['status']);
+    }
+
+    public function testStatusReportsResumeState(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $unknown = $endpoints->status(['artifact_id' => 'artifact-1']);
+        $this->assertSame(200, $unknown['http_code']);
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $unknown['body']
+        );
+
+        $this->upload($endpoints, 'artifact-1', 0, 'abcde');
+        $known = $endpoints->status(['artifact_id' => 'artifact-1']);
+        $this->assertSame(
+            ['exists' => true, 'committed_bytes' => 5, 'verified' => false],
+            $known['body']
+        );
+    }
+
+    public function testDiscardReportsHeldStoreAsRetriable(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $busy = $endpoints->discard(
+            ['artifact_id' => 'artifact-1'],
+            ['REQUEST_METHOD' => 'POST']
+        );
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertSame(423, $busy['http_code']);
+        $this->assertSame(['discarded' => false], $busy['body']);
+
+        $done = $endpoints->discard(
+            ['artifact_id' => 'artifact-1'],
+            ['REQUEST_METHOD' => 'POST']
+        );
+        $this->assertSame(200, $done['http_code']);
+        $this->assertSame(['discarded' => true], $done['body']);
+    }
+
+    // ---------------------------------------------------------------
+    // Request validation and server-owned options
+    // ---------------------------------------------------------------
+
+    public function testMutatingRoutesRequirePost(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $get = ['REQUEST_METHOD' => 'GET'];
+
+        $upload = $endpoints->upload(['artifact_id' => 'a', 'offset' => 0], $get, null);
+        $finalize = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 1], $get);
+        $discard = $endpoints->discard(['artifact_id' => 'a'], $get);
+
+        foreach ([$upload, $finalize, $discard] as $result) {
+            $this->assertSame(405, $result['http_code']);
+            $this->assertSame('method_not_allowed', $result['body']['reason']);
+        }
+    }
+
+    public function testMalformedParametersAreRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $post = ['REQUEST_METHOD' => 'POST'];
+
+        $no_id = $endpoints->upload(['offset' => 0], $post, null);
+        $this->assertSame([400, 'invalid_artifact_id'], [$no_id['http_code'], $no_id['body']['reason']]);
+
+        $bad_offset = $endpoints->upload(['artifact_id' => 'a', 'offset' => -1], $post, null);
+        $this->assertSame('invalid_offset', $bad_offset['body']['reason']);
+
+        $bad_total = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 'many'], $post);
+        $this->assertSame('invalid_total', $bad_total['body']['reason']);
+
+        $bad_status_id = $endpoints->status(['artifact_id' => '']);
+        $this->assertSame(400, $bad_status_id['http_code']);
+    }
+
+    public function testClientParametersCannotChooseServerOptions(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 1024]);
+        $evil_dir = $this->staging_dir . '-evil';
+        $body = str_repeat('x', 100);
+
+        $stream = $this->bodyStream($body);
+        $result = $endpoints->upload(
+            [
+                'artifact_id' => 'artifact-1',
+                'offset' => 0,
+                // Options are server-owned; parameters with the same names
+                // must be ignored.
+                'staging_dir' => $evil_dir,
+                'max_request_bytes' => 10,
+                'secret' => 'attacker-chosen',
+            ],
+            $this->signedHeaders($body),
+            $stream
+        );
+        fclose($stream);
+
+        $this->assertSame(200, $result['http_code']);
+        $this->assertFileExists($this->staging_dir . '/files/artifact-1');
+        $this->assertDirectoryDoesNotExist($evil_dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Dispatcher wiring
+    // ---------------------------------------------------------------
+
+    public function testHttpServerRoutesStagedEndpoints(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
+        ]);
+
+        ob_start();
+        $server->handle_request([
+            'get' => ['endpoint' => 'staged_status', 'artifact_id' => 'artifact-1'],
+            'server' => ['REQUEST_METHOD' => 'GET'],
+            'body' => '',
+        ]);
+        $output = ob_get_clean();
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            json_decode( (string) $output, true)
+        );
+    }
+
+    public function testStagedRoutesAreAbsentWithoutTheStagedOption(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid endpoint: 'staged_status'");
+
+        $server->dispatch(['endpoint' => 'staged_status']);
+    }
+
+    public function testExplicitHandlersWinOverStagedRegistration(): void
+    {
+        $called = false;
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'staged_status' => function (array $config) use (&$called): void {
+                    $called = true;
+                },
+            ],
+            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
+        ]);
+
+        $server->dispatch(['endpoint' => 'staged_status']);
+
+        $this->assertTrue($called);
+    }
+
+    public function testHandleRequestOnlyReadsTheBodyForJsonContent(): void
+    {
+        $reads = 0;
+        $options = [
+            'handlers' => ['preflight' => static function (array $config): void {}],
+            'body_reader' => function () use (&$reads): string {
+                ++$reads;
+                return '';
+            },
+        ];
+        $server = new Site_Export_HTTP_Server($options);
+
+        $server->handle_request([
+            'get' => ['endpoint' => 'preflight'],
+            'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/octet-stream'],
+        ]);
+        $this->assertSame(0, $reads, 'a raw body must not be buffered for config parsing');
+
+        $server->handle_request([
+            'get' => ['endpoint' => 'preflight'],
+            'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json; charset=utf-8'],
+        ]);
+        $this->assertSame(1, $reads, 'a JSON body still feeds config parsing');
+    }
+}

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -267,6 +267,48 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame(0, $endpoints->status(['artifact_id' => 'artifact-1'])['body']['committed_bytes']);
     }
 
+    public function testReplayedRequestIsAbsorbedAsADuplicate(): void
+    {
+        // There is no nonce cache; replay protection is the protocol's
+        // idempotence. A captured append replayed verbatim inside the
+        // timestamp window must land as a duplicate at the same offset —
+        // the frontier does not move and bytes are never doubled.
+        $endpoints = $this->makeEndpoints();
+        $body = 'replayable bytes';
+        $headers = $this->signedHeaders($body);
+
+        $stream = $this->bodyStream($body);
+        $first = $endpoints->upload(['artifact_id' => 'a.txt', 'offset' => 0], $headers, $stream);
+        fclose($stream);
+        $this->assertSame(200, $first['http_code']);
+        $this->assertSame(strlen($body), $first['body']['committed_bytes']);
+
+        // The exact same signed request again — same nonce, same
+        // timestamp, same signature, same body.
+        $stream = $this->bodyStream($body);
+        $replayed = $endpoints->upload(['artifact_id' => 'a.txt', 'offset' => 0], $headers, $stream);
+        fclose($stream);
+
+        $this->assertSame(200, $replayed['http_code']);
+        $this->assertSame('duplicate', $replayed['body']['status']);
+        $this->assertSame(strlen($body), $replayed['body']['committed_bytes'], 'the frontier must not move');
+        $this->assertSame(
+            strlen($body),
+            (int) filesize($this->staging_dir . '/files/a.txt'),
+            'bytes are never doubled'
+        );
+    }
+
+    public function testShortNonceIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'a.txt', 0, 'bytes', ['nonce' => 'short']);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/a.txt');
+    }
+
     public function testUploadWithoutAConfiguredSecretIsUnavailable(): void
     {
         $endpoints = $this->makeEndpoints(['secret' => null]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,5 +30,9 @@ if (!class_exists('Site_Export_Staged_Artifacts', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-artifacts.php';
 }
 
+if (!class_exists('Site_Export_Staged_Endpoints', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-endpoints.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -30,6 +30,7 @@
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
             <file>StagedArtifactsTest.php</file>
+            <file>StagedEndpointsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>


### PR DESCRIPTION
## What it does

Serves `Site_Export_Staged_Artifacts` (#298) over the export API — the chunk-upload endpoint work from #298's description, wiring the store to #293's split HMAC verification and #297's chunk sizing signals. Four routes join the existing endpoint dispatcher:

- `staged_upload` (POST, data plane): raw chunk bytes in the body, `artifact_id` and `offset` in the query string.
- `staged_finalize`, `staged_status`, `staged_discard` (control plane): small bodies, authenticated by the existing HMAC path like every other endpoint.

Nothing sends to it yet — the push upload client (the sender loop driving `UploadChunkSizer`) is the next PR. Part of the push plan in #276.

## Rationale

**A chunk body can be as large as the sizer's 1 GiB cap, and no unauthenticated or unverified byte may reach the store.** The existing auth path (`verify_globals`) buffers the whole body to hash it — fine for control commands, impossible for chunks. This is exactly what #293's split exists for, so `staged_upload` authenticates inside its handler in two steps:

1. `verify_signed_content_hash()` checks signature, nonce, and timestamp **before any body byte is read** — a caller without the secret never costs a body read.
2. The body streams into a spool (`php://temp`, memory up to 2 MiB then disk) while a SHA-256 digest accumulates. Only when the digest matches the signed claim does the spool drain into `append()`, one bounded buffer per call. A mismatched or oversized body is discarded with the spool — the store never sees it. The spool is one extra sequential disk pass over bytes the host already buffered for the request; that is the price of never committing an unverified byte.

**Chunk retries are the normal case, not an error.** A sender that timed out learns nothing about what landed, retries the same chunk, and may resend with shifted boundaries after a resync. The store's per-append contract stays strict (whole buffer at the committed offset, or nothing — #298), so the endpoint does the tolerant mapping: a fully-committed range answers `duplicate`, a chunk straddling the committed frontier has its committed prefix skipped, and only a chunk starting beyond the frontier is rejected (`offset_gap`, with `committed_bytes` to resume from). A replayed capture of a signed request within the timestamp tolerance lands as `duplicate` — idempotent, same as a retry.

**Rejections the sizer must learn from are typed for it.** A body over the request cap is HTTP 413 with `max_request_bytes` in the payload — exactly what `record_too_large()` consumes. The cap defaults to `post_max_size` (PHP would refuse larger bodies anyway), falling back to the sizer's own 1 GiB hard cap when PHP reports no limit. Preflight already reports `post_max_bytes`/`upload_max_bytes` for `apply_reported_limits()`.

**All options are server-owned.** Client config never chooses the staging directory, the secret, or the caps — a request parameter named like an option is ignored.

## Implementation

- **`Site_Export_Staged_Endpoints`** owns the four routes. Methods return `['http_code' => int, 'body' => array]` and never echo, so tests drive them directly; the dispatcher wiring emits the JSON. HTTP codes stay coarse: 200 `accepted`/`duplicate`/`verified`, 400 invalid params/empty body, 403 auth, 405 non-POST mutation, 409 `offset_gap`/`already_verified`/`size_mismatch`/`missing`, 413 too large, 423 `busy` (and a discard the store couldn't complete — retry), 500 `io_error`.
- **`Site_Export_HTTP_Server`** registers the routes when constructed with a `staged` option (explicitly-passed handlers still win), dispatches them budget-less like `preflight`, and now reads the request body lazily: config parsing only ever consumed JSON bodies, and buffering a raw upload before its handler can stream it is exactly the failure this PR exists to avoid.
- **`lib.php`** passes staged options to `serve()`: secret from the existing shared-secret plumbing, staging dir defaulting to the system temp dir keyed by `ABSPATH` (WordPress has no guaranteed writable directory outside the web-served tree; a host that cleans temp only costs a transfer its resume progress — define `SITE_EXPORT_STAGING_DIR` for a durable location). The default authenticate is skipped for `staged_upload` only — the handler owns it; a custom `authenticate` callable still runs for every endpoint.
- `phpstan-bootstrap.php` gains `wp_unslash`/`sanitize_key` stubs for the one new `$_GET` read in `lib.php`.

The wire contract, end to end:

```
POST ?reprint-api&endpoint=staged_upload&artifact_id=wp-content/uploads/a.jpg&offset=262144
X-Auth-Signature / X-Auth-Nonce / X-Auth-Timestamp / X-Auth-Content-Hash: <signed hash claim>
<raw chunk bytes>

=> 200 {"status":"accepted","reason":null,"detail":null,"committed_bytes":524288}

POST ?reprint-api&endpoint=staged_finalize&artifact_id=wp-content/uploads/a.jpg&total_bytes=524288
=> 200 {"status":"verified", ...}   — safe to apply
```

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit StagedEndpointsTest.php
composer analyze
```

26 tests (registered in `tests/phpunit.xml`) cover: multi-chunk staging with small append buffers and finalize round-trip, retried chunks landing as `duplicate`, a resent chunk straddling the frontier appending only its tail, `offset_gap` with the resume hint, rejection of uploads to verified artifacts, empty bodies, `busy` while the store lock is held, missing/wrong/expired auth headers rejected before the store, a body not matching its signed hash never reaching the store, uploads without a configured secret, the 413 contract for both an over-cap body and a declared `Content-Length` (before reading), finalize size-mismatch/missing/idempotency and zero-byte artifacts, status resume state, discard retry semantics, POST enforcement on mutating routes, malformed parameters, client parameters unable to choose server options, dispatcher routing with and without the `staged` option, explicit handler precedence, and the lazy body read (raw bodies never buffered for config parsing, JSON bodies still parsed).
