### PR TITLE
Walk a push plan through the staged upload client

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -62,6 +62,9 @@ require_once __DIR__ . '/lib/upload/class-upload-chunk-sizer.php';
 // Chunked, resumable uploads into the target's staged artifact store
 require_once __DIR__ . '/lib/upload/class-staged-upload-client.php';
 
+// Batch orchestration over the upload client: plan in, verified artifacts out
+require_once __DIR__ . '/lib/upload/class-staged-push-runner.php';
+
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Batch orchestration for staged chunk uploads: walks a transfer plan and
+ * drives StagedUploadClient once per artifact, resumably.
+ *
+ * The runner adds the two things a multi-artifact push needs on top of the
+ * single-artifact client:
+ *
+ * Resume without re-asking the target. The client already resumes one
+ * artifact from the store's committed offset, but a resumed 50k-file push
+ * must not spend two requests per finished artifact re-discovering that it
+ * is finished. The runner appends one line per verified artifact to
+ * .push-verified.jsonl and skips cache hits (same id, same size) without
+ * any request — trusted the way pull trusts the files already in its
+ * fs-root. A torn or missing cache line is never trusted: the artifact goes
+ * back through the client, whose status/finalize short-circuit re-confirms
+ * it against the store in two cheap requests. Skips only avoid traffic;
+ * the store stays the truth.
+ *
+ * Failure routing. A reason that is scoped to one artifact — its source
+ * file vanished or shrank, its plan size disagrees with what the store
+ * verified — is recorded and the batch continues; rerunning retries only
+ * the failures. Everything else (auth, transport, chunk-size exhaustion,
+ * a busy or erroring store, and any reason this list has never seen) would
+ * fail every following artifact the same way, so the batch aborts with the
+ * reason, and a rerun continues from the cache. Unknown reasons abort
+ * rather than continue so a protocol change cannot churn a huge plan
+ * through per-artifact failures.
+ *
+ * State lives in two files under the caller's state dir, pull-style:
+ * .push-verified.jsonl is the append-only done cache, and .push-state.json
+ * (rename-atomic) carries the chunk sizer's learned limits plus the last
+ * run's counters. The sizer state is written after every artifact and on
+ * abort, so a rerun starts at the limits the wire already taught us —
+ * read_state() restores it before the sizer and client are constructed.
+ * Killing the runner anywhere loses at most one cache line and one sizer
+ * update, both re-derived cheaply.
+ */
+class StagedPushRunner
+{
+    /** Failure reasons scoped to one artifact; the batch continues past them. */
+    private const ARTIFACT_SCOPED_REASONS = [
+        "source_unreadable",
+        "source_short",
+        "size_mismatch",
+        "invalid_artifact_id",
+        "invalid_offset",
+        "invalid_total",
+        "invalid_artifact_entry",
+    ];
+
+    private string $state_path;
+
+    private string $verified_path;
+
+    private StagedUploadClient $client;
+
+    private UploadChunkSizer $sizer;
+
+    /** @var callable|null */
+    private $on_progress;
+
+    /**
+     * @param array $options
+     *   - state_dir (string, required): holds .push-state.json and
+     *     .push-verified.jsonl; created if missing.
+     *   - client (StagedUploadClient, required): the per-artifact uploader.
+     *   - sizer (UploadChunkSizer, required): the same instance the client
+     *     was built with — the runner persists its learned state.
+     *   - on_progress (?callable): fn(array $progress) with files_done,
+     *     files_total, artifact_id, committed_bytes, total_bytes; called on
+     *     every chunk advance and once per finished artifact.
+     */
+    public function __construct(array $options)
+    {
+        $state_dir = $options["state_dir"] ?? null;
+        if (!is_string($state_dir) || $state_dir === "") {
+            throw new InvalidArgumentException("StagedPushRunner requires a state_dir option.");
+        }
+        if (!($options["client"] ?? null) instanceof StagedUploadClient) {
+            throw new InvalidArgumentException("StagedPushRunner requires a client option.");
+        }
+        if (!($options["sizer"] ?? null) instanceof UploadChunkSizer) {
+            throw new InvalidArgumentException("StagedPushRunner requires a sizer option.");
+        }
+
+        $base = rtrim($state_dir, "/");
+        $this->state_path = $base . "/.push-state.json";
+        $this->verified_path = $base . "/.push-verified.jsonl";
+        $this->client = $options["client"];
+        $this->sizer = $options["sizer"];
+        $this->on_progress = $options["on_progress"] ?? null;
+    }
+
+    /**
+     * Restore a previous run's persisted state, for constructing the sizer
+     * before the client and runner exist.
+     *
+     * @return array{sizer:array,files_total:int,files_done:int}
+     */
+    public static function read_state(string $state_dir): array
+    {
+        $defaults = [
+            "sizer" => [],
+            "files_total" => 0,
+            "files_done" => 0,
+        ];
+        $raw = @file_get_contents(rtrim($state_dir, "/") . "/.push-state.json");
+        if ($raw === false) {
+            return $defaults;
+        }
+        $state = json_decode($raw, true);
+        if (!is_array($state)) {
+            return $defaults;
+        }
+        return [
+            "sizer" => is_array($state["sizer"] ?? null) ? $state["sizer"] : [],
+            "files_total" => max(0, (int) ($state["files_total"] ?? 0)),
+            "files_done" => max(0, (int) ($state["files_done"] ?? 0)),
+        ];
+    }
+
+    /**
+     * Upload every artifact in the plan that is not already verified.
+     *
+     * @param array $artifacts Each entry: ['artifact_id' => string,
+     *   'source_path' => string, 'total_bytes' => ?int (defaults to the
+     *   file size)].
+     * @return array{status:string,files_total:int,files_done:int,failed:array,abort_reason:?string,abort_detail:?string}
+     *   status "completed" when the plan was walked to the end (failed may
+     *   still list artifact-scoped failures), "aborted" when a
+     *   transfer-scoped failure stopped the walk.
+     */
+    public function push(array $artifacts): array
+    {
+        if (!$this->ensure_state_dir()) {
+            return $this->aborted(0, 0, [], "state_dir_unwritable", dirname($this->state_path));
+        }
+
+        $files_total = count($artifacts);
+        $verified_cache = $this->read_verified_cache();
+        $files_done = 0;
+        $failed = [];
+
+        foreach ($artifacts as $entry) {
+            $artifact_id = $entry["artifact_id"] ?? null;
+            $source_path = $entry["source_path"] ?? null;
+            if (!is_string($artifact_id) || $artifact_id === "" || !is_string($source_path) || $source_path === "") {
+                $failed[] = [
+                    "artifact_id" => is_string($artifact_id) ? $artifact_id : "",
+                    "reason" => "invalid_artifact_entry",
+                    "detail" => null,
+                ];
+                continue;
+            }
+
+            $total_bytes = $entry["total_bytes"] ?? null;
+            if ($total_bytes === null) {
+                $size = @filesize($source_path);
+                if ($size === false) {
+                    $failed[] = [
+                        "artifact_id" => $artifact_id,
+                        "reason" => "source_unreadable",
+                        "detail" => $source_path,
+                    ];
+                    continue;
+                }
+                $total_bytes = $size;
+            }
+            $total_bytes = (int) $total_bytes;
+
+            // A cache hit at the planned size is done — no request. Any
+            // disagreement falls through to the client, whose verified
+            // short-circuit settles it against the store.
+            if (($verified_cache[$artifact_id] ?? null) === $total_bytes) {
+                $files_done++;
+                $this->report_progress($files_done, $files_total, $artifact_id, $total_bytes, $total_bytes);
+                continue;
+            }
+
+            $result = $this->client->upload_artifact(
+                $artifact_id,
+                $source_path,
+                $total_bytes,
+                function (int $committed, int $total) use ($files_done, $files_total, $artifact_id): void {
+                    $this->report_progress($files_done, $files_total, $artifact_id, $committed, $total);
+                }
+            );
+
+            if ($result["status"] === "verified") {
+                $files_done++;
+                $this->append_verified($artifact_id, $total_bytes);
+                $this->write_state($files_total, $files_done);
+                $this->report_progress($files_done, $files_total, $artifact_id, $total_bytes, $total_bytes);
+                continue;
+            }
+
+            $reason = is_string($result["reason"]) ? $result["reason"] : "unexpected_response";
+            if (in_array($reason, self::ARTIFACT_SCOPED_REASONS, true)) {
+                $failed[] = [
+                    "artifact_id" => $artifact_id,
+                    "reason" => $reason,
+                    "detail" => $result["detail"],
+                ];
+                $this->write_state($files_total, $files_done);
+                continue;
+            }
+
+            $this->write_state($files_total, $files_done);
+            return $this->aborted($files_total, $files_done, $failed, $reason, $result["detail"]);
+        }
+
+        $this->write_state($files_total, $files_done);
+        return [
+            "status" => "completed",
+            "files_total" => $files_total,
+            "files_done" => $files_done,
+            "failed" => $failed,
+            "abort_reason" => null,
+            "abort_detail" => null,
+        ];
+    }
+
+    private function report_progress(int $files_done, int $files_total, string $artifact_id, int $committed, int $total): void
+    {
+        if ($this->on_progress === null) {
+            return;
+        }
+        call_user_func($this->on_progress, [
+            "files_done" => $files_done,
+            "files_total" => $files_total,
+            "artifact_id" => $artifact_id,
+            "committed_bytes" => $committed,
+            "total_bytes" => $total,
+        ]);
+    }
+
+    /**
+     * @return array<string,int> artifact id to verified size.
+     */
+    private function read_verified_cache(): array
+    {
+        $raw = @file_get_contents($this->verified_path);
+        if ($raw === false || $raw === "") {
+            return [];
+        }
+        $cache = [];
+        foreach (explode("\n", $raw) as $line) {
+            $record = json_decode($line, true);
+            if (
+                !is_array($record)
+                || !is_string($record["artifact_id"] ?? null)
+                || !is_int($record["size"] ?? null)
+                || $record["size"] < 0
+            ) {
+                // A torn line from a kill mid-append; the artifact just
+                // takes the client's short-circuit path instead.
+                continue;
+            }
+            $cache[$record["artifact_id"]] = $record["size"];
+        }
+        return $cache;
+    }
+
+    private function append_verified(string $artifact_id, int $size): void
+    {
+        // The leading newline seals any torn tail from a killed writer onto
+        // its own (skipped) line, as the staged store does for its records.
+        $line = "\n" . json_encode([
+            "artifact_id" => $artifact_id,
+            "size" => $size,
+        ]) . "\n";
+        @file_put_contents($this->verified_path, $line, FILE_APPEND);
+    }
+
+    private function write_state(int $files_total, int $files_done): void
+    {
+        // Write-then-rename, like every cursor file in this codebase: a
+        // kill leaves the previous state, never a torn one.
+        $tmp_path = $this->state_path . ".tmp";
+        $json = json_encode([
+            "sizer" => $this->sizer->get_state(),
+            "files_total" => $files_total,
+            "files_done" => $files_done,
+        ]);
+        if (@file_put_contents($tmp_path, $json) !== strlen($json) || !@rename($tmp_path, $this->state_path)) {
+            // Best effort: stale sizer state costs a relearn, nothing more.
+            @unlink($tmp_path);
+        }
+    }
+
+    private function ensure_state_dir(): bool
+    {
+        $dir = dirname($this->state_path);
+        return is_dir($dir) || @mkdir($dir, 0700, true) || is_dir($dir);
+    }
+
+    /**
+     * @return array{status:string,files_total:int,files_done:int,failed:array,abort_reason:?string,abort_detail:?string}
+     */
+    private function aborted(int $files_total, int $files_done, array $failed, string $reason, ?string $detail): array
+    {
+        return [
+            "status" => "aborted",
+            "files_total" => $files_total,
+            "files_done" => $files_done,
+            "failed" => $failed,
+            "abort_reason" => $reason,
+            "abort_detail" => $detail,
+        ];
+    }
+}

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -47,6 +47,9 @@ class StagedPushRunner
         "invalid_offset",
         "invalid_total",
         "invalid_artifact_entry",
+        // A source rewritten mid-push fails its artifact; the next run
+        // re-plans with the current mtime and pushes the fresh content.
+        "source_changed",
     ];
 
     private string $state_path;
@@ -169,13 +172,27 @@ class StagedPushRunner
             }
             $total_bytes = (int) $total_bytes;
 
-            // A cache hit at the planned size is done — no request. Any
-            // disagreement falls through to the client, whose verified
-            // short-circuit settles it against the store.
-            if (($verified_cache[$artifact_id] ?? null) === $total_bytes) {
+            // A cache hit at the planned size and mtime is done — no
+            // request. The mtime matters because every other check in this
+            // pipeline is a byte count: a same-size edit is invisible to
+            // the store's verification, so the cache must not vouch for it.
+            $mtime = isset($entry["mtime"]) ? (int) $entry["mtime"] : null;
+            $cached = $verified_cache[$artifact_id] ?? null;
+            if (
+                $cached !== null
+                && $cached["size"] === $total_bytes
+                && ($mtime === null || $cached["mtime"] === null || $cached["mtime"] === $mtime)
+            ) {
                 $files_done++;
                 $this->report_progress($files_done, $files_total, $artifact_id, $total_bytes, $total_bytes);
                 continue;
+            }
+            if ($cached !== null) {
+                // The source changed since this artifact verified. The
+                // store's size checks cannot see a same-size edit, so the
+                // stale server copy must go before the fresh bytes come —
+                // its verified short-circuit would otherwise vouch for it.
+                $this->client->discard($artifact_id);
             }
 
             $result = $this->client->upload_artifact(
@@ -184,12 +201,13 @@ class StagedPushRunner
                 $total_bytes,
                 function (int $committed, int $total) use ($files_done, $files_total, $artifact_id): void {
                     $this->report_progress($files_done, $files_total, $artifact_id, $committed, $total);
-                }
+                },
+                $mtime
             );
 
             if ($result["status"] === "verified") {
                 $files_done++;
-                $this->append_verified($artifact_id, $total_bytes);
+                $this->append_verified($artifact_id, $total_bytes, $mtime);
                 $this->write_state($files_total, $files_done);
                 $this->report_progress($files_done, $files_total, $artifact_id, $total_bytes, $total_bytes);
                 continue;
@@ -236,7 +254,7 @@ class StagedPushRunner
     }
 
     /**
-     * @return array<string,int> artifact id to verified size.
+     * @return array<string,array{size:int,mtime:?int}> keyed by artifact id.
      */
     private function read_verified_cache(): array
     {
@@ -257,18 +275,22 @@ class StagedPushRunner
                 // takes the client's short-circuit path instead.
                 continue;
             }
-            $cache[$record["artifact_id"]] = $record["size"];
+            $cache[$record["artifact_id"]] = [
+                "size" => $record["size"],
+                "mtime" => is_int($record["mtime"] ?? null) ? $record["mtime"] : null,
+            ];
         }
         return $cache;
     }
 
-    private function append_verified(string $artifact_id, int $size): void
+    private function append_verified(string $artifact_id, int $size, ?int $mtime): void
     {
         // The leading newline seals any torn tail from a killed writer onto
         // its own (skipped) line, as the staged store does for its records.
         $line = "\n" . json_encode([
             "artifact_id" => $artifact_id,
             "size" => $size,
+            "mtime" => $mtime,
         ]) . "\n";
         @file_put_contents($this->verified_path, $line, FILE_APPEND);
     }

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -328,20 +328,86 @@ class StagedPushRunnerTest extends TestCase
         $this->assertCount(1, $this->requestsFor('staged_upload'), 'the abort stops the walk');
     }
 
-    public function testPlanSizeDisagreeingWithTheCacheFailsTyped(): void
+    public function testPlanSizeDisagreeingWithTheCacheDiscardsAndRetries(): void
     {
         $entry = $this->planEntry('artifact.bin', str_repeat('x', 10));
         $transport = $this->transportFor($this->makeEndpoints());
         [$runner] = $this->makeRunner($transport);
         $runner->push([$entry]);
 
-        // The next plan declares a different size for the verified artifact.
+        // The next plan declares a different size: the stale server copy is
+        // discarded, and the fresh upload honestly reports that the source
+        // does not match the plan either.
         $entry['total_bytes'] = 12;
         [$again] = $this->makeRunner($transport);
         $result = $again->push([$entry]);
 
         $this->assertSame('completed', $result['status']);
-        $this->assertSame('size_mismatch', $result['failed'][0]['reason']);
+        $this->assertSame('source_short', $result['failed'][0]['reason']);
+        $this->assertNotEmpty($this->requestsFor('staged_discard'), 'the stale artifact must be discarded');
+    }
+
+    public function testSourceChangedMidPushFailsTheArtifactAndContinues(): void
+    {
+        $volatile = $this->planEntry('volatile.bin', str_repeat('abcd', 6)); // 3 chunks
+        $stable = $this->planEntry('stable.bin', 'steady');
+        $base = $this->transportFor($this->makeEndpoints());
+        $rewritten = false;
+        $transport = function (...$args) use ($base, &$rewritten, $volatile): array {
+            $response = $base(...$args);
+            if (
+                !$rewritten
+                && strpos($args[1], 'staged_upload') !== false
+                && strpos($args[1], 'volatile.bin') !== false
+            ) {
+                $rewritten = true;
+                // An active site edits the file while the push reads it.
+                file_put_contents($volatile['source_path'], str_repeat('zzzz', 6));
+                touch($volatile['source_path'], time() + 10);
+            }
+            return $response;
+        };
+        [$runner] = $this->makeRunner($transport);
+
+        $result = $runner->push([$volatile, $stable]);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertSame('source_changed', $result['failed'][0]['reason']);
+        $this->assertSame(
+            'steady',
+            file_get_contents($this->staging_dir . '/files/stable.bin'),
+            'the rest of the batch still pushes'
+        );
+    }
+
+    public function testSameSizeEditReuploadsInsteadOfCacheSkipping(): void
+    {
+        $entry = $this->planEntry('plugin.php', '<?php // v1');
+        // Plan mtimes mirror the file's real mtime, as the plan builder
+        // records them — the client verifies the source against them.
+        touch($entry['source_path'], 1000);
+        $entry['mtime'] = 1000;
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $this->assertSame('completed', $runner->push([$entry])['status']);
+
+        // Same byte length, new content, newer mtime: every size check in
+        // the pipeline is blind to this — only the cache's mtime can see it.
+        file_put_contents($entry['source_path'], '<?php // v2');
+        touch($entry['source_path'], 2000);
+        $entry['mtime'] = 2000;
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $result = $again->push([$entry]);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertNotEmpty($this->requestsFor('staged_discard'));
+        $this->assertNotEmpty($this->requestsFor('staged_upload'), 'fresh bytes must upload');
+        $this->assertSame(
+            '<?php // v2',
+            file_get_contents($this->staging_dir . '/files/plugin.php')
+        );
     }
 
     public function testInvalidPlanEntriesAreRecordedNotFatal(): void

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -398,4 +398,42 @@ class StagedPushRunnerTest extends TestCase
 
         $this->assertSame(['sizer' => [], 'files_total' => 0, 'files_done' => 0], $state);
     }
+
+    public function testUnwritableStateDirAbortsTypedBeforeAnyRequest(): void
+    {
+        // A file where the state dir belongs makes mkdir fail: the runner
+        // must abort typed instead of pushing without a done cache (every
+        // rerun would then re-upload the world).
+        $blocker = $this->state_dir . '-blocker';
+        file_put_contents($blocker, 'not a directory');
+        $transport = function (...$args): array {
+            $this->requests[] = ['endpoint' => 'unexpected', 'params' => [], 'http_code' => 0];
+            return ['http_code' => 200, 'body' => '{}', 'error' => null];
+        };
+        $client = new StagedUploadClient([
+            'base_url' => 'https://target.example/?reprint-api',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+            'transport' => $transport,
+            'sleeper' => static function (int $microseconds): void {
+            },
+        ]);
+        $runner = new StagedPushRunner([
+            'state_dir' => $blocker . '/nested',
+            'client' => $client,
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+        ]);
+
+        try {
+            $result = $runner->push([
+                ['artifact_id' => 'a.txt', 'source_path' => $this->source_dir . '/never-read'],
+            ]);
+
+            $this->assertSame('aborted', $result['status']);
+            $this->assertSame('state_dir_unwritable', $result['abort_reason']);
+            $this->assertSame([], $this->requests, 'no request may travel without a state dir');
+        } finally {
+            @unlink($blocker);
+        }
+    }
 }

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -1,0 +1,401 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Artifacts;
+use Site_Export_Staged_Endpoints;
+use StagedPushRunner;
+use StagedUploadClient;
+use UploadChunkSizer;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Drives the real runner through the real client, endpoints, and store
+ * in-process; only the socket is a callable, which also records every
+ * request and response code.
+ */
+class StagedPushRunnerTest extends TestCase
+{
+    private const SECRET = 'staged-push-runner-test-secret';
+
+    private string $staging_dir;
+
+    private string $state_dir;
+
+    private string $source_dir;
+
+    /** @var array<int, array{endpoint:string, params:array, http_code:int}> */
+    private array $requests = [];
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/push-runner-staging-' . $suffix;
+        $this->state_dir = sys_get_temp_dir() . '/push-runner-state-' . $suffix;
+        $this->source_dir = sys_get_temp_dir() . '/push-runner-source-' . $suffix;
+        mkdir($this->source_dir, 0700, true);
+        $this->requests = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->staging_dir, $this->state_dir, $this->source_dir] as $dir) {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
+    {
+        return new Site_Export_Staged_Endpoints(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+        ], $overrides));
+    }
+
+    private function transportFor(Site_Export_Staged_Endpoints $endpoints): callable
+    {
+        return function (string $method, string $url, array $headers, string $body, int $timeout) use ($endpoints): array {
+            parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+            $endpoint = (string) ($params['endpoint'] ?? '');
+            unset($params['endpoint']);
+
+            $server = ['REQUEST_METHOD' => $method];
+            foreach ($headers as $name => $value) {
+                $server['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $value;
+            }
+
+            switch ($endpoint) {
+                case 'staged_upload':
+                    $stream = fopen('php://temp', 'w+b');
+                    fwrite($stream, $body);
+                    rewind($stream);
+                    $result = $endpoints->upload($params, $server, $stream);
+                    fclose($stream);
+                    break;
+                case 'staged_finalize':
+                    $result = $endpoints->finalize($params, $server);
+                    break;
+                case 'staged_status':
+                    $result = $endpoints->status($params);
+                    break;
+                case 'staged_discard':
+                    $result = $endpoints->discard($params, $server);
+                    break;
+                default:
+                    return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
+            }
+
+            $this->requests[] = [
+                'endpoint' => $endpoint,
+                'params' => $params,
+                'http_code' => $result['http_code'],
+            ];
+
+            return [
+                'http_code' => $result['http_code'],
+                'body' => (string) json_encode($result['body']),
+                'error' => null,
+            ];
+        };
+    }
+
+    /**
+     * @return array{0:StagedPushRunner,1:UploadChunkSizer}
+     */
+    private function makeRunner(callable $transport, array $client_overrides = [], ?callable $on_progress = null, ?UploadChunkSizer $sizer = null): array
+    {
+        $sizer = $sizer ?? new UploadChunkSizer(
+            ['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8],
+            StagedPushRunner::read_state($this->state_dir)['sizer']
+        );
+        $client = new StagedUploadClient(array_merge([
+            'base_url' => 'https://target.example/?reprint-api',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'sizer' => $sizer,
+            'transport' => $transport,
+            'sleeper' => static function (int $microseconds): void {
+            },
+        ], $client_overrides));
+
+        $options = [
+            'state_dir' => $this->state_dir,
+            'client' => $client,
+            'sizer' => $sizer,
+        ];
+        if ($on_progress !== null) {
+            $options['on_progress'] = $on_progress;
+        }
+        return [new StagedPushRunner($options), $sizer];
+    }
+
+    /**
+     * @return array{artifact_id:string,source_path:string}
+     */
+    private function planEntry(string $artifact_id, string $body): array
+    {
+        $path = $this->source_dir . '/' . str_replace('/', '_', $artifact_id);
+        file_put_contents($path, $body);
+        return ['artifact_id' => $artifact_id, 'source_path' => $path];
+    }
+
+    private function requestsFor(string $endpoint): array
+    {
+        return array_values(array_filter($this->requests, static function (array $request) use ($endpoint): bool {
+            return $request['endpoint'] === $endpoint;
+        }));
+    }
+
+    // ---------------------------------------------------------------
+    // Completion and state files
+    // ---------------------------------------------------------------
+
+    public function testPushesAPlanToCompletion(): void
+    {
+        $plan = [
+            $this->planEntry('wp-content/plugins/a.php', str_repeat('a', 20)),
+            $this->planEntry('wp-content/themes/b.css', str_repeat('b', 9)),
+            $this->planEntry('empty.txt', ''),
+        ];
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($plan);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(3, $result['files_total']);
+        $this->assertSame(3, $result['files_done']);
+        $this->assertSame([], $result['failed']);
+        $this->assertSame(
+            str_repeat('a', 20),
+            file_get_contents($this->staging_dir . '/files/wp-content/plugins/a.php')
+        );
+
+        $state = StagedPushRunner::read_state($this->state_dir);
+        $this->assertSame(3, $state['files_total']);
+        $this->assertSame(3, $state['files_done']);
+        $this->assertArrayHasKey('chunk_bytes', $state['sizer']);
+        $this->assertFileExists($this->state_dir . '/.push-verified.jsonl');
+    }
+
+    public function testProgressCoversChunksAndFiles(): void
+    {
+        $plan = [$this->planEntry('artifact.bin', str_repeat('x', 20))];
+        $progress = [];
+        [$runner] = $this->makeRunner(
+            $this->transportFor($this->makeEndpoints()),
+            [],
+            static function (array $record) use (&$progress): void {
+                $progress[] = $record;
+            }
+        );
+
+        $runner->push($plan);
+
+        $this->assertNotEmpty($progress);
+        $last = end($progress);
+        $this->assertSame(1, $last['files_done']);
+        $this->assertSame(1, $last['files_total']);
+        $this->assertSame(20, $last['committed_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Resume
+    // ---------------------------------------------------------------
+
+    public function testResumeSkipsCachedArtifactsWithoutRequests(): void
+    {
+        $plan = [
+            $this->planEntry('a.bin', str_repeat('a', 12)),
+            $this->planEntry('b.bin', str_repeat('b', 12)),
+        ];
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $this->assertSame('completed', $runner->push($plan)['status']);
+
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $result = $again->push($plan);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(2, $result['files_done']);
+        $this->assertCount(0, $this->requests, 'cache hits must not cost requests');
+    }
+
+    public function testTornCacheLineFallsBackToTheServerShortCircuit(): void
+    {
+        $plan = [$this->planEntry('artifact.bin', str_repeat('x', 12))];
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $runner->push($plan);
+
+        // A kill mid-append left a torn cache line instead of the record.
+        file_put_contents($this->state_dir . '/.push-verified.jsonl', '{"artifact_id":"artifact.bin","si');
+
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $result = $again->push($plan);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertCount(0, $this->requestsFor('staged_upload'), 'no bytes re-uploaded');
+        $this->assertCount(1, $this->requestsFor('staged_status'));
+        $this->assertCount(1, $this->requestsFor('staged_finalize'));
+    }
+
+    public function testMidArtifactResumeUploadsOnlyTheTail(): void
+    {
+        $body = str_repeat('resumable-', 3);
+        $plan = [$this->planEntry('artifact.bin', $body)];
+        // A previous run staged the first 16 bytes before dying; no cache
+        // line was written.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))
+            ->append('artifact.bin', 0, substr($body, 0, 16));
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($plan);
+
+        $this->assertSame('completed', $result['status']);
+        $uploads = $this->requestsFor('staged_upload');
+        $this->assertSame('16', $uploads[0]['params']['offset']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+    }
+
+    // ---------------------------------------------------------------
+    // Failure routing
+    // ---------------------------------------------------------------
+
+    public function testArtifactScopedFailureContinuesAndRerunRetriesIt(): void
+    {
+        $plan = [
+            $this->planEntry('a.bin', str_repeat('a', 8)),
+            $this->planEntry('gone.bin', str_repeat('g', 8)),
+            $this->planEntry('c.bin', str_repeat('c', 8)),
+        ];
+        unlink($plan[1]['source_path']);
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+
+        $result = $runner->push($plan);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(2, $result['files_done']);
+        $this->assertSame(
+            [['artifact_id' => 'gone.bin', 'reason' => 'source_unreadable', 'detail' => $plan[1]['source_path']]],
+            $result['failed']
+        );
+
+        // The source reappears; a rerun uploads only the failed artifact.
+        file_put_contents($plan[1]['source_path'], str_repeat('g', 8));
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $retry = $again->push($plan);
+
+        $this->assertSame(['completed', 3, []], [$retry['status'], $retry['files_done'], $retry['failed']]);
+        $uploads = $this->requestsFor('staged_upload');
+        $this->assertCount(1, $uploads);
+        $this->assertSame('gone.bin', $uploads[0]['params']['artifact_id']);
+    }
+
+    public function testTransferScopedFailureAborts(): void
+    {
+        $plan = [
+            $this->planEntry('a.bin', str_repeat('a', 8)),
+            $this->planEntry('b.bin', str_repeat('b', 8)),
+        ];
+        [$runner] = $this->makeRunner(
+            $this->transportFor($this->makeEndpoints()),
+            ['hmac_client' => new Site_Export_HMAC_Client('wrong-secret')]
+        );
+
+        $result = $runner->push($plan);
+
+        $this->assertSame('aborted', $result['status']);
+        $this->assertSame('auth_failed', $result['abort_reason']);
+        $this->assertSame(0, $result['files_done']);
+        $this->assertCount(1, $this->requestsFor('staged_upload'), 'the abort stops the walk');
+    }
+
+    public function testPlanSizeDisagreeingWithTheCacheFailsTyped(): void
+    {
+        $entry = $this->planEntry('artifact.bin', str_repeat('x', 10));
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $runner->push([$entry]);
+
+        // The next plan declares a different size for the verified artifact.
+        $entry['total_bytes'] = 12;
+        [$again] = $this->makeRunner($transport);
+        $result = $again->push([$entry]);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame('size_mismatch', $result['failed'][0]['reason']);
+    }
+
+    public function testInvalidPlanEntriesAreRecordedNotFatal(): void
+    {
+        $plan = [
+            ['artifact_id' => 'no-source.bin'],
+            $this->planEntry('ok.bin', 'fine'),
+        ];
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($plan);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertSame('invalid_artifact_entry', $result['failed'][0]['reason']);
+    }
+
+    // ---------------------------------------------------------------
+    // Sizer persistence
+    // ---------------------------------------------------------------
+
+    public function testLearnedChunkLimitsSurviveRuns(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 10]);
+        $transport = $this->transportFor($endpoints);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 32, 'max_bytes' => 32]);
+        [$runner] = $this->makeRunner($transport, [], null, $sizer);
+
+        $first = $runner->push([$this->planEntry('a.bin', str_repeat('a', 20))]);
+        $this->assertSame('completed', $first['status']);
+        $this->assertNotEmpty(array_filter($this->requests, static function (array $request): bool {
+            return $request['http_code'] === 413;
+        }), 'the first run learns the cap from a 413');
+
+        // A fresh process restores the sizer through read_state(); the
+        // learned ceiling means no new 413 probes.
+        $this->requests = [];
+        $restored = new UploadChunkSizer(
+            ['floor_bytes' => 4, 'start_bytes' => 32, 'max_bytes' => 32],
+            StagedPushRunner::read_state($this->state_dir)['sizer']
+        );
+        [$again] = $this->makeRunner($transport, [], null, $restored);
+        $second = $again->push([$this->planEntry('b.bin', str_repeat('b', 20))]);
+
+        $this->assertSame('completed', $second['status']);
+        $this->assertSame([], array_filter($this->requests, static function (array $request): bool {
+            return $request['http_code'] === 413;
+        }), 'the second run starts under the learned cap');
+    }
+
+    public function testReadStateDefaultsWhenNothingPersisted(): void
+    {
+        $state = StagedPushRunner::read_state($this->state_dir . '-never-created');
+
+        $this->assertSame(['sizer' => [], 'files_total' => 0, 'files_done' => 0], $state);
+    }
+}


### PR DESCRIPTION
## What it does

Adds `StagedPushRunner`: batch orchestration over `StagedUploadClient` (#301). A transfer plan goes in — `[['artifact_id' => ..., 'source_path' => ..., 'total_bytes' => ?], ...]` — and the runner drives every artifact to verified in the target's staged store, resumably, with pull-style state files under the caller's `--state-dir`.

The remaining sender-side piece is the CLI command that builds the plan from a local tree and hands it to this runner; that's the next PR. Part of the push plan in #276.

## Rationale

**Resume must not re-ask the target about finished work.** The client already resumes one artifact from the store's committed offset, but a resumed 50k-file push cannot afford two requests per finished artifact just to rediscover it is finished. The runner appends one line per verified artifact to `.push-verified.jsonl` and skips cache hits (same id, same size) with **zero requests** — trusted the way pull trusts the files already sitting in its fs-root. A torn or missing cache line is never trusted: that artifact goes back through the client, whose status/finalize short-circuit re-confirms it against the store in two cheap requests. Skips only save traffic; the store stays the truth.

**Failure routing decides what a rerun can fix.** Artifact-scoped reasons — a source file vanished or shrank, a plan size disagreeing with what the store verified, a malformed plan entry — are recorded in `failed` and the batch continues; rerunning retries exactly those. Everything else (auth, transport, chunk-size exhaustion, a busy or erroring store) would fail every following artifact identically, so the batch aborts with the reason. **Unknown reasons abort too**: a whitelist of continue-reasons means a future protocol change stops the walk instead of churning a huge plan through per-artifact failures.

**Learned chunk limits survive process boundaries.** The sizer's state (#297) is written into `.push-state.json` (rename-atomic) after every artifact and on abort; `StagedPushRunner::read_state()` restores it before the sizer and client are constructed, so a rerun starts under the ceiling the wire already taught us instead of re-probing with a fresh 413.

Killing the runner anywhere loses at most one cache line (re-derived by the short-circuit) and one sizer update (relearned) — no partial state needs cleanup.

## Implementation

- `packages/reprint-importer/src/lib/upload/class-staged-push-runner.php`, completing the trio next to the sizer and client; loaded by `import.php` alongside them.
- `push($artifacts)` returns `['status' => 'completed'|'aborted', 'files_total', 'files_done', 'failed' => [...], 'abort_reason', 'abort_detail']` — `files_done`/`files_total` matching the progress vocabulary pull already emits.
- `on_progress` fires per chunk advance and per finished artifact with `files_done`, `files_total`, `artifact_id`, `committed_bytes`, `total_bytes`.
- The done cache uses the same torn-tail discipline as the store's `verified.jsonl`: a leading newline seals a killed writer's fragment onto its own skipped line.

```php
$state  = StagedPushRunner::read_state($state_dir);
$sizer  = new UploadChunkSizer([], $state['sizer']);
$client = new StagedUploadClient([
    'base_url' => $url, 'hmac_client' => new Site_Export_HMAC_Client($secret), 'sizer' => $sizer,
]);
$runner = new StagedPushRunner([
    'state_dir' => $state_dir, 'client' => $client, 'sizer' => $sizer, 'on_progress' => $emit,
]);
$result = $runner->push($plan);
// => ['status' => 'completed', 'files_total' => 3, 'files_done' => 3, 'failed' => [], ...]
```

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/StagedPushRunnerTest.php
composer analyze
```

11 tests drive the real runner through the real client, endpoints, store, and HMAC verification in-process (the socket is a callable that also records response codes). Covered: a plan pushed to completion with state files written, chunk- and file-level progress, resume skipping cached artifacts with zero requests, a torn cache line falling back to the two-request short-circuit without re-uploading bytes, mid-artifact resume from the store's committed offset, an artifact-scoped failure continuing the batch and a rerun retrying only it, a transfer-scoped failure aborting the walk after one request, a plan size disagreeing with the cache failing typed as `size_mismatch`, malformed plan entries recorded rather than fatal, 413-learned chunk limits persisting across runs (second run provably issues no 413), and `read_state()` defaults with nothing persisted.
