### PR TITLE
Add the sender-side client for staged chunk uploads

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -59,6 +59,9 @@ require_once __DIR__ . '/lib/state/class-import-state.php';
 // Adaptive sizing for bounded local-to-remote upload chunks (push transfers)
 require_once __DIR__ . '/lib/upload/class-upload-chunk-sizer.php';
 
+// Chunked, resumable uploads into the target's staged artifact store
+require_once __DIR__ . '/lib/upload/class-staged-upload-client.php';
+
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -116,6 +116,10 @@ class StagedUploadClient
      * @param ?int $total_bytes Plan-declared size; defaults to the file size.
      * @param ?callable $on_progress fn(int $committed_bytes, int $total_bytes)
      *   after every advance.
+     * @param ?int $expected_mtime Plan-declared source mtime. A mismatch
+     *   before uploading means the plan is stale — the artifact fails
+     *   "source_changed" so a re-plan pushes the current content instead
+     *   of a mix.
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
      *   status "verified" on success, "failed" with a typed reason otherwise.
      */
@@ -123,7 +127,8 @@ class StagedUploadClient
         string $artifact_id,
         string $source_path,
         ?int $total_bytes = null,
-        ?callable $on_progress = null
+        ?callable $on_progress = null,
+        ?int $expected_mtime = null
     ): array {
         if ($total_bytes === null) {
             $size = @filesize($source_path);
@@ -151,6 +156,26 @@ class StagedUploadClient
         $source = @fopen($source_path, "rb");
         if ($source === false) {
             return $this->failed("source_unreadable", $source_path);
+        }
+        $opened_stat = fstat($source);
+
+        // Every check downstream is a byte count, so a rewrite of the
+        // source is invisible to all of them. The exporter re-checks its
+        // files after streaming (x-file-changed); the sender owes the same
+        // honesty about its own disk, before and after the upload.
+        if (
+            $expected_mtime !== null
+            && is_array($opened_stat)
+            && (int) $opened_stat["mtime"] !== $expected_mtime
+        ) {
+            fclose($source);
+            // Committed bytes may belong to the older version; a mixed
+            // artifact must never verify.
+            $this->discard($artifact_id);
+            return $this->failed(
+                "source_changed",
+                sprintf("planned mtime %d, found %d", $expected_mtime, (int) $opened_stat["mtime"])
+            );
         }
 
         try {
@@ -276,6 +301,22 @@ class StagedUploadClient
             }
         } finally {
             fclose($source);
+        }
+
+        // Post-upload volatility check: a rewrite during the read window
+        // can leave staged bytes that match no version of the file. Torn
+        // content must fail typed, not verify.
+        clearstatcache(true, $source_path);
+        $now_stat = @stat($source_path);
+        if (
+            !is_array($opened_stat)
+            || $now_stat === false
+            || $now_stat["ino"] !== $opened_stat["ino"]
+            || $now_stat["mtime"] !== $opened_stat["mtime"]
+            || $now_stat["size"] !== $opened_stat["size"]
+        ) {
+            $this->discard($artifact_id);
+            return $this->failed("source_changed", "source changed while uploading");
         }
 
         return $this->finalize($artifact_id, $total_bytes, $on_progress);

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -1,0 +1,496 @@
+<?php
+/**
+ * Client for the staged artifact endpoints: uploads one local file into the
+ * target's staged store in bounded, resumable chunks.
+ *
+ * This is the sender side of a push transfer. The target holds all transfer
+ * state — Site_Export_Staged_Artifacts tracks committed_bytes, and this
+ * client re-reads it from staged_status on every start — so the client
+ * persists nothing about its position. Interrupt it anywhere, rerun it, and
+ * it continues from whatever the store confirmed. The only client-side state
+ * worth carrying across runs is the chunk sizer's learned limits, and that
+ * belongs to the caller (UploadChunkSizer::get_state()).
+ *
+ * The upload loop translates the endpoints' typed responses into the next
+ * action and into UploadChunkSizer feedback:
+ *
+ * - accepted           advance to committed_bytes, record_success()
+ * - duplicate          advance to committed_bytes (a retried chunk landed
+ *                      before its response was lost); still a success signal
+ *                      for the sizer — the host accepted a body of this size
+ * - offset_gap         adopt committed_bytes and continue from there; bounded
+ *                      by a no-progress counter so a disagreeing server
+ *                      cannot loop the client forever
+ * - 413 too large      record_too_large(max_request_bytes) and retry the same
+ *                      offset with the shrunk chunk; "give_up" from the sizer
+ *                      ends the upload with a typed failure
+ * - busy               a predecessor request still holds the store's lock;
+ *                      short bounded backoff, same offset
+ * - io_error           bounded backoff — the target's disk, not the wire
+ * - transport failure  record_transport_failure() (halves the chunk, holds
+ *                      growth) and retry the same offset, bounded
+ * - auth failures      fatal immediately; retrying cannot fix a bad secret
+ *
+ * Every retry class resets when the transfer makes progress, so the bounds
+ * cap consecutive failures, not the transfer length. Every loop iteration
+ * either advances committed bytes, strictly shrinks the sizer's ceiling, or
+ * consumes one of those bounded counters — the loop terminates.
+ *
+ * The transport is a callable so tests drive the real endpoint classes
+ * in-process; the default is curl, signed per request by
+ * Site_Export_HMAC_Client (signature over nonce + timestamp + SHA256(body),
+ * which is exactly what staged_upload verifies before reading the body).
+ */
+class StagedUploadClient
+{
+    /** Consecutive transport failures before the upload is abandoned. */
+    private const MAX_TRANSPORT_RETRIES = 5;
+
+    /** Consecutive "busy" responses before the upload is abandoned. */
+    private const MAX_BUSY_RETRIES = 5;
+
+    /** Consecutive server io_error responses before the upload is abandoned. */
+    private const MAX_IO_RETRIES = 3;
+
+    /** Resyncs that fail to advance committed_bytes before giving up. */
+    private const MAX_STALLED_RESYNCS = 3;
+
+    /** Base backoff between retries, in microseconds. */
+    private const RETRY_BACKOFF_USEC = 250000;
+
+    /** Longest single backoff, in microseconds. */
+    private const MAX_BACKOFF_USEC = 5000000;
+
+    private string $base_url;
+
+    private ?Site_Export_HMAC_Client $hmac_client;
+
+    private UploadChunkSizer $sizer;
+
+    /** @var callable(string,string,array,string,int):array */
+    private $transport;
+
+    /** @var callable(int):void */
+    private $sleeper;
+
+    private int $request_timeout;
+
+    /**
+     * @param array $options
+     *   - base_url (string, required): the export API URL; endpoint and
+     *     artifact parameters are appended to its query string.
+     *   - hmac_client (?Site_Export_HMAC_Client): request signer. Without
+     *     one, requests go out unsigned and the target rejects uploads.
+     *   - sizer (?UploadChunkSizer): chunk-size decisions; defaults to a
+     *     fresh sizer. Pass one restored from persisted state to keep the
+     *     limits a previous run learned.
+     *   - transport (?callable): fn(method, url, headers, body, timeout) =>
+     *     ['http_code' => int, 'body' => string, 'error' => ?string], where
+     *     a non-null error means the request never produced an HTTP
+     *     response. Defaults to curl.
+     *   - sleeper (?callable): fn(int $microseconds), for tests.
+     *   - request_timeout (int): per-request timeout in seconds.
+     */
+    public function __construct(array $options)
+    {
+        $base_url = $options["base_url"] ?? null;
+        if (!is_string($base_url) || $base_url === "") {
+            throw new InvalidArgumentException("StagedUploadClient requires a base_url option.");
+        }
+        $this->base_url = $base_url;
+        $this->hmac_client = $options["hmac_client"] ?? null;
+        $this->sizer = $options["sizer"] ?? new UploadChunkSizer();
+        $this->transport = $options["transport"] ?? [$this, "curl_transport"];
+        $this->sleeper = $options["sleeper"] ?? static function (int $microseconds): void {
+            usleep($microseconds);
+        };
+        $timeout = $options["request_timeout"] ?? null;
+        $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
+    }
+
+    /**
+     * Upload one artifact until the target records it verified.
+     *
+     * @param string $artifact_id Target-relative path the artifact applies to.
+     * @param string $source_path Local file holding the artifact bytes.
+     * @param ?int $total_bytes Plan-declared size; defaults to the file size.
+     * @param ?callable $on_progress fn(int $committed_bytes, int $total_bytes)
+     *   after every advance.
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "verified" on success, "failed" with a typed reason otherwise.
+     */
+    public function upload_artifact(
+        string $artifact_id,
+        string $source_path,
+        ?int $total_bytes = null,
+        ?callable $on_progress = null
+    ): array {
+        if ($total_bytes === null) {
+            $size = @filesize($source_path);
+            if ($size === false) {
+                return $this->failed("source_unreadable", $source_path);
+            }
+            $total_bytes = $size;
+        }
+
+        // The store's committed offset is the resume point; the client
+        // keeps no position of its own.
+        $status = $this->request_json("GET", "staged_status", ["artifact_id" => $artifact_id]);
+        if ($status["error"] !== null || !is_array($status["json"])) {
+            return $this->failed("status_unavailable", $status["error"] ?? "invalid response");
+        }
+        if (!empty($status["json"]["verified"])) {
+            // A finished earlier run. Finalize re-confirms the size and is
+            // idempotent; a mismatch means this plan disagrees with what
+            // was verified, and only a discard can resolve that.
+            return $this->finalize($artifact_id, $total_bytes);
+        }
+        $offset = max(0, (int) ($status["json"]["committed_bytes"] ?? 0));
+        $offset = min($offset, $total_bytes);
+
+        $source = @fopen($source_path, "rb");
+        if ($source === false) {
+            return $this->failed("source_unreadable", $source_path);
+        }
+
+        try {
+            $transport_failures = 0;
+            $busy_responses = 0;
+            $io_errors = 0;
+            $stalled_resyncs = 0;
+
+            while ($offset < $total_bytes) {
+                $chunk_bytes = min($this->sizer->chunk_bytes(), $total_bytes - $offset);
+                if (fseek($source, $offset) !== 0) {
+                    return $this->failed("source_unreadable", "seek", $offset);
+                }
+                $chunk = $this->read_exactly($source, $chunk_bytes);
+                if ($chunk === null) {
+                    // The file ends before the declared total; uploading on
+                    // would just move the mismatch to finalize.
+                    return $this->failed("source_short", null, $offset);
+                }
+
+                $response = $this->request_json("POST", "staged_upload", [
+                    "artifact_id" => $artifact_id,
+                    "offset" => $offset,
+                ], $chunk);
+
+                if ($response["error"] !== null) {
+                    $decision = $this->sizer->record_transport_failure();
+                    if ($decision["action"] === "give_up") {
+                        return $this->failed("transport_failed", $response["error"], $offset);
+                    }
+                    $transport_failures++;
+                    if ($transport_failures > self::MAX_TRANSPORT_RETRIES) {
+                        return $this->failed("transport_failed", $response["error"], $offset);
+                    }
+                    $this->backoff($transport_failures);
+                    continue;
+                }
+
+                $json = is_array($response["json"]) ? $response["json"] : [];
+                $http_code = $response["http_code"];
+
+                if ($http_code === 413) {
+                    $reported = $json["max_request_bytes"] ?? null;
+                    $decision = $this->sizer->record_too_large(
+                        is_numeric($reported) ? (int) $reported : null
+                    );
+                    if ($decision["action"] === "give_up") {
+                        return $this->failed("chunk_size_exhausted", null, $offset);
+                    }
+                    continue;
+                }
+
+                $result_status = $json["status"] ?? null;
+                $reason = $json["reason"] ?? null;
+
+                if ($result_status === "accepted" || $result_status === "duplicate") {
+                    $committed = (int) ($json["committed_bytes"] ?? $offset);
+                    $advanced = $committed > $offset;
+                    $offset = max($offset, min($committed, $total_bytes));
+                    // Either way the host accepted a request of this size.
+                    $this->sizer->record_success();
+                    if ($advanced) {
+                        $transport_failures = 0;
+                        $busy_responses = 0;
+                        $io_errors = 0;
+                        $stalled_resyncs = 0;
+                        if ($on_progress !== null) {
+                            $on_progress($offset, $total_bytes);
+                        }
+                    }
+                    continue;
+                }
+
+                if ($result_status === "busy") {
+                    $busy_responses++;
+                    if ($busy_responses > self::MAX_BUSY_RETRIES) {
+                        return $this->failed("busy_exhausted", null, $offset);
+                    }
+                    $this->backoff($busy_responses);
+                    continue;
+                }
+
+                if ($reason === "offset_gap") {
+                    $committed = max(0, (int) ($json["committed_bytes"] ?? 0));
+                    if ($committed <= $offset) {
+                        // The store is behind us (a discard or another
+                        // sender); re-uploading from its offset is the only
+                        // way forward, but only while it moves.
+                        $stalled_resyncs++;
+                        if ($stalled_resyncs > self::MAX_STALLED_RESYNCS) {
+                            return $this->failed("resync_exhausted", null, $offset);
+                        }
+                    }
+                    $offset = min($committed, $total_bytes);
+                    continue;
+                }
+
+                if ($reason === "already_verified") {
+                    break;
+                }
+
+                if ($reason === "io_error") {
+                    $io_errors++;
+                    if ($io_errors > self::MAX_IO_RETRIES) {
+                        return $this->failed("server_io_error", $json["detail"] ?? null, $offset);
+                    }
+                    $this->backoff($io_errors);
+                    continue;
+                }
+
+                if ($reason === "auth_failed" || $reason === "content_hash_mismatch") {
+                    return $this->failed("auth_failed", $json["detail"] ?? null, $offset);
+                }
+
+                // invalid_artifact_id, invalid_offset, not_configured,
+                // method_not_allowed, or something newer: retrying cannot
+                // change the answer.
+                return $this->failed(
+                    is_string($reason) ? $reason : "unexpected_response",
+                    "HTTP " . $http_code,
+                    $offset
+                );
+            }
+        } finally {
+            fclose($source);
+        }
+
+        return $this->finalize($artifact_id, $total_bytes, $on_progress);
+    }
+
+    /**
+     * Report the store's resume state for an artifact.
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,exists:bool,verified:bool}|array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    public function status(string $artifact_id): array
+    {
+        $response = $this->request_json("GET", "staged_status", ["artifact_id" => $artifact_id]);
+        if ($response["error"] !== null || !is_array($response["json"])) {
+            return $this->failed("status_unavailable", $response["error"] ?? "invalid response");
+        }
+        return [
+            "status" => "ok",
+            "reason" => null,
+            "detail" => null,
+            "committed_bytes" => (int) ($response["json"]["committed_bytes"] ?? 0),
+            "exists" => (bool) ($response["json"]["exists"] ?? false),
+            "verified" => (bool) ($response["json"]["verified"] ?? false),
+        ];
+    }
+
+    /**
+     * Drop an artifact's staged data; retries while the store reports the
+     * discard incomplete, mirroring its retry-until-true contract.
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    public function discard(string $artifact_id): array
+    {
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES; $attempt++) {
+            $response = $this->request_json("POST", "staged_discard", ["artifact_id" => $artifact_id]);
+            if ($response["error"] !== null) {
+                return $this->failed("transport_failed", $response["error"]);
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            if (!empty($json["discarded"])) {
+                return [
+                    "status" => "discarded",
+                    "reason" => null,
+                    "detail" => null,
+                    "committed_bytes" => 0,
+                ];
+            }
+            if ($response["http_code"] !== 423) {
+                return $this->failed(
+                    is_string($json["reason"] ?? null) ? $json["reason"] : "unexpected_response",
+                    "HTTP " . $response["http_code"]
+                );
+            }
+            $this->backoff($attempt);
+        }
+        return $this->failed("busy_exhausted");
+    }
+
+    /**
+     * Confirm the assembled artifact; retried only for "busy".
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    private function finalize(string $artifact_id, int $total_bytes, ?callable $on_progress = null): array
+    {
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES; $attempt++) {
+            $response = $this->request_json("POST", "staged_finalize", [
+                "artifact_id" => $artifact_id,
+                "total_bytes" => $total_bytes,
+            ]);
+            if ($response["error"] !== null) {
+                return $this->failed("transport_failed", $response["error"], $total_bytes);
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            if (($json["status"] ?? null) === "verified") {
+                if ($on_progress !== null) {
+                    $on_progress($total_bytes, $total_bytes);
+                }
+                return [
+                    "status" => "verified",
+                    "reason" => null,
+                    "detail" => null,
+                    "committed_bytes" => (int) ($json["committed_bytes"] ?? $total_bytes),
+                ];
+            }
+            if (($json["status"] ?? null) === "busy") {
+                $this->backoff($attempt);
+                continue;
+            }
+            return $this->failed(
+                is_string($json["reason"] ?? null) ? $json["reason"] : "unexpected_response",
+                $json["detail"] ?? ("HTTP " . $response["http_code"]),
+                (int) ($json["committed_bytes"] ?? 0)
+            );
+        }
+        return $this->failed("busy_exhausted", null);
+    }
+
+    /**
+     * Sign and send one request, decoding the JSON response.
+     *
+     * @return array{http_code:int,json:mixed,error:?string}
+     */
+    private function request_json(string $method, string $endpoint, array $params, string $body = ""): array
+    {
+        $url = $this->base_url
+            . (strpos($this->base_url, "?") === false ? "?" : "&")
+            . http_build_query(array_merge(["endpoint" => $endpoint], $params));
+
+        $headers = $this->hmac_client !== null
+            ? $this->hmac_client->get_auth_headers($body)
+            : [];
+        $headers["Content-Type"] = "application/octet-stream";
+
+        $response = call_user_func($this->transport, $method, $url, $headers, $body, $this->request_timeout);
+
+        $error = $response["error"] ?? null;
+        if ($error !== null) {
+            return ["http_code" => 0, "json" => null, "error" => (string) $error];
+        }
+
+        $decoded = json_decode((string) ($response["body"] ?? ""), true);
+        if (!is_array($decoded)) {
+            // An HTTP response without the protocol's JSON body — a proxy
+            // error page, a truncated reply. A bare 413 still means "too
+            // large", so preserve the code and let the caller classify.
+            $code = (int) ($response["http_code"] ?? 0);
+            if ($code === 413) {
+                return ["http_code" => 413, "json" => [], "error" => null];
+            }
+            return ["http_code" => $code, "json" => null, "error" => "invalid JSON response (HTTP {$code})"];
+        }
+
+        return [
+            "http_code" => (int) ($response["http_code"] ?? 0),
+            "json" => $decoded,
+            "error" => null,
+        ];
+    }
+
+    /**
+     * Read exactly $bytes from the source, or null when the file ends first.
+     */
+    private function read_exactly($source, int $bytes): ?string
+    {
+        $data = "";
+        while (strlen($data) < $bytes) {
+            $piece = fread($source, $bytes - strlen($data));
+            if ($piece === false || $piece === "") {
+                return null;
+            }
+            $data .= $piece;
+        }
+        return $data;
+    }
+
+    private function backoff(int $attempt): void
+    {
+        $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $attempt - 1)));
+        call_user_func($this->sleeper, (int) $delay);
+    }
+
+    /**
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    private function failed(string $reason, ?string $detail = null, int $committed_bytes = 0): array
+    {
+        return [
+            "status" => "failed",
+            "reason" => $reason,
+            "detail" => $detail,
+            "committed_bytes" => $committed_bytes,
+        ];
+    }
+
+    /**
+     * Default transport: one curl request, honoring the proxy and CA bundle
+     * environment helpers when the importer runtime is loaded.
+     *
+     * @return array{http_code:int,body:string,error:?string}
+     */
+    private function curl_transport(string $method, string $url, array $headers, string $body, int $timeout): array
+    {
+        $ch = curl_init($url);
+        if (function_exists("reprint_apply_curl_proxy_from_env")) {
+            reprint_apply_curl_proxy_from_env($ch);
+        }
+        if (function_exists("reprint_apply_curl_ca_bundle")) {
+            reprint_apply_curl_ca_bundle($ch);
+        }
+
+        $header_lines = [];
+        foreach ($headers as $name => $value) {
+            $header_lines[] = "{$name}: {$value}";
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_POSTFIELDS => $method === "POST" ? $body : null,
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_TIMEOUT => $timeout,
+        ]);
+
+        $response_body = curl_exec($ch);
+        if ($response_body === false) {
+            $error = curl_error($ch) ?: ("curl errno " . curl_errno($ch));
+            curl_close($ch);
+            return ["http_code" => 0, "body" => "", "error" => $error];
+        }
+        $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return ["http_code" => $http_code, "body" => (string) $response_body, "error" => null];
+    }
+}

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -144,6 +144,9 @@ class StagedUploadClient
         if ($status["error"] !== null || !is_array($status["json"])) {
             return $this->failed("status_unavailable", $status["error"] ?? "invalid response");
         }
+        if ($this->is_auth_envelope($status)) {
+            return $this->failed("auth_failed", $this->envelope_error($status));
+        }
         if (!empty($status["json"]["verified"])) {
             // A finished earlier run. Finalize re-confirms the size and is
             // idempotent; a mismatch means this plan disagrees with what
@@ -333,6 +336,9 @@ class StagedUploadClient
         if ($response["error"] !== null || !is_array($response["json"])) {
             return $this->failed("status_unavailable", $response["error"] ?? "invalid response");
         }
+        if ($this->is_auth_envelope($response)) {
+            return $this->failed("auth_failed", $this->envelope_error($response));
+        }
         return [
             "status" => "ok",
             "reason" => null,
@@ -355,6 +361,9 @@ class StagedUploadClient
             $response = $this->request_json("POST", "staged_discard", ["artifact_id" => $artifact_id]);
             if ($response["error"] !== null) {
                 return $this->failed("transport_failed", $response["error"]);
+            }
+            if ($this->is_auth_envelope($response)) {
+                return $this->failed("auth_failed", $this->envelope_error($response));
             }
             $json = is_array($response["json"]) ? $response["json"] : [];
             if (!empty($json["discarded"])) {
@@ -390,6 +399,9 @@ class StagedUploadClient
             ]);
             if ($response["error"] !== null) {
                 return $this->failed("transport_failed", $response["error"], $total_bytes);
+            }
+            if ($this->is_auth_envelope($response)) {
+                return $this->failed("auth_failed", $this->envelope_error($response));
             }
             $json = is_array($response["json"]) ? $response["json"] : [];
             if (($json["status"] ?? null) === "verified") {
@@ -478,6 +490,25 @@ class StagedUploadClient
     {
         $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $attempt - 1)));
         call_user_func($this->sleeper, (int) $delay);
+    }
+
+    /**
+     * The embedding layer (lib.php in the WordPress wiring) answers
+     * control-plane auth failures with its own {error, code} envelope
+     * before any endpoint runs. Surface those as auth_failed — retrying
+     * cannot fix a bad secret — instead of an unexpected response.
+     */
+    private function is_auth_envelope(array $response): bool
+    {
+        return in_array($response["http_code"], [401, 403], true)
+            && is_array($response["json"])
+            && !isset($response["json"]["status"]);
+    }
+
+    private function envelope_error(array $response): string
+    {
+        $error = $response["json"]["error"] ?? null;
+        return is_string($error) ? $error : ("HTTP " . $response["http_code"]);
     }
 
     /**

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -338,6 +338,54 @@ class StagedUploadClientTest extends TestCase
         $this->assertCount(1, $this->uploadCalls(), 'auth failures must not be retried');
     }
 
+    public function testSourceRewrittenMidUploadFailsTyped(): void
+    {
+        $body = str_repeat('abcd', 8); // 32 bytes: several 8-byte chunks
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+        $rewritten = false;
+        $transport = function (...$args) use ($base, &$rewritten): array {
+            $response = $base(...$args);
+            if (!$rewritten && strpos($args[1], 'staged_upload') !== false) {
+                $rewritten = true;
+                // Same length, new content, future mtime — invisible to
+                // every byte-count check in the pipeline.
+                file_put_contents($this->source_path, str_repeat('zzzz', 8));
+                touch($this->source_path, time() + 10);
+            }
+            return $response;
+        };
+        $client = $this->makeClient($transport);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(['failed', 'source_changed'], [$result['status'], $result['reason']]);
+        $this->assertFalse(
+            $client->status('artifact.bin')['exists'],
+            'torn staged bytes must be discarded, never verified'
+        );
+    }
+
+    public function testStalePlanMtimeFailsBeforeAnyUpload(): void
+    {
+        $this->writeSource('current content');
+        // Remnants of the older version sit staged on the target.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('artifact.bin', 0, 'old-');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact(
+            'artifact.bin',
+            $this->source_path,
+            null,
+            null,
+            ((int) filemtime($this->source_path)) - 100
+        );
+
+        $this->assertSame(['failed', 'source_changed'], [$result['status'], $result['reason']]);
+        $this->assertCount(0, $this->uploadCalls(), 'a stale plan must not upload');
+        $this->assertFalse($client->status('artifact.bin')['exists'], 'stale remnants are discarded');
+    }
+
     public function testTransportHardFailureStopsBounded(): void
     {
         $this->writeSource(str_repeat('x', 32));

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -402,4 +402,55 @@ class StagedUploadClientTest extends TestCase
         $this->assertSame('discarded', $client->discard('artifact.bin')['status']);
         $this->assertFalse($client->status('artifact.bin')['exists']);
     }
+
+    // ---------------------------------------------------------------
+    // Hostile and broken responses
+    // ---------------------------------------------------------------
+
+    public function testHtmlErrorPageInsteadOfJsonFailsTypedWithoutARetryStorm(): void
+    {
+        // Shared hosts interpose HTML error pages (mod_security, WAFs,
+        // maintenance screens). The client must fail typed on the
+        // non-JSON body, not loop and not crash.
+        $this->writeSource('bytes');
+        $html = ['http_code' => 200, 'body' => '<html><h1>Request blocked</h1></html>', 'error' => null];
+
+        // At the status probe: the resume state is unavailable —
+        // typed and classified retryable by the CLI.
+        $calls = 0;
+        $probe_blocked = $this->makeClient(static function (...$args) use (&$calls, $html): array {
+            $calls++;
+            return $html;
+        })->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame(['failed', 'status_unavailable'], [$probe_blocked['status'], $probe_blocked['reason']]);
+        $this->assertLessThan(10, $calls, 'a non-JSON answer must not retry unbounded');
+
+        // Past the probe, at the upload itself: treated like a lost
+        // response — bounded retries with resyncs, then the retryable
+        // transport_failed instead of an opaque crash.
+        $base = $this->transportFor($this->makeEndpoints());
+        $upload_blocked = $this->makeClient(static function (...$args) use ($base, $html): array {
+            return strpos($args[1], 'staged_upload') !== false ? $html : $base(...$args);
+        })->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame(['failed', 'transport_failed'], [$upload_blocked['status'], $upload_blocked['reason']]);
+    }
+
+    public function testServerIoErrorSurfacesTyped(): void
+    {
+        // The store answering io_error (disk full, permissions) maps to
+        // the retryable server_io_error, not a generic failure.
+        $this->writeSource('bytes');
+        $transport = static function (...$args): array {
+            return [
+                'http_code' => 500,
+                'body' => '{"status":"rejected","reason":"io_error","detail":"open_lock_file","committed_bytes":0}',
+                'error' => null,
+            ];
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('server_io_error', $result['reason']);
+    }
 }

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Artifacts;
+use Site_Export_Staged_Endpoints;
+use StagedUploadClient;
+use UploadChunkSizer;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Drives the real StagedUploadClient against the real staged endpoints and
+ * store in-process: requests are signed by the real HMAC client and verified
+ * by the real HMAC server, only the socket is replaced by a callable.
+ */
+class StagedUploadClientTest extends TestCase
+{
+    private const SECRET = 'staged-upload-client-test-secret';
+
+    private string $staging_dir;
+
+    private string $source_path;
+
+    /** @var array<int, array{endpoint:string, params:array}> */
+    private array $requests = [];
+
+    /** @var int[] */
+    private array $sleeps = [];
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/staged-upload-client-' . $suffix;
+        $this->source_path = sys_get_temp_dir() . '/staged-upload-source-' . $suffix;
+        $this->requests = [];
+        $this->sleeps = [];
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->source_path);
+        $this->removeDir($this->staging_dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
+    {
+        return new Site_Export_Staged_Endpoints(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+        ], $overrides));
+    }
+
+    /**
+     * In-process transport: routes signed requests into the endpoint class
+     * the way the HTTP dispatcher would, recording every call.
+     */
+    private function transportFor(Site_Export_Staged_Endpoints $endpoints): callable
+    {
+        return function (string $method, string $url, array $headers, string $body, int $timeout) use ($endpoints): array {
+            parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+            $endpoint = (string) ($params['endpoint'] ?? '');
+            unset($params['endpoint']);
+            $this->requests[] = ['endpoint' => $endpoint, 'params' => $params];
+
+            $server = ['REQUEST_METHOD' => $method];
+            foreach ($headers as $name => $value) {
+                $server['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $value;
+            }
+
+            switch ($endpoint) {
+                case 'staged_upload':
+                    $stream = fopen('php://temp', 'w+b');
+                    fwrite($stream, $body);
+                    rewind($stream);
+                    $result = $endpoints->upload($params, $server, $stream);
+                    fclose($stream);
+                    break;
+                case 'staged_finalize':
+                    $result = $endpoints->finalize($params, $server);
+                    break;
+                case 'staged_status':
+                    $result = $endpoints->status($params);
+                    break;
+                case 'staged_discard':
+                    $result = $endpoints->discard($params, $server);
+                    break;
+                default:
+                    return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
+            }
+
+            return [
+                'http_code' => $result['http_code'],
+                'body' => (string) json_encode($result['body']),
+                'error' => null,
+            ];
+        };
+    }
+
+    private function makeClient(callable $transport, array $overrides = []): StagedUploadClient
+    {
+        return new StagedUploadClient(array_merge([
+            'base_url' => 'https://target.example/?reprint-api',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+            'transport' => $transport,
+            'sleeper' => function (int $microseconds): void {
+                $this->sleeps[] = $microseconds;
+            },
+        ], $overrides));
+    }
+
+    private function writeSource(string $body): void
+    {
+        file_put_contents($this->source_path, $body);
+    }
+
+    private function uploadCalls(): array
+    {
+        return array_values(array_filter($this->requests, static function (array $request): bool {
+            return $request['endpoint'] === 'staged_upload';
+        }));
+    }
+
+    // ---------------------------------------------------------------
+    // Happy paths
+    // ---------------------------------------------------------------
+
+    public function testUploadsAMultiChunkArtifactToVerified(): void
+    {
+        $body = str_repeat('0123456789', 6);
+        $this->writeSource($body);
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $progress = [];
+        $result = $client->upload_artifact(
+            'wp-content/uploads/a.bin',
+            $this->source_path,
+            null,
+            static function (int $committed, int $total) use (&$progress): void {
+                $progress[] = [$committed, $total];
+            }
+        );
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame(strlen($body), $result['committed_bytes']);
+        $this->assertSame(
+            $body,
+            file_get_contents($this->staging_dir . '/files/wp-content/uploads/a.bin')
+        );
+        $this->assertCount(8, $this->uploadCalls(), '60 bytes in 8-byte chunks');
+        $offsets = array_column($progress, 0);
+        $sorted = $offsets;
+        sort($sorted);
+        $this->assertSame($sorted, $offsets, 'progress never goes backward');
+        $this->assertSame([strlen($body), strlen($body)], end($progress));
+    }
+
+    public function testResumesFromTheStoreCommittedOffset(): void
+    {
+        $body = str_repeat('resumable-', 6);
+        $this->writeSource($body);
+        // A previous run staged the first 24 bytes.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))
+            ->append('artifact.bin', 0, substr($body, 0, 24));
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame('24', $this->uploadCalls()[0]['params']['offset']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+    }
+
+    public function testZeroByteArtifactVerifiesWithoutUploads(): void
+    {
+        $this->writeSource('');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('empty.txt', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertCount(0, $this->uploadCalls());
+    }
+
+    public function testAlreadyVerifiedArtifactShortCircuits(): void
+    {
+        $body = 'push-me-once';
+        $this->writeSource($body);
+        $transport = $this->transportFor($this->makeEndpoints());
+        $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+        $this->requests = [];
+
+        $again = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame('verified', $again['status']);
+        $this->assertCount(0, $this->uploadCalls());
+
+        $wrong_total = $this->makeClient($transport)
+            ->upload_artifact('artifact.bin', $this->source_path, strlen($body) + 5);
+        $this->assertSame(['failed', 'size_mismatch'], [$wrong_total['status'], $wrong_total['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Response-driven resync
+    // ---------------------------------------------------------------
+
+    public function testLostResponseRetryLandsAsDuplicateAndContinues(): void
+    {
+        $body = str_repeat('abcdefgh', 4);
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+
+        // The second chunk commits server-side but its response is lost.
+        $upload_seen = 0;
+        $transport = function (...$args) use ($base, &$upload_seen): array {
+            $response = $base(...$args);
+            if (strpos($args[1], 'staged_upload') !== false && ++$upload_seen === 2) {
+                return ['http_code' => 0, 'body' => '', 'error' => 'timeout after commit'];
+            }
+            return $response;
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+        $this->assertNotEmpty($this->sleeps, 'the lost response costs one backoff');
+    }
+
+    public function testServerSideDiscardMidTransferResyncsFromZero(): void
+    {
+        $body = str_repeat('resync!!', 5);
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+
+        // Someone discards the artifact on the target between two chunks.
+        $upload_seen = 0;
+        $transport = function (...$args) use ($base, &$upload_seen): array {
+            if (strpos($args[1], 'staged_upload') !== false && ++$upload_seen === 3) {
+                (new Site_Export_Staged_Artifacts($this->staging_dir))->discard('artifact.bin');
+            }
+            return $base(...$args);
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+    }
+
+    // ---------------------------------------------------------------
+    // Chunk-size learning
+    // ---------------------------------------------------------------
+
+    public function test413ShrinksToTheReportedCapAndSucceeds(): void
+    {
+        $body = str_repeat('x', 40);
+        $this->writeSource($body);
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 10]);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 32, 'max_bytes' => 32]);
+        $client = $this->makeClient($this->transportFor($endpoints), ['sizer' => $sizer]);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+        $this->assertLessThanOrEqual(9, $sizer->chunk_bytes(), 'ceiling learned from the 413');
+    }
+
+    public function testGivesUpWhenTheFloorIsStillTooLarge(): void
+    {
+        $this->writeSource(str_repeat('x', 40));
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 2]);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 8]);
+        $client = $this->makeClient($this->transportFor($endpoints), ['sizer' => $sizer]);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(
+            ['failed', 'chunk_size_exhausted'],
+            [$result['status'], $result['reason']]
+        );
+        $this->assertLessThan(4, count($this->uploadCalls()), 'no endless probing below the floor');
+    }
+
+    // ---------------------------------------------------------------
+    // Failure classes
+    // ---------------------------------------------------------------
+
+    public function testBusyStoreRetriesThenSucceeds(): void
+    {
+        $body = 'busy-then-fine';
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+
+        $injected = false;
+        $transport = function (...$args) use ($base, &$injected): array {
+            if (!$injected && strpos($args[1], 'staged_upload') !== false) {
+                $injected = true;
+                return [
+                    'http_code' => 423,
+                    'body' => '{"status":"busy","reason":null,"detail":null,"committed_bytes":0}',
+                    'error' => null,
+                ];
+            }
+            return $base(...$args);
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertNotEmpty($this->sleeps);
+    }
+
+    public function testWrongSecretFailsFastWithoutRetries(): void
+    {
+        $this->writeSource('some bytes');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [
+            'hmac_client' => new Site_Export_HMAC_Client('not-the-target-secret'),
+        ]);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']]);
+        $this->assertCount(1, $this->uploadCalls(), 'auth failures must not be retried');
+    }
+
+    public function testTransportHardFailureStopsBounded(): void
+    {
+        $this->writeSource(str_repeat('x', 32));
+        $transport = function (...$args): array {
+            parse_str((string) parse_url($args[1], PHP_URL_QUERY), $params);
+            if (($params['endpoint'] ?? '') === 'staged_status') {
+                return [
+                    'http_code' => 200,
+                    'body' => '{"exists":false,"committed_bytes":0,"verified":false}',
+                    'error' => null,
+                ];
+            }
+            $this->requests[] = ['endpoint' => (string) $params['endpoint'], 'params' => $params];
+            return ['http_code' => 0, 'body' => '', 'error' => 'connection refused'];
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(['failed', 'transport_failed'], [$result['status'], $result['reason']]);
+        $this->assertLessThanOrEqual(
+            6,
+            count($this->uploadCalls()),
+            'bounded by the sizer floor and the consecutive-failure cap'
+        );
+    }
+
+    public function testSourceShorterThanDeclaredTotalFails(): void
+    {
+        $this->writeSource('only-ten-b');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path, 20);
+
+        $this->assertSame(['failed', 'source_short'], [$result['status'], $result['reason']]);
+    }
+
+    public function testMissingSourceFileFails(): void
+    {
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path . '-missing');
+
+        $this->assertSame(['failed', 'source_unreadable'], [$result['status'], $result['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Status and discard passthrough
+    // ---------------------------------------------------------------
+
+    public function testStatusAndDiscardRoundTrip(): void
+    {
+        $body = 'discard-me';
+        $this->writeSource($body);
+        $transport = $this->transportFor($this->makeEndpoints());
+        $client = $this->makeClient($transport);
+        $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $status = $client->status('artifact.bin');
+        $this->assertSame(['ok', true, true], [$status['status'], $status['exists'], $status['verified']]);
+        $this->assertSame(strlen($body), $status['committed_bytes']);
+
+        $this->assertSame('discarded', $client->discard('artifact.bin')['status']);
+        $this->assertFalse($client->status('artifact.bin')['exists']);
+    }
+}

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -325,6 +325,31 @@ class StagedUploadClientTest extends TestCase
         $this->assertNotEmpty($this->sleeps);
     }
 
+    public function testControlPlaneAuthEnvelopeSurfacesAsAuthFailed(): void
+    {
+        // lib.php rejects control-plane requests with its own {error, code}
+        // envelope before any endpoint runs; the client must read that as
+        // an auth failure, not an unexpected response.
+        $envelope = static function (): array {
+            return [
+                'http_code' => 403,
+                'body' => '{"error":"HMAC signature verification failed","code":403}',
+                'error' => null,
+            ];
+        };
+        $client = $this->makeClient($envelope);
+        $this->writeSource('bytes');
+
+        $upload = $client->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame(['failed', 'auth_failed'], [$upload['status'], $upload['reason']]);
+
+        $status = $client->status('artifact.bin');
+        $this->assertSame(['failed', 'auth_failed'], [$status['status'], $status['reason']]);
+
+        $discard = $client->discard('artifact.bin');
+        $this->assertSame(['failed', 'auth_failed'], [$discard['status'], $discard['reason']]);
+    }
+
     public function testWrongSecretFailsFastWithoutRetries(): void
     {
         $this->writeSource('some bytes');


### PR DESCRIPTION
## What it does

Adds `StagedUploadClient`, the sender side of a push transfer: it uploads one local file into the target's staged artifact store (#300's endpoints, #298's store) in bounded, resumable chunks sized by `UploadChunkSizer` (#297) and signed per request by `Site_Export_HMAC_Client`.

Nothing drives it yet — the push orchestration command that walks the transfer plan and calls this per artifact is the next PR. Part of the push plan in #276.

## Rationale

**The target holds all transfer state, so the client persists none.** `Site_Export_Staged_Artifacts` already tracks `committed_bytes` as its rename-atomic cursor; the client re-reads it from `staged_status` on every start and resumes from there. Interrupt the process anywhere, rerun it, and it continues from whatever the store confirmed — no client-side offset file that could disagree with the server. The only state worth carrying across runs is the sizer's learned limits, and that stays with the caller (`UploadChunkSizer::get_state()`), same as #297 designed it.

**The upload loop is a response-driven state machine that provably terminates.** Every typed endpoint response maps to one action and, where the evidence warrants it, one sizer signal:

| response | action | sizer |
|---|---|---|
| `accepted` | advance to `committed_bytes` | `record_success()` |
| `duplicate` | advance (a retried chunk landed before its response was lost) | `record_success()` — the host accepted a body of this size |
| `offset_gap` | adopt `committed_bytes`, continue from there | — |
| HTTP 413 | retry same offset with the shrunk chunk | `record_too_large(max_request_bytes)` |
| `busy` | bounded backoff, same offset | — |
| `io_error` | bounded backoff — the target's disk, not the wire | — |
| transport failure | retry same offset, bounded | `record_transport_failure()` |
| `auth_failed` / hash mismatch | fatal immediately — retrying cannot fix a bad secret | — |

Retry counters cap **consecutive** failures and reset on progress, so they bound stalls, not transfer length. Each iteration either advances committed bytes, strictly shrinks the sizer's ceiling (413s converge to `give_up`), or consumes a bounded counter. `offset_gap` resyncs that fail to advance are capped too, so a disagreeing server cannot ping-pong the client forever.

**Cross-run edge cases fall out of the same machine.** A response lost after the server committed lands as `duplicate` on retry and the transfer continues; a server-side discard mid-transfer comes back as `offset_gap` at 0 and the client re-uploads; an artifact a previous run already verified short-circuits through idempotent `finalize` (and a total that disagrees with the verified size fails typed as `size_mismatch` — that plan needs a discard, not a retry).

## Implementation

- `packages/reprint-importer/src/lib/upload/class-staged-upload-client.php`, next to the sizer it drives; loaded by `import.php` alongside it.
- `upload_artifact($artifact_id, $source_path, $total_bytes = null, $on_progress = null)` returns the same typed shape the endpoints use: `['status' => 'verified'|'failed', 'reason', 'detail', 'committed_bytes']`. `status()` and `discard()` (retried while the store reports the discard incomplete, mirroring its retry-until-true contract) round out the surface an orchestrator needs.
- The transport is a callable — `fn(method, url, headers, body, timeout) => ['http_code', 'body', 'error']` — defaulting to curl with the importer's proxy/CA env helpers. Tests replace only this seam.
- Source reads guard the plan: a file that ends before the declared total fails `source_short` client-side instead of moving the mismatch to `finalize`.

```php
$client = new StagedUploadClient([
    'base_url' => 'https://target.example/?reprint-api',
    'hmac_client' => new Site_Export_HMAC_Client($secret),
    'sizer' => new UploadChunkSizer([], $persisted_sizer_state),
]);
$result = $client->upload_artifact('wp-content/uploads/a.bin', $local_path, $planned_size, $on_progress);
// => ['status' => 'verified', 'reason' => null, 'detail' => null, 'committed_bytes' => 1048576]
```

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/StagedUploadClientTest.php
composer analyze
```

14 tests drive the real client against the real `Site_Export_Staged_Endpoints`, store, and HMAC verification in-process — only the socket is a callable. Covered: multi-chunk upload to verified with monotonic progress, resume from the store's committed offset, zero-byte artifacts, already-verified short-circuit plus the `size_mismatch` disagreement, a lost response landing as `duplicate`, a server-side discard mid-transfer resyncing from zero, 413 shrinking to the reported cap and succeeding, `give_up` when the floor is still too large, `busy` retry with backoff, wrong secret failing fast without retries, hard transport failure stopping bounded, short and missing source files, and the status/discard round trip.
