### PR TITLE
Gate staged pull effects behind the apply window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,8 @@ During the file fetch phase, progress and heartbeat records include `files_done`
   - src/lib/target-runtime/: Runtime appliers (NginxFpmApplier, PhpBuiltinApplier, PlaygroundCliApplier)
   - src/lib/url-rewrite/: URL rewriting for db-apply
   - src/lib/mysql-query-stream/: MySQL query stream parser for direct streaming
+  - src/lib/state/: Typed persisted state (ImportState — the single source of the .import-state.json schema)
+  - src/lib/upload/: Push-side staged transfer (StagedUploadClient, StagedPushRunner, PushPlanBuilder, UploadChunkSizer)
 - reprint-exporter-wp/: Self-contained WordPress plugin distribution directory
   - index.php: WordPress plugin entry point — intercepts `?reprint-api` requests (and the legacy `?site-export-api` alias) during plugin load, requires lib.php
   - lib.php: Standalone library — constants, auth functions, and request handler. Can be required without index.php by projects that want to embed the export engine with their own URL routing and authentication (pass a custom `authenticate` callable in the `$options` array to `_site_export_handle_api_request()`)
@@ -241,6 +243,11 @@ Progress is computed client-side by reading state files (all in `--state-dir`):
 - `.import-remote-index.jsonl`: Remote file index (for delta comparison)
 - `.import-download-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
+
+Staged transfers add (also under `--state-dir`):
+- `.push-state.json` / `.push-verified.jsonl`: push chunk-sizer state and the push done cache (verified uploads; deletions derive from it)
+- `.pull-staging/`: staged pull artifact store (files/, verified/, state.json, lock)
+- `.pull-staged-manifest.jsonl`: the pending apply-window log for staged pulls (files, dirs, symlinks, deletions)
 
 And from `--fs-root`:
 - Actual downloaded files (recursive size/count)

--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-pull/apply-window-deletions",
+            "version": "dev-pull/dual-mode-windows",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",

--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/deletions-and-preflight",
+            "version": "dev-pull/apply-window-deletions",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -9,8 +9,6 @@
  */
 final class Site_Export_HMAC_Server {
 
-    private const DEFAULT_MAX_CONTROL_BODY_BYTES = 1048576;
-
     /** @var string */
     private $secret;
 
@@ -23,33 +21,13 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
-     * Verify a bounded control-plane request.
-     *
-     * HMAC is the guard for small protocol commands such as preflight, session
-     * start, plan confirmation, and abort/resume. Large data uploads should use
-     * authenticated sessions plus per-chunk hashes instead of signing one
-     * multi-megabyte request body.
-     */
-    public function verify_control_request(array $headers = [], string $body = '', ?float $now = null, ?int $max_body_bytes = null): ?string {
-        $body_limit = $max_body_bytes ?? self::DEFAULT_MAX_CONTROL_BODY_BYTES;
-        if (strlen($body) > $body_limit) {
-            return sprintf(
-                'HMAC control request body exceeds %d bytes',
-                $body_limit
-            );
-        }
-
-        return $this->verify($headers, $body, [], $now);
-    }
-
-    /**
      * Verify a request using explicit inputs.
      *
      * Returns null on success, or an error string on failure. This convenience
      * method receives the full body as a string and is only appropriate for
-     * compatibility with existing small request flows. New protocol code should
-     * use verify_control_request() for HMAC-protected commands and avoid
-     * HMAC-signing large data uploads.
+     * small request flows; large data uploads verify per chunk through
+     * verify_signed_content_hash() instead of HMAC-signing one
+     * multi-megabyte request body.
      *
      * When $files is non-empty, the content hash is computed from uploaded file
      * contents rather than $body so multipart uploads verify consistently.
@@ -59,24 +37,6 @@ final class Site_Export_HMAC_Server {
             $headers,
             function () use ($body, $files): string {
                 return $this->compute_received_content_hash($body, $files);
-            },
-            $now
-        );
-    }
-
-    /**
-     * Verify a request when the caller already computed the received digest.
-     *
-     * This exists for bounded protocol code that has already computed the body
-     * digest. It does not read a request body. Push chunk uploads should use
-     * session/request capabilities plus per-chunk hashes instead of routing
-     * large bodies through HMAC verification.
-     */
-    public function verify_content_hash(array $headers, string $received_content_hash, ?float $now = null): ?string {
-        return $this->verify_content_hash_callback(
-            $headers,
-            function () use ($received_content_hash): string {
-                return $received_content_hash;
             },
             $now
         );
@@ -139,9 +99,8 @@ final class Site_Export_HMAC_Server {
      *
      * Returns null on success, or an error string on failure. This legacy
      * convenience path buffers php://input and should only be used for small
-     * request bodies. New control-plane routes should bound the body and call
-     * verify_control_request(). Large data routes should not use whole-body
-     * HMAC verification.
+     * request bodies. Large data routes should not use whole-body HMAC
+     * verification.
      */
     public function verify_globals(?float $now = null): ?string {
         $body = file_get_contents('php://input');

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -81,6 +81,9 @@ final class Site_Export_Staged_Apply {
     /** @var bool */
     private $refuse_symlinked_parents;
 
+    /** @var callable|null */
+    private $on_protected;
+
     /**
      * @param array $options
      *   - staging_dir (string, required): same directory the store uses.
@@ -97,6 +100,12 @@ final class Site_Export_Staged_Apply {
      *     symlinked directory. Hosting layouts symlink plugins, themes,
      *     and core from shared locations; apply must not write into those
      *     through the link.
+     *   - on_protected (?callable): fn(string $artifact_id) — called once
+     *     per policy-protected entry during classification (check_only
+     *     included). This is the uncapped channel: in-process callers that
+     *     reconcile per-entry state (the pull window's index catch-up)
+     *     must use it. The result's skipped_paths list is capped for
+     *     bounded HTTP responses and is diagnostics only.
      */
     public function __construct(array $options) {
         $staging_dir = $options['staging_dir'] ?? null;
@@ -118,6 +127,7 @@ final class Site_Export_Staged_Apply {
         $this->store = new Site_Export_Staged_Artifacts($staging_dir);
         $this->on_existing = $on_existing;
         $this->refuse_symlinked_parents = !empty($options['refuse_symlinked_parents']);
+        $this->on_protected = $options['on_protected'] ?? null;
         $this->device_id = $options['device_id'] ?? static function (string $path): ?int {
             $stat = @stat($path);
             return $stat === false ? null : (int) $stat['dev'];
@@ -182,9 +192,11 @@ final class Site_Export_Staged_Apply {
                 }
                 if ($verdict === 'protected') {
                     $protected[$index] = true;
-                    // Callers audit-log each protected path (the
-                    // PRESERVE-LOCAL contract); capped so a 50k-skip
-                    // transfer stays a bounded response.
+                    if ($this->on_protected !== null) {
+                        call_user_func($this->on_protected, $entry['artifact_id']);
+                    }
+                    // The response list is capped so a 50k-skip transfer
+                    // stays bounded; per-entry consumers use on_protected.
                     if (count($skipped_paths) < self::SKIPPED_PATHS_LIMIT) {
                         $skipped_paths[] = $entry['artifact_id'];
                     }
@@ -213,29 +225,20 @@ final class Site_Export_Staged_Apply {
                     if (!empty($entry['delete']) !== $delete_pass) {
                         continue;
                     }
-                    if (isset($protected[$index])) {
-                        // The local path wins; consume the staged bytes so
-                        // they cannot be applied by a later,
-                        // differently-configured run.
-                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
-                        continue;
-                    }
-                    if (isset($already_applied[$index])) {
-                        // A rerun after a kill: the work is done; leftover
-                        // staged remains only need consuming. (For a
-                        // deletion, bytes an earlier resume staged under
-                        // the id can still sit here.)
-                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                    if (isset($protected[$index]) || isset($already_applied[$index])) {
+                        // Protected: the local path wins, and the staged
+                        // bytes must not be applied by a later,
+                        // differently-configured run. Already applied: a
+                        // rerun after a kill, where only leftover staged
+                        // remains linger. Both just consume.
+                        $this->consume_staged($entry['artifact_id']);
                         continue;
                     }
                     if ($delete_pass) {
                         // Staged bytes under a deleted id are garbage from
                         // before the remote dropped the file; consume them
                         // with the deletion.
-                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                        $this->consume_staged($entry['artifact_id']);
                         if (!$this->remove_path_without_following_symlinks($this->target_root . '/' . $entry['artifact_id'])) {
                             return $this->result('rejected', 'io_error', 'delete: ' . $entry['artifact_id'], $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
                         }
@@ -256,8 +259,7 @@ final class Site_Export_Staged_Apply {
             // The manifest is consumed with the transfer it described, and
             // a cursor still naming a consumed artifact must not survive to
             // answer a future upload with its stale offset.
-            @unlink($this->files_dir . '/' . $manifest_id);
-            @unlink($this->staging_dir . '/verified/' . $manifest_id);
+            $this->consume_staged($manifest_id);
             $this->clear_cursor_for($entries, $manifest_id);
 
             return $this->result('applied', null, null, $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
@@ -268,16 +270,12 @@ final class Site_Export_Staged_Apply {
     }
 
     /**
-     * Clears the store cursor when it names an artifact this apply consumed.
-     * Same write-then-rename commit as the store's own cursor writes.
+     * Clears the store cursor when it names an artifact this apply
+     * consumed. The cursor's schema and commit discipline live in the
+     * store; apply only decides whether the cursor was consumed.
      */
     private function clear_cursor_for(array $entries, string $manifest_id): void {
-        $state_path = $this->staging_dir . '/state.json';
-        $raw = @file_get_contents($state_path);
-        $state = $raw === false ? null : json_decode($raw, true);
-        $cursor_artifact = is_array($state) && is_string($state['artifact_id'] ?? null)
-            ? $state['artifact_id']
-            : null;
+        $cursor_artifact = $this->store->cursor_artifact_locked();
         if ($cursor_artifact === null) {
             return;
         }
@@ -289,16 +287,19 @@ final class Site_Export_Staged_Apply {
                 break;
             }
         }
-        if (!$consumed) {
-            return;
+        if ($consumed) {
+            $this->store->clear_cursor_locked();
         }
+    }
 
-        $json = json_encode(['artifact_id' => null, 'committed_bytes' => 0]);
-        $tmp_path = $state_path . '.tmp';
-        if (@file_put_contents($tmp_path, $json) === strlen($json)) {
-            @rename($tmp_path, $state_path);
-        }
-        @unlink($tmp_path);
+    /**
+     * Consumes an entry's staged remains: its bytes and its verified
+     * marker. Callers hold the store lock; the store's own discard()
+     * would contend on it.
+     */
+    private function consume_staged(string $artifact_id): void {
+        @unlink($this->files_dir . '/' . $artifact_id);
+        @unlink($this->staging_dir . '/verified/' . $artifact_id);
     }
 
     /**
@@ -351,14 +352,23 @@ final class Site_Export_Staged_Apply {
         if (!$status['verified']) {
             return 'manifest artifact is not verified: ' . $manifest_id;
         }
-        $raw = @file_get_contents($this->files_dir . '/' . $manifest_id);
-        if ($raw === false) {
+        // Streamed line by line: a 200k-entry manifest is tens of
+        // megabytes, and this runs on the memory-constrained side.
+        $handle = @fopen($this->files_dir . '/' . $manifest_id, 'rb');
+        if ($handle === false) {
             return 'manifest artifact is not readable: ' . $manifest_id;
         }
 
         $entries = [];
         $seen_ids = [];
-        foreach (explode("\n", $raw) as $line_number => $line) {
+        $line_number = -1;
+        $error = null;
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            ++$line_number;
             if (trim($line) === '') {
                 continue;
             }
@@ -369,10 +379,12 @@ final class Site_Export_Staged_Apply {
                 || !is_string($entry['artifact_id'] ?? null)
                 || ( !$is_delete && ( !is_int($entry['size'] ?? null) || $entry['size'] < 0 ) )
             ) {
-                return 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
+                break;
             }
             if ($entry['artifact_id'] === $manifest_id) {
-                return 'manifest lists itself';
+                $error = 'manifest lists itself';
+                break;
             }
             // One verdict per path. Neither sender can produce a duplicate
             // (both derive deletions as own-record-minus-current-set), and
@@ -380,14 +392,16 @@ final class Site_Export_Staged_Apply {
             // create has landed, the delete cannot tell the old occupant
             // from the new file.
             if (isset($seen_ids[$entry['artifact_id']])) {
-                return 'manifest line ' . ( $line_number + 1 ) . ' duplicates an artifact id';
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' duplicates an artifact id';
+                break;
             }
             $seen_ids[$entry['artifact_id']] = true;
             // Manifest content is sender data; ids must satisfy the same
             // path rule the store enforces at upload time, or a crafted
             // manifest could probe or write outside the target root.
             if (!$this->valid_artifact_id($entry['artifact_id'])) {
-                return 'manifest line ' . ( $line_number + 1 ) . ' has an invalid artifact id';
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' has an invalid artifact id';
+                break;
             }
             $entries[] = [
                 'artifact_id' => $entry['artifact_id'],
@@ -396,7 +410,8 @@ final class Site_Export_Staged_Apply {
                 'owned' => ( $is_delete || !empty($entry['owned']) ),
             ];
         }
-        return $entries;
+        fclose($handle);
+        return $error ?? $entries;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -41,11 +41,16 @@
  *
  * Policies cover the pull side of the same engine. on_existing "skip"
  * (pull's preserve-local) makes an occupied target path win: the entry is
- * not applied and its staged bytes are consumed. refuse_symlinked_parents
- * refuses to create anything through a symlinked directory. Protected
- * entries are classified before validation, so a rerun with nothing
- * staged does not reject a transfer over paths the policy was never going
- * to touch.
+ * not applied and its staged bytes are consumed. Entries the manifest
+ * marks "owned" are exempt — the sender's ship record (pull's local
+ * index, push's done cache) attests the transfer wrote that path, and
+ * preserve-local protects what the sync never owned, not its own previous
+ * copy. Delete entries are owned by construction: both senders derive
+ * them from those same records. refuse_symlinked_parents refuses to
+ * create or remove anything through a symlinked directory, owned or not.
+ * Protected entries are classified before validation, so a rerun with
+ * nothing staged does not reject a transfer over paths the policy was
+ * never going to touch.
  */
 final class Site_Export_Staged_Apply {
 
@@ -85,7 +90,9 @@ final class Site_Export_Staged_Apply {
      *   - on_existing ("replace"|"skip"): what an occupied target path
      *     means. "replace" is push's own-tree semantics; "skip" is pull's
      *     preserve-local — the local path wins and the staged bytes are
-     *     consumed unapplied.
+     *     consumed unapplied. Manifest entries marked "owned" (and every
+     *     delete entry) are exempt from "skip": the transfer's own ship
+     *     record vouches for those paths.
      *   - refuse_symlinked_parents (bool): never create anything through a
      *     symlinked directory. Hosting layouts symlink plugins, themes,
      *     and core from shared locations; apply must not write into those
@@ -215,12 +222,20 @@ final class Site_Export_Staged_Apply {
                         continue;
                     }
                     if (isset($already_applied[$index])) {
-                        // A rerun after a kill: the work is done; only a
-                        // leftover marker may remain to consume.
+                        // A rerun after a kill: the work is done; leftover
+                        // staged remains only need consuming. (For a
+                        // deletion, bytes an earlier resume staged under
+                        // the id can still sit here.)
+                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
                         @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
                         continue;
                     }
                     if ($delete_pass) {
+                        // Staged bytes under a deleted id are garbage from
+                        // before the remote dropped the file; consume them
+                        // with the deletion.
+                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
+                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
                         if (!$this->remove_path_without_following_symlinks($this->target_root . '/' . $entry['artifact_id'])) {
                             return $this->result('rejected', 'io_error', 'delete: ' . $entry['artifact_id'], $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
                         }
@@ -342,6 +357,7 @@ final class Site_Export_Staged_Apply {
         }
 
         $entries = [];
+        $seen_ids = [];
         foreach (explode("\n", $raw) as $line_number => $line) {
             if (trim($line) === '') {
                 continue;
@@ -358,6 +374,15 @@ final class Site_Export_Staged_Apply {
             if ($entry['artifact_id'] === $manifest_id) {
                 return 'manifest lists itself';
             }
+            // One verdict per path. Neither sender can produce a duplicate
+            // (both derive deletions as own-record-minus-current-set), and
+            // a same-id create-plus-delete is ambiguous on rerun: once the
+            // create has landed, the delete cannot tell the old occupant
+            // from the new file.
+            if (isset($seen_ids[$entry['artifact_id']])) {
+                return 'manifest line ' . ( $line_number + 1 ) . ' duplicates an artifact id';
+            }
+            $seen_ids[$entry['artifact_id']] = true;
             // Manifest content is sender data; ids must satisfy the same
             // path rule the store enforces at upload time, or a crafted
             // manifest could probe or write outside the target root.
@@ -368,6 +393,7 @@ final class Site_Export_Staged_Apply {
                 'artifact_id' => $entry['artifact_id'],
                 'size' => $is_delete ? null : $entry['size'],
                 'delete' => $is_delete,
+                'owned' => ( $is_delete || !empty($entry['owned']) ),
             ];
         }
         return $entries;
@@ -410,15 +436,17 @@ final class Site_Export_Staged_Apply {
      */
     private function classify(array $entry): string {
         // Policy verdicts come first: a protected path is out of bounds no
-        // matter what is or is not staged for it. Preserve-local means
-        // never overwrite AND never delete.
+        // matter what is or is not staged for it. The symlinked-parent
+        // guard binds even for owned entries — stale ownership must never
+        // reach through a link into shared content.
         if ($this->refuse_symlinked_parents && $this->has_symlinked_parent($entry['artifact_id'])) {
             return 'protected';
         }
-        if ($this->on_existing === 'skip') {
+        if ($this->on_existing === 'skip' && empty($entry['owned'])) {
             $occupied = $this->target_root . '/' . $entry['artifact_id'];
             // is_link covers dangling symlinks, which file_exists misses;
-            // preserve-local protects those too.
+            // preserve-local protects those too. Owned entries skip this
+            // check: the occupant is the transfer's own previous copy.
             if (file_exists($occupied) || is_link($occupied)) {
                 return 'protected';
             }

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -611,6 +611,23 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
+     * The artifact the cursor currently names, or null. Caller holds the
+     * store lock (the apply window's direct-consume contract): this reads
+     * without taking it.
+     */
+    public function cursor_artifact_locked(): ?string {
+        return $this->read_state()['artifact_id'];
+    }
+
+    /**
+     * Clears the cursor. Caller holds the store lock. The cursor schema
+     * and its write-then-rename commit stay owned by this class.
+     */
+    public function clear_cursor_locked(): bool {
+        return $this->write_state(null, 0);
+    }
+
+    /**
      * Reads the cursor as best-effort state.
      *
      * A missing or unreadable record is treated as no artifact in flight, so

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -128,7 +128,7 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
     /**
      * We're choosing a random boundary without checking for its presence in the content.
      * This may seem to contradict RFC 2046, where it says:
-     *
+     * 
      * > As stated previously, each body part is preceded by a boundary
      * > delimiter line that contains the boundary delimiter.  The boundary
      * > delimiter MUST NOT appear inside any of the encapsulated parts, on a
@@ -136,15 +136,15 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
      * > crucial that the composing agent be able to choose and specify a
      * > unique boundary parameter value that does not contain the boundary
      * > parameter value of an enclosing multipart as a prefix.
-     * >
+     * > 
      * > https://www.rfc-editor.org/rfc/rfc2046.html
      *
      * But in practice, we're okay. We use 128 bits of randomness. The chance of
      * it appearing in the data is about 1 in 2^128 — effectively zero. Curl does
-     * the same here:
+     * the same here: 
      *
      *    https://github.com/curl/curl/blob/462244447e8ba3a53b1ba9f0ba7baa52d8777daa/lib/mime.c#L1179-L1236
-     *
+     * 
      * Also, most chunks declare their Content-Length, so the client may skip the
      * boundary matching entirely and just consume that many bytes.
      */
@@ -2414,7 +2414,7 @@ function stream_file_producer(
     try {
         // @TODO: If an exception is thrown right after the previous chunk header,
         //        it read the fixed Content-Length value and will consume this next
-        //        chunk as data. We should try and backfill the output up to the
+        //        chunk as data. We should try and backfill the output up to the 
         //        previous content-length value if possible.
         if ($abort_payload !== null) {
             $json = json_encode_or_throw($abort_payload);
@@ -2499,11 +2499,11 @@ function encode_index_stack(array $stack): array
 
 /**
  * Resolve "." and ".." segments in a path without resolving symlinks.
- *
+ * 
  * Unlike realpath(), this only performs textual normalization — it collapses
  * "." and ".." but leaves symlink components intact.  This is useful when
  * you need a clean absolute path to inspect which components are symlinks.
- *
+ * 
  * @param string $path An absolute path that may contain "." or ".." segments.
  * @return string The normalized absolute path.
  */
@@ -2533,19 +2533,19 @@ function normalize_dot_segments(string $path): string
  * Given a path, such as `/srv/wordpress/wp-content/plugins/akismet/assets`, returns
  * a list of all the parent paths that are symlinks. It will check `/srv`,
  * `/srv/wordpress`, `/srv/wordpress/wp-content`, etc.
- *
+ * 
  * For example, given the following filesystem layout:
- *
+ * 
  *     /srv/wordpress/wp-content -> /htdocs/wp-content
  *     /srv/wordpress/wp-content/plugins/akismet -> /wordpress/plugins/akismet/latest
  *     /wordpress/plugins/akismet/latest -> /wordpress/plugins/akismet/5.0.5
- *
+ * 
  * Calling
- *
+ * 
  *     find_parents_symlinks("/srv/wordpress/wp-content/plugins/akismet/assets")
- *
+ * 
  * will return the following symlinks:
- *
+ * 
  * ['path' => '/srv/wordpress/wp-content', 'target' => '/htdocs/wp-content']
  * ['path' => '/htdocs/wp-content/plugins/akismet', 'target' => '/wordpress/plugins/akismet/latest']
  *

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -128,7 +128,7 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
     /**
      * We're choosing a random boundary without checking for its presence in the content.
      * This may seem to contradict RFC 2046, where it says:
-     * 
+     *
      * > As stated previously, each body part is preceded by a boundary
      * > delimiter line that contains the boundary delimiter.  The boundary
      * > delimiter MUST NOT appear inside any of the encapsulated parts, on a
@@ -136,15 +136,15 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
      * > crucial that the composing agent be able to choose and specify a
      * > unique boundary parameter value that does not contain the boundary
      * > parameter value of an enclosing multipart as a prefix.
-     * > 
+     * >
      * > https://www.rfc-editor.org/rfc/rfc2046.html
      *
      * But in practice, we're okay. We use 128 bits of randomness. The chance of
      * it appearing in the data is about 1 in 2^128 — effectively zero. Curl does
-     * the same here: 
+     * the same here:
      *
      *    https://github.com/curl/curl/blob/462244447e8ba3a53b1ba9f0ba7baa52d8777daa/lib/mime.c#L1179-L1236
-     * 
+     *
      * Also, most chunks declare their Content-Length, so the client may skip the
      * boundary matching entirely and just consume that many bytes.
      */
@@ -2414,7 +2414,7 @@ function stream_file_producer(
     try {
         // @TODO: If an exception is thrown right after the previous chunk header,
         //        it read the fixed Content-Length value and will consume this next
-        //        chunk as data. We should try and backfill the output up to the 
+        //        chunk as data. We should try and backfill the output up to the
         //        previous content-length value if possible.
         if ($abort_payload !== null) {
             $json = json_encode_or_throw($abort_payload);
@@ -2499,11 +2499,11 @@ function encode_index_stack(array $stack): array
 
 /**
  * Resolve "." and ".." segments in a path without resolving symlinks.
- * 
+ *
  * Unlike realpath(), this only performs textual normalization — it collapses
  * "." and ".." but leaves symlink components intact.  This is useful when
  * you need a clean absolute path to inspect which components are symlinks.
- * 
+ *
  * @param string $path An absolute path that may contain "." or ".." segments.
  * @return string The normalized absolute path.
  */
@@ -2533,19 +2533,19 @@ function normalize_dot_segments(string $path): string
  * Given a path, such as `/srv/wordpress/wp-content/plugins/akismet/assets`, returns
  * a list of all the parent paths that are symlinks. It will check `/srv`,
  * `/srv/wordpress`, `/srv/wordpress/wp-content`, etc.
- * 
+ *
  * For example, given the following filesystem layout:
- * 
+ *
  *     /srv/wordpress/wp-content -> /htdocs/wp-content
  *     /srv/wordpress/wp-content/plugins/akismet -> /wordpress/plugins/akismet/latest
  *     /wordpress/plugins/akismet/latest -> /wordpress/plugins/akismet/5.0.5
- * 
+ *
  * Calling
- * 
+ *
  *     find_parents_symlinks("/srv/wordpress/wp-content/plugins/akismet/assets")
- * 
+ *
  * will return the following symlinks:
- * 
+ *
  * ['path' => '/srv/wordpress/wp-content', 'target' => '/htdocs/wp-content']
  * ['path' => '/htdocs/wp-content/plugins/akismet', 'target' => '/wordpress/plugins/akismet/latest']
  *

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1238,6 +1238,13 @@ class ImportClient
     /** Artifact id the push manifest stages under; never applied itself. */
     private const PUSH_MANIFEST_ID = '.reprint-push-manifest.jsonl';
 
+    /**
+     * Push failures that follow the resumable convention (exit 2: run the
+     * same command again). One list for the transfer and the apply so a
+     * reason cannot be retryable in one phase and fatal in the other.
+     */
+    private const PUSH_RETRYABLE_REASONS = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
+
     /** Artifact id the staged pull manifest stages under. */
     private const PULL_MANIFEST_ID = '.reprint-pull-manifest.jsonl';
 
@@ -1249,6 +1256,9 @@ class ImportClient
 
     /** @var array<string,true> Owned remote paths in the batch being fetched. */
     private $staged_batch_owned = [];
+
+    /** @var string|null Cache key (list:offsets) for staged_batch_owned. */
+    private $staged_batch_owned_key = null;
 
     /**
      * True while the apply window replays deferred directory/symlink
@@ -4173,11 +4183,10 @@ class ImportClient
                 "PUSH ABORTED | {$result["abort_reason"]} | " . ($result["abort_detail"] ?? ""),
                 false,
             );
-            // Transient transfer failures follow the resumable convention
-            // (exit 2: run the same command again); a bad secret or a chunk
-            // size the host can never accept will not fix itself.
-            $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
-            $this->exit_code = in_array($result["abort_reason"], $retryable, true) ? 2 : 1;
+            // Transient transfer failures follow the resumable convention;
+            // a bad secret or a chunk size the host can never accept will
+            // not fix itself.
+            $this->exit_code = in_array($result["abort_reason"], self::PUSH_RETRYABLE_REASONS, true) ? 2 : 1;
             return;
         }
         if ($result["failed"] !== []) {
@@ -4286,8 +4295,7 @@ class ImportClient
             "PUSH APPLY FAILED | " . ($fields["abort_reason"] ?? "unknown") . " | " . ($fields["abort_detail"] ?? ""),
             false,
         );
-        $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
-        return in_array($fields["abort_reason"] ?? null, $retryable, true) ? 2 : 1;
+        return in_array($fields["abort_reason"] ?? null, self::PUSH_RETRYABLE_REASONS, true) ? 2 : 1;
     }
 
     private function staged_pull_staging_dir(): string
@@ -4309,7 +4317,7 @@ class ImportClient
         return $this->staged_pull_store;
     }
 
-    private function staged_pull_apply_engine(): Site_Export_Staged_Apply
+    private function staged_pull_apply_engine(?callable $on_protected = null): Site_Export_Staged_Apply
     {
         $preserve_local = $this->fs_root_nonempty_behavior === "preserve-local";
         return new Site_Export_Staged_Apply([
@@ -4320,6 +4328,10 @@ class ImportClient
             // symlinked directory.
             "on_existing" => $preserve_local ? "skip" : "replace",
             "refuse_symlinked_parents" => $preserve_local,
+            // The uncapped per-entry channel: index reconciliation after
+            // the window must see every protected id, not the capped
+            // diagnostic list in the result.
+            "on_protected" => $on_protected,
         ]);
     }
 
@@ -4522,9 +4534,13 @@ class ImportClient
         // and deleted remotely before the next accumulates both lines,
         // and the later one reflects the newer remote truth.
         $entries = [];
-        $raw = @file_get_contents($this->staged_pull_manifest_log());
-        if (is_string($raw) && $raw !== "") {
-            foreach (explode("\n", $raw) as $line) {
+        $log_handle = @fopen($this->staged_pull_manifest_log(), "r");
+        if ($log_handle !== false) {
+            while (true) {
+                $line = fgets($log_handle);
+                if ($line === false) {
+                    break;
+                }
                 $record = json_decode($line, true);
                 if (!is_array($record) || !is_string($record["artifact_id"] ?? null)) {
                     continue;
@@ -4563,6 +4579,7 @@ class ImportClient
                     ];
                 }
             }
+            fclose($log_handle);
         }
         if ($entries === []) {
             return;
@@ -4594,11 +4611,16 @@ class ImportClient
             "skipped_paths" => [],
             "deleted" => 0,
         ];
+        $protected_ids = [];
         if ($lines !== "") {
             $store = $this->staged_pull_store();
             $store->discard(self::PULL_MANIFEST_ID);
             $offset = 0;
-            foreach (str_split($lines, 262144) as $piece) {
+            // substr windows avoid str_split materializing a second full
+            // copy of a manifest that can reach tens of megabytes.
+            $lines_length = strlen($lines);
+            for ($piece_at = 0; $piece_at < $lines_length; $piece_at += 262144) {
+                $piece = substr($lines, $piece_at, 262144);
                 $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
                 if ($appended["status"] !== "accepted") {
                     throw new RuntimeException(
@@ -4612,29 +4634,24 @@ class ImportClient
             }
 
             $this->audit_log("STAGED APPLY | " . count($entries) . " entries", true);
-            $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
+            // Every protected id flows through the callback, uncapped —
+            // the PRESERVE-LOCAL audit contract and the index catch-up
+            // below both need the full set, not the response's capped
+            // diagnostic list.
+            $engine = $this->staged_pull_apply_engine(function (string $artifact_id) use (&$protected_ids): void {
+                if (isset($protected_ids[$artifact_id])) {
+                    return;
+                }
+                $protected_ids[$artifact_id] = true;
+                $this->audit_log("PRESERVE-LOCAL skip file (kept at apply) | {$artifact_id}", false);
+            });
+            $result = $engine->apply(self::PULL_MANIFEST_ID);
             if ($result["status"] !== "applied") {
                 throw new RuntimeException(
                     "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
                         " (" . ($result["detail"] ?? "") . ")",
                 );
             }
-        }
-
-        // Same audit contract as write-time preserve-local: every skipped
-        // operation is logged with the PRESERVE-LOCAL prefix.
-        $skipped_paths = is_array($result["skipped_paths"] ?? null) ? $result["skipped_paths"] : [];
-        foreach ($skipped_paths as $protected_path) {
-            $this->audit_log("PRESERVE-LOCAL skip file (kept at apply) | {$protected_path}", false);
-        }
-        if ($result["skipped"] > count($skipped_paths)) {
-            $this->audit_log(
-                sprintf(
-                    "PRESERVE-LOCAL skipped %d more files (path list capped)",
-                    $result["skipped"] - count($skipped_paths),
-                ),
-                false,
-            );
         }
 
         // The index merge consumes its updates as a path-sorted stream
@@ -4655,13 +4672,10 @@ class ImportClient
         // checks, same validation, same audit lines, just at window time
         // (their index upserts included). Applied files enter the index,
         // confirmed deletions leave it — mirroring push's
-        // forget-after-confirm. Protected entries (and everything, past
-        // the skipped-paths cap, where protected and applied cannot be
-        // told apart) keep their old state and re-derive next delta —
-        // a re-download or a no-op, never an orphan. Every step is
-        // idempotent, so a kill here reruns cleanly from the log.
-        $protected = array_fill_keys($skipped_paths, true);
-        $cap_overflowed = $result["skipped"] > count($skipped_paths);
+        // forget-after-confirm. Protected entries keep their old state
+        // and re-derive next delta — a re-download or a no-op, never an
+        // orphan. Every step is idempotent, so a kill here reruns
+        // cleanly from the log.
         $this->staged_replay = true;
         try {
             foreach ($entries as $artifact_id => $entry) {
@@ -4683,7 +4697,7 @@ class ImportClient
                     ]]);
                     continue;
                 }
-                if ($cap_overflowed || isset($protected[$artifact_id])) {
+                if (isset($protected_ids[$artifact_id])) {
                     continue;
                 }
                 if ($entry["kind"] === "delete") {
@@ -7448,11 +7462,17 @@ class ImportClient
             // The batch's ownership flags live in the download list slice
             // the fetch state brackets; rebuilding from there covers
             // resumed batches, whose batch file predates this process.
-            $this->staged_batch_owned = $this->read_download_list_owned(
-                $list_file,
-                $batch_offset,
-                $next_offset,
-            );
+            // One batch spans many requests, so rebuild only when the
+            // slice changes.
+            $batch_key = $list_file . ":" . $batch_offset . ":" . $next_offset;
+            if ($this->staged_batch_owned_key !== $batch_key) {
+                $this->staged_batch_owned = $this->read_download_list_owned(
+                    $list_file,
+                    $batch_offset,
+                    $next_offset,
+                );
+                $this->staged_batch_owned_key = $batch_key;
+            }
         }
 
         $post_data = [
@@ -11785,111 +11805,10 @@ class ImportClient
 
     public function default_state(): array
     {
-        return [
-            // Resume checkpoint for the lower-level command currently being
-            // run directly or as a stage inside a pull pipeline.
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
-            "preflight" => null,
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
-            "webhost" => null,
-            "follow_symlinks" => true,
-            "staged_apply" => false,
-            "fs_root_nonempty_behavior" => "error",
-            "filter" => "none",
-            "user_agent" => null,
-            "max_allowed_packet" => null,
-            "files_remap_fingerprint" => null,
-            "files_pull_only_fingerprint" => null,
-            "files_pull_summary" => [
-                "files_pulled" => 0,
-            ],
-            "db_index" => [
-                "file" => null,
-                "tables" => 0,
-                "rows_estimated" => 0,
-                "bytes" => 0,
-                "updated_at" => null,
-            ],
-            "diff" => [
-                "remote_offset" => 0,
-                "local_after" => null,
-            ],
-            "index" => [
-                "cursor" => null,
-            ],
-            "fetch" => [
-                "offset" => 0,
-                "next_offset" => 0,
-                "batch_file" => null,
-                "cursor" => null,
-                "batch_entries" => 0,
-            ],
-            "fetch_skipped" => [
-                "offset" => 0,
-                "next_offset" => 0,
-                "batch_file" => null,
-                "cursor" => null,
-                "batch_entries" => 0,
-            ],
-            // Crash recovery: track in-progress file downloads
-            // If we crash mid-write, we can truncate to the expected size on resume
-            "current_file" => null,        // Path to file being written
-            "current_file_bytes" => null,  // Expected bytes written so far
-            // Crash recovery: track SQL file size
-            "sql_bytes" => null,           // Expected SQL file size
-            // SQL streaming progress for user-facing statement counts.
-            "sql_statements_counted" => 0,
-            // db-apply state
-            "apply" => [
-                "statements_executed" => 0,
-                "bytes_read" => 0,
-                "rewrite_url" => null,
-                // Target database configuration — persisted by db-apply
-                // so that apply-runtime can generate DB_* constants.
-                "target_engine" => null,
-                "target_db" => null,
-                "target_host" => null,
-                "target_port" => null,
-                "target_user" => null,
-                "target_pass" => null,
-                "target_sqlite_path" => null,
-                "remote_paths_removed_from_local_site" => [],
-            ],
-            // SQL output mode (file, stdout, mysql) — persisted for resume
-            "sql_output" => null,
-            // MySQL connection parameters — persisted for resume (password excluded)
-            "mysql_host" => null,
-            "mysql_port" => null,
-            "mysql_user" => null,
-            "mysql_database" => null,
-            // Consecutive cURL timeout counter — tracks how many times in a
-            // row a timeout fired without the cursor advancing. After
-            // MAX_CONSECUTIVE_TIMEOUTS with no progress, the importer gives
-            // up instead of retrying forever.
-            "consecutive_timeouts" => 0,
-            // Adaptive tuning state/config
-            "tuning" => [
-                "config" => [],
-                "state" => [],
-            ],
-            // Resume checkpoint for the user-facing pull pipeline command
-            // being orchestrated.
-            "pull_pipeline" => [
-                "started_by_command" => null,
-                "stage_sequence" => [],
-                "last_completed_stage" => null,
-                "files_filter" => null,
-                "skipped_pending" => false,
-                "has_completed_once" => false,
-            ],
-        ];
+        // ImportState's typed properties are the single source of the
+        // persisted schema; a field added there appears here without a
+        // second hand-maintained copy to keep in lockstep.
+        return ImportState::from_array([])->to_array();
     }
 
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4635,22 +4635,6 @@ class ImportClient
         // Only files and deletions go through the store-backed engine;
         // directories and symlinks replay through their own handlers after
         // the renames land.
-        $lines = "";
-        foreach ($entries as $artifact_id => $entry) {
-            if ($entry["kind"] === "delete") {
-                $lines .= json_encode(["artifact_id" => $artifact_id, "delete" => true]) . "\n";
-                continue;
-            }
-            if ($entry["kind"] !== "file") {
-                continue;
-            }
-            $manifest_entry = ["artifact_id" => $artifact_id, "size" => $entry["size"]];
-            if ($entry["owned"]) {
-                $manifest_entry["owned"] = true;
-            }
-            $lines .= json_encode($manifest_entry) . "\n";
-        }
-
         $result = [
             "applied" => 0,
             "already_applied" => 0,
@@ -4659,24 +4643,41 @@ class ImportClient
             "deleted" => 0,
         ];
         $protected_ids = [];
-        if ($lines !== "") {
-            $store = $this->staged_pull_store();
-            $store->discard(self::PULL_MANIFEST_ID);
-            $offset = 0;
-            // substr windows avoid str_split materializing a second full
-            // copy of a manifest that can reach tens of megabytes.
-            $lines_length = strlen($lines);
-            for ($piece_at = 0; $piece_at < $lines_length; $piece_at += 262144) {
-                $piece = substr($lines, $piece_at, 262144);
-                $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
-                if ($appended["status"] !== "accepted") {
-                    throw new RuntimeException(
-                        "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
-                    );
+        $store = $this->staged_pull_store();
+        $store->discard(self::PULL_MANIFEST_ID);
+        $manifest_entries = 0;
+        $manifest_bytes = 0;
+        // Flush manifest lines to the store in bounded windows instead of
+        // materializing one string that can reach tens of megabytes.
+        $manifest_chunk = "";
+        foreach ($entries as $artifact_id => $entry) {
+            if ($entry["kind"] === "delete") {
+                $manifest_entry = ["artifact_id" => $artifact_id, "delete" => true];
+            } elseif ($entry["kind"] === "file") {
+                $manifest_entry = ["artifact_id" => $artifact_id, "size" => $entry["size"]];
+                if ($entry["owned"]) {
+                    $manifest_entry["owned"] = true;
                 }
-                $offset = $appended["committed_bytes"];
+            } else {
+                continue;
             }
-            if ($store->finalize(self::PULL_MANIFEST_ID, strlen($lines))["status"] !== "verified") {
+            $encoded = json_encode($manifest_entry);
+            if (!is_string($encoded)) {
+                throw new RuntimeException("Staged apply could not encode its manifest.");
+            }
+            $manifest_chunk .= $encoded . "\n";
+            $manifest_entries++;
+            if (strlen($manifest_chunk) >= 262144) {
+                $manifest_bytes = $this->append_staged_pull_manifest_chunk($store, $manifest_bytes, $manifest_chunk);
+                $manifest_chunk = "";
+            }
+        }
+
+        if ($manifest_entries > 0) {
+            if ($manifest_chunk !== "") {
+                $manifest_bytes = $this->append_staged_pull_manifest_chunk($store, $manifest_bytes, $manifest_chunk);
+            }
+            if ($store->finalize(self::PULL_MANIFEST_ID, $manifest_bytes)["status"] !== "verified") {
                 throw new RuntimeException("Staged apply could not verify its manifest.");
             }
 
@@ -4780,6 +4781,17 @@ class ImportClient
             "skipped" => $result["skipped"],
             "deleted" => $result["deleted"],
         ], true);
+    }
+
+    private function append_staged_pull_manifest_chunk(Site_Export_Staged_Artifacts $store, int $offset, string $chunk): int
+    {
+        $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $chunk);
+        if ($appended["status"] !== "accepted") {
+            throw new RuntimeException(
+                "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+            );
+        }
+        return $appended["committed_bytes"];
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1250,6 +1250,13 @@ class ImportClient
     /** @var array<string,true> Owned remote paths in the batch being fetched. */
     private $staged_batch_owned = [];
 
+    /**
+     * True while the apply window replays deferred directory/symlink
+     * records through their regular handlers — the same code that runs at
+     * fetch time in unstaged mode, just at window time.
+     */
+    private $staged_replay = false;
+
     public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
@@ -2028,6 +2035,22 @@ class ImportClient
                     @unlink($this->volatile_files_file);
                     $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
                 }
+
+                // Staged leftovers are sync progress too: unapplied bytes
+                // and the pending window log go with the cursor. Nothing
+                // in them reached the live tree or the index, so the next
+                // diff re-derives whatever still applies.
+                $staging_dir = $this->staged_pull_staging_dir();
+                if (is_dir($staging_dir)) {
+                    $this->remove_local_path_without_following_symlinks($staging_dir);
+                    $this->audit_log("FILE DELETE | {$staging_dir} | staged leftovers cleared");
+                    $this->staged_pull_store = null;
+                }
+                if (file_exists($this->staged_pull_manifest_log())) {
+                    @unlink($this->staged_pull_manifest_log());
+                    $this->audit_log("FILE DELETE | {$this->staged_pull_manifest_log()}");
+                }
+
                 $this->import_state()->index = new RemoteFileIndexCursorState();
                 $this->import_state()->fetch = new DownloadListFetchProgressState();
                 $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
@@ -4382,7 +4405,7 @@ class ImportClient
      *
      * @return string|null Failure reason, or null when the file verified.
      */
-    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime, bool $owned = false): ?string
+    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime, bool $owned, string $remote_path): ?string
     {
         $result = $this->staged_pull_store()->finalize($artifact_id, $expected_size);
         if ($result["status"] !== "verified") {
@@ -4393,12 +4416,56 @@ class ImportClient
             // against the remote ctime.
             @touch($this->staged_pull_staging_dir() . "/files/" . $artifact_id, $ctime);
         }
-        $record = ["artifact_id" => $artifact_id, "size" => $expected_size];
+        // The remote path and ctime ride along so the window can update
+        // the local index after the file actually lands — the index must
+        // describe the live tree, never the staging area, or an abort
+        // between fetch and apply leaves a delta that skips files the
+        // tree never received.
+        $record = [
+            "artifact_id" => $artifact_id,
+            "size" => $expected_size,
+            "path" => $remote_path,
+            "ctime" => $ctime,
+        ];
         if ($owned) {
             $record["owned"] = true;
         }
-        @file_put_contents($this->staged_pull_manifest_log(), json_encode($record) . "\n", FILE_APPEND);
+        $this->staged_pull_append_log(json_encode($record) . "\n");
         return null;
+    }
+
+    /**
+     * Appends a deferred record to the manifest log, keyed by the path's
+     * fs-root-relative artifact id. Directory and symlink parts defer here
+     * in staged mode; the apply window replays them through their regular
+     * handlers.
+     */
+    private function staged_pull_defer_record(array $record): void
+    {
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($record["path"]);
+            $record["artifact_id"] = $this->staged_pull_artifact_id($local_path);
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "Security: refusing to stage a {$record["type"]} record for invalid path '{$record["path"]}': " . $e->getMessage(),
+                true,
+            );
+            return;
+        }
+        $this->staged_pull_append_log(json_encode($record) . "\n");
+    }
+
+    /**
+     * All manifest-log appends go through here: a lost record is a file,
+     * directory, symlink, or deletion the window would silently never
+     * carry out, so short writes are fatal (disk full?) like the index
+     * updates writer's.
+     */
+    private function staged_pull_append_log(string $line): void
+    {
+        if (@file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND) !== strlen($line)) {
+            throw new RuntimeException("Failed to append to the staged manifest log (disk full?)");
+        }
     }
 
     /**
@@ -4423,12 +4490,11 @@ class ImportClient
         }
         // Any bytes staged under this id from an earlier resume are
         // garbage now; the apply window's delete pass consumes them.
-        $line = json_encode([
+        $this->staged_pull_append_log(json_encode([
             "artifact_id" => $artifact_id,
             "delete" => true,
             "path" => $remote_path,
-        ]) . "\n";
-        @file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND);
+        ]) . "\n");
         $this->audit_log("Deletion staged for the apply window: {$remote_path}", false);
     }
 
@@ -4439,6 +4505,12 @@ class ImportClient
      * accumulates across resumes and is deduplicated here; entries an
      * earlier window already applied classify as applied and only consume
      * their leftover markers.
+     *
+     * The window is: engine apply (file renames and deletions under the
+     * store lock), then a replay of deferred directory/symlink records
+     * through their regular handlers, then the index catch-up. Everything
+     * before the final log unlink is idempotent, so a kill anywhere in
+     * the window reruns cleanly.
      */
     private function run_staged_pull_apply(): void
     {
@@ -4457,18 +4529,37 @@ class ImportClient
                 if (!is_array($record) || !is_string($record["artifact_id"] ?? null)) {
                     continue;
                 }
+                $path = is_string($record["path"] ?? null) ? $record["path"] : null;
                 if (!empty($record["delete"])) {
+                    $entries[$record["artifact_id"]] = ["kind" => "delete", "path" => $path];
+                    continue;
+                }
+                $type = $record["type"] ?? null;
+                $ctime = is_int($record["ctime"] ?? null) ? $record["ctime"] : 0;
+                if ($type === "dir" && $path !== null) {
                     $entries[$record["artifact_id"]] = [
-                        "delete" => true,
-                        "path" => is_string($record["path"] ?? null) ? $record["path"] : null,
+                        "kind" => "dir",
+                        "path" => $path,
+                        "ctime" => $ctime,
                     ];
                     continue;
                 }
-                if (is_int($record["size"] ?? null)) {
+                if ($type === "symlink" && $path !== null && is_string($record["target"] ?? null)) {
                     $entries[$record["artifact_id"]] = [
-                        "delete" => false,
+                        "kind" => "symlink",
+                        "path" => $path,
+                        "target" => $record["target"],
+                        "ctime" => $ctime,
+                    ];
+                    continue;
+                }
+                if ($type === null && is_int($record["size"] ?? null)) {
+                    $entries[$record["artifact_id"]] = [
+                        "kind" => "file",
                         "size" => $record["size"],
                         "owned" => !empty($record["owned"]),
+                        "path" => $path,
+                        "ctime" => $ctime,
                     ];
                 }
             }
@@ -4477,10 +4568,16 @@ class ImportClient
             return;
         }
 
+        // Only files and deletions go through the store-backed engine;
+        // directories and symlinks replay through their own handlers after
+        // the renames land.
         $lines = "";
         foreach ($entries as $artifact_id => $entry) {
-            if ($entry["delete"]) {
+            if ($entry["kind"] === "delete") {
                 $lines .= json_encode(["artifact_id" => $artifact_id, "delete" => true]) . "\n";
+                continue;
+            }
+            if ($entry["kind"] !== "file") {
                 continue;
             }
             $manifest_entry = ["artifact_id" => $artifact_id, "size" => $entry["size"]];
@@ -4490,32 +4587,40 @@ class ImportClient
             $lines .= json_encode($manifest_entry) . "\n";
         }
 
-        $store = $this->staged_pull_store();
-        $store->discard(self::PULL_MANIFEST_ID);
-        $offset = 0;
-        foreach (str_split($lines, 262144) as $piece) {
-            $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
-            if ($appended["status"] !== "accepted") {
+        $result = [
+            "applied" => 0,
+            "already_applied" => 0,
+            "skipped" => 0,
+            "skipped_paths" => [],
+            "deleted" => 0,
+        ];
+        if ($lines !== "") {
+            $store = $this->staged_pull_store();
+            $store->discard(self::PULL_MANIFEST_ID);
+            $offset = 0;
+            foreach (str_split($lines, 262144) as $piece) {
+                $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
+                if ($appended["status"] !== "accepted") {
+                    throw new RuntimeException(
+                        "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+                    );
+                }
+                $offset = $appended["committed_bytes"];
+            }
+            if ($store->finalize(self::PULL_MANIFEST_ID, strlen($lines))["status"] !== "verified") {
+                throw new RuntimeException("Staged apply could not verify its manifest.");
+            }
+
+            $this->audit_log("STAGED APPLY | " . count($entries) . " entries", true);
+            $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
+            if ($result["status"] !== "applied") {
                 throw new RuntimeException(
-                    "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+                    "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
+                        " (" . ($result["detail"] ?? "") . ")",
                 );
             }
-            $offset = $appended["committed_bytes"];
-        }
-        if ($store->finalize(self::PULL_MANIFEST_ID, strlen($lines))["status"] !== "verified") {
-            throw new RuntimeException("Staged apply could not verify its manifest.");
         }
 
-        $this->audit_log("STAGED APPLY | " . count($entries) . " files", true);
-        $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
-        if ($result["status"] !== "applied") {
-            throw new RuntimeException(
-                "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
-                    " (" . ($result["detail"] ?? "") . ")",
-            );
-        }
-
-        @unlink($this->staged_pull_manifest_log());
         // Same audit contract as write-time preserve-local: every skipped
         // operation is logged with the PRESERVE-LOCAL prefix.
         $skipped_paths = is_array($result["skipped_paths"] ?? null) ? $result["skipped_paths"] : [];
@@ -4532,29 +4637,69 @@ class ImportClient
             );
         }
 
-        // Deletions the window confirmed leave the index now, mirroring
-        // push's forget-after-confirm. Protected deletions (symlinked
-        // parents) keep their entries and re-derive next delta; past the
-        // skipped-paths cap we cannot tell the two apart, so everything
-        // stays and re-derives — a no-op, never an orphan.
+        // The index merge consumes its updates as a path-sorted stream
+        // (trunk keeps it sorted by upserting in fetch order). Flush any
+        // fetch-phase leftovers as their own sorted run first, then walk
+        // the window's entries in path order so replays and index writes
+        // emit one sorted run of their own.
+        $this->finalize_index_updates();
+        uasort($entries, static function (array $a, array $b): int {
+            $a_path = (string) $a["path"];
+            $b_path = (string) $b["path"];
+            return strcmp($a_path, $b_path);
+        });
+
+        // The window's remaining effects, one path-ordered walk:
+        // directory and symlink records replay through the handlers that
+        // would have run at fetch time in unstaged mode — same policy
+        // checks, same validation, same audit lines, just at window time
+        // (their index upserts included). Applied files enter the index,
+        // confirmed deletions leave it — mirroring push's
+        // forget-after-confirm. Protected entries (and everything, past
+        // the skipped-paths cap, where protected and applied cannot be
+        // told apart) keep their old state and re-derive next delta —
+        // a re-download or a no-op, never an orphan. Every step is
+        // idempotent, so a kill here reruns cleanly from the log.
         $protected = array_fill_keys($skipped_paths, true);
         $cap_overflowed = $result["skipped"] > count($skipped_paths);
-        $confirmed_deletes = 0;
-        foreach ($entries as $artifact_id => $entry) {
-            if (
-                !$entry["delete"]
-                || $entry["path"] === null
-                || $cap_overflowed
-                || isset($protected[$artifact_id])
-            ) {
-                continue;
+        $this->staged_replay = true;
+        try {
+            foreach ($entries as $artifact_id => $entry) {
+                if ($entry["path"] === null) {
+                    continue;
+                }
+                if ($entry["kind"] === "dir") {
+                    $this->handle_directory_chunk(["headers" => [
+                        "x-directory-path" => base64_encode($entry["path"]),
+                        "x-directory-ctime" => (string) $entry["ctime"],
+                    ]]);
+                    continue;
+                }
+                if ($entry["kind"] === "symlink") {
+                    $this->handle_symlink_chunk(["headers" => [
+                        "x-symlink-path" => base64_encode($entry["path"]),
+                        "x-symlink-target" => base64_encode($entry["target"]),
+                        "x-symlink-ctime" => (string) $entry["ctime"],
+                    ]]);
+                    continue;
+                }
+                if ($cap_overflowed || isset($protected[$artifact_id])) {
+                    continue;
+                }
+                if ($entry["kind"] === "delete") {
+                    $this->delete_index_entry($entry["path"]);
+                } elseif ($entry["kind"] === "file" && $entry["ctime"] > 0) {
+                    $this->upsert_index_entry($entry["path"], $entry["ctime"], $entry["size"], "file");
+                }
             }
-            $this->delete_index_entry($entry["path"]);
-            ++$confirmed_deletes;
+        } finally {
+            $this->staged_replay = false;
         }
-        if ($confirmed_deletes > 0) {
-            $this->finalize_index_updates();
-        }
+        $this->finalize_index_updates();
+
+        // Unlinked last: everything above idempotently reruns from the
+        // log if the process dies mid-window.
+        @unlink($this->staged_pull_manifest_log());
 
         $this->audit_log(
             sprintf(
@@ -9809,6 +9954,7 @@ class ImportClient
                     $file_size,
                     $context->file_ctime ?? 0,
                     $context->staged_owned === true,
+                    $path,
                 );
                 if ($finalize_error !== null) {
                     $this->staged_pull_store()->discard($context->staged_artifact_id);
@@ -9816,13 +9962,9 @@ class ImportClient
                         "  Staged file did not verify ({$finalize_error}); discarded for refetch",
                         true,
                     );
-                } elseif ($context->file_ctime) {
-                    $this->upsert_index_entry(
-                        $path,
-                        $context->file_ctime,
-                        $file_size,
-                        "file",
-                    );
+                } else {
+                    // The index entry waits for the apply window; only
+                    // progress bookkeeping happens at stage time.
                     $this->files_imported++;
                     $this->clear_volatile_file($path);
                     $this->audit_log(
@@ -10121,6 +10263,17 @@ class ImportClient
             return;
         }
 
+        if ($this->staged_apply_mode && !$this->staged_replay) {
+            // Staged mode: the live tree stays untouched until the apply
+            // window, which replays this record through this same handler.
+            $this->staged_pull_defer_record([
+                "type" => "dir",
+                "path" => $path,
+                "ctime" => $ctime,
+            ]);
+            return;
+        }
+
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
 
         // In preserve-local mode, if the directory already exists (as a real
@@ -10204,6 +10357,19 @@ class ImportClient
                     true,
                 );
             }
+            return;
+        }
+
+        if ($this->staged_apply_mode && !$this->staged_replay) {
+            // Staged mode: defer, window replays. The raw remote target is
+            // recorded; mapping and validation run at replay, in the same
+            // code they always run in.
+            $this->staged_pull_defer_record([
+                "type" => "symlink",
+                "path" => $path,
+                "target" => $target,
+                "ctime" => $ctime,
+            ]);
             return;
         }
 
@@ -12745,7 +12911,10 @@ if (
             'target' => 'staged_apply',
             'help' => 'Download into a staging area under --state-dir and move files into ' .
                 '--fs-root in one rename window at the end, so the tree never holds a ' .
-                'half-written file (requires --state-dir and --fs-root on one filesystem)',
+                'half-written file (requires --state-dir and --fs-root on one filesystem). ' .
+                'The mode persists in state: resumes and later deltas stay staged. ' .
+                'To switch modes, run --abort first (pending staged data is discarded ' .
+                'and re-derived by the next sync)',
             'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1247,6 +1247,9 @@ class ImportClient
     /** @var Site_Export_Staged_Artifacts|null Lazy staged pull store. */
     private $staged_pull_store = null;
 
+    /** @var array<string,true> Owned remote paths in the batch being fetched. */
+    private $staged_batch_owned = [];
+
     public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
@@ -3026,6 +3029,10 @@ class ImportClient
             } elseif ($has_skipped) {
                 $stage = "fetch-skipped";
             } else {
+                // Nothing to download, but a deletions-only delta still
+                // has a window to run: the manifest log holds whatever
+                // the diff just staged for removal.
+                $this->run_staged_pull_apply();
                 $stage = null;
             }
             $this->import_state()->active_resumable_command->current_stage = $stage;
@@ -4375,7 +4382,7 @@ class ImportClient
      *
      * @return string|null Failure reason, or null when the file verified.
      */
-    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime): ?string
+    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime, bool $owned = false): ?string
     {
         $result = $this->staged_pull_store()->finalize($artifact_id, $expected_size);
         if ($result["status"] !== "verified") {
@@ -4386,9 +4393,43 @@ class ImportClient
             // against the remote ctime.
             @touch($this->staged_pull_staging_dir() . "/files/" . $artifact_id, $ctime);
         }
-        $line = json_encode(["artifact_id" => $artifact_id, "size" => $expected_size]) . "\n";
-        @file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND);
+        $record = ["artifact_id" => $artifact_id, "size" => $expected_size];
+        if ($owned) {
+            $record["owned"] = true;
+        }
+        @file_put_contents($this->staged_pull_manifest_log(), json_encode($record) . "\n", FILE_APPEND);
         return null;
+    }
+
+    /**
+     * Records a diff-derived deletion for the apply window instead of
+     * removing the file at diff time — staged mode's whole point is that
+     * the tree flips in one window, deletions included. The index entry
+     * stays until the window confirms: a crash or --abort in between just
+     * re-derives the same deletion from the next diff, never orphaning a
+     * file the index has already forgotten.
+     */
+    private function record_staged_pull_deletion(string $remote_path): void
+    {
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($remote_path);
+            $artifact_id = $this->staged_pull_artifact_id($local_path);
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "Security: refusing to stage a deletion for invalid path '{$remote_path}': " . $e->getMessage(),
+                true,
+            );
+            return;
+        }
+        // Any bytes staged under this id from an earlier resume are
+        // garbage now; the apply window's delete pass consumes them.
+        $line = json_encode([
+            "artifact_id" => $artifact_id,
+            "delete" => true,
+            "path" => $remote_path,
+        ]) . "\n";
+        @file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND);
+        $this->audit_log("Deletion staged for the apply window: {$remote_path}", false);
     }
 
     /**
@@ -4405,17 +4446,30 @@ class ImportClient
             return;
         }
 
+        // Last record wins per artifact id: a file staged by one resume
+        // and deleted remotely before the next accumulates both lines,
+        // and the later one reflects the newer remote truth.
         $entries = [];
         $raw = @file_get_contents($this->staged_pull_manifest_log());
         if (is_string($raw) && $raw !== "") {
             foreach (explode("\n", $raw) as $line) {
                 $record = json_decode($line, true);
-                if (
-                    is_array($record)
-                    && is_string($record["artifact_id"] ?? null)
-                    && is_int($record["size"] ?? null)
-                ) {
-                    $entries[$record["artifact_id"]] = $record["size"];
+                if (!is_array($record) || !is_string($record["artifact_id"] ?? null)) {
+                    continue;
+                }
+                if (!empty($record["delete"])) {
+                    $entries[$record["artifact_id"]] = [
+                        "delete" => true,
+                        "path" => is_string($record["path"] ?? null) ? $record["path"] : null,
+                    ];
+                    continue;
+                }
+                if (is_int($record["size"] ?? null)) {
+                    $entries[$record["artifact_id"]] = [
+                        "delete" => false,
+                        "size" => $record["size"],
+                        "owned" => !empty($record["owned"]),
+                    ];
                 }
             }
         }
@@ -4424,8 +4478,16 @@ class ImportClient
         }
 
         $lines = "";
-        foreach ($entries as $artifact_id => $size) {
-            $lines .= json_encode(["artifact_id" => $artifact_id, "size" => $size]) . "\n";
+        foreach ($entries as $artifact_id => $entry) {
+            if ($entry["delete"]) {
+                $lines .= json_encode(["artifact_id" => $artifact_id, "delete" => true]) . "\n";
+                continue;
+            }
+            $manifest_entry = ["artifact_id" => $artifact_id, "size" => $entry["size"]];
+            if ($entry["owned"]) {
+                $manifest_entry["owned"] = true;
+            }
+            $lines .= json_encode($manifest_entry) . "\n";
         }
 
         $store = $this->staged_pull_store();
@@ -4469,12 +4531,38 @@ class ImportClient
                 false,
             );
         }
+
+        // Deletions the window confirmed leave the index now, mirroring
+        // push's forget-after-confirm. Protected deletions (symlinked
+        // parents) keep their entries and re-derive next delta; past the
+        // skipped-paths cap we cannot tell the two apart, so everything
+        // stays and re-derives — a no-op, never an orphan.
+        $protected = array_fill_keys($skipped_paths, true);
+        $cap_overflowed = $result["skipped"] > count($skipped_paths);
+        $confirmed_deletes = 0;
+        foreach ($entries as $artifact_id => $entry) {
+            if (
+                !$entry["delete"]
+                || $entry["path"] === null
+                || $cap_overflowed
+                || isset($protected[$artifact_id])
+            ) {
+                continue;
+            }
+            $this->delete_index_entry($entry["path"]);
+            ++$confirmed_deletes;
+        }
+        if ($confirmed_deletes > 0) {
+            $this->finalize_index_updates();
+        }
+
         $this->audit_log(
             sprintf(
-                "STAGED APPLY COMPLETE | applied=%d already_applied=%d skipped=%d",
+                "STAGED APPLY COMPLETE | applied=%d already_applied=%d skipped=%d deleted=%d",
                 $result["applied"],
                 $result["already_applied"],
                 $result["skipped"],
+                $result["deleted"],
             ),
             true,
         );
@@ -4484,6 +4572,7 @@ class ImportClient
             "applied" => $result["applied"],
             "already_applied" => $result["already_applied"],
             "skipped" => $result["skipped"],
+            "deleted" => $result["deleted"],
         ], true);
     }
 
@@ -7031,8 +7120,14 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_local_file_path($local["path"]);
-                    $this->delete_index_entry($local["path"]);
+                    if ($this->staged_apply_mode) {
+                        // Staged mode defers the deletion into the apply
+                        // window, so removals and arrivals flip together.
+                        $this->record_staged_pull_deletion($local["path"]);
+                    } else {
+                        $this->delete_local_file_path($local["path"]);
+                        $this->delete_index_entry($local["path"]);
+                    }
                 }
                 $local_after = $local["path"];
                 $local = $this->read_index_line($local_handle);
@@ -7054,6 +7149,7 @@ class ImportClient
                     $this->append_download_list(
                         $remote["path"],
                         $target_handle,
+                        true,
                     );
                 }
                 $local_after = $local["path"];
@@ -7085,8 +7181,12 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_local_file_path($local["path"]);
-                $this->delete_index_entry($local["path"]);
+                if ($this->staged_apply_mode) {
+                    $this->record_staged_pull_deletion($local["path"]);
+                } else {
+                    $this->delete_local_file_path($local["path"]);
+                    $this->delete_index_entry($local["path"]);
+                }
             }
             $local_after = $local["path"];
             $local = $this->read_index_line($local_handle);
@@ -7197,6 +7297,17 @@ class ImportClient
                 "cursor" => null,
             ]));
             $this->save_state($this->state);
+        }
+
+        if ($this->staged_apply_mode) {
+            // The batch's ownership flags live in the download list slice
+            // the fetch state brackets; rebuilding from there covers
+            // resumed batches, whose batch file predates this process.
+            $this->staged_batch_owned = $this->read_download_list_owned(
+                $list_file,
+                $batch_offset,
+                $next_offset,
+            );
         }
 
         $post_data = [
@@ -7457,12 +7568,51 @@ class ImportClient
     /**
      * Append a path to the download list file.
      */
-    private function append_download_list(string $path, $handle): void
+    /**
+     * Owned paths within one batch's slice of the download list.
+     *
+     * @param int $from Byte offset of the batch's first list line.
+     * @param int $to   Byte offset just past its last line.
+     * @return array<string,true> keyed by remote path.
+     */
+    private function read_download_list_owned(string $list_file, int $from, int $to): array
     {
-        $line = json_encode(
-            ["path" => base64_encode($path)],
-            JSON_UNESCAPED_SLASHES,
-        );
+        $owned = [];
+        $handle = @fopen($list_file, "r");
+        if (!$handle) {
+            return $owned;
+        }
+        if ($from > 0) {
+            fseek($handle, $from);
+        }
+        while (ftell($handle) < $to) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            $record = json_decode(trim($line), true);
+            if (!is_array($record) || empty($record["owned"]) || !isset($record["path"])) {
+                continue;
+            }
+            $path = base64_decode($record["path"]);
+            if (is_string($path) && $path !== "") {
+                $owned[$path] = true;
+            }
+        }
+        fclose($handle);
+        return $owned;
+    }
+
+    private function append_download_list(string $path, $handle, bool $owned = false): void
+    {
+        $record = ["path" => base64_encode($path)];
+        if ($owned) {
+            // The diff found this path in the local index: the pull owns
+            // it. Staged apply needs the distinction — preserve-local
+            // protects what the sync never owned, not its own copies.
+            $record["owned"] = true;
+        }
+        $line = json_encode($record, JSON_UNESCAPED_SLASHES);
         if ($line !== false) {
             fwrite($handle, $line . "\n");
         }
@@ -9568,6 +9718,7 @@ class ImportClient
             // position starts at 0 and the store's frontier absorbs any
             // committed prefix a resumed server re-sends.
             $context->staged_artifact_id = $this->staged_pull_artifact_id($local_path);
+            $context->staged_owned = isset($this->staged_batch_owned[$path]);
             $context->file_path = $local_path;
             $context->file_ctime = (int) ($headers["x-file-ctime"] ?? 0);
             $context->file_bytes_written = 0;
@@ -9621,6 +9772,7 @@ class ImportClient
                     // checkpointed this file: the server re-sends it from
                     // the start, so the stream position begins at 0.
                     $context->staged_artifact_id = $this->staged_pull_artifact_id($local_path);
+                    $context->staged_owned = isset($this->staged_batch_owned[$path]);
                 }
                 $this->staged_pull_write_chunk($context, $chunk["body"]);
             } elseif ($context->file_handle) {
@@ -9656,6 +9808,7 @@ class ImportClient
                     $context->staged_artifact_id,
                     $file_size,
                     $context->file_ctime ?? 0,
+                    $context->staged_owned === true,
                 );
                 if ($finalize_error !== null) {
                     $this->staged_pull_store()->discard($context->staged_artifact_id);
@@ -12192,6 +12345,8 @@ class StreamingContext
     public $skip_current_file = false;
     // Staged pull: fs-root-relative artifact id of the file being staged
     public $staged_artifact_id = null;
+    // Staged pull: whether the download list marked this file owned
+    public $staged_owned = false;
 }
 
 /**

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -67,6 +67,14 @@ class StagedPushRunner
     private $on_progress;
 
     /**
+     * @var array<string,array{size:int,mtime:?int}>|null Parsed done cache;
+     *   one push-files run reads it for the plan walk, the deletion
+     *   derivation, and the post-apply forget — one parse serves all
+     *   three. Writers keep it current.
+     */
+    private $verified_cache_memo = null;
+
+    /**
      * @param array $options
      *   - state_dir (string, required): holds .push-state.json and
      *     .push-verified.jsonl; created if missing.
@@ -213,12 +221,17 @@ class StagedPushRunner
         // multipart discipline in the push direction. Files bigger than
         // the budget keep the resumable per-chunk path. A 413 shrinks the
         // budget (monotonically, so this terminates) and the affected
-        // batch repartitions.
-        while ($queue !== []) {
+        // batch repartitions. The queue is consumed by index — shifting
+        // a 200k-entry array reindexes it every time — and retries
+        // append to the tail.
+        $next = 0;
+        $queue_size = count($queue);
+        while ($next < $queue_size) {
             $budget = max(1, $this->sizer->chunk_bytes());
 
-            if ($queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
-                $entry = array_shift($queue);
+            if ($queue[$next]["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
+                $entry = $queue[$next];
+                ++$next;
                 $result = $this->client->upload_artifact(
                     $entry["artifact_id"],
                     $entry["source_path"],
@@ -250,14 +263,16 @@ class StagedPushRunner
                 return $this->aborted($files_total, $files_done, $failed, $reason, $result["detail"]);
             }
 
+            // One cumulative bound suffices: batch_bytes starts at 0, so
+            // the first entry's fit check and the running check coincide.
             $batch = [];
             $batch_bytes = 0;
             while (
-                $queue !== []
-                && $queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
-                && $batch_bytes + $queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
+                $next < $queue_size
+                && $batch_bytes + $queue[$next]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
             ) {
-                $entry = array_shift($queue);
+                $entry = $queue[$next];
+                ++$next;
                 $batch[$entry["artifact_id"]] = $entry;
                 $batch_bytes += $entry["total_bytes"] + self::BATCH_FRAME_OVERHEAD;
             }
@@ -269,6 +284,7 @@ class StagedPushRunner
                     // The sizer already shrank; repartition these entries.
                     foreach ($batch as $entry) {
                         $queue[] = $entry;
+                        ++$queue_size;
                     }
                     continue;
                 }
@@ -290,6 +306,7 @@ class StagedPushRunner
                 if ($outcome["status"] === "not_attempted") {
                     // The server stopped at an earlier frame; retry these.
                     $queue[] = $entry;
+                    ++$queue_size;
                     continue;
                 }
                 $reason = is_string($outcome["reason"]) ? $outcome["reason"] : "unexpected_response";
@@ -356,6 +373,9 @@ class StagedPushRunner
         $tmp_path = $this->verified_path . ".tmp";
         if (@file_put_contents($tmp_path, $lines) === strlen($lines)) {
             @rename($tmp_path, $this->verified_path);
+            foreach (array_keys($drop) as $artifact_id) {
+                unset($this->verified_cache_memo[$artifact_id]);
+            }
         }
         @unlink($tmp_path);
     }
@@ -379,8 +399,12 @@ class StagedPushRunner
      */
     private function read_verified_cache(): array
     {
+        if ($this->verified_cache_memo !== null) {
+            return $this->verified_cache_memo;
+        }
         $raw = @file_get_contents($this->verified_path);
         if ($raw === false || $raw === "") {
+            $this->verified_cache_memo = [];
             return [];
         }
         $cache = [];
@@ -401,6 +425,7 @@ class StagedPushRunner
                 "mtime" => is_int($record["mtime"] ?? null) ? $record["mtime"] : null,
             ];
         }
+        $this->verified_cache_memo = $cache;
         return $cache;
     }
 
@@ -414,6 +439,9 @@ class StagedPushRunner
             "mtime" => $mtime,
         ]) . "\n";
         @file_put_contents($this->verified_path, $line, FILE_APPEND);
+        if ($this->verified_cache_memo !== null) {
+            $this->verified_cache_memo[$artifact_id] = ["size" => $size, "mtime" => $mtime];
+        }
     }
 
     private function write_state(int $files_total, int $files_done): void

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -166,18 +166,14 @@ class StagedUploadClient
         // source is invisible to all of them. The exporter re-checks its
         // files after streaming (x-file-changed); the sender owes the same
         // honesty about its own disk, before and after the upload.
-        if (
-            $expected_mtime !== null
-            && is_array($opened_stat)
-            && (int) $opened_stat["mtime"] !== $expected_mtime
-        ) {
+        if ($this->planned_mtime_differs($opened_stat, $expected_mtime)) {
             fclose($source);
             // Committed bytes may belong to the older version; a mixed
             // artifact must never verify.
             $this->discard($artifact_id);
             return $this->failed(
                 "source_changed",
-                sprintf("planned mtime %d, found %d", $expected_mtime, (int) $opened_stat["mtime"])
+                sprintf("planned mtime %d, found %d", (int) $expected_mtime, (int) $opened_stat["mtime"])
             );
         }
 
@@ -309,15 +305,7 @@ class StagedUploadClient
         // Post-upload volatility check: a rewrite during the read window
         // can leave staged bytes that match no version of the file. Torn
         // content must fail typed, not verify.
-        clearstatcache(true, $source_path);
-        $now_stat = @stat($source_path);
-        if (
-            !is_array($opened_stat)
-            || $now_stat === false
-            || $now_stat["ino"] !== $opened_stat["ino"]
-            || $now_stat["mtime"] !== $opened_stat["mtime"]
-            || $now_stat["size"] !== $opened_stat["size"]
-        ) {
+        if ($this->source_changed_since($source_path, $opened_stat)) {
             $this->discard($artifact_id);
             return $this->failed("source_changed", "source changed while uploading");
         }
@@ -335,6 +323,11 @@ class StagedUploadClient
         $response = $this->request_json("GET", "staged_status", ["artifact_id" => $artifact_id]);
         if ($response["error"] !== null || !is_array($response["json"])) {
             return $this->failed("status_unavailable", $response["error"] ?? "invalid response");
+        }
+        if ($this->is_auth_envelope($response)) {
+            // Same reading as every other route: a control-plane auth
+            // envelope must not masquerade as "artifact absent".
+            return $this->failed("auth_failed", $this->envelope_error($response));
         }
         return [
             "status" => "ok",
@@ -414,11 +407,7 @@ class StagedUploadClient
             }
             $opened = fstat($source);
             $expected_mtime = isset($file["mtime"]) ? (int) $file["mtime"] : null;
-            if (
-                $expected_mtime !== null
-                && is_array($opened)
-                && (int) $opened["mtime"] !== $expected_mtime
-            ) {
+            if ($this->planned_mtime_differs($opened, $expected_mtime)) {
                 fclose($source);
                 $this->discard($artifact_id);
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
@@ -426,19 +415,11 @@ class StagedUploadClient
             }
             $payload = $total_bytes > 0 ? $this->read_exactly($source, $total_bytes) : "";
             fclose($source);
-            clearstatcache(true, (string) $file["source_path"]);
-            $now_stat = @stat((string) $file["source_path"]);
             if ($payload === null) {
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_short"];
                 continue;
             }
-            if (
-                !is_array($opened)
-                || $now_stat === false
-                || $now_stat["ino"] !== $opened["ino"]
-                || $now_stat["mtime"] !== $opened["mtime"]
-                || $now_stat["size"] !== $opened["size"]
-            ) {
+            if ($this->source_changed_since((string) $file["source_path"], $opened)) {
                 $this->discard($artifact_id);
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
                 continue;
@@ -577,6 +558,37 @@ class StagedUploadClient
      * before any endpoint runs. Surface those as auth_failed — retrying
      * cannot fix a bad secret — instead of an unexpected response.
      */
+    /**
+     * The plan promised an mtime and the opened file disagrees — the
+     * content is newer than the plan. One predicate for the chunked and
+     * batched paths, so both enforce the same torn-content rule.
+     *
+     * @param array|false $opened_stat fstat() of the opened source.
+     */
+    private function planned_mtime_differs($opened_stat, ?int $expected_mtime): bool
+    {
+        return $expected_mtime !== null
+            && is_array($opened_stat)
+            && (int) $opened_stat["mtime"] !== $expected_mtime;
+    }
+
+    /**
+     * Whether the source was rewritten since it was opened (inode, mtime,
+     * or size moved) — the post-read half of the same rule.
+     *
+     * @param array|false $opened_stat fstat() taken at open time.
+     */
+    private function source_changed_since(string $source_path, $opened_stat): bool
+    {
+        clearstatcache(true, $source_path);
+        $now_stat = @stat($source_path);
+        return !is_array($opened_stat)
+            || $now_stat === false
+            || $now_stat["ino"] !== $opened_stat["ino"]
+            || $now_stat["mtime"] !== $opened_stat["mtime"]
+            || $now_stat["size"] !== $opened_stat["size"];
+    }
+
     private function is_auth_envelope(array $response): bool
     {
         return in_array($response["http_code"], [401, 403], true)

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-pull/apply-window-deletions",
+            "version": "dev-pull/dual-mode-windows",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/deletions-and-preflight",
+            "version": "dev-pull/apply-window-deletions",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",

--- a/tests/HmacServerTest.php
+++ b/tests/HmacServerTest.php
@@ -143,36 +143,6 @@ final class HmacServerTest extends TestCase
         }
     }
 
-    public function testControlRequestVerifiesBoundedBody(): void
-    {
-        $body = '{"command":"preflight"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertNull($server->verify_control_request($headers, $body, 1700000001.0));
-    }
-
-    public function testControlRequestRejectsBodyAboveConfiguredLimit(): void
-    {
-        $body = '{"command":"preflight"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertSame(
-            'HMAC control request body exceeds 8 bytes',
-            $server->verify_control_request($headers, $body, 1700000001.0, 8)
-        );
-    }
-
-    public function testPrecomputedContentHashVerifiesWithoutBody(): void
-    {
-        $body = '{"command":"commit","manifest":"abc123"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertNull($server->verify_content_hash($headers, hash('sha256', $body), 1700000001.0));
-    }
-
     public function testSignedContentHashHeaderCanBeCheckedBeforeBodyIsRead(): void
     {
         $body = '{"command":"start-session"}';

--- a/tests/Import/StagedPullCliTest.php
+++ b/tests/Import/StagedPullCliTest.php
@@ -314,6 +314,137 @@ class StagedPullCliTest extends TestCase
         }
     }
 
+    public function testPreserveLocalDeltaStillUpdatesFilesWeOwn(): void
+    {
+        // Trunk's contract: "preserve-local does not protect files we own"
+        // — a file the pull itself shipped re-downloads and replaces on
+        // delta. The apply window must not re-protect it just because its
+        // own previous copy occupies the path.
+        $this->seedSource();
+        $this->runCli('preflight');
+        [$output, $code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+        $this->assertSame(0, $code, $output);
+        $this->assertSame(
+            '<?php // plugin v1',
+            file_get_contents($this->mappedRoot() . '/wp-content/plugins/my-plugin/my-plugin.php')
+        );
+
+        file_put_contents(
+            $this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php',
+            '<?php // plugin v2, still ours'
+        );
+        touch($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$delta_output, $delta_code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertSame(0, $delta_code, $delta_output);
+        $this->assertSame(
+            '<?php // plugin v2, still ours',
+            file_get_contents($this->mappedRoot() . '/wp-content/plugins/my-plugin/my-plugin.php'),
+            'an owned file must update on delta even under preserve-local'
+        );
+    }
+
+    public function testRemoteDeletionsLandInsideTheApplyWindow(): void
+    {
+        $this->seedSource();
+        $this->runCli('preflight');
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+        $this->assertSame(0, $code, $output);
+        $mapped = $this->mappedRoot();
+        $this->assertFileExists($mapped . '/empty.txt');
+
+        // The remote drops two files and updates a third — a delta mixing
+        // deletions with an arrival.
+        unlink($this->source_dir . '/empty.txt');
+        unlink($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php');
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index v2');
+        touch($this->source_dir . '/index.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+
+        // A held store lock fails the delta mid-fetch. Deletions used to
+        // happen at diff time; in staged mode nothing — removals included —
+        // may touch the live tree before the window.
+        $holder = fopen($this->state_dir . '/.pull-staging/lock', 'c+b');
+        flock($holder, LOCK_EX);
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertNotSame(0, $held_code, $held_output);
+        $this->assertFileExists(
+            $mapped . '/empty.txt',
+            'a deletion must wait for the apply window'
+        );
+        $this->assertFileExists($mapped . '/wp-content/plugins/my-plugin/my-plugin.php');
+        $this->assertSame('<?php // remote index', file_get_contents($mapped . '/index.php'));
+
+        // An abort in between must not orphan the pending deletions: the
+        // index still owns the files, so the fresh delta re-derives them.
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertFileDoesNotExist($mapped . '/empty.txt');
+        $this->assertFileDoesNotExist($mapped . '/wp-content/plugins/my-plugin/my-plugin.php');
+        $this->assertSame('<?php // remote index v2', file_get_contents($mapped . '/index.php'));
+        $audit = (string) @file_get_contents($this->state_dir . '/.import-audit.log');
+        $this->assertStringContainsString('Deletion staged for the apply window', $audit);
+        $this->assertStringContainsString('deleted=2', $audit);
+
+        // The confirmed deletions left the index; the next delta derives
+        // nothing new for them.
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+        $this->assertSame(0, $code, $output);
+        $this->assertFileDoesNotExist($mapped . '/empty.txt');
+        $audit = (string) @file_get_contents($this->state_dir . '/.import-audit.log');
+        $this->assertSame(
+            0,
+            substr_count(explode('deleted=2', $audit, 2)[1] ?? '', 'Deletion staged for the apply window'),
+            'a confirmed deletion must not re-derive on the next delta'
+        );
+    }
+
+    public function testPreserveLocalStillDeletesFilesWeOwn(): void
+    {
+        // Ownership beats occupancy for deletions too: a file the pull
+        // shipped disappears remotely, and preserve-local — which protects
+        // what the sync never owned — does not keep our own stale copy.
+        $this->seedSource();
+        $this->runCli('preflight');
+        [$output, $code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+        $this->assertSame(0, $code, $output);
+        $this->assertFileExists($this->mappedRoot() . '/empty.txt');
+
+        unlink($this->source_dir . '/empty.txt');
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$delta_output, $delta_code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertSame(0, $delta_code, $delta_output);
+        $this->assertFileDoesNotExist(
+            $this->mappedRoot() . '/empty.txt',
+            'preserve-local does not protect files we own from their own deletion'
+        );
+    }
+
     public function testCrossDeviceStateDirIsRefusedBeforeDownloading(): void
     {
         if (!is_dir('/dev/shm')) {

--- a/tests/Import/StagedPullCliTest.php
+++ b/tests/Import/StagedPullCliTest.php
@@ -164,6 +164,10 @@ class StagedPullCliTest extends TestCase
     {
         mkdir($this->source_dir . '/wp-content/uploads', 0700, true);
         mkdir($this->source_dir . '/wp-content/plugins/my-plugin', 0700, true);
+        // An empty directory and a symlink: parts that are not file
+        // content and must still respect the staged window.
+        mkdir($this->source_dir . '/wp-content/empty-dir', 0700, true);
+        symlink('index.php', $this->source_dir . '/link.php');
         // wp_detect needs these to recognize the directory as a root.
         file_put_contents($this->source_dir . '/wp-load.php', '<?php /* stub */');
         file_put_contents($this->source_dir . '/wp-config.php', '<?php /* stub config */');
@@ -171,6 +175,23 @@ class StagedPullCliTest extends TestCase
         file_put_contents($this->source_dir . '/empty.txt', '');
         file_put_contents($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', '<?php // plugin v1');
         file_put_contents($this->source_dir . '/wp-content/uploads/big.bin', str_repeat('reprint!', 40000));
+    }
+
+    /** Files, directories, and symlinks under $dir — the window must gate all three. */
+    private function countEntries(string $dir): int
+    {
+        if (!is_dir($dir)) {
+            return 0;
+        }
+        $count = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $entry) {
+            ++$count;
+        }
+        return $count;
     }
 
     /**
@@ -260,8 +281,8 @@ class StagedPullCliTest extends TestCase
         $this->assertNotSame(0, $held_code, $held_output);
         $this->assertSame(
             0,
-            $this->countFiles($this->fs_root),
-            'an interrupted staged pull must leave the live tree untouched'
+            $this->countEntries($this->fs_root),
+            'an interrupted staged pull must leave the live tree untouched — no files, directories, or symlinks'
         );
 
         [$output, $code] = $this->pullToCompletion(['--staged-apply']);
@@ -269,6 +290,53 @@ class StagedPullCliTest extends TestCase
         $this->assertSame(0, $code, $output);
         exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
         $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+        $this->assertTrue(is_link($this->mappedRoot() . '/link.php'), 'the deferred symlink lands with the window');
+        $this->assertDirectoryExists($this->mappedRoot() . '/wp-content/empty-dir');
+    }
+
+    public function testAbortSwitchesModesCleanlyInBothDirections(): void
+    {
+        // Modes are sticky per state dir (like preserve-local); --abort is
+        // the documented switch. Staged, interrupted, aborted, finished
+        // unstaged — then a remote change pulled staged again. The tree
+        // must come out complete every time: the index never claims
+        // anything the live tree does not have, so no delta ever skips a
+        // file the previous mode left behind.
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        $staging = $this->state_dir . '/.pull-staging';
+        mkdir($staging, 0700, true);
+        $holder = fopen($staging . '/lock', 'c+b');
+        flock($holder, LOCK_EX);
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertNotSame(0, $held_code, $held_output);
+
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        $this->assertDirectoryDoesNotExist($staging, '--abort clears staged leftovers');
+
+        // Unstaged from here: no --staged-apply flag, fresh state.
+        [$output, $code] = $this->pullToCompletion();
+        $this->assertSame(0, $code, $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+
+        // Back to staged for a delta.
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index v2');
+        touch($this->source_dir . '/index.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertSame(
+            '<?php // remote index v2',
+            file_get_contents($this->mappedRoot() . '/index.php')
+        );
+        $this->assertStringContainsString('staged_apply', $output, 'the delta ran through the window');
     }
 
     public function testPreserveLocalPoliciesHoldAtApplyTime(): void
@@ -372,7 +440,9 @@ class StagedPullCliTest extends TestCase
 
         // A held store lock fails the delta mid-fetch. Deletions used to
         // happen at diff time; in staged mode nothing — removals included —
-        // may touch the live tree before the window.
+        // may touch the live tree before the window. (--abort cleared the
+        // staging dir, so recreate the scaffolding to plant the lock.)
+        @mkdir($this->state_dir . '/.pull-staging', 0700, true);
         $holder = fopen($this->state_dir . '/.pull-staging/lock', 'c+b');
         flock($holder, LOCK_EX);
         [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -429,6 +429,9 @@ final class StagedApplyTest extends TestCase {
         file_put_contents($shared . '/keep.txt', 'shared');
         symlink($shared, $this->target_root . '/stale-link');
         $this->stageVerified('fresh.txt', 'new');
+        // An earlier resume staged bytes for a file the remote has since
+        // deleted; the delete pass must consume them with the deletion.
+        $this->stageVerified('stale.php', 'obsolete bytes');
         $manifest = $this->stageManifest([
             ['artifact_id' => 'fresh.txt', 'size' => 3],
             ['artifact_id' => 'stale.php', 'delete' => true],
@@ -451,6 +454,11 @@ final class StagedApplyTest extends TestCase {
                 'deleting the link must not follow it'
             );
             $this->assertSame('new', file_get_contents($this->target_root . '/fresh.txt'));
+            $this->assertFileDoesNotExist(
+                $this->staging_dir . '/files/stale.php',
+                'staged garbage under a deleted id is consumed'
+            );
+            $this->assertFileDoesNotExist($this->staging_dir . '/verified/stale.php');
         } finally {
             $this->removeDir($shared);
         }
@@ -458,14 +466,15 @@ final class StagedApplyTest extends TestCase {
 
     public function testDeletionsRunBeforeMovesRegardlessOfManifestOrder(): void
     {
-        // The old tree had a directory where the new tree lands a file, and
-        // the manifest lists the create before the delete. Move-first would
-        // rename the file in and then delete it.
-        mkdir($this->target_root . '/swap/nested', 0700, true);
-        file_put_contents($this->target_root . '/swap/nested/old.txt', 'old');
-        $this->stageVerified('swap', 'file now');
+        // The path was a file; the new tree turns it into a directory: the
+        // transfer deletes 'swap' and creates 'swap/new.txt'. Move-first
+        // would build the directory, land the file, and then have the
+        // delete pass tear down the freshly-created tree. The manifest
+        // lists the create first to prove passes, not line order, decide.
+        file_put_contents($this->target_root . '/swap', 'was a file');
+        $this->stageVerified('swap/new.txt', 'dir member');
         $manifest = $this->stageManifest([
-            ['artifact_id' => 'swap', 'size' => 8],
+            ['artifact_id' => 'swap/new.txt', 'size' => 10],
             ['artifact_id' => 'swap', 'delete' => true],
         ]);
 
@@ -473,7 +482,7 @@ final class StagedApplyTest extends TestCase {
 
         $this->assertSame('applied', $result['status']);
         $this->assertSame([1, 1], [$result['applied'], $result['deleted']]);
-        $this->assertSame('file now', file_get_contents($this->target_root . '/swap'));
+        $this->assertSame('dir member', file_get_contents($this->target_root . '/swap/new.txt'));
     }
 
     public function testDeletionsAreIdempotentAcrossReruns(): void
@@ -499,21 +508,47 @@ final class StagedApplyTest extends TestCase {
         $this->assertSame(1, $second['already_applied']);
     }
 
-    public function testPreserveLocalPoliciesProtectDeletions(): void
+    public function testSkipPolicyDoesNotProtectOwnedDeletions(): void
     {
-        // Preserve-local means never overwrite AND never delete.
-        file_put_contents($this->target_root . '/precious.txt', 'local');
+        // Delete entries only ever come from the sender's own ship record
+        // (pull's index, push's cache), so preserve-local — which protects
+        // what the sync never owned — does not stand in their way. This is
+        // trunk's diff-phase behavior: owned files delete under
+        // preserve-local too.
+        file_put_contents($this->target_root . '/shipped-earlier.txt', 'ours');
         $manifest = $this->stageManifest([
-            ['artifact_id' => 'precious.txt', 'delete' => true],
+            ['artifact_id' => 'shipped-earlier.txt', 'delete' => true],
         ]);
 
         $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
 
         $this->assertSame('applied', $result['status']);
-        $this->assertSame(0, $result['deleted']);
-        $this->assertSame(1, $result['skipped']);
-        $this->assertSame(['precious.txt'], $result['skipped_paths']);
-        $this->assertSame('local', file_get_contents($this->target_root . '/precious.txt'));
+        $this->assertSame(1, $result['deleted']);
+        $this->assertSame(0, $result['skipped']);
+        $this->assertFileDoesNotExist($this->target_root . '/shipped-earlier.txt');
+    }
+
+    public function testSkipPolicyDoesNotProtectOwnedEntries(): void
+    {
+        // An owned entry's occupant is the transfer's own previous copy:
+        // preserve-local must not freeze a file at the version the first
+        // pull shipped. The unowned sibling still gets protected.
+        file_put_contents($this->target_root . '/ours.php', 'v1 from a previous window');
+        file_put_contents($this->target_root . '/theirs.php', 'the user made this');
+        $this->stageVerified('ours.php', 'v2');
+        $this->stageVerified('theirs.php', 'remote bytes');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'ours.php', 'size' => 2, 'owned' => true],
+            ['artifact_id' => 'theirs.php', 'size' => 12],
+        ]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame([1, 1], [$result['applied'], $result['skipped']]);
+        $this->assertSame(['theirs.php'], $result['skipped_paths']);
+        $this->assertSame('v2', file_get_contents($this->target_root . '/ours.php'));
+        $this->assertSame('the user made this', file_get_contents($this->target_root . '/theirs.php'));
     }
 
     public function testSymlinkedParentGuardProtectsDeletions(): void
@@ -583,6 +618,16 @@ final class StagedApplyTest extends TestCase {
         $this->stageVerified('hostile-delete.jsonl', json_encode(['artifact_id' => '../escape', 'delete' => true]) . "\n");
         $hostile = $this->makeApply()->apply('hostile-delete.jsonl');
         $this->assertStringContainsString('invalid artifact id', (string) $hostile['detail']);
+
+        // One verdict per path: a same-id create-plus-delete is ambiguous
+        // on rerun, and neither sender can produce it.
+        $this->stageVerified(
+            'twice.jsonl',
+            json_encode(['artifact_id' => 'x.txt', 'size' => 1]) . "\n"
+                . json_encode(['artifact_id' => 'x.txt', 'delete' => true]) . "\n"
+        );
+        $twice = $this->makeApply()->apply('twice.jsonl');
+        $this->assertStringContainsString('duplicates an artifact id', (string) $twice['detail']);
     }
 
     // ---------------------------------------------------------------

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -630,6 +630,37 @@ final class StagedApplyTest extends TestCase {
         $this->assertStringContainsString('duplicates an artifact id', (string) $twice['detail']);
     }
 
+    public function testOnProtectedReportsEveryEntryBeyondTheResponseCap(): void
+    {
+        // skipped_paths is a bounded-HTTP-response diagnostic, capped at
+        // 1000. In-process callers reconcile per-entry state through
+        // on_protected, which must see every protected id — an index
+        // catch-up driven by the capped list would silently skip entries
+        // past the cap.
+        $manifest_entries = [];
+        for ($i = 0; $i < 1001; $i++) {
+            $name = sprintf('kept-%04d.txt', $i);
+            file_put_contents($this->target_root . '/' . $name, 'local');
+            $manifest_entries[] = ['artifact_id' => $name, 'size' => 5];
+        }
+        $manifest = $this->stageManifest($manifest_entries);
+
+        $reported = [];
+        $apply = $this->makeApply([
+            'on_existing' => 'skip',
+            'on_protected' => static function (string $artifact_id) use (&$reported): void {
+                $reported[] = $artifact_id;
+            },
+        ]);
+        $result = $apply->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1001, $result['skipped']);
+        $this->assertCount(1000, $result['skipped_paths'], 'the response list stays capped');
+        $this->assertCount(1001, $reported, 'the callback sees every protected entry');
+        $this->assertSame('kept-1000.txt', end($reported));
+    }
+
     // ---------------------------------------------------------------
     // Preflight facts on "ready"
     // ---------------------------------------------------------------


### PR DESCRIPTION
## What it does

Completes staged pull's apply-window contract by folding the follow-up directory/symlink/index work into this PR:

1. **Deletions join the window.** In `--staged-apply` mode, diff-derived deletions are recorded in the pull manifest log and carried out inside the same rename window as arrivals.
2. **Directory and symlink effects join the window.** Staged mode defers mkdir/symlink/type-swap work into the manifest log and replays it through the same handlers used by unstaged pull.
3. **The local index describes the live tree, not staged intent.** File, deletion, directory, and symlink index updates are written only after the apply window confirms the live-tree effect.
4. **Preserve-local uses ownership, not mere occupancy.** Owned files and deletions still update/delete under preserve-local; symlink-parent protection still wins.
5. **Mode switching is explicit.** `--staged-apply` persists in state, and `--abort` clears staged bytes and pending window logs before switching mode.

This also absorbs #311, so reviewers see one coherent staged-pull window invariant instead of reviewing a staged-pull feature that is corrected by a later PR.

## Notes

- Apply is still a short serial rename/delete window, not a globally atomic tree swap. It prevents half-written files and fetch-time live-tree drift, but a killed process can leave a mixed old/new tree until the same command is rerun.
- Non-staged pull keeps the existing fetch-time handlers.
- The window walk is path-sorted so index merges remain sorted and resumable.

## Testing instructions

```
cd tests
../vendor/bin/phpunit SiteExportLibraryAuthTest.php StagedArtifactsTest.php StagedEndpointsTest.php StagedApplyTest.php Import/StagedUploadClientTest.php Import/StagedPushRunnerTest.php Import/PushPlanBuilderTest.php Import/PushFilesCliTest.php Import/StagedPullCliTest.php
composer analyze
```

Local result: 179 PHPUnit tests, 791 assertions, 1 skipped; PHPStan clean. The e2e push test could not run in this local shell because the site setup requires passwordless `sudo`.
