### PR TITLE
Gate directory, symlink, and index effects behind the staged pull window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,8 @@ During the file fetch phase, progress and heartbeat records include `files_done`
   - src/lib/target-runtime/: Runtime appliers (NginxFpmApplier, PhpBuiltinApplier, PlaygroundCliApplier)
   - src/lib/url-rewrite/: URL rewriting for db-apply
   - src/lib/mysql-query-stream/: MySQL query stream parser for direct streaming
+  - src/lib/state/: Typed persisted state (ImportState — the single source of the .import-state.json schema)
+  - src/lib/upload/: Push-side staged transfer (StagedUploadClient, StagedPushRunner, PushPlanBuilder, UploadChunkSizer)
 - reprint-exporter-wp/: Self-contained WordPress plugin distribution directory
   - index.php: WordPress plugin entry point — intercepts `?reprint-api` requests (and the legacy `?site-export-api` alias) during plugin load, requires lib.php
   - lib.php: Standalone library — constants, auth functions, and request handler. Can be required without index.php by projects that want to embed the export engine with their own URL routing and authentication (pass a custom `authenticate` callable in the `$options` array to `_site_export_handle_api_request()`)
@@ -241,6 +243,11 @@ Progress is computed client-side by reading state files (all in `--state-dir`):
 - `.import-remote-index.jsonl`: Remote file index (for delta comparison)
 - `.import-download-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
+
+Staged transfers add (also under `--state-dir`):
+- `.push-state.json` / `.push-verified.jsonl`: push chunk-sizer state and the push done cache (verified uploads; deletions derive from it)
+- `.pull-staging/`: staged pull artifact store (files/, verified/, state.json, lock)
+- `.pull-staged-manifest.jsonl`: the pending apply-window log for staged pulls (files, dirs, symlinks, deletions)
 
 And from `--fs-root`:
 - Actual downloaded files (recursive size/count)

--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ The command returns one of three exit codes:
 
 Which is to say, you'll need to wrap it in a loop that runs until failure or full completion.
 
+Add `--staged-apply` when pulled files should download into a staging area
+under `--state-dir` and then move into `--fs-root` in one rename window at the
+end:
+
+```bash
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --staged-apply
+```
+
+`--staged-apply` keeps partially downloaded file bytes out of the live local
+tree. The final apply is rename-only, so `--state-dir` and `--fs-root` must be
+on the same filesystem. If they are not, Reprint rejects the run before moving
+anything; it does not copy staged files into place because that could expose
+half-written files. A killed apply can be rerun: files already renamed into
+place are recognized by size and the remaining staged files are moved.
+
 **Non-empty local fs-root**
 
 By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
@@ -725,7 +740,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
-* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
+* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed; add `--staged-apply` to land files by rename after download.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `push-files` — Upload local files into the remote staged artifact store; add `--apply` to rename the verified transfer into the remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.

--- a/README.md
+++ b/README.md
@@ -276,6 +276,30 @@ php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
     --only=:wp-content: --only=:wp-plugins:
 ```
 
+#### Push local files to remote staging.
+
+`push-files` uploads a local filesystem tree into the remote exporter's staged
+artifact store. It is resumable and safe to retry: completed files are skipped,
+partially uploaded files resume from the remote committed offset, and the live
+remote tree is not changed by this command.
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+```
+
+Use repeated `--only` values to push fs-root-relative prefixes instead of the
+whole tree:
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --only=wp-content/uploads
+```
+
+The remote WordPress wiring stores staged artifacts outside the web-served tree.
+Define `SITE_EXPORT_STAGING_DIR` on the exporter host to choose that directory;
+it must have enough free space for the pushed artifacts and should be on storage
+that persists across retries.
+
 #### Pull only the database.
 
 `pull-db` runs the database side of the high-level pull pipeline:
@@ -682,6 +706,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
+* `push-files` — Upload local files into the remote staged artifact store without changing the live remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,27 @@ Define `SITE_EXPORT_STAGING_DIR` on the exporter host to choose that directory;
 it must have enough free space for the pushed artifacts and should be on storage
 that persists across retries.
 
+Add `--apply` when the verified transfer should move into the remote tree after
+uploading:
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --apply
+```
+
+The exporter applies into `ABSPATH` by default. Define `SITE_EXPORT_APPLY_ROOT`
+on the exporter host to choose a different target root. Apply is rename-only:
+it probes before upload and refuses `cross_device` if `SITE_EXPORT_STAGING_DIR`
+and `SITE_EXPORT_APPLY_ROOT` are on different filesystems. Put staging on the
+same filesystem as the target when you plan to use `--apply`; Reprint will not
+fall back to copy-and-remove because that could expose half-written live files.
+
+An interrupted apply can be retried with the same command. Files already renamed
+into place are recognized by size, and files still in staging are moved on the
+next run. The apply window is intentionally short but serial; the remote site
+may briefly contain a mix of old and new files if the process is killed between
+renames, so keep the site in maintenance mode for deployments that need a
+whole-tree cutover.
+
 #### Pull only the database.
 
 `pull-db` runs the database side of the high-level pull pipeline:
@@ -706,7 +727,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
-* `push-files` — Upload local files into the remote staged artifact store without changing the live remote tree.
+* `push-files` — Upload local files into the remote staged artifact store; add `--apply` to rename the verified transfer into the remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.

--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-pull/apply-window-deletions",
+            "version": "dev-pull/dual-mode-windows",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -9,8 +9,6 @@
  */
 final class Site_Export_HMAC_Server {
 
-    private const DEFAULT_MAX_CONTROL_BODY_BYTES = 1048576;
-
     /** @var string */
     private $secret;
 
@@ -23,33 +21,13 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
-     * Verify a bounded control-plane request.
-     *
-     * HMAC is the guard for small protocol commands such as preflight, session
-     * start, plan confirmation, and abort/resume. Large data uploads should use
-     * authenticated sessions plus per-chunk hashes instead of signing one
-     * multi-megabyte request body.
-     */
-    public function verify_control_request(array $headers = [], string $body = '', ?float $now = null, ?int $max_body_bytes = null): ?string {
-        $body_limit = $max_body_bytes ?? self::DEFAULT_MAX_CONTROL_BODY_BYTES;
-        if (strlen($body) > $body_limit) {
-            return sprintf(
-                'HMAC control request body exceeds %d bytes',
-                $body_limit
-            );
-        }
-
-        return $this->verify($headers, $body, [], $now);
-    }
-
-    /**
      * Verify a request using explicit inputs.
      *
      * Returns null on success, or an error string on failure. This convenience
      * method receives the full body as a string and is only appropriate for
-     * compatibility with existing small request flows. New protocol code should
-     * use verify_control_request() for HMAC-protected commands and avoid
-     * HMAC-signing large data uploads.
+     * small request flows; large data uploads verify per chunk through
+     * verify_signed_content_hash() instead of HMAC-signing one
+     * multi-megabyte request body.
      *
      * When $files is non-empty, the content hash is computed from uploaded file
      * contents rather than $body so multipart uploads verify consistently.
@@ -59,24 +37,6 @@ final class Site_Export_HMAC_Server {
             $headers,
             function () use ($body, $files): string {
                 return $this->compute_received_content_hash($body, $files);
-            },
-            $now
-        );
-    }
-
-    /**
-     * Verify a request when the caller already computed the received digest.
-     *
-     * This exists for bounded protocol code that has already computed the body
-     * digest. It does not read a request body. Push chunk uploads should use
-     * session/request capabilities plus per-chunk hashes instead of routing
-     * large bodies through HMAC verification.
-     */
-    public function verify_content_hash(array $headers, string $received_content_hash, ?float $now = null): ?string {
-        return $this->verify_content_hash_callback(
-            $headers,
-            function () use ($received_content_hash): string {
-                return $received_content_hash;
             },
             $now
         );
@@ -139,9 +99,8 @@ final class Site_Export_HMAC_Server {
      *
      * Returns null on success, or an error string on failure. This legacy
      * convenience path buffers php://input and should only be used for small
-     * request bodies. New control-plane routes should bound the body and call
-     * verify_control_request(). Large data routes should not use whole-body
-     * HMAC verification.
+     * request bodies. Large data routes should not use whole-body HMAC
+     * verification.
      */
     public function verify_globals(?float $now = null): ?string {
         $body = file_get_contents('php://input');

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -81,6 +81,9 @@ final class Site_Export_Staged_Apply {
     /** @var bool */
     private $refuse_symlinked_parents;
 
+    /** @var callable|null */
+    private $on_protected;
+
     /**
      * @param array $options
      *   - staging_dir (string, required): same directory the store uses.
@@ -97,6 +100,12 @@ final class Site_Export_Staged_Apply {
      *     symlinked directory. Hosting layouts symlink plugins, themes,
      *     and core from shared locations; apply must not write into those
      *     through the link.
+     *   - on_protected (?callable): fn(string $artifact_id) — called once
+     *     per policy-protected entry during classification (check_only
+     *     included). This is the uncapped channel: in-process callers that
+     *     reconcile per-entry state (the pull window's index catch-up)
+     *     must use it. The result's skipped_paths list is capped for
+     *     bounded HTTP responses and is diagnostics only.
      */
     public function __construct(array $options) {
         $staging_dir = $options['staging_dir'] ?? null;
@@ -118,6 +127,7 @@ final class Site_Export_Staged_Apply {
         $this->store = new Site_Export_Staged_Artifacts($staging_dir);
         $this->on_existing = $on_existing;
         $this->refuse_symlinked_parents = !empty($options['refuse_symlinked_parents']);
+        $this->on_protected = $options['on_protected'] ?? null;
         $this->device_id = $options['device_id'] ?? static function (string $path): ?int {
             $stat = @stat($path);
             return $stat === false ? null : (int) $stat['dev'];
@@ -182,9 +192,11 @@ final class Site_Export_Staged_Apply {
                 }
                 if ($verdict === 'protected') {
                     $protected[$index] = true;
-                    // Callers audit-log each protected path (the
-                    // PRESERVE-LOCAL contract); capped so a 50k-skip
-                    // transfer stays a bounded response.
+                    if ($this->on_protected !== null) {
+                        call_user_func($this->on_protected, $entry['artifact_id']);
+                    }
+                    // The response list is capped so a 50k-skip transfer
+                    // stays bounded; per-entry consumers use on_protected.
                     if (count($skipped_paths) < self::SKIPPED_PATHS_LIMIT) {
                         $skipped_paths[] = $entry['artifact_id'];
                     }
@@ -213,29 +225,20 @@ final class Site_Export_Staged_Apply {
                     if (!empty($entry['delete']) !== $delete_pass) {
                         continue;
                     }
-                    if (isset($protected[$index])) {
-                        // The local path wins; consume the staged bytes so
-                        // they cannot be applied by a later,
-                        // differently-configured run.
-                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
-                        continue;
-                    }
-                    if (isset($already_applied[$index])) {
-                        // A rerun after a kill: the work is done; leftover
-                        // staged remains only need consuming. (For a
-                        // deletion, bytes an earlier resume staged under
-                        // the id can still sit here.)
-                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                    if (isset($protected[$index]) || isset($already_applied[$index])) {
+                        // Protected: the local path wins, and the staged
+                        // bytes must not be applied by a later,
+                        // differently-configured run. Already applied: a
+                        // rerun after a kill, where only leftover staged
+                        // remains linger. Both just consume.
+                        $this->consume_staged($entry['artifact_id']);
                         continue;
                     }
                     if ($delete_pass) {
                         // Staged bytes under a deleted id are garbage from
                         // before the remote dropped the file; consume them
                         // with the deletion.
-                        @unlink($this->files_dir . '/' . $entry['artifact_id']);
-                        @unlink($this->staging_dir . '/verified/' . $entry['artifact_id']);
+                        $this->consume_staged($entry['artifact_id']);
                         if (!$this->remove_path_without_following_symlinks($this->target_root . '/' . $entry['artifact_id'])) {
                             return $this->result('rejected', 'io_error', 'delete: ' . $entry['artifact_id'], $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
                         }
@@ -256,8 +259,7 @@ final class Site_Export_Staged_Apply {
             // The manifest is consumed with the transfer it described, and
             // a cursor still naming a consumed artifact must not survive to
             // answer a future upload with its stale offset.
-            @unlink($this->files_dir . '/' . $manifest_id);
-            @unlink($this->staging_dir . '/verified/' . $manifest_id);
+            $this->consume_staged($manifest_id);
             $this->clear_cursor_for($entries, $manifest_id);
 
             return $this->result('applied', null, null, $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
@@ -268,16 +270,12 @@ final class Site_Export_Staged_Apply {
     }
 
     /**
-     * Clears the store cursor when it names an artifact this apply consumed.
-     * Same write-then-rename commit as the store's own cursor writes.
+     * Clears the store cursor when it names an artifact this apply
+     * consumed. The cursor's schema and commit discipline live in the
+     * store; apply only decides whether the cursor was consumed.
      */
     private function clear_cursor_for(array $entries, string $manifest_id): void {
-        $state_path = $this->staging_dir . '/state.json';
-        $raw = @file_get_contents($state_path);
-        $state = $raw === false ? null : json_decode($raw, true);
-        $cursor_artifact = is_array($state) && is_string($state['artifact_id'] ?? null)
-            ? $state['artifact_id']
-            : null;
+        $cursor_artifact = $this->store->cursor_artifact_locked();
         if ($cursor_artifact === null) {
             return;
         }
@@ -289,16 +287,19 @@ final class Site_Export_Staged_Apply {
                 break;
             }
         }
-        if (!$consumed) {
-            return;
+        if ($consumed) {
+            $this->store->clear_cursor_locked();
         }
+    }
 
-        $json = json_encode(['artifact_id' => null, 'committed_bytes' => 0]);
-        $tmp_path = $state_path . '.tmp';
-        if (@file_put_contents($tmp_path, $json) === strlen($json)) {
-            @rename($tmp_path, $state_path);
-        }
-        @unlink($tmp_path);
+    /**
+     * Consumes an entry's staged remains: its bytes and its verified
+     * marker. Callers hold the store lock; the store's own discard()
+     * would contend on it.
+     */
+    private function consume_staged(string $artifact_id): void {
+        @unlink($this->files_dir . '/' . $artifact_id);
+        @unlink($this->staging_dir . '/verified/' . $artifact_id);
     }
 
     /**
@@ -351,14 +352,23 @@ final class Site_Export_Staged_Apply {
         if (!$status['verified']) {
             return 'manifest artifact is not verified: ' . $manifest_id;
         }
-        $raw = @file_get_contents($this->files_dir . '/' . $manifest_id);
-        if ($raw === false) {
+        // Streamed line by line: a 200k-entry manifest is tens of
+        // megabytes, and this runs on the memory-constrained side.
+        $handle = @fopen($this->files_dir . '/' . $manifest_id, 'rb');
+        if ($handle === false) {
             return 'manifest artifact is not readable: ' . $manifest_id;
         }
 
         $entries = [];
         $seen_ids = [];
-        foreach (explode("\n", $raw) as $line_number => $line) {
+        $line_number = -1;
+        $error = null;
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            ++$line_number;
             if (trim($line) === '') {
                 continue;
             }
@@ -369,10 +379,12 @@ final class Site_Export_Staged_Apply {
                 || !is_string($entry['artifact_id'] ?? null)
                 || ( !$is_delete && ( !is_int($entry['size'] ?? null) || $entry['size'] < 0 ) )
             ) {
-                return 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
+                break;
             }
             if ($entry['artifact_id'] === $manifest_id) {
-                return 'manifest lists itself';
+                $error = 'manifest lists itself';
+                break;
             }
             // One verdict per path. Neither sender can produce a duplicate
             // (both derive deletions as own-record-minus-current-set), and
@@ -380,14 +392,16 @@ final class Site_Export_Staged_Apply {
             // create has landed, the delete cannot tell the old occupant
             // from the new file.
             if (isset($seen_ids[$entry['artifact_id']])) {
-                return 'manifest line ' . ( $line_number + 1 ) . ' duplicates an artifact id';
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' duplicates an artifact id';
+                break;
             }
             $seen_ids[$entry['artifact_id']] = true;
             // Manifest content is sender data; ids must satisfy the same
             // path rule the store enforces at upload time, or a crafted
             // manifest could probe or write outside the target root.
             if (!$this->valid_artifact_id($entry['artifact_id'])) {
-                return 'manifest line ' . ( $line_number + 1 ) . ' has an invalid artifact id';
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' has an invalid artifact id';
+                break;
             }
             $entries[] = [
                 'artifact_id' => $entry['artifact_id'],
@@ -396,7 +410,8 @@ final class Site_Export_Staged_Apply {
                 'owned' => ( $is_delete || !empty($entry['owned']) ),
             ];
         }
-        return $entries;
+        fclose($handle);
+        return $error ?? $entries;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -611,6 +611,23 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
+     * The artifact the cursor currently names, or null. Caller holds the
+     * store lock (the apply window's direct-consume contract): this reads
+     * without taking it.
+     */
+    public function cursor_artifact_locked(): ?string {
+        return $this->read_state()['artifact_id'];
+    }
+
+    /**
+     * Clears the cursor. Caller holds the store lock. The cursor schema
+     * and its write-then-rename commit stay owned by this class.
+     */
+    public function clear_cursor_locked(): bool {
+        return $this->write_state(null, 0);
+    }
+
+    /**
      * Reads the cursor as best-effort state.
      *
      * A missing or unreadable record is treated as no artifact in flight, so

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -128,7 +128,7 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
     /**
      * We're choosing a random boundary without checking for its presence in the content.
      * This may seem to contradict RFC 2046, where it says:
-     *
+     * 
      * > As stated previously, each body part is preceded by a boundary
      * > delimiter line that contains the boundary delimiter.  The boundary
      * > delimiter MUST NOT appear inside any of the encapsulated parts, on a
@@ -136,15 +136,15 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
      * > crucial that the composing agent be able to choose and specify a
      * > unique boundary parameter value that does not contain the boundary
      * > parameter value of an enclosing multipart as a prefix.
-     * >
+     * > 
      * > https://www.rfc-editor.org/rfc/rfc2046.html
      *
      * But in practice, we're okay. We use 128 bits of randomness. The chance of
      * it appearing in the data is about 1 in 2^128 — effectively zero. Curl does
-     * the same here:
+     * the same here: 
      *
      *    https://github.com/curl/curl/blob/462244447e8ba3a53b1ba9f0ba7baa52d8777daa/lib/mime.c#L1179-L1236
-     *
+     * 
      * Also, most chunks declare their Content-Length, so the client may skip the
      * boundary matching entirely and just consume that many bytes.
      */
@@ -2414,7 +2414,7 @@ function stream_file_producer(
     try {
         // @TODO: If an exception is thrown right after the previous chunk header,
         //        it read the fixed Content-Length value and will consume this next
-        //        chunk as data. We should try and backfill the output up to the
+        //        chunk as data. We should try and backfill the output up to the 
         //        previous content-length value if possible.
         if ($abort_payload !== null) {
             $json = json_encode_or_throw($abort_payload);
@@ -2499,11 +2499,11 @@ function encode_index_stack(array $stack): array
 
 /**
  * Resolve "." and ".." segments in a path without resolving symlinks.
- *
+ * 
  * Unlike realpath(), this only performs textual normalization — it collapses
  * "." and ".." but leaves symlink components intact.  This is useful when
  * you need a clean absolute path to inspect which components are symlinks.
- *
+ * 
  * @param string $path An absolute path that may contain "." or ".." segments.
  * @return string The normalized absolute path.
  */
@@ -2533,19 +2533,19 @@ function normalize_dot_segments(string $path): string
  * Given a path, such as `/srv/wordpress/wp-content/plugins/akismet/assets`, returns
  * a list of all the parent paths that are symlinks. It will check `/srv`,
  * `/srv/wordpress`, `/srv/wordpress/wp-content`, etc.
- *
+ * 
  * For example, given the following filesystem layout:
- *
+ * 
  *     /srv/wordpress/wp-content -> /htdocs/wp-content
  *     /srv/wordpress/wp-content/plugins/akismet -> /wordpress/plugins/akismet/latest
  *     /wordpress/plugins/akismet/latest -> /wordpress/plugins/akismet/5.0.5
- *
+ * 
  * Calling
- *
+ * 
  *     find_parents_symlinks("/srv/wordpress/wp-content/plugins/akismet/assets")
- *
+ * 
  * will return the following symlinks:
- *
+ * 
  * ['path' => '/srv/wordpress/wp-content', 'target' => '/htdocs/wp-content']
  * ['path' => '/htdocs/wp-content/plugins/akismet', 'target' => '/wordpress/plugins/akismet/latest']
  *

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -128,7 +128,7 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
     /**
      * We're choosing a random boundary without checking for its presence in the content.
      * This may seem to contradict RFC 2046, where it says:
-     * 
+     *
      * > As stated previously, each body part is preceded by a boundary
      * > delimiter line that contains the boundary delimiter.  The boundary
      * > delimiter MUST NOT appear inside any of the encapsulated parts, on a
@@ -136,15 +136,15 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
      * > crucial that the composing agent be able to choose and specify a
      * > unique boundary parameter value that does not contain the boundary
      * > parameter value of an enclosing multipart as a prefix.
-     * > 
+     * >
      * > https://www.rfc-editor.org/rfc/rfc2046.html
      *
      * But in practice, we're okay. We use 128 bits of randomness. The chance of
      * it appearing in the data is about 1 in 2^128 — effectively zero. Curl does
-     * the same here: 
+     * the same here:
      *
      *    https://github.com/curl/curl/blob/462244447e8ba3a53b1ba9f0ba7baa52d8777daa/lib/mime.c#L1179-L1236
-     * 
+     *
      * Also, most chunks declare their Content-Length, so the client may skip the
      * boundary matching entirely and just consume that many bytes.
      */
@@ -2414,7 +2414,7 @@ function stream_file_producer(
     try {
         // @TODO: If an exception is thrown right after the previous chunk header,
         //        it read the fixed Content-Length value and will consume this next
-        //        chunk as data. We should try and backfill the output up to the 
+        //        chunk as data. We should try and backfill the output up to the
         //        previous content-length value if possible.
         if ($abort_payload !== null) {
             $json = json_encode_or_throw($abort_payload);
@@ -2499,11 +2499,11 @@ function encode_index_stack(array $stack): array
 
 /**
  * Resolve "." and ".." segments in a path without resolving symlinks.
- * 
+ *
  * Unlike realpath(), this only performs textual normalization — it collapses
  * "." and ".." but leaves symlink components intact.  This is useful when
  * you need a clean absolute path to inspect which components are symlinks.
- * 
+ *
  * @param string $path An absolute path that may contain "." or ".." segments.
  * @return string The normalized absolute path.
  */
@@ -2533,19 +2533,19 @@ function normalize_dot_segments(string $path): string
  * Given a path, such as `/srv/wordpress/wp-content/plugins/akismet/assets`, returns
  * a list of all the parent paths that are symlinks. It will check `/srv`,
  * `/srv/wordpress`, `/srv/wordpress/wp-content`, etc.
- * 
+ *
  * For example, given the following filesystem layout:
- * 
+ *
  *     /srv/wordpress/wp-content -> /htdocs/wp-content
  *     /srv/wordpress/wp-content/plugins/akismet -> /wordpress/plugins/akismet/latest
  *     /wordpress/plugins/akismet/latest -> /wordpress/plugins/akismet/5.0.5
- * 
+ *
  * Calling
- * 
+ *
  *     find_parents_symlinks("/srv/wordpress/wp-content/plugins/akismet/assets")
- * 
+ *
  * will return the following symlinks:
- * 
+ *
  * ['path' => '/srv/wordpress/wp-content', 'target' => '/htdocs/wp-content']
  * ['path' => '/htdocs/wp-content/plugins/akismet', 'target' => '/wordpress/plugins/akismet/latest']
  *

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1238,6 +1238,13 @@ class ImportClient
     /** Artifact id the push manifest stages under; never applied itself. */
     private const PUSH_MANIFEST_ID = '.reprint-push-manifest.jsonl';
 
+    /**
+     * Push failures that follow the resumable convention (exit 2: run the
+     * same command again). One list for the transfer and the apply so a
+     * reason cannot be retryable in one phase and fatal in the other.
+     */
+    private const PUSH_RETRYABLE_REASONS = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
+
     /** Artifact id the staged pull manifest stages under. */
     private const PULL_MANIFEST_ID = '.reprint-pull-manifest.jsonl';
 
@@ -1249,6 +1256,9 @@ class ImportClient
 
     /** @var array<string,true> Owned remote paths in the batch being fetched. */
     private $staged_batch_owned = [];
+
+    /** @var string|null Cache key (list:offsets) for staged_batch_owned. */
+    private $staged_batch_owned_key = null;
 
     /**
      * True while the apply window replays deferred directory/symlink
@@ -4173,11 +4183,10 @@ class ImportClient
                 "PUSH ABORTED | {$result["abort_reason"]} | " . ($result["abort_detail"] ?? ""),
                 false,
             );
-            // Transient transfer failures follow the resumable convention
-            // (exit 2: run the same command again); a bad secret or a chunk
-            // size the host can never accept will not fix itself.
-            $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
-            $this->exit_code = in_array($result["abort_reason"], $retryable, true) ? 2 : 1;
+            // Transient transfer failures follow the resumable convention;
+            // a bad secret or a chunk size the host can never accept will
+            // not fix itself.
+            $this->exit_code = in_array($result["abort_reason"], self::PUSH_RETRYABLE_REASONS, true) ? 2 : 1;
             return;
         }
         if ($result["failed"] !== []) {
@@ -4286,8 +4295,7 @@ class ImportClient
             "PUSH APPLY FAILED | " . ($fields["abort_reason"] ?? "unknown") . " | " . ($fields["abort_detail"] ?? ""),
             false,
         );
-        $retryable = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
-        return in_array($fields["abort_reason"] ?? null, $retryable, true) ? 2 : 1;
+        return in_array($fields["abort_reason"] ?? null, self::PUSH_RETRYABLE_REASONS, true) ? 2 : 1;
     }
 
     private function staged_pull_staging_dir(): string
@@ -4309,7 +4317,7 @@ class ImportClient
         return $this->staged_pull_store;
     }
 
-    private function staged_pull_apply_engine(): Site_Export_Staged_Apply
+    private function staged_pull_apply_engine(?callable $on_protected = null): Site_Export_Staged_Apply
     {
         $preserve_local = $this->fs_root_nonempty_behavior === "preserve-local";
         return new Site_Export_Staged_Apply([
@@ -4320,6 +4328,10 @@ class ImportClient
             // symlinked directory.
             "on_existing" => $preserve_local ? "skip" : "replace",
             "refuse_symlinked_parents" => $preserve_local,
+            // The uncapped per-entry channel: index reconciliation after
+            // the window must see every protected id, not the capped
+            // diagnostic list in the result.
+            "on_protected" => $on_protected,
         ]);
     }
 
@@ -4522,9 +4534,13 @@ class ImportClient
         // and deleted remotely before the next accumulates both lines,
         // and the later one reflects the newer remote truth.
         $entries = [];
-        $raw = @file_get_contents($this->staged_pull_manifest_log());
-        if (is_string($raw) && $raw !== "") {
-            foreach (explode("\n", $raw) as $line) {
+        $log_handle = @fopen($this->staged_pull_manifest_log(), "r");
+        if ($log_handle !== false) {
+            while (true) {
+                $line = fgets($log_handle);
+                if ($line === false) {
+                    break;
+                }
                 $record = json_decode($line, true);
                 if (!is_array($record) || !is_string($record["artifact_id"] ?? null)) {
                     continue;
@@ -4563,6 +4579,7 @@ class ImportClient
                     ];
                 }
             }
+            fclose($log_handle);
         }
         if ($entries === []) {
             return;
@@ -4594,11 +4611,16 @@ class ImportClient
             "skipped_paths" => [],
             "deleted" => 0,
         ];
+        $protected_ids = [];
         if ($lines !== "") {
             $store = $this->staged_pull_store();
             $store->discard(self::PULL_MANIFEST_ID);
             $offset = 0;
-            foreach (str_split($lines, 262144) as $piece) {
+            // substr windows avoid str_split materializing a second full
+            // copy of a manifest that can reach tens of megabytes.
+            $lines_length = strlen($lines);
+            for ($piece_at = 0; $piece_at < $lines_length; $piece_at += 262144) {
+                $piece = substr($lines, $piece_at, 262144);
                 $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
                 if ($appended["status"] !== "accepted") {
                     throw new RuntimeException(
@@ -4612,29 +4634,24 @@ class ImportClient
             }
 
             $this->audit_log("STAGED APPLY | " . count($entries) . " entries", true);
-            $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
+            // Every protected id flows through the callback, uncapped —
+            // the PRESERVE-LOCAL audit contract and the index catch-up
+            // below both need the full set, not the response's capped
+            // diagnostic list.
+            $engine = $this->staged_pull_apply_engine(function (string $artifact_id) use (&$protected_ids): void {
+                if (isset($protected_ids[$artifact_id])) {
+                    return;
+                }
+                $protected_ids[$artifact_id] = true;
+                $this->audit_log("PRESERVE-LOCAL skip file (kept at apply) | {$artifact_id}", false);
+            });
+            $result = $engine->apply(self::PULL_MANIFEST_ID);
             if ($result["status"] !== "applied") {
                 throw new RuntimeException(
                     "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
                         " (" . ($result["detail"] ?? "") . ")",
                 );
             }
-        }
-
-        // Same audit contract as write-time preserve-local: every skipped
-        // operation is logged with the PRESERVE-LOCAL prefix.
-        $skipped_paths = is_array($result["skipped_paths"] ?? null) ? $result["skipped_paths"] : [];
-        foreach ($skipped_paths as $protected_path) {
-            $this->audit_log("PRESERVE-LOCAL skip file (kept at apply) | {$protected_path}", false);
-        }
-        if ($result["skipped"] > count($skipped_paths)) {
-            $this->audit_log(
-                sprintf(
-                    "PRESERVE-LOCAL skipped %d more files (path list capped)",
-                    $result["skipped"] - count($skipped_paths),
-                ),
-                false,
-            );
         }
 
         // The index merge consumes its updates as a path-sorted stream
@@ -4655,13 +4672,10 @@ class ImportClient
         // checks, same validation, same audit lines, just at window time
         // (their index upserts included). Applied files enter the index,
         // confirmed deletions leave it — mirroring push's
-        // forget-after-confirm. Protected entries (and everything, past
-        // the skipped-paths cap, where protected and applied cannot be
-        // told apart) keep their old state and re-derive next delta —
-        // a re-download or a no-op, never an orphan. Every step is
-        // idempotent, so a kill here reruns cleanly from the log.
-        $protected = array_fill_keys($skipped_paths, true);
-        $cap_overflowed = $result["skipped"] > count($skipped_paths);
+        // forget-after-confirm. Protected entries keep their old state
+        // and re-derive next delta — a re-download or a no-op, never an
+        // orphan. Every step is idempotent, so a kill here reruns
+        // cleanly from the log.
         $this->staged_replay = true;
         try {
             foreach ($entries as $artifact_id => $entry) {
@@ -4683,7 +4697,7 @@ class ImportClient
                     ]]);
                     continue;
                 }
-                if ($cap_overflowed || isset($protected[$artifact_id])) {
+                if (isset($protected_ids[$artifact_id])) {
                     continue;
                 }
                 if ($entry["kind"] === "delete") {
@@ -7448,11 +7462,17 @@ class ImportClient
             // The batch's ownership flags live in the download list slice
             // the fetch state brackets; rebuilding from there covers
             // resumed batches, whose batch file predates this process.
-            $this->staged_batch_owned = $this->read_download_list_owned(
-                $list_file,
-                $batch_offset,
-                $next_offset,
-            );
+            // One batch spans many requests, so rebuild only when the
+            // slice changes.
+            $batch_key = $list_file . ":" . $batch_offset . ":" . $next_offset;
+            if ($this->staged_batch_owned_key !== $batch_key) {
+                $this->staged_batch_owned = $this->read_download_list_owned(
+                    $list_file,
+                    $batch_offset,
+                    $next_offset,
+                );
+                $this->staged_batch_owned_key = $batch_key;
+            }
         }
 
         $post_data = [
@@ -11785,111 +11805,10 @@ class ImportClient
 
     public function default_state(): array
     {
-        return [
-            // Resume checkpoint for the lower-level command currently being
-            // run directly or as a stage inside a pull pipeline.
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
-            "preflight" => null,
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
-            "webhost" => null,
-            "follow_symlinks" => true,
-            "staged_apply" => false,
-            "fs_root_nonempty_behavior" => "error",
-            "filter" => "none",
-            "user_agent" => null,
-            "max_allowed_packet" => null,
-            "files_remap_fingerprint" => null,
-            "files_pull_only_fingerprint" => null,
-            "files_pull_summary" => [
-                "files_pulled" => 0,
-            ],
-            "db_index" => [
-                "file" => null,
-                "tables" => 0,
-                "rows_estimated" => 0,
-                "bytes" => 0,
-                "updated_at" => null,
-            ],
-            "diff" => [
-                "remote_offset" => 0,
-                "local_after" => null,
-            ],
-            "index" => [
-                "cursor" => null,
-            ],
-            "fetch" => [
-                "offset" => 0,
-                "next_offset" => 0,
-                "batch_file" => null,
-                "cursor" => null,
-                "batch_entries" => 0,
-            ],
-            "fetch_skipped" => [
-                "offset" => 0,
-                "next_offset" => 0,
-                "batch_file" => null,
-                "cursor" => null,
-                "batch_entries" => 0,
-            ],
-            // Crash recovery: track in-progress file downloads
-            // If we crash mid-write, we can truncate to the expected size on resume
-            "current_file" => null,        // Path to file being written
-            "current_file_bytes" => null,  // Expected bytes written so far
-            // Crash recovery: track SQL file size
-            "sql_bytes" => null,           // Expected SQL file size
-            // SQL streaming progress for user-facing statement counts.
-            "sql_statements_counted" => 0,
-            // db-apply state
-            "apply" => [
-                "statements_executed" => 0,
-                "bytes_read" => 0,
-                "rewrite_url" => null,
-                // Target database configuration — persisted by db-apply
-                // so that apply-runtime can generate DB_* constants.
-                "target_engine" => null,
-                "target_db" => null,
-                "target_host" => null,
-                "target_port" => null,
-                "target_user" => null,
-                "target_pass" => null,
-                "target_sqlite_path" => null,
-                "remote_paths_removed_from_local_site" => [],
-            ],
-            // SQL output mode (file, stdout, mysql) — persisted for resume
-            "sql_output" => null,
-            // MySQL connection parameters — persisted for resume (password excluded)
-            "mysql_host" => null,
-            "mysql_port" => null,
-            "mysql_user" => null,
-            "mysql_database" => null,
-            // Consecutive cURL timeout counter — tracks how many times in a
-            // row a timeout fired without the cursor advancing. After
-            // MAX_CONSECUTIVE_TIMEOUTS with no progress, the importer gives
-            // up instead of retrying forever.
-            "consecutive_timeouts" => 0,
-            // Adaptive tuning state/config
-            "tuning" => [
-                "config" => [],
-                "state" => [],
-            ],
-            // Resume checkpoint for the user-facing pull pipeline command
-            // being orchestrated.
-            "pull_pipeline" => [
-                "started_by_command" => null,
-                "stage_sequence" => [],
-                "last_completed_stage" => null,
-                "files_filter" => null,
-                "skipped_pending" => false,
-                "has_completed_once" => false,
-            ],
-        ];
+        // ImportState's typed properties are the single source of the
+        // persisted schema; a field added there appears here without a
+        // second hand-maintained copy to keep in lockstep.
+        return ImportState::from_array([])->to_array();
     }
 
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1250,6 +1250,13 @@ class ImportClient
     /** @var array<string,true> Owned remote paths in the batch being fetched. */
     private $staged_batch_owned = [];
 
+    /**
+     * True while the apply window replays deferred directory/symlink
+     * records through their regular handlers — the same code that runs at
+     * fetch time in unstaged mode, just at window time.
+     */
+    private $staged_replay = false;
+
     public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
@@ -2028,6 +2035,22 @@ class ImportClient
                     @unlink($this->volatile_files_file);
                     $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
                 }
+
+                // Staged leftovers are sync progress too: unapplied bytes
+                // and the pending window log go with the cursor. Nothing
+                // in them reached the live tree or the index, so the next
+                // diff re-derives whatever still applies.
+                $staging_dir = $this->staged_pull_staging_dir();
+                if (is_dir($staging_dir)) {
+                    $this->remove_local_path_without_following_symlinks($staging_dir);
+                    $this->audit_log("FILE DELETE | {$staging_dir} | staged leftovers cleared");
+                    $this->staged_pull_store = null;
+                }
+                if (file_exists($this->staged_pull_manifest_log())) {
+                    @unlink($this->staged_pull_manifest_log());
+                    $this->audit_log("FILE DELETE | {$this->staged_pull_manifest_log()}");
+                }
+
                 $this->import_state()->index = new RemoteFileIndexCursorState();
                 $this->import_state()->fetch = new DownloadListFetchProgressState();
                 $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
@@ -4382,7 +4405,7 @@ class ImportClient
      *
      * @return string|null Failure reason, or null when the file verified.
      */
-    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime, bool $owned = false): ?string
+    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime, bool $owned, string $remote_path): ?string
     {
         $result = $this->staged_pull_store()->finalize($artifact_id, $expected_size);
         if ($result["status"] !== "verified") {
@@ -4393,12 +4416,56 @@ class ImportClient
             // against the remote ctime.
             @touch($this->staged_pull_staging_dir() . "/files/" . $artifact_id, $ctime);
         }
-        $record = ["artifact_id" => $artifact_id, "size" => $expected_size];
+        // The remote path and ctime ride along so the window can update
+        // the local index after the file actually lands — the index must
+        // describe the live tree, never the staging area, or an abort
+        // between fetch and apply leaves a delta that skips files the
+        // tree never received.
+        $record = [
+            "artifact_id" => $artifact_id,
+            "size" => $expected_size,
+            "path" => $remote_path,
+            "ctime" => $ctime,
+        ];
         if ($owned) {
             $record["owned"] = true;
         }
-        @file_put_contents($this->staged_pull_manifest_log(), json_encode($record) . "\n", FILE_APPEND);
+        $this->staged_pull_append_log(json_encode($record) . "\n");
         return null;
+    }
+
+    /**
+     * Appends a deferred record to the manifest log, keyed by the path's
+     * fs-root-relative artifact id. Directory and symlink parts defer here
+     * in staged mode; the apply window replays them through their regular
+     * handlers.
+     */
+    private function staged_pull_defer_record(array $record): void
+    {
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($record["path"]);
+            $record["artifact_id"] = $this->staged_pull_artifact_id($local_path);
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "Security: refusing to stage a {$record["type"]} record for invalid path '{$record["path"]}': " . $e->getMessage(),
+                true,
+            );
+            return;
+        }
+        $this->staged_pull_append_log(json_encode($record) . "\n");
+    }
+
+    /**
+     * All manifest-log appends go through here: a lost record is a file,
+     * directory, symlink, or deletion the window would silently never
+     * carry out, so short writes are fatal (disk full?) like the index
+     * updates writer's.
+     */
+    private function staged_pull_append_log(string $line): void
+    {
+        if (@file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND) !== strlen($line)) {
+            throw new RuntimeException("Failed to append to the staged manifest log (disk full?)");
+        }
     }
 
     /**
@@ -4423,12 +4490,11 @@ class ImportClient
         }
         // Any bytes staged under this id from an earlier resume are
         // garbage now; the apply window's delete pass consumes them.
-        $line = json_encode([
+        $this->staged_pull_append_log(json_encode([
             "artifact_id" => $artifact_id,
             "delete" => true,
             "path" => $remote_path,
-        ]) . "\n";
-        @file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND);
+        ]) . "\n");
         $this->audit_log("Deletion staged for the apply window: {$remote_path}", false);
     }
 
@@ -4439,6 +4505,12 @@ class ImportClient
      * accumulates across resumes and is deduplicated here; entries an
      * earlier window already applied classify as applied and only consume
      * their leftover markers.
+     *
+     * The window is: engine apply (file renames and deletions under the
+     * store lock), then a replay of deferred directory/symlink records
+     * through their regular handlers, then the index catch-up. Everything
+     * before the final log unlink is idempotent, so a kill anywhere in
+     * the window reruns cleanly.
      */
     private function run_staged_pull_apply(): void
     {
@@ -4457,18 +4529,37 @@ class ImportClient
                 if (!is_array($record) || !is_string($record["artifact_id"] ?? null)) {
                     continue;
                 }
+                $path = is_string($record["path"] ?? null) ? $record["path"] : null;
                 if (!empty($record["delete"])) {
+                    $entries[$record["artifact_id"]] = ["kind" => "delete", "path" => $path];
+                    continue;
+                }
+                $type = $record["type"] ?? null;
+                $ctime = is_int($record["ctime"] ?? null) ? $record["ctime"] : 0;
+                if ($type === "dir" && $path !== null) {
                     $entries[$record["artifact_id"]] = [
-                        "delete" => true,
-                        "path" => is_string($record["path"] ?? null) ? $record["path"] : null,
+                        "kind" => "dir",
+                        "path" => $path,
+                        "ctime" => $ctime,
                     ];
                     continue;
                 }
-                if (is_int($record["size"] ?? null)) {
+                if ($type === "symlink" && $path !== null && is_string($record["target"] ?? null)) {
                     $entries[$record["artifact_id"]] = [
-                        "delete" => false,
+                        "kind" => "symlink",
+                        "path" => $path,
+                        "target" => $record["target"],
+                        "ctime" => $ctime,
+                    ];
+                    continue;
+                }
+                if ($type === null && is_int($record["size"] ?? null)) {
+                    $entries[$record["artifact_id"]] = [
+                        "kind" => "file",
                         "size" => $record["size"],
                         "owned" => !empty($record["owned"]),
+                        "path" => $path,
+                        "ctime" => $ctime,
                     ];
                 }
             }
@@ -4477,10 +4568,16 @@ class ImportClient
             return;
         }
 
+        // Only files and deletions go through the store-backed engine;
+        // directories and symlinks replay through their own handlers after
+        // the renames land.
         $lines = "";
         foreach ($entries as $artifact_id => $entry) {
-            if ($entry["delete"]) {
+            if ($entry["kind"] === "delete") {
                 $lines .= json_encode(["artifact_id" => $artifact_id, "delete" => true]) . "\n";
+                continue;
+            }
+            if ($entry["kind"] !== "file") {
                 continue;
             }
             $manifest_entry = ["artifact_id" => $artifact_id, "size" => $entry["size"]];
@@ -4490,32 +4587,40 @@ class ImportClient
             $lines .= json_encode($manifest_entry) . "\n";
         }
 
-        $store = $this->staged_pull_store();
-        $store->discard(self::PULL_MANIFEST_ID);
-        $offset = 0;
-        foreach (str_split($lines, 262144) as $piece) {
-            $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
-            if ($appended["status"] !== "accepted") {
+        $result = [
+            "applied" => 0,
+            "already_applied" => 0,
+            "skipped" => 0,
+            "skipped_paths" => [],
+            "deleted" => 0,
+        ];
+        if ($lines !== "") {
+            $store = $this->staged_pull_store();
+            $store->discard(self::PULL_MANIFEST_ID);
+            $offset = 0;
+            foreach (str_split($lines, 262144) as $piece) {
+                $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $piece);
+                if ($appended["status"] !== "accepted") {
+                    throw new RuntimeException(
+                        "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+                    );
+                }
+                $offset = $appended["committed_bytes"];
+            }
+            if ($store->finalize(self::PULL_MANIFEST_ID, strlen($lines))["status"] !== "verified") {
+                throw new RuntimeException("Staged apply could not verify its manifest.");
+            }
+
+            $this->audit_log("STAGED APPLY | " . count($entries) . " entries", true);
+            $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
+            if ($result["status"] !== "applied") {
                 throw new RuntimeException(
-                    "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+                    "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
+                        " (" . ($result["detail"] ?? "") . ")",
                 );
             }
-            $offset = $appended["committed_bytes"];
-        }
-        if ($store->finalize(self::PULL_MANIFEST_ID, strlen($lines))["status"] !== "verified") {
-            throw new RuntimeException("Staged apply could not verify its manifest.");
         }
 
-        $this->audit_log("STAGED APPLY | " . count($entries) . " files", true);
-        $result = $this->staged_pull_apply_engine()->apply(self::PULL_MANIFEST_ID);
-        if ($result["status"] !== "applied") {
-            throw new RuntimeException(
-                "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
-                    " (" . ($result["detail"] ?? "") . ")",
-            );
-        }
-
-        @unlink($this->staged_pull_manifest_log());
         // Same audit contract as write-time preserve-local: every skipped
         // operation is logged with the PRESERVE-LOCAL prefix.
         $skipped_paths = is_array($result["skipped_paths"] ?? null) ? $result["skipped_paths"] : [];
@@ -4532,29 +4637,69 @@ class ImportClient
             );
         }
 
-        // Deletions the window confirmed leave the index now, mirroring
-        // push's forget-after-confirm. Protected deletions (symlinked
-        // parents) keep their entries and re-derive next delta; past the
-        // skipped-paths cap we cannot tell the two apart, so everything
-        // stays and re-derives — a no-op, never an orphan.
+        // The index merge consumes its updates as a path-sorted stream
+        // (trunk keeps it sorted by upserting in fetch order). Flush any
+        // fetch-phase leftovers as their own sorted run first, then walk
+        // the window's entries in path order so replays and index writes
+        // emit one sorted run of their own.
+        $this->finalize_index_updates();
+        uasort($entries, static function (array $a, array $b): int {
+            $a_path = (string) $a["path"];
+            $b_path = (string) $b["path"];
+            return strcmp($a_path, $b_path);
+        });
+
+        // The window's remaining effects, one path-ordered walk:
+        // directory and symlink records replay through the handlers that
+        // would have run at fetch time in unstaged mode — same policy
+        // checks, same validation, same audit lines, just at window time
+        // (their index upserts included). Applied files enter the index,
+        // confirmed deletions leave it — mirroring push's
+        // forget-after-confirm. Protected entries (and everything, past
+        // the skipped-paths cap, where protected and applied cannot be
+        // told apart) keep their old state and re-derive next delta —
+        // a re-download or a no-op, never an orphan. Every step is
+        // idempotent, so a kill here reruns cleanly from the log.
         $protected = array_fill_keys($skipped_paths, true);
         $cap_overflowed = $result["skipped"] > count($skipped_paths);
-        $confirmed_deletes = 0;
-        foreach ($entries as $artifact_id => $entry) {
-            if (
-                !$entry["delete"]
-                || $entry["path"] === null
-                || $cap_overflowed
-                || isset($protected[$artifact_id])
-            ) {
-                continue;
+        $this->staged_replay = true;
+        try {
+            foreach ($entries as $artifact_id => $entry) {
+                if ($entry["path"] === null) {
+                    continue;
+                }
+                if ($entry["kind"] === "dir") {
+                    $this->handle_directory_chunk(["headers" => [
+                        "x-directory-path" => base64_encode($entry["path"]),
+                        "x-directory-ctime" => (string) $entry["ctime"],
+                    ]]);
+                    continue;
+                }
+                if ($entry["kind"] === "symlink") {
+                    $this->handle_symlink_chunk(["headers" => [
+                        "x-symlink-path" => base64_encode($entry["path"]),
+                        "x-symlink-target" => base64_encode($entry["target"]),
+                        "x-symlink-ctime" => (string) $entry["ctime"],
+                    ]]);
+                    continue;
+                }
+                if ($cap_overflowed || isset($protected[$artifact_id])) {
+                    continue;
+                }
+                if ($entry["kind"] === "delete") {
+                    $this->delete_index_entry($entry["path"]);
+                } elseif ($entry["kind"] === "file" && $entry["ctime"] > 0) {
+                    $this->upsert_index_entry($entry["path"], $entry["ctime"], $entry["size"], "file");
+                }
             }
-            $this->delete_index_entry($entry["path"]);
-            ++$confirmed_deletes;
+        } finally {
+            $this->staged_replay = false;
         }
-        if ($confirmed_deletes > 0) {
-            $this->finalize_index_updates();
-        }
+        $this->finalize_index_updates();
+
+        // Unlinked last: everything above idempotently reruns from the
+        // log if the process dies mid-window.
+        @unlink($this->staged_pull_manifest_log());
 
         $this->audit_log(
             sprintf(
@@ -9809,6 +9954,7 @@ class ImportClient
                     $file_size,
                     $context->file_ctime ?? 0,
                     $context->staged_owned === true,
+                    $path,
                 );
                 if ($finalize_error !== null) {
                     $this->staged_pull_store()->discard($context->staged_artifact_id);
@@ -9816,13 +9962,9 @@ class ImportClient
                         "  Staged file did not verify ({$finalize_error}); discarded for refetch",
                         true,
                     );
-                } elseif ($context->file_ctime) {
-                    $this->upsert_index_entry(
-                        $path,
-                        $context->file_ctime,
-                        $file_size,
-                        "file",
-                    );
+                } else {
+                    // The index entry waits for the apply window; only
+                    // progress bookkeeping happens at stage time.
                     $this->files_imported++;
                     $this->clear_volatile_file($path);
                     $this->audit_log(
@@ -10121,6 +10263,17 @@ class ImportClient
             return;
         }
 
+        if ($this->staged_apply_mode && !$this->staged_replay) {
+            // Staged mode: the live tree stays untouched until the apply
+            // window, which replays this record through this same handler.
+            $this->staged_pull_defer_record([
+                "type" => "dir",
+                "path" => $path,
+                "ctime" => $ctime,
+            ]);
+            return;
+        }
+
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
 
         // In preserve-local mode, if the directory already exists (as a real
@@ -10204,6 +10357,19 @@ class ImportClient
                     true,
                 );
             }
+            return;
+        }
+
+        if ($this->staged_apply_mode && !$this->staged_replay) {
+            // Staged mode: defer, window replays. The raw remote target is
+            // recorded; mapping and validation run at replay, in the same
+            // code they always run in.
+            $this->staged_pull_defer_record([
+                "type" => "symlink",
+                "path" => $path,
+                "target" => $target,
+                "ctime" => $ctime,
+            ]);
             return;
         }
 
@@ -12745,7 +12911,10 @@ if (
             'target' => 'staged_apply',
             'help' => 'Download into a staging area under --state-dir and move files into ' .
                 '--fs-root in one rename window at the end, so the tree never holds a ' .
-                'half-written file (requires --state-dir and --fs-root on one filesystem)',
+                'half-written file (requires --state-dir and --fs-root on one filesystem). ' .
+                'The mode persists in state: resumes and later deltas stay staged. ' .
+                'To switch modes, run --abort first (pending staged data is discarded ' .
+                'and re-derived by the next sync)',
             'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -67,6 +67,14 @@ class StagedPushRunner
     private $on_progress;
 
     /**
+     * @var array<string,array{size:int,mtime:?int}>|null Parsed done cache;
+     *   one push-files run reads it for the plan walk, the deletion
+     *   derivation, and the post-apply forget — one parse serves all
+     *   three. Writers keep it current.
+     */
+    private $verified_cache_memo = null;
+
+    /**
      * @param array $options
      *   - state_dir (string, required): holds .push-state.json and
      *     .push-verified.jsonl; created if missing.
@@ -213,12 +221,17 @@ class StagedPushRunner
         // multipart discipline in the push direction. Files bigger than
         // the budget keep the resumable per-chunk path. A 413 shrinks the
         // budget (monotonically, so this terminates) and the affected
-        // batch repartitions.
-        while ($queue !== []) {
+        // batch repartitions. The queue is consumed by index — shifting
+        // a 200k-entry array reindexes it every time — and retries
+        // append to the tail.
+        $next = 0;
+        $queue_size = count($queue);
+        while ($next < $queue_size) {
             $budget = max(1, $this->sizer->chunk_bytes());
 
-            if ($queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
-                $entry = array_shift($queue);
+            if ($queue[$next]["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
+                $entry = $queue[$next];
+                ++$next;
                 $result = $this->client->upload_artifact(
                     $entry["artifact_id"],
                     $entry["source_path"],
@@ -250,14 +263,16 @@ class StagedPushRunner
                 return $this->aborted($files_total, $files_done, $failed, $reason, $result["detail"]);
             }
 
+            // One cumulative bound suffices: batch_bytes starts at 0, so
+            // the first entry's fit check and the running check coincide.
             $batch = [];
             $batch_bytes = 0;
             while (
-                $queue !== []
-                && $queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
-                && $batch_bytes + $queue[0]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
+                $next < $queue_size
+                && $batch_bytes + $queue[$next]["total_bytes"] + self::BATCH_FRAME_OVERHEAD <= $budget
             ) {
-                $entry = array_shift($queue);
+                $entry = $queue[$next];
+                ++$next;
                 $batch[$entry["artifact_id"]] = $entry;
                 $batch_bytes += $entry["total_bytes"] + self::BATCH_FRAME_OVERHEAD;
             }
@@ -269,6 +284,7 @@ class StagedPushRunner
                     // The sizer already shrank; repartition these entries.
                     foreach ($batch as $entry) {
                         $queue[] = $entry;
+                        ++$queue_size;
                     }
                     continue;
                 }
@@ -290,6 +306,7 @@ class StagedPushRunner
                 if ($outcome["status"] === "not_attempted") {
                     // The server stopped at an earlier frame; retry these.
                     $queue[] = $entry;
+                    ++$queue_size;
                     continue;
                 }
                 $reason = is_string($outcome["reason"]) ? $outcome["reason"] : "unexpected_response";
@@ -356,6 +373,9 @@ class StagedPushRunner
         $tmp_path = $this->verified_path . ".tmp";
         if (@file_put_contents($tmp_path, $lines) === strlen($lines)) {
             @rename($tmp_path, $this->verified_path);
+            foreach (array_keys($drop) as $artifact_id) {
+                unset($this->verified_cache_memo[$artifact_id]);
+            }
         }
         @unlink($tmp_path);
     }
@@ -379,8 +399,12 @@ class StagedPushRunner
      */
     private function read_verified_cache(): array
     {
+        if ($this->verified_cache_memo !== null) {
+            return $this->verified_cache_memo;
+        }
         $raw = @file_get_contents($this->verified_path);
         if ($raw === false || $raw === "") {
+            $this->verified_cache_memo = [];
             return [];
         }
         $cache = [];
@@ -401,6 +425,7 @@ class StagedPushRunner
                 "mtime" => is_int($record["mtime"] ?? null) ? $record["mtime"] : null,
             ];
         }
+        $this->verified_cache_memo = $cache;
         return $cache;
     }
 
@@ -414,6 +439,9 @@ class StagedPushRunner
             "mtime" => $mtime,
         ]) . "\n";
         @file_put_contents($this->verified_path, $line, FILE_APPEND);
+        if ($this->verified_cache_memo !== null) {
+            $this->verified_cache_memo[$artifact_id] = ["size" => $size, "mtime" => $mtime];
+        }
     }
 
     private function write_state(int $files_total, int $files_done): void

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -166,18 +166,14 @@ class StagedUploadClient
         // source is invisible to all of them. The exporter re-checks its
         // files after streaming (x-file-changed); the sender owes the same
         // honesty about its own disk, before and after the upload.
-        if (
-            $expected_mtime !== null
-            && is_array($opened_stat)
-            && (int) $opened_stat["mtime"] !== $expected_mtime
-        ) {
+        if ($this->planned_mtime_differs($opened_stat, $expected_mtime)) {
             fclose($source);
             // Committed bytes may belong to the older version; a mixed
             // artifact must never verify.
             $this->discard($artifact_id);
             return $this->failed(
                 "source_changed",
-                sprintf("planned mtime %d, found %d", $expected_mtime, (int) $opened_stat["mtime"])
+                sprintf("planned mtime %d, found %d", (int) $expected_mtime, (int) $opened_stat["mtime"])
             );
         }
 
@@ -309,15 +305,7 @@ class StagedUploadClient
         // Post-upload volatility check: a rewrite during the read window
         // can leave staged bytes that match no version of the file. Torn
         // content must fail typed, not verify.
-        clearstatcache(true, $source_path);
-        $now_stat = @stat($source_path);
-        if (
-            !is_array($opened_stat)
-            || $now_stat === false
-            || $now_stat["ino"] !== $opened_stat["ino"]
-            || $now_stat["mtime"] !== $opened_stat["mtime"]
-            || $now_stat["size"] !== $opened_stat["size"]
-        ) {
+        if ($this->source_changed_since($source_path, $opened_stat)) {
             $this->discard($artifact_id);
             return $this->failed("source_changed", "source changed while uploading");
         }
@@ -335,6 +323,11 @@ class StagedUploadClient
         $response = $this->request_json("GET", "staged_status", ["artifact_id" => $artifact_id]);
         if ($response["error"] !== null || !is_array($response["json"])) {
             return $this->failed("status_unavailable", $response["error"] ?? "invalid response");
+        }
+        if ($this->is_auth_envelope($response)) {
+            // Same reading as every other route: a control-plane auth
+            // envelope must not masquerade as "artifact absent".
+            return $this->failed("auth_failed", $this->envelope_error($response));
         }
         return [
             "status" => "ok",
@@ -414,11 +407,7 @@ class StagedUploadClient
             }
             $opened = fstat($source);
             $expected_mtime = isset($file["mtime"]) ? (int) $file["mtime"] : null;
-            if (
-                $expected_mtime !== null
-                && is_array($opened)
-                && (int) $opened["mtime"] !== $expected_mtime
-            ) {
+            if ($this->planned_mtime_differs($opened, $expected_mtime)) {
                 fclose($source);
                 $this->discard($artifact_id);
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
@@ -426,19 +415,11 @@ class StagedUploadClient
             }
             $payload = $total_bytes > 0 ? $this->read_exactly($source, $total_bytes) : "";
             fclose($source);
-            clearstatcache(true, (string) $file["source_path"]);
-            $now_stat = @stat((string) $file["source_path"]);
             if ($payload === null) {
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_short"];
                 continue;
             }
-            if (
-                !is_array($opened)
-                || $now_stat === false
-                || $now_stat["ino"] !== $opened["ino"]
-                || $now_stat["mtime"] !== $opened["mtime"]
-                || $now_stat["size"] !== $opened["size"]
-            ) {
+            if ($this->source_changed_since((string) $file["source_path"], $opened)) {
                 $this->discard($artifact_id);
                 $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
                 continue;
@@ -577,6 +558,37 @@ class StagedUploadClient
      * before any endpoint runs. Surface those as auth_failed — retrying
      * cannot fix a bad secret — instead of an unexpected response.
      */
+    /**
+     * The plan promised an mtime and the opened file disagrees — the
+     * content is newer than the plan. One predicate for the chunked and
+     * batched paths, so both enforce the same torn-content rule.
+     *
+     * @param array|false $opened_stat fstat() of the opened source.
+     */
+    private function planned_mtime_differs($opened_stat, ?int $expected_mtime): bool
+    {
+        return $expected_mtime !== null
+            && is_array($opened_stat)
+            && (int) $opened_stat["mtime"] !== $expected_mtime;
+    }
+
+    /**
+     * Whether the source was rewritten since it was opened (inode, mtime,
+     * or size moved) — the post-read half of the same rule.
+     *
+     * @param array|false $opened_stat fstat() taken at open time.
+     */
+    private function source_changed_since(string $source_path, $opened_stat): bool
+    {
+        clearstatcache(true, $source_path);
+        $now_stat = @stat($source_path);
+        return !is_array($opened_stat)
+            || $now_stat === false
+            || $now_stat["ino"] !== $opened_stat["ino"]
+            || $now_stat["mtime"] !== $opened_stat["mtime"]
+            || $now_stat["size"] !== $opened_stat["size"];
+    }
+
     private function is_auth_envelope(array $response): bool
     {
         return in_array($response["http_code"], [401, 403], true)

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-pull/apply-window-deletions",
+            "version": "dev-pull/dual-mode-windows",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -207,6 +207,18 @@ function _site_export_staged_options(): array {
 }
 
 /**
+ * Data-plane endpoints authenticate inside their handlers.
+ *
+ * The default HMAC handler buffers php://input to hash it, which defeats the
+ * staged upload handlers' spool-then-verify discipline. Keep this list next
+ * to the public request handler so every large-body route makes an explicit
+ * auth decision.
+ */
+function _site_export_endpoint_authenticates_in_handler(string $endpoint): bool {
+    return in_array($endpoint, ['staged_upload', 'staged_upload_batch'], true);
+}
+
+/**
  * Handle an export API request.
  *
  * WordPress is already loaded at this point — DB credentials, $table_prefix,
@@ -277,18 +289,18 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    // staged_upload authenticates inside its handler: the default handler
-    // here buffers the whole request body to hash it, which a chunk upload
-    // cannot afford. The upload route verifies the signed headers first and
-    // hashes the body as it streams. A custom authenticate callable still
-    // runs for every endpoint — its embedder owns that tradeoff.
+    // Staged data-plane endpoints authenticate inside their handlers: the
+    // default handler here buffers the whole request body to hash it, which
+    // chunk and batch uploads cannot afford. Those routes verify the signed
+    // headers first and hash the body as it streams. A custom authenticate
+    // callable still runs for every endpoint — its embedder owns that tradeoff.
     // filter_input, not WP sanitizers: lib.php also runs without WordPress
     // bootstrapped (hosts that route the API from their own index.php).
     $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
-    } elseif ($endpoint !== 'staged_upload') {
+    } elseif (!_site_export_endpoint_authenticates_in_handler($endpoint)) {
         _site_export_default_authenticate();
     }
 

--- a/tests/HmacServerTest.php
+++ b/tests/HmacServerTest.php
@@ -143,36 +143,6 @@ final class HmacServerTest extends TestCase
         }
     }
 
-    public function testControlRequestVerifiesBoundedBody(): void
-    {
-        $body = '{"command":"preflight"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertNull($server->verify_control_request($headers, $body, 1700000001.0));
-    }
-
-    public function testControlRequestRejectsBodyAboveConfiguredLimit(): void
-    {
-        $body = '{"command":"preflight"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertSame(
-            'HMAC control request body exceeds 8 bytes',
-            $server->verify_control_request($headers, $body, 1700000001.0, 8)
-        );
-    }
-
-    public function testPrecomputedContentHashVerifiesWithoutBody(): void
-    {
-        $body = '{"command":"commit","manifest":"abc123"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertNull($server->verify_content_hash($headers, hash('sha256', $body), 1700000001.0));
-    }
-
     public function testSignedContentHashHeaderCanBeCheckedBeforeBodyIsRead(): void
     {
         $body = '{"command":"start-session"}';

--- a/tests/Import/StagedPullCliTest.php
+++ b/tests/Import/StagedPullCliTest.php
@@ -164,6 +164,10 @@ class StagedPullCliTest extends TestCase
     {
         mkdir($this->source_dir . '/wp-content/uploads', 0700, true);
         mkdir($this->source_dir . '/wp-content/plugins/my-plugin', 0700, true);
+        // An empty directory and a symlink: parts that are not file
+        // content and must still respect the staged window.
+        mkdir($this->source_dir . '/wp-content/empty-dir', 0700, true);
+        symlink('index.php', $this->source_dir . '/link.php');
         // wp_detect needs these to recognize the directory as a root.
         file_put_contents($this->source_dir . '/wp-load.php', '<?php /* stub */');
         file_put_contents($this->source_dir . '/wp-config.php', '<?php /* stub config */');
@@ -171,6 +175,23 @@ class StagedPullCliTest extends TestCase
         file_put_contents($this->source_dir . '/empty.txt', '');
         file_put_contents($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', '<?php // plugin v1');
         file_put_contents($this->source_dir . '/wp-content/uploads/big.bin', str_repeat('reprint!', 40000));
+    }
+
+    /** Files, directories, and symlinks under $dir — the window must gate all three. */
+    private function countEntries(string $dir): int
+    {
+        if (!is_dir($dir)) {
+            return 0;
+        }
+        $count = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $entry) {
+            ++$count;
+        }
+        return $count;
     }
 
     /**
@@ -260,8 +281,8 @@ class StagedPullCliTest extends TestCase
         $this->assertNotSame(0, $held_code, $held_output);
         $this->assertSame(
             0,
-            $this->countFiles($this->fs_root),
-            'an interrupted staged pull must leave the live tree untouched'
+            $this->countEntries($this->fs_root),
+            'an interrupted staged pull must leave the live tree untouched — no files, directories, or symlinks'
         );
 
         [$output, $code] = $this->pullToCompletion(['--staged-apply']);
@@ -269,6 +290,53 @@ class StagedPullCliTest extends TestCase
         $this->assertSame(0, $code, $output);
         exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
         $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+        $this->assertTrue(is_link($this->mappedRoot() . '/link.php'), 'the deferred symlink lands with the window');
+        $this->assertDirectoryExists($this->mappedRoot() . '/wp-content/empty-dir');
+    }
+
+    public function testAbortSwitchesModesCleanlyInBothDirections(): void
+    {
+        // Modes are sticky per state dir (like preserve-local); --abort is
+        // the documented switch. Staged, interrupted, aborted, finished
+        // unstaged — then a remote change pulled staged again. The tree
+        // must come out complete every time: the index never claims
+        // anything the live tree does not have, so no delta ever skips a
+        // file the previous mode left behind.
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        $staging = $this->state_dir . '/.pull-staging';
+        mkdir($staging, 0700, true);
+        $holder = fopen($staging . '/lock', 'c+b');
+        flock($holder, LOCK_EX);
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertNotSame(0, $held_code, $held_output);
+
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        $this->assertDirectoryDoesNotExist($staging, '--abort clears staged leftovers');
+
+        // Unstaged from here: no --staged-apply flag, fresh state.
+        [$output, $code] = $this->pullToCompletion();
+        $this->assertSame(0, $code, $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+
+        // Back to staged for a delta.
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index v2');
+        touch($this->source_dir . '/index.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertSame(
+            '<?php // remote index v2',
+            file_get_contents($this->mappedRoot() . '/index.php')
+        );
+        $this->assertStringContainsString('staged_apply', $output, 'the delta ran through the window');
     }
 
     public function testPreserveLocalPoliciesHoldAtApplyTime(): void
@@ -372,7 +440,9 @@ class StagedPullCliTest extends TestCase
 
         // A held store lock fails the delta mid-fetch. Deletions used to
         // happen at diff time; in staged mode nothing — removals included —
-        // may touch the live tree before the window.
+        // may touch the live tree before the window. (--abort cleared the
+        // staging dir, so recreate the scaffolding to plant the lock.)
+        @mkdir($this->state_dir . '/.pull-staging', 0700, true);
         $holder = fopen($this->state_dir . '/.pull-staging/lock', 'c+b');
         flock($holder, LOCK_EX);
         [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);

--- a/tests/SiteExportLibraryAuthTest.php
+++ b/tests/SiteExportLibraryAuthTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SiteExportLibraryAuthTest extends TestCase
+{
+    private const LIB_PATH = __DIR__ . '/../reprint-exporter-wp/lib.php';
+
+    public function testLargeBodyStagedEndpointsAuthenticateInTheirHandlers(): void
+    {
+        $script = <<<PHP
+        define('ABSPATH', __DIR__ . '/');
+        define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/');
+        require '{$this->libPath()}';
+
+        echo '__RESULT__' . json_encode([
+            'chunk' => _site_export_endpoint_authenticates_in_handler('staged_upload'),
+            'batch' => _site_export_endpoint_authenticates_in_handler('staged_upload_batch'),
+            'control' => _site_export_endpoint_authenticates_in_handler('staged_status'),
+        ]);
+        PHP;
+
+        $result = json_decode($this->resultJson($this->runScript($script)), true);
+
+        $this->assertSame([
+            'chunk' => true,
+            'batch' => true,
+            'control' => false,
+        ], $result);
+    }
+
+    private function resultJson(string $output): string
+    {
+        $marker = '__RESULT__';
+        $position = strrpos($output, $marker);
+        $this->assertNotFalse($position, $output);
+        return substr($output, $position + strlen($marker));
+    }
+
+    private function libPath(): string
+    {
+        $path = realpath(self::LIB_PATH);
+        $this->assertNotFalse($path);
+        return $path;
+    }
+
+    private function runScript(string $body): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/site-export-library-auth-' . uniqid();
+        mkdir($tmp_dir, 0755, true);
+
+        try {
+            $php_path = $tmp_dir . '/run.php';
+            file_put_contents($php_path, "<?php\n" . $body . "\n");
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open([PHP_BINARY, $php_path], $descriptors, $pipes, $tmp_dir);
+            if (!is_resource($process)) {
+                $this->fail('Failed to spawn PHP subprocess');
+            }
+
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            if (($stdout ?: '') === '') {
+                return $stderr ?: '';
+            }
+            return $stdout;
+        } finally {
+            array_map('unlink', glob($tmp_dir . '/*') ?: []);
+            rmdir($tmp_dir);
+        }
+    }
+}

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -630,6 +630,37 @@ final class StagedApplyTest extends TestCase {
         $this->assertStringContainsString('duplicates an artifact id', (string) $twice['detail']);
     }
 
+    public function testOnProtectedReportsEveryEntryBeyondTheResponseCap(): void
+    {
+        // skipped_paths is a bounded-HTTP-response diagnostic, capped at
+        // 1000. In-process callers reconcile per-entry state through
+        // on_protected, which must see every protected id — an index
+        // catch-up driven by the capped list would silently skip entries
+        // past the cap.
+        $manifest_entries = [];
+        for ($i = 0; $i < 1001; $i++) {
+            $name = sprintf('kept-%04d.txt', $i);
+            file_put_contents($this->target_root . '/' . $name, 'local');
+            $manifest_entries[] = ['artifact_id' => $name, 'size' => 5];
+        }
+        $manifest = $this->stageManifest($manifest_entries);
+
+        $reported = [];
+        $apply = $this->makeApply([
+            'on_existing' => 'skip',
+            'on_protected' => static function (string $artifact_id) use (&$reported): void {
+                $reported[] = $artifact_id;
+            },
+        ]);
+        $result = $apply->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1001, $result['skipped']);
+        $this->assertCount(1000, $result['skipped_paths'], 'the response list stays capped');
+        $this->assertCount(1001, $reported, 'the callback sees every protected entry');
+        $this->assertSame('kept-1000.txt', end($reported));
+    }
+
     // ---------------------------------------------------------------
     // Preflight facts on "ready"
     // ---------------------------------------------------------------

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -1,10 +1,10 @@
-# Stages this PR's perf comment will benchmark.
+# Stages this PR stack's perf comment will benchmark.
 # One stage name per line; comments and blank lines ignored.
 # Both the PR build and the trunk baseline run the same set, so the
-# table shows two like-for-like wall-time numbers per row.
+# table shows like-for-like wall-time numbers per row.
 #
-# This PR loads the Rust wp_mysql_parser PHP.wasm extension for the PR side
-# and leaves it disabled for the trunk baseline. Both sides use the same
-# direct PHP.wasm runner so the wall-time delta isolates the extension.
-playground-sqlite-db-pull
-playground-sqlite-db-apply
+# This stack changes file transfer/apply behavior. Keep the focused benchmark
+# on file movement rather than unrelated database-only Playground SQLite
+# stages. Push-specific stages cannot be compared here until push-files exists
+# on the trunk baseline.
+files-pull

--- a/tests/e2e/tests/import-52-push-files.test.js
+++ b/tests/e2e/tests/import-52-push-files.test.js
@@ -12,6 +12,7 @@
  *    empty file, and a multi-chunk file
  *  - idempotent re-push (cache-skips, apply reports already applied)
  *  - resume after the client loses ALL local state (server is the truth)
+ *  - resume when a prior apply already moved one staged artifact
  *  - a same-size edit re-pushes (size checks alone cannot see it)
  *  - --only pushes a subset and applies only that subset
  *  - wrong secret fails fast without staging a byte
@@ -172,6 +173,32 @@ describe('Import: push-files stages and applies a local tree', () => {
         const resumed = runPush(['--apply']);
 
         assert.equal(resumed.exitCode, 0, `resume failed:\n${resumed.stderr}\n${resumed.stdout}`);
+        assert.equal(
+            readFileSync(join(appliedRoot, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php'), 'utf-8'),
+            '<?php // v1'
+        );
+    }, 120000);
+
+    it('finishes an apply window with one file already moved', () => {
+        freshWorkspace();
+        resetTarget();
+
+        const staged = runPush();
+        assert.equal(staged.exitCode, 0, `staging failed:\n${staged.stderr}\n${staged.stdout}`);
+
+        // Simulate a kill after the first rename but before apply could consume
+        // its verified marker. The rerun must treat that artifact as already
+        // applied and continue with the still-staged files.
+        execSync(
+            `sudo mv "${join(siteDir, '.push-staging', 'files', 'index.php')}" "${join(appliedRoot, 'index.php')}"`
+        );
+
+        const result = runPush(['--apply']);
+
+        assert.equal(result.exitCode, 0, `apply rerun failed:\n${result.stderr}\n${result.stdout}`);
+        const summary = JSON.parse(result.stdout.slice(result.stdout.lastIndexOf('{\n')));
+        assert.equal(summary.status, 'complete');
+        assert.equal(summary.already_applied, 1);
         assert.equal(
             readFileSync(join(appliedRoot, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php'), 'utf-8'),
             '<?php // v1'

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,7 @@
             <file>FileIndexDedupTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>SiteExportLibraryAuthTest.php</file>
             <file>StagedApplyTest.php</file>
             <file>StagedArtifactsTest.php</file>
             <file>StagedEndpointsTest.php</file>


### PR DESCRIPTION
## What it does

Closes the remaining gaps between staged pull's window promise and what actually happened before the window, and makes the staged/unstaged mode pair a clean, documented contract:

1. **Directory and symlink parts now respect the window.** They used to execute at fetch time even in `--staged-apply` mode — `mkdir` into the live tree, symlink creation, and worst of all the type-swap path that *removed* an occupant blocking a directory, all before the window. In staged mode they are now deferred into the manifest log and replayed at window time **through the exact same handlers** that run at fetch time in unstaged mode — same policy checks, same target validation, same audit lines, one code path.
2. **The local index describes the live tree, never the staging area.** Staged file fetches used to upsert the index at stage time. An `--abort` (or crash + mode switch) then left a delta that skipped files the tree never received — permanent holes the diff could not see. Index updates for staged files now happen after the window confirms, exactly like the deletion bookkeeping (#310) and push's forget-after-confirm.
3. **Mode contract.** `--staged-apply` persists in state like preserve-local: resumes and later deltas stay staged. `--abort` is the mode switch — it now also clears staged leftovers (unapplied bytes and the pending window log), which is safe precisely because of (2): nothing unapplied ever reached the index, so the next sync of either mode re-derives it. Documented in `--staged-apply`'s help.
4. **Manifest-log appends are fatal on short writes** (disk full), like the index-updates writer — a silently lost record is a file, deletion, directory, or symlink the window would never carry out.

## Implementation notes

- The window walk is one path-sorted loop driving replays and index writes together. This matters: the index merge consumes its updates as a path-sorted stream (trunk keeps it sorted by upserting in fetch order), and unsorted window writes corrupted the merged index — reproduced as a delta that derived deletions and re-downloads for every unchanged file, then fixed by sorting. Fetch-phase leftovers are flushed as their own sorted run first.
- Everything in the window before the final log unlink is idempotent; a kill anywhere reruns cleanly from the log.
- Unstaged pull is byte-for-byte unchanged: the handlers only defer when `staged_apply_mode` is set and no replay is in progress.
- One trunk quirk deliberately mirrored, not fixed: under preserve-local, an owned *symlink* changed remotely stays occupancy-protected (trunk's unstaged write path behaves the same); owned *files* update per #310's ownership rule.

## Testing instructions

```
cd tests
../vendor/bin/phpunit StagedApplyTest.php Import/StagedPullCliTest.php
```

Full staged sweep is 166 tests. The seed tree now includes an empty directory and a symlink, so every existing scenario exercises non-file parts. New/strengthened coverage: the mid-pull interruption assertion now counts directories and symlinks (zero entries may exist pre-window — the old code created directories at fetch time and fails this); deferred symlink and empty directory land with the window and survive `diff -r`; a staged pull interrupted, aborted, finished **unstaged**, then flipped back to staged for a delta — complete tree at every step, both switch directions.
