### PR TITLE
Batch small files into one upload request

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-pull/staged-pull",
+            "version": "dev-push/upload-batches",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -333,6 +333,18 @@ final class Site_Export_HTTP_Server {
             'staged_apply' => static function (array $config) use ($endpoints): void {
                 self::emit_json_response($endpoints->apply($config, $_SERVER));
             },
+            'staged_upload_batch' => static function (array $config) use ($endpoints): void {
+                $input = @fopen('php://input', 'rb');
+                try {
+                    self::emit_json_response(
+                        $endpoints->upload_batch($config, $_SERVER, $input === false ? null : $input)
+                    );
+                } finally {
+                    if (is_resource($input)) {
+                        fclose($input);
+                    }
+                }
+            },
         ];
 
         foreach ($routes as $endpoint => $handler) {

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -240,48 +240,20 @@ final class Site_Export_Staged_Endpoints {
             return $this->too_large($artifact_id);
         }
 
-        if (!is_resource($input)) {
-            return $this->rejected(500, 'io_error', 'open_request_body');
+        $spooled = $this->spool_verified_body($auth, $input, $artifact_id);
+        if (isset($spooled['response'])) {
+            return $spooled['response'];
         }
-
-        $spool = fopen('php://temp/maxmemory:' . self::SPOOL_MEMORY_BYTES, 'w+b');
-        if ($spool === false) {
-            return $this->rejected(500, 'io_error', 'open_spool');
-        }
+        $spool = $spooled['spool'];
+        $spooled_bytes = $spooled['bytes'];
 
         try {
-            $context = hash_init('sha256');
-            $spooled = 0;
-            while (( $buffer = fread($input, self::READ_BUFFER_BYTES) ) !== false && $buffer !== '') {
-                $spooled += strlen($buffer);
-                if ($spooled > $this->max_request_bytes) {
-                    return $this->too_large($artifact_id);
-                }
-                hash_update($context, $buffer);
-                if (fwrite($spool, $buffer) !== strlen($buffer)) {
-                    return $this->rejected(500, 'io_error', 'write_spool');
-                }
-            }
-            if ($buffer === false && !feof($input)) {
-                return $this->rejected(400, 'body_read_failed');
-            }
-
-            // The signature authenticated the hash claim; this comparison
-            // authenticates the bytes. Nothing reached the store yet.
-            if (!hash_equals( (string) $auth['content_hash'], hash_final($context))) {
-                return $this->rejected(403, 'content_hash_mismatch');
-            }
-
-            if ($spooled === 0) {
-                return $this->rejected(400, 'empty_body');
-            }
-
             $status = $this->store->status($artifact_id);
             if ($status['verified']) {
                 return $this->rejected(409, 'already_verified', null, $status['committed_bytes']);
             }
             $committed = $status['committed_bytes'];
-            if ($committed >= $offset + $spooled) {
+            if ($committed >= $offset + $spooled_bytes) {
                 // A retried chunk that fully landed before the sender's
                 // timeout. Nothing to write.
                 return [
@@ -326,6 +298,271 @@ final class Site_Export_Staged_Endpoints {
         } finally {
             fclose($spool);
         }
+    }
+
+    /**
+     * Stage many complete artifacts from one request body.
+     *
+     * The body is a sequence of length-prefixed frames — no boundary
+     * strings, so any filename frames verbatim:
+     *
+     *   {"artifact_id":"a/b.txt","offset":0,"length":9,"total_bytes":9,"final":true}\n
+     *   <9 raw payload bytes>
+     *   ... next frame ...
+     *
+     * This is push's answer to pull's multipart batching: one HTTP
+     * conversation carries a whole batch of small files instead of one
+     * request each. Authentication and the no-unverified-byte rule are
+     * identical to upload(): headers first, then the whole body spools and
+     * must match the signed digest before any frame touches the store.
+     *
+     * Frames process in order and stop at the first failure; the response
+     * lists a per-artifact result for everything that reached the store,
+     * so a retry resumes with only the unfinished tail (frames for
+     * already-verified artifacts at their recorded size come back
+     * "verified" without touching anything).
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function upload_batch(array $config, array $headers, $input): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        if ($this->secret === null) {
+            return $this->rejected(503, 'not_configured', 'shared_secret');
+        }
+
+        $hmac = new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance);
+        $auth = $hmac->verify_signed_content_hash($headers);
+        if ($auth['error'] !== null) {
+            return $this->rejected(403, 'auth_failed', $auth['error']);
+        }
+
+        $declared_length = $headers['CONTENT_LENGTH'] ?? ( $headers['HTTP_CONTENT_LENGTH'] ?? null );
+        if (is_numeric($declared_length) && (int) $declared_length > $this->max_request_bytes) {
+            return $this->batch_response(413, 'request_too_large', null, []);
+        }
+
+        $spooled = $this->spool_verified_body($auth, $input, null);
+        if (isset($spooled['response'])) {
+            return $spooled['response'];
+        }
+        $spool = $spooled['spool'];
+
+        try {
+            rewind($spool);
+            $results = [];
+            while (( $line = fgets($spool) ) !== false) {
+                if (trim($line) === '') {
+                    continue;
+                }
+                $frame = json_decode($line, true);
+                if (
+                    !is_array($frame)
+                    || !is_string($frame['artifact_id'] ?? null)
+                    || !is_int($frame['offset'] ?? null) || $frame['offset'] < 0
+                    || !is_int($frame['length'] ?? null) || $frame['length'] < 0
+                    || !is_int($frame['total_bytes'] ?? null) || $frame['total_bytes'] < 0
+                ) {
+                    return $this->batch_response(400, 'invalid_batch_frame', substr($line, 0, 200), $results);
+                }
+                $payload = $frame['length'] > 0 ? $this->read_spool_exactly($spool, $frame['length']) : '';
+                if ($payload === null) {
+                    return $this->batch_response(400, 'truncated_batch', $frame['artifact_id'], $results);
+                }
+
+                $outcome = $this->stage_batch_frame($frame, $payload);
+                $results[] = $outcome;
+                if ($outcome['status'] === 'rejected' || $outcome['status'] === 'busy') {
+                    // Everything before this frame is committed and
+                    // reported; the sender retries from here.
+                    $code = $outcome['status'] === 'busy'
+                        ? 423
+                        : ( ($outcome['reason'] ?? null) === 'io_error' ? 500 : 409 );
+                    return $this->batch_response($code, $outcome['reason'], $outcome['artifact_id'], $results);
+                }
+            }
+
+            if ($results === []) {
+                return $this->batch_response(400, 'empty_batch', null, []);
+            }
+            return $this->batch_response(200, null, null, $results);
+        } finally {
+            fclose($spool);
+        }
+    }
+
+    /**
+     * Runs one batch frame through the store's frontier discipline.
+     *
+     * @return array{artifact_id:string,status:string,reason:?string,committed_bytes:int}
+     */
+    private function stage_batch_frame(array $frame, string $payload): array {
+        $artifact_id = $frame['artifact_id'];
+        $offset = $frame['offset'];
+        $final = !empty($frame['final']);
+        $total_bytes = $frame['total_bytes'];
+
+        $status = $this->store->status($artifact_id);
+        if ($status['verified']) {
+            // A retried batch re-sends artifacts an earlier attempt already
+            // landed; at the recorded size that is success, not conflict.
+            if ($status['committed_bytes'] === $total_bytes) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'verified',
+                    'reason' => null,
+                    'committed_bytes' => $status['committed_bytes'],
+                ];
+            }
+            return [
+                'artifact_id' => $artifact_id,
+                'status' => 'rejected',
+                'reason' => 'already_verified',
+                'committed_bytes' => $status['committed_bytes'],
+            ];
+        }
+
+        $committed = $status['committed_bytes'];
+        $end = $offset + strlen($payload);
+        if ($committed < $offset) {
+            return [
+                'artifact_id' => $artifact_id,
+                'status' => 'rejected',
+                'reason' => 'offset_gap',
+                'committed_bytes' => $committed,
+            ];
+        }
+        if ($committed > $offset) {
+            // Skip the prefix the store already holds.
+            $payload = substr($payload, min(strlen($payload), $committed - $offset));
+            $offset = $committed;
+        }
+        while ($payload !== '') {
+            $piece = substr($payload, 0, $this->append_buffer_bytes);
+            $payload = (string) substr($payload, strlen($piece));
+            $result = $this->store->append($artifact_id, $offset, $piece);
+            if ($result['status'] !== 'accepted' && $result['status'] !== 'duplicate') {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => $result['status'],
+                    'reason' => $result['reason'],
+                    'committed_bytes' => $result['committed_bytes'],
+                ];
+            }
+            $offset = $result['committed_bytes'];
+        }
+        $offset = max($offset, $end);
+
+        if (!$final) {
+            return [
+                'artifact_id' => $artifact_id,
+                'status' => 'accepted',
+                'reason' => null,
+                'committed_bytes' => $offset,
+            ];
+        }
+
+        $finalized = $this->store->finalize($artifact_id, $total_bytes);
+        return [
+            'artifact_id' => $artifact_id,
+            'status' => $finalized['status'],
+            'reason' => $finalized['reason'],
+            'committed_bytes' => $finalized['committed_bytes'],
+        ];
+    }
+
+    /**
+     * @return array{http_code:int,body:array}
+     */
+    private function batch_response(int $http_code, ?string $reason, ?string $detail, array $results): array {
+        $body = [
+            'status' => $http_code === 200 ? 'ok' : ( $http_code === 423 ? 'busy' : 'rejected' ),
+            'reason' => $reason,
+            'detail' => $detail,
+            'results' => $results,
+        ];
+        if ($http_code === 413) {
+            $body['max_request_bytes'] = $this->max_request_bytes;
+        }
+        return [
+            'http_code' => $http_code,
+            'body' => $body,
+        ];
+    }
+
+    /**
+     * @return string|null Null when the spool ends before $bytes.
+     */
+    private function read_spool_exactly($spool, int $bytes): ?string {
+        $data = '';
+        while (strlen($data) < $bytes) {
+            $piece = fread($spool, $bytes - strlen($data));
+            if ($piece === false || $piece === '') {
+                return null;
+            }
+            $data .= $piece;
+        }
+        return $data;
+    }
+
+    /**
+     * Spools the request body while hashing it, then verifies the digest
+     * against the signed claim. Nothing may act on a body byte before the
+     * verification passes.
+     *
+     * @param resource|null $input
+     * @param ?string $too_large_artifact_id Names the artifact whose
+     *   committed offset a 413 should report; null for batch bodies.
+     * @return array{response?:array{http_code:int,body:array},spool?:resource,bytes?:int}
+     */
+    private function spool_verified_body(array $auth, $input, ?string $too_large_artifact_id): array {
+        if (!is_resource($input)) {
+            return ['response' => $this->rejected(500, 'io_error', 'open_request_body')];
+        }
+        $spool = fopen('php://temp/maxmemory:' . self::SPOOL_MEMORY_BYTES, 'w+b');
+        if ($spool === false) {
+            return ['response' => $this->rejected(500, 'io_error', 'open_spool')];
+        }
+
+        $context = hash_init('sha256');
+        $spooled = 0;
+        while (( $buffer = fread($input, self::READ_BUFFER_BYTES) ) !== false && $buffer !== '') {
+            $spooled += strlen($buffer);
+            if ($spooled > $this->max_request_bytes) {
+                fclose($spool);
+                return ['response' => $too_large_artifact_id !== null
+                    ? $this->too_large($too_large_artifact_id)
+                    : $this->batch_response(413, 'request_too_large', null, [])];
+            }
+            hash_update($context, $buffer);
+            if (fwrite($spool, $buffer) !== strlen($buffer)) {
+                fclose($spool);
+                return ['response' => $this->rejected(500, 'io_error', 'write_spool')];
+            }
+        }
+        if ($buffer === false && !feof($input)) {
+            fclose($spool);
+            return ['response' => $this->rejected(400, 'body_read_failed')];
+        }
+
+        // The signature authenticated the hash claim; this comparison
+        // authenticates the bytes. Nothing reached the store yet.
+        if (!hash_equals((string) $auth['content_hash'], hash_final($context))) {
+            fclose($spool);
+            return ['response' => $this->rejected(403, 'content_hash_mismatch')];
+        }
+        if ($spooled === 0) {
+            fclose($spool);
+            return ['response' => $this->rejected(400, 'empty_body')];
+        }
+
+        rewind($spool);
+        return [
+            'spool' => $spool,
+            'bytes' => $spooled,
+        ];
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -367,19 +367,21 @@ final class Site_Export_Staged_Endpoints {
                 ) {
                     return $this->batch_response(400, 'invalid_batch_frame', substr($line, 0, 200), $results);
                 }
-                $payload = $frame['length'] > 0 ? $this->read_spool_exactly($spool, $frame['length']) : '';
-                if ($payload === null) {
-                    return $this->batch_response(400, 'truncated_batch', $frame['artifact_id'], $results);
-                }
-
-                $outcome = $this->stage_batch_frame($frame, $payload);
+                $outcome = $this->stage_batch_frame($frame, $spool);
                 $results[] = $outcome;
                 if ($outcome['status'] === 'rejected' || $outcome['status'] === 'busy') {
                     // Everything before this frame is committed and
                     // reported; the sender retries from here.
-                    $code = $outcome['status'] === 'busy'
-                        ? 423
-                        : ( ($outcome['reason'] ?? null) === 'io_error' ? 500 : 409 );
+                    $reason = $outcome['reason'] ?? null;
+                    if ($outcome['status'] === 'busy') {
+                        $code = 423;
+                    } elseif ($reason === 'io_error') {
+                        $code = 500;
+                    } elseif ($reason === 'truncated_batch') {
+                        $code = 400;
+                    } else {
+                        $code = 409;
+                    }
                     return $this->batch_response($code, $outcome['reason'], $outcome['artifact_id'], $results);
                 }
             }
@@ -398,14 +400,23 @@ final class Site_Export_Staged_Endpoints {
      *
      * @return array{artifact_id:string,status:string,reason:?string,committed_bytes:int}
      */
-    private function stage_batch_frame(array $frame, string $payload): array {
+    private function stage_batch_frame(array $frame, $spool): array {
         $artifact_id = $frame['artifact_id'];
         $offset = $frame['offset'];
         $final = !empty($frame['final']);
         $total_bytes = $frame['total_bytes'];
+        $remaining = $frame['length'];
 
         $status = $this->store->status($artifact_id);
         if ($status['verified']) {
+            if (!$this->skip_spool_bytes($spool, $remaining)) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'rejected',
+                    'reason' => 'truncated_batch',
+                    'committed_bytes' => $status['committed_bytes'],
+                ];
+            }
             // A retried batch re-sends artifacts an earlier attempt already
             // landed; at the recorded size that is success, not conflict.
             if ($status['committed_bytes'] === $total_bytes) {
@@ -425,7 +436,7 @@ final class Site_Export_Staged_Endpoints {
         }
 
         $committed = $status['committed_bytes'];
-        $end = $offset + strlen($payload);
+        $end = $offset + $remaining;
         if ($committed < $offset) {
             return [
                 'artifact_id' => $artifact_id,
@@ -436,12 +447,28 @@ final class Site_Export_Staged_Endpoints {
         }
         if ($committed > $offset) {
             // Skip the prefix the store already holds.
-            $payload = substr($payload, min(strlen($payload), $committed - $offset));
+            $skipped = min($remaining, $committed - $offset);
+            if (!$this->skip_spool_bytes($spool, $skipped)) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'rejected',
+                    'reason' => 'truncated_batch',
+                    'committed_bytes' => $committed,
+                ];
+            }
+            $remaining -= $skipped;
             $offset = $committed;
         }
-        while ($payload !== '') {
-            $piece = substr($payload, 0, $this->append_buffer_bytes);
-            $payload = (string) substr($payload, strlen($piece));
+        while ($remaining > 0) {
+            $piece = $this->read_spool_exactly($spool, min($this->append_buffer_bytes, $remaining));
+            if ($piece === null) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'rejected',
+                    'reason' => 'truncated_batch',
+                    'committed_bytes' => $offset,
+                ];
+            }
             $result = $this->store->append($artifact_id, $offset, $piece);
             if ($result['status'] !== 'accepted' && $result['status'] !== 'duplicate') {
                 return [
@@ -452,6 +479,7 @@ final class Site_Export_Staged_Endpoints {
                 ];
             }
             $offset = $result['committed_bytes'];
+            $remaining -= strlen($piece);
         }
         $offset = max($offset, $end);
 
@@ -505,6 +533,30 @@ final class Site_Export_Staged_Endpoints {
             $data .= $piece;
         }
         return $data;
+    }
+
+    private function skip_spool_bytes($spool, int $bytes): bool {
+        if ($bytes <= 0) {
+            return true;
+        }
+        $position = ftell($spool);
+        $stat = fstat($spool);
+        if (is_int($position) && is_array($stat) && isset($stat['size'])) {
+            if ($position + $bytes > (int) $stat['size']) {
+                return false;
+            }
+            if (fseek($spool, $bytes, SEEK_CUR) === 0) {
+                return true;
+            }
+        }
+        while ($bytes > 0) {
+            $piece = fread($spool, min($this->append_buffer_bytes, $bytes));
+            if ($piece === false || $piece === '') {
+                return false;
+            }
+            $bytes -= strlen($piece);
+        }
+        return true;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -52,6 +52,9 @@ class StagedPushRunner
         "source_changed",
     ];
 
+    /** Per-file allowance for a batch frame's JSON header line. */
+    private const BATCH_FRAME_OVERHEAD = 256;
+
     private string $state_path;
 
     private string $verified_path;
@@ -145,6 +148,8 @@ class StagedPushRunner
         $files_done = 0;
         $failed = [];
 
+        // Collect the work first; batching decisions need the whole list.
+        $queue = [];
         foreach ($artifacts as $entry) {
             $artifact_id = $entry["artifact_id"] ?? null;
             $source_path = $entry["source_path"] ?? null;
@@ -195,37 +200,111 @@ class StagedPushRunner
                 $this->client->discard($artifact_id);
             }
 
-            $result = $this->client->upload_artifact(
-                $artifact_id,
-                $source_path,
-                $total_bytes,
-                function (int $committed, int $total) use ($files_done, $files_total, $artifact_id): void {
-                    $this->report_progress($files_done, $files_total, $artifact_id, $committed, $total);
-                },
-                $mtime
-            );
+            $queue[] = [
+                "artifact_id" => $artifact_id,
+                "source_path" => $source_path,
+                "total_bytes" => $total_bytes,
+                "mtime" => $mtime,
+            ];
+        }
 
-            if ($result["status"] === "verified") {
-                $files_done++;
-                $this->append_verified($artifact_id, $total_bytes, $mtime);
+        // Process the queue: files that fit the sizer's request budget
+        // travel together — one HTTP conversation per batch, pull's
+        // multipart discipline in the push direction. Files bigger than
+        // the budget keep the resumable per-chunk path. A 413 shrinks the
+        // budget (monotonically, so this terminates) and the affected
+        // batch repartitions.
+        while ($queue !== []) {
+            $budget = max(1, $this->sizer->chunk_bytes());
+
+            if ($queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
+                $entry = array_shift($queue);
+                $result = $this->client->upload_artifact(
+                    $entry["artifact_id"],
+                    $entry["source_path"],
+                    $entry["total_bytes"],
+                    function (int $committed, int $total) use ($files_done, $files_total, $entry): void {
+                        $this->report_progress($files_done, $files_total, $entry["artifact_id"], $committed, $total);
+                    },
+                    $entry["mtime"]
+                );
+
+                if ($result["status"] === "verified") {
+                    $files_done++;
+                    $this->append_verified($entry["artifact_id"], $entry["total_bytes"], $entry["mtime"]);
+                    $this->write_state($files_total, $files_done);
+                    $this->report_progress($files_done, $files_total, $entry["artifact_id"], $entry["total_bytes"], $entry["total_bytes"]);
+                    continue;
+                }
+                $reason = is_string($result["reason"]) ? $result["reason"] : "unexpected_response";
+                if (in_array($reason, self::ARTIFACT_SCOPED_REASONS, true)) {
+                    $failed[] = [
+                        "artifact_id" => $entry["artifact_id"],
+                        "reason" => $reason,
+                        "detail" => $result["detail"],
+                    ];
+                    $this->write_state($files_total, $files_done);
+                    continue;
+                }
                 $this->write_state($files_total, $files_done);
-                $this->report_progress($files_done, $files_total, $artifact_id, $total_bytes, $total_bytes);
-                continue;
+                return $this->aborted($files_total, $files_done, $failed, $reason, $result["detail"]);
             }
 
-            $reason = is_string($result["reason"]) ? $result["reason"] : "unexpected_response";
-            if (in_array($reason, self::ARTIFACT_SCOPED_REASONS, true)) {
-                $failed[] = [
-                    "artifact_id" => $artifact_id,
-                    "reason" => $reason,
-                    "detail" => $result["detail"],
-                ];
-                $this->write_state($files_total, $files_done);
-                continue;
+            $batch = [];
+            $batch_bytes = 0;
+            while (
+                $queue !== []
+                && $queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
+                && $batch_bytes + $queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
+            ) {
+                $entry = array_shift($queue);
+                $batch[$entry["artifact_id"]] = $entry;
+                $batch_bytes += $entry["total_bytes"] + self::BATCH_FRAME_OVERHEAD;
             }
 
+            $batch_result = $this->client->upload_batch(array_values($batch));
+
+            if ($batch_result["status"] === "failed") {
+                if ($batch_result["reason"] === "batch_too_large") {
+                    // The sizer already shrank; repartition these entries.
+                    foreach ($batch as $entry) {
+                        $queue[] = $entry;
+                    }
+                    continue;
+                }
+                $this->write_state($files_total, $files_done);
+                return $this->aborted($files_total, $files_done, $failed, $batch_result["reason"], $batch_result["detail"]);
+            }
+
+            foreach ($batch_result["per_file"] as $artifact_id => $outcome) {
+                $entry = $batch[$artifact_id] ?? null;
+                if ($entry === null) {
+                    continue;
+                }
+                if ($outcome["status"] === "verified") {
+                    $files_done++;
+                    $this->append_verified($artifact_id, $entry["total_bytes"], $entry["mtime"]);
+                    $this->report_progress($files_done, $files_total, $artifact_id, $entry["total_bytes"], $entry["total_bytes"]);
+                    continue;
+                }
+                if ($outcome["status"] === "not_attempted") {
+                    // The server stopped at an earlier frame; retry these.
+                    $queue[] = $entry;
+                    continue;
+                }
+                $reason = is_string($outcome["reason"]) ? $outcome["reason"] : "unexpected_response";
+                if (in_array($reason, self::ARTIFACT_SCOPED_REASONS, true)) {
+                    $failed[] = [
+                        "artifact_id" => $artifact_id,
+                        "reason" => $reason,
+                        "detail" => null,
+                    ];
+                    continue;
+                }
+                $this->write_state($files_total, $files_done);
+                return $this->aborted($files_total, $files_done, $failed, $reason, $artifact_id);
+            }
             $this->write_state($files_total, $files_done);
-            return $this->aborted($files_total, $files_done, $failed, $reason, $result["detail"]);
         }
 
         $this->write_state($files_total, $files_done);

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -383,6 +383,139 @@ class StagedUploadClient
     }
 
     /**
+     * Upload a batch of complete small files in one request.
+     *
+     * One HTTP conversation carries many files — push's answer to pull's
+     * multipart batching. Files are read whole (the caller only batches
+     * files that fit the sizer's budget), each with the same volatility
+     * checks as upload_artifact(); a file that changed underfoot fails
+     * "source_changed" locally and is excluded from the wire.
+     *
+     * @param array $files Entries: ['artifact_id','source_path','total_bytes','mtime'?].
+     * @return array{status:string,reason:?string,detail:?string,per_file:array<string,array{status:string,reason:?string}>}
+     *   "ok" means the request cycle finished and per_file holds each
+     *   file's outcome — "verified", "failed" (typed), or "not_attempted"
+     *   (the server stopped at an earlier frame; retry those). "failed"
+     *   carries a transfer-scoped reason; "batch_too_large" specifically
+     *   means the sizer shrank and the caller should repartition.
+     */
+    public function upload_batch(array $files): array
+    {
+        $per_file = [];
+        $body = "";
+        $sendable = [];
+        foreach ($files as $file) {
+            $artifact_id = (string) $file["artifact_id"];
+            $total_bytes = (int) $file["total_bytes"];
+            $source = @fopen((string) $file["source_path"], "rb");
+            if ($source === false) {
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_unreadable"];
+                continue;
+            }
+            $opened = fstat($source);
+            $expected_mtime = isset($file["mtime"]) ? (int) $file["mtime"] : null;
+            if (
+                $expected_mtime !== null
+                && is_array($opened)
+                && (int) $opened["mtime"] !== $expected_mtime
+            ) {
+                fclose($source);
+                $this->discard($artifact_id);
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
+                continue;
+            }
+            $payload = $total_bytes > 0 ? $this->read_exactly($source, $total_bytes) : "";
+            fclose($source);
+            clearstatcache(true, (string) $file["source_path"]);
+            $now_stat = @stat((string) $file["source_path"]);
+            if ($payload === null) {
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_short"];
+                continue;
+            }
+            if (
+                !is_array($opened)
+                || $now_stat === false
+                || $now_stat["ino"] !== $opened["ino"]
+                || $now_stat["mtime"] !== $opened["mtime"]
+                || $now_stat["size"] !== $opened["size"]
+            ) {
+                $this->discard($artifact_id);
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
+                continue;
+            }
+
+            $body .= json_encode([
+                "artifact_id" => $artifact_id,
+                "offset" => 0,
+                "length" => strlen($payload),
+                "total_bytes" => $total_bytes,
+                "final" => true,
+            ]) . "\n" . $payload;
+            $sendable[] = $artifact_id;
+        }
+
+        if ($sendable === []) {
+            return ["status" => "ok", "reason" => null, "detail" => null, "per_file" => $per_file];
+        }
+
+        $transport_failures = 0;
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES + self::MAX_TRANSPORT_RETRIES; $attempt++) {
+            $response = $this->request_json("POST", "staged_upload_batch", [], $body);
+            if ($response["error"] !== null) {
+                $decision = $this->sizer->record_transport_failure();
+                $transport_failures++;
+                if ($decision["action"] === "give_up" || $transport_failures > self::MAX_TRANSPORT_RETRIES) {
+                    return ["status" => "failed", "reason" => "transport_failed", "detail" => $response["error"], "per_file" => $per_file];
+                }
+                $this->backoff($transport_failures);
+                continue;
+            }
+            if ($this->is_auth_envelope($response)) {
+                return ["status" => "failed", "reason" => "auth_failed", "detail" => $this->envelope_error($response), "per_file" => $per_file];
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            if ($response["http_code"] === 413) {
+                $reported = $json["max_request_bytes"] ?? null;
+                $decision = $this->sizer->record_too_large(is_numeric($reported) ? (int) $reported : null);
+                if ($decision["action"] === "give_up") {
+                    return ["status" => "failed", "reason" => "chunk_size_exhausted", "detail" => null, "per_file" => $per_file];
+                }
+                return ["status" => "failed", "reason" => "batch_too_large", "detail" => null, "per_file" => $per_file];
+            }
+            if (($json["status"] ?? null) === "busy") {
+                $this->backoff($attempt);
+                continue;
+            }
+
+            foreach (($json["results"] ?? []) as $result) {
+                if (!is_array($result) || !is_string($result["artifact_id"] ?? null)) {
+                    continue;
+                }
+                if (($result["status"] ?? null) === "verified") {
+                    $per_file[$result["artifact_id"]] = ["status" => "verified", "reason" => null];
+                } else {
+                    $reason = $result["reason"] ?? null;
+                    $per_file[$result["artifact_id"]] = [
+                        "status" => "failed",
+                        "reason" => is_string($reason) ? $reason : "unexpected_response",
+                    ];
+                }
+            }
+            foreach ($sendable as $artifact_id) {
+                if (!isset($per_file[$artifact_id])) {
+                    // The server stopped at an earlier frame; these retry.
+                    $per_file[$artifact_id] = ["status" => "not_attempted", "reason" => null];
+                }
+            }
+            if (($json["status"] ?? null) === "ok") {
+                $this->sizer->record_success();
+            }
+            return ["status" => "ok", "reason" => null, "detail" => null, "per_file" => $per_file];
+        }
+        return ["status" => "failed", "reason" => "busy_exhausted", "detail" => null, "per_file" => $per_file];
+    }
+
+    /**
      * Ask the target to validate (check_only) or apply a staged transfer.
      *
      * check_only is the sender's early gate: an environment that can never

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -61,13 +61,19 @@ class StagedUploadClient
     /** Longest single backoff, in microseconds. */
     private const MAX_BACKOFF_USEC = 5000000;
 
+    /** Bytes copied at a time when composing streamed batch bodies. */
+    private const BATCH_STREAM_BUFFER_BYTES = 262144;
+
+    /** Batch spools stay in memory up to this size, then php://temp spills. */
+    private const BATCH_SPOOL_MEMORY_BYTES = 2097152;
+
     private string $base_url;
 
     private ?Site_Export_HMAC_Client $hmac_client;
 
     private UploadChunkSizer $sizer;
 
-    /** @var callable(string,string,array,string,int):array */
+    /** @var callable(string,string,array,mixed,int):array */
     private $transport;
 
     /** @var callable(int):void */
@@ -389,10 +395,11 @@ class StagedUploadClient
      * Upload a batch of complete small files in one request.
      *
      * One HTTP conversation carries many files — push's answer to pull's
-     * multipart batching. Files are read whole (the caller only batches
-     * files that fit the sizer's budget), each with the same volatility
-     * checks as upload_artifact(); a file that changed underfoot fails
-     * "source_changed" locally and is excluded from the wire.
+     * multipart batching. The request body is composed into a temp stream,
+     * not one PHP string: each source is copied through a bounded per-file
+     * spool, checked for volatility, then appended to the outgoing stream.
+     * Files that changed underfoot fail "source_changed" locally and are
+     * excluded from the wire.
      *
      * @param array $files Entries: ['artifact_id','source_path','total_bytes','mtime'?].
      * @return array{status:string,reason:?string,detail:?string,per_file:array<string,array{status:string,reason:?string}>}
@@ -405,7 +412,11 @@ class StagedUploadClient
     public function upload_batch(array $files): array
     {
         $per_file = [];
-        $body = "";
+        $body = $this->open_batch_spool();
+        if ($body === false) {
+            return ["status" => "failed", "reason" => "source_unreadable", "detail" => "open_batch_spool", "per_file" => $per_file];
+        }
+        $hash = hash_init("sha256");
         $sendable = [];
         foreach ($files as $file) {
             $artifact_id = (string) $file["artifact_id"];
@@ -427,7 +438,7 @@ class StagedUploadClient
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
                 continue;
             }
-            $payload = $total_bytes > 0 ? $this->read_exactly($source, $total_bytes) : "";
+            $payload = $this->copy_source_to_spool($source, $total_bytes);
             fclose($source);
             clearstatcache(true, (string) $file["source_path"]);
             $now_stat = @stat((string) $file["source_path"]);
@@ -442,38 +453,53 @@ class StagedUploadClient
                 || $now_stat["mtime"] !== $opened["mtime"]
                 || $now_stat["size"] !== $opened["size"]
             ) {
+                fclose($payload);
                 $this->discard($artifact_id);
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
                 continue;
             }
 
-            $body .= json_encode([
+            $header = json_encode([
                 "artifact_id" => $artifact_id,
                 "offset" => 0,
-                "length" => strlen($payload),
+                "length" => $total_bytes,
                 "total_bytes" => $total_bytes,
                 "final" => true,
-            ]) . "\n" . $payload;
+            ]) . "\n";
+            if (
+                !$this->write_batch_bytes($body, $hash, $header)
+                || !$this->write_batch_stream($body, $hash, $payload)
+            ) {
+                fclose($payload);
+                fclose($body);
+                return ["status" => "failed", "reason" => "source_unreadable", "detail" => "write_batch_spool", "per_file" => $per_file];
+            }
+            fclose($payload);
             $sendable[] = $artifact_id;
         }
 
         if ($sendable === []) {
+            fclose($body);
             return ["status" => "ok", "reason" => null, "detail" => null, "per_file" => $per_file];
         }
 
+        rewind($body);
+        $content_hash = hash_final($hash);
         $transport_failures = 0;
         for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES + self::MAX_TRANSPORT_RETRIES; $attempt++) {
-            $response = $this->request_json("POST", "staged_upload_batch", [], $body);
+            $response = $this->request_json("POST", "staged_upload_batch", [], $body, $content_hash);
             if ($response["error"] !== null) {
                 $decision = $this->sizer->record_transport_failure();
                 $transport_failures++;
                 if ($decision["action"] === "give_up" || $transport_failures > self::MAX_TRANSPORT_RETRIES) {
+                    fclose($body);
                     return ["status" => "failed", "reason" => "transport_failed", "detail" => $response["error"], "per_file" => $per_file];
                 }
                 $this->backoff($transport_failures);
                 continue;
             }
             if ($this->is_auth_envelope($response)) {
+                fclose($body);
                 return ["status" => "failed", "reason" => "auth_failed", "detail" => $this->envelope_error($response), "per_file" => $per_file];
             }
             $json = is_array($response["json"]) ? $response["json"] : [];
@@ -481,8 +507,10 @@ class StagedUploadClient
                 $reported = $json["max_request_bytes"] ?? null;
                 $decision = $this->sizer->record_too_large(is_numeric($reported) ? (int) $reported : null);
                 if ($decision["action"] === "give_up") {
+                    fclose($body);
                     return ["status" => "failed", "reason" => "chunk_size_exhausted", "detail" => null, "per_file" => $per_file];
                 }
+                fclose($body);
                 return ["status" => "failed", "reason" => "batch_too_large", "detail" => null, "per_file" => $per_file];
             }
             if (($json["status"] ?? null) === "busy") {
@@ -513,8 +541,10 @@ class StagedUploadClient
             if (($json["status"] ?? null) === "ok") {
                 $this->sizer->record_success();
             }
+            fclose($body);
             return ["status" => "ok", "reason" => null, "detail" => null, "per_file" => $per_file];
         }
+        fclose($body);
         return ["status" => "failed", "reason" => "busy_exhausted", "detail" => null, "per_file" => $per_file];
     }
 
@@ -646,16 +676,27 @@ class StagedUploadClient
      *
      * @return array{http_code:int,json:mixed,error:?string}
      */
-    private function request_json(string $method, string $endpoint, array $params, string $body = ""): array
+    private function request_json(string $method, string $endpoint, array $params, $body = "", ?string $content_hash = null): array
     {
         $url = $this->base_url
             . (strpos($this->base_url, "?") === false ? "?" : "&")
             . http_build_query(array_merge(["endpoint" => $endpoint], $params));
 
-        $headers = $this->hmac_client !== null
-            ? $this->hmac_client->get_auth_headers($body)
-            : [];
+        if (is_resource($body)) {
+            rewind($body);
+        }
+        $headers = [];
+        if ($this->hmac_client !== null) {
+            if ($content_hash === null) {
+                $content_hash = is_resource($body) ? $this->hash_stream($body) : hash("sha256", (string) $body);
+            }
+            $headers = $this->auth_headers_for_hash($content_hash);
+        }
         $headers["Content-Type"] = "application/octet-stream";
+        if (is_resource($body)) {
+            $headers["Content-Length"] = (string) $this->stream_size($body);
+            rewind($body);
+        }
 
         $response = call_user_func($this->transport, $method, $url, $headers, $body, $this->request_timeout);
 
@@ -681,6 +722,98 @@ class StagedUploadClient
             "json" => $decoded,
             "error" => null,
         ];
+    }
+
+    /** @return resource|false */
+    private function open_batch_spool()
+    {
+        return fopen("php://temp/maxmemory:" . self::BATCH_SPOOL_MEMORY_BYTES, "w+b");
+    }
+
+    /** @return resource|null */
+    private function copy_source_to_spool($source, int $bytes)
+    {
+        $spool = $this->open_batch_spool();
+        if ($spool === false) {
+            return null;
+        }
+        $remaining = $bytes;
+        while ($remaining > 0) {
+            $chunk = fread($source, min(self::BATCH_STREAM_BUFFER_BYTES, $remaining));
+            if ($chunk === false || $chunk === "") {
+                fclose($spool);
+                return null;
+            }
+            $written = fwrite($spool, $chunk);
+            if ($written !== strlen($chunk)) {
+                fclose($spool);
+                return null;
+            }
+            $remaining -= strlen($chunk);
+        }
+        rewind($spool);
+        return $spool;
+    }
+
+    private function write_batch_bytes($body, $hash, string $bytes): bool
+    {
+        hash_update($hash, $bytes);
+        return fwrite($body, $bytes) === strlen($bytes);
+    }
+
+    private function write_batch_stream($body, $hash, $source): bool
+    {
+        rewind($source);
+        while (!feof($source)) {
+            $chunk = fread($source, self::BATCH_STREAM_BUFFER_BYTES);
+            if ($chunk === false) {
+                return false;
+            }
+            if ($chunk === "") {
+                break;
+            }
+            if (!$this->write_batch_bytes($body, $hash, $chunk)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function auth_headers_for_hash(string $content_hash): array
+    {
+        $client = $this->hmac_client;
+        if ($client === null) {
+            return [];
+        }
+        $nonce = $client->generate_nonce();
+        $timestamp = $client->get_timestamp();
+        return [
+            "X-Auth-Signature" => $client->compute_signature($nonce, $timestamp, $content_hash),
+            "X-Auth-Nonce" => $nonce,
+            "X-Auth-Timestamp" => $timestamp,
+            "X-Auth-Content-Hash" => $content_hash,
+        ];
+    }
+
+    private function hash_stream($stream): string
+    {
+        rewind($stream);
+        $context = hash_init("sha256");
+        while (!feof($stream)) {
+            $chunk = fread($stream, self::BATCH_STREAM_BUFFER_BYTES);
+            if ($chunk === false || $chunk === "") {
+                break;
+            }
+            hash_update($context, $chunk);
+        }
+        rewind($stream);
+        return hash_final($context);
+    }
+
+    private function stream_size($stream): int
+    {
+        $stat = fstat($stream);
+        return is_array($stat) && isset($stat["size"]) ? (int) $stat["size"] : 0;
     }
 
     /**
@@ -724,7 +857,7 @@ class StagedUploadClient
      *
      * @return array{http_code:int,body:string,error:?string}
      */
-    private function curl_transport(string $method, string $url, array $headers, string $body, int $timeout): array
+    private function curl_transport(string $method, string $url, array $headers, $body, int $timeout): array
     {
         $ch = curl_init($url);
         if (function_exists("reprint_apply_curl_proxy_from_env")) {
@@ -739,14 +872,28 @@ class StagedUploadClient
             $header_lines[] = "{$name}: {$value}";
         }
 
-        curl_setopt_array($ch, [
+        $options = [
             CURLOPT_CUSTOMREQUEST => $method,
-            CURLOPT_POSTFIELDS => $method === "POST" ? $body : null,
             CURLOPT_HTTPHEADER => $header_lines,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_TIMEOUT => $timeout,
-        ]);
+        ];
+        if ($method === "POST") {
+            if (is_resource($body)) {
+                rewind($body);
+                $options[CURLOPT_UPLOAD] = true;
+                $options[CURLOPT_INFILESIZE] = $this->stream_size($body);
+                $options[CURLOPT_READFUNCTION] = static function ($ch, $fd, int $length) use ($body): string {
+                    $chunk = fread($body, $length);
+                    return $chunk === false ? "" : $chunk;
+                };
+            } else {
+                $options[CURLOPT_POSTFIELDS] = (string) $body;
+            }
+        }
+
+        curl_setopt_array($ch, $options);
 
         $response_body = curl_exec($ch);
         if ($response_body === false) {

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -535,7 +535,7 @@ class StagedUploadClient
             if (($json["status"] ?? null) === "rejected") {
                 $detail = $json["detail"] ?? null;
                 $reported = is_string($detail) ? ($per_file[$detail] ?? null) : null;
-                if (!is_array($reported) || ($reported["status"] ?? null) !== "failed") {
+                if (!is_array($reported) || $reported["status"] !== "failed") {
                     $reason = $json["reason"] ?? null;
                     fclose($body);
                     return [

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -532,6 +532,20 @@ class StagedUploadClient
                     ];
                 }
             }
+            if (($json["status"] ?? null) === "rejected") {
+                $detail = $json["detail"] ?? null;
+                $reported = is_string($detail) ? ($per_file[$detail] ?? null) : null;
+                if (!is_array($reported) || ($reported["status"] ?? null) !== "failed") {
+                    $reason = $json["reason"] ?? null;
+                    fclose($body);
+                    return [
+                        "status" => "failed",
+                        "reason" => is_string($reason) ? $reason : "unexpected_response",
+                        "detail" => is_string($detail) ? $detail : null,
+                        "per_file" => $per_file,
+                    ];
+                }
+            }
             foreach ($sendable as $artifact_id) {
                 if (!isset($per_file[$artifact_id])) {
                     // The server stopped at an earlier frame; these retry.

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-apply",
+            "version": "dev-push/upload-batches",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -207,6 +207,18 @@ function _site_export_staged_options(): array {
 }
 
 /**
+ * Data-plane endpoints authenticate inside their handlers.
+ *
+ * The default HMAC handler buffers php://input to hash it, which defeats the
+ * staged upload handlers' spool-then-verify discipline. Keep this list next
+ * to the public request handler so every large-body route makes an explicit
+ * auth decision.
+ */
+function _site_export_endpoint_authenticates_in_handler(string $endpoint): bool {
+    return in_array($endpoint, ['staged_upload', 'staged_upload_batch'], true);
+}
+
+/**
  * Handle an export API request.
  *
  * WordPress is already loaded at this point — DB credentials, $table_prefix,
@@ -277,18 +289,18 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    // staged_upload authenticates inside its handler: the default handler
-    // here buffers the whole request body to hash it, which a chunk upload
-    // cannot afford. The upload route verifies the signed headers first and
-    // hashes the body as it streams. A custom authenticate callable still
-    // runs for every endpoint — its embedder owns that tradeoff.
+    // Staged data-plane endpoints authenticate inside their handlers: the
+    // default handler here buffers the whole request body to hash it, which
+    // chunk and batch uploads cannot afford. Those routes verify the signed
+    // headers first and hash the body as it streams. A custom authenticate
+    // callable still runs for every endpoint — its embedder owns that tradeoff.
     // filter_input, not WP sanitizers: lib.php also runs without WordPress
     // bootstrapped (hosts that route the API from their own index.php).
     $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
-    } elseif ($endpoint !== 'staged_upload') {
+    } elseif (!_site_export_endpoint_authenticates_in_handler($endpoint)) {
         _site_export_default_authenticate();
     }
 

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -111,9 +111,9 @@ class PushFilesCliTest extends TestCase
         ]);
 
         $this->assertSame(2, $code, 'a transient connection failure follows the resume convention');
-        // The very first request is the status resync, so a dead target
-        // surfaces as status_unavailable — classified retryable.
-        $this->assertStringContainsString('status_unavailable', $output);
+        // Small files travel batched, so the dead target surfaces on the
+        // batch POST as transport_failed — classified retryable.
+        $this->assertStringContainsString('transport_failed', $output);
         $this->assertFileExists(
             $this->state_dir . '/.push-state.json',
             'learned sizer state persists across the abort'

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -95,6 +95,13 @@ class StagedPushRunnerTest extends TestCase
                 case 'staged_discard':
                     $result = $endpoints->discard($params, $server);
                     break;
+                case 'staged_upload_batch':
+                    $stream = fopen('php://temp', 'w+b');
+                    fwrite($stream, $body);
+                    rewind($stream);
+                    $result = $endpoints->upload_batch($params, $server, $stream);
+                    fclose($stream);
+                    break;
                 default:
                     return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
             }
@@ -463,5 +470,67 @@ class StagedPushRunnerTest extends TestCase
         $state = StagedPushRunner::read_state($this->state_dir . '-never-created');
 
         $this->assertSame(['sizer' => [], 'files_total' => 0, 'files_done' => 0], $state);
+    }
+
+    // ---------------------------------------------------------------
+    // Batched uploads
+    // ---------------------------------------------------------------
+
+    public function testSmallFilesTravelInBatchesNotOneRequestEach(): void
+    {
+        $plan = [];
+        for ($i = 0; $i < 6; $i++) {
+            $plan[] = $this->planEntry("small-{$i}.txt", "file number {$i}");
+        }
+        $sizer = new UploadChunkSizer(['floor_bytes' => 512, 'start_bytes' => 4096, 'max_bytes' => 4096]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()), [], null, $sizer);
+
+        $result = $runner->push($plan);
+
+        $this->assertSame(['completed', 6], [$result['status'], $result['files_done']]);
+        $this->assertCount(1, $this->requestsFor('staged_upload_batch'), 'six files, one conversation');
+        $this->assertCount(0, $this->requestsFor('staged_upload'), 'no per-file requests for small files');
+        $this->assertSame('file number 3', file_get_contents($this->staging_dir . '/files/small-3.txt'));
+    }
+
+    public function testMixedPlanBatchesSmallAndChunksLarge(): void
+    {
+        $plan = [
+            $this->planEntry('small-a.txt', 'aa'),
+            $this->planEntry('large.bin', str_repeat('L', 2000)),
+            $this->planEntry('small-b.txt', 'bb'),
+        ];
+        $sizer = new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 512, 'max_bytes' => 512]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()), [], null, $sizer);
+
+        $result = $runner->push($plan);
+
+        $this->assertSame(['completed', 3, []], [$result['status'], $result['files_done'], $result['failed']]);
+        $this->assertGreaterThanOrEqual(1, count($this->requestsFor('staged_upload_batch')));
+        $this->assertGreaterThanOrEqual(
+            4,
+            count($this->requestsFor('staged_upload')),
+            'the 2000-byte file streams in 512-byte chunks'
+        );
+        $this->assertSame(str_repeat('L', 2000), file_get_contents($this->staging_dir . '/files/large.bin'));
+    }
+
+    public function testBatchShrinksAfterA413AndCompletes(): void
+    {
+        $plan = [];
+        for ($i = 0; $i < 6; $i++) {
+            $plan[] = $this->planEntry("cap-{$i}.txt", str_repeat((string) $i, 40));
+        }
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 700]);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]);
+        [$runner] = $this->makeRunner($this->transportFor($endpoints), [], null, $sizer);
+
+        $result = $runner->push($plan);
+
+        $this->assertSame(['completed', 6, []], [$result['status'], $result['files_done'], $result['failed']]);
+        $this->assertNotEmpty(array_filter($this->requests, static function (array $request): bool {
+            return $request['http_code'] === 413;
+        }), 'the first oversized batch teaches the sizer');
+        $this->assertGreaterThanOrEqual(2, count($this->requestsFor('staged_upload_batch')), 'repartitioned batches');
     }
 }

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -68,7 +68,7 @@ class StagedPushRunnerTest extends TestCase
 
     private function transportFor(Site_Export_Staged_Endpoints $endpoints): callable
     {
-        return function (string $method, string $url, array $headers, string $body, int $timeout) use ($endpoints): array {
+        return function (string $method, string $url, array $headers, $body, int $timeout) use ($endpoints): array {
             parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
             $endpoint = (string) ($params['endpoint'] ?? '');
             unset($params['endpoint']);
@@ -81,7 +81,12 @@ class StagedPushRunnerTest extends TestCase
             switch ($endpoint) {
                 case 'staged_upload':
                     $stream = fopen('php://temp', 'w+b');
-                    fwrite($stream, $body);
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
                     rewind($stream);
                     $result = $endpoints->upload($params, $server, $stream);
                     fclose($stream);
@@ -97,7 +102,12 @@ class StagedPushRunnerTest extends TestCase
                     break;
                 case 'staged_upload_batch':
                     $stream = fopen('php://temp', 'w+b');
-                    fwrite($stream, $body);
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
                     rewind($stream);
                     $result = $endpoints->upload_batch($params, $server, $stream);
                     fclose($stream);

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -98,6 +98,13 @@ class StagedUploadClientTest extends TestCase
                 case 'staged_discard':
                     $result = $endpoints->discard($params, $server);
                     break;
+                case 'staged_upload_batch':
+                    $stream = fopen('php://temp', 'w+b');
+                    fwrite($stream, $body);
+                    rewind($stream);
+                    $result = $endpoints->upload_batch($params, $server, $stream);
+                    fclose($stream);
+                    break;
                 default:
                     return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
             }
@@ -451,6 +458,92 @@ class StagedUploadClientTest extends TestCase
         $result = $client->upload_artifact('artifact.bin', $this->source_path . '-missing');
 
         $this->assertSame(['failed', 'source_unreadable'], [$result['status'], $result['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Batched uploads
+    // ---------------------------------------------------------------
+
+    /** Creates one temp file per artifact; returns upload_batch entries. */
+    private function batchFiles(array $map): array
+    {
+        $entries = [];
+        foreach ($map as $artifact_id => $body) {
+            $path = $this->source_path . '-' . md5($artifact_id);
+            file_put_contents($path, $body);
+            $entries[] = [
+                'artifact_id' => $artifact_id,
+                'source_path' => $path,
+                'total_bytes' => strlen($body),
+                'mtime' => (int) filemtime($path),
+            ];
+        }
+        return $entries;
+    }
+
+    public function testUploadBatchVerifiesManyFilesInOneRequest(): void
+    {
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles([
+            'a.txt' => 'aaa',
+            'wp-content/b.bin' => str_repeat('b', 200),
+            'empty.txt' => '',
+        ]);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame('ok', $result['status']);
+        foreach ($files as $file) {
+            $this->assertSame(
+                'verified',
+                $result['per_file'][$file['artifact_id']]['status'],
+                $file['artifact_id']
+            );
+            $this->assertSame(
+                (string) file_get_contents($file['source_path']),
+                (string) file_get_contents($this->staging_dir . '/files/' . $file['artifact_id'])
+            );
+        }
+        $this->assertCount(1, array_filter($this->requests, static function (array $request): bool {
+            return $request['endpoint'] === 'staged_upload_batch';
+        }), 'many files, one conversation');
+    }
+
+    public function testUploadBatchRepartitionsWhenTooLarge(): void
+    {
+        $sizer = new UploadChunkSizer(['floor_bytes' => 16, 'start_bytes' => 256, 'max_bytes' => 256]);
+        $client = $this->makeClient(
+            $this->transportFor($this->makeEndpoints(['max_request_bytes' => 64])),
+            ['sizer' => $sizer]
+        );
+        $files = $this->batchFiles(['big-ish.bin' => str_repeat('x', 200)]);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame(['failed', 'batch_too_large'], [$result['status'], $result['reason']]);
+        $this->assertLessThanOrEqual(57, $sizer->chunk_bytes(), 'the sizer learned the cap');
+    }
+
+    public function testUploadBatchExcludesAVolatileFileLocally(): void
+    {
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles(['steady.txt' => 'fine', 'volatile.txt' => 'about to change']);
+        // The plan's mtime no longer matches the file: stale plan.
+        $files[1]['mtime'] = $files[1]['mtime'] - 100;
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertSame('verified', $result['per_file']['steady.txt']['status']);
+        $this->assertSame(
+            ['failed', 'source_changed'],
+            [$result['per_file']['volatile.txt']['status'], $result['per_file']['volatile.txt']['reason']]
+        );
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/volatile.txt', 'stale content never travels');
     }
 
     // ---------------------------------------------------------------

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -70,7 +70,7 @@ class StagedUploadClientTest extends TestCase
      */
     private function transportFor(Site_Export_Staged_Endpoints $endpoints): callable
     {
-        return function (string $method, string $url, array $headers, string $body, int $timeout) use ($endpoints): array {
+        return function (string $method, string $url, array $headers, $body, int $timeout) use ($endpoints): array {
             parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
             $endpoint = (string) ($params['endpoint'] ?? '');
             unset($params['endpoint']);
@@ -84,7 +84,12 @@ class StagedUploadClientTest extends TestCase
             switch ($endpoint) {
                 case 'staged_upload':
                     $stream = fopen('php://temp', 'w+b');
-                    fwrite($stream, $body);
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
                     rewind($stream);
                     $result = $endpoints->upload($params, $server, $stream);
                     fclose($stream);
@@ -100,7 +105,12 @@ class StagedUploadClientTest extends TestCase
                     break;
                 case 'staged_upload_batch':
                     $stream = fopen('php://temp', 'w+b');
-                    fwrite($stream, $body);
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
                     rewind($stream);
                     $result = $endpoints->upload_batch($params, $server, $stream);
                     fclose($stream);
@@ -515,6 +525,35 @@ class StagedUploadClientTest extends TestCase
         $this->assertCount(1, array_filter($this->requests, static function (array $request): bool {
             return $request['endpoint'] === 'staged_upload_batch';
         }), 'many files, one conversation');
+    }
+
+    public function testUploadBatchSendsAStreamedRequestBody(): void
+    {
+        $base = $this->transportFor($this->makeEndpoints());
+        $saw_batch_stream = false;
+        $transport = function (string $method, string $url, array $headers, $body, int $timeout) use ($base, &$saw_batch_stream): array {
+            parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+            if (($params['endpoint'] ?? '') === 'staged_upload_batch') {
+                $saw_batch_stream = true;
+                $this->assertTrue(is_resource($body), 'batch body should not be materialized as one PHP string');
+                $stat = fstat($body);
+                $this->assertIsArray($stat);
+                $this->assertSame((string) $stat['size'], $headers['Content-Length'] ?? null);
+            }
+            return $base($method, $url, $headers, $body, $timeout);
+        };
+        $client = $this->makeClient($transport, [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles([
+            'a.txt' => str_repeat('a', 128),
+            'b.txt' => str_repeat('b', 128),
+        ]);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertTrue($saw_batch_stream, 'the test must exercise the batch endpoint');
     }
 
     public function testUploadBatchRepartitionsWhenTooLarge(): void

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -571,6 +571,33 @@ class StagedUploadClientTest extends TestCase
         $this->assertLessThanOrEqual(57, $sizer->chunk_bytes(), 'the sizer learned the cap');
     }
 
+    public function testUploadBatchFailsTopLevelRejectedProtocolErrors(): void
+    {
+        $calls = 0;
+        $client = $this->makeClient(static function () use (&$calls): array {
+            $calls++;
+            return [
+                'http_code' => 400,
+                'body' => (string) json_encode([
+                    'status' => 'rejected',
+                    'reason' => 'invalid_batch_frame',
+                    'detail' => 'not json at all',
+                    'results' => [],
+                ]),
+                'error' => null,
+            ];
+        }, [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles(['a.txt' => 'aaa']);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame(['failed', 'invalid_batch_frame'], [$result['status'], $result['reason']]);
+        $this->assertSame('not json at all', $result['detail']);
+        $this->assertSame(1, $calls, 'malformed batch responses are not retried as sendable files');
+    }
+
     public function testUploadBatchExcludesAVolatileFileLocally(): void
     {
         $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [

--- a/tests/SiteExportLibraryAuthTest.php
+++ b/tests/SiteExportLibraryAuthTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SiteExportLibraryAuthTest extends TestCase
+{
+    private const LIB_PATH = __DIR__ . '/../reprint-exporter-wp/lib.php';
+
+    public function testLargeBodyStagedEndpointsAuthenticateInTheirHandlers(): void
+    {
+        $script = <<<PHP
+        define('ABSPATH', __DIR__ . '/');
+        define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/');
+        require '{$this->libPath()}';
+
+        echo '__RESULT__' . json_encode([
+            'chunk' => _site_export_endpoint_authenticates_in_handler('staged_upload'),
+            'batch' => _site_export_endpoint_authenticates_in_handler('staged_upload_batch'),
+            'control' => _site_export_endpoint_authenticates_in_handler('staged_status'),
+        ]);
+        PHP;
+
+        $result = json_decode($this->resultJson($this->runScript($script)), true);
+
+        $this->assertSame([
+            'chunk' => true,
+            'batch' => true,
+            'control' => false,
+        ], $result);
+    }
+
+    private function resultJson(string $output): string
+    {
+        $marker = '__RESULT__';
+        $position = strrpos($output, $marker);
+        $this->assertNotFalse($position, $output);
+        return substr($output, $position + strlen($marker));
+    }
+
+    private function libPath(): string
+    {
+        $path = realpath(self::LIB_PATH);
+        $this->assertNotFalse($path);
+        return $path;
+    }
+
+    private function runScript(string $body): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/site-export-library-auth-' . uniqid();
+        mkdir($tmp_dir, 0755, true);
+
+        try {
+            $php_path = $tmp_dir . '/run.php';
+            file_put_contents($php_path, "<?php\n" . $body . "\n");
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open([PHP_BINARY, $php_path], $descriptors, $pipes, $tmp_dir);
+            if (!is_resource($process)) {
+                $this->fail('Failed to spawn PHP subprocess');
+            }
+
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            if (($stdout ?: '') === '') {
+                return $stderr ?: '';
+            }
+            return $stdout;
+        } finally {
+            array_map('unlink', glob($tmp_dir . '/*') ?: []);
+            rmdir($tmp_dir);
+        }
+    }
+}

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -634,6 +634,51 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($this->staging_dir . '/files');
     }
 
+    public function testDuplicateIdWithinOneBatchIsIdempotent(): void
+    {
+        // A sender bug or a repartition edge can put the same file into
+        // one request twice. The second frame must land on the verified
+        // short-circuit — never doubled bytes, never a poisoned batch.
+        $endpoints = $this->makeEndpoints();
+        $frame = json_encode([
+            'artifact_id' => 'twice.txt',
+            'offset' => 0,
+            'length' => 5,
+            'total_bytes' => 5,
+            'final' => true,
+        ]) . "\nhello";
+
+        $result = $this->uploadBatch($endpoints, $frame . $frame);
+
+        $this->assertSame(200, $result['http_code'], json_encode($result['body']));
+        $this->assertCount(2, $result['body']['results']);
+        $this->assertSame('verified', $result['body']['results'][0]['status']);
+        $this->assertSame('verified', $result['body']['results'][1]['status']);
+        $this->assertSame('hello', file_get_contents($this->staging_dir . '/files/twice.txt'));
+    }
+
+    public function testHostileFrameFieldsAreTypedRejections(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        // A negative length must not be fed to a read loop.
+        $negative = $this->uploadBatch(
+            $endpoints,
+            json_encode(['artifact_id' => 'n.txt', 'offset' => 0, 'length' => -5, 'total_bytes' => 5, 'final' => true]) . "\nhello"
+        );
+        $this->assertSame(400, $negative['http_code']);
+
+        // A traversal id inside a frame goes through the same path rule
+        // as the single-upload route: the store's typed rejection, and
+        // nothing lands outside the staging dir.
+        $hostile = $this->uploadBatch(
+            $endpoints,
+            json_encode(['artifact_id' => '../escape.txt', 'offset' => 0, 'length' => 5, 'total_bytes' => 5, 'final' => true]) . "\nhello"
+        );
+        $this->assertSame(409, $hostile['http_code']);
+        $this->assertFileDoesNotExist(dirname($this->staging_dir) . '/escape.txt');
+    }
+
     // ---------------------------------------------------------------
     // Dispatcher wiring
     // ---------------------------------------------------------------

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -643,6 +643,23 @@ final class StagedEndpointsTest extends TestCase {
         }
     }
 
+    public function testBatchRetryWithTruncatedVerifiedPayloadIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->uploadBatch($endpoints, $this->batchBody(['a.txt' => 'abcde']));
+        $truncated = json_encode([
+            'artifact_id' => 'a.txt',
+            'offset' => 0,
+            'length' => 5,
+            'total_bytes' => 5,
+            'final' => true,
+        ]) . "\nab";
+
+        $result = $this->uploadBatch($endpoints, $truncated);
+
+        $this->assertSame([400, 'truncated_batch'], [$result['http_code'], $result['body']['reason']]);
+    }
+
     public function testBatchStopsAtTheFirstBadFrameAndReportsProgress(): void
     {
         $endpoints = $this->makeEndpoints();

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -535,6 +535,106 @@ final class StagedEndpointsTest extends TestCase {
     }
 
     // ---------------------------------------------------------------
+    // Batched uploads: many files, one request
+    // ---------------------------------------------------------------
+
+    /** Builds the length-prefixed frame body for complete files. */
+    private function batchBody(array $files): string
+    {
+        $body = '';
+        foreach ($files as $artifact_id => $payload) {
+            $body .= json_encode([
+                'artifact_id' => $artifact_id,
+                'offset' => 0,
+                'length' => strlen($payload),
+                'total_bytes' => strlen($payload),
+                'final' => true,
+            ]) . "\n" . $payload;
+        }
+        return $body;
+    }
+
+    private function uploadBatch(Site_Export_Staged_Endpoints $endpoints, string $body, array $header_overrides = []): array
+    {
+        $stream = $this->bodyStream($body);
+        try {
+            return $endpoints->upload_batch([], $this->signedHeaders($body, $header_overrides), $stream);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testBatchStagesManyFilesInOneRequest(): void
+    {
+        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 8]);
+        $files = [
+            'index.php' => '<?php // root',
+            'wp-content/uploads/a.bin' => str_repeat('x', 100),
+            'empty.txt' => '',
+        ];
+
+        $result = $this->uploadBatch($endpoints, $this->batchBody($files));
+
+        $this->assertSame(200, $result['http_code'], json_encode($result['body']));
+        $this->assertSame('ok', $result['body']['status']);
+        $this->assertCount(3, $result['body']['results']);
+        foreach ($result['body']['results'] as $file_result) {
+            $this->assertSame('verified', $file_result['status'], json_encode($file_result));
+        }
+        foreach ($files as $artifact_id => $payload) {
+            $this->assertSame($payload, file_get_contents($this->staging_dir . '/files/' . $artifact_id));
+        }
+    }
+
+    public function testBatchRetryIsIdempotent(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $body = $this->batchBody(['a.txt' => 'aaa', 'b.txt' => 'bbbb']);
+        $this->uploadBatch($endpoints, $body);
+
+        // The response was lost; the sender retries the identical batch.
+        $retry = $this->uploadBatch($endpoints, $body);
+
+        $this->assertSame(200, $retry['http_code']);
+        foreach ($retry['body']['results'] as $file_result) {
+            $this->assertSame('verified', $file_result['status']);
+        }
+    }
+
+    public function testBatchStopsAtTheFirstBadFrameAndReportsProgress(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $body = $this->batchBody(['good.txt' => 'landed']) . "not json at all\n";
+
+        $result = $this->uploadBatch($endpoints, $body);
+
+        $this->assertSame(400, $result['http_code']);
+        $this->assertSame('invalid_batch_frame', $result['body']['reason']);
+        $this->assertCount(1, $result['body']['results'], 'work before the bad frame is reported');
+        $this->assertSame('verified', $result['body']['results'][0]['status']);
+        $this->assertSame('landed', file_get_contents($this->staging_dir . '/files/good.txt'));
+
+        $truncated = $this->uploadBatch(
+            $endpoints,
+            json_encode(['artifact_id' => 'short.txt', 'offset' => 0, 'length' => 100, 'total_bytes' => 100, 'final' => true]) . "\nonly-a-few"
+        );
+        $this->assertSame([400, 'truncated_batch'], [$truncated['http_code'], $truncated['body']['reason']]);
+    }
+
+    public function testBatchBodyMismatchNeverReachesTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $body = $this->batchBody(['secret.php' => 'attacker bytes']);
+
+        $result = $this->uploadBatch($endpoints, $body, [
+            'content_hash' => hash('sha256', 'what was actually signed'),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/files');
+    }
+
+    // ---------------------------------------------------------------
     // Dispatcher wiring
     // ---------------------------------------------------------------
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,7 @@
             <file>FileIndexDedupTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>SiteExportLibraryAuthTest.php</file>
             <file>StagedApplyTest.php</file>
             <file>StagedArtifactsTest.php</file>
             <file>StagedEndpointsTest.php</file>


### PR DESCRIPTION
## What it does

Small files no longer cost one HTTP conversation each: `staged_upload_batch` carries a whole batch of complete files per request — push's answer to pull's multipart batching, and the missing half of the original "staged artifact batches" intent. Files bigger than the request budget keep the resumable per-chunk path; everything else travels together.

Stacked on #307; part of #276.

## Rationale

**The wire format is length-prefixed frames, not boundaries.** Each frame is one JSON header line followed by exactly `length` raw bytes:

```
{"artifact_id":"a/b.txt","offset":0,"length":9,"total_bytes":9,"final":true}\n<9 bytes>
```

No boundary strings means no escaping: any filename a site can contain frames verbatim (the adversarial-filenames CLI test now rides this path). It is the same JSONL discipline the codebase already uses for indexes and download lists.

**Authentication is byte-for-byte the same as single uploads.** Headers verify first; the whole body spools while hashing; nothing touches the store until the digest matches the signed claim. The spool the single-upload route already required is exactly what lets the batch route parse frames without any incremental network parser — `spool_verified_body()` is now shared by both.

**Batches are governed by the sizer, and retries are idempotent.** The runner packs files into the sizer's current budget (`chunk_bytes`, minus a per-frame allowance); a 413 teaches the sizer and the affected batch repartitions — monotonically, so it terminates. Frames process in order and stop at the first failure with per-artifact results for everything that landed; a retried batch gets `verified` back for artifacts an earlier attempt finished, and the runner requeues only the `not_attempted` tail. Volatile files are excluded on the sender before a byte travels, same `source_changed` discipline as the chunk path.

Request-count math: a 50k-small-file site drops from 50k+ conversations to roughly `total_bytes / budget` — with the default 32 MiB start budget, typically a few dozen.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit StagedEndpointsTest.php Import/StagedUploadClientTest.php Import/StagedPushRunnerTest.php Import/PushFilesCliTest.php
composer analyze
```

Ten new tests across three floors: endpoint (many files one request, idempotent batch retry, stop-at-first-bad-frame with partial results reported, truncated frames, body-hash mismatch never touching the store), client (one conversation for many files, 413 → `batch_too_large` with the sizer learning the cap, volatile file excluded locally), runner (six files = exactly one request and zero per-file requests, mixed plans batching small while chunking large, a 413 shrinking batches mid-run and completing). The full-push CLI suite now exercises real batches over HTTP end to end, and all 147 staged-stack tests pass.
