### PR TITLE
Add the push-files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,30 @@ php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
     --only=:wp-content: --only=:wp-plugins:
 ```
 
+#### Push local files to remote staging.
+
+`push-files` uploads a local filesystem tree into the remote exporter's staged
+artifact store. It is resumable and safe to retry: completed files are skipped,
+partially uploaded files resume from the remote committed offset, and the live
+remote tree is not changed by this command.
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+```
+
+Use repeated `--only` values to push fs-root-relative prefixes instead of the
+whole tree:
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --only=wp-content/uploads
+```
+
+The remote WordPress wiring stores staged artifacts outside the web-served tree.
+Define `SITE_EXPORT_STAGING_DIR` on the exporter host to choose that directory;
+it must have enough free space for the pushed artifacts and should be on storage
+that persists across retries.
+
 #### Pull only the database.
 
 `pull-db` runs the database side of the high-level pull pipeline:
@@ -682,6 +706,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
+* `push-files` — Upload local files into the remote staged artifact store without changing the live remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1856,6 +1856,10 @@ class ImportClient
             return;
         }
         if ($command === "push-files") {
+            if ($abort) {
+                $this->handle_abort($command);
+                return;
+            }
             $this->run_push_files($options);
             return;
         }
@@ -2008,6 +2012,20 @@ class ImportClient
                 $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
 
                 $this->save_state($this->state);
+                break;
+
+            case "push-files":
+                $this->audit_log(
+                    "RESTART | Clearing push-files state",
+                    true,
+                );
+                foreach ([".push-state.json", ".push-verified.jsonl", ".push-manifest.jsonl"] as $name) {
+                    $path = rtrim($this->state_dir, "/") . "/" . $name;
+                    if (file_exists($path)) {
+                        @unlink($path);
+                        $this->audit_log("FILE DELETE | {$path} | abort push-files");
+                    }
+                }
                 break;
 
             case "files-index":

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -65,6 +65,9 @@ require_once __DIR__ . '/lib/upload/class-staged-upload-client.php';
 // Batch orchestration over the upload client: plan in, verified artifacts out
 require_once __DIR__ . '/lib/upload/class-staged-push-runner.php';
 
+// Local-tree walk that produces the plan the push runner consumes
+require_once __DIR__ . '/lib/upload/class-push-plan-builder.php';
+
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';
 
@@ -1604,6 +1607,7 @@ class ImportClient
             "files-pull",
             "files-index",
             "files-stats",
+            "push-files",
             "db-pull",
             "db-index",
             "db-domains",
@@ -1849,6 +1853,10 @@ class ImportClient
         }
         if ($command === "files-stats") {
             $this->run_files_stats();
+            return;
+        }
+        if ($command === "push-files") {
+            $this->run_push_files($options);
             return;
         }
         if ($command === "flat-docroot") {
@@ -3930,6 +3938,106 @@ class ImportClient
         }
 
         echo json_encode($result, JSON_PRETTY_PRINT) . "\n";
+    }
+
+    /**
+     * Upload local files into the target's staged artifact store.
+     *
+     * The plan comes from walking --fs-root: each regular file becomes one
+     * artifact at its fs-root-relative path. Nothing on the target site
+     * changes — this command only fills staging; a later apply step moves
+     * verified artifacts into place. Rerunning resumes: finished artifacts
+     * are skipped from the local done cache, a half-uploaded artifact
+     * continues from the store's committed offset, and the chunk sizer
+     * restarts at its learned limits.
+     */
+    private function run_push_files(array $options): void
+    {
+        if ($this->hmac_client === null) {
+            throw new InvalidArgumentException(
+                "push-files requires --secret: the staged upload endpoints reject unsigned requests.",
+            );
+        }
+
+        $only = [];
+        foreach (($options["only"] ?? []) as $raw) {
+            // Push selection is fs-root-relative. The :token: forms --only
+            // accepts for pull describe remote paths and do not apply here.
+            $prefix = (string) $raw;
+            if (strpos($prefix, "./") === 0) {
+                $prefix = substr($prefix, 2);
+            }
+            $only[] = $prefix;
+        }
+
+        $build = PushPlanBuilder::build($this->fs_root, $only);
+        foreach ($build["skipped"] as $skip) {
+            $this->audit_log("PUSH-SKIP | {$skip["reason"]} | {$skip["path"]}", false);
+        }
+
+        $this->output_progress(
+            [
+                "type" => "push",
+                "status" => "starting",
+                "files_total" => count($build["plan"]),
+                "skipped" => count($build["skipped"]),
+            ],
+            true,
+        );
+
+        $persisted = StagedPushRunner::read_state($this->state_dir);
+        $sizer = new UploadChunkSizer([], $persisted["sizer"]);
+        $client = new StagedUploadClient([
+            "base_url" => $this->remote_url,
+            "hmac_client" => $this->hmac_client,
+            "sizer" => $sizer,
+        ]);
+        $runner = new StagedPushRunner([
+            "state_dir" => $this->state_dir,
+            "client" => $client,
+            "sizer" => $sizer,
+            "on_progress" => function (array $progress): void {
+                $this->output_progress([
+                    "type" => "push_progress",
+                    "files_done" => $progress["files_done"],
+                    "files_total" => $progress["files_total"],
+                    "path" => $progress["artifact_id"],
+                    "committed_bytes" => $progress["committed_bytes"],
+                    "total_bytes" => $progress["total_bytes"],
+                ]);
+            },
+        ]);
+
+        $result = $runner->push($build["plan"]);
+
+        $summary = [
+            "type" => "push",
+            "status" => $result["status"] === "completed" && $result["failed"] === []
+                ? "complete"
+                : "error",
+            "files_total" => $result["files_total"],
+            "files_done" => $result["files_done"],
+            "failed" => $result["failed"],
+            "skipped" => count($build["skipped"]),
+            "abort_reason" => $result["abort_reason"],
+            "abort_detail" => $result["abort_detail"],
+        ];
+        $this->output_progress($summary, true);
+        echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+
+        if ($result["status"] === "aborted") {
+            $this->audit_log(
+                "PUSH ABORTED | {$result["abort_reason"]} | " . ($result["abort_detail"] ?? ""),
+                false,
+            );
+            // Transient transfer failures follow the resumable convention
+            // (exit 2: run the same command again); a bad secret or a chunk
+            // size the host can never accept will not fix itself.
+            $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
+            $this->exit_code = in_array($result["abort_reason"], $retryable, true) ? 2 : 1;
+            return;
+        }
+        $this->exit_code = $result["failed"] === [] ? 0 : 1;
     }
 
     /**
@@ -11659,7 +11767,7 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert', 'push-files'],
         ],
         [
             'name' => 'abort',
@@ -11676,7 +11784,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime', 'push-files'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -11920,8 +12028,8 @@ if (
             'placeholder' => 'SOURCE',
             'repeatable' => true,
             'help' => 'Restrict the file pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
-                'repeat for several. Default pulls everything',
-            'commands' => ['pull-files', 'files-pull'],
+                'repeat for several. Default pulls everything. For push-files, SOURCE is an fs-root-relative prefix',
+            'commands' => ['pull-files', 'files-pull', 'push-files'],
         ],
 
         // ── flat-docroot options ────────────────────────────────
@@ -12590,6 +12698,35 @@ if (
                 "\n" .
                 "Does not download any file contents.\n",
             "extra" => null,
+        ],
+        "push-files" => [
+            "level" => "high",
+            "short" => "Upload local files into the remote staged store (push)",
+            "usage" => "reprint push-files <remote-url> --secret=TOKEN --state-dir=DIR --fs-root=DIR [options]",
+            "description" =>
+                "Walks --fs-root and uploads every regular file into the remote\n" .
+                "site's staged artifact store, in bounded resumable chunks. The\n" .
+                "remote site keeps running untouched: nothing changes there until\n" .
+                "a later apply step moves the verified artifacts into place.\n" .
+                "\n" .
+                "Rerunning the command resumes: finished files are skipped from\n" .
+                "the local done cache, a half-uploaded file continues from the\n" .
+                "byte offset the store confirmed, and chunk sizes start at the\n" .
+                "limits learned from the server last time.\n" .
+                "\n" .
+                "Symlinks are never followed; they are skipped and recorded in\n" .
+                "the audit log. Use --only with fs-root-relative prefixes to\n" .
+                "push a subset.\n",
+            "extra" =>
+                "Examples:\n" .
+                "  # Stage a full local tree on the remote:\n" .
+                "  reprint push-files https://example.com/?reprint-api \\\n" .
+                "    --secret=TOKEN --state-dir=./push-state --fs-root=./site\n" .
+                "\n" .
+                "  # Push only wp-content/uploads:\n" .
+                "  reprint push-files https://example.com/?reprint-api \\\n" .
+                "    --secret=TOKEN --state-dir=./push-state --fs-root=./site \\\n" .
+                "    --only=wp-content/uploads\n",
         ],
         "files-stats" => [
             "level" => "low",

--- a/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Builds a push transfer plan from a local tree.
+ *
+ * The plan is the input StagedPushRunner walks: one entry per regular file,
+ * with the artifact id being the fs-root-relative path the file will be
+ * applied to on the target. Entries come out in deterministic path order so
+ * two runs over the same tree produce the same plan and the runner's
+ * done-cache lines up across retries.
+ *
+ * Symlinks are skipped and reported, never followed: following them would
+ * push bytes from outside fs-root under an in-root artifact id, and
+ * symlinked directories are how hosting layouts create cycles. Anything
+ * unreadable is reported the same way instead of failing the whole plan —
+ * the caller decides whether a skip list is acceptable for its transfer.
+ *
+ * --only prefixes filter the plan to selected subtrees. Directories that
+ * can neither contain a match nor be contained by one are pruned without
+ * being walked, so restricting a push to wp-content does not pay for
+ * scanning an unrelated node_modules forest.
+ */
+class PushPlanBuilder
+{
+    /**
+     * @param string $fs_root Local tree to plan from.
+     * @param array $only_prefixes fs-root-relative path prefixes; empty
+     *   means everything.
+     * @return array{plan:array,skipped:array} plan entries are
+     *   ['artifact_id','source_path','total_bytes']; skipped entries are
+     *   ['path','reason'] with reason symlink|special|unreadable|unreadable_dir.
+     */
+    public static function build(string $fs_root, array $only_prefixes = []): array
+    {
+        $root = rtrim($fs_root, "/");
+        if ($root === "" || !is_dir($root)) {
+            throw new InvalidArgumentException("push plan fs-root is not a directory: {$fs_root}");
+        }
+
+        $only = [];
+        foreach ($only_prefixes as $prefix) {
+            if (!is_string($prefix)) {
+                throw new InvalidArgumentException("--only prefix must be a string");
+            }
+            $prefix = trim($prefix, "/");
+            if ($prefix === "" || strpos($prefix, "\\") !== false) {
+                throw new InvalidArgumentException("Invalid --only prefix: {$prefix}");
+            }
+            foreach (explode("/", $prefix) as $segment) {
+                if ($segment === "" || $segment === "." || $segment === "..") {
+                    throw new InvalidArgumentException("Invalid --only prefix: {$prefix}");
+                }
+            }
+            $only[] = $prefix;
+        }
+
+        $plan = [];
+        $skipped = [];
+        self::walk($root, "", $only, $plan, $skipped);
+        return [
+            "plan" => $plan,
+            "skipped" => $skipped,
+        ];
+    }
+
+    /**
+     * @param string $dir Absolute directory being walked.
+     * @param string $rel_dir fs-root-relative path of $dir ("" for the root).
+     */
+    private static function walk(string $dir, string $rel_dir, array $only, array &$plan, array &$skipped): void
+    {
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            $skipped[] = ["path" => $rel_dir, "reason" => "unreadable_dir"];
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $path = $dir . "/" . $entry;
+            $rel = $rel_dir === "" ? $entry : $rel_dir . "/" . $entry;
+
+            if (is_link($path)) {
+                $skipped[] = ["path" => $rel, "reason" => "symlink"];
+                continue;
+            }
+            if (is_dir($path)) {
+                if (self::prunable($rel, $only)) {
+                    continue;
+                }
+                self::walk($path, $rel, $only, $plan, $skipped);
+                continue;
+            }
+            if (!is_file($path)) {
+                $skipped[] = ["path" => $rel, "reason" => "special"];
+                continue;
+            }
+            if ($only !== [] && !self::selected($rel, $only)) {
+                continue;
+            }
+            $size = @filesize($path);
+            if ($size === false) {
+                $skipped[] = ["path" => $rel, "reason" => "unreadable"];
+                continue;
+            }
+            $plan[] = [
+                "artifact_id" => $rel,
+                "source_path" => $path,
+                "total_bytes" => $size,
+            ];
+        }
+    }
+
+    /** A file is selected when it sits at or under one of the prefixes. */
+    private static function selected(string $rel, array $only): bool
+    {
+        foreach ($only as $prefix) {
+            if ($rel === $prefix || strpos($rel, $prefix . "/") === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A directory is prunable when no prefix lies under it and it lies
+     * under no prefix — nothing inside can be selected.
+     */
+    private static function prunable(string $rel_dir, array $only): bool
+    {
+        if ($only === []) {
+            return false;
+        }
+        foreach ($only as $prefix) {
+            $under_prefix = $rel_dir === $prefix || strpos($rel_dir, $prefix . "/") === 0;
+            $contains_prefix = strpos($prefix, $rel_dir . "/") === 0;
+            if ($under_prefix || $contains_prefix) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
@@ -26,7 +26,7 @@ class PushPlanBuilder
      * @param array $only_prefixes fs-root-relative path prefixes; empty
      *   means everything.
      * @return array{plan:array,skipped:array} plan entries are
-     *   ['artifact_id','source_path','total_bytes']; skipped entries are
+     *   ['artifact_id','source_path','total_bytes','mtime']; skipped entries are
      *   ['path','reason'] with reason symlink|special|unreadable|unreadable_dir.
      */
     public static function build(string $fs_root, array $only_prefixes = []): array
@@ -100,7 +100,8 @@ class PushPlanBuilder
                 continue;
             }
             $size = @filesize($path);
-            if ($size === false) {
+            $mtime = @filemtime($path);
+            if ($size === false || $mtime === false) {
                 $skipped[] = ["path" => $rel, "reason" => "unreadable"];
                 continue;
             }
@@ -108,6 +109,7 @@ class PushPlanBuilder
                 "artifact_id" => $rel,
                 "source_path" => $path,
                 "total_bytes" => $size,
+                "mtime" => $mtime,
             ];
         }
     }

--- a/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
@@ -109,7 +109,9 @@ class PushPlanBuilder
                 "artifact_id" => $rel,
                 "source_path" => $path,
                 "total_bytes" => $size,
-                "mtime" => $mtime,
+                // Size alone cannot see a same-size edit; the runner keys
+                // its done-cache on mtime too.
+                "mtime" => (int) $mtime,
             ];
         }
     }

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -136,4 +136,66 @@ class PushFilesCliTest extends TestCase
         $this->assertSame(1, $code);
         $this->assertStringContainsString('Invalid --only prefix', $output);
     }
+
+    public function testWrongSecretAbortsFatalNotRetryable(): void
+    {
+        // A target that answers every request with the control-plane auth
+        // envelope, the way lib.php rejects a bad secret. Retrying cannot
+        // fix credentials: the abort must be exit 1, never the resume
+        // convention's exit 2.
+        $harness = sys_get_temp_dir() . '/push-cli-auth-' . bin2hex(random_bytes(8));
+        mkdir($harness, 0700, true);
+        file_put_contents(
+            $harness . '/router.php',
+            "<?php\n" .
+            "http_response_code(403);\n" .
+            "header('Content-Type: application/json');\n" .
+            "echo json_encode(['error' => 'HMAC signature verification failed', 'code' => 403]);\n"
+        );
+        $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($probe, "cannot allocate a port: {$errstr}");
+        $name = (string) stream_socket_get_name($probe, false);
+        $port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($probe);
+        $server = proc_open(
+            [PHP_BINARY, '-S', "127.0.0.1:{$port}", $harness . '/router.php'],
+            [1 => ['file', $harness . '/server.log', 'a'], 2 => ['file', $harness . '/server.log', 'a']],
+            $pipes
+        );
+        $this->assertIsResource($server);
+        $deadline = microtime(true) + 10;
+        $ready = false;
+        while (microtime(true) < $deadline) {
+            $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($conn !== false) {
+                fclose($conn);
+                $ready = true;
+                break;
+            }
+            usleep(100000);
+        }
+        $this->assertTrue($ready, 'php -S did not come up');
+
+        try {
+            file_put_contents($this->fs_root . '/index.php', '<?php');
+            [$output, $code] = $this->runCli([
+                'push-files',
+                "http://127.0.0.1:{$port}/?reprint-api",
+                '--secret=the-wrong-secret',
+                '--state-dir=' . $this->state_dir,
+                '--fs-root=' . $this->fs_root,
+            ]);
+
+            // The stable contract at every floor of the stack: credential
+            // rejections are fatal, never the resume convention's exit 2.
+            // (Higher floors classify the envelope as auth_failed; here it
+            // surfaces as an unexpected response — equally non-retryable.)
+            $this->assertSame(1, $code, $output);
+            $this->assertStringContainsString('"status": "error"', $output);
+        } finally {
+            proc_terminate($server);
+            proc_close($server);
+            $this->removeDir($harness);
+        }
+    }
 }

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Drives the real CLI in a subprocess, like OnlyCliParseTest: argument
+ * parsing, dispatch, exit codes, and the no-network paths of push-files.
+ */
+class PushFilesCliTest extends TestCase
+{
+    private string $state_dir;
+
+    private string $fs_root;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->state_dir = sys_get_temp_dir() . '/push-cli-state-' . $suffix;
+        $this->fs_root = sys_get_temp_dir() . '/push-cli-root-' . $suffix;
+        mkdir($this->state_dir, 0700, true);
+        mkdir($this->fs_root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->state_dir, $this->fs_root] as $dir) {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * @return array{0:string,1:int} Combined output and exit code.
+     */
+    private function runCli(array $args): array
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+        exec($cmd . ' 2>&1', $lines, $code);
+        return [implode("\n", $lines), $code];
+    }
+
+    public function testHelpDescribesTheCommand(): void
+    {
+        [$output] = $this->runCli(['push-files', '--help']);
+
+        $this->assertStringContainsString('reprint push-files <remote-url>', $output);
+        $this->assertStringContainsString('staged artifact store', $output);
+        $this->assertStringContainsString('--secret', $output);
+        $this->assertStringContainsString('--only', $output);
+    }
+
+    public function testMissingSecretFailsWithATypedError(): void
+    {
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('requires --secret', $output);
+    }
+
+    public function testEmptyTreeCompletesWithoutTouchingTheNetwork(): void
+    {
+        // Port 1 would refuse instantly; an empty plan must never get there.
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--secret=test-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(0, $code, $output);
+        // The summary is the pretty-printed JSON block at the end of the
+        // output, after the single-line progress records.
+        $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+        $this->assertSame('complete', $summary['status']);
+        $this->assertSame(0, $summary['files_total']);
+        $this->assertFileExists($this->state_dir . '/.push-state.json');
+    }
+
+    public function testUnreachableTargetAbortsWithTheRetryableExitCode(): void
+    {
+        file_put_contents($this->fs_root . '/wp-config-sample.php', '<?php');
+
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--secret=test-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(2, $code, 'a transient connection failure follows the resume convention');
+        // The very first request is the status resync, so a dead target
+        // surfaces as status_unavailable — classified retryable.
+        $this->assertStringContainsString('status_unavailable', $output);
+        $this->assertFileExists(
+            $this->state_dir . '/.push-state.json',
+            'learned sizer state persists across the abort'
+        );
+    }
+
+    public function testHostileOnlyPrefixIsRejectedBeforeAnyUpload(): void
+    {
+        file_put_contents($this->fs_root . '/a.txt', 'x');
+
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--secret=test-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+            '--only=../outside',
+        ]);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('Invalid --only prefix', $output);
+    }
+}

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -98,6 +98,28 @@ class PushFilesCliTest extends TestCase
         $this->assertFileExists($this->state_dir . '/.push-state.json');
     }
 
+    public function testAbortClearsPushStateWithoutSecretOrNetwork(): void
+    {
+        file_put_contents($this->state_dir . '/.push-state.json', '{}');
+        file_put_contents($this->state_dir . '/.push-verified.jsonl', "a.txt\n");
+        file_put_contents($this->state_dir . '/.push-manifest.jsonl', "{}\n");
+        file_put_contents($this->fs_root . '/a.txt', 'x');
+
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--abort',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('State cleared for push-files', $output);
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-state.json');
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-verified.jsonl');
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-manifest.jsonl');
+    }
+
     public function testUnreachableTargetAbortsWithTheRetryableExitCode(): void
     {
         file_put_contents($this->fs_root . '/wp-config-sample.php', '<?php');

--- a/tests/Import/PushPlanBuilderTest.php
+++ b/tests/Import/PushPlanBuilderTest.php
@@ -49,14 +49,16 @@ class PushPlanBuilderTest extends TestCase
     {
         $this->put('index.php', '<?php');
         $this->put('wp-content/themes/t/style.css', 'body{}');
+        touch($this->root . '/index.php', 1000);
+        touch($this->root . '/wp-content/themes/t/style.css', 2000);
 
         $result = PushPlanBuilder::build($this->root);
 
         $this->assertSame([], $result['skipped']);
         $this->assertSame(
             [
-                ['artifact_id' => 'index.php', 'source_path' => $this->root . '/index.php', 'total_bytes' => 5],
-                ['artifact_id' => 'wp-content/themes/t/style.css', 'source_path' => $this->root . '/wp-content/themes/t/style.css', 'total_bytes' => 6],
+                ['artifact_id' => 'index.php', 'source_path' => $this->root . '/index.php', 'total_bytes' => 5, 'mtime' => 1000],
+                ['artifact_id' => 'wp-content/themes/t/style.css', 'source_path' => $this->root . '/wp-content/themes/t/style.css', 'total_bytes' => 6, 'mtime' => 2000],
             ],
             $result['plan']
         );

--- a/tests/Import/PushPlanBuilderTest.php
+++ b/tests/Import/PushPlanBuilderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace ImportTests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use PushPlanBuilder;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class PushPlanBuilderTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/push-plan-' . bin2hex(random_bytes(8));
+        mkdir($this->root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->root);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            if (is_link($entry) || !is_dir($entry)) {
+                @unlink($entry);
+            } else {
+                $this->removeDir($entry);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function put(string $rel, string $body): void
+    {
+        $path = $this->root . '/' . $rel;
+        @mkdir(dirname($path), 0700, true);
+        file_put_contents($path, $body);
+    }
+
+    public function testPlansRegularFilesWithRelativeIdsAndSizes(): void
+    {
+        $this->put('index.php', '<?php');
+        $this->put('wp-content/themes/t/style.css', 'body{}');
+
+        $result = PushPlanBuilder::build($this->root);
+
+        $this->assertSame([], $result['skipped']);
+        $this->assertSame(
+            [
+                ['artifact_id' => 'index.php', 'source_path' => $this->root . '/index.php', 'total_bytes' => 5],
+                ['artifact_id' => 'wp-content/themes/t/style.css', 'source_path' => $this->root . '/wp-content/themes/t/style.css', 'total_bytes' => 6],
+            ],
+            $result['plan']
+        );
+    }
+
+    public function testPlanOrderIsDeterministic(): void
+    {
+        foreach (['b.txt', 'a.txt', 'c/inner.txt', 'a-dir/z.txt'] as $rel) {
+            $this->put($rel, 'x');
+        }
+
+        $first = PushPlanBuilder::build($this->root);
+        $second = PushPlanBuilder::build($this->root);
+
+        $this->assertSame($first['plan'], $second['plan']);
+        $ids = array_column($first['plan'], 'artifact_id');
+        $sorted = $ids;
+        sort($sorted, SORT_STRING);
+        $this->assertSame($sorted, $ids, 'scandir order is alphabetical per directory');
+    }
+
+    public function testSymlinksAreSkippedAndReportedNeverFollowed(): void
+    {
+        $this->put('real/wanted.txt', 'keep');
+        $this->put('outside-target.txt', 'outside');
+        symlink($this->root . '/outside-target.txt', $this->root . '/link.txt');
+        // A directory symlink that would create a cycle if followed.
+        symlink($this->root, $this->root . '/cycle');
+
+        $result = PushPlanBuilder::build($this->root);
+
+        $this->assertSame(
+            ['outside-target.txt', 'real/wanted.txt'],
+            array_column($result['plan'], 'artifact_id')
+        );
+        $skipped = $result['skipped'];
+        usort($skipped, static fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
+        $this->assertSame(
+            [
+                ['path' => 'cycle', 'reason' => 'symlink'],
+                ['path' => 'link.txt', 'reason' => 'symlink'],
+            ],
+            $skipped
+        );
+    }
+
+    public function testUnreadableDirectoryIsReportedNotFatal(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+        $this->put('ok.txt', 'fine');
+        $this->put('locked/secret.txt', 'hidden');
+        chmod($this->root . '/locked', 0000);
+
+        $result = PushPlanBuilder::build($this->root);
+        chmod($this->root . '/locked', 0700);
+
+        $this->assertSame(['ok.txt'], array_column($result['plan'], 'artifact_id'));
+        $this->assertSame([['path' => 'locked', 'reason' => 'unreadable_dir']], $result['skipped']);
+    }
+
+    public function testOnlyPrefixesFilterAndPrune(): void
+    {
+        $this->put('wp-content/uploads/a.jpg', 'aa');
+        $this->put('wp-content/plugins/p/p.php', 'pp');
+        $this->put('wp-includes/version.php', 'vv');
+        $this->put('node_modules/dep/dep.js', 'jj');
+
+        $result = PushPlanBuilder::build($this->root, ['wp-content/uploads', 'wp-includes/version.php']);
+
+        $this->assertSame(
+            ['wp-content/uploads/a.jpg', 'wp-includes/version.php'],
+            array_column($result['plan'], 'artifact_id')
+        );
+    }
+
+    public function testHostileOnlyPrefixesAreRejected(): void
+    {
+        foreach (['../outside', 'a/../b', '', '/', 'a\\b'] as $hostile) {
+            try {
+                PushPlanBuilder::build($this->root, [$hostile]);
+                $this->fail("prefix should have been rejected: {$hostile}");
+            } catch (InvalidArgumentException $e) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    public function testMissingRootIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PushPlanBuilder::build($this->root . '/never-existed');
+    }
+
+    public function testEmptyRootYieldsEmptyPlan(): void
+    {
+        $this->assertSame(['plan' => [], 'skipped' => []], PushPlanBuilder::build($this->root));
+    }
+}


### PR DESCRIPTION
## What it does

Adds the `push-files` CLI command: walk `--fs-root`, turn every regular file into a plan entry, and drive it through `StagedPushRunner` (#302) into the target's staged artifact store. First user-runnable push:

```bash
reprint push-files https://example.com/?reprint-api \
  --secret=TOKEN --state-dir=./push-state --fs-root=./site [--only=wp-content/uploads]
```

The remote site keeps running untouched — this fills staging only; the apply step is the next PR. Part of #276.

## Rationale

**The plan is deterministic and honest about what it excludes.** `PushPlanBuilder` walks in stable per-directory alphabetical order (so the runner's done-cache lines up across reruns), never follows symlinks (following them would push out-of-root bytes under an in-root artifact id, and symlinked directories are how hosting layouts make cycles), and reports every skip — symlinks, special files, unreadable entries — to the audit log instead of failing the plan or silently narrowing it. `--only` takes fs-root-relative prefixes (pull's `:token:` forms describe *remote* paths and don't apply to a local walk) and prunes directories that can't contain a match, so `--only=wp-content` doesn't pay to scan an unrelated `node_modules` forest.

**Exit codes follow the resume convention.** Transient transfer aborts (`status_unavailable`, `transport_failed`, `busy_exhausted`, `server_io_error`) exit 2 — run the same command again to continue, exactly like pull. A bad secret or a chunk size the host can never accept exits 1: retrying cannot fix those. Rerunning after any interruption resumes: finished files skip via the done cache, a half-uploaded file continues from the store's committed offset, and the chunk sizer restarts at its learned limits (all #301/#302 mechanics — this command adds no new state of its own).

**Progress speaks the existing vocabulary**: `files_done`/`files_total`/`path` records through `output_progress()`, plus a final machine-readable summary on stdout.

## Implementation

- `packages/reprint-importer/src/lib/upload/class-push-plan-builder.php` — the walk; hostile `--only` prefixes (`..`, absolute, backslash) throw before anything runs.
- `run_push_files()` in `import.php` plus dispatch, `$valid_commands`, option registrations (`--secret`, `--only`, `-v`), and a `push-files` entry in the command help table.
- No new option parsing: `push-files <remote-url> --state-dir --fs-root` rides the existing declarative CLI table.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/PushPlanBuilderTest.php Import/PushFilesCliTest.php
composer analyze
```

8 plan-builder tests (relative ids and sizes, deterministic order, symlinks skipped and reported — including a would-be cycle, unreadable directories reported not fatal, `--only` filter + pruning, hostile prefixes rejected, missing root, empty root) and 5 CLI tests that run the real binary in a subprocess: `--help` rendering, missing `--secret` fails typed, an empty tree completes with exit 0 without touching the network, a dead target aborts `status_unavailable` with exit 2 and persists the sizer state, and a hostile `--only` is rejected before any upload.
