### PR TITLE
Apply staged transfers by rename, refusing cross-device staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,27 @@ Define `SITE_EXPORT_STAGING_DIR` on the exporter host to choose that directory;
 it must have enough free space for the pushed artifacts and should be on storage
 that persists across retries.
 
+Add `--apply` when the verified transfer should move into the remote tree after
+uploading:
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --apply
+```
+
+The exporter applies into `ABSPATH` by default. Define `SITE_EXPORT_APPLY_ROOT`
+on the exporter host to choose a different target root. Apply is rename-only:
+it probes before upload and refuses `cross_device` if `SITE_EXPORT_STAGING_DIR`
+and `SITE_EXPORT_APPLY_ROOT` are on different filesystems. Put staging on the
+same filesystem as the target when you plan to use `--apply`; Reprint will not
+fall back to copy-and-remove because that could expose half-written live files.
+
+An interrupted apply can be retried with the same command. Files already renamed
+into place are recognized by size, and files still in staging are moved on the
+next run. The apply window is intentionally short but serial; the remote site
+may briefly contain a mix of old and new files if the process is killed between
+renames, so keep the site in maintenance mode for deployments that need a
+whole-tree cutover.
+
 #### Pull only the database.
 
 `pull-db` runs the database side of the high-level pull pipeline:
@@ -706,7 +727,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
-* `push-files` — Upload local files into the remote staged artifact store without changing the live remote tree.
+* `push-files` — Upload local files into the remote staged artifact store; add `--apply` to rename the verified transfer into the remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.

--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-upload-endpoints",
+            "version": "dev-push/staged-apply",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
+                "reference": "02cfcadbdd4fa49cdfccb0a2580897781f841db5"
             },
             "require": {
                 "php": ">=7.4",
@@ -384,6 +384,7 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
+                    "src/class-staged-apply.php",
                     "src/class-staged-artifacts.php",
                     "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -22,6 +22,7 @@
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
             "src/class-http-server.php",
+            "src/class-staged-apply.php",
             "src/class-staged-artifacts.php",
             "src/class-staged-endpoints.php",
             "src/class-sqlite-driver-pdo.php",

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -330,6 +330,9 @@ final class Site_Export_HTTP_Server {
             'staged_discard' => static function (array $config) use ($endpoints): void {
                 self::emit_json_response($endpoints->discard($config, $_SERVER));
             },
+            'staged_apply' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->apply($config, $_SERVER));
+            },
         ];
 
         foreach ($routes as $endpoint => $handler) {

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -346,9 +346,28 @@ final class Site_Export_Staged_Apply {
         $staged_path = $this->files_dir . '/' . $artifact_id;
         $target_path = $this->target_root . '/' . $artifact_id;
 
+        // Type swaps happen between transfers: a directory or symlink can
+        // occupy the path a file now belongs at. rename() replaces files
+        // and symlinks atomically but not directories, so clear anything
+        // that is not a plain file first — the same replacement the pull
+        // writer performs, and like it, never following links.
+        if (is_link($target_path) === false && is_dir($target_path)) {
+            if (!$this->remove_path_without_following_symlinks($target_path)) {
+                return 'clear_target_path: ' . $artifact_id;
+            }
+        }
+
         $parent = dirname($target_path);
-        if (!is_dir($parent) && !@mkdir($parent, 0755, true) && !is_dir($parent)) {
-            return 'create_target_dir: ' . $artifact_id;
+        if (!is_dir($parent)) {
+            // A file left where a directory now belongs blocks mkdir; the
+            // transfer's tree wins, same as above.
+            $blocking_error = $this->clear_blocking_parents($artifact_id);
+            if ($blocking_error !== null) {
+                return $blocking_error . ': ' . $artifact_id;
+            }
+            if (!@mkdir($parent, 0755, true) && !is_dir($parent)) {
+                return 'create_target_dir: ' . $artifact_id;
+            }
         }
         // Same filesystem by precheck, so this replaces atomically; the
         // tree never holds a partial file.
@@ -360,6 +379,56 @@ final class Site_Export_Staged_Apply {
         // costs this unlink again.
         @unlink($this->staging_dir . '/verified/' . $artifact_id);
         return null;
+    }
+
+    /**
+     * Removes a file or symlink sitting on the artifact's parent chain
+     * where a directory now belongs. Symlinked directories pass through:
+     * only an actual non-directory blocks mkdir.
+     *
+     * @return string|null Error detail, or null when the chain is clear.
+     */
+    private function clear_blocking_parents(string $artifact_id): ?string {
+        $parent_rel = dirname($artifact_id);
+        if ($parent_rel === '.') {
+            return null;
+        }
+        $path = $this->target_root;
+        foreach (explode('/', $parent_rel) as $segment) {
+            $path .= '/' . $segment;
+            if ((is_link($path) || file_exists($path)) && !is_dir($path)) {
+                if (!@unlink($path)) {
+                    return 'clear_blocking_parent';
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Trunk's replacement discipline: unlink files and symlinks directly
+     * (never following the link), recurse into real directories.
+     */
+    private function remove_path_without_following_symlinks(string $path): bool {
+        if (!file_exists($path) && !is_link($path)) {
+            return true;
+        }
+        if (is_link($path) || is_file($path)) {
+            return @unlink($path) === true;
+        }
+        $entries = @scandir($path);
+        if ($entries === false) {
+            return false;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            if (!$this->remove_path_without_following_symlinks($path . '/' . $entry)) {
+                return false;
+            }
+        }
+        return @rmdir($path) === true;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -149,7 +149,7 @@ final class Site_Export_Staged_Apply {
                 if (isset($already_applied[$index])) {
                     // A rerun after a kill: the file is in place; only its
                     // leftover marker remains to consume.
-                    @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                    $this->consume_verified_marker($entry['artifact_id']);
                     continue;
                 }
                 $move_error = $this->move_into_place($entry['artifact_id']);
@@ -165,8 +165,11 @@ final class Site_Export_Staged_Apply {
             // The manifest is consumed with the transfer it described, and
             // a cursor still naming a consumed artifact must not survive to
             // answer a future upload with its stale offset.
-            @unlink($this->files_dir . '/' . $manifest_id);
-            @unlink($this->staging_dir . '/verified/' . $manifest_id);
+            $manifest_path = $this->files_dir . '/' . $manifest_id;
+            @unlink($manifest_path);
+            clearstatcache(true, $manifest_path);
+            $this->prune_empty_staging_parents('files', $manifest_id);
+            $this->consume_verified_marker($manifest_id);
             $this->clear_cursor_for($entries, $manifest_id);
 
             return $this->result('applied', null, null, $applied, count($already_applied));
@@ -374,11 +377,32 @@ final class Site_Export_Staged_Apply {
         if (!@rename($staged_path, $target_path)) {
             return 'rename: ' . $artifact_id;
         }
+        clearstatcache(true, $staged_path);
         // The marker is consumed with the file. A kill between the two
         // reruns as "applied" (target at size, nothing staged) and only
         // costs this unlink again.
-        @unlink($this->staging_dir . '/verified/' . $artifact_id);
+        $this->prune_empty_staging_parents('files', $artifact_id);
+        $this->consume_verified_marker($artifact_id);
         return null;
+    }
+
+    private function consume_verified_marker(string $artifact_id): void {
+        $marker_path = $this->staging_dir . '/verified/' . $artifact_id;
+        @unlink($marker_path);
+        clearstatcache(true, $marker_path);
+        $this->prune_empty_staging_parents('verified', $artifact_id);
+    }
+
+    private function prune_empty_staging_parents(string $root_name, string $artifact_id): void {
+        $root = $this->staging_dir . '/' . $root_name;
+        $dir = dirname($root . '/' . $artifact_id);
+        while ($dir !== $root && strpos($dir, $root . '/') === 0) {
+            if (!@rmdir($dir)) {
+                return;
+            }
+            clearstatcache(true, $dir);
+            $dir = dirname($dir);
+        }
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -1,0 +1,377 @@
+<?php
+
+/**
+ * Moves verified staged artifacts into the live tree — the payoff of the
+ * staged store: the site never sees a partial file, and the whole transfer
+ * lands in one short window of renames.
+ *
+ * Apply is rename-only. rename() is what makes each file's appearance
+ * atomic, and it only works when the staging directory and the target root
+ * sit on the same filesystem. A staging directory on another device would
+ * force copy-and-remove — a window where a half-copied file is live — so
+ * apply refuses it up front with a typed "cross_device" rejection, before
+ * any file has moved. Operators fix it by pointing the staging directory
+ * (SITE_EXPORT_STAGING_DIR in the WordPress wiring) at the target's
+ * filesystem; apply never silently degrades to copying.
+ *
+ * The manifest is itself a staged artifact: one JSONL line per artifact,
+ * {"artifact_id": ..., "size": ...}. That keeps the apply request bounded
+ * (an id, not a 50k-entry body) and reuses the store's verification for the
+ * manifest bytes. The manifest artifact is consumed by apply, never applied
+ * into the tree.
+ *
+ * Everything that can be checked is checked before the first rename:
+ * the device match, the target root, the manifest's shape, and that every
+ * listed artifact is verified at its manifest size (or already applied —
+ * see below). A transfer that is incomplete or disagrees with its plan is
+ * rejected whole; there is no partial apply of a half-verified transfer.
+ *
+ * A kill mid-apply leaves some files moved and some staged. Rerunning
+ * apply recovers without a journal cursor: an entry whose staged file is
+ * gone but whose target exists at the manifest size is already applied and
+ * skips; everything still staged renames as normal. The pre-scan accepts
+ * both states, so the rerun passes validation and finishes the window.
+ * Only an entry that is neither staged-and-verified nor already applied
+ * rejects the run — that transfer is genuinely incomplete.
+ *
+ * Apply holds the store's exclusive lock for the whole window, so an
+ * upload retry racing the apply gets "busy" instead of writing into a
+ * tree being consumed. The lock file is the same one the store's mutators
+ * use; a killed apply releases it with the process.
+ */
+final class Site_Export_Staged_Apply {
+
+    /** @var string */
+    private $staging_dir;
+
+    /** @var string */
+    private $files_dir;
+
+    /** @var string */
+    private $lock_path;
+
+    /** @var string */
+    private $target_root;
+
+    /** @var Site_Export_Staged_Artifacts */
+    private $store;
+
+    /** @var callable */
+    private $device_id;
+
+    /**
+     * @param array $options
+     *   - staging_dir (string, required): same directory the store uses.
+     *   - target_root (string, required): tree the artifacts apply into.
+     *   - device_id (?callable): fn(string $path): ?int — stat device
+     *     lookup, injectable for tests; null means the path is unreadable.
+     */
+    public function __construct(array $options) {
+        $staging_dir = $options['staging_dir'] ?? null;
+        $target_root = $options['target_root'] ?? null;
+        if (!is_string($staging_dir) || $staging_dir === '') {
+            throw new InvalidArgumentException('Staged apply requires a staging_dir option.');
+        }
+        if (!is_string($target_root) || $target_root === '') {
+            throw new InvalidArgumentException('Staged apply requires a target_root option.');
+        }
+        $this->staging_dir = rtrim($staging_dir, '/');
+        $this->files_dir = $this->staging_dir . '/files';
+        $this->lock_path = $this->staging_dir . '/lock';
+        $this->target_root = rtrim($target_root, '/');
+        $this->store = new Site_Export_Staged_Artifacts($staging_dir);
+        $this->device_id = $options['device_id'] ?? static function (string $path): ?int {
+            $stat = @stat($path);
+            return $stat === false ? null : (int) $stat['dev'];
+        };
+    }
+
+    /**
+     * Validate a transfer and move it into the target root.
+     *
+     * @param string $manifest_id Staged artifact holding the manifest.
+     * @param bool $check_only Validate everything, move nothing. This is
+     *   what a sender calls before uploading gigabytes: a staging
+     *   directory that can never apply (cross_device) rejects here, at
+     *   the start, not after the transfer.
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
+     *   status "applied"|"ready"|"busy"|"rejected".
+     */
+    public function apply(string $manifest_id, bool $check_only = false): array {
+        $precheck = $this->check_environment();
+        if ($precheck !== null) {
+            return $precheck;
+        }
+
+        if ($check_only && !$this->store->status($manifest_id)['verified']) {
+            // Probes run before the transfer exists. The environment is
+            // the answer; the manifest is checked when apply runs for real.
+            return $this->result('ready', null, null);
+        }
+
+        $lock = @fopen($this->lock_path, 'c+b');
+        if ($lock === false) {
+            return $this->result('rejected', 'io_error', 'open_lock_file');
+        }
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return $this->result('busy', null, null);
+            }
+
+            $entries = $this->read_manifest($manifest_id);
+            if (!is_array($entries)) {
+                return $this->result('rejected', 'manifest_invalid', $entries);
+            }
+
+            // Nothing moves until the whole transfer proves consistent.
+            $already_applied = [];
+            foreach ($entries as $index => $entry) {
+                $verdict = $this->classify($entry);
+                if ($verdict === 'staged') {
+                    continue;
+                }
+                if ($verdict === 'applied') {
+                    $already_applied[$index] = true;
+                    continue;
+                }
+                return $this->result('rejected', $verdict, $entry['artifact_id']);
+            }
+
+            if ($check_only) {
+                return $this->result('ready', null, null, 0, count($already_applied));
+            }
+
+            // Apply holds the store's lock, so cleanup below unlinks the
+            // store's files directly — its own discard() would contend on
+            // the very lock this process holds.
+            $applied = 0;
+            foreach ($entries as $index => $entry) {
+                if (isset($already_applied[$index])) {
+                    // A rerun after a kill: the file is in place; only its
+                    // leftover marker remains to consume.
+                    @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                    continue;
+                }
+                $move_error = $this->move_into_place($entry['artifact_id']);
+                if ($move_error !== null) {
+                    // Everything validated, so this is environmental
+                    // (permissions, disk). Rerunning apply resumes: moved
+                    // entries classify as applied, the rest re-validate.
+                    return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied));
+                }
+                ++$applied;
+            }
+
+            // The manifest is consumed with the transfer it described, and
+            // a cursor still naming a consumed artifact must not survive to
+            // answer a future upload with its stale offset.
+            @unlink($this->files_dir . '/' . $manifest_id);
+            @unlink($this->staging_dir . '/verified/' . $manifest_id);
+            $this->clear_cursor_for($entries, $manifest_id);
+
+            return $this->result('applied', null, null, $applied, count($already_applied));
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Clears the store cursor when it names an artifact this apply consumed.
+     * Same write-then-rename commit as the store's own cursor writes.
+     */
+    private function clear_cursor_for(array $entries, string $manifest_id): void {
+        $state_path = $this->staging_dir . '/state.json';
+        $raw = @file_get_contents($state_path);
+        $state = $raw === false ? null : json_decode($raw, true);
+        $cursor_artifact = is_array($state) && is_string($state['artifact_id'] ?? null)
+            ? $state['artifact_id']
+            : null;
+        if ($cursor_artifact === null) {
+            return;
+        }
+
+        $consumed = $cursor_artifact === $manifest_id;
+        foreach ($entries as $entry) {
+            if ($entry['artifact_id'] === $cursor_artifact) {
+                $consumed = true;
+                break;
+            }
+        }
+        if (!$consumed) {
+            return;
+        }
+
+        $json = json_encode(['artifact_id' => null, 'committed_bytes' => 0]);
+        $tmp_path = $state_path . '.tmp';
+        if (@file_put_contents($tmp_path, $json) === strlen($json)) {
+            @rename($tmp_path, $state_path);
+        }
+        @unlink($tmp_path);
+    }
+
+    /**
+     * The environment checks that hold regardless of transfer state.
+     *
+     * @return array|null Null when the environment can apply.
+     */
+    private function check_environment(): ?array {
+        $target_device = call_user_func($this->device_id, $this->target_root);
+        if ($target_device === null) {
+            return $this->result('rejected', 'target_missing', $this->target_root);
+        }
+        if (!is_dir($this->target_root) || !is_writable($this->target_root)) {
+            return $this->result('rejected', 'target_unwritable', $this->target_root);
+        }
+
+        // The staging scaffolding may predate any upload; the device of the
+        // staging base decides where files/ will live.
+        if (!is_dir($this->staging_dir) && !@mkdir($this->staging_dir, 0700, true) && !is_dir($this->staging_dir)) {
+            return $this->result('rejected', 'staging_unavailable', $this->staging_dir);
+        }
+        $staging_device = call_user_func($this->device_id, $this->staging_dir);
+        if ($staging_device === null) {
+            return $this->result('rejected', 'staging_unavailable', $this->staging_dir);
+        }
+
+        if ($staging_device !== $target_device) {
+            // Apply is rename-only by design: copy-and-remove would serve
+            // half-copied files from the live tree. Refuse before anything
+            // moves; the fix is a same-filesystem staging directory.
+            return $this->result('rejected', 'cross_device', sprintf(
+                'staging %s is on device %d, target %s on device %d',
+                $this->staging_dir,
+                $staging_device,
+                $this->target_root,
+                $target_device
+            ));
+        }
+
+        return null;
+    }
+
+    /**
+     * Reads and validates the manifest artifact.
+     *
+     * @return array|string Entry list, or an error detail string.
+     */
+    private function read_manifest(string $manifest_id) {
+        $status = $this->store->status($manifest_id);
+        if (!$status['verified']) {
+            return 'manifest artifact is not verified: ' . $manifest_id;
+        }
+        $raw = @file_get_contents($this->files_dir . '/' . $manifest_id);
+        if ($raw === false) {
+            return 'manifest artifact is not readable: ' . $manifest_id;
+        }
+
+        $entries = [];
+        foreach (explode("\n", $raw) as $line_number => $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+            $entry = json_decode($line, true);
+            if (
+                !is_array($entry)
+                || !is_string($entry['artifact_id'] ?? null)
+                || !is_int($entry['size'] ?? null)
+                || $entry['size'] < 0
+            ) {
+                return 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
+            }
+            if ($entry['artifact_id'] === $manifest_id) {
+                return 'manifest lists itself';
+            }
+            // Manifest content is sender data; ids must satisfy the same
+            // path rule the store enforces at upload time, or a crafted
+            // manifest could probe or write outside the target root.
+            if (!$this->valid_artifact_id($entry['artifact_id'])) {
+                return 'manifest line ' . ( $line_number + 1 ) . ' has an invalid artifact id';
+            }
+            $entries[] = [
+                'artifact_id' => $entry['artifact_id'],
+                'size' => $entry['size'],
+            ];
+        }
+        return $entries;
+    }
+
+    /** Mirrors the store's artifact id rule (see its contract docblock). */
+    private function valid_artifact_id(string $artifact_id): bool {
+        if (
+            $artifact_id === ''
+            || $artifact_id[0] === '/'
+            || strpos($artifact_id, "\0") !== false
+            || strpos($artifact_id, '\\') !== false
+        ) {
+            return false;
+        }
+        foreach (explode('/', $artifact_id) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * One manifest entry is either staged (verified at the manifest size),
+     * already applied (a rerun after a kill), or a typed problem.
+     */
+    private function classify(array $entry): string {
+        $status = $this->store->status($entry['artifact_id']);
+        if ($status['verified'] && $status['committed_bytes'] === $entry['size'] && $status['exists']) {
+            return 'staged';
+        }
+
+        $target_path = $this->target_root . '/' . $entry['artifact_id'];
+        $target_size = @filesize($target_path);
+        if ($target_size !== false && $target_size === $entry['size'] && !$status['exists']) {
+            return 'applied';
+        }
+
+        if ($status['verified'] && !$status['exists']) {
+            return 'artifact_file_missing';
+        }
+        if ($status['exists'] && !$status['verified']) {
+            return 'unverified_artifact';
+        }
+        return 'missing_artifact';
+    }
+
+    /**
+     * @return string|null Error detail, or null when the artifact moved.
+     */
+    private function move_into_place(string $artifact_id): ?string {
+        $staged_path = $this->files_dir . '/' . $artifact_id;
+        $target_path = $this->target_root . '/' . $artifact_id;
+
+        $parent = dirname($target_path);
+        if (!is_dir($parent) && !@mkdir($parent, 0755, true) && !is_dir($parent)) {
+            return 'create_target_dir: ' . $artifact_id;
+        }
+        // Same filesystem by precheck, so this replaces atomically; the
+        // tree never holds a partial file.
+        if (!@rename($staged_path, $target_path)) {
+            return 'rename: ' . $artifact_id;
+        }
+        // The marker is consumed with the file. A kill between the two
+        // reruns as "applied" (target at size, nothing staged) and only
+        // costs this unlink again.
+        @unlink($this->staging_dir . '/verified/' . $artifact_id);
+        return null;
+    }
+
+    /**
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
+     */
+    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0): array {
+        return [
+            'status' => $status,
+            'reason' => $reason,
+            'detail' => $detail,
+            'applied' => $applied,
+            'already_applied' => $already_applied,
+        ];
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -92,6 +92,15 @@ final class Site_Export_Staged_Endpoints {
     /** @var int */
     private $timestamp_tolerance;
 
+    /** @var string|null */
+    private $apply_target_root;
+
+    /** @var callable|null */
+    private $apply_device_id;
+
+    /** @var string */
+    private $staging_dir;
+
     /**
      * @param array $options Server-owned configuration:
      *   - staging_dir (string, required): passed to the artifact store.
@@ -132,6 +141,63 @@ final class Site_Export_Staged_Endpoints {
         $this->timestamp_tolerance = is_numeric($tolerance) && (int) $tolerance > 0
             ? (int) $tolerance
             : 300;
+
+        $target_root = $options['apply_target_root'] ?? null;
+        $this->apply_target_root = is_string($target_root) && $target_root !== '' ? $target_root : null;
+        $this->apply_device_id = $options['apply_device_id'] ?? null;
+        $this->staging_dir = $staging_dir;
+    }
+
+    /**
+     * Validate a transfer (check_only) or move it into the target root.
+     *
+     * A sender probes with check_only=1 before uploading anything: an
+     * environment that can never apply — cross-device staging above all —
+     * rejects here, before a byte of transfer has been spent.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function apply(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $manifest_id = $config['manifest_id'] ?? null;
+        if (!is_string($manifest_id) || $manifest_id === '') {
+            return $this->rejected(400, 'invalid_manifest_id');
+        }
+        if ($this->apply_target_root === null) {
+            return $this->rejected(503, 'not_configured', 'apply_target_root');
+        }
+
+        $apply_options = [
+            'staging_dir' => $this->staging_dir,
+            'target_root' => $this->apply_target_root,
+        ];
+        if ($this->apply_device_id !== null) {
+            $apply_options['device_id'] = $this->apply_device_id;
+        }
+        $engine = new Site_Export_Staged_Apply($apply_options);
+
+        $check_only = filter_var($config['check_only'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $result = $engine->apply($manifest_id, $check_only);
+
+        switch ($result['status']) {
+            case 'applied':
+            case 'ready':
+                $code = 200;
+                break;
+            case 'busy':
+                $code = 423;
+                break;
+            default:
+                $code = $result['reason'] === 'io_error' ? 500 : 409;
+        }
+        return [
+            'http_code' => $code,
+            'body' => $result,
+        ];
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1235,6 +1235,9 @@ class ImportClient
      */
     public $exit_code = 0;
 
+    /** Artifact id the push manifest stages under; never applied itself. */
+    private const PUSH_MANIFEST_ID = '.reprint-push-manifest.jsonl';
+
     public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
@@ -3992,6 +3995,55 @@ class ImportClient
             "hmac_client" => $this->hmac_client,
             "sizer" => $sizer,
         ]);
+
+        // Probe the apply environment before any byte is uploaded. Apply is
+        // rename-only, so staging on a different device than the target
+        // root can never land — that must surface now, not after the
+        // transfer. Probe failures that only mean "this target cannot apply
+        // yet" stay fatal only when --apply asked for an apply.
+        $apply = !empty($options["apply"]);
+        $probe = $client->apply(self::PUSH_MANIFEST_ID, true);
+        if ($probe["status"] === "failed") {
+            $environment_verdicts = ["cross_device", "target_missing", "target_unwritable", "staging_unavailable"];
+            if (in_array($probe["reason"], $environment_verdicts, true)) {
+                $this->output_progress([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], true);
+                echo json_encode([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = 1;
+                return;
+            }
+            if ($apply) {
+                $retryable = ["transport_failed", "busy_exhausted"];
+                $this->output_progress([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], true);
+                echo json_encode([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = in_array($probe["reason"], $retryable, true) ? 2 : 1;
+                return;
+            }
+            $this->audit_log(
+                "PUSH APPLY PROBE | {$probe["reason"]} | staging only, apply deferred",
+                false,
+            );
+        }
+
         $runner = new StagedPushRunner([
             "state_dir" => $this->state_dir,
             "client" => $client,
@@ -4037,7 +4089,89 @@ class ImportClient
             $this->exit_code = in_array($result["abort_reason"], $retryable, true) ? 2 : 1;
             return;
         }
-        $this->exit_code = $result["failed"] === [] ? 0 : 1;
+        if ($result["failed"] !== []) {
+            $this->exit_code = 1;
+            return;
+        }
+        if (!$apply) {
+            $this->exit_code = 0;
+            return;
+        }
+        $this->exit_code = $this->run_push_apply($client, $build["plan"]);
+    }
+
+    /**
+     * Stage the manifest for a completed transfer and apply it.
+     *
+     * The manifest lists every planned artifact with its size; the target
+     * validates the whole transfer against it (device match included)
+     * before the first rename, so an incomplete or inconsistent transfer
+     * rejects instead of half-applying.
+     *
+     * @return int Process exit code.
+     */
+    private function run_push_apply(StagedUploadClient $client, array $plan): int
+    {
+        $lines = "";
+        foreach ($plan as $entry) {
+            $lines .= json_encode([
+                "artifact_id" => $entry["artifact_id"],
+                "size" => $entry["total_bytes"],
+            ]) . "\n";
+        }
+        $manifest_path = $this->state_dir . "/.push-manifest.jsonl";
+        if (@file_put_contents($manifest_path, $lines) !== strlen($lines)) {
+            echo json_encode([
+                "type" => "push_apply",
+                "status" => "error",
+                "abort_reason" => "manifest_write_failed",
+                "abort_detail" => $manifest_path,
+            ], JSON_PRETTY_PRINT) . "\n";
+            return 1;
+        }
+
+        // A manifest from an earlier, different plan may sit at this id;
+        // replace it wholesale. Failures surface on the upload right after.
+        $client->discard(self::PUSH_MANIFEST_ID);
+        $uploaded = $client->upload_artifact(self::PUSH_MANIFEST_ID, $manifest_path);
+        if ($uploaded["status"] !== "verified") {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => $uploaded["reason"],
+                "abort_detail" => $uploaded["detail"],
+            ]);
+        }
+
+        $applied = $client->apply(self::PUSH_MANIFEST_ID);
+        if ($applied["status"] !== "applied") {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => $applied["reason"],
+                "abort_detail" => $applied["detail"],
+            ]);
+        }
+
+        return $this->finish_push_apply("complete", [
+            "applied" => $applied["applied"],
+            "already_applied" => $applied["already_applied"],
+        ]);
+    }
+
+    /**
+     * @return int Process exit code.
+     */
+    private function finish_push_apply(string $status, array $fields): int
+    {
+        $summary = array_merge(["type" => "push_apply", "status" => $status], $fields);
+        $this->output_progress($summary, true);
+        echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+        if ($status === "complete") {
+            return 0;
+        }
+        $this->audit_log(
+            "PUSH APPLY FAILED | " . ($fields["abort_reason"] ?? "unknown") . " | " . ($fields["abort_detail"] ?? ""),
+            false,
+        );
+        $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
+        return in_array($fields["abort_reason"] ?? null, $retryable, true) ? 2 : 1;
     }
 
     /**
@@ -12030,6 +12164,14 @@ if (
             'help' => 'Restrict the file pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
                 'repeat for several. Default pulls everything. For push-files, SOURCE is an fs-root-relative prefix',
             'commands' => ['pull-files', 'files-pull', 'push-files'],
+        ],
+        [
+            'name' => 'apply',
+            'type' => 'flag',
+            'target' => 'apply',
+            'help' => 'After staging completes, apply the transfer into the remote tree ' .
+                '(rename-only; the environment is probed before any upload)',
+            'commands' => ['push-files'],
         ],
 
         // ── flat-docroot options ────────────────────────────────

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -406,6 +406,9 @@ class StagedUploadClient
             if ($response["error"] !== null) {
                 return $this->apply_failed("transport_failed", $response["error"]);
             }
+            if ($this->is_auth_envelope($response)) {
+                return $this->apply_failed("auth_failed", $this->envelope_error($response));
+            }
             $json = is_array($response["json"]) ? $response["json"] : [];
             $status = $json["status"] ?? null;
             if ($status === "applied" || $status === "ready") {

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -433,6 +433,25 @@ class StagedUploadClient
     }
 
     /**
+     * The embedding layer (lib.php in the WordPress wiring) answers
+     * control-plane auth failures with its own {error, code} envelope
+     * before any endpoint runs. Surface those as auth_failed — retrying
+     * cannot fix a bad secret — instead of an unexpected response.
+     */
+    private function is_auth_envelope(array $response): bool
+    {
+        return in_array($response["http_code"], [401, 403], true)
+            && is_array($response["json"])
+            && !isset($response["json"]["status"]);
+    }
+
+    private function envelope_error(array $response): string
+    {
+        $error = $response["json"]["error"] ?? null;
+        return is_string($error) ? $error : ("HTTP " . $response["http_code"]);
+    }
+
+    /**
      * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
      */
     private function apply_failed(string $reason, ?string $detail): array
@@ -551,25 +570,6 @@ class StagedUploadClient
     {
         $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $attempt - 1)));
         call_user_func($this->sleeper, (int) $delay);
-    }
-
-    /**
-     * The embedding layer (lib.php in the WordPress wiring) answers
-     * control-plane auth failures with its own {error, code} envelope
-     * before any endpoint runs. Surface those as auth_failed — retrying
-     * cannot fix a bad secret — instead of an unexpected response.
-     */
-    private function is_auth_envelope(array $response): bool
-    {
-        return in_array($response["http_code"], [401, 403], true)
-            && is_array($response["json"])
-            && !isset($response["json"]["status"]);
-    }
-
-    private function envelope_error(array $response): string
-    {
-        $error = $response["json"]["error"] ?? null;
-        return is_string($error) ? $error : ("HTTP " . $response["http_code"]);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -336,6 +336,64 @@ class StagedUploadClient
     }
 
     /**
+     * Ask the target to validate (check_only) or apply a staged transfer.
+     *
+     * check_only is the sender's early gate: an environment that can never
+     * apply — cross-device staging above all — answers "rejected" here,
+     * before any chunk has been uploaded.
+     *
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
+     *   status "applied"|"ready"|"failed".
+     */
+    public function apply(string $manifest_id, bool $check_only = false): array
+    {
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES; $attempt++) {
+            $params = ["manifest_id" => $manifest_id];
+            if ($check_only) {
+                $params["check_only"] = 1;
+            }
+            $response = $this->request_json("POST", "staged_apply", $params);
+            if ($response["error"] !== null) {
+                return $this->apply_failed("transport_failed", $response["error"]);
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            $status = $json["status"] ?? null;
+            if ($status === "applied" || $status === "ready") {
+                return [
+                    "status" => $status,
+                    "reason" => null,
+                    "detail" => null,
+                    "applied" => (int) ($json["applied"] ?? 0),
+                    "already_applied" => (int) ($json["already_applied"] ?? 0),
+                ];
+            }
+            if ($status === "busy") {
+                $this->backoff($attempt);
+                continue;
+            }
+            return $this->apply_failed(
+                is_string($json["reason"] ?? null) ? $json["reason"] : "unexpected_response",
+                $json["detail"] ?? ("HTTP " . $response["http_code"])
+            );
+        }
+        return $this->apply_failed("busy_exhausted", null);
+    }
+
+    /**
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
+     */
+    private function apply_failed(string $reason, ?string $detail): array
+    {
+        return [
+            "status" => "failed",
+            "reason" => $reason,
+            "detail" => $detail,
+            "applied" => 0,
+            "already_applied" => 0,
+        ];
+    }
+
+    /**
      * Confirm the assembled artifact; retried only for "busy".
      *
      * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-upload-endpoints",
+            "version": "dev-push/staged-apply",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
+                "reference": "02cfcadbdd4fa49cdfccb0a2580897781f841db5"
             },
             "require": {
                 "php": ">=7.4",
@@ -384,6 +384,7 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
+                    "src/class-staged-apply.php",
                     "src/class-staged-artifacts.php",
                     "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -198,6 +198,11 @@ function _site_export_staged_options(): array {
         'staging_dir' => $staging_dir,
         'secret' => _site_export_get_shared_secret(),
         'timestamp_tolerance' => SITE_EXPORT_TIMESTAMP_TOLERANCE,
+        // Where staged_apply moves verified artifacts. Apply is rename-only,
+        // so the staging dir must sit on this root's filesystem — apply
+        // rejects "cross_device" otherwise, and senders probe that with
+        // check_only before uploading anything.
+        'apply_target_root' => defined('SITE_EXPORT_APPLY_ROOT') ? SITE_EXPORT_APPLY_ROOT : ABSPATH,
     ];
 }
 

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -120,6 +120,98 @@ class PushFilesCliTest extends TestCase
         );
     }
 
+    /**
+     * The full sender-to-target loop against a real HTTP server: the
+     * plugin's lib.php serving the staged endpoints WP-less (the same
+     * bootstrap the atomic e2e scenarios use), the real CLI pushing with
+     * --apply, files landing in the target root by rename.
+     */
+    public function testFullPushWithApplyLandsFilesInTheTargetRoot(): void
+    {
+        $harness = sys_get_temp_dir() . '/push-cli-harness-' . bin2hex(random_bytes(8));
+        $site_root = $harness . '/site';
+        mkdir($site_root, 0700, true);
+        mkdir($harness . '/abspath', 0700, true);
+
+        $repo = (string) realpath(__DIR__ . '/../..');
+        file_put_contents($harness . '/secret.php', "<?php return 'push-cli-e2e-secret';\n");
+        file_put_contents(
+            $harness . '/router.php',
+            "<?php\n" .
+            "define('ABSPATH', '{$harness}/abspath/');\n" .
+            "define('SITE_EXPORT_PLUGIN_DIR', '{$repo}/reprint-exporter-wp/');\n" .
+            "define('SITE_EXPORT_SECRET_FILE', '{$harness}/secret.php');\n" .
+            "define('SITE_EXPORT_STAGING_DIR', '{$harness}/staging');\n" .
+            "define('SITE_EXPORT_APPLY_ROOT', '{$site_root}');\n" .
+            "if (!function_exists('plugin_dir_path')) {\n" .
+            "    function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }\n" .
+            "}\n" .
+            "require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';\n" .
+            "_site_export_handle_api_request();\n"
+        );
+
+        $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($probe, "cannot allocate a port: {$errstr}");
+        $name = (string) stream_socket_get_name($probe, false);
+        $port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($probe);
+
+        $server = proc_open(
+            [PHP_BINARY, '-S', "127.0.0.1:{$port}", $harness . '/router.php'],
+            [
+                1 => ['file', $harness . '/server.log', 'a'],
+                2 => ['file', $harness . '/server.log', 'a'],
+            ],
+            $pipes
+        );
+        $this->assertIsResource($server);
+
+        try {
+            $deadline = microtime(true) + 10;
+            $ready = false;
+            while (microtime(true) < $deadline) {
+                $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+                if ($conn !== false) {
+                    fclose($conn);
+                    $ready = true;
+                    break;
+                }
+                usleep(100000);
+            }
+            $this->assertTrue($ready, 'php -S did not come up');
+
+            file_put_contents($this->fs_root . '/index.php', '<?php // pushed');
+            mkdir($this->fs_root . '/wp-content/uploads', 0700, true);
+            $big = str_repeat('reprint!', 40000); // 320 KB: several append steps
+            file_put_contents($this->fs_root . '/wp-content/uploads/a.bin', $big);
+
+            $url = "http://127.0.0.1:{$port}/?reprint-api";
+            $args = [
+                'push-files',
+                $url,
+                '--secret=push-cli-e2e-secret',
+                '--state-dir=' . $this->state_dir,
+                '--fs-root=' . $this->fs_root,
+                '--apply',
+            ];
+
+            [$output, $code] = $this->runCli($args);
+            $this->assertSame(0, $code, $output);
+            $this->assertSame('<?php // pushed', file_get_contents($site_root . '/index.php'));
+            $this->assertSame($big, file_get_contents($site_root . '/wp-content/uploads/a.bin'));
+            $this->assertStringContainsString('push_apply', $output);
+
+            // Re-pushing the identical tree is a no-op that still succeeds:
+            // uploads cache-skip, apply classifies everything as applied.
+            [$again_output, $again_code] = $this->runCli($args);
+            $this->assertSame(0, $again_code, $again_output);
+        } finally {
+            proc_terminate($server);
+            proc_close($server);
+            $this->removeDir($harness);
+        }
+    }
+
     public function testHostileOnlyPrefixIsRejectedBeforeAnyUpload(): void
     {
         file_put_contents($this->fs_root . '/a.txt', 'x');

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -340,6 +340,9 @@ class StagedUploadClientTest extends TestCase
         $client = $this->makeClient($envelope);
         $this->writeSource('bytes');
 
+        $probe = $client->apply('.manifest.jsonl', true);
+        $this->assertSame(['failed', 'auth_failed'], [$probe['status'], $probe['reason']]);
+
         $upload = $client->upload_artifact('artifact.bin', $this->source_path);
         $this->assertSame(['failed', 'auth_failed'], [$upload['status'], $upload['reason']]);
 

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -98,6 +98,8 @@ final class StagedApplyTest extends TestCase {
         $this->assertFileDoesNotExist($this->staging_dir . '/files/index.php');
         $this->assertFileDoesNotExist($this->staging_dir . '/verified/index.php');
         $this->assertFileDoesNotExist($this->staging_dir . '/files/.manifest.jsonl');
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/files/wp-content');
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/verified/wp-content');
         $this->assertFalse($this->store()->status('index.php')['verified']);
     }
 

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -235,6 +235,65 @@ final class StagedApplyTest extends TestCase {
     }
 
     // ---------------------------------------------------------------
+    // Type swaps between transfers
+    // ---------------------------------------------------------------
+
+    public function testReplacesADirectoryWithAFile(): void
+    {
+        // The previous site version had a directory here; the new one has
+        // a file. Trunk's writer replaces it, so apply must too.
+        mkdir($this->target_root . '/was-a-dir/nested', 0700, true);
+        file_put_contents($this->target_root . '/was-a-dir/nested/old.txt', 'old');
+        $this->stageVerified('was-a-dir', 'now a file');
+        $manifest = $this->stageManifest([['artifact_id' => 'was-a-dir', 'size' => 10]]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame('now a file', file_get_contents($this->target_root . '/was-a-dir'));
+    }
+
+    public function testReplacesASymlinkWithoutFollowingIt(): void
+    {
+        // A symlinked directory occupies the path; replacing it must swap
+        // the link itself and never reach through into the shared target.
+        $shared = $this->target_root . '-shared';
+        mkdir($shared, 0700, true);
+        file_put_contents($shared . '/keep.txt', 'shared content');
+        symlink($shared, $this->target_root . '/linked');
+        $this->stageVerified('linked', 'plain file now');
+        $manifest = $this->stageManifest([['artifact_id' => 'linked', 'size' => 14]]);
+
+        try {
+            $result = $this->makeApply()->apply($manifest);
+
+            $this->assertSame('applied', $result['status']);
+            $this->assertFalse(is_link($this->target_root . '/linked'));
+            $this->assertSame('plain file now', file_get_contents($this->target_root . '/linked'));
+            $this->assertSame(
+                'shared content',
+                file_get_contents($shared . '/keep.txt'),
+                'the link target must survive untouched'
+            );
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testClearsAFileBlockingTheParentChain(): void
+    {
+        // wp-content used to be a file; the new tree needs it as a dir.
+        file_put_contents($this->target_root . '/wp-content', 'blocking file');
+        $this->stageVerified('wp-content/plugins/p.php', '<?php');
+        $manifest = $this->stageManifest([['artifact_id' => 'wp-content/plugins/p.php', 'size' => 5]]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame('<?php', file_get_contents($this->target_root . '/wp-content/plugins/p.php'));
+    }
+
+    // ---------------------------------------------------------------
     // Kill windows and contention
     // ---------------------------------------------------------------
 

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -1,0 +1,292 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedApplyTest extends TestCase {
+
+    private string $staging_dir;
+
+    private string $target_root;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/staged-apply-staging-' . $suffix;
+        $this->target_root = sys_get_temp_dir() . '/staged-apply-target-' . $suffix;
+        mkdir($this->target_root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->staging_dir);
+        $this->removeDir($this->target_root);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeApply(array $overrides = []): Site_Export_Staged_Apply
+    {
+        return new Site_Export_Staged_Apply(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'target_root' => $this->target_root,
+        ], $overrides));
+    }
+
+    private function store(): Site_Export_Staged_Artifacts
+    {
+        return new Site_Export_Staged_Artifacts($this->staging_dir);
+    }
+
+    private function stageVerified(string $artifact_id, string $body): void
+    {
+        $store = $this->store();
+        if ($body !== '') {
+            $result = $store->append($artifact_id, 0, $body);
+            assert($result['status'] === 'accepted');
+        }
+        $finalized = $store->finalize($artifact_id, strlen($body));
+        assert($finalized['status'] === 'verified');
+    }
+
+    /**
+     * Stages a manifest listing the given artifacts, returning its id.
+     */
+    private function stageManifest(array $entries, string $manifest_id = '.manifest.jsonl'): string
+    {
+        $lines = '';
+        foreach ($entries as $entry) {
+            $lines .= json_encode($entry) . "\n";
+        }
+        $this->stageVerified($manifest_id, $lines);
+        return $manifest_id;
+    }
+
+    // ---------------------------------------------------------------
+    // The happy window
+    // ---------------------------------------------------------------
+
+    public function testAppliesAVerifiedTransferIntoTheTargetRoot(): void
+    {
+        $this->stageVerified('index.php', '<?php new');
+        $this->stageVerified('wp-content/themes/t/style.css', 'body{}');
+        $this->stageVerified('empty.txt', '');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'index.php', 'size' => 9],
+            ['artifact_id' => 'wp-content/themes/t/style.css', 'size' => 6],
+            ['artifact_id' => 'empty.txt', 'size' => 0],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(3, $result['applied']);
+        $this->assertSame(0, $result['already_applied']);
+        $this->assertSame('<?php new', file_get_contents($this->target_root . '/index.php'));
+        $this->assertSame('body{}', file_get_contents($this->target_root . '/wp-content/themes/t/style.css'));
+        $this->assertSame('', file_get_contents($this->target_root . '/empty.txt'));
+
+        // The transfer is consumed: files, markers, and the manifest.
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/index.php');
+        $this->assertFileDoesNotExist($this->staging_dir . '/verified/index.php');
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/.manifest.jsonl');
+        $this->assertFalse($this->store()->status('index.php')['verified']);
+    }
+
+    public function testReplacesExistingTargetFilesAtomically(): void
+    {
+        mkdir($this->target_root . '/wp-content', 0700, true);
+        file_put_contents($this->target_root . '/wp-content/old.php', 'old content');
+        $this->stageVerified('wp-content/old.php', 'new!');
+        $manifest = $this->stageManifest([['artifact_id' => 'wp-content/old.php', 'size' => 4]]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame('new!', file_get_contents($this->target_root . '/wp-content/old.php'));
+    }
+
+    public function testApplyClearsACursorNamingAConsumedArtifact(): void
+    {
+        $this->stageVerified('artifact.bin', 'payload');
+        // Simulate finalize killed before its best-effort cursor clear.
+        file_put_contents(
+            $this->staging_dir . '/state.json',
+            json_encode(['artifact_id' => 'artifact.bin', 'committed_bytes' => 7])
+        );
+        $manifest = $this->stageManifest([['artifact_id' => 'artifact.bin', 'size' => 7]]);
+
+        $this->assertSame('applied', $this->makeApply()->apply($manifest)['status']);
+
+        $state = json_decode( (string) file_get_contents($this->staging_dir . '/state.json'), true);
+        $this->assertNull($state['artifact_id'], 'a stale cursor must not answer a future upload');
+    }
+
+    // ---------------------------------------------------------------
+    // Same-device requirement
+    // ---------------------------------------------------------------
+
+    public function testCrossDeviceStagingIsRejectedBeforeAnythingMoves(): void
+    {
+        $this->stageVerified('index.php', 'payload');
+        $manifest = $this->stageManifest([['artifact_id' => 'index.php', 'size' => 7]]);
+        $apply = $this->makeApply([
+            // Staging and target report different stat devices.
+            'device_id' => function (string $path): ?int {
+                return strpos($path, 'staged-apply-staging') !== false ? 11 : 22;
+            },
+        ]);
+
+        $result = $apply->apply($manifest);
+
+        $this->assertSame(['rejected', 'cross_device'], [$result['status'], $result['reason']]);
+        $this->assertStringContainsString('device', (string) $result['detail']);
+        $this->assertFileDoesNotExist($this->target_root . '/index.php');
+        $this->assertFileExists($this->staging_dir . '/files/index.php', 'nothing may move');
+
+        // The probe form rejects identically, before any upload happens.
+        $probe = $apply->apply('never-staged-manifest', true);
+        $this->assertSame(['rejected', 'cross_device'], [$probe['status'], $probe['reason']]);
+    }
+
+    public function testCheckOnlyReportsReadyBeforeTheTransferExists(): void
+    {
+        $result = $this->makeApply()->apply('not-yet-staged-manifest', true);
+
+        $this->assertSame('ready', $result['status']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/files');
+    }
+
+    public function testCheckOnlyValidatesAFullTransferWithoutMoving(): void
+    {
+        $this->stageVerified('a.txt', 'aaa');
+        $manifest = $this->stageManifest([['artifact_id' => 'a.txt', 'size' => 3]]);
+
+        $result = $this->makeApply()->apply($manifest, true);
+
+        $this->assertSame('ready', $result['status']);
+        $this->assertFileDoesNotExist($this->target_root . '/a.txt');
+        $this->assertFileExists($this->staging_dir . '/files/a.txt');
+    }
+
+    // ---------------------------------------------------------------
+    // Whole-transfer validation before the first rename
+    // ---------------------------------------------------------------
+
+    public function testUnverifiedArtifactRejectsTheWholeTransfer(): void
+    {
+        $this->stageVerified('good-1.txt', 'aaa');
+        $this->store()->append('half-done.txt', 0, 'bb');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'good-1.txt', 'size' => 3],
+            ['artifact_id' => 'half-done.txt', 'size' => 2],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame(['rejected', 'unverified_artifact'], [$result['status'], $result['reason']]);
+        $this->assertSame('half-done.txt', $result['detail']);
+        $this->assertFileDoesNotExist(
+            $this->target_root . '/good-1.txt',
+            'no partial apply of a half-verified transfer'
+        );
+    }
+
+    public function testMissingArtifactRejectsTheWholeTransfer(): void
+    {
+        $this->stageVerified('present.txt', 'here');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'present.txt', 'size' => 4],
+            ['artifact_id' => 'never-uploaded.txt', 'size' => 9],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame(['rejected', 'missing_artifact'], [$result['status'], $result['reason']]);
+        $this->assertFileDoesNotExist($this->target_root . '/present.txt');
+    }
+
+    public function testManifestProblemsAreTypedRejections(): void
+    {
+        $apply = $this->makeApply();
+
+        $this->stageVerified('torn.jsonl', '{"artifact_id":"x","si');
+        $torn = $apply->apply('torn.jsonl');
+        $this->assertSame(['rejected', 'manifest_invalid'], [$torn['status'], $torn['reason']]);
+
+        $this->stageVerified('selfish.jsonl', json_encode(['artifact_id' => 'selfish.jsonl', 'size' => 1]) . "\n");
+        $selfish = $apply->apply('selfish.jsonl');
+        $this->assertSame('manifest lists itself', $selfish['detail']);
+
+        $this->stageVerified('hostile.jsonl', json_encode(['artifact_id' => '../escape', 'size' => 1]) . "\n");
+        $hostile = $apply->apply('hostile.jsonl');
+        $this->assertStringContainsString('invalid artifact id', (string) $hostile['detail']);
+
+        $unverified = $apply->apply('never-staged.jsonl');
+        $this->assertSame(['rejected', 'manifest_invalid'], [$unverified['status'], $unverified['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Kill windows and contention
+    // ---------------------------------------------------------------
+
+    public function testRerunAfterAKillMidApplyFinishesTheWindow(): void
+    {
+        $this->stageVerified('moved-before-kill.txt', 'first');
+        $this->stageVerified('still-staged.txt', 'second');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'moved-before-kill.txt', 'size' => 5],
+            ['artifact_id' => 'still-staged.txt', 'size' => 6],
+        ]);
+
+        // The kill hit between the first rename and its marker unlink.
+        rename(
+            $this->staging_dir . '/files/moved-before-kill.txt',
+            $this->target_root . '/moved-before-kill.txt'
+        );
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1, $result['applied']);
+        $this->assertSame(1, $result['already_applied']);
+        $this->assertSame('first', file_get_contents($this->target_root . '/moved-before-kill.txt'));
+        $this->assertSame('second', file_get_contents($this->target_root . '/still-staged.txt'));
+        $this->assertFileDoesNotExist(
+            $this->staging_dir . '/verified/moved-before-kill.txt',
+            'the leftover marker is consumed by the rerun'
+        );
+    }
+
+    public function testBusyWhileAWriterHoldsTheStore(): void
+    {
+        $this->stageVerified('a.txt', 'aaa');
+        $manifest = $this->stageManifest([['artifact_id' => 'a.txt', 'size' => 3]]);
+
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $result = $this->makeApply()->apply($manifest);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertSame('busy', $result['status']);
+        $this->assertFileDoesNotExist($this->target_root . '/a.txt');
+    }
+
+    public function testMissingTargetRootIsRejected(): void
+    {
+        $apply = $this->makeApply(['target_root' => $this->target_root . '/never-created']);
+
+        $result = $apply->apply('whatever', true);
+
+        $this->assertSame(['rejected', 'target_missing'], [$result['status'], $result['reason']]);
+    }
+}

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -394,6 +394,83 @@ final class StagedEndpointsTest extends TestCase {
     }
 
     // ---------------------------------------------------------------
+    // Apply route
+    // ---------------------------------------------------------------
+
+    public function testApplyRouteProbesThenMovesAVerifiedTransfer(): void
+    {
+        $target_root = $this->staging_dir . '-target';
+        mkdir($target_root, 0700, true);
+        try {
+            $endpoints = $this->makeEndpoints(['apply_target_root' => $target_root]);
+            $this->upload($endpoints, 'wp-content/a.txt', 0, 'applied!');
+            $this->finalize($endpoints, 'wp-content/a.txt', 8);
+            $manifest = json_encode(['artifact_id' => 'wp-content/a.txt', 'size' => 8]) . "\n";
+            $this->upload($endpoints, 'm.jsonl', 0, $manifest);
+            $this->finalize($endpoints, 'm.jsonl', strlen($manifest));
+
+            $probe = $endpoints->apply(
+                ['manifest_id' => 'm.jsonl', 'check_only' => '1'],
+                ['REQUEST_METHOD' => 'POST']
+            );
+            $this->assertSame([200, 'ready'], [$probe['http_code'], $probe['body']['status']]);
+            $this->assertFileDoesNotExist($target_root . '/wp-content/a.txt');
+
+            $result = $endpoints->apply(['manifest_id' => 'm.jsonl'], ['REQUEST_METHOD' => 'POST']);
+            $this->assertSame(
+                [200, 'applied', 1],
+                [$result['http_code'], $result['body']['status'], $result['body']['applied']]
+            );
+            $this->assertSame('applied!', file_get_contents($target_root . '/wp-content/a.txt'));
+        } finally {
+            $this->removeDir($target_root);
+        }
+    }
+
+    public function testApplyRouteReportsCrossDeviceOnTheProbe(): void
+    {
+        $target_root = $this->staging_dir . '-target';
+        mkdir($target_root, 0700, true);
+        try {
+            $endpoints = $this->makeEndpoints([
+                'apply_target_root' => $target_root,
+                'apply_device_id' => function (string $path): ?int {
+                    return strpos($path, '-target') !== false ? 22 : 11;
+                },
+            ]);
+
+            // No transfer exists yet — the environment verdict alone must
+            // reject, so a sender learns before uploading anything.
+            $probe = $endpoints->apply(
+                ['manifest_id' => 'not-yet-staged', 'check_only' => '1'],
+                ['REQUEST_METHOD' => 'POST']
+            );
+
+            $this->assertSame(409, $probe['http_code']);
+            $this->assertSame('cross_device', $probe['body']['reason']);
+        } finally {
+            $this->removeDir($target_root);
+        }
+    }
+
+    public function testApplyRouteValidatesConfigurationAndMethod(): void
+    {
+        $unconfigured = $this->makeEndpoints();
+        $missing_root = $unconfigured->apply(['manifest_id' => 'm'], ['REQUEST_METHOD' => 'POST']);
+        $this->assertSame(
+            [503, 'not_configured', 'apply_target_root'],
+            [$missing_root['http_code'], $missing_root['body']['reason'], $missing_root['body']['detail']]
+        );
+
+        $configured = $this->makeEndpoints(['apply_target_root' => sys_get_temp_dir()]);
+        $get = $configured->apply(['manifest_id' => 'm'], ['REQUEST_METHOD' => 'GET']);
+        $this->assertSame(405, $get['http_code']);
+
+        $no_manifest = $configured->apply([], ['REQUEST_METHOD' => 'POST']);
+        $this->assertSame([400, 'invalid_manifest_id'], [$no_manifest['http_code'], $no_manifest['body']['reason']]);
+    }
+
+    // ---------------------------------------------------------------
     // Request validation and server-owned options
     // ---------------------------------------------------------------
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,5 +34,9 @@ if (!class_exists('Site_Export_Staged_Endpoints', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-endpoints.php';
 }
 
+if (!class_exists('Site_Export_Staged_Apply', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,7 @@
             <file>FileIndexDedupTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>StagedApplyTest.php</file>
             <file>StagedArtifactsTest.php</file>
             <file>StagedEndpointsTest.php</file>
         </testsuite>


### PR DESCRIPTION
## What it does

Adds `Site_Export_Staged_Apply` and the `staged_apply` route: the payoff of the staged store — verified artifacts move into the live tree by rename, in one short window. The sender side grows `StagedUploadClient::apply()` and a `push-files --apply` flag, so this PR completes the loop:

```bash
reprint push-files https://example.com/?reprint-api \
  --secret=TOKEN --state-dir=./push-state --fs-root=./site --apply
```

Part of #276, stacked on #303.

## Rationale

**Apply is rename-only, and cross-device staging is refused up front.** `rename()` is what makes each file's appearance atomic; it only works when staging and the target root share a filesystem. Copy-and-remove would open exactly the window staging exists to close — a half-copied file served live — so apply never degrades to it: a `stat()` device comparison runs before anything else and rejects `cross_device` with both devices named in the detail. The rejection comes at the earliest possible moment on both sides:

- the engine checks the environment **before the first rename**;
- the sender probes `staged_apply` with `check_only=1` **before uploading a single byte**, so a staging directory that can never apply costs nothing. `push-files` always probes; definitive environment verdicts (`cross_device`, `target_missing`, `target_unwritable`, `staging_unavailable`) are fatal even for staging-only runs — staging that can never land is a mistake worth stopping — while "this target has no apply configured yet" only stops runs that asked for `--apply`.

The fix for `cross_device` is operator config: `SITE_EXPORT_STAGING_DIR` on the target root's filesystem (the WP wiring documents this next to the temp-dir default).

**The manifest is itself a staged artifact** — one JSONL line per artifact, `{"artifact_id", "size"}`. The apply request stays bounded (an id, not a 50k-entry body), the store's verification covers the manifest bytes, and apply consumes it without ever applying it into the tree. Manifest content is sender data, so ids are re-validated against the store's path rule — a crafted manifest cannot probe or write outside the target root.

**Whole-transfer validation precedes the first rename.** Every listed artifact must be verified at its manifest size (or already applied, see below); one unverified or missing artifact rejects the whole run. There is no partial apply of a half-verified transfer.

**A kill mid-apply recovers without a journal cursor.** Rerunning classifies each entry: staged-and-verified → rename; staged gone but target at the manifest size → already applied, skip (and consume the leftover marker). The rerun passes validation and finishes the window. Apply holds the store's flock throughout, so upload retries racing it get `busy`; cleanup unlinks the store's files directly because the store's own `discard()` would contend on the very lock apply holds. A cursor still naming a consumed artifact is cleared, so it can never answer a future upload with a stale offset.

## Implementation

- `class-staged-apply.php` — engine; `device_id` is injectable for tests.
- `class-staged-endpoints.php` — `apply()` route (`manifest_id`, `check_only`), 200 `applied`/`ready`, 409 environment/transfer verdicts, 423 busy, 503 without a configured `apply_target_root`.
- `lib.php` — `apply_target_root` defaults to `ABSPATH`, `SITE_EXPORT_APPLY_ROOT` overrides.
- `StagedUploadClient::apply()` + `run_push_apply()` in `import.php`: manifest written from the plan, staged (replacing any stale one), applied; exit codes follow the resume convention.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit StagedApplyTest.php StagedEndpointsTest.php Import/PushFilesCliTest.php
composer analyze
```

12 engine tests (full transfer applied and consumed, atomic replacement of existing files, cursor cleanup, cross-device rejected before anything moves — probe and apply forms, check_only without side effects, unverified/missing artifacts rejecting the whole transfer, manifest validation incl. hostile ids, kill-mid-apply rerun, busy, missing target root), 3 endpoint route tests, and a full local end-to-end CLI test: `php -S` serving the plugin's `lib.php` WP-less (the same bootstrap the atomic E2E scenarios use), the real `push-files --apply` subprocess pushing a multi-chunk tree, files landing in the target root by rename, and an idempotent re-push succeeding. 117 tests across the push stack pass.


**Review round:** apply now handles type swaps between transfers the way trunk's writer does — a directory or symlink occupying a file's path is replaced (never following links, mirroring `remove_local_path_without_following_symlinks`), and a file blocking the parent chain is cleared. Three new engine tests.
