### PR TITLE
Teach staged apply the preserve-local policies

### DIFF
--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -49,6 +49,9 @@
  */
 final class Site_Export_Staged_Apply {
 
+    /** Protected paths reported by name; beyond this, only the count. */
+    private const SKIPPED_PATHS_LIMIT = 1000;
+
     /** @var string */
     private $staging_dir;
 
@@ -158,6 +161,7 @@ final class Site_Export_Staged_Apply {
             // over a path the policy was never going to touch.
             $already_applied = [];
             $protected = [];
+            $skipped_paths = [];
             foreach ($entries as $index => $entry) {
                 $verdict = $this->classify($entry);
                 if ($verdict === 'staged') {
@@ -169,13 +173,19 @@ final class Site_Export_Staged_Apply {
                 }
                 if ($verdict === 'protected') {
                     $protected[$index] = true;
+                    // Callers audit-log each protected path (the
+                    // PRESERVE-LOCAL contract); capped so a 50k-skip
+                    // transfer stays a bounded response.
+                    if (count($skipped_paths) < self::SKIPPED_PATHS_LIMIT) {
+                        $skipped_paths[] = $entry['artifact_id'];
+                    }
                     continue;
                 }
                 return $this->result('rejected', $verdict, $entry['artifact_id']);
             }
 
             if ($check_only) {
-                return $this->result('ready', null, null, 0, count($already_applied), count($protected));
+                return $this->result('ready', null, null, 0, count($already_applied), count($protected), $skipped_paths);
             }
 
             // Apply holds the store's lock, so cleanup below unlinks the
@@ -202,7 +212,7 @@ final class Site_Export_Staged_Apply {
                     // Everything validated, so this is environmental
                     // (permissions, disk). Rerunning apply resumes: moved
                     // entries classify as applied, the rest re-validate.
-                    return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied), count($protected));
+                    return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied), count($protected), $skipped_paths);
                 }
                 ++$applied;
             }
@@ -214,7 +224,7 @@ final class Site_Export_Staged_Apply {
             @unlink($this->staging_dir . '/verified/' . $manifest_id);
             $this->clear_cursor_for($entries, $manifest_id);
 
-            return $this->result('applied', null, null, $applied, count($already_applied), count($protected));
+            return $this->result('applied', null, null, $applied, count($already_applied), count($protected), $skipped_paths);
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -513,7 +523,7 @@ final class Site_Export_Staged_Apply {
         return false;
     }
 
-    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0, int $skipped = 0): array {
+    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0, int $skipped = 0, array $skipped_paths = []): array {
         return [
             'status' => $status,
             'reason' => $reason,
@@ -521,6 +531,7 @@ final class Site_Export_Staged_Apply {
             'applied' => $applied,
             'already_applied' => $already_applied,
             'skipped' => $skipped,
+            'skipped_paths' => $skipped_paths,
         ];
     }
 }

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -125,7 +125,7 @@ final class Site_Export_Staged_Apply {
      *   what a sender calls before uploading gigabytes: a staging
      *   directory that can never apply (cross_device) rejects here, at
      *   the start, not after the transfer.
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int}
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,skipped_paths:array<int,string>}
      *   status "applied"|"ready"|"busy"|"rejected"; skipped counts entries
      *   the on_existing/symlink policies protected.
      */

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -38,6 +38,14 @@
  * upload retry racing the apply gets "busy" instead of writing into a
  * tree being consumed. The lock file is the same one the store's mutators
  * use; a killed apply releases it with the process.
+ *
+ * Policies cover the pull side of the same engine. on_existing "skip"
+ * (pull's preserve-local) makes an occupied target path win: the entry is
+ * not applied and its staged bytes are consumed. refuse_symlinked_parents
+ * refuses to create anything through a symlinked directory. Protected
+ * entries are classified before validation, so a rerun with nothing
+ * staged does not reject a transfer over paths the policy was never going
+ * to touch.
  */
 final class Site_Export_Staged_Apply {
 
@@ -59,12 +67,26 @@ final class Site_Export_Staged_Apply {
     /** @var callable */
     private $device_id;
 
+    /** @var string */
+    private $on_existing;
+
+    /** @var bool */
+    private $refuse_symlinked_parents;
+
     /**
      * @param array $options
      *   - staging_dir (string, required): same directory the store uses.
      *   - target_root (string, required): tree the artifacts apply into.
      *   - device_id (?callable): fn(string $path): ?int — stat device
      *     lookup, injectable for tests; null means the path is unreadable.
+     *   - on_existing ("replace"|"skip"): what an occupied target path
+     *     means. "replace" is push's own-tree semantics; "skip" is pull's
+     *     preserve-local — the local path wins and the staged bytes are
+     *     consumed unapplied.
+     *   - refuse_symlinked_parents (bool): never create anything through a
+     *     symlinked directory. Hosting layouts symlink plugins, themes,
+     *     and core from shared locations; apply must not write into those
+     *     through the link.
      */
     public function __construct(array $options) {
         $staging_dir = $options['staging_dir'] ?? null;
@@ -75,11 +97,17 @@ final class Site_Export_Staged_Apply {
         if (!is_string($target_root) || $target_root === '') {
             throw new InvalidArgumentException('Staged apply requires a target_root option.');
         }
+        $on_existing = $options['on_existing'] ?? 'replace';
+        if (!in_array($on_existing, ['replace', 'skip'], true)) {
+            throw new InvalidArgumentException('Staged apply on_existing must be "replace" or "skip".');
+        }
         $this->staging_dir = rtrim($staging_dir, '/');
         $this->files_dir = $this->staging_dir . '/files';
         $this->lock_path = $this->staging_dir . '/lock';
         $this->target_root = rtrim($target_root, '/');
         $this->store = new Site_Export_Staged_Artifacts($staging_dir);
+        $this->on_existing = $on_existing;
+        $this->refuse_symlinked_parents = !empty($options['refuse_symlinked_parents']);
         $this->device_id = $options['device_id'] ?? static function (string $path): ?int {
             $stat = @stat($path);
             return $stat === false ? null : (int) $stat['dev'];
@@ -94,8 +122,9 @@ final class Site_Export_Staged_Apply {
      *   what a sender calls before uploading gigabytes: a staging
      *   directory that can never apply (cross_device) rejects here, at
      *   the start, not after the transfer.
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
-     *   status "applied"|"ready"|"busy"|"rejected".
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int}
+     *   status "applied"|"ready"|"busy"|"rejected"; skipped counts entries
+     *   the on_existing/symlink policies protected.
      */
     public function apply(string $manifest_id, bool $check_only = false): array {
         $precheck = $this->check_environment();
@@ -124,7 +153,11 @@ final class Site_Export_Staged_Apply {
             }
 
             // Nothing moves until the whole transfer proves consistent.
+            // Protected entries are decided here too, before validation:
+            // a rerun with nothing staged must not reject the transfer
+            // over a path the policy was never going to touch.
             $already_applied = [];
+            $protected = [];
             foreach ($entries as $index => $entry) {
                 $verdict = $this->classify($entry);
                 if ($verdict === 'staged') {
@@ -134,11 +167,15 @@ final class Site_Export_Staged_Apply {
                     $already_applied[$index] = true;
                     continue;
                 }
+                if ($verdict === 'protected') {
+                    $protected[$index] = true;
+                    continue;
+                }
                 return $this->result('rejected', $verdict, $entry['artifact_id']);
             }
 
             if ($check_only) {
-                return $this->result('ready', null, null, 0, count($already_applied));
+                return $this->result('ready', null, null, 0, count($already_applied), count($protected));
             }
 
             // Apply holds the store's lock, so cleanup below unlinks the
@@ -146,6 +183,14 @@ final class Site_Export_Staged_Apply {
             // the very lock this process holds.
             $applied = 0;
             foreach ($entries as $index => $entry) {
+                if (isset($protected[$index])) {
+                    // The local path wins; consume the staged bytes so they
+                    // cannot be applied by a later, differently-configured
+                    // run.
+                    @unlink($this->files_dir . '/' . $entry['artifact_id']);
+                    @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                    continue;
+                }
                 if (isset($already_applied[$index])) {
                     // A rerun after a kill: the file is in place; only its
                     // leftover marker remains to consume.
@@ -157,7 +202,7 @@ final class Site_Export_Staged_Apply {
                     // Everything validated, so this is environmental
                     // (permissions, disk). Rerunning apply resumes: moved
                     // entries classify as applied, the rest re-validate.
-                    return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied));
+                    return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied), count($protected));
                 }
                 ++$applied;
             }
@@ -169,7 +214,7 @@ final class Site_Export_Staged_Apply {
             @unlink($this->staging_dir . '/verified/' . $manifest_id);
             $this->clear_cursor_for($entries, $manifest_id);
 
-            return $this->result('applied', null, null, $applied, count($already_applied));
+            return $this->result('applied', null, null, $applied, count($already_applied), count($protected));
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -319,6 +364,20 @@ final class Site_Export_Staged_Apply {
      * already applied (a rerun after a kill), or a typed problem.
      */
     private function classify(array $entry): string {
+        // Policy verdicts come first: a protected path is out of bounds no
+        // matter what is or is not staged for it.
+        if ($this->refuse_symlinked_parents && $this->has_symlinked_parent($entry['artifact_id'])) {
+            return 'protected';
+        }
+        if ($this->on_existing === 'skip') {
+            $occupied = $this->target_root . '/' . $entry['artifact_id'];
+            // is_link covers dangling symlinks, which file_exists misses;
+            // preserve-local protects those too.
+            if (file_exists($occupied) || is_link($occupied)) {
+                return 'protected';
+            }
+        }
+
         $status = $this->store->status($entry['artifact_id']);
         if ($status['verified'] && $status['committed_bytes'] === $entry['size'] && $status['exists']) {
             return 'staged';
@@ -365,13 +424,34 @@ final class Site_Export_Staged_Apply {
     /**
      * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
      */
-    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0): array {
+    /**
+     * Whether any directory component of the artifact's target path is a
+     * symlink. Only the relative components are checked — the target root
+     * itself may legitimately be reached through links.
+     */
+    private function has_symlinked_parent(string $artifact_id): bool {
+        $parent = dirname($artifact_id);
+        if ($parent === '.') {
+            return false;
+        }
+        $path = $this->target_root;
+        foreach (explode('/', $parent) as $segment) {
+            $path .= '/' . $segment;
+            if (is_link($path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0, int $skipped = 0): array {
         return [
             'status' => $status,
             'reason' => $reason,
             'detail' => $detail,
             'applied' => $applied,
             'already_applied' => $already_applied,
+            'skipped' => $skipped,
         ];
     }
 }

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -254,6 +254,7 @@ final class StagedApplyTest extends TestCase {
         $this->assertSame('applied', $result['status']);
         $this->assertSame(1, $result['applied']);
         $this->assertSame(1, $result['skipped']);
+        $this->assertSame(['index.php'], $result['skipped_paths'], 'callers audit-log the protected paths');
         $this->assertSame('local wins', file_get_contents($this->target_root . '/index.php'));
         $this->assertSame('lands', file_get_contents($this->target_root . '/fresh.txt'));
         $this->assertFileDoesNotExist(

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -235,6 +235,127 @@ final class StagedApplyTest extends TestCase {
     }
 
     // ---------------------------------------------------------------
+    // Preserve-local policies
+    // ---------------------------------------------------------------
+
+    public function testSkipPolicyLetsAnOccupiedTargetPathWin(): void
+    {
+        file_put_contents($this->target_root . '/index.php', 'local wins');
+        $this->stageVerified('index.php', 'remote bytes');
+        $this->stageVerified('fresh.txt', 'lands');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'index.php', 'size' => 12],
+            ['artifact_id' => 'fresh.txt', 'size' => 5],
+        ]);
+        $apply = $this->makeApply(['on_existing' => 'skip']);
+
+        $result = $apply->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1, $result['applied']);
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame('local wins', file_get_contents($this->target_root . '/index.php'));
+        $this->assertSame('lands', file_get_contents($this->target_root . '/fresh.txt'));
+        $this->assertFileDoesNotExist(
+            $this->staging_dir . '/files/index.php',
+            'protected entries consume their staged bytes'
+        );
+        $this->assertFileDoesNotExist($this->staging_dir . '/verified/index.php');
+    }
+
+    public function testSkipPolicyProtectsDanglingSymlinksAtTheTarget(): void
+    {
+        symlink($this->target_root . '/never-created', $this->target_root . '/link.php');
+        $this->stageVerified('link.php', 'remote');
+        $manifest = $this->stageManifest([['artifact_id' => 'link.php', 'size' => 6]]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
+
+        $this->assertSame(['applied', 1], [$result['status'], $result['skipped']]);
+        $this->assertTrue(is_link($this->target_root . '/link.php'), 'the symlink survives');
+    }
+
+    public function testSymlinkedParentGuardNeverWritesThroughTheLink(): void
+    {
+        // A hosting layout: wp-content/plugins is a symlink to a shared dir.
+        mkdir($this->target_root . '/wp-content', 0700, true);
+        $shared = $this->target_root . '-shared-plugins';
+        mkdir($shared, 0700, true);
+        symlink($shared, $this->target_root . '/wp-content/plugins');
+
+        $this->stageVerified('wp-content/plugins/p/p.php', 'through the link');
+        $this->stageVerified('wp-content/regular.txt', 'fine');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'wp-content/plugins/p/p.php', 'size' => 16],
+            ['artifact_id' => 'wp-content/regular.txt', 'size' => 4],
+        ]);
+
+        try {
+            $result = $this->makeApply(['refuse_symlinked_parents' => true])->apply($manifest);
+
+            $this->assertSame('applied', $result['status']);
+            $this->assertSame(1, $result['applied']);
+            $this->assertSame(1, $result['skipped']);
+            $this->assertSame([], glob($shared . '/*'), 'nothing may appear behind the link');
+            $this->assertSame('fine', file_get_contents($this->target_root . '/wp-content/regular.txt'));
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testSkipPolicyRerunWithNothingStagedStillApplies(): void
+    {
+        file_put_contents($this->target_root . '/protected.php', 'kept');
+        $this->stageVerified('protected.php', 'remote-1');
+        $this->stageVerified('normal.txt', 'moved');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'protected.php', 'size' => 8],
+            ['artifact_id' => 'normal.txt', 'size' => 5],
+        ]);
+        $apply = $this->makeApply(['on_existing' => 'skip']);
+        $this->assertSame('applied', $apply->apply($manifest)['status']);
+
+        // The next transfer lists the protected path again. Nothing is
+        // staged for it and its local size differs from the manifest —
+        // without the policy-first classification this would reject the
+        // whole run as missing_artifact.
+        $this->stageVerified('normal.txt', 'move2');
+        $again = $this->stageManifest([
+            ['artifact_id' => 'protected.php', 'size' => 8],
+            ['artifact_id' => 'normal.txt', 'size' => 5],
+        ], '.manifest-2.jsonl');
+
+        $result = $apply->apply($again);
+
+        // Preserve-local means never overwrite — including files an earlier
+        // run applied. The rerun protects both and consumes the fresh bytes.
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(2, $result['skipped']);
+        $this->assertSame('kept', file_get_contents($this->target_root . '/protected.php'));
+        $this->assertSame('moved', file_get_contents($this->target_root . '/normal.txt'));
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/normal.txt');
+    }
+
+    public function testCheckOnlyReportsProtectedEntriesWithoutConsuming(): void
+    {
+        file_put_contents($this->target_root . '/here.php', 'local');
+        $this->stageVerified('here.php', 'remote');
+        $manifest = $this->stageManifest([['artifact_id' => 'here.php', 'size' => 6]]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest, true);
+
+        $this->assertSame(['ready', 1], [$result['status'], $result['skipped']]);
+        $this->assertFileExists($this->staging_dir . '/files/here.php', 'check_only must not consume');
+    }
+
+    public function testInvalidOnExistingPolicyIsRejectedAtConstruction(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->makeApply(['on_existing' => 'merge']);
+    }
+
+    // ---------------------------------------------------------------
     // Kill windows and contention
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## What it does

Extends `Site_Export_Staged_Apply` with the two policies pull's preserve-local mode needs, so the same engine can serve both directions of a transfer:

- `on_existing: "skip"` — an occupied target path wins: the entry is not applied and its staged bytes are consumed. `"replace"` (the default) keeps push's own-tree semantics unchanged.
- `refuse_symlinked_parents` — never create anything through a symlinked directory. Hosting layouts symlink plugins, themes, and core from shared locations; apply must not write into those through the link.

Groundwork for staged pull (next PR in this stack); part of #276.

## Rationale

**Policy verdicts are classified before validation, not during the move.** A protected path is out of bounds no matter what is or is not staged for it — and that ordering is what makes reruns work: a second transfer that lists a protected path (nothing staged for it, local size disagreeing with the manifest) must skip it, not reject the whole run as `missing_artifact`.

**Protected entries consume their staged bytes.** The local path won; leaving the bytes staged would let a later, differently-configured run apply them. Consuming follows the same direct-unlink discipline as the rest of apply (the engine holds the store's lock).

**Never overwrite means never** — including files an earlier run applied. That is preserve-local's documented write-time semantic today ("if anything already exists at a remote file's path, the remote file is skipped"), carried to apply time unchanged. `is_link` sits beside `file_exists` in the occupied check because dangling symlinks are protected too, and `file_exists` can't see them.

`check_only` reports the would-be `skipped` count without consuming anything, and the result shape gains an additive `skipped` field (existing consumers unaffected).

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit StagedApplyTest.php
composer analyze
```

Six new tests: occupied path wins and staged bytes are consumed, dangling symlink at the target protected, symlinked-parent guard keeps the shared directory empty while siblings apply, rerun with nothing staged applies instead of rejecting (and re-protects earlier applies), `check_only` reports without consuming, invalid policy value throws. 18 apply tests total; push-side suites unchanged and green.


**Review round:** the result now reports `skipped_paths` (capped at 1000) so callers can honor the documented PRESERVE-LOCAL audit contract per path, not just a count.
