### PR TITLE
Pull files through the staged store and apply in one window

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ The command returns one of three exit codes:
 
 Which is to say, you'll need to wrap it in a loop that runs until failure or full completion.
 
+Add `--staged-apply` when pulled files should download into a staging area
+under `--state-dir` and then move into `--fs-root` in one rename window at the
+end:
+
+```bash
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --staged-apply
+```
+
+`--staged-apply` keeps partially downloaded file bytes out of the live local
+tree. The final apply is rename-only, so `--state-dir` and `--fs-root` must be
+on the same filesystem. If they are not, Reprint rejects the run before moving
+anything; it does not copy staged files into place because that could expose
+half-written files. A killed apply can be rerun: files already renamed into
+place are recognized by size and the remaining staged files are moved.
+
 **Non-empty local fs-root**
 
 By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
@@ -725,7 +740,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
-* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
+* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed; add `--staged-apply` to land files by rename after download.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `push-files` — Upload local files into the remote staged artifact store; add `--apply` to rename the verified transfer into the remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.

--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-apply",
+            "version": "dev-pull/staged-pull",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -125,7 +125,7 @@ final class Site_Export_Staged_Apply {
      *   what a sender calls before uploading gigabytes: a staging
      *   directory that can never apply (cross_device) rejects here, at
      *   the start, not after the transfer.
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int}
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,skipped_paths:array<int,string>}
      *   status "applied"|"ready"|"busy"|"rejected"; skipped counts entries
      *   the on_existing/symlink policies protected.
      */

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4397,6 +4397,21 @@ class ImportClient
         }
 
         @unlink($this->staged_pull_manifest_log());
+        // Same audit contract as write-time preserve-local: every skipped
+        // operation is logged with the PRESERVE-LOCAL prefix.
+        $skipped_paths = is_array($result["skipped_paths"] ?? null) ? $result["skipped_paths"] : [];
+        foreach ($skipped_paths as $protected_path) {
+            $this->audit_log("PRESERVE-LOCAL skip file (kept at apply) | {$protected_path}", false);
+        }
+        if ($result["skipped"] > count($skipped_paths)) {
+            $this->audit_log(
+                sprintf(
+                    "PRESERVE-LOCAL skipped %d more files (path list capped)",
+                    $result["skipped"] - count($skipped_paths),
+                ),
+                false,
+            );
+        }
         $this->audit_log(
             sprintf(
                 "STAGED APPLY COMPLETE | applied=%d already_applied=%d skipped=%d",

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1238,6 +1238,15 @@ class ImportClient
     /** Artifact id the push manifest stages under; never applied itself. */
     private const PUSH_MANIFEST_ID = '.reprint-push-manifest.jsonl';
 
+    /** Artifact id the staged pull manifest stages under. */
+    private const PULL_MANIFEST_ID = '.reprint-pull-manifest.jsonl';
+
+    /** @var bool Files download into staging and apply in one rename window. */
+    private $staged_apply_mode = false;
+
+    /** @var Site_Export_Staged_Artifacts|null Lazy staged pull store. */
+    private $staged_pull_store = null;
+
     public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
@@ -1665,6 +1674,16 @@ class ImportClient
             $this->save_state($this->state);
         } else {
             $this->fs_root_nonempty_behavior = $this->import_state()->fs_root_nonempty_behavior ?? 'error';
+        }
+
+        // Persist staged apply mode like the flags above: a resumed pull
+        // must keep staging where the interrupted run was staging.
+        if (isset($options["staged_apply"])) {
+            $this->staged_apply_mode = (bool) $options["staged_apply"];
+            $this->import_state()->staged_apply = $this->staged_apply_mode;
+            $this->save_state($this->state);
+        } else {
+            $this->staged_apply_mode = !empty($this->import_state()->staged_apply);
         }
 
         // Persist filter in state so it survives across resume cycles.
@@ -2809,6 +2828,13 @@ class ImportClient
             file_exists($this->index_file) &&
             filesize($this->index_file) > 0;
 
+        // Staged mode: refuse now if the apply window could never run —
+        // a state dir on another filesystem above all — not after the
+        // download has been paid for.
+        if ($this->staged_apply_mode) {
+            $this->assert_staged_pull_ready();
+        }
+
         // Resuming an in-progress sync
         if ($has_progress) {
             // Don't reset files_imported here — it counts files within
@@ -3063,6 +3089,7 @@ class ImportClient
                 // Essential files are done — mark the sync as complete.
                 // The skipped list stays on disk for a later
                 // --filter=skipped-earlier run.
+                $this->run_staged_pull_apply();
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->save_state($this->state);
                 $this->audit_log(
@@ -3081,6 +3108,7 @@ class ImportClient
                 );
                 $this->write_status_file();
             } else {
+                $this->run_staged_pull_apply();
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->save_state($this->state);
                 $stage = null;
@@ -3097,6 +3125,7 @@ class ImportClient
                 $this->save_state($this->state);
                 return;
             }
+            $this->run_staged_pull_apply();
             $this->import_state()->active_resumable_command->current_stage = null;
             $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
             $this->save_state($this->state);
@@ -4172,6 +4201,218 @@ class ImportClient
         );
         $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
         return in_array($fields["abort_reason"] ?? null, $retryable, true) ? 2 : 1;
+    }
+
+    private function staged_pull_staging_dir(): string
+    {
+        return $this->state_dir . "/.pull-staging";
+    }
+
+    /** The manifest log accumulates one line per staged file across resumes. */
+    private function staged_pull_manifest_log(): string
+    {
+        return $this->state_dir . "/.pull-staged-manifest.jsonl";
+    }
+
+    private function staged_pull_store(): Site_Export_Staged_Artifacts
+    {
+        if ($this->staged_pull_store === null) {
+            $this->staged_pull_store = new Site_Export_Staged_Artifacts($this->staged_pull_staging_dir());
+        }
+        return $this->staged_pull_store;
+    }
+
+    private function staged_pull_apply_engine(): Site_Export_Staged_Apply
+    {
+        $preserve_local = $this->fs_root_nonempty_behavior === "preserve-local";
+        return new Site_Export_Staged_Apply([
+            "staging_dir" => $this->staged_pull_staging_dir(),
+            "target_root" => $this->fs_root,
+            // Preserve-local keeps its write-time meaning at apply time:
+            // occupied paths win, and nothing is created through a
+            // symlinked directory.
+            "on_existing" => $preserve_local ? "skip" : "replace",
+            "refuse_symlinked_parents" => $preserve_local,
+        ]);
+    }
+
+    /** The fs-root-relative artifact id for a mapped local path. */
+    private function staged_pull_artifact_id(string $local_path): string
+    {
+        // The path mapper may hand back a resolved fs-root (macOS /var is
+        // a symlink to /private/var); accept either spelling.
+        $roots = [rtrim($this->fs_root, "/")];
+        $real_root = realpath($this->fs_root);
+        if (is_string($real_root) && $real_root !== "") {
+            $roots[] = rtrim($real_root, "/");
+        }
+        foreach (array_unique($roots) as $root) {
+            if (strpos($local_path, $root . "/") === 0) {
+                return substr($local_path, strlen($root) + 1);
+            }
+        }
+        throw new RuntimeException(
+            "Staged pull cannot stage a path outside --fs-root: {$local_path}",
+        );
+    }
+
+    /**
+     * Refuses a staged pull the apply step could never finish — above all
+     * a state dir on a different filesystem than --fs-root, where the
+     * rename-only apply would reject cross_device only after the download.
+     * The probe id never exists, so this checks the environment only.
+     */
+    private function assert_staged_pull_ready(): void
+    {
+        if (!is_dir($this->fs_root)) {
+            @mkdir($this->fs_root, 0755, true);
+        }
+        $probe = $this->staged_pull_apply_engine()->apply(".reprint-pull-probe", true);
+        if ($probe["status"] !== "ready") {
+            throw new RuntimeException(
+                "Staged apply cannot run here: " . ($probe["reason"] ?? $probe["status"]) .
+                    " (" . ($probe["detail"] ?? "") . "). Put --state-dir on the same " .
+                    "filesystem as --fs-root, or drop --staged-apply.",
+            );
+        }
+    }
+
+    /**
+     * Stages one body buffer for the file the stream is delivering.
+     *
+     * context->file_bytes_written tracks the STREAM position; the store
+     * enforces its own committed offset. Bytes the server re-sends after a
+     * resume land as duplicates and only the unseen tail is appended — the
+     * same frontier handling the push endpoint uses.
+     */
+    private function staged_pull_write_chunk(StreamingContext $context, string $data): void
+    {
+        $store = $this->staged_pull_store();
+        $artifact_id = $context->staged_artifact_id;
+        $offset = $context->file_bytes_written;
+        $committed = $store->status($artifact_id)["committed_bytes"];
+
+        if ($committed >= $offset + strlen($data)) {
+            $context->file_bytes_written = $offset + strlen($data);
+            return;
+        }
+        if ($committed > $offset) {
+            $data = substr($data, $committed - $offset);
+            $offset = $committed;
+        }
+
+        $result = $store->append($artifact_id, $offset, $data);
+        if ($result["status"] === "accepted" || $result["status"] === "duplicate") {
+            $context->file_bytes_written = $result["committed_bytes"];
+            return;
+        }
+        throw new RuntimeException(
+            "Staged write failed for {$artifact_id}: " .
+                ($result["reason"] ?? $result["status"]) .
+                " " . ($result["detail"] ?? ""),
+        );
+    }
+
+    /**
+     * Verifies a fully-streamed file and records it for the apply window.
+     *
+     * @return string|null Failure reason, or null when the file verified.
+     */
+    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime): ?string
+    {
+        $result = $this->staged_pull_store()->finalize($artifact_id, $expected_size);
+        if ($result["status"] !== "verified") {
+            return ($result["reason"] ?? $result["status"]) . " " . ($result["detail"] ?? "");
+        }
+        if ($ctime) {
+            // Rename preserves this mtime, which delta syncs compare
+            // against the remote ctime.
+            @touch($this->staged_pull_staging_dir() . "/files/" . $artifact_id, $ctime);
+        }
+        $line = json_encode(["artifact_id" => $artifact_id, "size" => $expected_size]) . "\n";
+        @file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND);
+        return null;
+    }
+
+    /**
+     * Applies everything staged so far in one rename window.
+     *
+     * Runs at each point the file phase completes. The manifest log
+     * accumulates across resumes and is deduplicated here; entries an
+     * earlier window already applied classify as applied and only consume
+     * their leftover markers.
+     */
+    private function run_staged_pull_apply(): void
+    {
+        if (!$this->staged_apply_mode) {
+            return;
+        }
+
+        $entries = [];
+        $raw = @file_get_contents($this->staged_pull_manifest_log());
+        if (is_string($raw) && $raw !== "") {
+            foreach (explode("\n", $raw) as $line) {
+                $record = json_decode($line, true);
+                if (
+                    is_array($record)
+                    && is_string($record["artifact_id"] ?? null)
+                    && is_int($record["size"] ?? null)
+                ) {
+                    $entries[$record["artifact_id"]] = $record["size"];
+                }
+            }
+        }
+        if ($entries === []) {
+            return;
+        }
+
+        $lines = "";
+        foreach ($entries as $artifact_id => $size) {
+            $lines .= json_encode(["artifact_id" => $artifact_id, "size" => $size]) . "\n";
+        }
+
+        $store = $this->staged_pull_store();
+        $store->discard(self::PULL_MANIFEST_ID);
+        $offset = 0;
+        foreach (str_split($lines, 262144) as $piece) {
+            $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
+            if ($appended["status"] !== "accepted") {
+                throw new RuntimeException(
+                    "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+                );
+            }
+            $offset = $appended["committed_bytes"];
+        }
+        if ($store->finalize(self::PULL_MANIFEST_ID, strlen($lines))["status"] !== "verified") {
+            throw new RuntimeException("Staged apply could not verify its manifest.");
+        }
+
+        $this->audit_log("STAGED APPLY | " . count($entries) . " files", true);
+        $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
+        if ($result["status"] !== "applied") {
+            throw new RuntimeException(
+                "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
+                    " (" . ($result["detail"] ?? "") . ")",
+            );
+        }
+
+        @unlink($this->staged_pull_manifest_log());
+        $this->audit_log(
+            sprintf(
+                "STAGED APPLY COMPLETE | applied=%d already_applied=%d skipped=%d",
+                $result["applied"],
+                $result["already_applied"],
+                $result["skipped"],
+            ),
+            true,
+        );
+        $this->output_progress([
+            "type" => "staged_apply",
+            "status" => "complete",
+            "applied" => $result["applied"],
+            "already_applied" => $result["already_applied"],
+            "skipped" => $result["skipped"],
+        ], true);
     }
 
     /**
@@ -6154,7 +6395,11 @@ class ImportClient
         // the new cursor, so we'll re-fetch the same data.
         $tracked_file = $this->import_state()->current_file ?? null;
         $tracked_bytes = $this->import_state()->current_file_bytes ?? null;
-        if ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
+        // Staged mode must not run this: the tracked path is the FINAL
+        // location, which during a delta still holds the previous version
+        // of the file — truncating it would destroy live content the apply
+        // step has not replaced yet. The store trims its own tails.
+        if (!$this->staged_apply_mode && $tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
             $actual_size = filesize($tracked_file);
             if ($actual_size > $tracked_bytes) {
                 $this->audit_log(
@@ -6193,7 +6438,22 @@ class ImportClient
         // request, re-open it in append mode so continuation chunks (where
         // is_first=false) can still be written.  Without this, the context
         // starts with file_handle=null and non-first chunks are silently dropped.
-        if ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
+        if ($this->staged_apply_mode && $tracked_file !== null && $tracked_bytes !== null) {
+            // Staged mode: nothing exists at the final path. Continuation
+            // chunks resume at the stream position saved with the cursor;
+            // the store's frontier absorbs any replayed prefix.
+            $context->staged_artifact_id = $this->staged_pull_artifact_id($tracked_file);
+            $context->file_path = $tracked_file;
+            $context->file_bytes_written = $tracked_bytes;
+            $this->audit_log(
+                sprintf(
+                    "RESUME STAGED FILE | %s at stream offset %d",
+                    $tracked_file,
+                    $tracked_bytes,
+                ),
+                true,
+            );
+        } elseif ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
             $context->file_handle = fopen($tracked_file, "ab");
             if ($context->file_handle) {
                 $context->file_path = $tracked_file;
@@ -6240,6 +6500,12 @@ class ImportClient
                     if ($context->file_handle && $context->file_path) {
                         // Flush to ensure bytes are on disk before saving state
                         fflush($context->file_handle);
+                        $this->import_state()->current_file = $context->file_path;
+                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                    } elseif ($context->staged_artifact_id !== null && $context->file_path) {
+                        // Staged mode: every append already flushed. Save
+                        // the stream position alongside the cursor so a
+                        // resumed request re-enters at the same offset.
                         $this->import_state()->current_file = $context->file_path;
                         $this->import_state()->current_file_bytes = $context->file_bytes_written;
                     } else {
@@ -9164,6 +9430,7 @@ class ImportClient
             $context->skip_current_file = false;
 
             if (
+                !$this->staged_apply_mode &&
                 (file_exists($local_path) || is_link($local_path)) &&
                 (!is_file($local_path) || is_link($local_path))
             ) {
@@ -9224,7 +9491,15 @@ class ImportClient
         }
 
         // Open file handle on first chunk
-        if ($is_first) {
+        if ($is_first && $this->staged_apply_mode) {
+            // Bytes go to the staged store, not the live tree; the stream
+            // position starts at 0 and the store's frontier absorbs any
+            // committed prefix a resumed server re-sends.
+            $context->staged_artifact_id = $this->staged_pull_artifact_id($local_path);
+            $context->file_path = $local_path;
+            $context->file_ctime = (int) ($headers["x-file-ctime"] ?? 0);
+            $context->file_bytes_written = 0;
+        } elseif ($is_first) {
             // Close previous file if any
             if ($context->file_handle) {
                 fclose($context->file_handle);
@@ -9268,7 +9543,15 @@ class ImportClient
 
         // Write body data if present
         if (isset($chunk["body"]) && $chunk["body"] !== "") {
-            if ($context->file_handle) {
+            if ($this->staged_apply_mode) {
+                if ($context->staged_artifact_id === null) {
+                    // Mid-file continuation after a restart that never
+                    // checkpointed this file: the server re-sends it from
+                    // the start, so the stream position begins at 0.
+                    $context->staged_artifact_id = $this->staged_pull_artifact_id($local_path);
+                }
+                $this->staged_pull_write_chunk($context, $chunk["body"]);
+            } elseif ($context->file_handle) {
                 $data = $chunk["body"];
                 $bytes = fwrite($context->file_handle, $data);
                 if ($bytes === false || $bytes !== strlen($data)) {
@@ -9280,6 +9563,57 @@ class ImportClient
                 }
                 $context->file_bytes_written += $bytes;
             }
+        }
+
+        // Complete a staged file on last chunk
+        if ($is_last && $this->staged_apply_mode && $context->staged_artifact_id !== null) {
+            $file_size = (int) ($headers["x-file-size"] ?? 0);
+            $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
+
+            if ($file_changed) {
+                // Same tolerance as the direct path: the exporter saw the
+                // file change mid-stream, so drop the staged copy and let
+                // the next delta refetch it.
+                $this->staged_pull_store()->discard($context->staged_artifact_id);
+                $this->audit_log(
+                    "  File changed during stream; staged copy discarded",
+                    true,
+                );
+            } else {
+                $finalize_error = $this->staged_pull_finalize_file(
+                    $context->staged_artifact_id,
+                    $file_size,
+                    $context->file_ctime ?? 0,
+                );
+                if ($finalize_error !== null) {
+                    $this->staged_pull_store()->discard($context->staged_artifact_id);
+                    $this->audit_log(
+                        "  Staged file did not verify ({$finalize_error}); discarded for refetch",
+                        true,
+                    );
+                } elseif ($context->file_ctime) {
+                    $this->upsert_index_entry(
+                        $path,
+                        $context->file_ctime,
+                        $file_size,
+                        "file",
+                    );
+                    $this->files_imported++;
+                    $this->clear_volatile_file($path);
+                    $this->audit_log(
+                        sprintf("  Staged (%d bytes)", $file_size),
+                        false,
+                    );
+                }
+            }
+
+            $context->staged_artifact_id = null;
+            $context->file_path = null;
+            $context->file_ctime = null;
+            $context->file_bytes_written = 0;
+            $this->import_state()->current_file = null;
+            $this->import_state()->current_file_bytes = null;
+            return;
         }
 
         // Close on last chunk
@@ -11075,6 +11409,7 @@ class ImportClient
             "version" => null,
             "webhost" => null,
             "follow_symlinks" => true,
+            "staged_apply" => false,
             "fs_root_nonempty_behavior" => "error",
             "filter" => "none",
             "user_agent" => null,
@@ -11783,6 +12118,8 @@ class StreamingContext
     public $saw_completion = false;
     // When true, skip writing the current file (preserve-local mode)
     public $skip_current_file = false;
+    // Staged pull: fs-root-relative artifact id of the file being staged
+    public $staged_artifact_id = null;
 }
 
 /**
@@ -12172,6 +12509,15 @@ if (
             'help' => 'After staging completes, apply the transfer into the remote tree ' .
                 '(rename-only; the environment is probed before any upload)',
             'commands' => ['push-files'],
+        ],
+        [
+            'name' => 'staged-apply',
+            'type' => 'flag',
+            'target' => 'staged_apply',
+            'help' => 'Download into a staging area under --state-dir and move files into ' .
+                '--fs-root in one rename window at the end, so the tree never holds a ' .
+                'half-written file (requires --state-dir and --fs-root on one filesystem)',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
 
         // ── flat-docroot options ────────────────────────────────

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -346,6 +346,8 @@ class ImportState
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
     public bool $follow_symlinks = true;
+    /** @var bool Files download into staging and apply in one rename window. */
+    public bool $staged_apply = false;
     public string $fs_root_nonempty_behavior = 'error';
     public string $filter = 'none';
     /** @var string|null User-Agent that worked during preflight. */
@@ -398,6 +400,7 @@ class ImportState
         $state->version = isset($data['version']) ? (string) $data['version'] : null;
         $state->webhost = isset($data['webhost']) ? (string) $data['webhost'] : null;
         $state->follow_symlinks = (bool) ($data['follow_symlinks'] ?? true);
+        $state->staged_apply = (bool) ($data['staged_apply'] ?? false);
         $state->fs_root_nonempty_behavior = isset($data['fs_root_nonempty_behavior']) ? (string) $data['fs_root_nonempty_behavior'] : 'error';
         $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
         $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
@@ -436,6 +439,7 @@ class ImportState
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
+            'staged_apply' => $this->staged_apply,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,

--- a/tests/Import/StagedPullCliTest.php
+++ b/tests/Import/StagedPullCliTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Drives the real CLI against a real WP-less export server (php -S serving
+ * lib.php, the test-44 bootstrap): files-pull --staged-apply downloads into
+ * the store under --state-dir and lands in --fs-root in one rename window.
+ */
+class StagedPullCliTest extends TestCase
+{
+    private const SECRET = 'staged-pull-cli-secret';
+
+    private string $state_dir;
+
+    private string $fs_root;
+
+    private string $source_dir;
+
+    private string $harness;
+
+    /** @var resource|null */
+    private $server = null;
+
+    private int $port = 0;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $base = (string) realpath(sys_get_temp_dir());
+        $this->state_dir = $base . '/staged-pull-state-' . $suffix;
+        $this->fs_root = $base . '/staged-pull-root-' . $suffix;
+        $this->source_dir = $base . '/staged-pull-source-' . $suffix;
+        $this->harness = $base . '/staged-pull-harness-' . $suffix;
+        foreach ([$this->state_dir, $this->fs_root, $this->source_dir, $this->harness] as $dir) {
+            mkdir($dir, 0700, true);
+        }
+        $this->startServer();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server)) {
+            proc_terminate($this->server);
+            proc_close($this->server);
+        }
+        foreach ([$this->state_dir, $this->fs_root, $this->source_dir, $this->harness] as $dir) {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (is_link($dir)) {
+            @unlink($dir);
+            return;
+        }
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            if (is_link($entry) || !is_dir($entry)) {
+                @unlink($entry);
+            } else {
+                $this->removeDir($entry);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function startServer(): void
+    {
+        $repo = (string) realpath(__DIR__ . '/../..');
+        file_put_contents($this->harness . '/secret.php', "<?php return '" . self::SECRET . "';\n");
+        file_put_contents(
+            $this->harness . '/router.php',
+            "<?php\n" .
+            "define('ABSPATH', '{$this->harness}/abspath/');\n" .
+            "define('SITE_EXPORT_PLUGIN_DIR', '{$repo}/reprint-exporter-wp/');\n" .
+            "define('SITE_EXPORT_SECRET_FILE', '{$this->harness}/secret.php');\n" .
+            "if (!function_exists('plugin_dir_path')) {\n" .
+            "    function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }\n" .
+            "}\n" .
+            "require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';\n" .
+            "_site_export_handle_api_request();\n"
+        );
+        mkdir($this->harness . '/abspath', 0700, true);
+
+        $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $name = (string) stream_socket_get_name($probe, false);
+        $this->port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($probe);
+
+        // -t points DOCUMENT_ROOT at the source tree: the exporter
+        // advertises it as a root, and it must not leak the harness or the
+        // repo checkout into the export.
+        $this->server = proc_open(
+            [PHP_BINARY, '-S', "127.0.0.1:{$this->port}", '-t', $this->source_dir, $this->harness . '/router.php'],
+            [
+                1 => ['file', $this->harness . '/server.log', 'a'],
+                2 => ['file', $this->harness . '/server.log', 'a'],
+            ],
+            $pipes
+        );
+
+        $deadline = microtime(true) + 10;
+        while (microtime(true) < $deadline) {
+            $conn = @fsockopen('127.0.0.1', $this->port, $errno, $errstr, 0.2);
+            if ($conn !== false) {
+                fclose($conn);
+                return;
+            }
+            usleep(100000);
+        }
+        $this->fail('php -S did not come up');
+    }
+
+    private function url(): string
+    {
+        return "http://127.0.0.1:{$this->port}/?reprint-api&directory[]=" . rawurlencode($this->source_dir);
+    }
+
+    private function baseArgs(array $extra = []): array
+    {
+        return array_merge([
+            $this->url(),
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+            '--secret=' . self::SECRET,
+        ], $extra);
+    }
+
+    /**
+     * @return array{0:string,1:int}
+     */
+    private function runCli(string $command, array $extra = []): array
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry) . ' ' . escapeshellarg($command);
+        foreach ($this->baseArgs($extra) as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+        exec($cmd . ' 2>&1', $lines, $code);
+        return [implode("\n", $lines), $code];
+    }
+
+    /** Runs a pull command to completion, following the exit-2 resume protocol. */
+    private function pullToCompletion(array $extra = [], string $command = 'files-pull'): array
+    {
+        $output = '';
+        for ($attempt = 0; $attempt < 20; $attempt++) {
+            [$out, $code] = $this->runCli($command, $extra);
+            $output .= $out . "\n";
+            if ($code !== 2) {
+                return [$output, $code];
+            }
+        }
+        return [$output, 2];
+    }
+
+    private function seedSource(): void
+    {
+        mkdir($this->source_dir . '/wp-content/uploads', 0700, true);
+        mkdir($this->source_dir . '/wp-content/plugins/my-plugin', 0700, true);
+        // wp_detect needs these to recognize the directory as a root.
+        file_put_contents($this->source_dir . '/wp-load.php', '<?php /* stub */');
+        file_put_contents($this->source_dir . '/wp-config.php', '<?php /* stub config */');
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index');
+        file_put_contents($this->source_dir . '/empty.txt', '');
+        file_put_contents($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', '<?php // plugin v1');
+        file_put_contents($this->source_dir . '/wp-content/uploads/big.bin', str_repeat('reprint!', 40000));
+    }
+
+    /**
+     * Where the pulled tree lands: pull mirrors absolute remote paths
+     * under --fs-root (flat-docroot reassembles them later), so the source
+     * tree appears at fs_root + realpath(source).
+     */
+    private function mappedRoot(): string
+    {
+        return $this->fs_root . (string) realpath($this->source_dir);
+    }
+
+    private function countFiles(string $dir): int
+    {
+        if (!is_dir($dir)) {
+            return 0;
+        }
+        $count = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $entry) {
+            if ($entry->isFile()) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    public function testStagedPullLandsTheTreeInOneWindowAndDeltaReplaces(): void
+    {
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('staged_apply', $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+        $this->assertSame(
+            0,
+            $this->countFiles($this->state_dir . '/.pull-staging/files'),
+            'the apply window consumes the staged transfer'
+        );
+
+        // Delta: the remote plugin changes; the next staged pull replaces
+        // it in place (no preserve-local), old bytes never truncated early.
+        file_put_contents(
+            $this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php',
+            '<?php // plugin v2 — longer than before'
+        );
+        touch($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', time() + 5);
+        // Deltas re-enter through --abort, the same way the delta e2e
+        // scenarios drive files-pull: state clears, the local index
+        // survives, and the rerun diffs against it.
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$delta_output, $delta_code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $delta_code, $delta_output);
+        $this->assertSame(
+            '<?php // plugin v2 — longer than before',
+            file_get_contents($this->mappedRoot() . '/wp-content/plugins/my-plugin/my-plugin.php'),
+            $delta_output
+        );
+    }
+
+    public function testMidPullFailureNeverTouchesFsRootAndResumes(): void
+    {
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        // A held store lock makes the first staged write fail mid-fetch —
+        // a deterministic interruption, no timing games. The essence under
+        // test: no failure between download start and apply may leave
+        // anything in the live tree.
+        $staging = $this->state_dir . '/.pull-staging';
+        mkdir($staging, 0700, true);
+        $holder = fopen($staging . '/lock', 'c+b');
+        flock($holder, LOCK_EX);
+
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertNotSame(0, $held_code, $held_output);
+        $this->assertSame(
+            0,
+            $this->countFiles($this->fs_root),
+            'an interrupted staged pull must leave the live tree untouched'
+        );
+
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+    }
+
+    public function testPreserveLocalPoliciesHoldAtApplyTime(): void
+    {
+        $this->seedSource();
+        // Pre-seed the target at the MAPPED paths (pull mirrors absolute
+        // remote paths under fs-root): a local file that must win, and a
+        // symlinked plugins dir nothing may be created through.
+        $mapped = $this->mappedRoot();
+        mkdir($mapped . '/wp-content', 0700, true);
+        file_put_contents($mapped . '/index.php', 'local wins');
+        $shared = $this->fs_root . '-shared-plugins';
+        mkdir($shared, 0700, true);
+        symlink($shared, $mapped . '/wp-content/plugins');
+
+        try {
+            $this->runCli('preflight');
+            [$output, $code] = $this->pullToCompletion([
+                '--staged-apply',
+                '--on-fs-root-nonempty=preserve-local',
+            ]);
+
+            $this->assertSame(0, $code, $output);
+            $this->assertSame('local wins', file_get_contents($mapped . '/index.php'));
+            $this->assertSame([], glob($shared . '/*'), 'nothing may appear behind the symlink');
+            $this->assertSame(
+                str_repeat('reprint!', 40000),
+                file_get_contents($mapped . '/wp-content/uploads/big.bin'),
+                'unprotected content still lands'
+            );
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testCrossDeviceStateDirIsRefusedBeforeDownloading(): void
+    {
+        if (!is_dir('/dev/shm')) {
+            $this->markTestSkipped('needs a tmpfs to make a real device boundary');
+        }
+        $this->seedSource();
+        $xdev_state = '/dev/shm/staged-pull-xdev-' . bin2hex(random_bytes(6));
+        mkdir($xdev_state, 0700, true);
+
+        try {
+            $entry = __DIR__ . '/../../importer/import.php';
+            $args = [
+                $this->url(),
+                '--state-dir=' . $xdev_state,
+                '--fs-root=' . $this->fs_root,
+                '--secret=' . self::SECRET,
+            ];
+            $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry) . ' preflight';
+            foreach ($args as $arg) {
+                $cmd .= ' ' . escapeshellarg($arg);
+            }
+            exec($cmd . ' 2>&1');
+
+            $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry) . ' files-pull';
+            foreach (array_merge($args, ['--staged-apply']) as $arg) {
+                $cmd .= ' ' . escapeshellarg($arg);
+            }
+            exec($cmd . ' 2>&1', $lines, $code);
+            $output = implode("\n", $lines);
+
+            $this->assertSame(1, $code, $output);
+            $this->assertStringContainsString('cross_device', $output);
+            $this->assertSame(0, $this->countFiles($this->fs_root), 'nothing may download');
+        } finally {
+            $this->removeDir($xdev_state);
+        }
+    }
+}

--- a/tests/Import/StagedPullCliTest.php
+++ b/tests/Import/StagedPullCliTest.php
@@ -294,6 +294,16 @@ class StagedPullCliTest extends TestCase
             $this->assertSame(0, $code, $output);
             $this->assertSame('local wins', file_get_contents($mapped . '/index.php'));
             $this->assertSame([], glob($shared . '/*'), 'nothing may appear behind the symlink');
+            // Protection fires at download time (trunk's write-time checks
+            // stay active in staged mode, so protected files are never even
+            // fetched); the apply engine enforces the same policies as a
+            // backstop. Either way, every skip is audit-logged.
+            $audit = (string) @file_get_contents($this->state_dir . '/.import-audit.log');
+            $this->assertStringContainsString(
+                'PRESERVE-LOCAL skip file',
+                $audit,
+                'every protected path is audit-logged'
+            );
             $this->assertSame(
                 str_repeat('reprint!', 40000),
                 file_get_contents($mapped . '/wp-content/uploads/big.bin'),

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -5,6 +5,8 @@
 #
 # This stack changes file transfer/apply behavior. Keep the focused benchmark
 # on file movement rather than unrelated database-only Playground SQLite
-# stages. Push-specific stages cannot be compared here until push-files exists
+# stages. `files-pull` requires preflight state, so benchmark both stages
+# together. Push-specific stages cannot be compared here until push-files exists
 # on the trunk baseline.
+preflight
 files-pull

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -1,10 +1,10 @@
-# Stages this PR's perf comment will benchmark.
+# Stages this PR stack's perf comment will benchmark.
 # One stage name per line; comments and blank lines ignored.
 # Both the PR build and the trunk baseline run the same set, so the
-# table shows two like-for-like wall-time numbers per row.
+# table shows like-for-like wall-time numbers per row.
 #
-# This PR loads the Rust wp_mysql_parser PHP.wasm extension for the PR side
-# and leaves it disabled for the trunk baseline. Both sides use the same
-# direct PHP.wasm runner so the wall-time delta isolates the extension.
-playground-sqlite-db-pull
-playground-sqlite-db-apply
+# This stack changes file transfer/apply behavior. Keep the focused benchmark
+# on file movement rather than unrelated database-only Playground SQLite
+# stages. Push-specific stages cannot be compared here until push-files exists
+# on the trunk baseline.
+files-pull

--- a/tests/e2e/tests/import-53-staged-pull.test.js
+++ b/tests/e2e/tests/import-53-staged-pull.test.js
@@ -1,0 +1,75 @@
+/**
+ * Test 53: files-pull --staged-apply against a real WordPress site
+ *
+ * The pull downloads into a staged store under --state-dir and lands in
+ * --fs-root in one rename window at the end — the same staged store and
+ * apply engine push uses, driven from the pull side. The live tree never
+ * holds a half-written file; a mid-transfer failure leaves it untouched.
+ *
+ * The deterministic-interruption, delta, preserve-local, and cross-device
+ * nuances live in the PHPUnit CLI suite (StagedPullCliTest); this scenario
+ * covers the real-site dimension: a full WordPress tree over nginx +
+ * PHP-FPM arrives byte-identical through the staged path.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    assertTreesMatch,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: staged pull applies in one rename window', () => {
+    const site = 'basic';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-staged-pull');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function countStagedFiles() {
+        const staged = join(tempDir, '.pull-staging', 'files');
+        if (!existsSync(staged)) {
+            return 0;
+        }
+        const walk = (dir) => readdirSync(dir, { withFileTypes: true }).reduce(
+            (count, entry) => count + (entry.isDirectory()
+                ? walk(join(dir, entry.name))
+                : 1),
+            0
+        );
+        return walk(staged);
+    }
+
+    it('pulls the full site through staging, byte-identical', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--staged-apply'],
+        });
+
+        assert.equal(result.exitCode, 0, `staged pull failed:\n${result.stderr}\n${result.stdout}`);
+        assert.ok(
+            result.stdout.includes('staged_apply'),
+            `apply summary expected in output:\n${result.stdout.slice(-2000)}`
+        );
+        assertTreesMatch(getSiteDir(site), join(fsRootDir(tempDir), getSiteDir(site)));
+        assert.equal(
+            countStagedFiles(),
+            0,
+            'the apply window consumes the staged transfer'
+        );
+    }, 120000);
+});


### PR DESCRIPTION
## What it does

Adds `--staged-apply` to `files-pull` (and the pull pipeline): downloaded files accumulate in the same `Site_Export_Staged_Artifacts` store push uses — under `--state-dir`, driven client-side — and land in `--fs-root` through the same `Site_Export_Staged_Apply` rename window. The live tree never holds a half-written file; a plugin update arrives whole or not at all.

```bash
reprint files-pull https://example.com/?reprint-api \
  --secret=TOKEN --state-dir=./state --fs-root=./site --staged-apply
```

This is the pull side of the reuse this stack exists for: store and engine are shared verbatim, only the byte source differs (multipart download stream instead of chunk uploads). Stacked on #306; part of #276.

## Rationale

**One write path, one frontier discipline.** `handle_file_chunk()` keeps all its bookkeeping (progress, audit, index upserts) and swaps only the IO: bytes go through `append()` with the same frontier handling the push endpoint uses — the stream position and the store's committed offset reconcile, so replayed bytes after a resume land as duplicates and only the unseen tail is written. File completion becomes `finalize(x-file-size)`; a file the exporter reports changed mid-stream is discarded for the next delta, same tolerance as the direct path.

**The resume machinery needed one guard, not a rewrite.** Staged mode never creates the file at its final path, so the crash-recovery reopen naturally no-ops; the checkpoint saves the stream position alongside the cursor so a restarted request re-enters at the right offset. The one mandatory change: the crash-recovery *truncate* must not run in staged mode — during a delta the tracked final path still holds the previous version of the file, and truncating it would have destroyed live content the apply window hadn't replaced yet.

**Cross-device is refused before the download is paid for.** At pull start, the apply engine's environment probe runs locally (a never-existing manifest id makes it environment-only): a `--state-dir` on a different filesystem than `--fs-root` fails immediately with `cross_device`, mirroring push's pre-upload probe.

**Preserve-local keeps its meaning at apply time.** `--on-fs-root-nonempty=preserve-local` maps to #306's policies: occupied paths win, nothing is created through a symlinked directory, and the write-time mutation of existing paths is skipped in staged mode so protection decisions happen exactly once, at the rename.

The apply window runs at every point the file phase completes (including the essential-files early completion), and the manifest log accumulates across resumes — entries an earlier window applied classify as `already_applied` and only consume their markers. `--staged-apply` persists in state like `--follow-symlinks`, so resumed runs keep staging where the interrupted run was staging.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/StagedPullCliTest.php
cd ../tests/e2e && npm run test -- tests/import-53-staged-pull.test.js
composer analyze
```

`StagedPullCliTest` drives the real CLI in subprocesses against a real WP-less export server (`php -S` + `lib.php`, the test-44 bootstrap): a full pull lands byte-identical (`diff -r`) with staging consumed, a delta after `--abort` replaces a changed plugin in place, a deterministic mid-pull failure (held store lock — no timing games) leaves `--fs-root` with zero files and the rerun completes, preserve-local protects a local file and a symlinked plugins dir at apply time, and a tmpfs `--state-dir` is refused `cross_device` before anything downloads (self-skips without `/dev/shm`). The Docker scenario pulls a full WordPress site through nginx/PHP-FPM byte-identical through the staged path. Direct-mode pull is untouched: the full Import suite passes.


**Review round + correction:** trunk's write-time preserve-local checks remain active in staged mode, so protected files are skipped at download (never fetched, never staged — same audit wording as trunk); the apply engine enforces the same policies as a backstop for anything that becomes protected between download and apply, and apply-time skips are audit-logged with the PRESERVE-LOCAL prefix.
