### PR TITLE
Support push deletions and preflight space gates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/upload-batches",
+            "version": "dev-push/deletions-and-preflight",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -125,9 +125,11 @@ final class Site_Export_Staged_Apply {
      *   what a sender calls before uploading gigabytes: a staging
      *   directory that can never apply (cross_device) rejects here, at
      *   the start, not after the transfer.
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,skipped_paths:array<int,string>}
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,skipped_paths:array<int,string>,deleted:int,staging_free_bytes?:?int,target_free_bytes?:?int}
      *   status "applied"|"ready"|"busy"|"rejected"; skipped counts entries
-     *   the on_existing/symlink policies protected.
+     *   the on_existing/symlink policies protected; deleted counts manifest
+     *   delete entries carried out. "ready" also reports free space (null
+     *   when the filesystem won't say).
      */
     public function apply(string $manifest_id, bool $check_only = false): array {
         $precheck = $this->check_environment();
@@ -138,7 +140,7 @@ final class Site_Export_Staged_Apply {
         if ($check_only && !$this->store->status($manifest_id)['verified']) {
             // Probes run before the transfer exists. The environment is
             // the answer; the manifest is checked when apply runs for real.
-            return $this->result('ready', null, null);
+            return $this->with_environment_facts($this->result('ready', null, null));
         }
 
         $lock = @fopen($this->lock_path, 'c+b');
@@ -185,36 +187,55 @@ final class Site_Export_Staged_Apply {
             }
 
             if ($check_only) {
-                return $this->result('ready', null, null, 0, count($already_applied), count($protected), $skipped_paths);
+                return $this->with_environment_facts(
+                    $this->result('ready', null, null, 0, count($already_applied), count($protected), $skipped_paths)
+                );
             }
 
             // Apply holds the store's lock, so cleanup below unlinks the
             // store's files directly — its own discard() would contend on
             // the very lock this process holds.
+            //
+            // Deletions run before file moves: a transfer that removes a
+            // directory and lands a file where it stood must not depend on
+            // manifest order to get that right.
             $applied = 0;
-            foreach ($entries as $index => $entry) {
-                if (isset($protected[$index])) {
-                    // The local path wins; consume the staged bytes so they
-                    // cannot be applied by a later, differently-configured
-                    // run.
-                    @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                    @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
-                    continue;
+            $deleted = 0;
+            foreach ([true, false] as $delete_pass) {
+                foreach ($entries as $index => $entry) {
+                    if (!empty($entry['delete']) !== $delete_pass) {
+                        continue;
+                    }
+                    if (isset($protected[$index])) {
+                        // The local path wins; consume the staged bytes so
+                        // they cannot be applied by a later,
+                        // differently-configured run.
+                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
+                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                        continue;
+                    }
+                    if (isset($already_applied[$index])) {
+                        // A rerun after a kill: the work is done; only a
+                        // leftover marker may remain to consume.
+                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                        continue;
+                    }
+                    if ($delete_pass) {
+                        if (!$this->remove_path_without_following_symlinks($this->target_root . '/' . $entry['artifact_id'])) {
+                            return $this->result('rejected', 'io_error', 'delete: ' . $entry['artifact_id'], $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
+                        }
+                        ++$deleted;
+                        continue;
+                    }
+                    $move_error = $this->move_into_place($entry['artifact_id']);
+                    if ($move_error !== null) {
+                        // Everything validated, so this is environmental
+                        // (permissions, disk). Rerunning apply resumes: moved
+                        // entries classify as applied, the rest re-validate.
+                        return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
+                    }
+                    ++$applied;
                 }
-                if (isset($already_applied[$index])) {
-                    // A rerun after a kill: the file is in place; only its
-                    // leftover marker remains to consume.
-                    @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
-                    continue;
-                }
-                $move_error = $this->move_into_place($entry['artifact_id']);
-                if ($move_error !== null) {
-                    // Everything validated, so this is environmental
-                    // (permissions, disk). Rerunning apply resumes: moved
-                    // entries classify as applied, the rest re-validate.
-                    return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied), count($protected), $skipped_paths);
-                }
-                ++$applied;
             }
 
             // The manifest is consumed with the transfer it described, and
@@ -224,7 +245,7 @@ final class Site_Export_Staged_Apply {
             @unlink($this->staging_dir . '/verified/' . $manifest_id);
             $this->clear_cursor_for($entries, $manifest_id);
 
-            return $this->result('applied', null, null, $applied, count($already_applied), count($protected), $skipped_paths);
+            return $this->result('applied', null, null, $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -326,11 +347,11 @@ final class Site_Export_Staged_Apply {
                 continue;
             }
             $entry = json_decode($line, true);
+            $is_delete = is_array($entry) && !empty($entry['delete']);
             if (
                 !is_array($entry)
                 || !is_string($entry['artifact_id'] ?? null)
-                || !is_int($entry['size'] ?? null)
-                || $entry['size'] < 0
+                || ( !$is_delete && ( !is_int($entry['size'] ?? null) || $entry['size'] < 0 ) )
             ) {
                 return 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
             }
@@ -345,10 +366,24 @@ final class Site_Export_Staged_Apply {
             }
             $entries[] = [
                 'artifact_id' => $entry['artifact_id'],
-                'size' => $entry['size'],
+                'size' => $is_delete ? null : $entry['size'],
+                'delete' => $is_delete,
             ];
         }
         return $entries;
+    }
+
+    /**
+     * "ready" doubles as the sender's preflight: staging and target free
+     * space let it refuse a transfer that could never fit, before a byte
+     * travels.
+     */
+    private function with_environment_facts(array $result): array {
+        $staging_free = @disk_free_space($this->staging_dir);
+        $target_free = @disk_free_space($this->target_root);
+        $result['staging_free_bytes'] = $staging_free === false ? null : (int) $staging_free;
+        $result['target_free_bytes'] = $target_free === false ? null : (int) $target_free;
+        return $result;
     }
 
     /** Mirrors the store's artifact id rule (see its contract docblock). */
@@ -375,7 +410,8 @@ final class Site_Export_Staged_Apply {
      */
     private function classify(array $entry): string {
         // Policy verdicts come first: a protected path is out of bounds no
-        // matter what is or is not staged for it.
+        // matter what is or is not staged for it. Preserve-local means
+        // never overwrite AND never delete.
         if ($this->refuse_symlinked_parents && $this->has_symlinked_parent($entry['artifact_id'])) {
             return 'protected';
         }
@@ -386,6 +422,13 @@ final class Site_Export_Staged_Apply {
             if (file_exists($occupied) || is_link($occupied)) {
                 return 'protected';
             }
+        }
+
+        if (!empty($entry['delete'])) {
+            // Deletions need nothing staged: the path either still exists
+            // (ready) or a previous window already removed it (idempotent).
+            $target = $this->target_root . '/' . $entry['artifact_id'];
+            return ( file_exists($target) || is_link($target) ) ? 'staged' : 'applied';
         }
 
         $status = $this->store->status($entry['artifact_id']);
@@ -501,9 +544,6 @@ final class Site_Export_Staged_Apply {
     }
 
     /**
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
-     */
-    /**
      * Whether any directory component of the artifact's target path is a
      * symlink. Only the relative components are checked — the target root
      * itself may legitimately be reached through links.
@@ -523,7 +563,7 @@ final class Site_Export_Staged_Apply {
         return false;
     }
 
-    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0, int $skipped = 0, array $skipped_paths = []): array {
+    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0, int $skipped = 0, array $skipped_paths = [], int $deleted = 0): array {
         return [
             'status' => $status,
             'reason' => $reason,
@@ -532,6 +572,7 @@ final class Site_Export_Staged_Apply {
             'already_applied' => $already_applied,
             'skipped' => $skipped,
             'skipped_paths' => $skipped_paths,
+            'deleted' => $deleted,
         ];
     }
 }

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -194,6 +194,11 @@ final class Site_Export_Staged_Endpoints {
             default:
                 $code = $result['reason'] === 'io_error' ? 500 : 409;
         }
+        if ($result['status'] === 'ready') {
+            // The probe doubles as push preflight: the request cap seeds
+            // the sender's chunk sizer without waiting for a 413.
+            $result['max_request_bytes'] = $this->max_request_bytes;
+        }
         return [
             'http_code' => $code,
             'body' => $result,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -12579,7 +12579,9 @@ if (
             'type' => 'flag',
             'target' => 'apply',
             'help' => 'After staging completes, apply the transfer into the remote tree ' .
-                '(rename-only; the environment is probed before any upload)',
+                '(rename-only; the environment is probed before any upload). Files earlier ' .
+                'pushes shipped that no longer exist locally are deleted from the remote ' .
+                'tree in the same window',
             'commands' => ['push-files'],
         ],
         [
@@ -13276,7 +13278,12 @@ if (
                 "\n" .
                 "Symlinks are never followed; they are skipped and recorded in\n" .
                 "the audit log. Use --only with fs-root-relative prefixes to\n" .
-                "push a subset.\n",
+                "push a subset.\n" .
+                "\n" .
+                "With --apply, the verified transfer moves into the remote tree\n" .
+                "in one atomic window, and files that earlier pushes shipped but\n" .
+                "the local tree no longer has are deleted with it. A scoped push\n" .
+                "(--only) only deletes inside its prefixes.\n",
             "extra" =>
                 "Examples:\n" .
                 "  # Stage a full local tree on the remote:\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4093,36 +4093,6 @@ class ImportClient
             );
         }
 
-        if ($probe["status"] === "ready") {
-            if (($probe["max_request_bytes"] ?? null) !== null) {
-                // Seed the sizer from the target's declared cap instead of
-                // waiting for the first 413 to teach it.
-                $sizer->apply_reported_limits([$probe["max_request_bytes"]]);
-            }
-            $plan_bytes = 0;
-            foreach ($build["plan"] as $plan_entry) {
-                $plan_bytes += (int) ($plan_entry["total_bytes"] ?? 0);
-            }
-            $staging_free = $probe["staging_free_bytes"] ?? null;
-            if ($staging_free !== null && $plan_bytes > $staging_free) {
-                // The transfer could never fit; refuse before uploading.
-                $summary = [
-                    "type" => "push",
-                    "status" => "error",
-                    "abort_reason" => "insufficient_staging_space",
-                    "abort_detail" => sprintf(
-                        "plan needs %d bytes, staging has %d free",
-                        $plan_bytes,
-                        $staging_free,
-                    ),
-                ];
-                $this->output_progress($summary, true);
-                echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
-                $this->exit_code = 1;
-                return;
-            }
-        }
-
         $runner = new StagedPushRunner([
             "state_dir" => $this->state_dir,
             "client" => $client,
@@ -4138,6 +4108,33 @@ class ImportClient
                 ]);
             },
         ]);
+
+        if ($probe["status"] === "ready") {
+            if (($probe["max_request_bytes"] ?? null) !== null) {
+                // Seed the sizer from the target's declared cap instead of
+                // waiting for the first 413 to teach it.
+                $sizer->apply_reported_limits([$probe["max_request_bytes"]]);
+            }
+            $pending_bytes = $runner->pending_bytes($build["plan"]);
+            $staging_free = $probe["staging_free_bytes"] ?? null;
+            if ($staging_free !== null && $pending_bytes > $staging_free) {
+                // The transfer could never fit; refuse before uploading.
+                $summary = [
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => "insufficient_staging_space",
+                    "abort_detail" => sprintf(
+                        "pending upload needs %d bytes, staging has %d free",
+                        $pending_bytes,
+                        $staging_free,
+                    ),
+                ];
+                $this->output_progress($summary, true);
+                echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = 1;
+                return;
+            }
+        }
 
         $result = $runner->push($build["plan"]);
 
@@ -4204,28 +4201,43 @@ class ImportClient
             }
         }
 
-        $lines = "";
-        foreach ($plan as $entry) {
-            $lines .= json_encode([
-                "artifact_id" => $entry["artifact_id"],
-                "size" => $entry["total_bytes"],
-            ]) . "\n";
-        }
-        foreach ($stale_ids as $stale_id) {
-            $lines .= json_encode([
-                "artifact_id" => $stale_id,
-                "delete" => true,
-            ]) . "\n";
-        }
         $manifest_path = $this->state_dir . "/.push-manifest.jsonl";
-        if (@file_put_contents($manifest_path, $lines) !== strlen($lines)) {
-            echo json_encode([
-                "type" => "push_apply",
-                "status" => "error",
+        $manifest = @fopen($manifest_path, "wb");
+        if ($manifest === false) {
+            return $this->finish_push_apply("error", [
                 "abort_reason" => "manifest_write_failed",
                 "abort_detail" => $manifest_path,
-            ], JSON_PRETTY_PRINT) . "\n";
-            return 1;
+            ]);
+        }
+        foreach ($plan as $entry) {
+            if (!$this->write_push_manifest_entry($manifest, [
+                "artifact_id" => $entry["artifact_id"],
+                "size" => $entry["total_bytes"],
+            ])) {
+                fclose($manifest);
+                return $this->finish_push_apply("error", [
+                    "abort_reason" => "manifest_write_failed",
+                    "abort_detail" => $manifest_path,
+                ]);
+            }
+        }
+        foreach ($stale_ids as $stale_id) {
+            if (!$this->write_push_manifest_entry($manifest, [
+                "artifact_id" => $stale_id,
+                "delete" => true,
+            ])) {
+                fclose($manifest);
+                return $this->finish_push_apply("error", [
+                    "abort_reason" => "manifest_write_failed",
+                    "abort_detail" => $manifest_path,
+                ]);
+            }
+        }
+        if (!@fclose($manifest)) {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => "manifest_write_failed",
+                "abort_detail" => $manifest_path,
+            ]);
         }
 
         // A manifest from an earlier, different plan may sit at this id;
@@ -4257,6 +4269,23 @@ class ImportClient
             "already_applied" => $applied["already_applied"],
             "deleted" => $applied["deleted"],
         ]);
+    }
+
+    private function write_push_manifest_entry($manifest, array $entry): bool
+    {
+        $encoded = json_encode($entry);
+        if (!is_string($encoded)) {
+            return false;
+        }
+        $line = $encoded . "\n";
+        while ($line !== "") {
+            $written = @fwrite($manifest, $line);
+            if ($written === false || $written === 0) {
+                return false;
+            }
+            $line = substr($line, $written);
+        }
+        return true;
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3999,7 +3999,9 @@ class ImportClient
             if (strpos($prefix, "./") === 0) {
                 $prefix = substr($prefix, 2);
             }
-            $only[] = $prefix;
+            // Same normalization the plan builder applies, so the deletion
+            // scope in run_push_apply matches the plan's selection exactly.
+            $only[] = trim($prefix, "/");
         }
 
         $build = PushPlanBuilder::build($this->fs_root, $only);
@@ -4073,6 +4075,36 @@ class ImportClient
             );
         }
 
+        if ($probe["status"] === "ready") {
+            if (($probe["max_request_bytes"] ?? null) !== null) {
+                // Seed the sizer from the target's declared cap instead of
+                // waiting for the first 413 to teach it.
+                $sizer->apply_reported_limits([$probe["max_request_bytes"]]);
+            }
+            $plan_bytes = 0;
+            foreach ($build["plan"] as $plan_entry) {
+                $plan_bytes += (int) ($plan_entry["total_bytes"] ?? 0);
+            }
+            $staging_free = $probe["staging_free_bytes"] ?? null;
+            if ($staging_free !== null && $plan_bytes > $staging_free) {
+                // The transfer could never fit; refuse before uploading.
+                $summary = [
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => "insufficient_staging_space",
+                    "abort_detail" => sprintf(
+                        "plan needs %d bytes, staging has %d free",
+                        $plan_bytes,
+                        $staging_free,
+                    ),
+                ];
+                $this->output_progress($summary, true);
+                echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = 1;
+                return;
+            }
+        }
+
         $runner = new StagedPushRunner([
             "state_dir" => $this->state_dir,
             "client" => $client,
@@ -4126,7 +4158,7 @@ class ImportClient
             $this->exit_code = 0;
             return;
         }
-        $this->exit_code = $this->run_push_apply($client, $build["plan"]);
+        $this->exit_code = $this->run_push_apply($client, $runner, $build["plan"], $only);
     }
 
     /**
@@ -4139,13 +4171,32 @@ class ImportClient
      *
      * @return int Process exit code.
      */
-    private function run_push_apply(StagedUploadClient $client, array $plan): int
+    private function run_push_apply(StagedUploadClient $client, StagedPushRunner $runner, array $plan, array $only): int
     {
+        // Files previous pushes shipped that the local tree no longer has
+        // become delete entries — the push counterpart of pull's delta
+        // deletions, derived from the same done cache that skips finished
+        // uploads. A scoped push (--only) derives deletions only inside its
+        // prefixes: everything else was excluded from the plan on purpose,
+        // not removed locally.
+        $stale_ids = [];
+        foreach ($runner->cached_ids_not_in(array_column($plan, "artifact_id")) as $stale_id) {
+            if ($only === [] || PushPlanBuilder::selected($stale_id, $only)) {
+                $stale_ids[] = $stale_id;
+            }
+        }
+
         $lines = "";
         foreach ($plan as $entry) {
             $lines .= json_encode([
                 "artifact_id" => $entry["artifact_id"],
                 "size" => $entry["total_bytes"],
+            ]) . "\n";
+        }
+        foreach ($stale_ids as $stale_id) {
+            $lines .= json_encode([
+                "artifact_id" => $stale_id,
+                "delete" => true,
             ]) . "\n";
         }
         $manifest_path = $this->state_dir . "/.push-manifest.jsonl";
@@ -4178,9 +4229,15 @@ class ImportClient
             ]);
         }
 
+        // Deleted paths leave the done cache only after the target confirmed
+        // the apply; a kill in between re-derives the same deletions, which
+        // rerun as idempotent no-ops.
+        $runner->forget_cached($stale_ids);
+
         return $this->finish_push_apply("complete", [
             "applied" => $applied["applied"],
             "already_applied" => $applied["already_applied"],
+            "deleted" => $applied["deleted"],
         ]);
     }
 

--- a/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
@@ -116,7 +116,7 @@ class PushPlanBuilder
     }
 
     /** A file is selected when it sits at or under one of the prefixes. */
-    private static function selected(string $rel, array $only): bool
+    public static function selected(string $rel, array $only): bool
     {
         foreach ($only as $prefix) {
             if ($rel === $prefix || strpos($rel, $prefix . "/") === 0) {

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -318,6 +318,48 @@ class StagedPushRunner
         ];
     }
 
+    /**
+     * Ids the done cache remembers that the current plan no longer lists —
+     * files previous pushes shipped and the local tree has since removed.
+     * These become the transfer's deletions, mirroring pull's delta drain.
+     */
+    public function cached_ids_not_in(array $artifact_ids): array
+    {
+        $planned = array_fill_keys($artifact_ids, true);
+        $stale = [];
+        foreach (array_keys($this->read_verified_cache()) as $cached_id) {
+            if (!isset($planned[$cached_id])) {
+                $stale[] = $cached_id;
+            }
+        }
+        return $stale;
+    }
+
+    /** Drops ids from the done cache once their deletion applied. */
+    public function forget_cached(array $artifact_ids): void
+    {
+        if ($artifact_ids === []) {
+            return;
+        }
+        $drop = array_fill_keys($artifact_ids, true);
+        $lines = "";
+        foreach ($this->read_verified_cache() as $artifact_id => $record) {
+            if (isset($drop[$artifact_id])) {
+                continue;
+            }
+            $lines .= json_encode([
+                "artifact_id" => $artifact_id,
+                "size" => $record["size"],
+                "mtime" => $record["mtime"],
+            ]) . "\n";
+        }
+        $tmp_path = $this->verified_path . ".tmp";
+        if (@file_put_contents($tmp_path, $lines) === strlen($lines)) {
+            @rename($tmp_path, $this->verified_path);
+        }
+        @unlink($tmp_path);
+    }
+
     private function report_progress(int $files_done, int $files_total, string $artifact_id, int $committed, int $total): void
     {
         if ($this->on_progress === null) {

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -127,6 +127,41 @@ class StagedPushRunner
     }
 
     /**
+     * Bytes that a resumed run still needs to stage.
+     *
+     * Invalid or unreadable plan entries do not count here because push()
+     * records them as artifact-scoped failures before any upload attempt.
+     */
+    public function pending_bytes(array $artifacts): int
+    {
+        $verified_cache = $this->read_verified_cache();
+        $bytes = 0;
+        foreach ($artifacts as $entry) {
+            $artifact_id = $entry["artifact_id"] ?? null;
+            $source_path = $entry["source_path"] ?? null;
+            if (!is_string($artifact_id) || $artifact_id === "" || !is_string($source_path) || $source_path === "") {
+                continue;
+            }
+
+            $total_bytes = $entry["total_bytes"] ?? null;
+            if ($total_bytes === null) {
+                $size = @filesize($source_path);
+                if ($size === false) {
+                    continue;
+                }
+                $total_bytes = $size;
+            }
+            $total_bytes = (int) $total_bytes;
+            $mtime = isset($entry["mtime"]) ? (int) $entry["mtime"] : null;
+            if ($this->cache_hit($verified_cache, $artifact_id, $total_bytes, $mtime)) {
+                continue;
+            }
+            $bytes += $total_bytes;
+        }
+        return $bytes;
+    }
+
+    /**
      * Upload every artifact in the plan that is not already verified.
      *
      * @param array $artifacts Each entry: ['artifact_id' => string,
@@ -183,11 +218,7 @@ class StagedPushRunner
             // the store's verification, so the cache must not vouch for it.
             $mtime = isset($entry["mtime"]) ? (int) $entry["mtime"] : null;
             $cached = $verified_cache[$artifact_id] ?? null;
-            if (
-                $cached !== null
-                && $cached["size"] === $total_bytes
-                && ($mtime === null || $cached["mtime"] === null || $cached["mtime"] === $mtime)
-            ) {
+            if ($this->cache_hit($verified_cache, $artifact_id, $total_bytes, $mtime)) {
                 $files_done++;
                 $this->report_progress($files_done, $files_total, $artifact_id, $total_bytes, $total_bytes);
                 continue;
@@ -358,6 +389,19 @@ class StagedPushRunner
             @rename($tmp_path, $this->verified_path);
         }
         @unlink($tmp_path);
+    }
+
+    /**
+     * The done cache keys on size and, when the plan supplies one, mtime.
+     * A same-size edit is invisible to the store's verification, so any
+     * mtime movement must invalidate the cache entry before upload/apply.
+     */
+    private function cache_hit(array $verified_cache, string $artifact_id, int $total_bytes, ?int $mtime): bool
+    {
+        $cached = $verified_cache[$artifact_id] ?? null;
+        return $cached !== null
+            && $cached["size"] === $total_bytes
+            && ($mtime === null || $cached["mtime"] === null || $cached["mtime"] === $mtime);
     }
 
     private function report_progress(int $files_done, int $files_total, string $artifact_id, int $committed, int $total): void

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -522,8 +522,9 @@ class StagedUploadClient
      * apply — cross-device staging above all — answers "rejected" here,
      * before any chunk has been uploaded.
      *
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
-     *   status "applied"|"ready"|"failed".
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,deleted:int,staging_free_bytes:?int,max_request_bytes:?int}
+     *   status "applied"|"ready"|"failed". "ready" carries the target's
+     *   preflight facts: free staging space and its request cap.
      */
     public function apply(string $manifest_id, bool $check_only = false): array
     {
@@ -548,6 +549,14 @@ class StagedUploadClient
                     "detail" => null,
                     "applied" => (int) ($json["applied"] ?? 0),
                     "already_applied" => (int) ($json["already_applied"] ?? 0),
+                    "skipped" => (int) ($json["skipped"] ?? 0),
+                    "deleted" => (int) ($json["deleted"] ?? 0),
+                    "staging_free_bytes" => is_numeric($json["staging_free_bytes"] ?? null)
+                        ? (int) $json["staging_free_bytes"]
+                        : null,
+                    "max_request_bytes" => is_numeric($json["max_request_bytes"] ?? null)
+                        ? (int) $json["max_request_bytes"]
+                        : null,
                 ];
             }
             if ($status === "busy") {
@@ -582,7 +591,7 @@ class StagedUploadClient
     }
 
     /**
-     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int}
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,deleted:int,staging_free_bytes:?int,max_request_bytes:?int}
      */
     private function apply_failed(string $reason, ?string $detail): array
     {
@@ -592,6 +601,10 @@ class StagedUploadClient
             "detail" => $detail,
             "applied" => 0,
             "already_applied" => 0,
+            "skipped" => 0,
+            "deleted" => 0,
+            "staging_free_bytes" => null,
+            "max_request_bytes" => null,
         ];
     }
 

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/upload-batches",
+            "version": "dev-push/deletions-and-preflight",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -382,6 +382,50 @@ class PushFilesCliTest extends TestCase
         }
     }
 
+    public function testInsufficientStagingSpaceIgnoresCachedArtifacts(): void
+    {
+        // A resumed push may have already staged more bytes than the target
+        // currently reports free. The preflight gate must compare only the
+        // bytes still pending, or it falsely rejects the resume.
+        $harness = sys_get_temp_dir() . '/push-cli-space-resume-' . bin2hex(random_bytes(8));
+        mkdir($harness, 0700, true);
+        $router = <<<'PHP'
+<?php
+file_put_contents('__REQUESTS_LOG__', ($_GET['endpoint'] ?? '?') . "\n", FILE_APPEND);
+header('Content-Type: application/json');
+echo json_encode(['status' => 'ready', 'staging_free_bytes' => 1, 'target_free_bytes' => 1, 'max_request_bytes' => 65536]);
+PHP;
+        file_put_contents($harness . '/router.php', str_replace('__REQUESTS_LOG__', $harness . '/requests.log', $router));
+        $url = $this->serveRouter($harness);
+        try {
+            file_put_contents($this->fs_root . '/already.bin', str_repeat('x', 4096));
+            $mtime = (int) filemtime($this->fs_root . '/already.bin');
+            file_put_contents(
+                $this->state_dir . '/.push-verified.jsonl',
+                "\n" . json_encode(['artifact_id' => 'already.bin', 'size' => 4096, 'mtime' => $mtime]) . "\n"
+            );
+
+            [$output, $code] = $this->runCli([
+                'push-files',
+                $url,
+                '--secret=push-cli-e2e-secret',
+                '--state-dir=' . $this->state_dir,
+                '--fs-root=' . $this->fs_root,
+            ]);
+
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame('complete', $summary['status']);
+            $this->assertSame(
+                ['staged_apply'],
+                array_unique(array_filter(explode("\n", (string) file_get_contents($harness . '/requests.log')))),
+                'the cached artifact must not upload just to satisfy the space gate'
+            );
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
     public function testLocalDeletionPropagatesOnTheNextPushApply(): void
     {
         [$url, $site_root] = $this->startApplyHarness();

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -311,6 +311,19 @@ class PushFilesCliTest extends TestCase
                     "mangled in transit: {$name}"
                 );
             }
+
+            // Deletion ids ride the same manifest lines, so the weird
+            // names must survive that direction too.
+            unlink($this->fs_root . '/100%+done.txt');
+            unlink($this->fs_root . '/emoji-😀.php');
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame(2, $summary['deleted']);
+            $this->assertFileDoesNotExist($site_root . '/100%+done.txt');
+            $this->assertFileDoesNotExist($site_root . '/emoji-😀.php');
+            $this->assertFileExists($site_root . '/file with space.txt', 'the survivors stay');
         } finally {
             $this->stopApplyHarness();
         }
@@ -378,6 +391,33 @@ class PushFilesCliTest extends TestCase
             $this->assertSame(0, $code, $output);
             $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
             $this->assertSame(0, $summary['deleted']);
+
+            // A kill between the confirmed apply and the cache update
+            // resurrects the stale line. The next push re-derives the
+            // deletion, which no-ops (the path is already gone) and heals
+            // the cache.
+            $verified_path = $this->state_dir . '/.push-verified.jsonl';
+            file_put_contents(
+                $verified_path,
+                "\n" . json_encode(['artifact_id' => 'b.txt', 'size' => 15, 'mtime' => 1]) . "\n",
+                FILE_APPEND
+            );
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame(0, $summary['deleted']);
+            $this->assertStringNotContainsString(
+                'b.txt',
+                (string) file_get_contents($verified_path),
+                'the resurrected line is forgotten again'
+            );
+
+            // The deletion broke something? Restoring the file locally
+            // ships it back on the next push — the fix-forward loop.
+            file_put_contents($this->fs_root . '/b.txt', 'restored, new content');
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertSame('restored, new content', file_get_contents($site_root . '/b.txt'));
         } finally {
             $this->stopApplyHarness();
         }

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -161,6 +161,12 @@ class PushFilesCliTest extends TestCase
             "_site_export_handle_api_request();\n"
         );
 
+        return [$this->serveRouter($harness), $site_root, $harness . '/staging'];
+    }
+
+    /** Serves $harness/router.php over php -S and returns the API url. */
+    private function serveRouter(string $harness): string
+    {
         $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
         $this->assertNotFalse($probe, "cannot allocate a port: {$errstr}");
         $name = (string) stream_socket_get_name($probe, false);
@@ -191,7 +197,7 @@ class PushFilesCliTest extends TestCase
         }
         $this->assertTrue($ready, 'php -S did not come up');
 
-        return ["http://127.0.0.1:{$port}/?reprint-api", $site_root, $harness . '/staging'];
+        return "http://127.0.0.1:{$port}/?reprint-api";
     }
 
     private function stopApplyHarness(): void
@@ -305,6 +311,106 @@ class PushFilesCliTest extends TestCase
                     "mangled in transit: {$name}"
                 );
             }
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testInsufficientStagingSpaceRefusesBeforeUploading(): void
+    {
+        // A scripted target whose probe answers ready with 1 byte free: the
+        // gate must refuse the transfer without a single upload request.
+        $harness = sys_get_temp_dir() . '/push-cli-space-' . bin2hex(random_bytes(8));
+        mkdir($harness, 0700, true);
+        file_put_contents(
+            $harness . '/router.php',
+            "<?php\n" .
+            "file_put_contents('{$harness}/requests.log', (\$_GET['endpoint'] ?? '?') . \"\\n\", FILE_APPEND);\n" .
+            "header('Content-Type: application/json');\n" .
+            "echo json_encode(['status' => 'ready', 'staging_free_bytes' => 1, 'target_free_bytes' => 1, 'max_request_bytes' => 65536]);\n"
+        );
+        $url = $this->serveRouter($harness);
+        try {
+            file_put_contents($this->fs_root . '/too-big.bin', str_repeat('x', 4096));
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+
+            $this->assertSame(1, $code, $output);
+            $this->assertStringContainsString('insufficient_staging_space', $output);
+            $this->assertSame(
+                ['staged_apply'],
+                array_unique(array_filter(explode("\n", (string) file_get_contents($harness . '/requests.log')))),
+                'the probe must be the only request'
+            );
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testLocalDeletionPropagatesOnTheNextPushApply(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            file_put_contents($this->fs_root . '/a.txt', 'stays');
+            file_put_contents($this->fs_root . '/b.txt', 'will be removed');
+            mkdir($this->fs_root . '/wp-content', 0700, true);
+            file_put_contents($this->fs_root . '/wp-content/c.php', '<?php // stays');
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileExists($site_root . '/b.txt');
+
+            // The file disappears locally; the next push must remove it
+            // from the target in the same apply window.
+            unlink($this->fs_root . '/b.txt');
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame('complete', $summary['status']);
+            $this->assertSame(1, $summary['deleted']);
+            $this->assertFileDoesNotExist($site_root . '/b.txt');
+            $this->assertSame('stays', file_get_contents($site_root . '/a.txt'));
+            $this->assertSame('<?php // stays', file_get_contents($site_root . '/wp-content/c.php'));
+
+            // The deletion left the done cache with the apply: rerunning
+            // does not re-delete or fail.
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame(0, $summary['deleted']);
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testOnlyScopedPushDerivesDeletionsOnlyInsideItsPrefixes(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            file_put_contents($this->fs_root . '/out.txt', 'outside the scope');
+            mkdir($this->fs_root . '/wp-content', 0700, true);
+            file_put_contents($this->fs_root . '/wp-content/in.txt', 'inside');
+            file_put_contents($this->fs_root . '/wp-content/keep.txt', 'kept');
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+
+            // Both files vanish locally, but the scoped push may only act
+            // inside its prefixes: out.txt was excluded from the plan on
+            // purpose, not removed relative to it.
+            unlink($this->fs_root . '/out.txt');
+            unlink($this->fs_root . '/wp-content/in.txt');
+            [$output, $code] = $this->runCli(array_merge($this->pushArgs($url), ['--only=wp-content']));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileDoesNotExist($site_root . '/wp-content/in.txt');
+            $this->assertFileExists($site_root . '/out.txt', 'out-of-scope paths must survive a scoped push');
+
+            // The next full push sees out.txt gone from the plan and
+            // finishes the deletion.
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileDoesNotExist($site_root . '/out.txt');
+            $this->assertSame('kept', file_get_contents($site_root . '/wp-content/keep.txt'));
         } finally {
             $this->stopApplyHarness();
         }

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -515,6 +515,33 @@ class StagedPushRunnerTest extends TestCase
         $this->assertSame(str_repeat('L', 2000), file_get_contents($this->staging_dir . '/files/large.bin'));
     }
 
+    public function testBatchMemberChangedSincePlanFailsScopedAndContinues(): void
+    {
+        // The volatility discipline must hold on the batch path too: a
+        // small file edited between the plan walk and the upload fails
+        // typed and local, and the rest of its batch still travels.
+        $volatile = $this->planEntry('volatile.txt', 'original');
+        $volatile['mtime'] = (int) filemtime($volatile['source_path']);
+        $stable = $this->planEntry('stable.txt', 'steady');
+        file_put_contents($volatile['source_path'], 'rewritten');
+        touch($volatile['source_path'], $volatile['mtime'] + 10);
+
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+        $result = $runner->push([$volatile, $stable]);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertSame(
+            ['volatile.txt', 'source_changed'],
+            [$result['failed'][0]['artifact_id'], $result['failed'][0]['reason']]
+        );
+        $this->assertSame('steady', file_get_contents($this->staging_dir . '/files/stable.txt'));
+        $this->assertFileDoesNotExist(
+            $this->staging_dir . '/files/volatile.txt',
+            'stale content never travels'
+        );
+    }
+
     // ---------------------------------------------------------------
     // Done-cache deletion bookkeeping
     // ---------------------------------------------------------------

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -515,6 +515,40 @@ class StagedPushRunnerTest extends TestCase
         $this->assertSame(str_repeat('L', 2000), file_get_contents($this->staging_dir . '/files/large.bin'));
     }
 
+    // ---------------------------------------------------------------
+    // Done-cache deletion bookkeeping
+    // ---------------------------------------------------------------
+
+    public function testCacheRemembersDeletionsUntilForgotten(): void
+    {
+        $plan = [
+            $this->planEntry('keep.txt', 'kept'),
+            $this->planEntry('gone.txt', 'soon gone'),
+            $this->planEntry('wp-content/gone-too.php', 'also'),
+        ];
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $this->assertSame('completed', $runner->push($plan)['status']);
+
+        // The next plan no longer lists two of the files: they are the
+        // transfer's deletions.
+        $this->assertSame([], $runner->cached_ids_not_in(['keep.txt', 'gone.txt', 'wp-content/gone-too.php']));
+        $stale = $runner->cached_ids_not_in(['keep.txt']);
+        sort($stale);
+        $this->assertSame(['gone.txt', 'wp-content/gone-too.php'], $stale);
+
+        // Forgetting them (after a confirmed apply) keeps the rest cached:
+        // the next push still skips keep.txt without a request.
+        $runner->forget_cached($stale);
+        $this->assertSame([], $runner->cached_ids_not_in(['keep.txt']));
+
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $result = $again->push([$plan[0]]);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertCount(0, $this->requests, 'surviving cache lines still skip');
+    }
+
     public function testBatchShrinksAfterA413AndCompletes(): void
     {
         $plan = [];

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -251,6 +251,28 @@ class StagedPushRunnerTest extends TestCase
         $this->assertCount(0, $this->requests, 'cache hits must not cost requests');
     }
 
+    public function testPendingBytesIgnoreCachedArtifacts(): void
+    {
+        $plan = [
+            $this->planEntry('a.bin', str_repeat('a', 12)),
+            $this->planEntry('b.bin', str_repeat('b', 10)),
+        ];
+        touch($plan[0]['source_path'], 1000);
+        touch($plan[1]['source_path'], 1000);
+        $plan[0]['mtime'] = 1000;
+        $plan[1]['mtime'] = 1000;
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $this->assertSame('completed', $runner->push($plan)['status']);
+        $this->assertSame(0, $runner->pending_bytes($plan));
+
+        file_put_contents($plan[1]['source_path'], str_repeat('B', 10));
+        touch($plan[1]['source_path'], 2000);
+        $plan[1]['mtime'] = 2000;
+
+        $this->assertSame(10, $runner->pending_bytes($plan));
+    }
+
     public function testTornCacheLineFallsBackToTheServerShortCircuit(): void
     {
         $plan = [$this->planEntry('artifact.bin', str_repeat('x', 12))];

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -576,6 +576,69 @@ class StagedPushRunnerTest extends TestCase
         $this->assertCount(0, $this->requests, 'surviving cache lines still skip');
     }
 
+    public function testSameSecondSameSizeEditIsTheDocumentedCacheBoundary(): void
+    {
+        // The done cache keys on (size, mtime). An edit that preserves
+        // both — same byte count, same filesystem second — is invisible
+        // to it, exactly like trunk's ctime+size delta comparison. This
+        // pins the boundary so a future cache change that widens or
+        // narrows it fails a test instead of drifting silently.
+        $entry = $this->planEntry('boundary.txt', 'aaaa');
+        $mtime = (int) filemtime($entry['source_path']);
+        $entry['mtime'] = $mtime;
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $this->assertSame('completed', $runner->push([$entry])['status']);
+
+        // Rewrite with the same size and force the same mtime second.
+        file_put_contents($entry['source_path'], 'bbbb');
+        touch($entry['source_path'], $mtime);
+        clearstatcache();
+
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $result = $again->push([$entry]);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertCount(0, $this->requests, 'a same-size same-second edit skips: the documented boundary');
+        $this->assertSame(
+            'aaaa',
+            file_get_contents($this->staging_dir . '/files/boundary.txt'),
+            'the staged copy still holds the version the cache vouched for'
+        );
+
+        // Any mtime movement re-ships — the boundary is exactly one
+        // filesystem second wide.
+        touch($entry['source_path'], $mtime + 1);
+        clearstatcache();
+        $entry['mtime'] = $mtime + 1;
+        [$third] = $this->makeRunner($transport);
+        $this->assertSame('completed', $third->push([$entry])['status']);
+        $this->assertSame('bbbb', file_get_contents($this->staging_dir . '/files/boundary.txt'));
+    }
+
+    public function testForgetCachedToleratesAStaleTmpOrphan(): void
+    {
+        // A kill between the tmp write and the rename leaves an orphan;
+        // the next forget must overwrite it and still commit atomically.
+        $plan = [
+            $this->planEntry('stays.txt', 'stays'),
+            $this->planEntry('goes.txt', 'goes'),
+        ];
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+        $this->assertSame('completed', $runner->push($plan)['status']);
+
+        file_put_contents($this->state_dir . '/.push-verified.jsonl.tmp', 'torn garbage from a kill');
+
+        $runner->forget_cached(['goes.txt']);
+
+        $this->assertSame([], $runner->cached_ids_not_in(['stays.txt']));
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-verified.jsonl.tmp');
+        [$fresh] = $this->makeRunner($transport);
+        $this->assertSame(['stays.txt'], $fresh->cached_ids_not_in([]), 'the rewritten cache holds exactly the survivor');
+    }
+
     public function testBatchShrinksAfterA413AndCompletes(): void
     {
         $plan = [];

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -105,6 +105,9 @@ class StagedUploadClientTest extends TestCase
                     $result = $endpoints->upload_batch($params, $server, $stream);
                     fclose($stream);
                     break;
+                case 'staged_apply':
+                    $result = $endpoints->apply($params, $server);
+                    break;
                 default:
                     return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
             }
@@ -564,5 +567,45 @@ class StagedUploadClientTest extends TestCase
 
         $this->assertSame('discarded', $client->discard('artifact.bin')['status']);
         $this->assertFalse($client->status('artifact.bin')['exists']);
+    }
+
+    // ---------------------------------------------------------------
+    // Apply passthrough
+    // ---------------------------------------------------------------
+
+    public function testApplyRoundTripCarriesPreflightFactsAndDeletions(): void
+    {
+        $target_root = $this->staging_dir . '-target';
+        mkdir($target_root, 0700, true);
+        file_put_contents($target_root . '/stale.txt', 'old');
+        $manifest_path = $this->source_path . '-manifest';
+        $endpoints = $this->makeEndpoints(['apply_target_root' => $target_root]);
+        $client = $this->makeClient($this->transportFor($endpoints));
+
+        try {
+            $this->writeSource('fresh');
+            $this->assertSame('verified', $client->upload_artifact('fresh.txt', $this->source_path)['status']);
+
+            $manifest = json_encode(['artifact_id' => 'fresh.txt', 'size' => 5]) . "\n"
+                . json_encode(['artifact_id' => 'stale.txt', 'delete' => true]) . "\n";
+            file_put_contents($manifest_path, $manifest);
+            $this->assertSame('verified', $client->upload_artifact('.m.jsonl', $manifest_path)['status']);
+
+            $probe = $client->apply('.m.jsonl', true);
+            $this->assertSame('ready', $probe['status']);
+            $this->assertIsInt($probe['staging_free_bytes']);
+            $this->assertIsInt($probe['max_request_bytes']);
+
+            $result = $client->apply('.m.jsonl');
+            $this->assertSame(
+                ['applied', 1, 1],
+                [$result['status'], $result['applied'], $result['deleted']]
+            );
+            $this->assertSame('fresh', file_get_contents($target_root . '/fresh.txt'));
+            $this->assertFileDoesNotExist($target_root . '/stale.txt');
+        } finally {
+            @unlink($manifest_path);
+            $this->removeDir($target_root);
+        }
     }
 }

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -416,6 +416,158 @@ final class StagedApplyTest extends TestCase {
     }
 
     // ---------------------------------------------------------------
+    // Deletions
+    // ---------------------------------------------------------------
+
+    public function testDeleteEntriesRemoveFilesDirectoriesAndLinks(): void
+    {
+        file_put_contents($this->target_root . '/stale.php', 'old');
+        mkdir($this->target_root . '/stale-dir/nested', 0700, true);
+        file_put_contents($this->target_root . '/stale-dir/nested/deep.txt', 'old');
+        $shared = $this->target_root . '-shared-del';
+        mkdir($shared, 0700, true);
+        file_put_contents($shared . '/keep.txt', 'shared');
+        symlink($shared, $this->target_root . '/stale-link');
+        $this->stageVerified('fresh.txt', 'new');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'fresh.txt', 'size' => 3],
+            ['artifact_id' => 'stale.php', 'delete' => true],
+            ['artifact_id' => 'stale-dir', 'delete' => true],
+            ['artifact_id' => 'stale-link', 'delete' => true],
+        ]);
+
+        try {
+            $result = $this->makeApply()->apply($manifest);
+
+            $this->assertSame('applied', $result['status']);
+            $this->assertSame(1, $result['applied']);
+            $this->assertSame(3, $result['deleted']);
+            $this->assertFileDoesNotExist($this->target_root . '/stale.php');
+            $this->assertDirectoryDoesNotExist($this->target_root . '/stale-dir');
+            $this->assertFalse(is_link($this->target_root . '/stale-link'));
+            $this->assertSame(
+                'shared',
+                file_get_contents($shared . '/keep.txt'),
+                'deleting the link must not follow it'
+            );
+            $this->assertSame('new', file_get_contents($this->target_root . '/fresh.txt'));
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testDeletionsRunBeforeMovesRegardlessOfManifestOrder(): void
+    {
+        // The old tree had a directory where the new tree lands a file, and
+        // the manifest lists the create before the delete. Move-first would
+        // rename the file in and then delete it.
+        mkdir($this->target_root . '/swap/nested', 0700, true);
+        file_put_contents($this->target_root . '/swap/nested/old.txt', 'old');
+        $this->stageVerified('swap', 'file now');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'swap', 'size' => 8],
+            ['artifact_id' => 'swap', 'delete' => true],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame([1, 1], [$result['applied'], $result['deleted']]);
+        $this->assertSame('file now', file_get_contents($this->target_root . '/swap'));
+    }
+
+    public function testDeletionsAreIdempotentAcrossReruns(): void
+    {
+        file_put_contents($this->target_root . '/goner.txt', 'x');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'goner.txt', 'delete' => true],
+        ]);
+
+        $first = $this->makeApply()->apply($manifest);
+        $this->assertSame(['applied', 1], [$first['status'], $first['deleted']]);
+        $this->assertFileDoesNotExist($this->target_root . '/goner.txt');
+
+        // A kill after apply but before the sender's cache update re-sends
+        // the same deletion; the path being gone already is the done state.
+        $again = $this->stageManifest([
+            ['artifact_id' => 'goner.txt', 'delete' => true],
+        ], '.manifest-2.jsonl');
+        $second = $this->makeApply()->apply($again);
+
+        $this->assertSame('applied', $second['status']);
+        $this->assertSame(0, $second['deleted']);
+        $this->assertSame(1, $second['already_applied']);
+    }
+
+    public function testPreserveLocalPoliciesProtectDeletions(): void
+    {
+        // Preserve-local means never overwrite AND never delete.
+        file_put_contents($this->target_root . '/precious.txt', 'local');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'precious.txt', 'delete' => true],
+        ]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(0, $result['deleted']);
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame(['precious.txt'], $result['skipped_paths']);
+        $this->assertSame('local', file_get_contents($this->target_root . '/precious.txt'));
+    }
+
+    public function testSymlinkedParentGuardProtectsDeletions(): void
+    {
+        mkdir($this->target_root . '/wp-content', 0700, true);
+        $shared = $this->target_root . '-shared-linked';
+        mkdir($shared, 0700, true);
+        file_put_contents($shared . '/keep.php', 'shared');
+        symlink($shared, $this->target_root . '/wp-content/plugins');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'wp-content/plugins/keep.php', 'delete' => true],
+        ]);
+
+        try {
+            $result = $this->makeApply(['refuse_symlinked_parents' => true])->apply($manifest);
+
+            $this->assertSame(['applied', 1], [$result['status'], $result['skipped']]);
+            $this->assertSame(0, $result['deleted']);
+            $this->assertSame('shared', file_get_contents($shared . '/keep.php'));
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testMalformedDeleteEntriesRejectTheManifest(): void
+    {
+        // delete:false is not a delete, so the entry needs its size.
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'x.txt', 'delete' => false],
+        ]);
+        $result = $this->makeApply()->apply($manifest);
+        $this->assertSame(['rejected', 'manifest_invalid'], [$result['status'], $result['reason']]);
+
+        // Delete ids go through the same path rule as everything else.
+        $this->stageVerified('hostile-delete.jsonl', json_encode(['artifact_id' => '../escape', 'delete' => true]) . "\n");
+        $hostile = $this->makeApply()->apply('hostile-delete.jsonl');
+        $this->assertStringContainsString('invalid artifact id', (string) $hostile['detail']);
+    }
+
+    // ---------------------------------------------------------------
+    // Preflight facts on "ready"
+    // ---------------------------------------------------------------
+
+    public function testReadyReportsFreeSpaceForTheSendersPreflight(): void
+    {
+        $result = $this->makeApply()->apply('not-yet-staged', true);
+
+        $this->assertSame('ready', $result['status']);
+        $this->assertIsInt($result['staging_free_bytes']);
+        $this->assertIsInt($result['target_free_bytes']);
+        $this->assertGreaterThan(0, $result['target_free_bytes']);
+    }
+
+    // ---------------------------------------------------------------
     // Kill windows and contention
     // ---------------------------------------------------------------
 

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -538,6 +538,38 @@ final class StagedApplyTest extends TestCase {
         }
     }
 
+    public function testDeletePassIoErrorIsTypedAndRerunResumes(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('permission barriers do not bind as root');
+        }
+        mkdir($this->target_root . '/locked', 0700, true);
+        file_put_contents($this->target_root . '/locked/goner.txt', 'x');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'locked/goner.txt', 'delete' => true],
+        ]);
+
+        // The environment turns hostile mid-transfer: the parent loses its
+        // write bit, so the unlink fails.
+        chmod($this->target_root . '/locked', 0555);
+        try {
+            $result = $this->makeApply()->apply($manifest);
+
+            $this->assertSame(['rejected', 'io_error'], [$result['status'], $result['reason']]);
+            $this->assertStringContainsString('delete: locked/goner.txt', (string) $result['detail']);
+        } finally {
+            chmod($this->target_root . '/locked', 0700);
+        }
+
+        // A rejection consumes nothing; once the operator fixes the
+        // permissions, rerunning the same manifest finishes the window.
+        $second = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $second['status']);
+        $this->assertSame(1, $second['deleted']);
+        $this->assertFileDoesNotExist($this->target_root . '/locked/goner.txt');
+    }
+
     public function testMalformedDeleteEntriesRejectTheManifest(): void
     {
         // delete:false is not a delete, so the entry needs its size.

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -416,6 +416,13 @@ final class StagedEndpointsTest extends TestCase {
             $this->assertSame([200, 'ready'], [$probe['http_code'], $probe['body']['status']]);
             $this->assertFileDoesNotExist($target_root . '/wp-content/a.txt');
 
+            // "ready" is the sender's preflight: the request cap seeds its
+            // chunk sizer and free space gates the transfer size.
+            $this->assertIsInt($probe['body']['max_request_bytes']);
+            $this->assertGreaterThan(0, $probe['body']['max_request_bytes']);
+            $this->assertIsInt($probe['body']['staging_free_bytes']);
+            $this->assertIsInt($probe['body']['target_free_bytes']);
+
             $result = $endpoints->apply(['manifest_id' => 'm.jsonl'], ['REQUEST_METHOD' => 'POST']);
             $this->assertSame(
                 [200, 'applied', 1],


### PR DESCRIPTION
## What it does

Completes two production gaps in the push pipeline:

1. **Deletions.** A file that previous pushes shipped and the local tree no longer has is now removed from the target in the same atomic apply window that lands new files. `push-files --apply` derives deletions from the runner's done cache (the ids it remembers minus the current plan), sends them as `{"artifact_id": ..., "delete": true}` manifest lines, and forgets them from the cache only after the target confirms the apply.
2. **Preflight assertions.** The pre-upload probe (`check_only` apply) now doubles as push preflight, like pull's preflight does: `ready` reports `staging_free_bytes` / `target_free_bytes` and the server's `max_request_bytes`. The sender refuses a transfer that cannot fit (`insufficient_staging_space`, exit 1) before a byte travels, and seeds its chunk sizer from the declared request cap instead of waiting for the first 413.

## Rationale

Without deletions, a push could only ever add or replace — a plugin removed locally would live on the target forever. Without the space gate, a transfer that could never fit would fail mid-upload after minutes of traffic instead of immediately.

## Implementation

- `Site_Export_Staged_Apply::read_manifest()` accepts size-less delete entries; ids go through the same path rule as everything else. `classify()` treats an existing target path as `staged` and a missing one as `applied`, so deletions are idempotent across reruns and kills.
- The move phase runs deletions first, so a transfer that removes a directory and lands a file where it stood does not depend on manifest order. Removal uses the existing `remove_path_without_following_symlinks()` (trunk's replacement discipline — a symlink is unlinked, never followed).
- Policies protect deletions the same way they protect writes: preserve-local (`on_existing=skip`) and `refuse_symlinked_parents` classify a delete as protected, count it in `skipped`/`skipped_paths`, and never touch the path.
- Deletions from a scoped push (`--only`) are derived only inside the pushed prefixes (via the plan builder's own `selected()` rule): everything else was excluded from the plan on purpose, not removed locally.
- `StagedPushRunner` gains `cached_ids_not_in()` / `forget_cached()`; the cache rewrite is tmp+rename like every cursor in this codebase. A kill between apply and forget re-derives the same deletions, which rerun as no-ops.
- `ready` responses pass free-space facts (engine) and `max_request_bytes` (endpoint) through the client to the CLI gate.

First push from a fresh state dir has no cache and therefore derives no deletions — same as pull, which needs a previous index before it can delta.

## Testing instructions

```
cd tests
../vendor/bin/phpunit StagedArtifactsTest.php StagedApplyTest.php StagedEndpointsTest.php \
  Import/StagedUploadClientTest.php Import/StagedPushRunnerTest.php \
  Import/PushPlanBuilderTest.php Import/PushFilesCliTest.php Import/StagedPullCliTest.php
```

159 tests. New coverage: delete of files/directories/symlinks (without following), deletions-before-moves ordering, rerun idempotence, preserve-local and symlinked-parent protection of deletions, hostile delete ids, ready free-space facts, client passthrough, runner cache bookkeeping, and three CLI end-to-end scenarios against a real HTTP target: local deletion propagating on the next push, `--only` scoping of deletions, and the staging-space gate refusing before any upload.
