### PR TITLE
Staged file transfer: push and staged pull on one shared engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,8 @@ During the file fetch phase, progress and heartbeat records include `files_done`
   - src/lib/target-runtime/: Runtime appliers (NginxFpmApplier, PhpBuiltinApplier, PlaygroundCliApplier)
   - src/lib/url-rewrite/: URL rewriting for db-apply
   - src/lib/mysql-query-stream/: MySQL query stream parser for direct streaming
+  - src/lib/state/: Typed persisted state (ImportState — the single source of the .import-state.json schema)
+  - src/lib/upload/: Push-side staged transfer (StagedUploadClient, StagedPushRunner, PushPlanBuilder, UploadChunkSizer)
 - reprint-exporter-wp/: Self-contained WordPress plugin distribution directory
   - index.php: WordPress plugin entry point — intercepts `?reprint-api` requests (and the legacy `?site-export-api` alias) during plugin load, requires lib.php
   - lib.php: Standalone library — constants, auth functions, and request handler. Can be required without index.php by projects that want to embed the export engine with their own URL routing and authentication (pass a custom `authenticate` callable in the `$options` array to `_site_export_handle_api_request()`)
@@ -241,6 +243,12 @@ Progress is computed client-side by reading state files (all in `--state-dir`):
 - `.import-remote-index.jsonl`: Remote file index (for delta comparison)
 - `.import-download-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
+
+Staged transfers add (also under `--state-dir`):
+- `.push-state.json`: push chunk-sizer state and progress counters
+- `.push-shipped-index.jsonl`: the shipped index — what the target holds, in the shared `{path,ctime,size,type}` format, updated after each confirmed apply. Push's analog of pull's local index; the delta base the fs-root walk diffs against (via the same sorted-merge classifier pull uses) to derive the upload list and deletions. Transient per-run work files: `.push-source-index.jsonl` (the fs-root walk), `.push-upload-list.jsonl`, `.push-deletions.jsonl`
+- `.pull-staging/`: staged pull artifact store (files/, verified/, state.json, lock)
+- `.pull-staged-manifest.jsonl`: the pending apply-window log for staged pulls (files, dirs, symlinks, deletions)
 
 And from `--fs-root`:
 - Actual downloaded files (recursive size/count)

--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ The command returns one of three exit codes:
 
 Which is to say, you'll need to wrap it in a loop that runs until failure or full completion.
 
+Add `--staged-apply` when pulled files should download into a staging area
+under `--state-dir` and then move into `--fs-root` in one rename window at the
+end:
+
+```bash
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --staged-apply
+```
+
+`--staged-apply` keeps partially downloaded file bytes out of the live local
+tree. The final apply is rename-only, so `--state-dir` and `--fs-root` must be
+on the same filesystem. If they are not, Reprint rejects the run before moving
+anything; it does not copy staged files into place because that could expose
+half-written files. A killed apply can be rerun: files already renamed into
+place are recognized by size and the remaining staged files are moved.
+
 **Non-empty local fs-root**
 
 By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
@@ -275,6 +290,51 @@ It accepts the `pull` file filters (`--filter=none` and
 php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --only=:wp-content: --only=:wp-plugins:
 ```
+
+#### Push local files to remote staging.
+
+`push-files` uploads a local filesystem tree into the remote exporter's staged
+artifact store. It is resumable and safe to retry: completed files are skipped,
+partially uploaded files resume from the remote committed offset, and the live
+remote tree is not changed by this command.
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+```
+
+Use repeated `--only` values to push fs-root-relative prefixes instead of the
+whole tree:
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --only=wp-content/uploads
+```
+
+The remote WordPress wiring stores staged artifacts outside the web-served tree.
+Define `SITE_EXPORT_STAGING_DIR` on the exporter host to choose that directory;
+it must have enough free space for the pushed artifacts and should be on storage
+that persists across retries.
+
+Add `--apply` when the verified transfer should move into the remote tree after
+uploading:
+
+```bash
+php reprint.phar push-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --apply
+```
+
+The exporter applies into `ABSPATH` by default. Define `SITE_EXPORT_APPLY_ROOT`
+on the exporter host to choose a different target root. Apply is rename-only:
+it probes before upload and refuses `cross_device` if `SITE_EXPORT_STAGING_DIR`
+and `SITE_EXPORT_APPLY_ROOT` are on different filesystems. Put staging on the
+same filesystem as the target when you plan to use `--apply`; Reprint will not
+fall back to copy-and-remove because that could expose half-written live files.
+
+An interrupted apply can be retried with the same command. Files already renamed
+into place are recognized by size, and files still in staging are moved on the
+next run. The apply window is intentionally short but serial; the remote site
+may briefly contain a mix of old and new files if the process is killed between
+renames, so keep the site in maintenance mode for deployments that need a
+whole-tree cutover.
 
 #### Pull only the database.
 
@@ -680,8 +740,9 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
-* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
+* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed; add `--staged-apply` to land files by rename after download.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
+* `push-files` — Upload local files into the remote staged artifact store; add `--apply` to rename the verified transfer into the remote tree.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.

--- a/composer.lock
+++ b/composer.lock
@@ -358,18 +358,20 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-pull/dual-mode-windows",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
+                "reference": "02cfcadbdd4fa49cdfccb0a2580897781f841db5"
             },
             "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
                 "php": ">=7.4",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
+            },
+            "suggest": {
+                "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+                "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
             },
             "type": "library",
             "autoload": {
@@ -382,10 +384,15 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
-                    "src/class-sqlite-driver-pdo.php"
+                    "src/class-staged-apply.php",
+                    "src/class-staged-artifacts.php",
+                    "src/class-staged-endpoints.php",
+                    "src/class-sqlite-driver-pdo.php",
+                    "src/class-wpdb-driver-pdo.php"
                 ],
                 "files": [
-                    "src/utils.php"
+                    "src/utils.php",
+                    "src/class-pdo-polyfill.php"
                 ]
             },
             "license": [

--- a/markdown/PUSH-FAILURE-MODES.md
+++ b/markdown/PUSH-FAILURE-MODES.md
@@ -1,0 +1,137 @@
+# Push Failure Modes
+
+Every way a push can go wrong, layer by layer, with the test that pins each
+mode. The suites live in `tests/` (PHPUnit) and `tests/e2e/` (Docker); test
+names are exact so `phpunit --filter <name>` finds them.
+
+The push pipeline is an inverted pull: `PushPlanBuilder` walks `--fs-root` into
+a source index in the shared `{path,ctime,size,type}` format, the importer
+diffs it against the shipped index (`.push-shipped-index.jsonl` — what the
+target holds) with the **same sorted-merge classifier pull uses** to produce
+an upload list and deletions, then `StagedPushRunner` streams the upload list →
+`StagedUploadClient` (per-artifact/batch HTTP) →
+`Site_Export_Staged_Endpoints` (auth + routing) → `Site_Export_Staged_Artifacts`
+(store) → `Site_Export_Staged_Apply` (atomic window). The shipped index updates
+after a confirmed apply through pull's own `finalize_index_updates` merge, so
+resume trusts the store (not a separate done cache).
+
+## Store (`StagedArtifactsTest`)
+
+| Failure mode | Test |
+| --- | --- |
+| Kill between append and cursor write | `testKilledCursorWriteLeavesRecoverableState` |
+| Kill mid-append (uncommitted tail beyond cursor) | `testStoppingInsideAStepDiscardsTheUncommittedTail` |
+| Torn/corrupt cursor record | `testCorruptCommitRecordRestartsTheArtifact` |
+| Torn verified marker | `testTornVerifiedRecordIsIgnoredAndRefinalizeRecovers` |
+| Kill between finalize and cursor clear | `testFinalizeKilledBeforeClearingCursorStaysConsistent` |
+| Staging file shrunk outside the store | `testShrunkenStagingFileIsZeroFilledBackToTheCursor` |
+| Marker without artifact bytes | `testVerifiedRecordWithoutTheArtifactFileReportsMissing` |
+| Duplicate / straddling / gapped offsets | `testResendingCommittedBytesIsADuplicateNoOp`, `testOffsetGapIsRejectedWithCommittedBytesForResync` |
+| Concurrent writers | `testConcurrentWriterGetsBusy` |
+| Discard killed midway / discard vs lock | `testDiscardKilledMidwayIsRetriable`, `testDiscardOfAnUntracedArtifactRespectsTheWriterLock` |
+| Discard I/O failures (file, cursor, marker) | `testDiscardReportsFailureWhen*` (three) |
+| Traversal ids, ids that mirror store internals | `testIdsOutsideTheStagingDirAreRejected`, `testSiteFilenamesThatLookLikeStagingRecordsStageVerbatim` (incl. `lock`, `files`) |
+| Deep nesting | `testDeeplyNestedIdsStageAndDiscardCleanly` |
+| Unwritable staging dir | `testUnwritableStagingDirectoryIsATypedError` |
+| Write to a verified artifact | `testWritingToAVerifiedArtifactIsRejected` |
+
+## Endpoints (`StagedEndpointsTest`)
+
+| Failure mode | Test |
+| --- | --- |
+| Missing/forged/expired auth headers | `testUploadWithoutAuthHeadersIsRejectedBeforeTheStore`, `testUploadWithWrongSignatureIsRejected`, `testUploadWithExpiredTimestampIsRejected` |
+| Body swapped under a valid signature | `testBodyNotMatchingTheSignedHashNeverReachesTheStore`, `testBatchBodyMismatchNeverReachesTheStore` |
+| Captured request replayed (no nonce cache by design) | `testReplayedRequestIsAbsorbedAsADuplicate` |
+| Malformed nonce | `testShortNonceIsRejected` |
+| Request over the size cap | 413 + `max_request_bytes` (`UploadChunkSizer` feedback tests) |
+| Torn batch frame header | `testBatchStopsAtTheFirstBadFrameAndReportsProgress` |
+| Frame length overruns the body (truncated request) | same test, `truncated_batch` |
+| Same file twice in one batch | `testDuplicateIdWithinOneBatchIsIdempotent` |
+| Negative lengths, traversal ids in frames | `testHostileFrameFieldsAreTypedRejections` |
+| Store busy during any route | `testUploadWhileTheStoreIsHeldReportsBusy` (+ discard/apply busy tests) |
+| Wrong method / missing params / unconfigured | `testMutatingRoutesRequirePost`, `testApplyRouteValidatesConfigurationAndMethod` |
+
+Replay posture: HMAC has a timestamp window but no nonce cache
+(trunk-inherited). The protocol is replay-*tolerant*: every mutating verb is
+idempotent and appends are absorbed by the committed frontier.
+
+## Upload client (`StagedUploadClientTest`)
+
+| Failure mode | Test |
+| --- | --- |
+| Transport dies mid-artifact | `testTransportHardFailureStopsBounded` |
+| Response lost after the server committed | `testLostResponseRetryLandsAsDuplicateAndContinues` |
+| Server-side discard mid-transfer | `testServerSideDiscardMidTransferResyncsFromZero` |
+| Host cap smaller than the chunk | `test413ShrinksToTheReportedCapAndSucceeds`, `testGivesUpWhenTheFloorIsStillTooLarge` |
+| Busy store | `testBusyStoreRetriesThenSucceeds` |
+| Bad credentials (fail fast, never retried) | `testWrongSecretFailsFastWithoutRetries`, `testControlPlaneAuthEnvelopeSurfacesAsAuthFailed` |
+| HTML error page instead of JSON (WAF, mod_security) | `testHtmlErrorPageInsteadOfJsonFailsTypedWithoutARetryStorm` |
+| Server disk full / io_error | `testServerIoErrorSurfacesTyped` |
+| Source rewritten before/during upload | `testSourceRewrittenMidUploadFailsTyped`, `testStalePlanMtimeFailsBeforeAnyUpload`, `testUploadBatchExcludesAVolatileFileLocally` |
+| Source shorter than declared / missing | `testSourceShorterThanDeclaredTotalFails`, `testMissingSourceFileFails` |
+| Batch too large for the learned budget | `testUploadBatchRepartitionsWhenTooLarge` |
+
+## Runner (`StagedPushRunnerTest`)
+
+| Failure mode | Test |
+| --- | --- |
+| Rerun resumes from the store, not a cache (committed offset; fully-staged short-circuit) | `testMidArtifactResumeUploadsOnlyTheTail`, `testFullyStagedArtifactShortCircuitsWithoutReuploadingBytes` |
+| Malformed upload-list line skipped | `testMalformedUploadLineIsSkipped` |
+| Per-file vs transfer-wide failures | `testArtifactScopedFailureContinuesAndRerunRetriesIt`, `testTransferScopedFailureAborts` |
+| Declared size longer than source | `testDeclaredSizeLongerThanSourceFailsScoped` |
+| Source rewritten mid-push (chunk + batch) | `testSourceChangedMidPushFailsTheArtifactAndContinues`, `testBatchMemberChangedSinceDiffFailsScopedAndContinues` |
+| Batching and 413 repartition | `testSmallFilesTravelInBatchesNotOneRequestEach`, `testMixedListBatchesSmallAndChunksLarge`, `testBatchShrinksAfterA413AndCompletes` |
+| Unwritable state dir | `testUnwritableStateDirAbortsTypedBeforeAnyRequest` |
+| Learned limits survive runs | `testLearnedChunkLimitsSurviveRuns` |
+
+Delta and deletion behavior lives in the diff (the importer, not the runner)
+and is pinned by `PushFilesCliTest`:
+`testLocalDeletionPropagatesOnTheNextPushApply`,
+`testOnlyScopedPushDerivesDeletionsOnlyInsideItsPrefixes`,
+`testSkippedPathIsNotDerivedAsADeletion`, and
+`testInsufficientStagingSpaceIgnoresCachedArtifacts` (an unchanged file is
+"same" in the diff and never lists for upload).
+
+Known bound: deletions and same-size-edit detection derive from the shipped
+index — the delta base, updated only at apply. A wiped state dir re-derives
+the full upload (the store short-circuits already-staged bytes) but loses the
+shipped index, so files removed in the interim are not deleted until the next
+full push against a fresh apply — the same contract as two pulls sharing an
+fs-root. A file edited to the same byte length between a stage-only run and a
+later apply is invisible to the byte-count store: the documented boundary the
+old done-cache mtime once covered.
+
+## Apply window (`StagedApplyTest`)
+
+| Failure mode | Test |
+| --- | --- |
+| Kill mid-window, rerun finishes | `testRerunAfterAKillMidApplyFinishesTheWindow` |
+| Incomplete/unverified transfer rejects whole | `testUnverifiedArtifactRejectsTheWholeTransfer`, `testMissingArtifactRejectsTheWholeTransfer` |
+| Cross-device staging (rename impossible) | `testCrossDeviceStagingIsRejectedBeforeAnythingMoves` |
+| Manifest forgery (traversal, self-listing, duplicates, torn) | `testManifestProblemsAreTypedRejections`, `testMalformedDeleteEntriesRejectTheManifest` |
+| Type swaps (dir↔file↔symlink) between pushes | `testReplacesADirectoryWithAFile`, `testReplacesASymlinkWithoutFollowingIt`, `testClearsAFileBlockingTheParentChain`, `testDeletionsRunBeforeMovesRegardlessOfManifestOrder` |
+| Deletion kill windows / staged garbage | `testDeletionsAreIdempotentAcrossReruns`, staged-consumption asserts in `testDeleteEntriesRemoveFilesDirectoriesAndLinks` |
+| Policy protection (ownership vs occupancy) | `testSkipPolicyDoesNotProtectOwnedEntries`, `testSkipPolicyDoesNotProtectOwnedDeletions`, `testSymlinkedParentGuardProtectsDeletions` |
+| Protected-set reporting past the response cap | `testOnProtectedReportsEveryEntryBeyondTheResponseCap` |
+| Upload racing the window | `testBusyWhileAWriterHoldsTheStore` |
+
+Trust note: `owned`/delete exemptions are sender-attested manifest data. Safe
+because the push endpoint pins `on_existing=replace`; if a skip policy is ever
+wired into the endpoint, strip sender exemptions there first.
+
+## CLI (`PushFilesCliTest`) and e2e (`import-52`)
+
+| Failure mode | Test |
+| --- | --- |
+| Dead target (retryable, exit 2) | `testUnreachableTargetAbortsWithTheRetryableExitCode` |
+| Bad credentials (fatal, exit 1) | `testWrongSecretAbortsFatalNotRetryable` |
+| Interrupted push then push | `testInterruptedPushResumesFromTheCommittedOffset` |
+| Staging too small for the plan | `testInsufficientStagingSpaceRefusesBeforeUploading` |
+| Local deletions propagate; `--only` scoping | `testLocalDeletionPropagatesOnTheNextPushApply`, `testOnlyScopedPushDerivesDeletionsOnlyInsideItsPrefixes` |
+| Adversarial names end to end | `testAdversarialFilenamesSurviveTheWire` |
+| Hostile `--only` | `testHostileOnlyPrefixIsRejectedBeforeAnyUpload` |
+| Break-the-remote-then-fix-it | mtime re-push + type-swap engine tests + `import-52` scenarios |
+
+Not portably testable (documented, not covered): mid-operation `chmod`
+failures (CI containers run as root), true disk-full on append (needs a
+quota'd filesystem), and kernel-level rename atomicity (assumed per POSIX).

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -22,6 +22,9 @@
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
             "src/class-http-server.php",
+            "src/class-staged-apply.php",
+            "src/class-staged-artifacts.php",
+            "src/class-staged-endpoints.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"
         ],

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -9,8 +9,6 @@
  */
 final class Site_Export_HMAC_Server {
 
-    private const DEFAULT_MAX_CONTROL_BODY_BYTES = 1048576;
-
     /** @var string */
     private $secret;
 
@@ -23,33 +21,13 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
-     * Verify a bounded control-plane request.
-     *
-     * HMAC is the guard for small protocol commands such as preflight, session
-     * start, plan confirmation, and abort/resume. Large data uploads should use
-     * authenticated sessions plus per-chunk hashes instead of signing one
-     * multi-megabyte request body.
-     */
-    public function verify_control_request(array $headers = [], string $body = '', ?float $now = null, ?int $max_body_bytes = null): ?string {
-        $body_limit = $max_body_bytes ?? self::DEFAULT_MAX_CONTROL_BODY_BYTES;
-        if (strlen($body) > $body_limit) {
-            return sprintf(
-                'HMAC control request body exceeds %d bytes',
-                $body_limit
-            );
-        }
-
-        return $this->verify($headers, $body, [], $now);
-    }
-
-    /**
      * Verify a request using explicit inputs.
      *
      * Returns null on success, or an error string on failure. This convenience
      * method receives the full body as a string and is only appropriate for
-     * compatibility with existing small request flows. New protocol code should
-     * use verify_control_request() for HMAC-protected commands and avoid
-     * HMAC-signing large data uploads.
+     * small request flows; large data uploads verify per chunk through
+     * verify_signed_content_hash() instead of HMAC-signing one
+     * multi-megabyte request body.
      *
      * When $files is non-empty, the content hash is computed from uploaded file
      * contents rather than $body so multipart uploads verify consistently.
@@ -59,24 +37,6 @@ final class Site_Export_HMAC_Server {
             $headers,
             function () use ($body, $files): string {
                 return $this->compute_received_content_hash($body, $files);
-            },
-            $now
-        );
-    }
-
-    /**
-     * Verify a request when the caller already computed the received digest.
-     *
-     * This exists for bounded protocol code that has already computed the body
-     * digest. It does not read a request body. Push chunk uploads should use
-     * session/request capabilities plus per-chunk hashes instead of routing
-     * large bodies through HMAC verification.
-     */
-    public function verify_content_hash(array $headers, string $received_content_hash, ?float $now = null): ?string {
-        return $this->verify_content_hash_callback(
-            $headers,
-            function () use ($received_content_hash): string {
-                return $received_content_hash;
             },
             $now
         );
@@ -139,9 +99,8 @@ final class Site_Export_HMAC_Server {
      *
      * Returns null on success, or an error string on failure. This legacy
      * convenience path buffers php://input and should only be used for small
-     * request bodies. New control-plane routes should bound the body and call
-     * verify_control_request(). Large data routes should not use whole-body
-     * HMAC verification.
+     * request bodies. Large data routes should not use whole-body HMAC
+     * verification.
      */
     public function verify_globals(?float $now = null): ?string {
         $body = file_get_contents('php://input');

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -22,6 +22,9 @@ final class Site_Export_HTTP_Server {
     /** @var string|null */
     private $default_directory;
 
+    /** @var string[] Endpoints dispatched without a resource budget. */
+    private $no_budget_endpoints = ['preflight'];
+
     public function __construct(array $options = []) {
         $this->handlers = $options['handlers'] ?? $this->default_handlers();
         $this->budget_factory = $options['budget_factory'] ?? [$this, 'default_budget_factory'];
@@ -31,11 +34,22 @@ final class Site_Export_HTTP_Server {
         };
         $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
         $this->default_directory = $options['default_directory'] ?? null;
+
+        if (isset($options['staged']) && is_array($options['staged'])) {
+            $this->register_staged_handlers(new Site_Export_Staged_Endpoints($options['staged']));
+        }
     }
 
     public function handle_request(array $request = []): void {
         $server = $request['server'] ?? $_SERVER;
-        $body = array_key_exists('body', $request) ? (string) $request['body'] : call_user_func($this->body_reader);
+        if (array_key_exists('body', $request)) {
+            $body = (string) $request['body'];
+        } else {
+            // Config parsing only consumes JSON bodies. Reading anything
+            // else here would buffer a raw upload body (staged_upload) in
+            // memory before its handler can stream it.
+            $body = $this->is_json_content_type($server) ? call_user_func($this->body_reader) : '';
+        }
         $config = $request['config'] ?? $this->parse_http_config(
             $request['get'] ?? $_GET,
             $request['post'] ?? $_POST,
@@ -262,7 +276,7 @@ final class Site_Export_HTTP_Server {
         }
 
         $handler = $this->handlers[$endpoint];
-        if ($endpoint === 'preflight') {
+        if (in_array($endpoint, $this->no_budget_endpoints, true)) {
             call_user_func($handler, $config);
             return;
         }
@@ -285,6 +299,74 @@ final class Site_Export_HTTP_Server {
             'db_index' => 'endpoint_db_index',
             'preflight' => 'endpoint_preflight',
         ];
+    }
+
+    /**
+     * Wire the staged artifact routes to the shared dispatcher.
+     *
+     * Explicitly-passed handlers win over these, matching how the
+     * handlers option replaces the default map.
+     */
+    private function register_staged_handlers(Site_Export_Staged_Endpoints $endpoints): void {
+        $routes = [
+            'staged_upload' => static function (array $config) use ($endpoints): void {
+                $input = @fopen('php://input', 'rb');
+                try {
+                    self::emit_json_response(
+                        $endpoints->upload($config, $_SERVER, $input === false ? null : $input)
+                    );
+                } finally {
+                    if (is_resource($input)) {
+                        fclose($input);
+                    }
+                }
+            },
+            'staged_finalize' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->finalize($config, $_SERVER));
+            },
+            'staged_status' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->status($config));
+            },
+            'staged_discard' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->discard($config, $_SERVER));
+            },
+            'staged_apply' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->apply($config, $_SERVER));
+            },
+            'staged_upload_batch' => static function (array $config) use ($endpoints): void {
+                $input = @fopen('php://input', 'rb');
+                try {
+                    self::emit_json_response(
+                        $endpoints->upload_batch($config, $_SERVER, $input === false ? null : $input)
+                    );
+                } finally {
+                    if (is_resource($input)) {
+                        fclose($input);
+                    }
+                }
+            },
+        ];
+
+        foreach ($routes as $endpoint => $handler) {
+            if (!isset($this->handlers[$endpoint])) {
+                $this->handlers[$endpoint] = $handler;
+            }
+            $this->no_budget_endpoints[] = $endpoint;
+        }
+    }
+
+    /**
+     * @param array{http_code:int,body:array} $response
+     */
+    private static function emit_json_response(array $response): void {
+        http_response_code($response['http_code']);
+        header('Content-Type: application/json');
+        echo json_encode($response['body']);
+    }
+
+    private function is_json_content_type(array $server): bool {
+        $content_type = (string) ( $server['CONTENT_TYPE'] ?? '' );
+        return strtolower(trim( (string) strtok($content_type, ';'))) === 'application/json';
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-apply.php
+++ b/packages/reprint-exporter/src/class-staged-apply.php
@@ -1,0 +1,654 @@
+<?php
+
+/**
+ * Moves verified staged artifacts into the live tree — the payoff of the
+ * staged store: the site never sees a partial file, and the whole transfer
+ * lands in one short window of renames.
+ *
+ * Apply is rename-only. rename() is what makes each file's appearance
+ * atomic, and it only works when the staging directory and the target root
+ * sit on the same filesystem. A staging directory on another device would
+ * force copy-and-remove — a window where a half-copied file is live — so
+ * apply refuses it up front with a typed "cross_device" rejection, before
+ * any file has moved. Operators fix it by pointing the staging directory
+ * (SITE_EXPORT_STAGING_DIR in the WordPress wiring) at the target's
+ * filesystem; apply never silently degrades to copying.
+ *
+ * The manifest is itself a staged artifact: one JSONL line per artifact,
+ * {"artifact_id": ..., "size": ...}. That keeps the apply request bounded
+ * (an id, not a 50k-entry body) and reuses the store's verification for the
+ * manifest bytes. The manifest artifact is consumed by apply, never applied
+ * into the tree.
+ *
+ * Everything that can be checked is checked before the first rename:
+ * the device match, the target root, the manifest's shape, and that every
+ * listed artifact is verified at its manifest size (or already applied —
+ * see below). A transfer that is incomplete or disagrees with its plan is
+ * rejected whole; there is no partial apply of a half-verified transfer.
+ *
+ * A kill mid-apply leaves some files moved and some staged. Rerunning
+ * apply recovers without a journal cursor: an entry whose staged file is
+ * gone but whose target exists at the manifest size is already applied and
+ * skips; everything still staged renames as normal. The pre-scan accepts
+ * both states, so the rerun passes validation and finishes the window.
+ * Only an entry that is neither staged-and-verified nor already applied
+ * rejects the run — that transfer is genuinely incomplete.
+ *
+ * Apply holds the store's exclusive lock for the whole window, so an
+ * upload retry racing the apply gets "busy" instead of writing into a
+ * tree being consumed. The lock file is the same one the store's mutators
+ * use; a killed apply releases it with the process.
+ *
+ * Policies cover the pull side of the same engine. on_existing "skip"
+ * (pull's preserve-local) makes an occupied target path win: the entry is
+ * not applied and its staged bytes are consumed. Entries the manifest
+ * marks "owned" are exempt — the sender's ship record (pull's local
+ * index, push's done cache) attests the transfer wrote that path, and
+ * preserve-local protects what the sync never owned, not its own previous
+ * copy. Delete entries are owned by construction: both senders derive
+ * them from those same records. refuse_symlinked_parents refuses to
+ * create or remove anything through a symlinked directory, owned or not.
+ * Protected entries are classified before validation, so a rerun with
+ * nothing staged does not reject a transfer over paths the policy was
+ * never going to touch.
+ */
+final class Site_Export_Staged_Apply {
+
+    /** Protected paths reported by name; beyond this, only the count. */
+    private const SKIPPED_PATHS_LIMIT = 1000;
+
+    /** @var string */
+    private $staging_dir;
+
+    /** @var string */
+    private $files_dir;
+
+    /** @var string */
+    private $lock_path;
+
+    /** @var string */
+    private $target_root;
+
+    /** @var Site_Export_Staged_Artifacts */
+    private $store;
+
+    /** @var callable */
+    private $device_id;
+
+    /** @var string */
+    private $on_existing;
+
+    /** @var bool */
+    private $refuse_symlinked_parents;
+
+    /** @var callable|null */
+    private $on_protected;
+
+    /**
+     * @param array $options
+     *   - staging_dir (string, required): same directory the store uses.
+     *   - target_root (string, required): tree the artifacts apply into.
+     *   - device_id (?callable): fn(string $path): ?int — stat device
+     *     lookup, injectable for tests; null means the path is unreadable.
+     *   - on_existing ("replace"|"skip"): what an occupied target path
+     *     means. "replace" is push's own-tree semantics; "skip" is pull's
+     *     preserve-local — the local path wins and the staged bytes are
+     *     consumed unapplied. Manifest entries marked "owned" (and every
+     *     delete entry) are exempt from "skip": the transfer's own ship
+     *     record vouches for those paths.
+     *   - refuse_symlinked_parents (bool): never create anything through a
+     *     symlinked directory. Hosting layouts symlink plugins, themes,
+     *     and core from shared locations; apply must not write into those
+     *     through the link.
+     *   - on_protected (?callable): fn(string $artifact_id) — called once
+     *     per policy-protected entry during classification (check_only
+     *     included). This is the uncapped channel: in-process callers that
+     *     reconcile per-entry state (the pull window's index catch-up)
+     *     must use it. The result's skipped_paths list is capped for
+     *     bounded HTTP responses and is diagnostics only.
+     */
+    public function __construct(array $options) {
+        $staging_dir = $options['staging_dir'] ?? null;
+        $target_root = $options['target_root'] ?? null;
+        if (!is_string($staging_dir) || $staging_dir === '') {
+            throw new InvalidArgumentException('Staged apply requires a staging_dir option.');
+        }
+        if (!is_string($target_root) || $target_root === '') {
+            throw new InvalidArgumentException('Staged apply requires a target_root option.');
+        }
+        $on_existing = $options['on_existing'] ?? 'replace';
+        if (!in_array($on_existing, ['replace', 'skip'], true)) {
+            throw new InvalidArgumentException('Staged apply on_existing must be "replace" or "skip".');
+        }
+        $this->staging_dir = rtrim($staging_dir, '/');
+        $this->files_dir = $this->staging_dir . '/files';
+        $this->lock_path = $this->staging_dir . '/lock';
+        $this->target_root = rtrim($target_root, '/');
+        $this->store = new Site_Export_Staged_Artifacts($staging_dir);
+        $this->on_existing = $on_existing;
+        $this->refuse_symlinked_parents = !empty($options['refuse_symlinked_parents']);
+        $this->on_protected = $options['on_protected'] ?? null;
+        $this->device_id = $options['device_id'] ?? static function (string $path): ?int {
+            $stat = @stat($path);
+            return $stat === false ? null : (int) $stat['dev'];
+        };
+    }
+
+    /**
+     * Validate a transfer and move it into the target root.
+     *
+     * @param string $manifest_id Staged artifact holding the manifest.
+     * @param bool $check_only Validate everything, move nothing. This is
+     *   what a sender calls before uploading gigabytes: a staging
+     *   directory that can never apply (cross_device) rejects here, at
+     *   the start, not after the transfer.
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,skipped_paths:array<int,string>,deleted:int,staging_free_bytes?:?int,target_free_bytes?:?int}
+     *   status "applied"|"ready"|"busy"|"rejected"; skipped counts entries
+     *   the on_existing/symlink policies protected; deleted counts manifest
+     *   delete entries carried out. "ready" also reports free space (null
+     *   when the filesystem won't say).
+     */
+    public function apply(string $manifest_id, bool $check_only = false): array {
+        $precheck = $this->check_environment();
+        if ($precheck !== null) {
+            return $precheck;
+        }
+
+        if ($check_only && !$this->store->status($manifest_id)['verified']) {
+            // Probes run before the transfer exists. The environment is
+            // the answer; the manifest is checked when apply runs for real.
+            return $this->with_environment_facts($this->result('ready', null, null));
+        }
+
+        $lock = @fopen($this->lock_path, 'c+b');
+        if ($lock === false) {
+            return $this->result('rejected', 'io_error', 'open_lock_file');
+        }
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return $this->result('busy', null, null);
+            }
+
+            $entries = $this->read_manifest($manifest_id);
+            if (!is_array($entries)) {
+                return $this->result('rejected', 'manifest_invalid', $entries);
+            }
+
+            // Nothing moves until the whole transfer proves consistent.
+            // Protected entries are decided here too, before validation:
+            // a rerun with nothing staged must not reject the transfer
+            // over a path the policy was never going to touch.
+            $already_applied = [];
+            $protected = [];
+            $skipped_paths = [];
+            foreach ($entries as $index => $entry) {
+                $verdict = $this->classify($entry);
+                if ($verdict === 'staged') {
+                    continue;
+                }
+                if ($verdict === 'applied') {
+                    $already_applied[$index] = true;
+                    continue;
+                }
+                if ($verdict === 'protected') {
+                    $protected[$index] = true;
+                    if ($this->on_protected !== null) {
+                        call_user_func($this->on_protected, $entry['artifact_id']);
+                    }
+                    // The response list is capped so a 50k-skip transfer
+                    // stays bounded; per-entry consumers use on_protected.
+                    if (count($skipped_paths) < self::SKIPPED_PATHS_LIMIT) {
+                        $skipped_paths[] = $entry['artifact_id'];
+                    }
+                    continue;
+                }
+                return $this->result('rejected', $verdict, $entry['artifact_id']);
+            }
+
+            if ($check_only) {
+                return $this->with_environment_facts(
+                    $this->result('ready', null, null, 0, count($already_applied), count($protected), $skipped_paths)
+                );
+            }
+
+            // Apply holds the store's lock, so cleanup below unlinks the
+            // store's files directly — its own discard() would contend on
+            // the very lock this process holds.
+            //
+            // Deletions run before file moves: a transfer that removes a
+            // directory and lands a file where it stood must not depend on
+            // manifest order to get that right.
+            $applied = 0;
+            $deleted = 0;
+            foreach ([true, false] as $delete_pass) {
+                foreach ($entries as $index => $entry) {
+                    if (!empty($entry['delete']) !== $delete_pass) {
+                        continue;
+                    }
+                    if (isset($protected[$index]) || isset($already_applied[$index])) {
+                        // Protected: the local path wins, and the staged
+                        // bytes must not be applied by a later,
+                        // differently-configured run. Already applied: a
+                        // rerun after a kill, where only leftover staged
+                        // remains linger. Both just consume.
+                        $this->consume_staged($entry['artifact_id']);
+                        continue;
+                    }
+                    if ($delete_pass) {
+                        // Staged bytes under a deleted id are garbage from
+                        // before the remote dropped the file; consume them
+                        // with the deletion.
+                        $this->consume_staged($entry['artifact_id']);
+                        if (!$this->remove_path_without_following_symlinks($this->target_root . '/' . $entry['artifact_id'])) {
+                            return $this->result('rejected', 'io_error', 'delete: ' . $entry['artifact_id'], $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
+                        }
+                        ++$deleted;
+                        continue;
+                    }
+                    $move_error = $this->move_into_place($entry['artifact_id']);
+                    if ($move_error !== null) {
+                        // Everything validated, so this is environmental
+                        // (permissions, disk). Rerunning apply resumes: moved
+                        // entries classify as applied, the rest re-validate.
+                        return $this->result('rejected', 'io_error', $move_error, $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
+                    }
+                    ++$applied;
+                }
+            }
+
+            // The manifest is consumed with the transfer it described, and
+            // a cursor still naming a consumed artifact must not survive to
+            // answer a future upload with its stale offset.
+            $this->consume_staged($manifest_id);
+            $this->clear_cursor_for($entries, $manifest_id);
+
+            return $this->result('applied', null, null, $applied, count($already_applied), count($protected), $skipped_paths, $deleted);
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Clears the store cursor when it names an artifact this apply
+     * consumed. The cursor's schema and commit discipline live in the
+     * store; apply only decides whether the cursor was consumed.
+     */
+    private function clear_cursor_for(array $entries, string $manifest_id): void {
+        $cursor_artifact = $this->store->cursor_artifact_locked();
+        if ($cursor_artifact === null) {
+            return;
+        }
+
+        $consumed = $cursor_artifact === $manifest_id;
+        foreach ($entries as $entry) {
+            if ($entry['artifact_id'] === $cursor_artifact) {
+                $consumed = true;
+                break;
+            }
+        }
+        if ($consumed) {
+            $this->store->clear_cursor_locked();
+        }
+    }
+
+    /**
+     * Consumes an entry's staged remains: its bytes and its verified
+     * marker. Callers hold the store lock; the store's own discard()
+     * would contend on it.
+     */
+    private function consume_staged(string $artifact_id): void {
+        $staged_path = $this->files_dir . '/' . $artifact_id;
+        @unlink($staged_path);
+        clearstatcache(true, $staged_path);
+        $this->prune_empty_staging_parents('files', $artifact_id);
+        $this->consume_verified_marker($artifact_id);
+    }
+
+    /**
+     * The environment checks that hold regardless of transfer state.
+     *
+     * @return array|null Null when the environment can apply.
+     */
+    private function check_environment(): ?array {
+        $target_device = call_user_func($this->device_id, $this->target_root);
+        if ($target_device === null) {
+            return $this->result('rejected', 'target_missing', $this->target_root);
+        }
+        if (!is_dir($this->target_root) || !is_writable($this->target_root)) {
+            return $this->result('rejected', 'target_unwritable', $this->target_root);
+        }
+
+        // The staging scaffolding may predate any upload; the device of the
+        // staging base decides where files/ will live.
+        if (!is_dir($this->staging_dir) && !@mkdir($this->staging_dir, 0700, true) && !is_dir($this->staging_dir)) {
+            return $this->result('rejected', 'staging_unavailable', $this->staging_dir);
+        }
+        $staging_device = call_user_func($this->device_id, $this->staging_dir);
+        if ($staging_device === null) {
+            return $this->result('rejected', 'staging_unavailable', $this->staging_dir);
+        }
+
+        if ($staging_device !== $target_device) {
+            // Apply is rename-only by design: copy-and-remove would serve
+            // half-copied files from the live tree. Refuse before anything
+            // moves; the fix is a same-filesystem staging directory.
+            return $this->result('rejected', 'cross_device', sprintf(
+                'staging %s is on device %d, target %s on device %d',
+                $this->staging_dir,
+                $staging_device,
+                $this->target_root,
+                $target_device
+            ));
+        }
+
+        return null;
+    }
+
+    /**
+     * Reads and validates the manifest artifact.
+     *
+     * @return array|string Entry list, or an error detail string.
+     */
+    private function read_manifest(string $manifest_id) {
+        $status = $this->store->status($manifest_id);
+        if (!$status['verified']) {
+            return 'manifest artifact is not verified: ' . $manifest_id;
+        }
+        // Streamed line by line: a 200k-entry manifest is tens of
+        // megabytes, and this runs on the memory-constrained side.
+        $handle = @fopen($this->files_dir . '/' . $manifest_id, 'rb');
+        if ($handle === false) {
+            return 'manifest artifact is not readable: ' . $manifest_id;
+        }
+
+        $entries = [];
+        $seen_ids = [];
+        $line_number = -1;
+        $error = null;
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            ++$line_number;
+            if (trim($line) === '') {
+                continue;
+            }
+            $entry = json_decode($line, true);
+            $is_delete = is_array($entry) && !empty($entry['delete']);
+            if (
+                !is_array($entry)
+                || !is_string($entry['artifact_id'] ?? null)
+                || ( !$is_delete && ( !is_int($entry['size'] ?? null) || $entry['size'] < 0 ) )
+            ) {
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' is malformed';
+                break;
+            }
+            if ($entry['artifact_id'] === $manifest_id) {
+                $error = 'manifest lists itself';
+                break;
+            }
+            // One verdict per path. Neither sender can produce a duplicate
+            // (both derive deletions as own-record-minus-current-set), and
+            // a same-id create-plus-delete is ambiguous on rerun: once the
+            // create has landed, the delete cannot tell the old occupant
+            // from the new file.
+            if (isset($seen_ids[$entry['artifact_id']])) {
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' duplicates an artifact id';
+                break;
+            }
+            $seen_ids[$entry['artifact_id']] = true;
+            // Manifest content is sender data; ids must satisfy the same
+            // path rule the store enforces at upload time, or a crafted
+            // manifest could probe or write outside the target root.
+            if (!$this->valid_artifact_id($entry['artifact_id'])) {
+                $error = 'manifest line ' . ( $line_number + 1 ) . ' has an invalid artifact id';
+                break;
+            }
+            $entries[] = [
+                'artifact_id' => $entry['artifact_id'],
+                'size' => $is_delete ? null : $entry['size'],
+                'delete' => $is_delete,
+                'owned' => ( $is_delete || !empty($entry['owned']) ),
+            ];
+        }
+        fclose($handle);
+        return $error ?? $entries;
+    }
+
+    /**
+     * "ready" doubles as the sender's preflight: staging and target free
+     * space let it refuse a transfer that could never fit, before a byte
+     * travels.
+     */
+    private function with_environment_facts(array $result): array {
+        $staging_free = @disk_free_space($this->staging_dir);
+        $target_free = @disk_free_space($this->target_root);
+        $result['staging_free_bytes'] = $staging_free === false ? null : (int) $staging_free;
+        $result['target_free_bytes'] = $target_free === false ? null : (int) $target_free;
+        return $result;
+    }
+
+    /** Mirrors the store's artifact id rule (see its contract docblock). */
+    private function valid_artifact_id(string $artifact_id): bool {
+        if (
+            $artifact_id === ''
+            || $artifact_id[0] === '/'
+            || strpos($artifact_id, "\0") !== false
+            || strpos($artifact_id, '\\') !== false
+        ) {
+            return false;
+        }
+        foreach (explode('/', $artifact_id) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * One manifest entry is either staged (verified at the manifest size),
+     * already applied (a rerun after a kill), or a typed problem.
+     */
+    private function classify(array $entry): string {
+        // Policy verdicts come first: a protected path is out of bounds no
+        // matter what is or is not staged for it. The symlinked-parent
+        // guard binds even for owned entries — stale ownership must never
+        // reach through a link into shared content.
+        if ($this->refuse_symlinked_parents && $this->has_symlinked_parent($entry['artifact_id'])) {
+            return 'protected';
+        }
+        if ($this->on_existing === 'skip' && empty($entry['owned'])) {
+            $occupied = $this->target_root . '/' . $entry['artifact_id'];
+            // is_link covers dangling symlinks, which file_exists misses;
+            // preserve-local protects those too. Owned entries skip this
+            // check: the occupant is the transfer's own previous copy.
+            if (file_exists($occupied) || is_link($occupied)) {
+                return 'protected';
+            }
+        }
+
+        if (!empty($entry['delete'])) {
+            // Deletions need nothing staged: the path either still exists
+            // (ready) or a previous window already removed it (idempotent).
+            $target = $this->target_root . '/' . $entry['artifact_id'];
+            return ( file_exists($target) || is_link($target) ) ? 'staged' : 'applied';
+        }
+
+        $status = $this->store->status($entry['artifact_id']);
+        if ($status['verified'] && $status['committed_bytes'] === $entry['size'] && $status['exists']) {
+            return 'staged';
+        }
+
+        $target_path = $this->target_root . '/' . $entry['artifact_id'];
+        $target_size = @filesize($target_path);
+        if ($target_size !== false && $target_size === $entry['size'] && !$status['exists']) {
+            return 'applied';
+        }
+
+        if ($status['verified'] && !$status['exists']) {
+            return 'artifact_file_missing';
+        }
+        if ($status['exists'] && !$status['verified']) {
+            return 'unverified_artifact';
+        }
+        return 'missing_artifact';
+    }
+
+    /**
+     * @return string|null Error detail, or null when the artifact moved.
+     */
+    private function move_into_place(string $artifact_id): ?string {
+        $staged_path = $this->files_dir . '/' . $artifact_id;
+        $target_path = $this->target_root . '/' . $artifact_id;
+
+        // Type swaps happen between transfers: a directory or symlink can
+        // occupy the path a file now belongs at. rename() replaces files
+        // and symlinks atomically but not directories, so clear anything
+        // that is not a plain file first — the same replacement the pull
+        // writer performs, and like it, never following links.
+        if (is_link($target_path) === false && is_dir($target_path)) {
+            if (!$this->remove_path_without_following_symlinks($target_path)) {
+                return 'clear_target_path: ' . $artifact_id;
+            }
+        }
+
+        $parent = dirname($target_path);
+        if (!is_dir($parent)) {
+            // A file left where a directory now belongs blocks mkdir; the
+            // transfer's tree wins, same as above.
+            $blocking_error = $this->clear_blocking_parents($artifact_id);
+            if ($blocking_error !== null) {
+                return $blocking_error . ': ' . $artifact_id;
+            }
+            if (!@mkdir($parent, 0755, true) && !is_dir($parent)) {
+                return 'create_target_dir: ' . $artifact_id;
+            }
+        }
+        // Same filesystem by precheck, so this replaces atomically; the
+        // tree never holds a partial file.
+        if (!@rename($staged_path, $target_path)) {
+            return 'rename: ' . $artifact_id;
+        }
+        clearstatcache(true, $staged_path);
+        // A pushed PHP file replacing live code must evict the target's
+        // opcode cache, or its FPM workers keep executing the old bytecode on
+        // hosts tuned with opcache.validate_timestamps=0 — and as entries
+        // evict piecemeal the site runs a mix of old and new files, the exact
+        // half-applied state staging exists to prevent. Non-PHP paths and a
+        // disabled opcache are a cheap no-op.
+        if (function_exists('opcache_invalidate')) {
+            @opcache_invalidate($target_path, true);
+        }
+        // The marker is consumed with the file. A kill between the two
+        // reruns as "applied" (target at size, nothing staged) and only
+        // costs this unlink again.
+        $this->prune_empty_staging_parents('files', $artifact_id);
+        $this->consume_verified_marker($artifact_id);
+        return null;
+    }
+
+    private function consume_verified_marker(string $artifact_id): void {
+        $marker_path = $this->staging_dir . '/verified/' . $artifact_id;
+        @unlink($marker_path);
+        clearstatcache(true, $marker_path);
+        $this->prune_empty_staging_parents('verified', $artifact_id);
+    }
+
+    private function prune_empty_staging_parents(string $root_name, string $artifact_id): void {
+        $root = $this->staging_dir . '/' . $root_name;
+        $dir = dirname($root . '/' . $artifact_id);
+        while ($dir !== $root && strpos($dir, $root . '/') === 0) {
+            if (!@rmdir($dir)) {
+                return;
+            }
+            clearstatcache(true, $dir);
+            $dir = dirname($dir);
+        }
+    }
+
+    /**
+     * Removes a file or symlink sitting on the artifact's parent chain
+     * where a directory now belongs. Symlinked directories pass through:
+     * only an actual non-directory blocks mkdir.
+     *
+     * @return string|null Error detail, or null when the chain is clear.
+     */
+    private function clear_blocking_parents(string $artifact_id): ?string {
+        $parent_rel = dirname($artifact_id);
+        if ($parent_rel === '.') {
+            return null;
+        }
+        $path = $this->target_root;
+        foreach (explode('/', $parent_rel) as $segment) {
+            $path .= '/' . $segment;
+            if ((is_link($path) || file_exists($path)) && !is_dir($path)) {
+                if (!@unlink($path)) {
+                    return 'clear_blocking_parent';
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Trunk's replacement discipline: unlink files and symlinks directly
+     * (never following the link), recurse into real directories.
+     */
+    private function remove_path_without_following_symlinks(string $path): bool {
+        if (!file_exists($path) && !is_link($path)) {
+            return true;
+        }
+        if (is_link($path) || is_file($path)) {
+            return @unlink($path) === true;
+        }
+        $entries = @scandir($path);
+        if ($entries === false) {
+            return false;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            if (!$this->remove_path_without_following_symlinks($path . '/' . $entry)) {
+                return false;
+            }
+        }
+        return @rmdir($path) === true;
+    }
+
+    /**
+     * Whether any directory component of the artifact's target path is a
+     * symlink. Only the relative components are checked — the target root
+     * itself may legitimately be reached through links.
+     */
+    private function has_symlinked_parent(string $artifact_id): bool {
+        $parent = dirname($artifact_id);
+        if ($parent === '.') {
+            return false;
+        }
+        $path = $this->target_root;
+        foreach (explode('/', $parent) as $segment) {
+            $path .= '/' . $segment;
+            if (is_link($path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function result(string $status, ?string $reason, ?string $detail, int $applied = 0, int $already_applied = 0, int $skipped = 0, array $skipped_paths = [], int $deleted = 0): array {
+        return [
+            'status' => $status,
+            'reason' => $reason,
+            'detail' => $detail,
+            'applied' => $applied,
+            'already_applied' => $already_applied,
+            'skipped' => $skipped,
+            'skipped_paths' => $skipped_paths,
+            'deleted' => $deleted,
+        ];
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -1,0 +1,745 @@
+<?php
+
+/**
+ * Staged storage for chunked artifact transfers.
+ *
+ * A transfer moves many files plus database changes at network speed and can
+ * be interrupted or aborted at any point — the live site must never see that
+ * as half-applied state, and partial content must never exist under the
+ * web-served tree, where the server would hand out a half-uploaded plugin
+ * file as plain text. So staging exists for apply atomicity and containment,
+ * not for authentication: nothing a transfer receives touches the site
+ * directly, the bytes accumulate here while the site keeps running, aborting
+ * before apply is free (discard the staged data), and the apply step later
+ * moves verified artifacts into place in one short, controlled window
+ * instead of mutating the live tree for the duration of the transfer.
+ *
+ * The first consumer is push: bounded chunk uploads from an outbound-only
+ * local site (see UploadChunkSizer on the importer side). The pull file
+ * writer has the same needs whenever its target is a live site — today it
+ * streams downloads straight to their final paths, which is fine for a fresh
+ * local directory but not for a web-served tree — so nothing here is
+ * upload-specific: sequential offsets match pull's byte-offset resume model.
+ *
+ * The caller drives the loop, matching the streaming producers: where a
+ * reader calls next_chunk() until the producer is done, a sender calls
+ * append() once per buffer it read, and the store performs exactly one
+ * bounded, individually-committed step per call. Nothing is held between
+ * calls, so the transfer can stop after any step and resume from
+ * committed_bytes — in the next request, the next process, or a test that
+ * stops the loop at a chosen iteration. Stopping inside a step leaves an
+ * uncommitted tail the next append truncates away. Reading the request
+ * body, sizing buffers, and skipping bytes the store reports as duplicate
+ * all belong to the caller's loop.
+ *
+ * Integrity checks are byte counts, the same discipline pull uses: an
+ * append is accepted only at the committed offset and only whole, and
+ * finalize() compares the assembled size against the total declared at plan
+ * time. That catches truncation, missing bytes, and resume-offset bugs; it
+ * does not read the artifact back, so finalize() costs the same for a 1 KB
+ * file and a 50 GB dump. Corruption that preserves length — including a
+ * staging file that shrank between requests and was zero-filled back to the
+ * committed size by the next append's ftruncate — is not detected, the same
+ * trust pull's writer places in its local disk. The wire belongs to TLS and
+ * request authorization to the control plane's HMAC.
+ *
+ * Layout and state follow the pull importer's mechanics. Artifact bytes live
+ * at their plain target-relative paths under files/ — no suffixes, so any
+ * name a site can contain stages verbatim — and progress lives outside the
+ * mirror: state.json holds the cursor for the single in-flight artifact,
+ * and each artifact finalize() accepted has a marker at the same relative
+ * path under verified/, holding the verified size. Markers, not a shared
+ * log, because the already-verified check runs on every append: one stat
+ * per call no matter how many artifacts a transfer has finished, where a
+ * log would be re-read and re-parsed in full each time and a 50k-file
+ * push would spend its appends parsing it.
+ *
+ * Transfers are sequential, like pull: progress is tracked for one artifact
+ * at a time — the one currently being uploaded. That artifact can be
+ * interrupted and resumed freely, because the cursor survives across
+ * requests. Starting a different artifact forgets the unfinished one's
+ * progress: its partial bytes stay under files/, but returning to it means
+ * re-uploading from offset 0. Senders must finish or discard one artifact
+ * before starting the next; interleaving two uploads is not supported.
+ *
+ * Locking: every mutator — append(), finalize(), discard() — holds one
+ * exclusive non-blocking flock on the lock file for its single step and
+ * releases it before returning. This is not for parallelism (transfers are
+ * sequential); it exists so a retry racing its timed-out predecessor gets
+ * "busy" instead of interleaving writes. The lock needs its own
+ * never-replaced file: state.json commits by rename, and renaming a locked
+ * file strands the held flock on the orphaned inode while the next opener
+ * locks the fresh one. Readers stay lock-free — state.json and verified
+ * markers appear whole or not at all (both commit by rename), and
+ * committed_bytes only grows — so status() always reads a safe resume hint.
+ *
+ * Contract:
+ *
+ * - Appends are sequential: a buffer is accepted only at the committed
+ *   offset, whole or not at all. Re-sending already-committed bytes is an
+ *   idempotent no-op ("duplicate"), and every response carries
+ *   committed_bytes so an out-of-sync sender can resume at the right offset.
+ * - Bytes become committed only after they are flushed and the cursor
+ *   record moved, in that order — a crash mid-step leaves an uncommitted
+ *   tail that the next append discards.
+ * - finalize() compares the assembled size against the plan-declared total
+ *   before writing the artifact's verified marker; append() refuses
+ *   verified artifacts.
+ * - An artifact id is the files/-relative path the artifact will be applied
+ *   from, mirroring the target tree — apply resolves artifacts by id, never
+ *   by enumerating the staging directory. Ids with absolute, empty, "." or
+ *   ".." segments or any backslash are rejected — stricter than the
+ *   importer's fs-root path rule, which tolerates backslashes and empty
+ *   segments.
+ *
+ * The endpoint owns authentication, request-size limits, and buffer sizing.
+ * It must also place the staging directory outside the web-served tree, and
+ * preferably on the same filesystem as the apply target so the apply step
+ * can move verified artifacts with an atomic rename().
+ */
+final class Site_Export_Staged_Artifacts {
+
+    /** @var string */
+    private $files_dir;
+
+    /** @var string */
+    private $state_path;
+
+    /** @var string */
+    private $verified_dir;
+
+    /** @var string */
+    private $verified_tmp_path;
+
+    /** @var string */
+    private $lock_path;
+
+    public function __construct(string $staging_dir) {
+        $base = rtrim($staging_dir, '/');
+        $this->files_dir = $base . '/files';
+        $this->state_path = $base . '/state.json';
+        $this->verified_dir = $base . '/verified';
+        // One reusable temp file, outside verified/: a marker's own ".tmp"
+        // sibling would collide with the marker of an artifact actually
+        // named that way. Marker writes happen under the lock, so a single
+        // temp path cannot race itself.
+        $this->verified_tmp_path = $base . '/verified.tmp';
+        $this->lock_path = $base . '/lock';
+    }
+
+    /**
+     * Append one caller-provided buffer at the committed offset.
+     *
+     * One call is one reentrant step: validate, lock, write the whole
+     * buffer, flush, move the cursor, unlock. The caller's loop reads its
+     * source and sizes the buffers; a "duplicate" response means these
+     * bytes are already committed and the caller should skip forward in
+     * its own source and continue from committed_bytes.
+     *
+     * @param string $artifact_id Opaque artifact identifier.
+     * @param int    $offset      Byte offset this buffer starts at.
+     * @param string $bytes       The buffer to append.
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "accepted"|"duplicate"|"busy"|"rejected"; reason is set on
+     *   "rejected", and detail names the failing operation when the same
+     *   reason can come from more than one place.
+     */
+    public function append(string $artifact_id, int $offset, string $bytes): array {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_artifact_id',
+                'detail' => null,
+                'committed_bytes' => 0,
+            ];
+        }
+        if ($offset < 0) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_offset',
+                'detail' => null,
+                'committed_bytes' => 0,
+            ];
+        }
+        if ($bytes === '') {
+            return [
+                'status' => 'rejected',
+                'reason' => 'empty_body',
+                'detail' => null,
+                'committed_bytes' => 0,
+            ];
+        }
+
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'io_error',
+                'detail' => 'open_lock_file',
+                'committed_bytes' => 0,
+            ];
+        }
+
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return [
+                    'status' => 'busy',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $this->status($artifact_id)['committed_bytes'],
+                ];
+            }
+
+            $verified_size = $this->read_verified_size($artifact_id);
+            if ($verified_size !== null) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'already_verified',
+                    'detail' => null,
+                    'committed_bytes' => $verified_size,
+                ];
+            }
+
+            // Sequential transfers: the cursor tracks one artifact. An
+            // append to any other artifact starts it from scratch.
+            $state = $this->read_state();
+            $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            // The cursor can outlive its bytes: a discard killed between
+            // unlinking the artifact and clearing the cursor leaves
+            // committed > 0 with no file. Recreating the file below and
+            // ftruncate()-ing it up to the committed size would zero-fill a
+            // phantom prefix that then passes the byte-count finalize and
+            // applies as corruption. Trust nothing we cannot see — restart
+            // the artifact from offset 0. (A file that only shrank is the
+            // separate, documented zero-fill case handled below.)
+            if ($committed > 0 && !file_exists($file_path)) {
+                $committed = 0;
+            }
+
+            if ($offset + strlen($bytes) <= $committed) {
+                return [
+                    'status' => 'duplicate',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                ];
+            }
+            if ($offset !== $committed) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'offset_gap',
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                ];
+            }
+
+            if (!$this->ensure_parent_dir($file_path)) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'create_staging_dir',
+                    'committed_bytes' => $committed,
+                ];
+            }
+
+            // Open without truncating: a resumed transfer must keep committed
+            // bytes until the cursor decides what tail to discard.
+            $file = @fopen($file_path, 'c+b');
+            if ($file === false) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'open_artifact_file',
+                    'committed_bytes' => $committed,
+                ];
+            }
+
+            try {
+                // Discard any uncommitted tail from an interrupted earlier
+                // step, then append at the only offset the cursor says is
+                // committed.
+                if (!ftruncate($file, $committed) || fseek($file, $committed) !== 0) {
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'truncate_uncommitted_tail',
+                        'committed_bytes' => $committed,
+                    ];
+                }
+
+                if (fwrite($file, $bytes) !== strlen($bytes)) {
+                    // A partial write leaves bytes past the committed offset;
+                    // trim them before the caller retries this step.
+                    ftruncate($file, $committed);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'write_body',
+                        'committed_bytes' => $committed,
+                    ];
+                }
+
+                // The data is flushed before the cursor record moves: a crash
+                // between the two leaves a tail that the next append truncates.
+                if (!fflush($file)) {
+                    ftruncate($file, $committed);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'flush_body',
+                        'committed_bytes' => $committed,
+                    ];
+                }
+
+                if (!$this->write_state($artifact_id, $committed + strlen($bytes))) {
+                    ftruncate($file, $committed);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'persist_cursor',
+                        'committed_bytes' => $committed,
+                    ];
+                }
+
+                return [
+                    'status' => 'accepted',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $committed + strlen($bytes),
+                ];
+            } finally {
+                fclose($file);
+            }
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Confirm the assembled artifact against its declared size and record it
+     * as applyable.
+     *
+     * Idempotent: finalizing an already-verified artifact with the same size
+     * succeeds again.
+     *
+     * $expected_total_bytes is the size declared when the transfer was
+     * planned. The check never reads the artifact back, so it costs the same
+     * regardless of artifact size.
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,path:?string}
+     *   status "verified"|"busy"|"rejected"; path is set on "verified", and
+     *   detail names the failing operation when the same reason can come
+     *   from more than one place.
+     */
+    public function finalize(string $artifact_id, int $expected_total_bytes): array {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_artifact_id',
+                'detail' => null,
+                'committed_bytes' => 0,
+                'path' => null,
+            ];
+        }
+        if ($expected_total_bytes < 0) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'invalid_total',
+                'detail' => null,
+                'committed_bytes' => 0,
+                'path' => null,
+            ];
+        }
+
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return [
+                'status' => 'rejected',
+                'reason' => 'io_error',
+                'detail' => 'open_lock_file',
+                'committed_bytes' => 0,
+                'path' => null,
+            ];
+        }
+
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return [
+                    'status' => 'busy',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $this->status($artifact_id)['committed_bytes'],
+                    'path' => null,
+                ];
+            }
+
+            $verified_size = $this->read_verified_size($artifact_id);
+            if ($verified_size !== null) {
+                // The record can outlive the file — a discard killed between
+                // its steps, or external cleanup. There is nothing left to
+                // apply, so verified must not be re-affirmed.
+                if (!file_exists($file_path)) {
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'missing',
+                        'detail' => 'verified_record',
+                        'committed_bytes' => $verified_size,
+                        'path' => null,
+                    ];
+                }
+                if ($verified_size === $expected_total_bytes) {
+                    return [
+                        'status' => 'verified',
+                        'reason' => null,
+                        'detail' => null,
+                        'committed_bytes' => $verified_size,
+                        'path' => $file_path,
+                    ];
+                }
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'size_mismatch',
+                    'detail' => 'verified_record',
+                    'committed_bytes' => $verified_size,
+                    'path' => null,
+                ];
+            }
+
+            $state = $this->read_state();
+            $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+
+            if (!file_exists($file_path)) {
+                // A zero-byte artifact legitimately has no appends; the fopen
+                // below creates its empty file.
+                if ($expected_total_bytes > 0) {
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'missing',
+                        'detail' => null,
+                        'committed_bytes' => $committed,
+                        'path' => null,
+                    ];
+                }
+                if (!$this->ensure_parent_dir($file_path)) {
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'io_error',
+                        'detail' => 'create_staging_dir',
+                        'committed_bytes' => 0,
+                        'path' => null,
+                    ];
+                }
+            }
+
+            if ($committed !== $expected_total_bytes) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'size_mismatch',
+                    'detail' => null,
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
+            }
+
+            $file = @fopen($file_path, 'c+b');
+            if ($file === false) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'open_artifact_file',
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
+            }
+            // Drop any uncommitted tail so the artifact holds committed bytes only.
+            $truncated = ftruncate($file, $committed);
+            fclose($file);
+            if (!$truncated) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'truncate_uncommitted_tail',
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
+            }
+
+            if (!$this->write_verified_marker($artifact_id, $expected_total_bytes)) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'persist_verified_record',
+                    'committed_bytes' => $committed,
+                    'path' => null,
+                ];
+            }
+            if ($state['artifact_id'] === $artifact_id) {
+                // Best effort: a stale cursor is harmless once the verified
+                // record exists — already_verified wins on the next append.
+                $this->write_state(null, 0);
+            }
+
+            return [
+                'status' => 'verified',
+                'reason' => null,
+                'detail' => null,
+                'committed_bytes' => $committed,
+                'path' => $file_path,
+            ];
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Returns the recorded staging state for an artifact.
+     *
+     * This is advisory and intentionally lock-free; writers still enforce the
+     * committed offset under the lock before accepting bytes.
+     *
+     * @return array{exists:bool,committed_bytes:int,verified:bool}
+     */
+    public function status(string $artifact_id): array {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
+            return [
+                'exists' => false,
+                'committed_bytes' => 0,
+                'verified' => false,
+            ];
+        }
+
+        $verified_size = $this->read_verified_size($artifact_id);
+        if ($verified_size !== null) {
+            return [
+                'exists' => file_exists($file_path),
+                'committed_bytes' => $verified_size,
+                'verified' => true,
+            ];
+        }
+
+        $state = $this->read_state();
+        return [
+            'exists' => file_exists($file_path),
+            'committed_bytes' => $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0,
+            'verified' => false,
+        ];
+    }
+
+    /**
+     * Remove all staged data and records for an artifact. Safe to call for
+     * unknown ids.
+     *
+     * Retry until true: a discard killed between its steps — or stopped by
+     * a failing one — leaves a partial state that only another discard
+     * fully cleans up. Every partial state is retriable.
+     *
+     * @return bool False when a concurrent writer holds the store (an
+     *              unguarded unlink would let that writer's commit resurrect
+     *              a discarded artifact) or when a cleanup step failed and
+     *              staged data remains.
+     */
+    public function discard(string $artifact_id): bool {
+        $file_path = $this->artifact_path($artifact_id);
+        if ($file_path === null) {
+            return true;
+        }
+
+        // A missing staging directory proves nothing is staged and no writer
+        // is mid-step, so this one no-op may skip locking (open_lock() would
+        // create the scaffolding as a side effect). Every other check belongs
+        // under the lock: a first append can be in flight with no trace on
+        // disk yet, and its commit would resurrect an artifact this call just
+        // reported discarded.
+        if (!is_dir(dirname($this->lock_path))) {
+            return true;
+        }
+
+        $lock = $this->open_lock();
+        if ($lock === false) {
+            return false;
+        }
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return false;
+            }
+
+            if (file_exists($file_path) && !@unlink($file_path)) {
+                return false;
+            }
+            $state = $this->read_state();
+            if ($state['artifact_id'] === $artifact_id && !$this->write_state(null, 0)) {
+                return false;
+            }
+            return $this->remove_verified_marker($artifact_id);
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Resolve an artifact id to its path under files/, or null when the id
+     * is not a clean staging-relative path.
+     */
+    private function artifact_path(string $artifact_id): ?string {
+        if ($artifact_id === '' || $artifact_id[0] === '/' || strpos($artifact_id, "\0") !== false || strpos($artifact_id, '\\') !== false) {
+            return null;
+        }
+        foreach (explode('/', $artifact_id) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return null;
+            }
+        }
+
+        return $this->files_dir . '/' . $artifact_id;
+    }
+
+    /**
+     * Opens the flock target, creating the staging directory on first use.
+     *
+     * The lock file must never be written or rename-replaced: a rename
+     * strands a held flock on the orphaned inode and lets the next opener
+     * lock the store concurrently.
+     *
+     * @return resource|false
+     */
+    private function open_lock() {
+        if (!$this->ensure_parent_dir($this->lock_path)) {
+            return false;
+        }
+        return @fopen($this->lock_path, 'c+b');
+    }
+
+    private function ensure_parent_dir(string $path): bool {
+        $dir = dirname($path);
+        // A concurrent creator winning the mkdir race is success, not failure.
+        return is_dir($dir) || @mkdir($dir, 0700, true) || is_dir($dir);
+    }
+
+    /**
+     * The artifact the cursor currently names, or null. Caller holds the
+     * store lock (the apply window's direct-consume contract): this reads
+     * without taking it.
+     */
+    public function cursor_artifact_locked(): ?string {
+        return $this->read_state()['artifact_id'];
+    }
+
+    /**
+     * Clears the cursor. Caller holds the store lock. The cursor schema
+     * and its write-then-rename commit stay owned by this class.
+     */
+    public function clear_cursor_locked(): bool {
+        return $this->write_state(null, 0);
+    }
+
+    /**
+     * Reads the cursor as best-effort state.
+     *
+     * A missing or unreadable record is treated as no artifact in flight, so
+     * the next writer must restart its artifact from offset 0 instead of
+     * trusting stale bytes.
+     *
+     * @return array{artifact_id:?string,committed_bytes:int}
+     */
+    private function read_state(): array {
+        $defaults = [
+            'artifact_id' => null,
+            'committed_bytes' => 0,
+        ];
+
+        $raw = @file_get_contents($this->state_path);
+        if ($raw === false) {
+            return $defaults;
+        }
+        $state = json_decode($raw, true);
+        if (!is_array($state) || !is_string($state['artifact_id'] ?? null)) {
+            return $defaults;
+        }
+
+        $committed_bytes = isset($state['committed_bytes']) ? (int) $state['committed_bytes'] : 0;
+        return [
+            'artifact_id' => $state['artifact_id'],
+            'committed_bytes' => max(0, $committed_bytes),
+        ];
+    }
+
+    private function write_state(?string $artifact_id, int $committed_bytes): bool {
+        // Write-then-rename keeps the cursor atomic: readers see the old
+        // record or the new one, never a torn file. The temp file sits next
+        // to the target so rename stays on the same filesystem.
+        $tmp_path = $this->state_path . '.tmp';
+        $json = json_encode([
+            'artifact_id' => $artifact_id,
+            'committed_bytes' => $committed_bytes,
+        ]);
+        // A short write (disk full) returns a byte count, not false — never
+        // rename a torn record over the good one.
+        if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
+            @unlink($tmp_path);
+            return false;
+        }
+        if (!@rename($tmp_path, $this->state_path)) {
+            @unlink($tmp_path);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * The verified marker mirrors the artifact's relative path under
+     * verified/, so lookup is one stat regardless of transfer size.
+     */
+    private function verified_marker_path(string $artifact_id): string {
+        return $this->verified_dir . '/' . $artifact_id;
+    }
+
+    /**
+     * Reads an artifact's verified size, or null when it is not verified.
+     *
+     * A malformed marker — torn by a crash, since markers commit by rename
+     * this means external interference — reads as not verified, so the
+     * worst case is re-finalizing an artifact, never trusting a torn record.
+     */
+    private function read_verified_size(string $artifact_id): ?int {
+        $raw = @file_get_contents($this->verified_marker_path($artifact_id));
+        if ($raw === false) {
+            return null;
+        }
+        $record = json_decode($raw, true);
+        if (!is_array($record) || !is_int($record['size'] ?? null) || $record['size'] < 0) {
+            return null;
+        }
+        return $record['size'];
+    }
+
+    private function write_verified_marker(string $artifact_id, int $size): bool {
+        $marker_path = $this->verified_marker_path($artifact_id);
+        if (!$this->ensure_parent_dir($marker_path)) {
+            return false;
+        }
+        $json = json_encode(['size' => $size]);
+        // Same discipline as the cursor: a short write (disk full) must
+        // never become a marker, so write whole to the temp file and rename.
+        if (@file_put_contents($this->verified_tmp_path, $json) !== strlen($json)) {
+            @unlink($this->verified_tmp_path);
+            return false;
+        }
+        if (!@rename($this->verified_tmp_path, $marker_path)) {
+            @unlink($this->verified_tmp_path);
+            return false;
+        }
+        return true;
+    }
+
+    private function remove_verified_marker(string $artifact_id): bool {
+        $marker_path = $this->verified_marker_path($artifact_id);
+        return !file_exists($marker_path) || @unlink($marker_path);
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -1,0 +1,779 @@
+<?php
+
+use function WordPress\Reprint\Exporter\parse_size;
+
+/**
+ * HTTP endpoints for the staged artifact store.
+ *
+ * This is the target side of a push chunk upload: the sender reads its
+ * source in bounded chunks (sized by UploadChunkSizer on the importer
+ * side) and posts each chunk here, where it accumulates in
+ * Site_Export_Staged_Artifacts instead of touching the live site.
+ *
+ * Four routes share the existing endpoint dispatcher:
+ *
+ * - staged_upload   (POST, data plane): raw chunk bytes in the request
+ *   body, artifact_id and offset in the query string.
+ * - staged_finalize (POST, control plane): confirm the assembled size.
+ * - staged_status   (GET, control plane): resume hint for a sender.
+ * - staged_discard  (POST, control plane): drop an artifact; retry
+ *   until the response says discarded.
+ *
+ * Control-plane routes have small bodies and ride the embedding layer's
+ * existing HMAC verification, like every other endpoint. staged_upload
+ * cannot: that verification buffers the whole request body to hash it,
+ * and a chunk can be as large as the sizer's 1 GiB cap. So the upload
+ * route authenticates inside the handler, in two steps that keep memory
+ * bounded and keep unauthenticated bytes away from the store:
+ *
+ * 1. verify_signed_content_hash() checks the signature, nonce, and
+ *    timestamp headers before a single body byte is read. A caller
+ *    without the shared secret is rejected without costing a body read.
+ * 2. The body streams into a spool (memory up to a small threshold,
+ *    then a temp file) while a SHA-256 digest accumulates. Only when
+ *    the digest matches the signed claim does the spool drain into
+ *    append(), one bounded buffer per call. A mismatched or oversized
+ *    body is discarded with the spool — the store never sees it. The
+ *    spool is one extra sequential disk pass over bytes the host
+ *    already buffered for the request; that is the price of never
+ *    committing an unverified byte.
+ *
+ * A replayed capture of a signed upload within the timestamp tolerance
+ * re-appends bytes the store already committed and comes back
+ * "duplicate" — idempotent, same as a sender retry.
+ *
+ * Chunk retries are the normal case, not an error: a sender that timed
+ * out learns nothing about what landed, retries the same chunk, and may
+ * later resend with shifted boundaries. The upload route therefore
+ * compares the store's committed offset with the chunk's range first,
+ * answers "duplicate" for fully-committed ranges, skips the committed
+ * prefix of a straddling chunk, and answers offset_gap (with
+ * committed_bytes) only when the chunk starts beyond the frontier.
+ *
+ * Rejections the chunk sizer must learn from are typed for it: a body
+ * over the request cap is HTTP 413 with max_request_bytes in the
+ * payload, exactly what record_too_large() consumes. The cap defaults
+ * to post_max_size (falling back to the sizer's own 1 GiB hard cap when
+ * PHP reports none), because a proxy or PHP itself would refuse larger
+ * bodies before this code runs anyway.
+ *
+ * All options are server-owned. Client config never chooses the staging
+ * directory, the secret, or the caps — a request parameter named like
+ * an option is ignored. Methods return ['http_code' => int, 'body' =>
+ * array] and never echo, so tests drive them directly; the dispatcher
+ * wiring in Site_Export_HTTP_Server emits the JSON.
+ */
+final class Site_Export_Staged_Endpoints {
+
+    /** The chunk sizer never sends more than this, so accept up to it. */
+    private const DEFAULT_MAX_REQUEST_BYTES = 1073741824;
+
+    /** One append() step per this many spooled bytes. */
+    private const DEFAULT_APPEND_BUFFER_BYTES = 262144;
+
+    /** Spool bytes held in memory before php://temp spills to disk. */
+    private const SPOOL_MEMORY_BYTES = 2097152;
+
+    /** Request-body read size while spooling. */
+    private const READ_BUFFER_BYTES = 65536;
+
+    /** @var Site_Export_Staged_Artifacts */
+    private $store;
+
+    /** @var string|null */
+    private $secret;
+
+    /** @var int */
+    private $max_request_bytes;
+
+    /** @var int */
+    private $append_buffer_bytes;
+
+    /** @var int */
+    private $timestamp_tolerance;
+
+    /** @var string|null */
+    private $apply_target_root;
+
+    /** @var callable|null */
+    private $apply_device_id;
+
+    /** @var string */
+    private $staging_dir;
+
+    /**
+     * @param array $options Server-owned configuration:
+     *   - staging_dir (string, required): passed to the artifact store.
+     *     Must live outside the web-served tree.
+     *   - secret (?string): shared secret for upload authentication.
+     *     Null leaves uploads answering 503 until one is configured.
+     *   - max_request_bytes (int): upload body cap; defaults to
+     *     post_max_size, or 1 GiB when PHP reports no limit.
+     *   - append_buffer_bytes (int): spool-to-store step size.
+     *   - timestamp_tolerance (int): HMAC freshness window in seconds.
+     */
+    public function __construct(array $options) {
+        $staging_dir = $options['staging_dir'] ?? null;
+        if (!is_string($staging_dir) || $staging_dir === '') {
+            throw new InvalidArgumentException('Staged endpoints require a staging_dir option.');
+        }
+        $this->store = new Site_Export_Staged_Artifacts($staging_dir);
+
+        $secret = $options['secret'] ?? null;
+        $this->secret = is_string($secret) && $secret !== '' ? $secret : null;
+
+        $max = $options['max_request_bytes'] ?? null;
+        if (!is_numeric($max) || (int) $max <= 0) {
+            $post_max = ini_get('post_max_size');
+            $max = is_string($post_max) && $post_max !== '' ? parse_size($post_max) : 0;
+            if ($max <= 0) {
+                $max = self::DEFAULT_MAX_REQUEST_BYTES;
+            }
+        }
+        $this->max_request_bytes = (int) $max;
+
+        $buffer = $options['append_buffer_bytes'] ?? null;
+        $this->append_buffer_bytes = is_numeric($buffer) && (int) $buffer > 0
+            ? (int) $buffer
+            : self::DEFAULT_APPEND_BUFFER_BYTES;
+
+        $tolerance = $options['timestamp_tolerance'] ?? null;
+        $this->timestamp_tolerance = is_numeric($tolerance) && (int) $tolerance > 0
+            ? (int) $tolerance
+            : 300;
+
+        $target_root = $options['apply_target_root'] ?? null;
+        $this->apply_target_root = is_string($target_root) && $target_root !== '' ? $target_root : null;
+        $this->apply_device_id = $options['apply_device_id'] ?? null;
+        $this->staging_dir = $staging_dir;
+    }
+
+    /**
+     * Validate a transfer (check_only) or move it into the target root.
+     *
+     * A sender probes with check_only=1 before uploading anything: an
+     * environment that can never apply — cross-device staging above all —
+     * rejects here, before a byte of transfer has been spent.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function apply(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $manifest_id = $config['manifest_id'] ?? null;
+        if (!is_string($manifest_id) || $manifest_id === '') {
+            return $this->rejected(400, 'invalid_manifest_id');
+        }
+        if ($this->apply_target_root === null) {
+            return $this->rejected(503, 'not_configured', 'apply_target_root');
+        }
+
+        $apply_options = [
+            'staging_dir' => $this->staging_dir,
+            'target_root' => $this->apply_target_root,
+        ];
+        if ($this->apply_device_id !== null) {
+            $apply_options['device_id'] = $this->apply_device_id;
+        }
+        $engine = new Site_Export_Staged_Apply($apply_options);
+
+        $check_only = filter_var($config['check_only'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $result = $engine->apply($manifest_id, $check_only);
+
+        switch ($result['status']) {
+            case 'applied':
+            case 'ready':
+                $code = 200;
+                break;
+            case 'busy':
+                $code = 423;
+                break;
+            default:
+                $code = $result['reason'] === 'io_error' ? 500 : 409;
+        }
+        if ($result['status'] === 'ready') {
+            // The probe doubles as push preflight: the request cap seeds
+            // the sender's chunk sizer without waiting for a 413.
+            $result['max_request_bytes'] = $this->max_request_bytes;
+        }
+        return [
+            'http_code' => $code,
+            'body' => $result,
+        ];
+    }
+
+    /**
+     * Stage one chunk of an artifact.
+     *
+     * @param array $config Request parameters (artifact_id, offset).
+     * @param array $headers Request headers/server vars ($_SERVER shape).
+     * @param resource|null $input Request body stream (php://input).
+     * @return array{http_code:int,body:array}
+     */
+    public function upload(array $config, array $headers, $input): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+        $offset = $config['offset'] ?? null;
+        if (!is_numeric($offset) || (int) $offset < 0) {
+            return $this->rejected(400, 'invalid_offset');
+        }
+        $offset = (int) $offset;
+
+        if ($this->secret === null) {
+            return $this->rejected(503, 'not_configured', 'shared_secret');
+        }
+
+        // Headers first: nobody without the secret gets a body read.
+        $hmac = new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance);
+        $auth = $hmac->verify_signed_content_hash($headers);
+        if ($auth['error'] !== null) {
+            return $this->rejected(403, 'auth_failed', $auth['error']);
+        }
+
+        $declared_length = $headers['CONTENT_LENGTH'] ?? ( $headers['HTTP_CONTENT_LENGTH'] ?? null );
+        if (is_numeric($declared_length) && (int) $declared_length > $this->max_request_bytes) {
+            return $this->too_large($artifact_id);
+        }
+
+        $spooled = $this->spool_verified_body($auth, $input, $artifact_id);
+        if (isset($spooled['response'])) {
+            return $spooled['response'];
+        }
+        $spool = $spooled['spool'];
+        $spooled_bytes = $spooled['bytes'];
+
+        try {
+            $status = $this->store->status($artifact_id);
+            if ($status['verified']) {
+                return $this->rejected(409, 'already_verified', null, $status['committed_bytes']);
+            }
+            $committed = $status['committed_bytes'];
+            if ($committed >= $offset + $spooled_bytes) {
+                // A retried chunk that fully landed before the sender's
+                // timeout. Nothing to write.
+                return [
+                    'http_code' => 200,
+                    'body' => [
+                        'status' => 'duplicate',
+                        'reason' => null,
+                        'detail' => null,
+                        'committed_bytes' => $committed,
+                    ],
+                ];
+            }
+            if ($committed < $offset) {
+                return $this->rejected(409, 'offset_gap', null, $committed);
+            }
+
+            // A resent chunk may straddle the committed frontier; skip the
+            // prefix the store already has so appends line up with it.
+            rewind($spool);
+            if ($committed > $offset && fseek($spool, $committed - $offset) !== 0) {
+                return $this->rejected(500, 'io_error', 'seek_spool');
+            }
+
+            $position = $committed;
+            while (( $buffer = fread($spool, $this->append_buffer_bytes) ) !== false && $buffer !== '') {
+                $result = $this->store->append($artifact_id, $position, $buffer);
+                if ($result['status'] !== 'accepted') {
+                    return $this->from_store_result($result);
+                }
+                $position = $result['committed_bytes'];
+            }
+
+            return [
+                'http_code' => 200,
+                'body' => [
+                    'status' => 'accepted',
+                    'reason' => null,
+                    'detail' => null,
+                    'committed_bytes' => $position,
+                ],
+            ];
+        } finally {
+            fclose($spool);
+        }
+    }
+
+    /**
+     * Stage many complete artifacts from one request body.
+     *
+     * The body is a sequence of length-prefixed frames — no boundary
+     * strings, so any filename frames verbatim:
+     *
+     *   {"artifact_id":"a/b.txt","offset":0,"length":9,"total_bytes":9,"final":true}\n
+     *   <9 raw payload bytes>
+     *   ... next frame ...
+     *
+     * This is push's answer to pull's multipart batching: one HTTP
+     * conversation carries a whole batch of small files instead of one
+     * request each. Authentication and the no-unverified-byte rule are
+     * identical to upload(): headers first, then the whole body spools and
+     * must match the signed digest before any frame touches the store.
+     *
+     * Frames process in order and stop at the first failure; the response
+     * lists a per-artifact result for everything that reached the store,
+     * so a retry resumes with only the unfinished tail (frames for
+     * already-verified artifacts at their recorded size come back
+     * "verified" without touching anything).
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function upload_batch(array $config, array $headers, $input): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        if ($this->secret === null) {
+            return $this->rejected(503, 'not_configured', 'shared_secret');
+        }
+
+        $hmac = new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance);
+        $auth = $hmac->verify_signed_content_hash($headers);
+        if ($auth['error'] !== null) {
+            return $this->rejected(403, 'auth_failed', $auth['error']);
+        }
+
+        $declared_length = $headers['CONTENT_LENGTH'] ?? ( $headers['HTTP_CONTENT_LENGTH'] ?? null );
+        if (is_numeric($declared_length) && (int) $declared_length > $this->max_request_bytes) {
+            return $this->batch_response(413, 'request_too_large', null, []);
+        }
+
+        $spooled = $this->spool_verified_body($auth, $input, null);
+        if (isset($spooled['response'])) {
+            return $spooled['response'];
+        }
+        $spool = $spooled['spool'];
+
+        try {
+            rewind($spool);
+            $results = [];
+            while (( $line = fgets($spool) ) !== false) {
+                if (trim($line) === '') {
+                    continue;
+                }
+                $frame = json_decode($line, true);
+                if (
+                    !is_array($frame)
+                    || !is_string($frame['artifact_id'] ?? null)
+                    || !is_int($frame['offset'] ?? null) || $frame['offset'] < 0
+                    || !is_int($frame['length'] ?? null) || $frame['length'] < 0
+                    || !is_int($frame['total_bytes'] ?? null) || $frame['total_bytes'] < 0
+                ) {
+                    return $this->batch_response(400, 'invalid_batch_frame', substr($line, 0, 200), $results);
+                }
+                $outcome = $this->stage_batch_frame($frame, $spool);
+                $results[] = $outcome;
+                if ($outcome['status'] === 'rejected' || $outcome['status'] === 'busy') {
+                    // Everything before this frame is committed and
+                    // reported; the sender retries from here.
+                    $reason = $outcome['reason'] ?? null;
+                    if ($outcome['status'] === 'busy') {
+                        $code = 423;
+                    } elseif ($reason === 'io_error') {
+                        $code = 500;
+                    } elseif ($reason === 'truncated_batch') {
+                        $code = 400;
+                    } else {
+                        $code = 409;
+                    }
+                    return $this->batch_response($code, $outcome['reason'], $outcome['artifact_id'], $results);
+                }
+            }
+
+            if ($results === []) {
+                return $this->batch_response(400, 'empty_batch', null, []);
+            }
+            return $this->batch_response(200, null, null, $results);
+        } finally {
+            fclose($spool);
+        }
+    }
+
+    /**
+     * Runs one batch frame through the store's frontier discipline.
+     *
+     * @return array{artifact_id:string,status:string,reason:?string,committed_bytes:int}
+     */
+    private function stage_batch_frame(array $frame, $spool): array {
+        $artifact_id = $frame['artifact_id'];
+        $offset = $frame['offset'];
+        $final = !empty($frame['final']);
+        $total_bytes = $frame['total_bytes'];
+        $remaining = $frame['length'];
+
+        $status = $this->store->status($artifact_id);
+        if ($status['verified']) {
+            if (!$this->skip_spool_bytes($spool, $remaining)) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'rejected',
+                    'reason' => 'truncated_batch',
+                    'committed_bytes' => $status['committed_bytes'],
+                ];
+            }
+            // A retried batch re-sends artifacts an earlier attempt already
+            // landed; at the recorded size that is success, not conflict.
+            if ($status['committed_bytes'] === $total_bytes) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'verified',
+                    'reason' => null,
+                    'committed_bytes' => $status['committed_bytes'],
+                ];
+            }
+            return [
+                'artifact_id' => $artifact_id,
+                'status' => 'rejected',
+                'reason' => 'already_verified',
+                'committed_bytes' => $status['committed_bytes'],
+            ];
+        }
+
+        $committed = $status['committed_bytes'];
+        $end = $offset + $remaining;
+        if ($committed < $offset) {
+            return [
+                'artifact_id' => $artifact_id,
+                'status' => 'rejected',
+                'reason' => 'offset_gap',
+                'committed_bytes' => $committed,
+            ];
+        }
+        if ($committed > $offset) {
+            // Skip the prefix the store already holds.
+            $skipped = min($remaining, $committed - $offset);
+            if (!$this->skip_spool_bytes($spool, $skipped)) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'rejected',
+                    'reason' => 'truncated_batch',
+                    'committed_bytes' => $committed,
+                ];
+            }
+            $remaining -= $skipped;
+            $offset = $committed;
+        }
+        while ($remaining > 0) {
+            $piece = $this->read_spool_exactly($spool, min($this->append_buffer_bytes, $remaining));
+            if ($piece === null) {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => 'rejected',
+                    'reason' => 'truncated_batch',
+                    'committed_bytes' => $offset,
+                ];
+            }
+            $result = $this->store->append($artifact_id, $offset, $piece);
+            if ($result['status'] !== 'accepted' && $result['status'] !== 'duplicate') {
+                return [
+                    'artifact_id' => $artifact_id,
+                    'status' => $result['status'],
+                    'reason' => $result['reason'],
+                    'committed_bytes' => $result['committed_bytes'],
+                ];
+            }
+            $offset = $result['committed_bytes'];
+            $remaining -= strlen($piece);
+        }
+        $offset = max($offset, $end);
+
+        if (!$final) {
+            return [
+                'artifact_id' => $artifact_id,
+                'status' => 'accepted',
+                'reason' => null,
+                'committed_bytes' => $offset,
+            ];
+        }
+
+        $finalized = $this->store->finalize($artifact_id, $total_bytes);
+        return [
+            'artifact_id' => $artifact_id,
+            'status' => $finalized['status'],
+            'reason' => $finalized['reason'],
+            'committed_bytes' => $finalized['committed_bytes'],
+        ];
+    }
+
+    /**
+     * @return array{http_code:int,body:array}
+     */
+    private function batch_response(int $http_code, ?string $reason, ?string $detail, array $results): array {
+        $body = [
+            'status' => $http_code === 200 ? 'ok' : ( $http_code === 423 ? 'busy' : 'rejected' ),
+            'reason' => $reason,
+            'detail' => $detail,
+            'results' => $results,
+        ];
+        if ($http_code === 413) {
+            $body['max_request_bytes'] = $this->max_request_bytes;
+        }
+        return [
+            'http_code' => $http_code,
+            'body' => $body,
+        ];
+    }
+
+    /**
+     * @return string|null Null when the spool ends before $bytes.
+     */
+    private function read_spool_exactly($spool, int $bytes): ?string {
+        $data = '';
+        while (strlen($data) < $bytes) {
+            $piece = fread($spool, $bytes - strlen($data));
+            if ($piece === false || $piece === '') {
+                return null;
+            }
+            $data .= $piece;
+        }
+        return $data;
+    }
+
+    private function skip_spool_bytes($spool, int $bytes): bool {
+        if ($bytes <= 0) {
+            return true;
+        }
+        $position = ftell($spool);
+        $stat = fstat($spool);
+        if (is_int($position) && is_array($stat) && isset($stat['size'])) {
+            if ($position + $bytes > (int) $stat['size']) {
+                return false;
+            }
+            if (fseek($spool, $bytes, SEEK_CUR) === 0) {
+                return true;
+            }
+        }
+        while ($bytes > 0) {
+            $piece = fread($spool, min($this->append_buffer_bytes, $bytes));
+            if ($piece === false || $piece === '') {
+                return false;
+            }
+            $bytes -= strlen($piece);
+        }
+        return true;
+    }
+
+    /**
+     * Spools the request body while hashing it, then verifies the digest
+     * against the signed claim. Nothing may act on a body byte before the
+     * verification passes.
+     *
+     * @param resource|null $input
+     * @param ?string $too_large_artifact_id Names the artifact whose
+     *   committed offset a 413 should report; null for batch bodies.
+     * @return array{response?:array{http_code:int,body:array},spool?:resource,bytes?:int}
+     */
+    private function spool_verified_body(array $auth, $input, ?string $too_large_artifact_id): array {
+        if (!is_resource($input)) {
+            return ['response' => $this->rejected(500, 'io_error', 'open_request_body')];
+        }
+        $spool = fopen('php://temp/maxmemory:' . self::SPOOL_MEMORY_BYTES, 'w+b');
+        if ($spool === false) {
+            return ['response' => $this->rejected(500, 'io_error', 'open_spool')];
+        }
+
+        $context = hash_init('sha256');
+        $spooled = 0;
+        while (( $buffer = fread($input, self::READ_BUFFER_BYTES) ) !== false && $buffer !== '') {
+            $spooled += strlen($buffer);
+            if ($spooled > $this->max_request_bytes) {
+                fclose($spool);
+                return ['response' => $too_large_artifact_id !== null
+                    ? $this->too_large($too_large_artifact_id)
+                    : $this->batch_response(413, 'request_too_large', null, [])];
+            }
+            hash_update($context, $buffer);
+            if (fwrite($spool, $buffer) !== strlen($buffer)) {
+                fclose($spool);
+                return ['response' => $this->rejected(500, 'io_error', 'write_spool')];
+            }
+        }
+        if ($buffer === false && !feof($input)) {
+            fclose($spool);
+            return ['response' => $this->rejected(400, 'body_read_failed')];
+        }
+
+        // The signature authenticated the hash claim; this comparison
+        // authenticates the bytes. Nothing reached the store yet.
+        if (!hash_equals((string) $auth['content_hash'], hash_final($context))) {
+            fclose($spool);
+            return ['response' => $this->rejected(403, 'content_hash_mismatch')];
+        }
+        if ($spooled === 0) {
+            fclose($spool);
+            return ['response' => $this->rejected(400, 'empty_body')];
+        }
+
+        rewind($spool);
+        return [
+            'spool' => $spool,
+            'bytes' => $spooled,
+        ];
+    }
+
+    /**
+     * Confirm an assembled artifact against its plan-declared size.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function finalize(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+        $total_bytes = $config['total_bytes'] ?? null;
+        if (!is_numeric($total_bytes) || (int) $total_bytes < 0) {
+            return $this->rejected(400, 'invalid_total');
+        }
+
+        $result = $this->store->finalize($artifact_id, (int) $total_bytes);
+        // The staged path is server-local detail; apply resolves by id.
+        unset($result['path']);
+        return $this->from_store_result($result);
+    }
+
+    /**
+     * Resume hint for a sender: committed offset and verified flag.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function status(array $config): array {
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+
+        return [
+            'http_code' => 200,
+            'body' => $this->store->status($artifact_id),
+        ];
+    }
+
+    /**
+     * Drop an artifact's staged bytes and records.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    public function discard(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return $this->rejected(400, 'invalid_artifact_id');
+        }
+
+        if (!$this->store->discard($artifact_id)) {
+            // Held by a concurrent writer or a failed cleanup step; both
+            // are the store's retry-until-true contract.
+            return [
+                'http_code' => 423,
+                'body' => ['discarded' => false],
+            ];
+        }
+        return [
+            'http_code' => 200,
+            'body' => ['discarded' => true],
+        ];
+    }
+
+    /**
+     * @return array{http_code:int,body:array}|null Null when the method is POST.
+     */
+    private function require_post(array $headers): ?array {
+        $method = strtoupper( (string) ( $headers['REQUEST_METHOD'] ?? '' ));
+        if ($method === 'POST') {
+            return null;
+        }
+        return $this->rejected(405, 'method_not_allowed');
+    }
+
+    /**
+     * Map a store result onto an HTTP code, passing its typed body through.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    private function from_store_result(array $result): array {
+        switch ($result['status']) {
+            case 'accepted':
+            case 'duplicate':
+            case 'verified':
+                $code = 200;
+                break;
+            case 'busy':
+                $code = 423;
+                break;
+            default:
+                $code = $this->code_for_reason( (string) $result['reason']);
+        }
+
+        return [
+            'http_code' => $code,
+            'body' => $result,
+        ];
+    }
+
+    private function code_for_reason(string $reason): int {
+        switch ($reason) {
+            case 'io_error':
+                return 500;
+            case 'offset_gap':
+            case 'already_verified':
+            case 'size_mismatch':
+            case 'missing':
+                return 409;
+            default:
+                return 400;
+        }
+    }
+
+    /**
+     * @return array{http_code:int,body:array}
+     */
+    private function rejected(int $http_code, string $reason, ?string $detail = null, int $committed_bytes = 0): array {
+        return [
+            'http_code' => $http_code,
+            'body' => [
+                'status' => 'rejected',
+                'reason' => $reason,
+                'detail' => $detail,
+                'committed_bytes' => $committed_bytes,
+            ],
+        ];
+    }
+
+    /**
+     * The structured too-large rejection UploadChunkSizer::record_too_large()
+     * consumes: HTTP 413 plus the cap it must stay under.
+     *
+     * @return array{http_code:int,body:array}
+     */
+    private function too_large(string $artifact_id): array {
+        $response = $this->rejected(
+            413,
+            'request_too_large',
+            null,
+            $this->store->status($artifact_id)['committed_bytes']
+        );
+        $response['body']['max_request_bytes'] = $this->max_request_bytes;
+        return $response;
+    }
+}

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -59,6 +59,15 @@ require_once __DIR__ . '/lib/state/class-import-state.php';
 // Adaptive sizing for bounded local-to-remote upload chunks (push transfers)
 require_once __DIR__ . '/lib/upload/class-upload-chunk-sizer.php';
 
+// Chunked, resumable uploads into the target's staged artifact store
+require_once __DIR__ . '/lib/upload/class-staged-upload-client.php';
+
+// Batch orchestration over the upload client: plan in, verified artifacts out
+require_once __DIR__ . '/lib/upload/class-staged-push-runner.php';
+
+// Local-tree walk that produces the plan the push runner consumes
+require_once __DIR__ . '/lib/upload/class-push-plan-builder.php';
+
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';
 
@@ -1045,6 +1054,18 @@ class ImportClient
     /** @var string Path to .import-download-list-skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
     private $skipped_download_list_file;
 
+    /** @var string Push source index (fs-root walk) in the shared index format; transient per run. */
+    private $push_source_index_file;
+
+    /** @var string Push shipped index — what the target holds, updated after each confirmed apply. Push's analog of the local index. */
+    private $push_shipped_index_file;
+
+    /** @var string Push upload list — files the diff says to upload (download-list format plus size). */
+    private $push_upload_list_file;
+
+    /** @var string Push deletions list — target paths the diff says to remove. */
+    private $push_deletions_file;
+
     /** @var string Path to .import-audit.log — append-only log of every operation for debugging. */
     private $audit_log;
 
@@ -1226,6 +1247,49 @@ class ImportClient
      */
     public $exit_code = 0;
 
+    /** Artifact id the push manifest stages under; never applied itself. */
+    private const PUSH_MANIFEST_ID = '.reprint-push-manifest.jsonl';
+
+    /**
+     * Push failures that follow the resumable convention (exit 2: run the
+     * same command again). One list for the transfer and the apply so a
+     * reason cannot be retryable in one phase and fatal in the other.
+     */
+    private const PUSH_RETRYABLE_REASONS = ["transport_failed", "busy_exhausted", "status_unavailable", "server_io_error"];
+
+    /** Artifact id the staged pull manifest stages under. */
+    private const PULL_MANIFEST_ID = '.reprint-pull-manifest.jsonl';
+
+    /** @var bool Files download into staging and apply in one rename window. */
+    private $staged_apply_mode = false;
+
+    /**
+     * @var string Index/transfer path style. "absolute" mirrors the whole
+     * filesystem layout (pull's default; lets a transfer carry paths from
+     * outside the document root). "relative" mirrors just the --fs-root
+     * subtree (push's default) — that subtree is what appears in staging.
+     * Resolved in run(): explicit option, else persisted state, else the
+     * per-command default. Governs how index paths validate and how they
+     * map to store artifact ids.
+     */
+    private $index_path_style = "absolute";
+
+    /** @var Site_Export_Staged_Artifacts|null Lazy staged pull store. */
+    private $staged_pull_store = null;
+
+    /** @var array<string,true> Owned remote paths in the batch being fetched. */
+    private $staged_batch_owned = [];
+
+    /** @var string|null Cache key (list:offsets) for staged_batch_owned. */
+    private $staged_batch_owned_key = null;
+
+    /**
+     * True while the apply window replays deferred directory/symlink
+     * records through their regular handlers — the same code that runs at
+     * fetch time in unstaged mode, just at window time.
+     */
+    private $staged_replay = false;
+
     public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
@@ -1241,6 +1305,10 @@ class ImportClient
             $this->state_dir . "/.import-download-list.jsonl";
         $this->skipped_download_list_file =
             $this->state_dir . "/.import-download-list-skipped.jsonl";
+        $this->push_source_index_file = $this->state_dir . "/.push-source-index.jsonl";
+        $this->push_shipped_index_file = $this->state_dir . "/.push-shipped-index.jsonl";
+        $this->push_upload_list_file = $this->state_dir . "/.push-upload-list.jsonl";
+        $this->push_deletions_file = $this->state_dir . "/.push-deletions.jsonl";
         $this->audit_log = $this->state_dir . "/.import-audit.log";
         $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
         $this->status_file = $this->state_dir . "/.import-status.json";
@@ -1598,6 +1666,7 @@ class ImportClient
             "files-pull",
             "files-index",
             "files-stats",
+            "push-files",
             "db-pull",
             "db-index",
             "db-domains",
@@ -1652,6 +1721,31 @@ class ImportClient
             $this->save_state($this->state);
         } else {
             $this->fs_root_nonempty_behavior = $this->import_state()->fs_root_nonempty_behavior ?? 'error';
+        }
+
+        // Persist staged apply mode like the flags above: a resumed pull
+        // must keep staging where the interrupted run was staging.
+        if (isset($options["staged_apply"])) {
+            $this->staged_apply_mode = (bool) $options["staged_apply"];
+            $this->import_state()->staged_apply = $this->staged_apply_mode;
+            $this->save_state($this->state);
+        } else {
+            $this->staged_apply_mode = !empty($this->import_state()->staged_apply);
+        }
+
+        // Path style persists like the flags above. Explicit option wins;
+        // otherwise a resumed run keeps what it started with; otherwise the
+        // per-command default — push mirrors just its --fs-root subtree
+        // (relative), pull mirrors the exporter's absolute layout.
+        if (isset($options["index_path_style"])) {
+            $this->index_path_style = $options["index_path_style"];
+            $this->import_state()->index_path_style = $this->index_path_style;
+            $this->save_state($this->state);
+        } elseif (!empty($this->import_state()->index_path_style)) {
+            $this->index_path_style = $this->import_state()->index_path_style;
+        } else {
+            $command = $options["command"] ?? "";
+            $this->index_path_style = $command === "push-files" ? "relative" : "absolute";
         }
 
         // Persist filter in state so it survives across resume cycles.
@@ -1845,6 +1939,14 @@ class ImportClient
             $this->run_files_stats();
             return;
         }
+        if ($command === "push-files") {
+            if ($abort) {
+                $this->handle_abort($command);
+                return;
+            }
+            $this->run_push_files($options);
+            return;
+        }
         if ($command === "flat-docroot") {
             $this->run_flat_document_root($options);
             return;
@@ -1989,11 +2091,53 @@ class ImportClient
                     @unlink($this->volatile_files_file);
                     $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
                 }
+
+                // Staged leftovers are sync progress too: unapplied bytes
+                // and the pending window log go with the cursor. Nothing
+                // in them reached the live tree or the index, so the next
+                // diff re-derives whatever still applies.
+                $staging_dir = $this->staged_pull_staging_dir();
+                if (is_dir($staging_dir)) {
+                    $this->remove_local_path_without_following_symlinks($staging_dir);
+                    $this->audit_log("FILE DELETE | {$staging_dir} | staged leftovers cleared");
+                    $this->staged_pull_store = null;
+                }
+                if (file_exists($this->staged_pull_manifest_log())) {
+                    @unlink($this->staged_pull_manifest_log());
+                    $this->audit_log("FILE DELETE | {$this->staged_pull_manifest_log()}");
+                }
+
                 $this->import_state()->index = new RemoteFileIndexCursorState();
                 $this->import_state()->fetch = new DownloadListFetchProgressState();
                 $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
 
                 $this->save_state($this->state);
+                break;
+
+            case "push-files":
+                $this->audit_log(
+                    "RESTART | Clearing push-files state",
+                    true,
+                );
+                // Transient per-run work files clear; the shipped index is
+                // preserved, exactly as pull's --abort keeps its local index —
+                // it is the delta base the next push diffs against.
+                // (.push-verified.jsonl is a legacy done cache, removed if a
+                // pre-collapse run left one behind.)
+                foreach ([
+                    ".push-state.json",
+                    ".push-verified.jsonl",
+                    ".push-manifest.jsonl",
+                    ".push-source-index.jsonl",
+                    ".push-upload-list.jsonl",
+                    ".push-deletions.jsonl",
+                ] as $name) {
+                    $path = rtrim($this->state_dir, "/") . "/" . $name;
+                    if (file_exists($path)) {
+                        @unlink($path);
+                        $this->audit_log("FILE DELETE | {$path} | abort push-files");
+                    }
+                }
                 break;
 
             case "files-index":
@@ -2792,6 +2936,13 @@ class ImportClient
             file_exists($this->index_file) &&
             filesize($this->index_file) > 0;
 
+        // Staged mode: refuse now if the apply window could never run —
+        // a state dir on another filesystem above all — not after the
+        // download has been paid for.
+        if ($this->staged_apply_mode) {
+            $this->assert_staged_pull_ready();
+        }
+
         // Resuming an in-progress sync
         if ($has_progress) {
             // Don't reset files_imported here — it counts files within
@@ -2983,6 +3134,10 @@ class ImportClient
             } elseif ($has_skipped) {
                 $stage = "fetch-skipped";
             } else {
+                // Nothing to download, but a deletions-only delta still
+                // has a window to run: the manifest log holds whatever
+                // the diff just staged for removal.
+                $this->run_staged_pull_apply();
                 $stage = null;
             }
             $this->import_state()->active_resumable_command->current_stage = $stage;
@@ -3046,6 +3201,7 @@ class ImportClient
                 // Essential files are done — mark the sync as complete.
                 // The skipped list stays on disk for a later
                 // --filter=skipped-earlier run.
+                $this->run_staged_pull_apply();
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->save_state($this->state);
                 $this->audit_log(
@@ -3064,6 +3220,7 @@ class ImportClient
                 );
                 $this->write_status_file();
             } else {
+                $this->run_staged_pull_apply();
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->save_state($this->state);
                 $stage = null;
@@ -3080,6 +3237,7 @@ class ImportClient
                 $this->save_state($this->state);
                 return;
             }
+            $this->run_staged_pull_apply();
             $this->import_state()->active_resumable_command->current_stage = null;
             $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
             $this->save_state($this->state);
@@ -3924,6 +4082,1093 @@ class ImportClient
         }
 
         echo json_encode($result, JSON_PRETTY_PRINT) . "\n";
+    }
+
+    /**
+     * Upload local files into the target's staged artifact store.
+     *
+     * The plan comes from walking --fs-root: each regular file becomes one
+     * artifact at its fs-root-relative path. Nothing on the target site
+     * changes — this command only fills staging; a later apply step moves
+     * verified artifacts into place. Rerunning resumes: finished artifacts
+     * are skipped from the local done cache, a half-uploaded artifact
+     * continues from the store's committed offset, and the chunk sizer
+     * restarts at its learned limits.
+     */
+    private function run_push_files(array $options): void
+    {
+        if ($this->hmac_client === null) {
+            throw new InvalidArgumentException(
+                "push-files requires --secret: the staged upload endpoints reject unsigned requests.",
+            );
+        }
+
+        // Push selection is fs-root-relative. The :token: forms --only
+        // accepts for pull describe remote paths and do not apply here.
+        $only_raw = [];
+        foreach (($options["only"] ?? []) as $raw) {
+            $prefix = (string) $raw;
+            if (strpos($prefix, "./") === 0) {
+                $prefix = substr($prefix, 2);
+            }
+            $only_raw[] = $prefix;
+        }
+        // Validates hostile prefixes before anything runs.
+        $only = PushPlanBuilder::normalize_only($only_raw);
+
+        // Enumerate the local tree into a source index, then diff it against
+        // the shipped index (what the target already holds) to build the
+        // upload list and deletions — pull's index/diff path, inverted. Push
+        // carries no separate plan array or done cache.
+        $skipped = $this->build_push_source_index($only);
+        foreach ($skipped as $skip) {
+            $this->audit_log("PUSH-SKIP | {$skip["reason"]} | {$skip["path"]}", false);
+        }
+        $diff = $this->diff_push_indexes($only, array_column($skipped, "path"));
+
+        $this->output_progress(
+            [
+                "type" => "push",
+                "status" => "starting",
+                "files_total" => $diff["upload_count"],
+                "skipped" => count($skipped),
+            ],
+            true,
+        );
+
+        $persisted = StagedPushRunner::read_state($this->state_dir);
+        $sizer = new UploadChunkSizer([], $persisted["sizer"]);
+        $client = new StagedUploadClient([
+            "base_url" => $this->remote_url,
+            "hmac_client" => $this->hmac_client,
+            "sizer" => $sizer,
+        ]);
+
+        // Probe the apply environment before any byte is uploaded. Apply is
+        // rename-only, so staging on a different device than the target
+        // root can never land — that must surface now, not after the
+        // transfer. Probe failures that only mean "this target cannot apply
+        // yet" stay fatal only when --apply asked for an apply.
+        $apply = !empty($options["apply"]);
+        $probe = $client->apply(self::PUSH_MANIFEST_ID, true);
+        if ($probe["status"] === "failed") {
+            $environment_verdicts = ["cross_device", "target_missing", "target_unwritable", "staging_unavailable"];
+            if (in_array($probe["reason"], $environment_verdicts, true)) {
+                $this->output_progress([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], true);
+                echo json_encode([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = 1;
+                return;
+            }
+            if ($apply) {
+                $retryable = ["transport_failed", "busy_exhausted"];
+                $this->output_progress([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], true);
+                echo json_encode([
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => $probe["reason"],
+                    "abort_detail" => $probe["detail"],
+                ], JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = in_array($probe["reason"], $retryable, true) ? 2 : 1;
+                return;
+            }
+            $this->audit_log(
+                "PUSH APPLY PROBE | {$probe["reason"]} | staging only, apply deferred",
+                false,
+            );
+        }
+
+        $runner = new StagedPushRunner([
+            "state_dir" => $this->state_dir,
+            "client" => $client,
+            "sizer" => $sizer,
+            // Absolute-mode ids are already rooted, so source_root is empty;
+            // relative-mode ids resolve under --fs-root.
+            "source_root" => $this->index_path_style === "absolute" ? "" : $this->fs_root,
+            "on_progress" => function (array $progress): void {
+                $this->output_progress([
+                    "type" => "push_progress",
+                    "files_done" => $progress["files_done"],
+                    "files_total" => $progress["files_total"],
+                    "path" => $progress["artifact_id"],
+                    "committed_bytes" => $progress["committed_bytes"],
+                    "total_bytes" => $progress["total_bytes"],
+                ]);
+            },
+        ]);
+
+        if ($probe["status"] === "ready") {
+            if (($probe["max_request_bytes"] ?? null) !== null) {
+                // Seed the sizer from the target's declared cap instead of
+                // waiting for the first 413 to teach it.
+                $sizer->apply_reported_limits([$probe["max_request_bytes"]]);
+            }
+            $staging_free = $probe["staging_free_bytes"] ?? null;
+            if ($staging_free !== null && $diff["pending_bytes"] > $staging_free) {
+                // The transfer could never fit; refuse before uploading.
+                $summary = [
+                    "type" => "push",
+                    "status" => "error",
+                    "abort_reason" => "insufficient_staging_space",
+                    "abort_detail" => sprintf(
+                        "pending upload needs %d bytes, staging has %d free",
+                        $diff["pending_bytes"],
+                        $staging_free,
+                    ),
+                ];
+                $this->output_progress($summary, true);
+                echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+                $this->exit_code = 1;
+                return;
+            }
+        }
+
+        $result = $runner->push($this->push_upload_list_file);
+
+        $summary = [
+            "type" => "push",
+            "status" => $result["status"] === "completed" && $result["failed"] === []
+                ? "complete"
+                : "error",
+            "files_total" => $result["files_total"],
+            "files_done" => $result["files_done"],
+            "failed" => $result["failed"],
+            "skipped" => count($skipped),
+            "abort_reason" => $result["abort_reason"],
+            "abort_detail" => $result["abort_detail"],
+        ];
+        $this->output_progress($summary, true);
+        echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+
+        if ($result["status"] === "aborted") {
+            $this->audit_log(
+                "PUSH ABORTED | {$result["abort_reason"]} | " . ($result["abort_detail"] ?? ""),
+                false,
+            );
+            // Transient transfer failures follow the resumable convention;
+            // a bad secret or a chunk size the host can never accept will
+            // not fix itself.
+            $this->exit_code = in_array($result["abort_reason"], self::PUSH_RETRYABLE_REASONS, true) ? 2 : 1;
+            return;
+        }
+        if ($result["failed"] !== []) {
+            $this->exit_code = 1;
+            return;
+        }
+        if (!$apply) {
+            $this->exit_code = 0;
+            return;
+        }
+        $this->exit_code = $this->run_push_apply($client);
+    }
+
+    /**
+     * Stage the manifest for a completed transfer and apply it.
+     *
+     * The manifest lists every planned artifact with its size; the target
+     * validates the whole transfer against it (device match included)
+     * before the first rename, so an incomplete or inconsistent transfer
+     * rejects instead of half-applying.
+     *
+     * @return int Process exit code.
+     */
+    private function run_push_apply(StagedUploadClient $client): int
+    {
+        // The manifest lists every uploaded file (rename into place) and every
+        // deletion the diff derived (remove) — nothing else. Unchanged files
+        // are "same" in the diff, never staged and never listed. Both work
+        // lists are written in path order, so streaming them keeps the
+        // manifest bounded regardless of transfer size.
+        $manifest_path = $this->state_dir . "/.push-manifest.jsonl";
+        $manifest = @fopen($manifest_path, "wb");
+        if ($manifest === false) {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => "manifest_write_failed",
+                "abort_detail" => $manifest_path,
+            ]);
+        }
+
+        $upload_handle = @fopen($this->push_upload_list_file, "r");
+        if ($upload_handle !== false) {
+            while (true) {
+                $entry = $this->read_push_upload_entry($upload_handle);
+                if ($entry === null) {
+                    break;
+                }
+                // Store artifact ids drop the leading slash absolute-mode
+                // index paths carry (a no-op in relative mode).
+                if (!$this->write_push_manifest_entry($manifest, [
+                    "artifact_id" => ltrim($entry["path"], "/"),
+                    "size" => $entry["size"],
+                ])) {
+                    fclose($upload_handle);
+                    fclose($manifest);
+                    return $this->finish_push_apply("error", [
+                        "abort_reason" => "manifest_write_failed",
+                        "abort_detail" => $manifest_path,
+                    ]);
+                }
+            }
+            fclose($upload_handle);
+        }
+
+        $delete_handle = @fopen($this->push_deletions_file, "r");
+        if ($delete_handle !== false) {
+            while (true) {
+                $path = $this->read_push_deletion($delete_handle);
+                if ($path === null) {
+                    break;
+                }
+                if (!$this->write_push_manifest_entry($manifest, [
+                    "artifact_id" => ltrim($path, "/"),
+                    "delete" => true,
+                ])) {
+                    fclose($delete_handle);
+                    fclose($manifest);
+                    return $this->finish_push_apply("error", [
+                        "abort_reason" => "manifest_write_failed",
+                        "abort_detail" => $manifest_path,
+                    ]);
+                }
+            }
+            fclose($delete_handle);
+        }
+
+        if (!@fclose($manifest)) {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => "manifest_write_failed",
+                "abort_detail" => $manifest_path,
+            ]);
+        }
+
+        // A manifest from an earlier, different diff may sit at this id;
+        // replace it wholesale. Failures surface on the upload right after.
+        $client->discard(self::PUSH_MANIFEST_ID);
+        $uploaded = $client->upload_artifact(self::PUSH_MANIFEST_ID, $manifest_path);
+        if ($uploaded["status"] !== "verified") {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => $uploaded["reason"],
+                "abort_detail" => $uploaded["detail"],
+            ]);
+        }
+
+        $applied = $client->apply(self::PUSH_MANIFEST_ID);
+        if ($applied["status"] !== "applied") {
+            return $this->finish_push_apply("error", [
+                "abort_reason" => $applied["reason"],
+                "abort_detail" => $applied["detail"],
+            ]);
+        }
+
+        // The target confirmed the window: fold the uploaded files and
+        // deletions into the shipped index (push's local index) through the
+        // same streaming merge pull uses. A kill before this re-derives the
+        // identical diff next run, which reruns as idempotent no-ops.
+        $this->update_shipped_index_after_apply();
+
+        return $this->finish_push_apply("complete", [
+            "applied" => $applied["applied"],
+            "already_applied" => $applied["already_applied"],
+            "deleted" => $applied["deleted"],
+        ]);
+    }
+
+    /**
+     * Walk --fs-root into a sorted source index in the shared index format,
+     * reusing the same sort the exporter-built remote index goes through.
+     *
+     * @return array<int,array{path:string,reason:string}> skipped entries.
+     */
+    private function build_push_source_index(array $only): array
+    {
+        $handle = @fopen($this->push_source_index_file, "wb");
+        if ($handle === false) {
+            throw new RuntimeException("Failed to open push source index for writing");
+        }
+        try {
+            $build = PushPlanBuilder::build_index($this->fs_root, $only, $handle, $this->push_path_prefix());
+        } finally {
+            fclose($handle);
+        }
+        $this->sort_index_file($this->push_source_index_file);
+        return $build["skipped"];
+    }
+
+    /**
+     * The prefix push index paths carry for the active style: empty in
+     * relative (document-root) mode, the absolute fs-root in filesystem mode.
+     * Index paths and the skip list share this space; store artifact ids drop
+     * the leading slash (see the runner and manifest).
+     */
+    private function push_path_prefix(): string
+    {
+        if ($this->index_path_style !== "absolute") {
+            return "";
+        }
+        $real = realpath($this->fs_root);
+        return rtrim($real !== false ? $real : $this->fs_root, "/");
+    }
+
+    /**
+     * Diff the source index (the local tree) against the shipped index (what
+     * the target holds) with the same sorted-merge classifier pull's fetch
+     * diff uses, writing the upload list and the deletions list.
+     *
+     * @return array{upload_count:int,delete_count:int,pending_bytes:int}
+     */
+    private function diff_push_indexes(array $only, array $skipped_paths): array
+    {
+        $source_handle = file_exists($this->push_source_index_file)
+            ? fopen($this->push_source_index_file, "r")
+            : null;
+        $shipped_handle = file_exists($this->push_shipped_index_file)
+            ? fopen($this->push_shipped_index_file, "r")
+            : null;
+        $upload_handle = fopen($this->push_upload_list_file, "w");
+        $delete_handle = fopen($this->push_deletions_file, "w");
+        if (!$upload_handle || !$delete_handle) {
+            throw new RuntimeException("Failed to open push work lists");
+        }
+
+        // Index paths carry the style's prefix; --only prefixes are always
+        // fs-root-relative, so lift them into the same space to scope
+        // deletions correctly in either mode.
+        $prefix = $this->push_path_prefix();
+        $only_matched = $prefix === "" ? $only : array_map(
+            static fn(string $p): string => $prefix . "/" . $p,
+            $only
+        );
+
+        $source = $this->read_index_line($source_handle);
+        $shipped = $this->read_index_line($shipped_handle);
+        $upload_count = 0;
+        $delete_count = 0;
+        $pending_bytes = 0;
+
+        while (true) {
+            $verdict = self::classify_index_pair($source, $shipped);
+            if ($verdict === "done") {
+                break;
+            }
+            if ($verdict === "new") {
+                $this->write_push_upload_entry($upload_handle, $source);
+                $upload_count++;
+                $pending_bytes += $source["size"];
+                $source = $this->read_index_line($source_handle);
+            } elseif ($verdict === "removed") {
+                // A shipped path missing from the source is a deletion —
+                // unless it is outside the --only scope (excluded on purpose,
+                // not removed) or at/under a skipped local path (not read this
+                // run, so not proven removed; mirrors pull's --only guard).
+                $in_scope = $only === [] || PushPlanBuilder::selected($shipped["path"], $only_matched);
+                if ($in_scope && !$this->push_id_under_skipped($shipped["path"], $skipped_paths)) {
+                    $this->write_push_deletion($delete_handle, $shipped["path"]);
+                    $delete_count++;
+                }
+                $shipped = $this->read_index_line($shipped_handle);
+            } else {
+                // "changed" re-uploads; "same" skips. Push always replaces its
+                // own tree, so ownership needs no separate tracking here.
+                if ($verdict === "changed") {
+                    $this->write_push_upload_entry($upload_handle, $source);
+                    $upload_count++;
+                    $pending_bytes += $source["size"];
+                }
+                $source = $this->read_index_line($source_handle);
+                $shipped = $this->read_index_line($shipped_handle);
+            }
+        }
+
+        if ($source_handle) {
+            fclose($source_handle);
+        }
+        if ($shipped_handle) {
+            fclose($shipped_handle);
+        }
+        fclose($upload_handle);
+        fclose($delete_handle);
+
+        return [
+            "upload_count" => $upload_count,
+            "delete_count" => $delete_count,
+            "pending_bytes" => $pending_bytes,
+        ];
+    }
+
+    /**
+     * Fold the confirmed transfer into the shipped index: uploaded files enter
+     * at their source ctime/size, deletions leave. Both work lists are path
+     * sorted with disjoint paths, so a two-way merge feeds the index-update
+     * buffer in sorted order for finalize_index_updates.
+     */
+    private function update_shipped_index_after_apply(): void
+    {
+        $upload_handle = @fopen($this->push_upload_list_file, "r");
+        $delete_handle = @fopen($this->push_deletions_file, "r");
+        $up = $upload_handle !== false ? $this->read_push_upload_entry($upload_handle) : null;
+        $del = $delete_handle !== false ? $this->read_push_deletion($delete_handle) : null;
+
+        $this->begin_index_updates();
+        while ($up !== null || $del !== null) {
+            $take_upload = $del === null || ( $up !== null && strcmp($up["path"], $del) <= 0 );
+            if ($take_upload) {
+                $this->record_index_update_file($up["path"], $up["ctime"], $up["size"], "file");
+                $up = $this->read_push_upload_entry($upload_handle);
+            } else {
+                $this->record_index_update_deletion($del);
+                $del = $this->read_push_deletion($delete_handle);
+            }
+        }
+        $this->finalize_index_updates($this->push_shipped_index_file);
+
+        if ($upload_handle !== false) {
+            fclose($upload_handle);
+        }
+        if ($delete_handle !== false) {
+            fclose($delete_handle);
+        }
+    }
+
+    /** Upload-list line: base64 path plus the size/ctime apply and the shipped index need. */
+    private function write_push_upload_entry($handle, array $entry): void
+    {
+        $line = json_encode([
+            "path" => base64_encode($entry["path"]),
+            "size" => (int) $entry["size"],
+            "ctime" => (int) $entry["ctime"],
+        ], JSON_UNESCAPED_SLASHES);
+        if ($line === false || fwrite($handle, $line . "\n") === false) {
+            throw new RuntimeException("Failed to write the push upload list (disk full?)");
+        }
+    }
+
+    /**
+     * @return array{path:string,size:int,ctime:int}|null
+     */
+    private function read_push_upload_entry($handle): ?array
+    {
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                return null;
+            }
+            $line = trim($line);
+            if ($line === "") {
+                continue;
+            }
+            $data = json_decode($line, true);
+            if (!is_array($data)) {
+                continue;
+            }
+            $encoded = isset($data["path"]) ? (string) $data["path"] : "";
+            $path = base64_decode($encoded, true);
+            if ($path === false || $path === "") {
+                continue;
+            }
+            $size = isset($data["size"]) ? (int) $data["size"] : 0;
+            $ctime = isset($data["ctime"]) ? (int) $data["ctime"] : 0;
+            return [
+                "path" => $path,
+                "size" => $size,
+                "ctime" => $ctime,
+            ];
+        }
+    }
+
+    private function write_push_deletion($handle, string $path): void
+    {
+        $line = json_encode(["path" => base64_encode($path)], JSON_UNESCAPED_SLASHES);
+        if ($line === false || fwrite($handle, $line . "\n") === false) {
+            throw new RuntimeException("Failed to write the push deletions list (disk full?)");
+        }
+    }
+
+    private function read_push_deletion($handle): ?string
+    {
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                return null;
+            }
+            $line = trim($line);
+            if ($line === "") {
+                continue;
+            }
+            $data = json_decode($line, true);
+            if (!is_array($data)) {
+                continue;
+            }
+            $encoded = isset($data["path"]) ? (string) $data["path"] : "";
+            $path = base64_decode($encoded, true);
+            if ($path !== false && $path !== "") {
+                return $path;
+            }
+        }
+    }
+
+    private function write_push_manifest_entry($manifest, array $entry): bool
+    {
+        $encoded = json_encode($entry);
+        if (!is_string($encoded)) {
+            return false;
+        }
+        $line = $encoded . "\n";
+        while ($line !== "") {
+            $written = @fwrite($manifest, $line);
+            if ($written === false || $written === 0) {
+                return false;
+            }
+            $line = substr($line, $written);
+        }
+        return true;
+    }
+
+    /**
+     * Whether an id sits at or under a path the plan builder skipped.
+     *
+     * Skips (symlinks, special files, unreadable entries, and the subtree
+     * under an unreadable directory) mean the local tree was not fully read,
+     * never that a file was removed — so previously-pushed ids beneath them
+     * must not be derived as deletions. An empty skipped path is the root
+     * (its own scandir failed), which covers every id.
+     */
+    private function push_id_under_skipped(string $id, array $skipped_paths): bool
+    {
+        foreach ($skipped_paths as $skipped) {
+            if (!is_string($skipped)) {
+                continue;
+            }
+            if ($skipped === "" || $id === $skipped || strpos($id, $skipped . "/") === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return int Process exit code.
+     */
+    private function finish_push_apply(string $status, array $fields): int
+    {
+        $summary = array_merge(["type" => "push_apply", "status" => $status], $fields);
+        $this->output_progress($summary, true);
+        echo json_encode($summary, JSON_PRETTY_PRINT) . "\n";
+        if ($status === "complete") {
+            return 0;
+        }
+        $this->audit_log(
+            "PUSH APPLY FAILED | " . ($fields["abort_reason"] ?? "unknown") . " | " . ($fields["abort_detail"] ?? ""),
+            false,
+        );
+        return in_array($fields["abort_reason"] ?? null, self::PUSH_RETRYABLE_REASONS, true) ? 2 : 1;
+    }
+
+    private function staged_pull_staging_dir(): string
+    {
+        return $this->state_dir . "/.pull-staging";
+    }
+
+    /** The manifest log accumulates one line per staged file across resumes. */
+    private function staged_pull_manifest_log(): string
+    {
+        return $this->state_dir . "/.pull-staged-manifest.jsonl";
+    }
+
+    private function staged_pull_store(): Site_Export_Staged_Artifacts
+    {
+        if ($this->staged_pull_store === null) {
+            $this->staged_pull_store = new Site_Export_Staged_Artifacts($this->staged_pull_staging_dir());
+        }
+        return $this->staged_pull_store;
+    }
+
+    private function staged_pull_apply_engine(?callable $on_protected = null): Site_Export_Staged_Apply
+    {
+        $preserve_local = $this->fs_root_nonempty_behavior === "preserve-local";
+        return new Site_Export_Staged_Apply([
+            "staging_dir" => $this->staged_pull_staging_dir(),
+            "target_root" => $this->fs_root,
+            // Preserve-local keeps its write-time meaning at apply time:
+            // occupied paths win, and nothing is created through a
+            // symlinked directory.
+            "on_existing" => $preserve_local ? "skip" : "replace",
+            "refuse_symlinked_parents" => $preserve_local,
+            // The uncapped per-entry channel: index reconciliation after
+            // the window must see every protected id, not the capped
+            // diagnostic list in the result.
+            "on_protected" => $on_protected,
+        ]);
+    }
+
+    /** The fs-root-relative artifact id for a mapped local path. */
+    private function staged_pull_artifact_id(string $local_path): string
+    {
+        // The path mapper may hand back a resolved fs-root (macOS /var is
+        // a symlink to /private/var); accept either spelling.
+        $roots = [rtrim($this->fs_root, "/")];
+        $real_root = realpath($this->fs_root);
+        if (is_string($real_root) && $real_root !== "") {
+            $roots[] = rtrim($real_root, "/");
+        }
+        foreach (array_unique($roots) as $root) {
+            if (strpos($local_path, $root . "/") === 0) {
+                return substr($local_path, strlen($root) + 1);
+            }
+        }
+        throw new RuntimeException(
+            "Staged pull cannot stage a path outside --fs-root: {$local_path}",
+        );
+    }
+
+    /**
+     * Refuses a staged pull the apply step could never finish — above all
+     * a state dir on a different filesystem than --fs-root, where the
+     * rename-only apply would reject cross_device only after the download.
+     * The probe id never exists, so this checks the environment only.
+     */
+    private function assert_staged_pull_ready(): void
+    {
+        if (!is_dir($this->fs_root)) {
+            @mkdir($this->fs_root, 0755, true);
+        }
+        $probe = $this->staged_pull_apply_engine()->apply(".reprint-pull-probe", true);
+        if ($probe["status"] !== "ready") {
+            throw new RuntimeException(
+                "Staged apply cannot run here: " . ($probe["reason"] ?? $probe["status"]) .
+                    " (" . ($probe["detail"] ?? "") . "). Put --state-dir on the same " .
+                    "filesystem as --fs-root, or drop --staged-apply.",
+            );
+        }
+    }
+
+    /**
+     * Stages one body buffer for the file the stream is delivering.
+     *
+     * context->file_bytes_written tracks the STREAM position; the store
+     * enforces its own committed offset. Bytes the server re-sends after a
+     * resume land as duplicates and only the unseen tail is appended — the
+     * same frontier handling the push endpoint uses.
+     */
+    private function staged_pull_write_chunk(StreamingContext $context, string $data): void
+    {
+        $store = $this->staged_pull_store();
+        $artifact_id = $context->staged_artifact_id;
+        $offset = $context->file_bytes_written;
+        $committed = $store->status($artifact_id)["committed_bytes"];
+
+        if ($committed >= $offset + strlen($data)) {
+            $context->file_bytes_written = $offset + strlen($data);
+            return;
+        }
+        if ($committed > $offset) {
+            $data = substr($data, $committed - $offset);
+            $offset = $committed;
+        }
+
+        $result = $store->append($artifact_id, $offset, $data);
+        if ($result["status"] === "accepted" || $result["status"] === "duplicate") {
+            $context->file_bytes_written = $result["committed_bytes"];
+            return;
+        }
+        if ($result["status"] === "rejected" && $result["reason"] === "already_verified") {
+            // A lost checkpoint made the server re-send a file the store
+            // already verified, and it now sends bytes past the verified
+            // size — the remote grew since we staged it, so the staged copy
+            // is stale. We lack the resent prefix to re-stage it in place, so
+            // drop it and let the next delta refetch it whole (the same
+            // tolerance x-file-changed uses). This turns what used to be a
+            // rethrown wedge on every resume into a clean skip.
+            $store->discard($artifact_id);
+            $context->skip_current_file = true;
+            return;
+        }
+        throw new RuntimeException(
+            "Staged write failed for {$artifact_id}: " .
+                ($result["reason"] ?? $result["status"]) .
+                " " . ($result["detail"] ?? ""),
+        );
+    }
+
+    /**
+     * Verifies a fully-streamed file and records it for the apply window.
+     *
+     * @return string|null Failure reason, or null when the file verified.
+     */
+    private function staged_pull_finalize_file(string $artifact_id, int $expected_size, int $ctime, bool $owned, string $remote_path): ?string
+    {
+        $result = $this->staged_pull_store()->finalize($artifact_id, $expected_size);
+        if ($result["status"] !== "verified") {
+            return ($result["reason"] ?? $result["status"]) . " " . ($result["detail"] ?? "");
+        }
+        if ($ctime) {
+            // Rename preserves this mtime, which delta syncs compare
+            // against the remote ctime.
+            @touch($this->staged_pull_staging_dir() . "/files/" . $artifact_id, $ctime);
+        }
+        // The remote path and ctime ride along so the window can update
+        // the local index after the file actually lands — the index must
+        // describe the live tree, never the staging area, or an abort
+        // between fetch and apply leaves a delta that skips files the
+        // tree never received.
+        $record = [
+            "artifact_id" => $artifact_id,
+            "size" => $expected_size,
+            "path" => $remote_path,
+            "ctime" => $ctime,
+        ];
+        if ($owned) {
+            $record["owned"] = true;
+        }
+        $this->staged_pull_append_log(json_encode($record) . "\n");
+        return null;
+    }
+
+    /**
+     * Appends a deferred record to the manifest log, keyed by the path's
+     * fs-root-relative artifact id. Directory and symlink parts defer here
+     * in staged mode; the apply window replays them through their regular
+     * handlers.
+     */
+    private function staged_pull_defer_record(array $record): void
+    {
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($record["path"]);
+            $record["artifact_id"] = $this->staged_pull_artifact_id($local_path);
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "Security: refusing to stage a {$record["type"]} record for invalid path '{$record["path"]}': " . $e->getMessage(),
+                true,
+            );
+            return;
+        }
+        $this->staged_pull_append_log(json_encode($record) . "\n");
+    }
+
+    /**
+     * All manifest-log appends go through here: a lost record is a file,
+     * directory, symlink, or deletion the window would silently never
+     * carry out, so short writes are fatal (disk full?) like the index
+     * updates writer's.
+     */
+    private function staged_pull_append_log(string $line): void
+    {
+        if (@file_put_contents($this->staged_pull_manifest_log(), $line, FILE_APPEND) !== strlen($line)) {
+            throw new RuntimeException("Failed to append to the staged manifest log (disk full?)");
+        }
+    }
+
+    /**
+     * Whether a delivered file landed in the live tree at the size we staged
+     * it — a plain file, not a symlink or directory. Used to tell our own
+     * kill-interrupted apply from a genuinely preserve-local-protected path
+     * when deciding whether a protected entry still belongs in the index.
+     */
+    private function staged_pull_delivered_size_matches(string $remote_path, int $size): bool
+    {
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($remote_path);
+        } catch (RuntimeException $e) {
+            return false;
+        }
+        return !is_link($local_path) && is_file($local_path) && @filesize($local_path) === $size;
+    }
+
+    /**
+     * Records a diff-derived deletion for the apply window instead of
+     * removing the file at diff time — staged mode's whole point is that
+     * the tree flips in one window, deletions included. The index entry
+     * stays until the window confirms: a crash or --abort in between just
+     * re-derives the same deletion from the next diff, never orphaning a
+     * file the index has already forgotten.
+     */
+    private function record_staged_pull_deletion(string $remote_path): void
+    {
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($remote_path);
+            $artifact_id = $this->staged_pull_artifact_id($local_path);
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "Security: refusing to stage a deletion for invalid path '{$remote_path}': " . $e->getMessage(),
+                true,
+            );
+            return;
+        }
+        // Any bytes staged under this id from an earlier resume are
+        // garbage now; the apply window's delete pass consumes them.
+        $this->staged_pull_append_log(json_encode([
+            "artifact_id" => $artifact_id,
+            "delete" => true,
+            "path" => $remote_path,
+        ]) . "\n");
+        $this->audit_log("Deletion staged for the apply window: {$remote_path}", false);
+    }
+
+    /**
+     * Applies everything staged so far in one rename window.
+     *
+     * Runs at each point the file phase completes. The manifest log
+     * accumulates across resumes and is deduplicated here; entries an
+     * earlier window already applied classify as applied and only consume
+     * their leftover markers.
+     *
+     * The window is: engine apply (file renames and deletions under the
+     * store lock), then a replay of deferred directory/symlink records
+     * through their regular handlers, then the index catch-up. Everything
+     * before the final log unlink is idempotent, so a kill anywhere in
+     * the window reruns cleanly.
+     */
+    private function run_staged_pull_apply(): void
+    {
+        if (!$this->staged_apply_mode) {
+            return;
+        }
+
+        // Last record wins per artifact id: a file staged by one resume
+        // and deleted remotely before the next accumulates both lines,
+        // and the later one reflects the newer remote truth.
+        $entries = [];
+        $log_handle = @fopen($this->staged_pull_manifest_log(), "r");
+        if ($log_handle !== false) {
+            while (true) {
+                $line = fgets($log_handle);
+                if ($line === false) {
+                    break;
+                }
+                $record = json_decode($line, true);
+                if (!is_array($record) || !is_string($record["artifact_id"] ?? null)) {
+                    continue;
+                }
+                $path = is_string($record["path"] ?? null) ? $record["path"] : null;
+                if (!empty($record["delete"])) {
+                    $entries[$record["artifact_id"]] = ["kind" => "delete", "path" => $path];
+                    continue;
+                }
+                $type = $record["type"] ?? null;
+                $ctime = is_int($record["ctime"] ?? null) ? $record["ctime"] : 0;
+                if ($type === "dir" && $path !== null) {
+                    $entries[$record["artifact_id"]] = [
+                        "kind" => "dir",
+                        "path" => $path,
+                        "ctime" => $ctime,
+                    ];
+                    continue;
+                }
+                if ($type === "symlink" && $path !== null && is_string($record["target"] ?? null)) {
+                    $entries[$record["artifact_id"]] = [
+                        "kind" => "symlink",
+                        "path" => $path,
+                        "target" => $record["target"],
+                        "ctime" => $ctime,
+                    ];
+                    continue;
+                }
+                if ($type === null && is_int($record["size"] ?? null)) {
+                    $entries[$record["artifact_id"]] = [
+                        "kind" => "file",
+                        "size" => $record["size"],
+                        "owned" => !empty($record["owned"]),
+                        "path" => $path,
+                        "ctime" => $ctime,
+                    ];
+                }
+            }
+            fclose($log_handle);
+        }
+        if ($entries === []) {
+            return;
+        }
+
+        // Only files and deletions go through the store-backed engine;
+        // directories and symlinks replay through their own handlers after
+        // the renames land.
+        $result = [
+            "applied" => 0,
+            "already_applied" => 0,
+            "skipped" => 0,
+            "skipped_paths" => [],
+            "deleted" => 0,
+        ];
+        $protected_ids = [];
+        $store = $this->staged_pull_store();
+        $store->discard(self::PULL_MANIFEST_ID);
+        $manifest_entries = 0;
+        $manifest_bytes = 0;
+        // Flush manifest lines to the store in bounded windows instead of
+        // materializing one string that can reach tens of megabytes.
+        $manifest_chunk = "";
+        foreach ($entries as $artifact_id => $entry) {
+            if ($entry["kind"] === "delete") {
+                $manifest_entry = ["artifact_id" => $artifact_id, "delete" => true];
+            } elseif ($entry["kind"] === "file") {
+                $manifest_entry = ["artifact_id" => $artifact_id, "size" => $entry["size"]];
+                if ($entry["owned"]) {
+                    $manifest_entry["owned"] = true;
+                }
+            } else {
+                continue;
+            }
+            $encoded = json_encode($manifest_entry);
+            if (!is_string($encoded)) {
+                throw new RuntimeException("Staged apply could not encode its manifest.");
+            }
+            $manifest_chunk .= $encoded . "\n";
+            $manifest_entries++;
+            if (strlen($manifest_chunk) >= 262144) {
+                $manifest_bytes = $this->append_staged_pull_manifest_chunk($store, $manifest_bytes, $manifest_chunk);
+                $manifest_chunk = "";
+            }
+        }
+
+        if ($manifest_entries > 0) {
+            if ($manifest_chunk !== "") {
+                $manifest_bytes = $this->append_staged_pull_manifest_chunk($store, $manifest_bytes, $manifest_chunk);
+            }
+            if ($store->finalize(self::PULL_MANIFEST_ID, $manifest_bytes)["status"] !== "verified") {
+                throw new RuntimeException("Staged apply could not verify its manifest.");
+            }
+
+            $this->audit_log("STAGED APPLY | " . count($entries) . " entries", true);
+            // Every protected id flows through the callback, uncapped —
+            // the PRESERVE-LOCAL audit contract and the index catch-up
+            // below both need the full set, not the response's capped
+            // diagnostic list.
+            $engine = $this->staged_pull_apply_engine(function (string $artifact_id) use (&$protected_ids): void {
+                if (isset($protected_ids[$artifact_id])) {
+                    return;
+                }
+                $protected_ids[$artifact_id] = true;
+                $this->audit_log("PRESERVE-LOCAL skip file (kept at apply) | {$artifact_id}", false);
+            });
+            $result = $engine->apply(self::PULL_MANIFEST_ID);
+            if ($result["status"] !== "applied") {
+                throw new RuntimeException(
+                    "Staged apply failed: " . ($result["reason"] ?? $result["status"]) .
+                        " (" . ($result["detail"] ?? "") . ")",
+                );
+            }
+        }
+
+        // The index merge consumes its updates as a path-sorted stream
+        // (trunk keeps it sorted by upserting in fetch order). Flush any
+        // fetch-phase leftovers as their own sorted run first, then walk
+        // the window's entries in path order so replays and index writes
+        // emit one sorted run of their own.
+        $this->finalize_index_updates();
+        uasort($entries, static function (array $a, array $b): int {
+            $a_path = (string) $a["path"];
+            $b_path = (string) $b["path"];
+            return strcmp($a_path, $b_path);
+        });
+
+        // The window's remaining effects, one path-ordered walk:
+        // directory and symlink records replay through the handlers that
+        // would have run at fetch time in unstaged mode — same policy
+        // checks, same validation, same audit lines, just at window time
+        // (their index upserts included). Applied files enter the index,
+        // confirmed deletions leave it — mirroring push's
+        // forget-after-confirm. Protected entries keep their old state
+        // and re-derive next delta — a re-download or a no-op, never an
+        // orphan. Every step is idempotent, so a kill here reruns
+        // cleanly from the log.
+        $this->staged_replay = true;
+        try {
+            foreach ($entries as $artifact_id => $entry) {
+                if ($entry["path"] === null) {
+                    continue;
+                }
+                if ($entry["kind"] === "dir") {
+                    $this->handle_directory_chunk(["headers" => [
+                        "x-directory-path" => base64_encode($entry["path"]),
+                        "x-directory-ctime" => (string) $entry["ctime"],
+                    ]]);
+                    continue;
+                }
+                if ($entry["kind"] === "symlink") {
+                    $this->handle_symlink_chunk(["headers" => [
+                        "x-symlink-path" => base64_encode($entry["path"]),
+                        "x-symlink-target" => base64_encode($entry["target"]),
+                        "x-symlink-ctime" => (string) $entry["ctime"],
+                    ]]);
+                    continue;
+                }
+                if (isset($protected_ids[$artifact_id])) {
+                    // A file entry the engine reported protected may be our
+                    // own delivery from a prior window that a kill interrupted
+                    // before this index catch-up. Everything in the manifest
+                    // log was fetched by us, and preserve-local only fetches
+                    // paths that were empty at fetch time, so an occupant
+                    // matching our delivered size is our copy — not a
+                    // pre-existing local file. Record it, or the next delta
+                    // finds an occupied-but-unindexed path, re-fetches, and
+                    // re-skips it forever. A genuine protection (size
+                    // mismatch, a foreign occupant) is left untouched.
+                    if (
+                        $entry["kind"] === "file"
+                        && $entry["ctime"] > 0
+                        && $this->staged_pull_delivered_size_matches($entry["path"], $entry["size"])
+                    ) {
+                        $this->upsert_index_entry($entry["path"], $entry["ctime"], $entry["size"], "file");
+                    }
+                    continue;
+                }
+                if ($entry["kind"] === "delete") {
+                    $this->delete_index_entry($entry["path"]);
+                } elseif ($entry["kind"] === "file" && $entry["ctime"] > 0) {
+                    $this->upsert_index_entry($entry["path"], $entry["ctime"], $entry["size"], "file");
+                }
+            }
+        } finally {
+            $this->staged_replay = false;
+        }
+        $this->finalize_index_updates();
+
+        // Unlinked last: everything above idempotently reruns from the
+        // log if the process dies mid-window.
+        @unlink($this->staged_pull_manifest_log());
+
+        $this->audit_log(
+            sprintf(
+                "STAGED APPLY COMPLETE | applied=%d already_applied=%d skipped=%d deleted=%d",
+                $result["applied"],
+                $result["already_applied"],
+                $result["skipped"],
+                $result["deleted"],
+            ),
+            true,
+        );
+        $this->output_progress([
+            "type" => "staged_apply",
+            "status" => "complete",
+            "applied" => $result["applied"],
+            "already_applied" => $result["already_applied"],
+            "skipped" => $result["skipped"],
+            "deleted" => $result["deleted"],
+        ], true);
+    }
+
+    private function append_staged_pull_manifest_chunk(Site_Export_Staged_Artifacts $store, int $offset, string $chunk): int
+    {
+        $appended = $store->append(self::PULL_MANIFEST_ID, $offset, $chunk);
+        if ($appended["status"] !== "accepted") {
+            throw new RuntimeException(
+                "Staged apply could not stage its manifest: " . ($appended["reason"] ?? ""),
+            );
+        }
+        return $appended["committed_bytes"];
     }
 
     /**
@@ -5906,7 +7151,11 @@ class ImportClient
         // the new cursor, so we'll re-fetch the same data.
         $tracked_file = $this->import_state()->current_file ?? null;
         $tracked_bytes = $this->import_state()->current_file_bytes ?? null;
-        if ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
+        // Staged mode must not run this: the tracked path is the FINAL
+        // location, which during a delta still holds the previous version
+        // of the file — truncating it would destroy live content the apply
+        // step has not replaced yet. The store trims its own tails.
+        if (!$this->staged_apply_mode && $tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
             $actual_size = filesize($tracked_file);
             if ($actual_size > $tracked_bytes) {
                 $this->audit_log(
@@ -5945,7 +7194,28 @@ class ImportClient
         // request, re-open it in append mode so continuation chunks (where
         // is_first=false) can still be written.  Without this, the context
         // starts with file_handle=null and non-first chunks are silently dropped.
-        if ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
+        if ($this->staged_apply_mode && $tracked_file !== null && $tracked_bytes !== null) {
+            // Staged mode: nothing exists at the final path. Continuation
+            // chunks resume at the stream position saved with the cursor;
+            // the store's frontier absorbs any replayed prefix.
+            $context->staged_artifact_id = $this->staged_pull_artifact_id($tracked_file);
+            $context->file_path = $tracked_file;
+            $context->file_bytes_written = $tracked_bytes;
+            // Restore the ownership flag with the stream position. Without it
+            // a file that straddles a request boundary finalizes owned=false,
+            // and preserve-local then protects the pull's own old copy at
+            // apply time — the update never lands and every later delta
+            // re-downloads and re-skips it.
+            $context->staged_owned = $this->import_state()->current_file_owned === true;
+            $this->audit_log(
+                sprintf(
+                    "RESUME STAGED FILE | %s at stream offset %d",
+                    $tracked_file,
+                    $tracked_bytes,
+                ),
+                true,
+            );
+        } elseif ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
             $context->file_handle = fopen($tracked_file, "ab");
             if ($context->file_handle) {
                 $context->file_path = $tracked_file;
@@ -5994,9 +7264,18 @@ class ImportClient
                         fflush($context->file_handle);
                         $this->import_state()->current_file = $context->file_path;
                         $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                    } elseif ($context->staged_artifact_id !== null && $context->file_path) {
+                        // Staged mode: every append already flushed. Save
+                        // the stream position and ownership flag alongside
+                        // the cursor so a resumed request re-enters at the
+                        // same offset with the same preserve-local ownership.
+                        $this->import_state()->current_file = $context->file_path;
+                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                        $this->import_state()->current_file_owned = $context->staged_owned;
                     } else {
                         $this->import_state()->current_file = null;
                         $this->import_state()->current_file_bytes = null;
+                        $this->import_state()->current_file_owned = null;
                     }
                     $this->save_state($this->state);
                     $chunks_since_save = 0;
@@ -6445,8 +7724,14 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_local_file_path($local["path"]);
-                    $this->delete_index_entry($local["path"]);
+                    if ($this->staged_apply_mode) {
+                        // Staged mode defers the deletion into the apply
+                        // window, so removals and arrivals flip together.
+                        $this->record_staged_pull_deletion($local["path"]);
+                    } else {
+                        $this->delete_local_file_path($local["path"]);
+                        $this->delete_index_entry($local["path"]);
+                    }
                 }
                 $local_after = $local["path"];
                 $local = $this->read_index_line($local_handle);
@@ -6468,6 +7753,7 @@ class ImportClient
                     $this->append_download_list(
                         $remote["path"],
                         $target_handle,
+                        true,
                     );
                 }
                 $local_after = $local["path"];
@@ -6499,8 +7785,12 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_local_file_path($local["path"]);
-                $this->delete_index_entry($local["path"]);
+                if ($this->staged_apply_mode) {
+                    $this->record_staged_pull_deletion($local["path"]);
+                } else {
+                    $this->delete_local_file_path($local["path"]);
+                    $this->delete_index_entry($local["path"]);
+                }
             }
             $local_after = $local["path"];
             $local = $this->read_index_line($local_handle);
@@ -6611,6 +7901,23 @@ class ImportClient
                 "cursor" => null,
             ]));
             $this->save_state($this->state);
+        }
+
+        if ($this->staged_apply_mode) {
+            // The batch's ownership flags live in the download list slice
+            // the fetch state brackets; rebuilding from there covers
+            // resumed batches, whose batch file predates this process.
+            // One batch spans many requests, so rebuild only when the
+            // slice changes.
+            $batch_key = $list_file . ":" . $batch_offset . ":" . $next_offset;
+            if ($this->staged_batch_owned_key !== $batch_key) {
+                $this->staged_batch_owned = $this->read_download_list_owned(
+                    $list_file,
+                    $batch_offset,
+                    $next_offset,
+                );
+                $this->staged_batch_owned_key = $batch_key;
+            }
         }
 
         $post_data = [
@@ -6871,12 +8178,51 @@ class ImportClient
     /**
      * Append a path to the download list file.
      */
-    private function append_download_list(string $path, $handle): void
+    /**
+     * Owned paths within one batch's slice of the download list.
+     *
+     * @param int $from Byte offset of the batch's first list line.
+     * @param int $to   Byte offset just past its last line.
+     * @return array<string,true> keyed by remote path.
+     */
+    private function read_download_list_owned(string $list_file, int $from, int $to): array
     {
-        $line = json_encode(
-            ["path" => base64_encode($path)],
-            JSON_UNESCAPED_SLASHES,
-        );
+        $owned = [];
+        $handle = @fopen($list_file, "r");
+        if (!$handle) {
+            return $owned;
+        }
+        if ($from > 0) {
+            fseek($handle, $from);
+        }
+        while (ftell($handle) < $to) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            $record = json_decode(trim($line), true);
+            if (!is_array($record) || empty($record["owned"]) || !isset($record["path"])) {
+                continue;
+            }
+            $path = base64_decode($record["path"]);
+            if (is_string($path) && $path !== "") {
+                $owned[$path] = true;
+            }
+        }
+        fclose($handle);
+        return $owned;
+    }
+
+    private function append_download_list(string $path, $handle, bool $owned = false): void
+    {
+        $record = ["path" => base64_encode($path)];
+        if ($owned) {
+            // The diff found this path in the local index: the pull owns
+            // it. Staged apply needs the distinction — preserve-local
+            // protects what the sync never owned, not its own copies.
+            $record["owned"] = true;
+        }
+        $line = json_encode($record, JSON_UNESCAPED_SLASHES);
         if ($line !== false) {
             fwrite($handle, $line . "\n");
         }
@@ -6955,6 +8301,76 @@ class ImportClient
     /**
      * Parse one JSON index line into an array.
      */
+    /**
+     * Classify one step of a sorted-index merge join between a "source" index
+     * (what we want the target to hold) and a "base" index (what it holds
+     * now). Both entries are ?array with a 'path' (null at end-of-stream),
+     * read in ascending path order. Returns:
+     *   'new'     — path only in source: add it     (caller advances source)
+     *   'changed' — same path, ctime/size/type differ (caller advances both)
+     *   'same'    — same path, identical              (caller advances both)
+     *   'removed' — path only in base: gone from source (caller advances base)
+     *   'done'    — both streams exhausted
+     * Pull's fetch diff and push's upload diff both drive from this one rule.
+     */
+    private static function classify_index_pair(?array $source, ?array $base): string
+    {
+        if ($source === null && $base === null) {
+            return "done";
+        }
+        if ($base === null) {
+            return "new";
+        }
+        if ($source === null) {
+            return "removed";
+        }
+        $cmp = strcmp($source["path"], $base["path"]);
+        if ($cmp < 0) {
+            return "new";
+        }
+        if ($cmp > 0) {
+            return "removed";
+        }
+        if (
+            $source["ctime"] !== $base["ctime"] ||
+            $source["size"] !== $base["size"] ||
+            $source["type"] !== $base["type"]
+        ) {
+            return "changed";
+        }
+        return "same";
+    }
+
+    /**
+     * Validate an index/transfer path for the active path style. Absolute
+     * mode requires a leading slash (the shared assert_valid_path rule);
+     * relative mode requires a clean fs-root-relative path with no leading
+     * slash and no dot-segments — the same shape the staged store accepts as
+     * an artifact id.
+     */
+    private function assert_valid_index_path(string $path): void
+    {
+        if ($this->index_path_style !== "relative") {
+            assert_valid_path($path, "index path");
+            return;
+        }
+        $trimmed = trim($path);
+        if ($trimmed === "") {
+            throw new InvalidArgumentException("index path must be a non-empty string");
+        }
+        if ($trimmed[0] === "/") {
+            throw new InvalidArgumentException("index path must be relative in relative path style");
+        }
+        if (strpos($trimmed, "\0") !== false) {
+            throw new InvalidArgumentException("index path must not contain NUL bytes");
+        }
+        foreach (explode("/", $trimmed) as $segment) {
+            if ($segment === "" || $segment === "." || $segment === "..") {
+                throw new InvalidArgumentException("index path must not contain empty or dot-segments");
+            }
+        }
+    }
+
     private function parse_index_line(string $line): ?array
     {
         $line = trim($line);
@@ -6973,7 +8389,7 @@ class ImportClient
         if ($path === "" || $path === false) {
             throw new RuntimeException("Invalid index path (base64 decode failed)");
         }
-        assert_valid_path($path, "index path");
+        $this->assert_valid_index_path($path);
         return [
             "path" => $path,
             "ctime" => (int) ($data["ctime"] ?? 0),
@@ -7109,8 +8525,11 @@ class ImportClient
     /**
      * Merge the collected updates with the existing sorted index without loading it into memory.
      */
-    private function finalize_index_updates(): void
+    private function finalize_index_updates(?string $index_file = null): void
     {
+        // Push reuses this exact streaming merge for its shipped index by
+        // passing that file; pull passes nothing and merges its local index.
+        $index_file = $index_file ?? $this->index_file;
         if ($this->index_updates_handle) {
             fclose($this->index_updates_handle);
             $this->index_updates_handle = null;
@@ -7142,14 +8561,14 @@ class ImportClient
         }
 
         $updates_path = $this->index_updates_file;
-        $new_index = $this->index_file . ".new";
+        $new_index = $index_file . ".new";
 
         $this->audit_log(
-            "INDEX MERGE START | merging updates into {$this->index_file}",
+            "INDEX MERGE START | merging updates into {$index_file}",
         );
 
-        $old_handle = file_exists($this->index_file)
-            ? fopen($this->index_file, "r")
+        $old_handle = file_exists($index_file)
+            ? fopen($index_file, "r")
             : null;
         $upd_handle = fopen($updates_path, "r");
         $new_handle = fopen($new_index, "w");
@@ -7226,10 +8645,10 @@ class ImportClient
         fclose($upd_handle);
         fclose($new_handle);
 
-        if (!rename($new_index, $this->index_file)) {
+        if (!rename($new_index, $index_file)) {
             throw new RuntimeException("Failed to replace index file");
         }
-        $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
+        $this->audit_log("INDEX MERGE COMPLETE | {$index_file} updated");
 
         @unlink($updates_path);
         $this->audit_log("FILE DELETE | {$updates_path} | updates merged");
@@ -8916,6 +10335,7 @@ class ImportClient
             $context->skip_current_file = false;
 
             if (
+                !$this->staged_apply_mode &&
                 (file_exists($local_path) || is_link($local_path)) &&
                 (!is_file($local_path) || is_link($local_path))
             ) {
@@ -8976,7 +10396,24 @@ class ImportClient
         }
 
         // Open file handle on first chunk
-        if ($is_first) {
+        if ($is_first && $this->staged_apply_mode) {
+            // Bytes go to the staged store, not the live tree; the stream
+            // position starts at 0 and the store's frontier absorbs any
+            // committed prefix a resumed server re-sends.
+            $context->staged_artifact_id = $this->staged_pull_artifact_id($local_path);
+            $context->staged_owned = isset($this->staged_batch_owned[$path]);
+            $context->file_path = $local_path;
+            $context->file_ctime = (int) ($headers["x-file-ctime"] ?? 0);
+            $context->file_bytes_written = 0;
+            // A lost checkpoint can make the server re-send a file the store
+            // already verified. Its staged bytes may be stale — the remote
+            // could have changed at the same size (invisible to byte counts)
+            // or grown since — so discard them and let this fresh stream
+            // re-verify the current content instead of trusting the old copy.
+            if ($this->staged_pull_store()->status($context->staged_artifact_id)["verified"]) {
+                $this->staged_pull_store()->discard($context->staged_artifact_id);
+            }
+        } elseif ($is_first) {
             // Close previous file if any
             if ($context->file_handle) {
                 fclose($context->file_handle);
@@ -9020,7 +10457,16 @@ class ImportClient
 
         // Write body data if present
         if (isset($chunk["body"]) && $chunk["body"] !== "") {
-            if ($context->file_handle) {
+            if ($this->staged_apply_mode) {
+                if ($context->staged_artifact_id === null) {
+                    // Mid-file continuation after a restart that never
+                    // checkpointed this file: the server re-sends it from
+                    // the start, so the stream position begins at 0.
+                    $context->staged_artifact_id = $this->staged_pull_artifact_id($local_path);
+                    $context->staged_owned = isset($this->staged_batch_owned[$path]);
+                }
+                $this->staged_pull_write_chunk($context, $chunk["body"]);
+            } elseif ($context->file_handle) {
                 $data = $chunk["body"];
                 $bytes = fwrite($context->file_handle, $data);
                 if ($bytes === false || $bytes !== strlen($data)) {
@@ -9032,6 +10478,56 @@ class ImportClient
                 }
                 $context->file_bytes_written += $bytes;
             }
+        }
+
+        // Complete a staged file on last chunk
+        if ($is_last && $this->staged_apply_mode && $context->staged_artifact_id !== null) {
+            $file_size = (int) ($headers["x-file-size"] ?? 0);
+            $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
+
+            if ($file_changed) {
+                // Same tolerance as the direct path: the exporter saw the
+                // file change mid-stream, so drop the staged copy and let
+                // the next delta refetch it.
+                $this->staged_pull_store()->discard($context->staged_artifact_id);
+                $this->audit_log(
+                    "  File changed during stream; staged copy discarded",
+                    true,
+                );
+            } else {
+                $finalize_error = $this->staged_pull_finalize_file(
+                    $context->staged_artifact_id,
+                    $file_size,
+                    $context->file_ctime ?? 0,
+                    $context->staged_owned === true,
+                    $path,
+                );
+                if ($finalize_error !== null) {
+                    $this->staged_pull_store()->discard($context->staged_artifact_id);
+                    $this->audit_log(
+                        "  Staged file did not verify ({$finalize_error}); discarded for refetch",
+                        true,
+                    );
+                } else {
+                    // The index entry waits for the apply window; only
+                    // progress bookkeeping happens at stage time.
+                    $this->files_imported++;
+                    $this->clear_volatile_file($path);
+                    $this->audit_log(
+                        sprintf("  Staged (%d bytes)", $file_size),
+                        false,
+                    );
+                }
+            }
+
+            $context->staged_artifact_id = null;
+            $context->file_path = null;
+            $context->file_ctime = null;
+            $context->file_bytes_written = 0;
+            $this->import_state()->current_file = null;
+            $this->import_state()->current_file_bytes = null;
+            $this->import_state()->current_file_owned = null;
+            return;
         }
 
         // Close on last chunk
@@ -9314,6 +10810,17 @@ class ImportClient
             return;
         }
 
+        if ($this->staged_apply_mode && !$this->staged_replay) {
+            // Staged mode: the live tree stays untouched until the apply
+            // window, which replays this record through this same handler.
+            $this->staged_pull_defer_record([
+                "type" => "dir",
+                "path" => $path,
+                "ctime" => $ctime,
+            ]);
+            return;
+        }
+
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
 
         // In preserve-local mode, if the directory already exists (as a real
@@ -9397,6 +10904,19 @@ class ImportClient
                     true,
                 );
             }
+            return;
+        }
+
+        if ($this->staged_apply_mode && !$this->staged_replay) {
+            // Staged mode: defer, window replays. The raw remote target is
+            // recorded; mapping and validation run at replay, in the same
+            // code they always run in.
+            $this->staged_pull_defer_record([
+                "type" => "symlink",
+                "path" => $path,
+                "target" => $target,
+                "ctime" => $ctime,
+            ]);
             return;
         }
 
@@ -10812,110 +12332,10 @@ class ImportClient
 
     public function default_state(): array
     {
-        return [
-            // Resume checkpoint for the lower-level command currently being
-            // run directly or as a stage inside a pull pipeline.
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
-            "preflight" => null,
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
-            "webhost" => null,
-            "follow_symlinks" => true,
-            "fs_root_nonempty_behavior" => "error",
-            "filter" => "none",
-            "user_agent" => null,
-            "max_allowed_packet" => null,
-            "files_remap_fingerprint" => null,
-            "files_pull_only_fingerprint" => null,
-            "files_pull_summary" => [
-                "files_pulled" => 0,
-            ],
-            "db_index" => [
-                "file" => null,
-                "tables" => 0,
-                "rows_estimated" => 0,
-                "bytes" => 0,
-                "updated_at" => null,
-            ],
-            "diff" => [
-                "remote_offset" => 0,
-                "local_after" => null,
-            ],
-            "index" => [
-                "cursor" => null,
-            ],
-            "fetch" => [
-                "offset" => 0,
-                "next_offset" => 0,
-                "batch_file" => null,
-                "cursor" => null,
-                "batch_entries" => 0,
-            ],
-            "fetch_skipped" => [
-                "offset" => 0,
-                "next_offset" => 0,
-                "batch_file" => null,
-                "cursor" => null,
-                "batch_entries" => 0,
-            ],
-            // Crash recovery: track in-progress file downloads
-            // If we crash mid-write, we can truncate to the expected size on resume
-            "current_file" => null,        // Path to file being written
-            "current_file_bytes" => null,  // Expected bytes written so far
-            // Crash recovery: track SQL file size
-            "sql_bytes" => null,           // Expected SQL file size
-            // SQL streaming progress for user-facing statement counts.
-            "sql_statements_counted" => 0,
-            // db-apply state
-            "apply" => [
-                "statements_executed" => 0,
-                "bytes_read" => 0,
-                "rewrite_url" => null,
-                // Target database configuration — persisted by db-apply
-                // so that apply-runtime can generate DB_* constants.
-                "target_engine" => null,
-                "target_db" => null,
-                "target_host" => null,
-                "target_port" => null,
-                "target_user" => null,
-                "target_pass" => null,
-                "target_sqlite_path" => null,
-                "remote_paths_removed_from_local_site" => [],
-            ],
-            // SQL output mode (file, stdout, mysql) — persisted for resume
-            "sql_output" => null,
-            // MySQL connection parameters — persisted for resume (password excluded)
-            "mysql_host" => null,
-            "mysql_port" => null,
-            "mysql_user" => null,
-            "mysql_database" => null,
-            // Consecutive cURL timeout counter — tracks how many times in a
-            // row a timeout fired without the cursor advancing. After
-            // MAX_CONSECUTIVE_TIMEOUTS with no progress, the importer gives
-            // up instead of retrying forever.
-            "consecutive_timeouts" => 0,
-            // Adaptive tuning state/config
-            "tuning" => [
-                "config" => [],
-                "state" => [],
-            ],
-            // Resume checkpoint for the user-facing pull pipeline command
-            // being orchestrated.
-            "pull_pipeline" => [
-                "started_by_command" => null,
-                "stage_sequence" => [],
-                "last_completed_stage" => null,
-                "files_filter" => null,
-                "skipped_pending" => false,
-                "has_completed_once" => false,
-            ],
-        ];
+        // ImportState's typed properties are the single source of the
+        // persisted schema; a field added there appears here without a
+        // second hand-maintained copy to keep in lockstep.
+        return ImportState::from_array([])->to_array();
     }
 
 
@@ -11535,6 +12955,10 @@ class StreamingContext
     public $saw_completion = false;
     // When true, skip writing the current file (preserve-local mode)
     public $skip_current_file = false;
+    // Staged pull: fs-root-relative artifact id of the file being staged
+    public $staged_artifact_id = null;
+    // Staged pull: whether the download list marked this file owned
+    public $staged_owned = false;
 }
 
 /**
@@ -11653,7 +13077,7 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert', 'push-files'],
         ],
         [
             'name' => 'abort',
@@ -11670,7 +13094,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime', 'push-files'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -11914,8 +13338,43 @@ if (
             'placeholder' => 'SOURCE',
             'repeatable' => true,
             'help' => 'Restrict the file pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
-                'repeat for several. Default pulls everything',
-            'commands' => ['pull-files', 'files-pull'],
+                'repeat for several. Default pulls everything. For push-files, SOURCE is an fs-root-relative prefix',
+            'commands' => ['pull-files', 'files-pull', 'push-files'],
+        ],
+        [
+            'name' => 'apply',
+            'type' => 'flag',
+            'target' => 'apply',
+            'help' => 'After staging completes, apply the transfer into the remote tree ' .
+                '(rename-only; the environment is probed before any upload). Files earlier ' .
+                'pushes shipped that no longer exist locally are deleted from the remote ' .
+                'tree in the same window',
+            'commands' => ['push-files'],
+        ],
+        [
+            'name' => 'staged-apply',
+            'type' => 'flag',
+            'target' => 'staged_apply',
+            'help' => 'Download into a staging area under --state-dir and move files into ' .
+                '--fs-root in one rename window at the end, so the tree never holds a ' .
+                'half-written file (requires --state-dir and --fs-root on one filesystem). ' .
+                'The mode persists in state: resumes and later deltas stay staged. ' .
+                'To switch modes, run --abort first (pending staged data is discarded ' .
+                'and re-derived by the next sync)',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
+        ],
+        [
+            'name' => 'index-path-style',
+            'type' => 'value',
+            'target' => 'index_path_style',
+            'placeholder' => 'STYLE',
+            'valid_values' => ['absolute', 'relative'],
+            'help' => 'How transfer paths are represented: "absolute" mirrors the whole ' .
+                'filesystem layout (can carry paths from outside the document root); ' .
+                '"relative" mirrors just the --fs-root subtree, which is what appears in ' .
+                'staging. Defaults: pull=absolute, push=relative. Persists in state; ' .
+                '--abort before switching',
+            'commands' => ['pull', 'pull-files', 'files-pull', 'push-files'],
         ],
 
         // ── flat-docroot options ────────────────────────────────
@@ -12584,6 +14043,40 @@ if (
                 "\n" .
                 "Does not download any file contents.\n",
             "extra" => null,
+        ],
+        "push-files" => [
+            "level" => "high",
+            "short" => "Upload local files into the remote staged store (push)",
+            "usage" => "reprint push-files <remote-url> --secret=TOKEN --state-dir=DIR --fs-root=DIR [options]",
+            "description" =>
+                "Walks --fs-root and uploads every regular file into the remote\n" .
+                "site's staged artifact store, in bounded resumable chunks. The\n" .
+                "remote site keeps running untouched: nothing changes there until\n" .
+                "a later apply step moves the verified artifacts into place.\n" .
+                "\n" .
+                "Rerunning the command resumes: finished files are skipped from\n" .
+                "the local done cache, a half-uploaded file continues from the\n" .
+                "byte offset the store confirmed, and chunk sizes start at the\n" .
+                "limits learned from the server last time.\n" .
+                "\n" .
+                "Symlinks are never followed; they are skipped and recorded in\n" .
+                "the audit log. Use --only with fs-root-relative prefixes to\n" .
+                "push a subset.\n" .
+                "\n" .
+                "With --apply, the verified transfer moves into the remote tree\n" .
+                "in one atomic window, and files that earlier pushes shipped but\n" .
+                "the local tree no longer has are deleted with it. A scoped push\n" .
+                "(--only) only deletes inside its prefixes.\n",
+            "extra" =>
+                "Examples:\n" .
+                "  # Stage a full local tree on the remote:\n" .
+                "  reprint push-files https://example.com/?reprint-api \\\n" .
+                "    --secret=TOKEN --state-dir=./push-state --fs-root=./site\n" .
+                "\n" .
+                "  # Push only wp-content/uploads:\n" .
+                "  reprint push-files https://example.com/?reprint-api \\\n" .
+                "    --secret=TOKEN --state-dir=./push-state --fs-root=./site \\\n" .
+                "    --only=wp-content/uploads\n",
         ],
         "files-stats" => [
             "level" => "low",

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -346,7 +346,11 @@ class ImportState
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
     public bool $follow_symlinks = true;
+    /** @var bool Files download into staging and apply in one rename window. */
+    public bool $staged_apply = false;
     public string $fs_root_nonempty_behavior = 'error';
+    /** @var ?string Index path style: "absolute" (whole-filesystem layout) or "relative" (document-root subtree). */
+    public ?string $index_path_style = null;
     public string $filter = 'none';
     /** @var string|null User-Agent that worked during preflight. */
     public ?string $user_agent = null;
@@ -361,6 +365,8 @@ class ImportState
     public DownloadListFetchProgressState $fetch_skipped;
     public ?string $current_file = null;
     public ?int $current_file_bytes = null;
+    /** Whether the in-flight staged file is owned (preserve-local override). */
+    public ?bool $current_file_owned = null;
     public ?int $sql_bytes = null;
     /** @var int SQL statements counted while streaming db.sql. */
     public int $sql_statements_counted = 0;
@@ -398,6 +404,8 @@ class ImportState
         $state->version = isset($data['version']) ? (string) $data['version'] : null;
         $state->webhost = isset($data['webhost']) ? (string) $data['webhost'] : null;
         $state->follow_symlinks = (bool) ($data['follow_symlinks'] ?? true);
+        $state->staged_apply = (bool) ($data['staged_apply'] ?? false);
+        $state->index_path_style = isset($data['index_path_style']) ? (string) $data['index_path_style'] : null;
         $state->fs_root_nonempty_behavior = isset($data['fs_root_nonempty_behavior']) ? (string) $data['fs_root_nonempty_behavior'] : 'error';
         $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
         $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
@@ -412,6 +420,7 @@ class ImportState
         $state->fetch_skipped = self::download_list_fetch_progress_from($data['fetch_skipped'] ?? []);
         $state->current_file = isset($data['current_file']) ? (string) $data['current_file'] : null;
         $state->current_file_bytes = isset($data['current_file_bytes']) ? (int) $data['current_file_bytes'] : null;
+        $state->current_file_owned = isset($data['current_file_owned']) ? (bool) $data['current_file_owned'] : null;
         $state->sql_bytes = isset($data['sql_bytes']) ? (int) $data['sql_bytes'] : null;
         $state->sql_statements_counted = (int) ($data['sql_statements_counted'] ?? 0);
         $state->apply = self::database_apply_command_from($data['apply'] ?? []);
@@ -436,6 +445,8 @@ class ImportState
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
+            'staged_apply' => $this->staged_apply,
+            'index_path_style' => $this->index_path_style,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,
@@ -450,6 +461,7 @@ class ImportState
             'fetch_skipped' => $this->fetch_skipped->to_array(),
             'current_file' => $this->current_file,
             'current_file_bytes' => $this->current_file_bytes,
+            'current_file_owned' => $this->current_file_owned,
             'sql_bytes' => $this->sql_bytes,
             'sql_statements_counted' => $this->sql_statements_counted,
             'apply' => $this->apply->to_array(),

--- a/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-plan-builder.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Streams a push "source index" from a local tree — the inverted-pull
+ * counterpart of the remote index the exporter streams for a pull.
+ *
+ * One line per regular file in the shared index format
+ * ({path, ctime, size, type}), written unsorted for the caller to sort with
+ * sort_index_file(). The caller then diffs it against the shipped index (what
+ * the target already holds) to derive the upload list and deletions, exactly
+ * the way pull diffs the remote index against its local index — so push does
+ * not carry its own plan/done-cache data model.
+ *
+ * "ctime" carries the file's mtime: on the sender that is the change signal a
+ * same-size edit needs, and the field is only ever compared against another
+ * source/shipped line written the same way.
+ *
+ * Symlinks are skipped and reported, never followed: following them would
+ * push bytes from outside fs-root under an in-root artifact id, and symlinked
+ * directories are how hosting layouts create cycles. Anything unreadable is
+ * reported the same way instead of failing the whole walk — the caller
+ * decides whether a skip list is acceptable, and (as with pull) a skipped
+ * path is "not read this run", never "removed", so it is excluded from
+ * deletion derivation.
+ *
+ * --only prefixes filter the index to selected subtrees. Directories that can
+ * neither contain a match nor be contained by one are pruned without being
+ * walked, so restricting a push to wp-content does not pay for scanning an
+ * unrelated node_modules forest.
+ */
+class PushPlanBuilder
+{
+    /**
+     * Walk $fs_root and write one shared-format index line per regular file
+     * to $index_handle (unsorted; the caller sorts with sort_index_file).
+     *
+     * @param resource $index_handle
+     * @param string $path_prefix Prepended to every emitted path (index and
+     *   skipped): "" keeps paths fs-root-relative (document-root mode); an
+     *   absolute prefix like realpath(fs-root) makes them absolute
+     *   (filesystem mode), so index paths and the skip list share one space.
+     * @return array{skipped:array<int,array{path:string,reason:string}>}
+     *   skip reasons: symlink|special|unreadable|unreadable_dir.
+     */
+    public static function build_index(string $fs_root, array $only_prefixes, $index_handle, string $path_prefix = ""): array
+    {
+        $root = rtrim($fs_root, "/");
+        if ($root === "" || !is_dir($root)) {
+            throw new InvalidArgumentException("push plan fs-root is not a directory: {$fs_root}");
+        }
+
+        $only = self::normalize_only($only_prefixes);
+
+        $skipped = [];
+        self::walk($root, "", $only, $index_handle, $skipped, rtrim($path_prefix, "/"));
+        return ["skipped" => $skipped];
+    }
+
+    /** Prepend the path prefix (filesystem mode) or leave relative. */
+    private static function prefixed(string $prefix, string $rel): string
+    {
+        return $prefix === "" ? $rel : $prefix . "/" . $rel;
+    }
+
+    /**
+     * Validate and normalize --only prefixes. Hostile forms (absolute, empty,
+     * backslash, or a "." / ".." segment) are rejected before anything runs.
+     *
+     * @return array<int,string>
+     */
+    public static function normalize_only(array $only_prefixes): array
+    {
+        $only = [];
+        foreach ($only_prefixes as $prefix) {
+            if (!is_string($prefix)) {
+                throw new InvalidArgumentException("--only prefix must be a string");
+            }
+            $prefix = trim($prefix, "/");
+            if ($prefix === "" || strpos($prefix, "\\") !== false) {
+                throw new InvalidArgumentException("Invalid --only prefix: {$prefix}");
+            }
+            foreach (explode("/", $prefix) as $segment) {
+                if ($segment === "" || $segment === "." || $segment === "..") {
+                    throw new InvalidArgumentException("Invalid --only prefix: {$prefix}");
+                }
+            }
+            $only[] = $prefix;
+        }
+        return $only;
+    }
+
+    /**
+     * @param string $dir Absolute directory being walked.
+     * @param string $rel_dir fs-root-relative path of $dir ("" for the root).
+     * @param resource $index_handle
+     */
+    private static function walk(string $dir, string $rel_dir, array $only, $index_handle, array &$skipped, string $path_prefix): void
+    {
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            $skipped[] = ["path" => self::prefixed($path_prefix, $rel_dir), "reason" => "unreadable_dir"];
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $path = $dir . "/" . $entry;
+            // --only prefixes are always fs-root-relative, so pruning and
+            // selection stay in the relative space; only the emitted path
+            // carries the prefix.
+            $rel = $rel_dir === "" ? $entry : $rel_dir . "/" . $entry;
+
+            if (is_link($path)) {
+                $skipped[] = ["path" => self::prefixed($path_prefix, $rel), "reason" => "symlink"];
+                continue;
+            }
+            if (is_dir($path)) {
+                if (self::prunable($rel, $only)) {
+                    continue;
+                }
+                self::walk($path, $rel, $only, $index_handle, $skipped, $path_prefix);
+                continue;
+            }
+            if (!is_file($path)) {
+                $skipped[] = ["path" => self::prefixed($path_prefix, $rel), "reason" => "special"];
+                continue;
+            }
+            if ($only !== [] && !self::selected($rel, $only)) {
+                continue;
+            }
+            $size = @filesize($path);
+            $mtime = @filemtime($path);
+            if ($size === false || $mtime === false) {
+                $skipped[] = ["path" => self::prefixed($path_prefix, $rel), "reason" => "unreadable"];
+                continue;
+            }
+            // Shared index format: base64 path so any filename survives, and
+            // mtime in the "ctime" field (see the class docblock).
+            $line = json_encode([
+                "path" => base64_encode(self::prefixed($path_prefix, $rel)),
+                "ctime" => (int) $mtime,
+                "size" => (int) $size,
+                "type" => "file",
+            ], JSON_UNESCAPED_SLASHES);
+            if ($line !== false) {
+                fwrite($index_handle, $line . "\n");
+            }
+        }
+    }
+
+    /** A path is selected when it sits at or under one of the prefixes. */
+    public static function selected(string $rel, array $only): bool
+    {
+        foreach ($only as $prefix) {
+            if ($rel === $prefix || strpos($rel, $prefix . "/") === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A directory is prunable when no prefix lies under it and it lies under
+     * no prefix — nothing inside can be selected.
+     */
+    private static function prunable(string $rel_dir, array $only): bool
+    {
+        if ($only === []) {
+            return false;
+        }
+        foreach ($only as $prefix) {
+            $under_prefix = $rel_dir === $prefix || strpos($rel_dir, $prefix . "/") === 0;
+            $contains_prefix = strpos($prefix, $rel_dir . "/") === 0;
+            if ($under_prefix || $contains_prefix) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-runner.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * Batch orchestration for staged chunk uploads: streams the upload list the
+ * diff produced and drives StagedUploadClient once per artifact, resumably.
+ *
+ * The upload list is the push counterpart of pull's download list — one line
+ * per file the diff decided to send, in path order. The runner adds the two
+ * things a multi-artifact push needs on top of the single-artifact client:
+ *
+ * Batching. Files that fit the sizer's request budget travel together — one
+ * HTTP conversation per batch, pull's multipart discipline in the push
+ * direction. Files bigger than the budget keep the resumable per-chunk path.
+ * A 413 shrinks the budget (monotonically, so this terminates) and the
+ * affected files repartition.
+ *
+ * Failure routing. A reason scoped to one artifact — its source vanished or
+ * shrank, its size disagrees with the store — is recorded and the run
+ * continues; rerunning retries only the failures. Everything else (auth,
+ * transport, chunk-size exhaustion, a busy or erroring store, or any reason
+ * this list has never seen) would fail every following artifact the same way,
+ * so the run aborts with the reason. Unknown reasons abort rather than
+ * continue so a protocol change cannot churn a huge list through per-artifact
+ * failures.
+ *
+ * The runner keeps no done cache. Resume trusts the store the way pull trusts
+ * the files already in its fs-root: a file finished in a prior run is still
+ * verified in the store, so the client's status/finalize short-circuit
+ * re-confirms it in two cheap requests without re-sending bytes; deletions
+ * and ownership come from the diff, not from a cache. The only state it
+ * persists is .push-state.json (rename-atomic) — the chunk sizer's learned
+ * limits plus the last run's counters — written after every artifact so a
+ * rerun starts at the limits the wire already taught us.
+ */
+class StagedPushRunner
+{
+    /** Failure reasons scoped to one artifact; the run continues past them. */
+    private const ARTIFACT_SCOPED_REASONS = [
+        "source_unreadable",
+        "source_short",
+        "size_mismatch",
+        "invalid_artifact_id",
+        "invalid_offset",
+        "invalid_total",
+        "invalid_artifact_entry",
+        // A source rewritten mid-push fails its artifact; the next run
+        // re-diffs with the current mtime and pushes the fresh content.
+        "source_changed",
+    ];
+
+    /** Per-file allowance for a batch frame's JSON header line. */
+    private const BATCH_FRAME_OVERHEAD = 256;
+
+    private string $state_path;
+
+    /** Prefix a store artifact id resolves under to its local source file: the
+     * fs-root in relative mode, "" in absolute mode (ids are already rooted). */
+    private string $source_root;
+
+    private StagedUploadClient $client;
+
+    private UploadChunkSizer $sizer;
+
+    /** @var callable|null */
+    private $on_progress;
+
+    /**
+     * @param array $options
+     *   - state_dir (string, required): holds .push-state.json; created if missing.
+     *   - source_root (string, required): prefix the upload-list ids resolve
+     *     their local source files under ("" in absolute mode).
+     *   - client (StagedUploadClient, required): the per-artifact uploader.
+     *   - sizer (UploadChunkSizer, required): the same instance the client
+     *     was built with — the runner persists its learned state.
+     *   - on_progress (?callable): fn(array $progress) with files_done,
+     *     files_total, artifact_id, committed_bytes, total_bytes.
+     */
+    public function __construct(array $options)
+    {
+        $state_dir = $options["state_dir"] ?? null;
+        if (!is_string($state_dir) || $state_dir === "") {
+            throw new InvalidArgumentException("StagedPushRunner requires a state_dir option.");
+        }
+        $source_root = $options["source_root"] ?? null;
+        if (!is_string($source_root)) {
+            throw new InvalidArgumentException("StagedPushRunner requires a source_root option.");
+        }
+        if (!($options["client"] ?? null) instanceof StagedUploadClient) {
+            throw new InvalidArgumentException("StagedPushRunner requires a client option.");
+        }
+        if (!($options["sizer"] ?? null) instanceof UploadChunkSizer) {
+            throw new InvalidArgumentException("StagedPushRunner requires a sizer option.");
+        }
+
+        $this->state_path = rtrim($state_dir, "/") . "/.push-state.json";
+        $this->source_root = rtrim($source_root, "/");
+        $this->client = $options["client"];
+        $this->sizer = $options["sizer"];
+        $this->on_progress = $options["on_progress"] ?? null;
+    }
+
+    /**
+     * Restore a previous run's persisted state, for constructing the sizer
+     * before the client and runner exist.
+     *
+     * @return array{sizer:array,files_total:int,files_done:int}
+     */
+    public static function read_state(string $state_dir): array
+    {
+        $defaults = [
+            "sizer" => [],
+            "files_total" => 0,
+            "files_done" => 0,
+        ];
+        $raw = @file_get_contents(rtrim($state_dir, "/") . "/.push-state.json");
+        if ($raw === false) {
+            return $defaults;
+        }
+        $state = json_decode($raw, true);
+        if (!is_array($state)) {
+            return $defaults;
+        }
+        return [
+            "sizer" => is_array($state["sizer"] ?? null) ? $state["sizer"] : [],
+            "files_total" => max(0, (int) ($state["files_total"] ?? 0)),
+            "files_done" => max(0, (int) ($state["files_done"] ?? 0)),
+        ];
+    }
+
+    /**
+     * Upload every file the upload list names, streaming it so memory stays
+     * bounded regardless of transfer size.
+     *
+     * @param string $upload_list_file JSONL {path (base64), size, ctime}.
+     * @return array{status:string,files_total:int,files_done:int,failed:array,abort_reason:?string,abort_detail:?string}
+     */
+    public function push(string $upload_list_file): array
+    {
+        if (!$this->ensure_state_dir()) {
+            return $this->aborted(0, 0, [], "state_dir_unwritable", dirname($this->state_path));
+        }
+
+        $files_total = $this->count_upload_entries($upload_list_file);
+        $handle = @fopen($upload_list_file, "r");
+        if ($handle === false) {
+            // No upload list means the diff found nothing to send.
+            $this->write_state($files_total, 0);
+            return $this->completed($files_total, 0, []);
+        }
+
+        $files_done = 0;
+        $failed = [];
+        // Entries requeued by a 413 repartition or a partial batch buffer
+        // here; the main pull takes from this before reading new lines.
+        $pending = [];
+        $eof = false;
+
+        try {
+            while (true) {
+                $entry = $this->next_entry($handle, $pending, $eof);
+                if ($entry === null) {
+                    break;
+                }
+
+                $budget = max(1, $this->sizer->chunk_bytes());
+
+                if ($entry["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
+                    $abort = $this->upload_one($entry, $files_done, $files_total, $failed);
+                    if ($abort !== null) {
+                        return $abort;
+                    }
+                    continue;
+                }
+
+                // Pack files up to the budget into one batch conversation.
+                $batch = [$entry["artifact_id"] => $entry];
+                $batch_bytes = $entry["total_bytes"] + self::BATCH_FRAME_OVERHEAD;
+                while (true) {
+                    $peek = $this->next_entry($handle, $pending, $eof);
+                    if ($peek === null) {
+                        break;
+                    }
+                    if ($batch_bytes + $peek["total_bytes"] + self::BATCH_FRAME_OVERHEAD > $budget) {
+                        array_unshift($pending, $peek);
+                        break;
+                    }
+                    $batch[$peek["artifact_id"]] = $peek;
+                    $batch_bytes += $peek["total_bytes"] + self::BATCH_FRAME_OVERHEAD;
+                }
+
+                $abort = $this->upload_batch($batch, $pending, $files_done, $files_total, $failed);
+                if ($abort !== null) {
+                    return $abort;
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        $this->write_state($files_total, $files_done);
+        return $this->completed($files_total, $files_done, $failed);
+    }
+
+    /**
+     * Drive one big file down the resumable per-chunk path.
+     *
+     * @return array|null An aborted result to return, or null to continue.
+     */
+    private function upload_one(array $entry, int &$files_done, int $files_total, array &$failed): ?array
+    {
+        $result = $this->client->upload_artifact(
+            $entry["artifact_id"],
+            $entry["source_path"],
+            $entry["total_bytes"],
+            function (int $committed, int $total) use ($files_done, $files_total, $entry): void {
+                $this->report_progress($files_done, $files_total, $entry["artifact_id"], $committed, $total);
+            },
+            $entry["mtime"]
+        );
+
+        if ($result["status"] === "verified") {
+            $files_done++;
+            $this->write_state($files_total, $files_done);
+            $this->report_progress($files_done, $files_total, $entry["artifact_id"], $entry["total_bytes"], $entry["total_bytes"]);
+            return null;
+        }
+        $reason = is_string($result["reason"]) ? $result["reason"] : "unexpected_response";
+        if (in_array($reason, self::ARTIFACT_SCOPED_REASONS, true)) {
+            $failed[] = [
+                "artifact_id" => $entry["artifact_id"],
+                "reason" => $reason,
+                "detail" => $result["detail"],
+            ];
+            $this->write_state($files_total, $files_done);
+            return null;
+        }
+        $this->write_state($files_total, $files_done);
+        return $this->aborted($files_total, $files_done, $failed, $reason, $result["detail"]);
+    }
+
+    /**
+     * Send one packed batch in a single conversation.
+     *
+     * @return array|null An aborted result to return, or null to continue.
+     */
+    private function upload_batch(array $batch, array &$pending, int &$files_done, int $files_total, array &$failed): ?array
+    {
+        $batch_result = $this->client->upload_batch(array_values($batch));
+
+        if ($batch_result["status"] === "failed") {
+            if ($batch_result["reason"] === "batch_too_large") {
+                // The sizer already shrank; repartition these files.
+                foreach ($batch as $entry) {
+                    $pending[] = $entry;
+                }
+                return null;
+            }
+            $this->write_state($files_total, $files_done);
+            return $this->aborted($files_total, $files_done, $failed, $batch_result["reason"], $batch_result["detail"]);
+        }
+
+        foreach ($batch_result["per_file"] as $artifact_id => $outcome) {
+            $entry = $batch[$artifact_id] ?? null;
+            if ($entry === null) {
+                continue;
+            }
+            if ($outcome["status"] === "verified") {
+                $files_done++;
+                $this->report_progress($files_done, $files_total, $artifact_id, $entry["total_bytes"], $entry["total_bytes"]);
+                continue;
+            }
+            if ($outcome["status"] === "not_attempted") {
+                // The server stopped at an earlier frame; retry these.
+                $pending[] = $entry;
+                continue;
+            }
+            $reason = is_string($outcome["reason"]) ? $outcome["reason"] : "unexpected_response";
+            if (in_array($reason, self::ARTIFACT_SCOPED_REASONS, true)) {
+                $failed[] = [
+                    "artifact_id" => $artifact_id,
+                    "reason" => $reason,
+                    "detail" => null,
+                ];
+                continue;
+            }
+            $this->write_state($files_total, $files_done);
+            return $this->aborted($files_total, $files_done, $failed, $reason, $artifact_id);
+        }
+        $this->write_state($files_total, $files_done);
+        return null;
+    }
+
+    /**
+     * Next artifact to process — requeued entries first, then the stream.
+     *
+     * @return array{artifact_id:string,source_path:string,total_bytes:int,mtime:?int}|null
+     */
+    private function next_entry($handle, array &$pending, bool &$eof): ?array
+    {
+        if ($pending !== []) {
+            return array_shift($pending);
+        }
+        if ($eof) {
+            return null;
+        }
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            $line = trim($line);
+            if ($line === "") {
+                continue;
+            }
+            $data = json_decode($line, true);
+            if (!is_array($data)) {
+                continue;
+            }
+            $encoded = isset($data["path"]) ? (string) $data["path"] : "";
+            $index_path = base64_decode($encoded, true);
+            if ($index_path === false || $index_path === "") {
+                continue;
+            }
+            // The store artifact id is the index path without any leading
+            // slash (a no-op in relative mode); the source file sits under
+            // source_root (fs-root in relative mode, "" so ids are already
+            // absolute in filesystem mode).
+            $artifact_id = ltrim($index_path, "/");
+            $size = isset($data["size"]) ? (int) $data["size"] : 0;
+            $ctime = isset($data["ctime"]) ? (int) $data["ctime"] : null;
+            return [
+                "artifact_id" => $artifact_id,
+                "source_path" => $this->source_root . "/" . $artifact_id,
+                "total_bytes" => $size,
+                "mtime" => $ctime,
+            ];
+        }
+        $eof = true;
+        return null;
+    }
+
+    private function count_upload_entries(string $upload_list_file): int
+    {
+        $handle = @fopen($upload_list_file, "r");
+        if ($handle === false) {
+            return 0;
+        }
+        $count = 0;
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            if (trim($line) !== "") {
+                $count++;
+            }
+        }
+        fclose($handle);
+        return $count;
+    }
+
+    private function report_progress(int $files_done, int $files_total, string $artifact_id, int $committed, int $total): void
+    {
+        if ($this->on_progress === null) {
+            return;
+        }
+        call_user_func($this->on_progress, [
+            "files_done" => $files_done,
+            "files_total" => $files_total,
+            "artifact_id" => $artifact_id,
+            "committed_bytes" => $committed,
+            "total_bytes" => $total,
+        ]);
+    }
+
+    private function write_state(int $files_total, int $files_done): void
+    {
+        // Write-then-rename, like every cursor file in this codebase: a kill
+        // leaves the previous state, never a torn one.
+        $tmp_path = $this->state_path . ".tmp";
+        $json = json_encode([
+            "sizer" => $this->sizer->get_state(),
+            "files_total" => $files_total,
+            "files_done" => $files_done,
+        ]);
+        if (@file_put_contents($tmp_path, $json) !== strlen($json) || !@rename($tmp_path, $this->state_path)) {
+            // Best effort: stale sizer state costs a relearn, nothing more.
+            @unlink($tmp_path);
+        }
+    }
+
+    private function ensure_state_dir(): bool
+    {
+        $dir = dirname($this->state_path);
+        return is_dir($dir) || @mkdir($dir, 0700, true) || is_dir($dir);
+    }
+
+    /**
+     * @return array{status:string,files_total:int,files_done:int,failed:array,abort_reason:?string,abort_detail:?string}
+     */
+    private function completed(int $files_total, int $files_done, array $failed): array
+    {
+        return [
+            "status" => "completed",
+            "files_total" => $files_total,
+            "files_done" => $files_done,
+            "failed" => $failed,
+            "abort_reason" => null,
+            "abort_detail" => null,
+        ];
+    }
+
+    /**
+     * @return array{status:string,files_total:int,files_done:int,failed:array,abort_reason:?string,abort_detail:?string}
+     */
+    private function aborted(int $files_total, int $files_done, array $failed, string $reason, ?string $detail): array
+    {
+        return [
+            "status" => "aborted",
+            "files_total" => $files_total,
+            "files_done" => $files_done,
+            "failed" => $failed,
+            "abort_reason" => $reason,
+            "abort_detail" => $detail,
+        ];
+    }
+}

--- a/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-upload-client.php
@@ -1,0 +1,936 @@
+<?php
+/**
+ * Client for the staged artifact endpoints: uploads one local file into the
+ * target's staged store in bounded, resumable chunks.
+ *
+ * This is the sender side of a push transfer. The target holds all transfer
+ * state — Site_Export_Staged_Artifacts tracks committed_bytes, and this
+ * client re-reads it from staged_status on every start — so the client
+ * persists nothing about its position. Interrupt it anywhere, rerun it, and
+ * it continues from whatever the store confirmed. The only client-side state
+ * worth carrying across runs is the chunk sizer's learned limits, and that
+ * belongs to the caller (UploadChunkSizer::get_state()).
+ *
+ * The upload loop translates the endpoints' typed responses into the next
+ * action and into UploadChunkSizer feedback:
+ *
+ * - accepted           advance to committed_bytes, record_success()
+ * - duplicate          advance to committed_bytes (a retried chunk landed
+ *                      before its response was lost); still a success signal
+ *                      for the sizer — the host accepted a body of this size
+ * - offset_gap         adopt committed_bytes and continue from there; bounded
+ *                      by a no-progress counter so a disagreeing server
+ *                      cannot loop the client forever
+ * - 413 too large      record_too_large(max_request_bytes) and retry the same
+ *                      offset with the shrunk chunk; "give_up" from the sizer
+ *                      ends the upload with a typed failure
+ * - busy               a predecessor request still holds the store's lock;
+ *                      short bounded backoff, same offset
+ * - io_error           bounded backoff — the target's disk, not the wire
+ * - transport failure  record_transport_failure() (halves the chunk, holds
+ *                      growth) and retry the same offset, bounded
+ * - auth failures      fatal immediately; retrying cannot fix a bad secret
+ *
+ * Every retry class resets when the transfer makes progress, so the bounds
+ * cap consecutive failures, not the transfer length. Every loop iteration
+ * either advances committed bytes, strictly shrinks the sizer's ceiling, or
+ * consumes one of those bounded counters — the loop terminates.
+ *
+ * The transport is a callable so tests drive the real endpoint classes
+ * in-process; the default is curl, signed per request by
+ * Site_Export_HMAC_Client (signature over nonce + timestamp + SHA256(body),
+ * which is exactly what staged_upload verifies before reading the body).
+ */
+class StagedUploadClient
+{
+    /** Consecutive transport failures before the upload is abandoned. */
+    private const MAX_TRANSPORT_RETRIES = 5;
+
+    /** Consecutive "busy" responses before the upload is abandoned. */
+    private const MAX_BUSY_RETRIES = 5;
+
+    /** Consecutive server io_error responses before the upload is abandoned. */
+    private const MAX_IO_RETRIES = 3;
+
+    /** Resyncs that fail to advance committed_bytes before giving up. */
+    private const MAX_STALLED_RESYNCS = 3;
+
+    /** Base backoff between retries, in microseconds. */
+    private const RETRY_BACKOFF_USEC = 250000;
+
+    /** Longest single backoff, in microseconds. */
+    private const MAX_BACKOFF_USEC = 5000000;
+
+    /** Bytes copied at a time when composing streamed batch bodies. */
+    private const BATCH_STREAM_BUFFER_BYTES = 262144;
+
+    /** Batch spools stay in memory up to this size, then php://temp spills. */
+    private const BATCH_SPOOL_MEMORY_BYTES = 2097152;
+
+    private string $base_url;
+
+    private ?Site_Export_HMAC_Client $hmac_client;
+
+    private UploadChunkSizer $sizer;
+
+    /** @var callable(string,string,array,mixed,int):array */
+    private $transport;
+
+    /** @var callable(int):void */
+    private $sleeper;
+
+    private int $request_timeout;
+
+    /**
+     * @param array $options
+     *   - base_url (string, required): the export API URL; endpoint and
+     *     artifact parameters are appended to its query string.
+     *   - hmac_client (?Site_Export_HMAC_Client): request signer. Without
+     *     one, requests go out unsigned and the target rejects uploads.
+     *   - sizer (?UploadChunkSizer): chunk-size decisions; defaults to a
+     *     fresh sizer. Pass one restored from persisted state to keep the
+     *     limits a previous run learned.
+     *   - transport (?callable): fn(method, url, headers, body, timeout) =>
+     *     ['http_code' => int, 'body' => string, 'error' => ?string], where
+     *     a non-null error means the request never produced an HTTP
+     *     response. Defaults to curl.
+     *   - sleeper (?callable): fn(int $microseconds), for tests.
+     *   - request_timeout (int): per-request timeout in seconds.
+     */
+    public function __construct(array $options)
+    {
+        $base_url = $options["base_url"] ?? null;
+        if (!is_string($base_url) || $base_url === "") {
+            throw new InvalidArgumentException("StagedUploadClient requires a base_url option.");
+        }
+        $this->base_url = $base_url;
+        $this->hmac_client = $options["hmac_client"] ?? null;
+        $this->sizer = $options["sizer"] ?? new UploadChunkSizer();
+        $this->transport = $options["transport"] ?? [$this, "curl_transport"];
+        $this->sleeper = $options["sleeper"] ?? static function (int $microseconds): void {
+            usleep($microseconds);
+        };
+        $timeout = $options["request_timeout"] ?? null;
+        $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
+    }
+
+    /**
+     * Upload one artifact until the target records it verified.
+     *
+     * @param string $artifact_id Target-relative path the artifact applies to.
+     * @param string $source_path Local file holding the artifact bytes.
+     * @param ?int $total_bytes Plan-declared size; defaults to the file size.
+     * @param ?callable $on_progress fn(int $committed_bytes, int $total_bytes)
+     *   after every advance.
+     * @param ?int $expected_mtime Plan-declared source mtime. A mismatch
+     *   before uploading means the plan is stale — the artifact fails
+     *   "source_changed" so a re-plan pushes the current content instead
+     *   of a mix.
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     *   status "verified" on success, "failed" with a typed reason otherwise.
+     */
+    public function upload_artifact(
+        string $artifact_id,
+        string $source_path,
+        ?int $total_bytes = null,
+        ?callable $on_progress = null,
+        ?int $expected_mtime = null
+    ): array {
+        if ($total_bytes === null) {
+            $size = @filesize($source_path);
+            if ($size === false) {
+                return $this->failed("source_unreadable", $source_path);
+            }
+            $total_bytes = $size;
+        }
+
+        // The store's committed offset is the resume point; the client
+        // keeps no position of its own.
+        $status = $this->request_json("GET", "staged_status", ["artifact_id" => $artifact_id]);
+        if ($status["error"] !== null || !is_array($status["json"])) {
+            return $this->failed("status_unavailable", $status["error"] ?? "invalid response");
+        }
+        if ($this->is_auth_envelope($status)) {
+            return $this->failed("auth_failed", $this->envelope_error($status));
+        }
+        if (!empty($status["json"]["verified"])) {
+            // A finished earlier run. Finalize re-confirms the size and is
+            // idempotent; a mismatch means this plan disagrees with what
+            // was verified, and only a discard can resolve that.
+            return $this->finalize($artifact_id, $total_bytes);
+        }
+        $offset = max(0, (int) ($status["json"]["committed_bytes"] ?? 0));
+        $offset = min($offset, $total_bytes);
+
+        $source = @fopen($source_path, "rb");
+        if ($source === false) {
+            return $this->failed("source_unreadable", $source_path);
+        }
+        $opened_stat = fstat($source);
+
+        // Every check downstream is a byte count, so a rewrite of the
+        // source is invisible to all of them. The exporter re-checks its
+        // files after streaming (x-file-changed); the sender owes the same
+        // honesty about its own disk, before and after the upload.
+        if ($this->planned_mtime_differs($opened_stat, $expected_mtime)) {
+            fclose($source);
+            // Committed bytes may belong to the older version; a mixed
+            // artifact must never verify.
+            $this->discard($artifact_id);
+            return $this->failed(
+                "source_changed",
+                sprintf("planned mtime %d, found %d", (int) $expected_mtime, (int) $opened_stat["mtime"])
+            );
+        }
+
+        try {
+            $transport_failures = 0;
+            $busy_responses = 0;
+            $io_errors = 0;
+            $stalled_resyncs = 0;
+
+            while ($offset < $total_bytes) {
+                $chunk_bytes = min($this->sizer->chunk_bytes(), $total_bytes - $offset);
+                if (fseek($source, $offset) !== 0) {
+                    return $this->failed("source_unreadable", "seek", $offset);
+                }
+                // Spool the chunk through a bounded temp stream rather than a
+                // single string: a negotiated chunk can approach the host's
+                // request cap (up to ~1 GiB when it reports no post_max_size),
+                // and materializing that in memory — plus libcurl's own copy
+                // of a string body — OOMs the sender. The batch path already
+                // streams this way.
+                $chunk = $this->copy_source_to_spool($source, $chunk_bytes);
+                if ($chunk === null) {
+                    // The file ends before the declared total; uploading on
+                    // would just move the mismatch to finalize.
+                    return $this->failed("source_short", null, $offset);
+                }
+
+                $response = $this->request_json("POST", "staged_upload", [
+                    "artifact_id" => $artifact_id,
+                    "offset" => $offset,
+                ], $chunk);
+                fclose($chunk);
+
+                if ($response["error"] !== null) {
+                    $decision = $this->sizer->record_transport_failure();
+                    if ($decision["action"] === "give_up") {
+                        return $this->failed("transport_failed", $response["error"], $offset);
+                    }
+                    $transport_failures++;
+                    if ($transport_failures > self::MAX_TRANSPORT_RETRIES) {
+                        return $this->failed("transport_failed", $response["error"], $offset);
+                    }
+                    $this->backoff($transport_failures);
+                    continue;
+                }
+
+                $json = is_array($response["json"]) ? $response["json"] : [];
+                $http_code = $response["http_code"];
+
+                if ($http_code === 413) {
+                    $reported = $json["max_request_bytes"] ?? null;
+                    $decision = $this->sizer->record_too_large(
+                        is_numeric($reported) ? (int) $reported : null
+                    );
+                    if ($decision["action"] === "give_up") {
+                        return $this->failed("chunk_size_exhausted", null, $offset);
+                    }
+                    continue;
+                }
+
+                $result_status = $json["status"] ?? null;
+                $reason = $json["reason"] ?? null;
+
+                if ($result_status === "accepted" || $result_status === "duplicate") {
+                    $committed = (int) ($json["committed_bytes"] ?? $offset);
+                    $advanced = $committed > $offset;
+                    $offset = max($offset, min($committed, $total_bytes));
+                    // Either way the host accepted a request of this size.
+                    $this->sizer->record_success();
+                    if ($advanced) {
+                        $transport_failures = 0;
+                        $busy_responses = 0;
+                        $io_errors = 0;
+                        $stalled_resyncs = 0;
+                        if ($on_progress !== null) {
+                            $on_progress($offset, $total_bytes);
+                        }
+                    }
+                    continue;
+                }
+
+                if ($result_status === "busy") {
+                    $busy_responses++;
+                    if ($busy_responses > self::MAX_BUSY_RETRIES) {
+                        return $this->failed("busy_exhausted", null, $offset);
+                    }
+                    $this->backoff($busy_responses);
+                    continue;
+                }
+
+                if ($reason === "offset_gap") {
+                    $committed = max(0, (int) ($json["committed_bytes"] ?? 0));
+                    if ($committed <= $offset) {
+                        // The store is behind us (a discard or another
+                        // sender); re-uploading from its offset is the only
+                        // way forward, but only while it moves.
+                        $stalled_resyncs++;
+                        if ($stalled_resyncs > self::MAX_STALLED_RESYNCS) {
+                            return $this->failed("resync_exhausted", null, $offset);
+                        }
+                    }
+                    $offset = min($committed, $total_bytes);
+                    continue;
+                }
+
+                if ($reason === "already_verified") {
+                    break;
+                }
+
+                if ($reason === "io_error") {
+                    $io_errors++;
+                    if ($io_errors > self::MAX_IO_RETRIES) {
+                        return $this->failed("server_io_error", $json["detail"] ?? null, $offset);
+                    }
+                    $this->backoff($io_errors);
+                    continue;
+                }
+
+                if ($reason === "auth_failed" || $reason === "content_hash_mismatch") {
+                    return $this->failed("auth_failed", $json["detail"] ?? null, $offset);
+                }
+
+                // invalid_artifact_id, invalid_offset, not_configured,
+                // method_not_allowed, or something newer: retrying cannot
+                // change the answer.
+                return $this->failed(
+                    is_string($reason) ? $reason : "unexpected_response",
+                    "HTTP " . $http_code,
+                    $offset
+                );
+            }
+        } finally {
+            fclose($source);
+        }
+
+        // Post-upload volatility check: a rewrite during the read window
+        // can leave staged bytes that match no version of the file. Torn
+        // content must fail typed, not verify.
+        if ($this->source_changed_since($source_path, $opened_stat)) {
+            $this->discard($artifact_id);
+            return $this->failed("source_changed", "source changed while uploading");
+        }
+
+        return $this->finalize($artifact_id, $total_bytes, $on_progress);
+    }
+
+    /**
+     * Report the store's resume state for an artifact.
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int,exists:bool,verified:bool}|array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    public function status(string $artifact_id): array
+    {
+        $response = $this->request_json("GET", "staged_status", ["artifact_id" => $artifact_id]);
+        if ($response["error"] !== null || !is_array($response["json"])) {
+            return $this->failed("status_unavailable", $response["error"] ?? "invalid response");
+        }
+        if ($this->is_auth_envelope($response)) {
+            // Same reading as every other route: a control-plane auth
+            // envelope must not masquerade as "artifact absent".
+            return $this->failed("auth_failed", $this->envelope_error($response));
+        }
+        return [
+            "status" => "ok",
+            "reason" => null,
+            "detail" => null,
+            "committed_bytes" => (int) ($response["json"]["committed_bytes"] ?? 0),
+            "exists" => (bool) ($response["json"]["exists"] ?? false),
+            "verified" => (bool) ($response["json"]["verified"] ?? false),
+        ];
+    }
+
+    /**
+     * Drop an artifact's staged data; retries while the store reports the
+     * discard incomplete, mirroring its retry-until-true contract.
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    public function discard(string $artifact_id): array
+    {
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES; $attempt++) {
+            $response = $this->request_json("POST", "staged_discard", ["artifact_id" => $artifact_id]);
+            if ($response["error"] !== null) {
+                return $this->failed("transport_failed", $response["error"]);
+            }
+            if ($this->is_auth_envelope($response)) {
+                return $this->failed("auth_failed", $this->envelope_error($response));
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            if (!empty($json["discarded"])) {
+                return [
+                    "status" => "discarded",
+                    "reason" => null,
+                    "detail" => null,
+                    "committed_bytes" => 0,
+                ];
+            }
+            if ($response["http_code"] !== 423) {
+                return $this->failed(
+                    is_string($json["reason"] ?? null) ? $json["reason"] : "unexpected_response",
+                    "HTTP " . $response["http_code"]
+                );
+            }
+            $this->backoff($attempt);
+        }
+        return $this->failed("busy_exhausted");
+    }
+
+    /**
+     * Upload a batch of complete small files in one request.
+     *
+     * One HTTP conversation carries many files — push's answer to pull's
+     * multipart batching. The request body is composed into a temp stream,
+     * not one PHP string: each source is copied through a bounded per-file
+     * spool, checked for volatility, then appended to the outgoing stream.
+     * Files that changed underfoot fail "source_changed" locally and are
+     * excluded from the wire.
+     *
+     * @param array $files Entries: ['artifact_id','source_path','total_bytes','mtime'?].
+     * @return array{status:string,reason:?string,detail:?string,per_file:array<string,array{status:string,reason:?string}>}
+     *   "ok" means the request cycle finished and per_file holds each
+     *   file's outcome — "verified", "failed" (typed), or "not_attempted"
+     *   (the server stopped at an earlier frame; retry those). "failed"
+     *   carries a transfer-scoped reason; "batch_too_large" specifically
+     *   means the sizer shrank and the caller should repartition.
+     */
+    public function upload_batch(array $files): array
+    {
+        $per_file = [];
+        $body = $this->open_batch_spool();
+        if ($body === false) {
+            return ["status" => "failed", "reason" => "source_unreadable", "detail" => "open_batch_spool", "per_file" => $per_file];
+        }
+        $hash = hash_init("sha256");
+        $sendable = [];
+        foreach ($files as $file) {
+            $artifact_id = (string) $file["artifact_id"];
+            $total_bytes = (int) $file["total_bytes"];
+            $source = @fopen((string) $file["source_path"], "rb");
+            if ($source === false) {
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_unreadable"];
+                continue;
+            }
+            $opened = fstat($source);
+            $expected_mtime = isset($file["mtime"]) ? (int) $file["mtime"] : null;
+            if ($this->planned_mtime_differs($opened, $expected_mtime)) {
+                fclose($source);
+                $this->discard($artifact_id);
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
+                continue;
+            }
+            $payload = $this->copy_source_to_spool($source, $total_bytes);
+            fclose($source);
+            if ($payload === null) {
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_short"];
+                continue;
+            }
+            if ($this->source_changed_since((string) $file["source_path"], $opened)) {
+                fclose($payload);
+                $this->discard($artifact_id);
+                $per_file[$artifact_id] = ["status" => "failed", "reason" => "source_changed"];
+                continue;
+            }
+
+            $header = json_encode([
+                "artifact_id" => $artifact_id,
+                "offset" => 0,
+                "length" => $total_bytes,
+                "total_bytes" => $total_bytes,
+                "final" => true,
+            ]) . "\n";
+            if (
+                !$this->write_batch_bytes($body, $hash, $header)
+                || !$this->write_batch_stream($body, $hash, $payload)
+            ) {
+                fclose($payload);
+                fclose($body);
+                return ["status" => "failed", "reason" => "source_unreadable", "detail" => "write_batch_spool", "per_file" => $per_file];
+            }
+            fclose($payload);
+            $sendable[] = $artifact_id;
+        }
+
+        if ($sendable === []) {
+            fclose($body);
+            return ["status" => "ok", "reason" => null, "detail" => null, "per_file" => $per_file];
+        }
+
+        rewind($body);
+        $content_hash = hash_final($hash);
+        $transport_failures = 0;
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES + self::MAX_TRANSPORT_RETRIES; $attempt++) {
+            $response = $this->request_json("POST", "staged_upload_batch", [], $body, $content_hash);
+            if ($response["error"] !== null) {
+                $decision = $this->sizer->record_transport_failure();
+                $transport_failures++;
+                if ($decision["action"] === "give_up" || $transport_failures > self::MAX_TRANSPORT_RETRIES) {
+                    fclose($body);
+                    return ["status" => "failed", "reason" => "transport_failed", "detail" => $response["error"], "per_file" => $per_file];
+                }
+                $this->backoff($transport_failures);
+                continue;
+            }
+            if ($this->is_auth_envelope($response)) {
+                fclose($body);
+                return ["status" => "failed", "reason" => "auth_failed", "detail" => $this->envelope_error($response), "per_file" => $per_file];
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            if ($response["http_code"] === 413) {
+                $reported = $json["max_request_bytes"] ?? null;
+                $decision = $this->sizer->record_too_large(is_numeric($reported) ? (int) $reported : null);
+                if ($decision["action"] === "give_up") {
+                    fclose($body);
+                    return ["status" => "failed", "reason" => "chunk_size_exhausted", "detail" => null, "per_file" => $per_file];
+                }
+                fclose($body);
+                return ["status" => "failed", "reason" => "batch_too_large", "detail" => null, "per_file" => $per_file];
+            }
+            if (($json["status"] ?? null) === "busy") {
+                $this->backoff($attempt);
+                continue;
+            }
+
+            foreach (($json["results"] ?? []) as $result) {
+                if (!is_array($result) || !is_string($result["artifact_id"] ?? null)) {
+                    continue;
+                }
+                if (($result["status"] ?? null) === "verified") {
+                    $per_file[$result["artifact_id"]] = ["status" => "verified", "reason" => null];
+                } else {
+                    $reason = $result["reason"] ?? null;
+                    $per_file[$result["artifact_id"]] = [
+                        "status" => "failed",
+                        "reason" => is_string($reason) ? $reason : "unexpected_response",
+                    ];
+                }
+            }
+            if (($json["status"] ?? null) === "rejected") {
+                $detail = $json["detail"] ?? null;
+                $reported = is_string($detail) ? ($per_file[$detail] ?? null) : null;
+                if (!is_array($reported) || $reported["status"] !== "failed") {
+                    $reason = $json["reason"] ?? null;
+                    fclose($body);
+                    return [
+                        "status" => "failed",
+                        "reason" => is_string($reason) ? $reason : "unexpected_response",
+                        "detail" => is_string($detail) ? $detail : null,
+                        "per_file" => $per_file,
+                    ];
+                }
+            }
+            foreach ($sendable as $artifact_id) {
+                if (!isset($per_file[$artifact_id])) {
+                    // The server stopped at an earlier frame; these retry.
+                    $per_file[$artifact_id] = ["status" => "not_attempted", "reason" => null];
+                }
+            }
+            if (($json["status"] ?? null) === "ok") {
+                $this->sizer->record_success();
+            }
+            fclose($body);
+            return ["status" => "ok", "reason" => null, "detail" => null, "per_file" => $per_file];
+        }
+        fclose($body);
+        return ["status" => "failed", "reason" => "busy_exhausted", "detail" => null, "per_file" => $per_file];
+    }
+
+    /**
+     * Ask the target to validate (check_only) or apply a staged transfer.
+     *
+     * check_only is the sender's early gate: an environment that can never
+     * apply — cross-device staging above all — answers "rejected" here,
+     * before any chunk has been uploaded.
+     *
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,deleted:int,staging_free_bytes:?int,max_request_bytes:?int}
+     *   status "applied"|"ready"|"failed". "ready" carries the target's
+     *   preflight facts: free staging space and its request cap.
+     */
+    public function apply(string $manifest_id, bool $check_only = false): array
+    {
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES; $attempt++) {
+            $params = ["manifest_id" => $manifest_id];
+            if ($check_only) {
+                $params["check_only"] = 1;
+            }
+            $response = $this->request_json("POST", "staged_apply", $params);
+            if ($response["error"] !== null) {
+                return $this->apply_failed("transport_failed", $response["error"]);
+            }
+            if ($this->is_auth_envelope($response)) {
+                return $this->apply_failed("auth_failed", $this->envelope_error($response));
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            $status = $json["status"] ?? null;
+            if ($status === "applied" || $status === "ready") {
+                return [
+                    "status" => $status,
+                    "reason" => null,
+                    "detail" => null,
+                    "applied" => (int) ($json["applied"] ?? 0),
+                    "already_applied" => (int) ($json["already_applied"] ?? 0),
+                    "skipped" => (int) ($json["skipped"] ?? 0),
+                    "deleted" => (int) ($json["deleted"] ?? 0),
+                    "staging_free_bytes" => is_numeric($json["staging_free_bytes"] ?? null)
+                        ? (int) $json["staging_free_bytes"]
+                        : null,
+                    "max_request_bytes" => is_numeric($json["max_request_bytes"] ?? null)
+                        ? (int) $json["max_request_bytes"]
+                        : null,
+                ];
+            }
+            if ($status === "busy") {
+                $this->backoff($attempt);
+                continue;
+            }
+            return $this->apply_failed(
+                is_string($json["reason"] ?? null) ? $json["reason"] : "unexpected_response",
+                $json["detail"] ?? ("HTTP " . $response["http_code"])
+            );
+        }
+        return $this->apply_failed("busy_exhausted", null);
+    }
+
+    /**
+     * The embedding layer (lib.php in the WordPress wiring) answers
+     * control-plane auth failures with its own {error, code} envelope
+     * before any endpoint runs. Surface those as auth_failed — retrying
+     * cannot fix a bad secret — instead of an unexpected response.
+     */
+    /**
+     * The plan promised an mtime and the opened file disagrees — the
+     * content is newer than the plan. One predicate for the chunked and
+     * batched paths, so both enforce the same torn-content rule.
+     *
+     * @param array|false $opened_stat fstat() of the opened source.
+     */
+    private function planned_mtime_differs($opened_stat, ?int $expected_mtime): bool
+    {
+        return $expected_mtime !== null
+            && is_array($opened_stat)
+            && (int) $opened_stat["mtime"] !== $expected_mtime;
+    }
+
+    /**
+     * Whether the source was rewritten since it was opened (inode, mtime,
+     * or size moved) — the post-read half of the same rule.
+     *
+     * @param array|false $opened_stat fstat() taken at open time.
+     */
+    private function source_changed_since(string $source_path, $opened_stat): bool
+    {
+        clearstatcache(true, $source_path);
+        $now_stat = @stat($source_path);
+        return !is_array($opened_stat)
+            || $now_stat === false
+            || $now_stat["ino"] !== $opened_stat["ino"]
+            || $now_stat["mtime"] !== $opened_stat["mtime"]
+            || $now_stat["size"] !== $opened_stat["size"];
+    }
+
+    private function is_auth_envelope(array $response): bool
+    {
+        return in_array($response["http_code"], [401, 403], true)
+            && is_array($response["json"])
+            && !isset($response["json"]["status"]);
+    }
+
+    private function envelope_error(array $response): string
+    {
+        $error = $response["json"]["error"] ?? null;
+        return is_string($error) ? $error : ("HTTP " . $response["http_code"]);
+    }
+
+    /**
+     * @return array{status:string,reason:?string,detail:?string,applied:int,already_applied:int,skipped:int,deleted:int,staging_free_bytes:?int,max_request_bytes:?int}
+     */
+    private function apply_failed(string $reason, ?string $detail): array
+    {
+        return [
+            "status" => "failed",
+            "reason" => $reason,
+            "detail" => $detail,
+            "applied" => 0,
+            "already_applied" => 0,
+            "skipped" => 0,
+            "deleted" => 0,
+            "staging_free_bytes" => null,
+            "max_request_bytes" => null,
+        ];
+    }
+
+    /**
+     * Confirm the assembled artifact; retried only for "busy".
+     *
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    private function finalize(string $artifact_id, int $total_bytes, ?callable $on_progress = null): array
+    {
+        for ($attempt = 1; $attempt <= self::MAX_BUSY_RETRIES; $attempt++) {
+            $response = $this->request_json("POST", "staged_finalize", [
+                "artifact_id" => $artifact_id,
+                "total_bytes" => $total_bytes,
+            ]);
+            if ($response["error"] !== null) {
+                return $this->failed("transport_failed", $response["error"], $total_bytes);
+            }
+            if ($this->is_auth_envelope($response)) {
+                return $this->failed("auth_failed", $this->envelope_error($response));
+            }
+            $json = is_array($response["json"]) ? $response["json"] : [];
+            if (($json["status"] ?? null) === "verified") {
+                if ($on_progress !== null) {
+                    $on_progress($total_bytes, $total_bytes);
+                }
+                return [
+                    "status" => "verified",
+                    "reason" => null,
+                    "detail" => null,
+                    "committed_bytes" => (int) ($json["committed_bytes"] ?? $total_bytes),
+                ];
+            }
+            if (($json["status"] ?? null) === "busy") {
+                $this->backoff($attempt);
+                continue;
+            }
+            return $this->failed(
+                is_string($json["reason"] ?? null) ? $json["reason"] : "unexpected_response",
+                $json["detail"] ?? ("HTTP " . $response["http_code"]),
+                (int) ($json["committed_bytes"] ?? 0)
+            );
+        }
+        return $this->failed("busy_exhausted", null);
+    }
+
+    /**
+     * Sign and send one request, decoding the JSON response.
+     *
+     * @return array{http_code:int,json:mixed,error:?string}
+     */
+    private function request_json(string $method, string $endpoint, array $params, $body = "", ?string $content_hash = null): array
+    {
+        $url = $this->base_url
+            . (strpos($this->base_url, "?") === false ? "?" : "&")
+            . http_build_query(array_merge(["endpoint" => $endpoint], $params));
+
+        if (is_resource($body)) {
+            rewind($body);
+        }
+        $headers = [];
+        if ($this->hmac_client !== null) {
+            if ($content_hash === null) {
+                $content_hash = is_resource($body) ? $this->hash_stream($body) : hash("sha256", (string) $body);
+            }
+            $headers = $this->auth_headers_for_hash($content_hash);
+        }
+        $headers["Content-Type"] = "application/octet-stream";
+        if (is_resource($body)) {
+            $headers["Content-Length"] = (string) $this->stream_size($body);
+            rewind($body);
+        }
+
+        $response = call_user_func($this->transport, $method, $url, $headers, $body, $this->request_timeout);
+
+        $error = $response["error"] ?? null;
+        if ($error !== null) {
+            return ["http_code" => 0, "json" => null, "error" => (string) $error];
+        }
+
+        $decoded = json_decode((string) ($response["body"] ?? ""), true);
+        if (!is_array($decoded)) {
+            // An HTTP response without the protocol's JSON body — a proxy
+            // error page, a truncated reply. A bare 413 still means "too
+            // large", so preserve the code and let the caller classify.
+            $code = (int) ($response["http_code"] ?? 0);
+            if ($code === 413) {
+                return ["http_code" => 413, "json" => [], "error" => null];
+            }
+            return ["http_code" => $code, "json" => null, "error" => "invalid JSON response (HTTP {$code})"];
+        }
+
+        return [
+            "http_code" => (int) ($response["http_code"] ?? 0),
+            "json" => $decoded,
+            "error" => null,
+        ];
+    }
+
+    /** @return resource|false */
+    private function open_batch_spool()
+    {
+        return fopen("php://temp/maxmemory:" . self::BATCH_SPOOL_MEMORY_BYTES, "w+b");
+    }
+
+    /** @return resource|null */
+    private function copy_source_to_spool($source, int $bytes)
+    {
+        $spool = $this->open_batch_spool();
+        if ($spool === false) {
+            return null;
+        }
+        $remaining = $bytes;
+        while ($remaining > 0) {
+            $chunk = fread($source, min(self::BATCH_STREAM_BUFFER_BYTES, $remaining));
+            if ($chunk === false || $chunk === "") {
+                fclose($spool);
+                return null;
+            }
+            $written = fwrite($spool, $chunk);
+            if ($written !== strlen($chunk)) {
+                fclose($spool);
+                return null;
+            }
+            $remaining -= strlen($chunk);
+        }
+        rewind($spool);
+        return $spool;
+    }
+
+    private function write_batch_bytes($body, $hash, string $bytes): bool
+    {
+        hash_update($hash, $bytes);
+        return fwrite($body, $bytes) === strlen($bytes);
+    }
+
+    private function write_batch_stream($body, $hash, $source): bool
+    {
+        rewind($source);
+        while (!feof($source)) {
+            $chunk = fread($source, self::BATCH_STREAM_BUFFER_BYTES);
+            if ($chunk === false) {
+                return false;
+            }
+            if ($chunk === "") {
+                break;
+            }
+            if (!$this->write_batch_bytes($body, $hash, $chunk)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function auth_headers_for_hash(string $content_hash): array
+    {
+        $client = $this->hmac_client;
+        if ($client === null) {
+            return [];
+        }
+        $nonce = $client->generate_nonce();
+        $timestamp = $client->get_timestamp();
+        return [
+            "X-Auth-Signature" => $client->compute_signature($nonce, $timestamp, $content_hash),
+            "X-Auth-Nonce" => $nonce,
+            "X-Auth-Timestamp" => $timestamp,
+            "X-Auth-Content-Hash" => $content_hash,
+        ];
+    }
+
+    private function hash_stream($stream): string
+    {
+        rewind($stream);
+        $context = hash_init("sha256");
+        while (!feof($stream)) {
+            $chunk = fread($stream, self::BATCH_STREAM_BUFFER_BYTES);
+            if ($chunk === false || $chunk === "") {
+                break;
+            }
+            hash_update($context, $chunk);
+        }
+        rewind($stream);
+        return hash_final($context);
+    }
+
+    private function stream_size($stream): int
+    {
+        $stat = fstat($stream);
+        return is_array($stat) && isset($stat["size"]) ? (int) $stat["size"] : 0;
+    }
+
+    private function backoff(int $attempt): void
+    {
+        $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $attempt - 1)));
+        call_user_func($this->sleeper, (int) $delay);
+    }
+
+    /**
+     * @return array{status:string,reason:?string,detail:?string,committed_bytes:int}
+     */
+    private function failed(string $reason, ?string $detail = null, int $committed_bytes = 0): array
+    {
+        return [
+            "status" => "failed",
+            "reason" => $reason,
+            "detail" => $detail,
+            "committed_bytes" => $committed_bytes,
+        ];
+    }
+
+    /**
+     * Default transport: one curl request, honoring the proxy and CA bundle
+     * environment helpers when the importer runtime is loaded.
+     *
+     * @return array{http_code:int,body:string,error:?string}
+     */
+    private function curl_transport(string $method, string $url, array $headers, $body, int $timeout): array
+    {
+        $ch = curl_init($url);
+        if (function_exists("reprint_apply_curl_proxy_from_env")) {
+            reprint_apply_curl_proxy_from_env($ch);
+        }
+        if (function_exists("reprint_apply_curl_ca_bundle")) {
+            reprint_apply_curl_ca_bundle($ch);
+        }
+
+        $header_lines = [];
+        foreach ($headers as $name => $value) {
+            $header_lines[] = "{$name}: {$value}";
+        }
+
+        $options = [
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_TIMEOUT => $timeout,
+        ];
+        if ($method === "POST") {
+            if (is_resource($body)) {
+                rewind($body);
+                $options[CURLOPT_UPLOAD] = true;
+                $options[CURLOPT_INFILESIZE] = $this->stream_size($body);
+                $options[CURLOPT_READFUNCTION] = static function ($ch, $fd, int $length) use ($body): string {
+                    $chunk = fread($body, $length);
+                    return $chunk === false ? "" : $chunk;
+                };
+            } else {
+                $options[CURLOPT_POSTFIELDS] = (string) $body;
+            }
+        }
+
+        curl_setopt_array($ch, $options);
+
+        $response_body = curl_exec($ch);
+        if ($response_body === false) {
+            $error = curl_error($ch) ?: ("curl errno " . curl_errno($ch));
+            curl_close($ch);
+            return ["http_code" => 0, "body" => "", "error" => $error];
+        }
+        $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return ["http_code" => $http_code, "body" => (string) $response_body, "error" => null];
+    }
+}

--- a/packages/reprint-importer/src/lib/upload/class-upload-chunk-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-upload-chunk-sizer.php
@@ -89,6 +89,8 @@ class UploadChunkSizer
         $config["growth_holdoff_successes"] = max(0, (int) $config["growth_holdoff_successes"]);
         $this->config = $config;
 
+        // Persisted state may come from an older config or version; clamp it
+        // through the current floor, ceiling, and hard cap before resuming.
         $ceiling = $state["ceiling_bytes"] ?? null;
         $this->ceiling_bytes = is_numeric($ceiling) && (int) $ceiling > 0 ? (int) $ceiling : null;
         $this->chunk_bytes = $this->clamp_chunk(
@@ -133,6 +135,8 @@ class UploadChunkSizer
             return $this->decision("steady");
         }
 
+        // Limits only lower the ceiling; a later, higher preflight value
+        // cannot erase a smaller limit learned earlier in the session.
         return $this->lower_ceiling((int) ($smallest * $this->config["limit_safety_ratio"]));
     }
 
@@ -225,6 +229,9 @@ class UploadChunkSizer
     }
 
     /**
+     * Lowers the learned per-session ceiling and shrinks the current chunk
+     * when it no longer fits.
+     *
      * @return array{action:string,chunk_bytes:int}
      */
     private function lower_ceiling(int $ceiling): array
@@ -246,11 +253,18 @@ class UploadChunkSizer
         return $this->decision("shrink");
     }
 
+    /**
+     * Returns the active ceiling after applying the unconditional hard cap.
+     */
     private function effective_ceiling(): int
     {
         return min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]);
     }
 
+    /**
+     * Normalizes restored state without converting an already-impossible
+     * ceiling into an invalid chunk size.
+     */
     private function clamp_chunk(int $chunk_bytes): int
     {
         return max(

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,18 +358,20 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-pull/dual-mode-windows",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
+                "reference": "02cfcadbdd4fa49cdfccb0a2580897781f841db5"
             },
             "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
                 "php": ">=7.4",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
+            },
+            "suggest": {
+                "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+                "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
             },
             "type": "library",
             "autoload": {
@@ -382,10 +384,15 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
-                    "src/class-sqlite-driver-pdo.php"
+                    "src/class-staged-apply.php",
+                    "src/class-staged-artifacts.php",
+                    "src/class-staged-endpoints.php",
+                    "src/class-sqlite-driver-pdo.php",
+                    "src/class-wpdb-driver-pdo.php"
                 ],
                 "files": [
-                    "src/utils.php"
+                    "src/utils.php",
+                    "src/class-pdo-polyfill.php"
                 ]
             },
             "license": [

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -180,6 +180,68 @@ function _site_export_default_authenticate(): void {
 }
 
 /**
+ * Server-side options for the staged artifact endpoints.
+ *
+ * The staging directory must live outside the web-served tree, and WordPress
+ * has no guaranteed writable directory there, so the default sits under the
+ * system temp dir, keyed by ABSPATH so co-hosted sites do not share staging
+ * state. A host that cleans its temp dir only costs a transfer its progress —
+ * artifacts re-upload from offset 0. Define SITE_EXPORT_STAGING_DIR to pick a
+ * durable location instead.
+ */
+function _site_export_staged_options(): array {
+    $staging_dir = defined('SITE_EXPORT_STAGING_DIR')
+        ? SITE_EXPORT_STAGING_DIR
+        : rtrim(sys_get_temp_dir(), '/') . '/reprint-staging-' . md5(ABSPATH);
+
+    return [
+        'staging_dir' => $staging_dir,
+        'secret' => _site_export_get_shared_secret(),
+        'timestamp_tolerance' => SITE_EXPORT_TIMESTAMP_TOLERANCE,
+        // Where staged_apply moves verified artifacts. Apply is rename-only,
+        // so the staging dir must sit on this root's filesystem — apply
+        // rejects "cross_device" otherwise, and senders probe that with
+        // check_only before uploading anything.
+        'apply_target_root' => defined('SITE_EXPORT_APPLY_ROOT') ? SITE_EXPORT_APPLY_ROOT : ABSPATH,
+    ];
+}
+
+/**
+ * Data-plane endpoints authenticate inside their handlers.
+ *
+ * The default HMAC handler buffers php://input to hash it, which defeats the
+ * staged upload handlers' spool-then-verify discipline. Keep this list next
+ * to the public request handler so every large-body route makes an explicit
+ * auth decision.
+ */
+function _site_export_endpoint_authenticates_in_handler(string $endpoint): bool {
+    return in_array($endpoint, ['staged_upload', 'staged_upload_batch'], true);
+}
+
+/**
+ * Resolves the endpoint the dispatcher will actually run, so the auth gate
+ * authorizes that endpoint and not a different one named in the query string.
+ *
+ * Site_Export_HTTP_Server::parse_http_config() merges GET and POST with POST
+ * winning. If the gate read only the query string, a request could name a
+ * self-authenticating data-plane route (staged_upload) there — skipping the
+ * default HMAC check — while a form body carried endpoint=file_index, which
+ * POST-over-GET then dispatches unauthenticated. Resolving with the same
+ * precedence closes that seam. Takes the already-read filter_input() values;
+ * a non-string endpoint (e.g. endpoint[]=..., which arrives as false)
+ * resolves to '' so the default auth still runs and the dispatcher rejects.
+ *
+ * @param mixed $get_endpoint  filter_input(INPUT_GET, 'endpoint')
+ * @param mixed $post_endpoint filter_input(INPUT_POST, 'endpoint')
+ */
+function _site_export_resolve_endpoint($get_endpoint, $post_endpoint): string {
+    if (is_string($post_endpoint) && $post_endpoint !== '') {
+        return $post_endpoint;
+    }
+    return is_string($get_endpoint) ? $get_endpoint : '';
+}
+
+/**
  * Handle an export API request.
  *
  * WordPress is already loaded at this point — DB credentials, $table_prefix,
@@ -250,8 +312,25 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
-    $authenticate();
+    // Staged data-plane endpoints authenticate inside their handlers: the
+    // default handler here buffers the whole request body to hash it, which
+    // chunk and batch uploads cannot afford. Those routes verify the signed
+    // headers first and hash the body as it streams. A custom authenticate
+    // callable still runs for every endpoint — its embedder owns that tradeoff.
+    // Resolve the endpoint the same way the dispatcher does (POST over GET),
+    // so a form body cannot route to an unauthenticated endpoint while the
+    // query string names a self-authenticating one. filter_input, not the raw
+    // superglobals: lib.php also runs without WordPress bootstrapped.
+    $endpoint = _site_export_resolve_endpoint(
+        filter_input(INPUT_GET, 'endpoint'),
+        filter_input(INPUT_POST, 'endpoint')
+    );
+    $authenticate = $options['authenticate'] ?? null;
+    if ($authenticate !== null) {
+        $authenticate();
+    } elseif (!_site_export_endpoint_authenticates_in_handler($endpoint)) {
+        _site_export_default_authenticate();
+    }
 
     // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server
     // is resolvable. The class itself will require export.php on demand
@@ -267,6 +346,7 @@ function _site_export_handle_api_request(array $options = []): void {
     try {
         Site_Export_HTTP_Server::serve([
             'default_directory' => ABSPATH,
+            'staged' => _site_export_staged_options(),
         ]);
     } catch (Exception $e) {
         if (!headers_sent()) {

--- a/tests/HmacServerTest.php
+++ b/tests/HmacServerTest.php
@@ -143,36 +143,6 @@ final class HmacServerTest extends TestCase
         }
     }
 
-    public function testControlRequestVerifiesBoundedBody(): void
-    {
-        $body = '{"command":"preflight"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertNull($server->verify_control_request($headers, $body, 1700000001.0));
-    }
-
-    public function testControlRequestRejectsBodyAboveConfiguredLimit(): void
-    {
-        $body = '{"command":"preflight"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertSame(
-            'HMAC control request body exceeds 8 bytes',
-            $server->verify_control_request($headers, $body, 1700000001.0, 8)
-        );
-    }
-
-    public function testPrecomputedContentHashVerifiesWithoutBody(): void
-    {
-        $body = '{"command":"commit","manifest":"abc123"}';
-        $headers = $this->buildHeadersForBody($body);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
-
-        $this->assertNull($server->verify_content_hash($headers, hash('sha256', $body), 1700000001.0));
-    }
-
     public function testSignedContentHashHeaderCanBeCheckedBeforeBodyIsRead(): void
     {
         $body = '{"command":"start-session"}';

--- a/tests/Import/ImportStateTest.php
+++ b/tests/Import/ImportStateTest.php
@@ -55,6 +55,52 @@ class ImportStateTest extends TestCase
         $this->assertSame(99, $array['sql_statements_counted']);
     }
 
+    /**
+     * The staged-pull resume path checkpoints the in-flight file's ownership
+     * so a file that straddles a request boundary keeps its preserve-local
+     * override at apply time. That only works if the flag survives the
+     * state round-trip.
+     */
+    public function testCurrentFileOwnedRoundTrips(): void
+    {
+        foreach ([true, false, null] as $owned) {
+            $state = \ImportState::from_array([]);
+            $state->current_file = 'wp-content/plugins/a/a.php';
+            $state->current_file_bytes = 4096;
+            $state->current_file_owned = $owned;
+
+            $restored = \ImportState::from_array($state->to_array());
+
+            $this->assertSame($owned, $restored->current_file_owned, var_export($owned, true));
+            $this->assertSame('wp-content/plugins/a/a.php', $restored->current_file);
+            $this->assertSame(4096, $restored->current_file_bytes);
+        }
+    }
+
+    /** State written before this field existed reads as null (owned=false). */
+    public function testMissingCurrentFileOwnedDefaultsToNull(): void
+    {
+        $restored = \ImportState::from_array(['current_file' => 'x', 'current_file_bytes' => 1]);
+
+        $this->assertNull($restored->current_file_owned);
+    }
+
+    /**
+     * The path style persists like the sync flags so a resumed transfer keeps
+     * the representation it started with (absolute vs relative).
+     */
+    public function testIndexPathStyleRoundTrips(): void
+    {
+        foreach (['absolute', 'relative', null] as $style) {
+            $state = \ImportState::from_array([]);
+            $state->index_path_style = $style;
+
+            $restored = \ImportState::from_array($state->to_array());
+
+            $this->assertSame($style, $restored->index_path_style, var_export($style, true));
+        }
+    }
+
     public function testStateRoundTripMatchesDefaultStateSchema(): void
     {
         $client = new \ImportClient(

--- a/tests/Import/PushFilesCliTest.php
+++ b/tests/Import/PushFilesCliTest.php
@@ -1,0 +1,624 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Drives the real CLI in a subprocess, like OnlyCliParseTest: argument
+ * parsing, dispatch, exit codes, and the no-network paths of push-files.
+ */
+class PushFilesCliTest extends TestCase
+{
+    private string $state_dir;
+
+    private string $fs_root;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->state_dir = sys_get_temp_dir() . '/push-cli-state-' . $suffix;
+        $this->fs_root = sys_get_temp_dir() . '/push-cli-root-' . $suffix;
+        mkdir($this->state_dir, 0700, true);
+        mkdir($this->fs_root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->state_dir, $this->fs_root] as $dir) {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * @return array{0:string,1:int} Combined output and exit code.
+     */
+    private function runCli(array $args): array
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+        exec($cmd . ' 2>&1', $lines, $code);
+        return [implode("\n", $lines), $code];
+    }
+
+    public function testHelpDescribesTheCommand(): void
+    {
+        [$output] = $this->runCli(['push-files', '--help']);
+
+        $this->assertStringContainsString('reprint push-files <remote-url>', $output);
+        $this->assertStringContainsString('staged artifact store', $output);
+        $this->assertStringContainsString('--secret', $output);
+        $this->assertStringContainsString('--only', $output);
+    }
+
+    public function testMissingSecretFailsWithATypedError(): void
+    {
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('requires --secret', $output);
+    }
+
+    public function testEmptyTreeCompletesWithoutTouchingTheNetwork(): void
+    {
+        // Port 1 would refuse instantly; an empty plan must never get there.
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--secret=test-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(0, $code, $output);
+        // The summary is the pretty-printed JSON block at the end of the
+        // output, after the single-line progress records.
+        $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+        $this->assertSame('complete', $summary['status']);
+        $this->assertSame(0, $summary['files_total']);
+        $this->assertFileExists($this->state_dir . '/.push-state.json');
+    }
+
+    public function testAbortClearsPushStateWithoutSecretOrNetwork(): void
+    {
+        file_put_contents($this->state_dir . '/.push-state.json', '{}');
+        file_put_contents($this->state_dir . '/.push-verified.jsonl', "a.txt\n");
+        file_put_contents($this->state_dir . '/.push-manifest.jsonl', "{}\n");
+        file_put_contents($this->fs_root . '/a.txt', 'x');
+
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--abort',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('State cleared for push-files', $output);
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-state.json');
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-verified.jsonl');
+        $this->assertFileDoesNotExist($this->state_dir . '/.push-manifest.jsonl');
+    }
+
+    public function testUnreachableTargetAbortsWithTheRetryableExitCode(): void
+    {
+        file_put_contents($this->fs_root . '/wp-config-sample.php', '<?php');
+
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--secret=test-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+        ]);
+
+        $this->assertSame(2, $code, 'a transient connection failure follows the resume convention');
+        // Small files travel batched, so the dead target surfaces on the
+        // batch POST as transport_failed — classified retryable.
+        $this->assertStringContainsString('transport_failed', $output);
+        $this->assertFileExists(
+            $this->state_dir . '/.push-state.json',
+            'learned sizer state persists across the abort'
+        );
+    }
+
+    /**
+     * The full sender-to-target loop against a real HTTP server: the
+     * plugin's lib.php serving the staged endpoints WP-less (the same
+     * bootstrap the atomic e2e scenarios use), the real CLI pushing with
+     * --apply, files landing in the target root by rename.
+     */
+    /** @var resource|null */
+    private $apply_server = null;
+
+    private string $apply_harness = '';
+
+    /**
+     * Serves lib.php WP-less over php -S with staging and an apply root,
+     * like the atomic e2e sites do. Returns [url, site_root, staging_dir].
+     *
+     * @return array{0:string,1:string,2:string}
+     */
+    private function startApplyHarness(): array
+    {
+        $harness = sys_get_temp_dir() . '/push-cli-harness-' . bin2hex(random_bytes(8));
+        $site_root = $harness . '/site';
+        mkdir($site_root, 0700, true);
+        mkdir($harness . '/abspath', 0700, true);
+
+        $repo = (string) realpath(__DIR__ . '/../..');
+        file_put_contents($harness . '/secret.php', "<?php return 'push-cli-e2e-secret';\n");
+        file_put_contents(
+            $harness . '/router.php',
+            "<?php\n" .
+            "define('ABSPATH', '{$harness}/abspath/');\n" .
+            "define('SITE_EXPORT_PLUGIN_DIR', '{$repo}/reprint-exporter-wp/');\n" .
+            "define('SITE_EXPORT_SECRET_FILE', '{$harness}/secret.php');\n" .
+            "define('SITE_EXPORT_STAGING_DIR', '{$harness}/staging');\n" .
+            "define('SITE_EXPORT_APPLY_ROOT', '{$site_root}');\n" .
+            "if (!function_exists('plugin_dir_path')) {\n" .
+            "    function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }\n" .
+            "}\n" .
+            "require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';\n" .
+            "_site_export_handle_api_request();\n"
+        );
+
+        return [$this->serveRouter($harness), $site_root, $harness . '/staging'];
+    }
+
+    /** Serves $harness/router.php over php -S and returns the API url. */
+    private function serveRouter(string $harness): string
+    {
+        $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($probe, "cannot allocate a port: {$errstr}");
+        $name = (string) stream_socket_get_name($probe, false);
+        $port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($probe);
+
+        $this->apply_server = proc_open(
+            [PHP_BINARY, '-S', "127.0.0.1:{$port}", $harness . '/router.php'],
+            [
+                1 => ['file', $harness . '/server.log', 'a'],
+                2 => ['file', $harness . '/server.log', 'a'],
+            ],
+            $pipes
+        );
+        $this->assertIsResource($this->apply_server);
+        $this->apply_harness = $harness;
+
+        $deadline = microtime(true) + 10;
+        $ready = false;
+        while (microtime(true) < $deadline) {
+            $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($conn !== false) {
+                fclose($conn);
+                $ready = true;
+                break;
+            }
+            usleep(100000);
+        }
+        $this->assertTrue($ready, 'php -S did not come up');
+
+        return "http://127.0.0.1:{$port}/?reprint-api";
+    }
+
+    private function stopApplyHarness(): void
+    {
+        if (is_resource($this->apply_server)) {
+            proc_terminate($this->apply_server);
+            proc_close($this->apply_server);
+            $this->apply_server = null;
+        }
+        if ($this->apply_harness !== '') {
+            $this->removeDir($this->apply_harness);
+            $this->apply_harness = '';
+        }
+    }
+
+    private function pushArgs(string $url): array
+    {
+        return [
+            'push-files',
+            $url,
+            '--secret=push-cli-e2e-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+            '--apply',
+        ];
+    }
+
+    public function testFullPushWithApplyLandsFilesInTheTargetRoot(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            file_put_contents($this->fs_root . '/index.php', '<?php // pushed');
+            mkdir($this->fs_root . '/wp-content/uploads', 0700, true);
+            $big = str_repeat('reprint!', 40000); // 320 KB: several append steps
+            file_put_contents($this->fs_root . '/wp-content/uploads/a.bin', $big);
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertSame('<?php // pushed', file_get_contents($site_root . '/index.php'));
+            $this->assertSame($big, file_get_contents($site_root . '/wp-content/uploads/a.bin'));
+            $this->assertStringContainsString('push_apply', $output);
+
+            // Re-pushing the identical tree is a no-op that still succeeds:
+            // uploads cache-skip, apply classifies everything as applied.
+            [$again_output, $again_code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $again_code, $again_output);
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testInterruptedPushResumesFromTheCommittedOffset(): void
+    {
+        [$url, $site_root, $staging] = $this->startApplyHarness();
+        try {
+            mkdir($this->fs_root . '/wp-content/uploads', 0700, true);
+            $big = str_repeat('resumable-bytes', 20000); // 300 KB
+            file_put_contents($this->fs_root . '/wp-content/uploads/a.bin', $big);
+
+            // A previous push died mid-artifact: the target already holds a
+            // committed prefix. The next push must continue from it over
+            // HTTP, not restart or corrupt.
+            $store = new \Site_Export_Staged_Artifacts($staging);
+            $prefix = substr($big, 0, 100000);
+            $this->assertSame(
+                'accepted',
+                $store->append('wp-content/uploads/a.bin', 0, $prefix)['status']
+            );
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+
+            $this->assertSame(0, $code, $output);
+            $this->assertSame(
+                $big,
+                file_get_contents($site_root . '/wp-content/uploads/a.bin'),
+                'the resumed artifact must assemble byte-identical'
+            );
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testAdversarialFilenamesSurviveTheWire(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            // Names that stress the query-string transport (space, plus,
+            // percent, ampersand, quotes, unicode) and the store's
+            // record-lookalike handling.
+            $names = [
+                'file with space.txt',
+                '100%+done.txt',
+                'name&param=value.txt',
+                "it's \"quoted\".txt",
+                'emoji-😀.php',
+                'wp-content/uploads/déjà vu.bin',
+            ];
+            foreach ($names as $index => $name) {
+                $path = $this->fs_root . '/' . $name;
+                @mkdir(dirname($path), 0700, true);
+                file_put_contents($path, "body #{$index} of {$name}");
+            }
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+
+            $this->assertSame(0, $code, $output);
+            foreach ($names as $index => $name) {
+                $this->assertSame(
+                    "body #{$index} of {$name}",
+                    file_get_contents($site_root . '/' . $name),
+                    "mangled in transit: {$name}"
+                );
+            }
+
+            // Deletion ids ride the same manifest lines, so the weird
+            // names must survive that direction too.
+            unlink($this->fs_root . '/100%+done.txt');
+            unlink($this->fs_root . '/emoji-😀.php');
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame(2, $summary['deleted']);
+            $this->assertFileDoesNotExist($site_root . '/100%+done.txt');
+            $this->assertFileDoesNotExist($site_root . '/emoji-😀.php');
+            $this->assertFileExists($site_root . '/file with space.txt', 'the survivors stay');
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testInsufficientStagingSpaceRefusesBeforeUploading(): void
+    {
+        // A scripted target whose probe answers ready with 1 byte free: the
+        // gate must refuse the transfer without a single upload request.
+        $harness = sys_get_temp_dir() . '/push-cli-space-' . bin2hex(random_bytes(8));
+        mkdir($harness, 0700, true);
+        file_put_contents(
+            $harness . '/router.php',
+            "<?php\n" .
+            "file_put_contents('{$harness}/requests.log', (\$_GET['endpoint'] ?? '?') . \"\\n\", FILE_APPEND);\n" .
+            "header('Content-Type: application/json');\n" .
+            "echo json_encode(['status' => 'ready', 'staging_free_bytes' => 1, 'target_free_bytes' => 1, 'max_request_bytes' => 65536]);\n"
+        );
+        $url = $this->serveRouter($harness);
+        try {
+            file_put_contents($this->fs_root . '/too-big.bin', str_repeat('x', 4096));
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+
+            $this->assertSame(1, $code, $output);
+            $this->assertStringContainsString('insufficient_staging_space', $output);
+            $this->assertSame(
+                ['staged_apply'],
+                array_unique(array_filter(explode("\n", (string) file_get_contents($harness . '/requests.log')))),
+                'the probe must be the only request'
+            );
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testInsufficientStagingSpaceIgnoresCachedArtifacts(): void
+    {
+        // A resumed push may have already staged more bytes than the target
+        // currently reports free. The preflight gate must compare only the
+        // bytes still pending, or it falsely rejects the resume.
+        $harness = sys_get_temp_dir() . '/push-cli-space-resume-' . bin2hex(random_bytes(8));
+        mkdir($harness, 0700, true);
+        $router = <<<'PHP'
+<?php
+file_put_contents('__REQUESTS_LOG__', ($_GET['endpoint'] ?? '?') . "\n", FILE_APPEND);
+header('Content-Type: application/json');
+echo json_encode(['status' => 'ready', 'staging_free_bytes' => 1, 'target_free_bytes' => 1, 'max_request_bytes' => 65536]);
+PHP;
+        file_put_contents($harness . '/router.php', str_replace('__REQUESTS_LOG__', $harness . '/requests.log', $router));
+        $url = $this->serveRouter($harness);
+        try {
+            file_put_contents($this->fs_root . '/already.bin', str_repeat('x', 4096));
+            $mtime = (int) filemtime($this->fs_root . '/already.bin');
+            // Seed the shipped index (the delta base) so the diff sees this
+            // file as unchanged — "same" — and never lists it for upload, so
+            // it contributes nothing to the space gate.
+            file_put_contents(
+                $this->state_dir . '/.push-shipped-index.jsonl',
+                json_encode(['path' => base64_encode('already.bin'), 'ctime' => $mtime, 'size' => 4096, 'type' => 'file']) . "\n"
+            );
+
+            [$output, $code] = $this->runCli([
+                'push-files',
+                $url,
+                '--secret=push-cli-e2e-secret',
+                '--state-dir=' . $this->state_dir,
+                '--fs-root=' . $this->fs_root,
+            ]);
+
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame('complete', $summary['status']);
+            $this->assertSame(
+                ['staged_apply'],
+                array_unique(array_filter(explode("\n", (string) file_get_contents($harness . '/requests.log')))),
+                'the cached artifact must not upload just to satisfy the space gate'
+            );
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testLocalDeletionPropagatesOnTheNextPushApply(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            file_put_contents($this->fs_root . '/a.txt', 'stays');
+            file_put_contents($this->fs_root . '/b.txt', 'will be removed');
+            mkdir($this->fs_root . '/wp-content', 0700, true);
+            file_put_contents($this->fs_root . '/wp-content/c.php', '<?php // stays');
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileExists($site_root . '/b.txt');
+
+            // The file disappears locally; the next push must remove it
+            // from the target in the same apply window.
+            unlink($this->fs_root . '/b.txt');
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame('complete', $summary['status']);
+            $this->assertSame(1, $summary['deleted']);
+            $this->assertFileDoesNotExist($site_root . '/b.txt');
+            $this->assertSame('stays', file_get_contents($site_root . '/a.txt'));
+            $this->assertSame('<?php // stays', file_get_contents($site_root . '/wp-content/c.php'));
+
+            // The apply folded the deletion into the shipped index, so
+            // rerunning re-diffs against a base that no longer lists b.txt:
+            // nothing to re-delete, no failure.
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $summary = json_decode((string) substr($output, (int) strrpos($output, "{\n")), true);
+            $this->assertSame(0, $summary['deleted']);
+            $this->assertStringNotContainsString(
+                'b.txt',
+                (string) file_get_contents($this->state_dir . '/.push-shipped-index.jsonl'),
+                'the deletion left the shipped index'
+            );
+
+            // The deletion broke something? Restoring the file locally
+            // ships it back on the next push — the fix-forward loop.
+            file_put_contents($this->fs_root . '/b.txt', 'restored, new content');
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertSame('restored, new content', file_get_contents($site_root . '/b.txt'));
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testOnlyScopedPushDerivesDeletionsOnlyInsideItsPrefixes(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            file_put_contents($this->fs_root . '/out.txt', 'outside the scope');
+            mkdir($this->fs_root . '/wp-content', 0700, true);
+            file_put_contents($this->fs_root . '/wp-content/in.txt', 'inside');
+            file_put_contents($this->fs_root . '/wp-content/keep.txt', 'kept');
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+
+            // Both files vanish locally, but the scoped push may only act
+            // inside its prefixes: out.txt was excluded from the plan on
+            // purpose, not removed relative to it.
+            unlink($this->fs_root . '/out.txt');
+            unlink($this->fs_root . '/wp-content/in.txt');
+            [$output, $code] = $this->runCli(array_merge($this->pushArgs($url), ['--only=wp-content']));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileDoesNotExist($site_root . '/wp-content/in.txt');
+            $this->assertFileExists($site_root . '/out.txt', 'out-of-scope paths must survive a scoped push');
+
+            // The next full push sees out.txt gone from the plan and
+            // finishes the deletion.
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileDoesNotExist($site_root . '/out.txt');
+            $this->assertSame('kept', file_get_contents($site_root . '/wp-content/keep.txt'));
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testSkippedPathIsNotDerivedAsADeletion(): void
+    {
+        [$url, $site_root] = $this->startApplyHarness();
+        try {
+            file_put_contents($this->fs_root . '/keep.txt', 'kept');
+            mkdir($this->fs_root . '/wp-content/plugins/foo', 0700, true);
+            file_put_contents($this->fs_root . '/wp-content/plugins/foo/bar.php', '<?php // plugin');
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileExists($site_root . '/wp-content/plugins/foo/bar.php');
+
+            // The plugin directory becomes a symlink to shared storage — the
+            // hosting layout CLAUDE.md describes. The plan builder skips the
+            // symlink and everything under it, so those files leave the plan.
+            // That is "not read", not "removed locally": the previous copy on
+            // the target must survive, not be derived as a deletion.
+            $this->removeDir($this->fs_root . '/wp-content/plugins/foo');
+            symlink('/srv/htdocs/shared/plugins/foo', $this->fs_root . '/wp-content/plugins/foo');
+
+            [$output, $code] = $this->runCli($this->pushArgs($url));
+            $this->assertSame(0, $code, $output);
+            $this->assertFileExists(
+                $site_root . '/wp-content/plugins/foo/bar.php',
+                'files under a skipped symlink must not be deleted from the target'
+            );
+            $this->assertSame('kept', file_get_contents($site_root . '/keep.txt'));
+        } finally {
+            $this->stopApplyHarness();
+        }
+    }
+
+    public function testHostileOnlyPrefixIsRejectedBeforeAnyUpload(): void
+    {
+        file_put_contents($this->fs_root . '/a.txt', 'x');
+
+        [$output, $code] = $this->runCli([
+            'push-files',
+            'http://127.0.0.1:1/?reprint-api',
+            '--secret=test-secret',
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+            '--only=../outside',
+        ]);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('Invalid --only prefix', $output);
+    }
+
+    public function testWrongSecretAbortsFatalNotRetryable(): void
+    {
+        // A target that answers every request with the control-plane auth
+        // envelope, the way lib.php rejects a bad secret. Retrying cannot
+        // fix credentials: the abort must be exit 1, never the resume
+        // convention's exit 2.
+        $harness = sys_get_temp_dir() . '/push-cli-auth-' . bin2hex(random_bytes(8));
+        mkdir($harness, 0700, true);
+        file_put_contents(
+            $harness . '/router.php',
+            "<?php\n" .
+            "http_response_code(403);\n" .
+            "header('Content-Type: application/json');\n" .
+            "echo json_encode(['error' => 'HMAC signature verification failed', 'code' => 403]);\n"
+        );
+        $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($probe, "cannot allocate a port: {$errstr}");
+        $name = (string) stream_socket_get_name($probe, false);
+        $port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($probe);
+        $server = proc_open(
+            [PHP_BINARY, '-S', "127.0.0.1:{$port}", $harness . '/router.php'],
+            [1 => ['file', $harness . '/server.log', 'a'], 2 => ['file', $harness . '/server.log', 'a']],
+            $pipes
+        );
+        $this->assertIsResource($server);
+        $deadline = microtime(true) + 10;
+        $ready = false;
+        while (microtime(true) < $deadline) {
+            $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if ($conn !== false) {
+                fclose($conn);
+                $ready = true;
+                break;
+            }
+            usleep(100000);
+        }
+        $this->assertTrue($ready, 'php -S did not come up');
+
+        try {
+            file_put_contents($this->fs_root . '/index.php', '<?php');
+            [$output, $code] = $this->runCli([
+                'push-files',
+                "http://127.0.0.1:{$port}/?reprint-api",
+                '--secret=the-wrong-secret',
+                '--state-dir=' . $this->state_dir,
+                '--fs-root=' . $this->fs_root,
+            ]);
+
+            // The stable contract at every floor of the stack: credential
+            // rejections are fatal, never the resume convention's exit 2.
+            // (Higher floors classify the envelope as auth_failed; here it
+            // surfaces as an unexpected response — equally non-retryable.)
+            $this->assertSame(1, $code, $output);
+            $this->assertStringContainsString('"status": "error"', $output);
+        } finally {
+            proc_terminate($server);
+            proc_close($server);
+            $this->removeDir($harness);
+        }
+    }
+}

--- a/tests/Import/PushPlanBuilderTest.php
+++ b/tests/Import/PushPlanBuilderTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace ImportTests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use PushPlanBuilder;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class PushPlanBuilderTest extends TestCase {
+
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/push-plan-' . bin2hex(random_bytes(8));
+        mkdir($this->root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->root);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            if (is_link($entry) || !is_dir($entry)) {
+                @unlink($entry);
+            } else {
+                $this->removeDir($entry);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function put(string $rel, string $body): void
+    {
+        $path = $this->root . '/' . $rel;
+        @mkdir(dirname($path), 0700, true);
+        file_put_contents($path, $body);
+    }
+
+    /**
+     * Run build_index into a temp file and read it back as decoded entries
+     * (path-sorted, mirroring the sort_index_file the caller applies) plus
+     * the raw emission order.
+     *
+     * @return array{entries:array,skipped:array,order:array}
+     */
+    private function buildIndex(array $only = [], string $prefix = ''): array
+    {
+        $file = sys_get_temp_dir() . '/push-idx-' . bin2hex(random_bytes(6));
+        $handle = fopen($file, 'wb');
+        $build = PushPlanBuilder::build_index($this->root, $only, $handle, $prefix);
+        fclose($handle);
+
+        $entries = [];
+        $order = [];
+        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $d = json_decode($line, true);
+            $path = base64_decode($d['path']);
+            $order[] = $path;
+            $entries[] = [
+                'path' => $path,
+                'ctime' => $d['ctime'],
+                'size' => $d['size'],
+                'type' => $d['type'],
+            ];
+        }
+        @unlink($file);
+        usort($entries, static fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
+        return ['entries' => $entries, 'skipped' => $build['skipped'], 'order' => $order];
+    }
+
+    public function testIndexesRegularFilesInTheSharedFormat(): void
+    {
+        $this->put('index.php', '<?php');
+        $this->put('wp-content/themes/t/style.css', 'body{}');
+        touch($this->root . '/index.php', 1000);
+        touch($this->root . '/wp-content/themes/t/style.css', 2000);
+
+        $result = $this->buildIndex();
+
+        $this->assertSame([], $result['skipped']);
+        $this->assertSame(
+            [
+                ['path' => 'index.php', 'ctime' => 1000, 'size' => 5, 'type' => 'file'],
+                ['path' => 'wp-content/themes/t/style.css', 'ctime' => 2000, 'size' => 6, 'type' => 'file'],
+            ],
+            $result['entries']
+        );
+    }
+
+    public function testAbsolutePrefixMakesPathsWholeFilesystem(): void
+    {
+        $this->put('wp-content/x.php', 'x');
+        touch($this->root . '/wp-content/x.php', 1000);
+        $prefix = rtrim( (string) realpath($this->root), '/');
+
+        $result = $this->buildIndex([], $prefix);
+
+        $this->assertSame(
+            [['path' => $prefix . '/wp-content/x.php', 'ctime' => 1000, 'size' => 1, 'type' => 'file']],
+            $result['entries']
+        );
+    }
+
+    public function testEmissionOrderIsDeterministic(): void
+    {
+        foreach (['b.txt', 'a.txt', 'c/inner.txt', 'a-dir/z.txt'] as $rel) {
+            $this->put($rel, 'x');
+        }
+
+        $first = $this->buildIndex();
+        $second = $this->buildIndex();
+
+        $this->assertSame($first['order'], $second['order'], 'two walks of the same tree emit identically');
+        $sorted = $first['order'];
+        sort($sorted, SORT_STRING);
+        $this->assertSame($sorted, $first['order'], 'scandir order is alphabetical per directory');
+    }
+
+    public function testSymlinksAreSkippedAndReportedNeverFollowed(): void
+    {
+        $this->put('real/wanted.txt', 'keep');
+        $this->put('outside-target.txt', 'outside');
+        symlink($this->root . '/outside-target.txt', $this->root . '/link.txt');
+        // A directory symlink that would create a cycle if followed.
+        symlink($this->root, $this->root . '/cycle');
+
+        $result = $this->buildIndex();
+
+        $this->assertSame(
+            ['outside-target.txt', 'real/wanted.txt'],
+            array_column($result['entries'], 'path')
+        );
+        $skipped = $result['skipped'];
+        usort($skipped, static fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
+        $this->assertSame(
+            [
+                ['path' => 'cycle', 'reason' => 'symlink'],
+                ['path' => 'link.txt', 'reason' => 'symlink'],
+            ],
+            $skipped
+        );
+    }
+
+    public function testUnreadableDirectoryIsReportedNotFatal(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+        $this->put('ok.txt', 'fine');
+        $this->put('locked/secret.txt', 'hidden');
+        chmod($this->root . '/locked', 0000);
+
+        $result = $this->buildIndex();
+        chmod($this->root . '/locked', 0700);
+
+        $this->assertSame(['ok.txt'], array_column($result['entries'], 'path'));
+        $this->assertSame([['path' => 'locked', 'reason' => 'unreadable_dir']], $result['skipped']);
+    }
+
+    public function testOnlyPrefixesFilterAndPrune(): void
+    {
+        $this->put('wp-content/uploads/a.jpg', 'aa');
+        $this->put('wp-content/plugins/p/p.php', 'pp');
+        $this->put('wp-includes/version.php', 'vv');
+        $this->put('node_modules/dep/dep.js', 'jj');
+
+        $result = $this->buildIndex(['wp-content/uploads', 'wp-includes/version.php']);
+
+        $this->assertSame(
+            ['wp-content/uploads/a.jpg', 'wp-includes/version.php'],
+            array_column($result['entries'], 'path')
+        );
+    }
+
+    public function testHostileOnlyPrefixesAreRejected(): void
+    {
+        foreach (['../outside', 'a/../b', '', '/', 'a\\b'] as $hostile) {
+            try {
+                PushPlanBuilder::normalize_only([$hostile]);
+                $this->fail("prefix should have been rejected: {$hostile}");
+            } catch (InvalidArgumentException $e) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    public function testMissingRootIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $handle = fopen('php://memory', 'wb');
+        PushPlanBuilder::build_index($this->root . '/never-existed', [], $handle);
+    }
+
+    public function testEmptyRootYieldsEmptyIndex(): void
+    {
+        $result = $this->buildIndex();
+        $this->assertSame([], $result['entries']);
+        $this->assertSame([], $result['skipped']);
+    }
+}

--- a/tests/Import/StagedPullCliTest.php
+++ b/tests/Import/StagedPullCliTest.php
@@ -1,0 +1,555 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Drives the real CLI against a real WP-less export server (php -S serving
+ * lib.php, the test-44 bootstrap): files-pull --staged-apply downloads into
+ * the store under --state-dir and lands in --fs-root in one rename window.
+ */
+class StagedPullCliTest extends TestCase
+{
+    private const SECRET = 'staged-pull-cli-secret';
+
+    private string $state_dir;
+
+    private string $fs_root;
+
+    private string $source_dir;
+
+    private string $harness;
+
+    /** @var resource|null */
+    private $server = null;
+
+    private int $port = 0;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $base = (string) realpath(sys_get_temp_dir());
+        $this->state_dir = $base . '/staged-pull-state-' . $suffix;
+        $this->fs_root = $base . '/staged-pull-root-' . $suffix;
+        $this->source_dir = $base . '/staged-pull-source-' . $suffix;
+        $this->harness = $base . '/staged-pull-harness-' . $suffix;
+        foreach ([$this->state_dir, $this->fs_root, $this->source_dir, $this->harness] as $dir) {
+            mkdir($dir, 0700, true);
+        }
+        $this->startServer();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server)) {
+            proc_terminate($this->server);
+            proc_close($this->server);
+        }
+        foreach ([$this->state_dir, $this->fs_root, $this->source_dir, $this->harness] as $dir) {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (is_link($dir)) {
+            @unlink($dir);
+            return;
+        }
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            if (is_link($entry) || !is_dir($entry)) {
+                @unlink($entry);
+            } else {
+                $this->removeDir($entry);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function startServer(): void
+    {
+        $repo = (string) realpath(__DIR__ . '/../..');
+        file_put_contents($this->harness . '/secret.php', "<?php return '" . self::SECRET . "';\n");
+        file_put_contents(
+            $this->harness . '/router.php',
+            "<?php\n" .
+            "define('ABSPATH', '{$this->harness}/abspath/');\n" .
+            "define('SITE_EXPORT_PLUGIN_DIR', '{$repo}/reprint-exporter-wp/');\n" .
+            "define('SITE_EXPORT_SECRET_FILE', '{$this->harness}/secret.php');\n" .
+            "if (!function_exists('plugin_dir_path')) {\n" .
+            "    function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }\n" .
+            "}\n" .
+            "require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';\n" .
+            "_site_export_handle_api_request();\n"
+        );
+        mkdir($this->harness . '/abspath', 0700, true);
+
+        $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $name = (string) stream_socket_get_name($probe, false);
+        $this->port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($probe);
+
+        // -t points DOCUMENT_ROOT at the source tree: the exporter
+        // advertises it as a root, and it must not leak the harness or the
+        // repo checkout into the export.
+        $this->server = proc_open(
+            [PHP_BINARY, '-S', "127.0.0.1:{$this->port}", '-t', $this->source_dir, $this->harness . '/router.php'],
+            [
+                1 => ['file', $this->harness . '/server.log', 'a'],
+                2 => ['file', $this->harness . '/server.log', 'a'],
+            ],
+            $pipes
+        );
+
+        $deadline = microtime(true) + 10;
+        while (microtime(true) < $deadline) {
+            $conn = @fsockopen('127.0.0.1', $this->port, $errno, $errstr, 0.2);
+            if ($conn !== false) {
+                fclose($conn);
+                return;
+            }
+            usleep(100000);
+        }
+        $this->fail('php -S did not come up');
+    }
+
+    private function url(): string
+    {
+        return "http://127.0.0.1:{$this->port}/?reprint-api&directory[]=" . rawurlencode($this->source_dir);
+    }
+
+    private function baseArgs(array $extra = []): array
+    {
+        return array_merge([
+            $this->url(),
+            '--state-dir=' . $this->state_dir,
+            '--fs-root=' . $this->fs_root,
+            '--secret=' . self::SECRET,
+        ], $extra);
+    }
+
+    /**
+     * @return array{0:string,1:int}
+     */
+    private function runCli(string $command, array $extra = []): array
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry) . ' ' . escapeshellarg($command);
+        foreach ($this->baseArgs($extra) as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+        exec($cmd . ' 2>&1', $lines, $code);
+        return [implode("\n", $lines), $code];
+    }
+
+    /** Runs a pull command to completion, following the exit-2 resume protocol. */
+    private function pullToCompletion(array $extra = [], string $command = 'files-pull'): array
+    {
+        $output = '';
+        for ($attempt = 0; $attempt < 20; $attempt++) {
+            [$out, $code] = $this->runCli($command, $extra);
+            $output .= $out . "\n";
+            if ($code !== 2) {
+                return [$output, $code];
+            }
+        }
+        return [$output, 2];
+    }
+
+    private function seedSource(): void
+    {
+        mkdir($this->source_dir . '/wp-content/uploads', 0700, true);
+        mkdir($this->source_dir . '/wp-content/plugins/my-plugin', 0700, true);
+        // An empty directory and a symlink: parts that are not file
+        // content and must still respect the staged window.
+        mkdir($this->source_dir . '/wp-content/empty-dir', 0700, true);
+        symlink('index.php', $this->source_dir . '/link.php');
+        // wp_detect needs these to recognize the directory as a root.
+        file_put_contents($this->source_dir . '/wp-load.php', '<?php /* stub */');
+        file_put_contents($this->source_dir . '/wp-config.php', '<?php /* stub config */');
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index');
+        file_put_contents($this->source_dir . '/empty.txt', '');
+        file_put_contents($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', '<?php // plugin v1');
+        file_put_contents($this->source_dir . '/wp-content/uploads/big.bin', str_repeat('reprint!', 40000));
+    }
+
+    /** Files, directories, and symlinks under $dir — the window must gate all three. */
+    private function countEntries(string $dir): int
+    {
+        if (!is_dir($dir)) {
+            return 0;
+        }
+        $count = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $entry) {
+            ++$count;
+        }
+        return $count;
+    }
+
+    /**
+     * Where the pulled tree lands: pull mirrors absolute remote paths
+     * under --fs-root (flat-docroot reassembles them later), so the source
+     * tree appears at fs_root + realpath(source).
+     */
+    private function mappedRoot(): string
+    {
+        return $this->fs_root . (string) realpath($this->source_dir);
+    }
+
+    private function countFiles(string $dir): int
+    {
+        if (!is_dir($dir)) {
+            return 0;
+        }
+        $count = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $entry) {
+            if ($entry->isFile()) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    public function testStagedPullLandsTheTreeInOneWindowAndDeltaReplaces(): void
+    {
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('staged_apply', $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+        $this->assertSame(
+            0,
+            $this->countFiles($this->state_dir . '/.pull-staging/files'),
+            'the apply window consumes the staged transfer'
+        );
+
+        // Delta: the remote plugin changes; the next staged pull replaces
+        // it in place (no preserve-local), old bytes never truncated early.
+        file_put_contents(
+            $this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php',
+            '<?php // plugin v2 — longer than before'
+        );
+        touch($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', time() + 5);
+        // Deltas re-enter through --abort, the same way the delta e2e
+        // scenarios drive files-pull: state clears, the local index
+        // survives, and the rerun diffs against it.
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$delta_output, $delta_code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $delta_code, $delta_output);
+        $this->assertSame(
+            '<?php // plugin v2 — longer than before',
+            file_get_contents($this->mappedRoot() . '/wp-content/plugins/my-plugin/my-plugin.php'),
+            $delta_output
+        );
+    }
+
+    public function testMidPullFailureNeverTouchesFsRootAndResumes(): void
+    {
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        // A held store lock makes the first staged write fail mid-fetch —
+        // a deterministic interruption, no timing games. The essence under
+        // test: no failure between download start and apply may leave
+        // anything in the live tree.
+        $staging = $this->state_dir . '/.pull-staging';
+        mkdir($staging, 0700, true);
+        $holder = fopen($staging . '/lock', 'c+b');
+        flock($holder, LOCK_EX);
+
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertNotSame(0, $held_code, $held_output);
+        $this->assertSame(
+            0,
+            $this->countEntries($this->fs_root),
+            'an interrupted staged pull must leave the live tree untouched — no files, directories, or symlinks'
+        );
+
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+        $this->assertTrue(is_link($this->mappedRoot() . '/link.php'), 'the deferred symlink lands with the window');
+        $this->assertDirectoryExists($this->mappedRoot() . '/wp-content/empty-dir');
+    }
+
+    public function testAbortSwitchesModesCleanlyInBothDirections(): void
+    {
+        // Modes are sticky per state dir (like preserve-local); --abort is
+        // the documented switch. Staged, interrupted, aborted, finished
+        // unstaged — then a remote change pulled staged again. The tree
+        // must come out complete every time: the index never claims
+        // anything the live tree does not have, so no delta ever skips a
+        // file the previous mode left behind.
+        $this->seedSource();
+        $this->runCli('preflight');
+
+        $staging = $this->state_dir . '/.pull-staging';
+        mkdir($staging, 0700, true);
+        $holder = fopen($staging . '/lock', 'c+b');
+        flock($holder, LOCK_EX);
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertNotSame(0, $held_code, $held_output);
+
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        $this->assertDirectoryDoesNotExist($staging, '--abort clears staged leftovers');
+
+        // Unstaged from here: no --staged-apply flag, fresh state.
+        [$output, $code] = $this->pullToCompletion();
+        $this->assertSame(0, $code, $output);
+        exec('diff -r ' . escapeshellarg($this->source_dir) . ' ' . escapeshellarg($this->mappedRoot()) . ' 2>&1', $diff_lines, $diff_code);
+        $this->assertSame(0, $diff_code, implode("\n", $diff_lines));
+
+        // Back to staged for a delta.
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index v2');
+        touch($this->source_dir . '/index.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertSame(
+            '<?php // remote index v2',
+            file_get_contents($this->mappedRoot() . '/index.php')
+        );
+        $this->assertStringContainsString('staged_apply', $output, 'the delta ran through the window');
+    }
+
+    public function testPreserveLocalPoliciesHoldAtApplyTime(): void
+    {
+        $this->seedSource();
+        // Pre-seed the target at the MAPPED paths (pull mirrors absolute
+        // remote paths under fs-root): a local file that must win, and a
+        // symlinked plugins dir nothing may be created through.
+        $mapped = $this->mappedRoot();
+        mkdir($mapped . '/wp-content', 0700, true);
+        file_put_contents($mapped . '/index.php', 'local wins');
+        $shared = $this->fs_root . '-shared-plugins';
+        mkdir($shared, 0700, true);
+        symlink($shared, $mapped . '/wp-content/plugins');
+
+        try {
+            $this->runCli('preflight');
+            [$output, $code] = $this->pullToCompletion([
+                '--staged-apply',
+                '--on-fs-root-nonempty=preserve-local',
+            ]);
+
+            $this->assertSame(0, $code, $output);
+            $this->assertSame('local wins', file_get_contents($mapped . '/index.php'));
+            $this->assertSame([], glob($shared . '/*'), 'nothing may appear behind the symlink');
+            // Protection fires at download time (trunk's write-time checks
+            // stay active in staged mode, so protected files are never even
+            // fetched); the apply engine enforces the same policies as a
+            // backstop. Either way, every skip is audit-logged.
+            $audit = (string) @file_get_contents($this->state_dir . '/.import-audit.log');
+            $this->assertStringContainsString(
+                'PRESERVE-LOCAL skip file',
+                $audit,
+                'every protected path is audit-logged'
+            );
+            $this->assertSame(
+                str_repeat('reprint!', 40000),
+                file_get_contents($mapped . '/wp-content/uploads/big.bin'),
+                'unprotected content still lands'
+            );
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testPreserveLocalDeltaStillUpdatesFilesWeOwn(): void
+    {
+        // Trunk's contract: "preserve-local does not protect files we own"
+        // — a file the pull itself shipped re-downloads and replaces on
+        // delta. The apply window must not re-protect it just because its
+        // own previous copy occupies the path.
+        $this->seedSource();
+        $this->runCli('preflight');
+        [$output, $code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+        $this->assertSame(0, $code, $output);
+        $this->assertSame(
+            '<?php // plugin v1',
+            file_get_contents($this->mappedRoot() . '/wp-content/plugins/my-plugin/my-plugin.php')
+        );
+
+        file_put_contents(
+            $this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php',
+            '<?php // plugin v2, still ours'
+        );
+        touch($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$delta_output, $delta_code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertSame(0, $delta_code, $delta_output);
+        $this->assertSame(
+            '<?php // plugin v2, still ours',
+            file_get_contents($this->mappedRoot() . '/wp-content/plugins/my-plugin/my-plugin.php'),
+            'an owned file must update on delta even under preserve-local'
+        );
+    }
+
+    public function testRemoteDeletionsLandInsideTheApplyWindow(): void
+    {
+        $this->seedSource();
+        $this->runCli('preflight');
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+        $this->assertSame(0, $code, $output);
+        $mapped = $this->mappedRoot();
+        $this->assertFileExists($mapped . '/empty.txt');
+
+        // The remote drops two files and updates a third — a delta mixing
+        // deletions with an arrival.
+        unlink($this->source_dir . '/empty.txt');
+        unlink($this->source_dir . '/wp-content/plugins/my-plugin/my-plugin.php');
+        file_put_contents($this->source_dir . '/index.php', '<?php // remote index v2');
+        touch($this->source_dir . '/index.php', time() + 5);
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+
+        // A held store lock fails the delta mid-fetch. Deletions used to
+        // happen at diff time; in staged mode nothing — removals included —
+        // may touch the live tree before the window. (--abort cleared the
+        // staging dir, so recreate the scaffolding to plant the lock.)
+        @mkdir($this->state_dir . '/.pull-staging', 0700, true);
+        $holder = fopen($this->state_dir . '/.pull-staging/lock', 'c+b');
+        flock($holder, LOCK_EX);
+        [$held_output, $held_code] = $this->runCli('files-pull', ['--staged-apply']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertNotSame(0, $held_code, $held_output);
+        $this->assertFileExists(
+            $mapped . '/empty.txt',
+            'a deletion must wait for the apply window'
+        );
+        $this->assertFileExists($mapped . '/wp-content/plugins/my-plugin/my-plugin.php');
+        $this->assertSame('<?php // remote index', file_get_contents($mapped . '/index.php'));
+
+        // An abort in between must not orphan the pending deletions: the
+        // index still owns the files, so the fresh delta re-derives them.
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+
+        $this->assertSame(0, $code, $output);
+        $this->assertFileDoesNotExist($mapped . '/empty.txt');
+        $this->assertFileDoesNotExist($mapped . '/wp-content/plugins/my-plugin/my-plugin.php');
+        $this->assertSame('<?php // remote index v2', file_get_contents($mapped . '/index.php'));
+        $audit = (string) @file_get_contents($this->state_dir . '/.import-audit.log');
+        $this->assertStringContainsString('Deletion staged for the apply window', $audit);
+        $this->assertStringContainsString('deleted=2', $audit);
+
+        // The confirmed deletions left the index; the next delta derives
+        // nothing new for them.
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$output, $code] = $this->pullToCompletion(['--staged-apply']);
+        $this->assertSame(0, $code, $output);
+        $this->assertFileDoesNotExist($mapped . '/empty.txt');
+        $audit = (string) @file_get_contents($this->state_dir . '/.import-audit.log');
+        $this->assertSame(
+            0,
+            substr_count(explode('deleted=2', $audit, 2)[1] ?? '', 'Deletion staged for the apply window'),
+            'a confirmed deletion must not re-derive on the next delta'
+        );
+    }
+
+    public function testPreserveLocalStillDeletesFilesWeOwn(): void
+    {
+        // Ownership beats occupancy for deletions too: a file the pull
+        // shipped disappears remotely, and preserve-local — which protects
+        // what the sync never owned — does not keep our own stale copy.
+        $this->seedSource();
+        $this->runCli('preflight');
+        [$output, $code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+        $this->assertSame(0, $code, $output);
+        $this->assertFileExists($this->mappedRoot() . '/empty.txt');
+
+        unlink($this->source_dir . '/empty.txt');
+        [$abort_output, $abort_code] = $this->runCli('files-pull', ['--abort']);
+        $this->assertSame(0, $abort_code, $abort_output);
+        [$delta_output, $delta_code] = $this->pullToCompletion([
+            '--staged-apply',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertSame(0, $delta_code, $delta_output);
+        $this->assertFileDoesNotExist(
+            $this->mappedRoot() . '/empty.txt',
+            'preserve-local does not protect files we own from their own deletion'
+        );
+    }
+
+    public function testCrossDeviceStateDirIsRefusedBeforeDownloading(): void
+    {
+        if (!is_dir('/dev/shm')) {
+            $this->markTestSkipped('needs a tmpfs to make a real device boundary');
+        }
+        $this->seedSource();
+        $xdev_state = '/dev/shm/staged-pull-xdev-' . bin2hex(random_bytes(6));
+        mkdir($xdev_state, 0700, true);
+
+        try {
+            $entry = __DIR__ . '/../../importer/import.php';
+            $args = [
+                $this->url(),
+                '--state-dir=' . $xdev_state,
+                '--fs-root=' . $this->fs_root,
+                '--secret=' . self::SECRET,
+            ];
+            $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry) . ' preflight';
+            foreach ($args as $arg) {
+                $cmd .= ' ' . escapeshellarg($arg);
+            }
+            exec($cmd . ' 2>&1');
+
+            $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($entry) . ' files-pull';
+            foreach (array_merge($args, ['--staged-apply']) as $arg) {
+                $cmd .= ' ' . escapeshellarg($arg);
+            }
+            exec($cmd . ' 2>&1', $lines, $code);
+            $output = implode("\n", $lines);
+
+            $this->assertSame(1, $code, $output);
+            $this->assertStringContainsString('cross_device', $output);
+            $this->assertSame(0, $this->countFiles($this->fs_root), 'nothing may download');
+        } finally {
+            $this->removeDir($xdev_state);
+        }
+    }
+}

--- a/tests/Import/StagedPushRunnerTest.php
+++ b/tests/Import/StagedPushRunnerTest.php
@@ -1,0 +1,603 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Artifacts;
+use Site_Export_Staged_Endpoints;
+use StagedPushRunner;
+use StagedUploadClient;
+use UploadChunkSizer;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Drives the real runner through the real client, endpoints, and store
+ * in-process; only the socket is a callable, which also records every
+ * request and response code.
+ *
+ * The runner consumes the upload list the diff produced (path/size/ctime per
+ * line) and keeps no done cache: resume trusts the store's committed offset
+ * and verified short-circuit, the way pull trusts the files in its fs-root.
+ */
+class StagedPushRunnerTest extends TestCase {
+
+    private const SECRET = 'staged-push-runner-test-secret';
+
+    private string $staging_dir;
+
+    private string $state_dir;
+
+    private string $source_dir;
+
+    /** @var array<int, array{endpoint:string, params:array, http_code:int}> */
+    private array $requests = [];
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/push-runner-staging-' . $suffix;
+        $this->state_dir = sys_get_temp_dir() . '/push-runner-state-' . $suffix;
+        $this->source_dir = sys_get_temp_dir() . '/push-runner-source-' . $suffix;
+        mkdir($this->source_dir, 0700, true);
+        mkdir($this->state_dir, 0700, true);
+        $this->requests = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->staging_dir, $this->state_dir, $this->source_dir] as $dir) {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
+    {
+        return new Site_Export_Staged_Endpoints(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+        ], $overrides));
+    }
+
+    private function transportFor(Site_Export_Staged_Endpoints $endpoints): callable
+    {
+        return function (string $method, string $url, array $headers, $body, int $timeout) use ($endpoints): array {
+            parse_str( (string) parse_url($url, PHP_URL_QUERY), $params);
+            $endpoint = (string) ( $params['endpoint'] ?? '' );
+            unset($params['endpoint']);
+
+            $server = ['REQUEST_METHOD' => $method];
+            foreach ($headers as $name => $value) {
+                $server['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $value;
+            }
+
+            switch ($endpoint) {
+                case 'staged_upload':
+                    $stream = fopen('php://temp', 'w+b');
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
+                    rewind($stream);
+                    $result = $endpoints->upload($params, $server, $stream);
+                    fclose($stream);
+                    break;
+                case 'staged_finalize':
+                    $result = $endpoints->finalize($params, $server);
+                    break;
+                case 'staged_status':
+                    $result = $endpoints->status($params);
+                    break;
+                case 'staged_discard':
+                    $result = $endpoints->discard($params, $server);
+                    break;
+                case 'staged_upload_batch':
+                    $stream = fopen('php://temp', 'w+b');
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
+                    rewind($stream);
+                    $result = $endpoints->upload_batch($params, $server, $stream);
+                    fclose($stream);
+                    break;
+                default:
+                    return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
+            }
+
+            $this->requests[] = [
+                'endpoint' => $endpoint,
+                'params' => $params,
+                'http_code' => $result['http_code'],
+            ];
+
+            return [
+                'http_code' => $result['http_code'],
+                'body' => (string) json_encode($result['body']),
+                'error' => null,
+            ];
+        };
+    }
+
+    /**
+     * @return array{0:StagedPushRunner,1:UploadChunkSizer}
+     */
+    private function makeRunner(callable $transport, array $client_overrides = [], ?callable $on_progress = null, ?UploadChunkSizer $sizer = null): array
+    {
+        $sizer = $sizer ?? new UploadChunkSizer(
+            ['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8],
+            StagedPushRunner::read_state($this->state_dir)['sizer']
+        );
+        $client = new StagedUploadClient(array_merge([
+            'base_url' => 'https://target.example/?reprint-api',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'sizer' => $sizer,
+            'transport' => $transport,
+            'sleeper' => static function (int $microseconds): void {
+            },
+        ], $client_overrides));
+
+        $options = [
+            'state_dir' => $this->state_dir,
+            'source_root' => $this->source_dir,
+            'client' => $client,
+            'sizer' => $sizer,
+        ];
+        if ($on_progress !== null) {
+            $options['on_progress'] = $on_progress;
+        }
+        return [new StagedPushRunner($options), $sizer];
+    }
+
+    /** Stage a source file the runner will read under source_root. */
+    private function stageSource(string $artifact_id, string $body, ?int $mtime = null): void
+    {
+        $path = $this->source_dir . '/' . $artifact_id;
+        @mkdir(dirname($path), 0700, true);
+        file_put_contents($path, $body);
+        if ($mtime !== null) {
+            touch($path, $mtime);
+        }
+    }
+
+    /**
+     * Write an upload list (the diff's output) from specs, staging each
+     * source. Each spec: ['id'=>string, 'body'=>string, 'mtime'=>?int,
+     * 'size'=>?int (overrides the real size, to force a mismatch)].
+     */
+    private function uploadList(array $specs): string
+    {
+        $lines = '';
+        foreach ($specs as $spec) {
+            $this->stageSource($spec['id'], $spec['body'], $spec['mtime'] ?? null);
+            $ctime = (int) ( $spec['mtime'] ?? filemtime($this->source_dir . '/' . $spec['id']) );
+            $lines .= json_encode([
+                'path' => base64_encode($spec['id']),
+                'size' => $spec['size'] ?? strlen($spec['body']),
+                'ctime' => $ctime,
+            ]) . "\n";
+        }
+        $file = $this->state_dir . '/.push-upload-list.jsonl';
+        file_put_contents($file, $lines);
+        return $file;
+    }
+
+    private function requestsFor(string $endpoint): array
+    {
+        return array_values(array_filter($this->requests, static function (array $request) use ($endpoint): bool {
+            return $request['endpoint'] === $endpoint;
+        }));
+    }
+
+    // ---------------------------------------------------------------
+    // Completion and state files
+    // ---------------------------------------------------------------
+
+    public function testPushesAnUploadListToCompletion(): void
+    {
+        $list = $this->uploadList([
+            ['id' => 'wp-content/plugins/a.php', 'body' => str_repeat('a', 20)],
+            ['id' => 'wp-content/themes/b.css', 'body' => str_repeat('b', 9)],
+            ['id' => 'empty.txt', 'body' => ''],
+        ]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(3, $result['files_total']);
+        $this->assertSame(3, $result['files_done']);
+        $this->assertSame([], $result['failed']);
+        $this->assertSame(
+            str_repeat('a', 20),
+            file_get_contents($this->staging_dir . '/files/wp-content/plugins/a.php')
+        );
+
+        $state = StagedPushRunner::read_state($this->state_dir);
+        $this->assertSame(3, $state['files_total']);
+        $this->assertSame(3, $state['files_done']);
+        $this->assertArrayHasKey('chunk_bytes', $state['sizer']);
+        $this->assertFileDoesNotExist(
+            $this->state_dir . '/.push-verified.jsonl',
+            'the collapse dropped the done cache'
+        );
+    }
+
+    public function testProgressCoversChunksAndFiles(): void
+    {
+        $list = $this->uploadList([['id' => 'artifact.bin', 'body' => str_repeat('x', 20)]]);
+        $progress = [];
+        [$runner] = $this->makeRunner(
+            $this->transportFor($this->makeEndpoints()),
+            [],
+            static function (array $record) use (&$progress): void {
+                $progress[] = $record;
+            }
+        );
+
+        $runner->push($list);
+
+        $this->assertNotEmpty($progress);
+        $last = end($progress);
+        $this->assertSame(1, $last['files_done']);
+        $this->assertSame(1, $last['files_total']);
+        $this->assertSame(20, $last['committed_bytes']);
+    }
+
+    public function testEmptyUploadListCompletesWithoutRequests(): void
+    {
+        $list = $this->uploadList([]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($list);
+
+        $this->assertSame(['completed', 0, 0], [$result['status'], $result['files_total'], $result['files_done']]);
+        $this->assertCount(0, $this->requests);
+    }
+
+    public function testMalformedUploadLineIsSkipped(): void
+    {
+        $list = $this->uploadList([['id' => 'good.txt', 'body' => 'ok']]);
+        file_put_contents($list, "not json at all\n" . file_get_contents($list) . "{\"path\":\"\"}\n");
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertSame('ok', file_get_contents($this->staging_dir . '/files/good.txt'));
+    }
+
+    // ---------------------------------------------------------------
+    // Resume through the store, not a cache
+    // ---------------------------------------------------------------
+
+    public function testMidArtifactResumeUploadsOnlyTheTail(): void
+    {
+        $body = str_repeat('resumable-', 3);
+        // A previous run staged the first 16 bytes before dying.
+        ( new Site_Export_Staged_Artifacts($this->staging_dir) )
+            ->append('artifact.bin', 0, substr($body, 0, 16));
+        $list = $this->uploadList([['id' => 'artifact.bin', 'body' => $body]]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $uploads = $this->requestsFor('staged_upload');
+        $this->assertSame('16', $uploads[0]['params']['offset']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+    }
+
+    public function testFullyStagedArtifactShortCircuitsWithoutReuploadingBytes(): void
+    {
+        // A large file finished in a prior run is still verified in the
+        // store; the client confirms it through status/finalize without
+        // sending a byte — pull's "already in fs-root" trust, inverted.
+        $body = str_repeat('x', 20);
+        $store = new Site_Export_Staged_Artifacts($this->staging_dir);
+        $store->append('big.bin', 0, $body);
+        $this->assertSame('verified', $store->finalize('big.bin', 20)['status']);
+
+        $list = $this->uploadList([['id' => 'big.bin', 'body' => $body]]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($list);
+
+        $this->assertSame(['completed', 1], [$result['status'], $result['files_done']]);
+        $this->assertCount(0, $this->requestsFor('staged_upload'), 'no bytes re-uploaded');
+        $this->assertNotEmpty($this->requestsFor('staged_status'));
+    }
+
+    // ---------------------------------------------------------------
+    // Failure routing
+    // ---------------------------------------------------------------
+
+    public function testArtifactScopedFailureContinuesAndRerunRetriesIt(): void
+    {
+        $list = $this->uploadList([
+            ['id' => 'a.bin', 'body' => str_repeat('a', 8)],
+            ['id' => 'gone.bin', 'body' => str_repeat('g', 8)],
+            ['id' => 'c.bin', 'body' => str_repeat('c', 8)],
+        ]);
+        unlink($this->source_dir . '/gone.bin');
+        $transport = $this->transportFor($this->makeEndpoints());
+        [$runner] = $this->makeRunner($transport);
+
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(2, $result['files_done']);
+        $this->assertCount(1, $result['failed']);
+        $this->assertSame('gone.bin', $result['failed'][0]['artifact_id']);
+        $this->assertContains(
+            $result['failed'][0]['reason'],
+            ['source_unreadable', 'source_short', 'source_changed'],
+            'a missing source fails artifact-scoped'
+        );
+
+        // The source reappears; a rerun uploads only the failed artifact.
+        file_put_contents($this->source_dir . '/gone.bin', str_repeat('g', 8));
+        $this->requests = [];
+        [$again] = $this->makeRunner($transport);
+        $retry = $again->push($list);
+
+        $this->assertSame(['completed', 3, []], [$retry['status'], $retry['files_done'], $retry['failed']]);
+        $uploads = array_values(array_filter(
+            $this->requestsFor('staged_upload'),
+            static fn(array $r): bool => ( $r['params']['artifact_id'] ?? '' ) === 'gone.bin'
+        ));
+        $this->assertNotEmpty($uploads, 'only the previously-failed artifact re-uploads its bytes');
+    }
+
+    public function testTransferScopedFailureAborts(): void
+    {
+        $list = $this->uploadList([
+            ['id' => 'a.bin', 'body' => str_repeat('a', 8)],
+            ['id' => 'b.bin', 'body' => str_repeat('b', 8)],
+        ]);
+        [$runner] = $this->makeRunner(
+            $this->transportFor($this->makeEndpoints()),
+            ['hmac_client' => new Site_Export_HMAC_Client('wrong-secret')]
+        );
+
+        $result = $runner->push($list);
+
+        $this->assertSame('aborted', $result['status']);
+        $this->assertSame('auth_failed', $result['abort_reason']);
+        $this->assertSame(0, $result['files_done']);
+    }
+
+    public function testDeclaredSizeLongerThanSourceFailsScoped(): void
+    {
+        // The diff declared 12 bytes but the source holds 10: the client
+        // refuses rather than move the mismatch to finalize.
+        $list = $this->uploadList([['id' => 'short.bin', 'body' => str_repeat('x', 10), 'size' => 12]]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame('source_short', $result['failed'][0]['reason']);
+    }
+
+    public function testSourceChangedMidPushFailsTheArtifactAndContinues(): void
+    {
+        $volatile_body = str_repeat('abcd', 6); // 3 chunks at the 8-byte sizer
+        $list = $this->uploadList([
+            ['id' => 'volatile.bin', 'body' => $volatile_body],
+            ['id' => 'stable.bin', 'body' => 'steady'],
+        ]);
+        $base = $this->transportFor($this->makeEndpoints());
+        $rewritten = false;
+        $transport = function (...$args) use ($base, &$rewritten): array {
+            $response = $base(...$args);
+            if (
+                !$rewritten
+                && strpos($args[1], 'staged_upload') !== false
+                && strpos($args[1], 'volatile.bin') !== false
+            ) {
+                $rewritten = true;
+                // An active site edits the file while the push reads it.
+                file_put_contents($this->source_dir . '/volatile.bin', str_repeat('zzzz', 6));
+                touch($this->source_dir . '/volatile.bin', time() + 10);
+            }
+            return $response;
+        };
+        [$runner] = $this->makeRunner($transport);
+
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertSame('source_changed', $result['failed'][0]['reason']);
+        $this->assertSame(
+            'steady',
+            file_get_contents($this->staging_dir . '/files/stable.bin'),
+            'the rest of the transfer still pushes'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Sizer persistence
+    // ---------------------------------------------------------------
+
+    public function testLearnedChunkLimitsSurviveRuns(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 10]);
+        $transport = $this->transportFor($endpoints);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 32, 'max_bytes' => 32]);
+        [$runner] = $this->makeRunner($transport, [], null, $sizer);
+
+        $first = $runner->push($this->uploadList([['id' => 'a.bin', 'body' => str_repeat('a', 20)]]));
+        $this->assertSame('completed', $first['status']);
+        $this->assertNotEmpty(array_filter($this->requests, static function (array $request): bool {
+            return $request['http_code'] === 413;
+        }), 'the first run learns the cap from a 413');
+
+        // A fresh process restores the sizer through read_state(); the
+        // learned ceiling means no new 413 probes.
+        $this->requests = [];
+        $restored = new UploadChunkSizer(
+            ['floor_bytes' => 4, 'start_bytes' => 32, 'max_bytes' => 32],
+            StagedPushRunner::read_state($this->state_dir)['sizer']
+        );
+        [$again] = $this->makeRunner($transport, [], null, $restored);
+        $second = $again->push($this->uploadList([['id' => 'b.bin', 'body' => str_repeat('b', 20)]]));
+
+        $this->assertSame('completed', $second['status']);
+        $this->assertSame([], array_filter($this->requests, static function (array $request): bool {
+            return $request['http_code'] === 413;
+        }), 'the second run starts under the learned cap');
+    }
+
+    public function testReadStateDefaultsWhenNothingPersisted(): void
+    {
+        $state = StagedPushRunner::read_state($this->state_dir . '-never-created');
+
+        $this->assertSame(['sizer' => [], 'files_total' => 0, 'files_done' => 0], $state);
+    }
+
+    // ---------------------------------------------------------------
+    // Batched uploads
+    // ---------------------------------------------------------------
+
+    public function testSmallFilesTravelInBatchesNotOneRequestEach(): void
+    {
+        $specs = [];
+        for ($i = 0; $i < 6; $i++) {
+            $specs[] = ['id' => "small-{$i}.txt", 'body' => "file number {$i}"];
+        }
+        $sizer = new UploadChunkSizer(['floor_bytes' => 512, 'start_bytes' => 4096, 'max_bytes' => 4096]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()), [], null, $sizer);
+
+        $result = $runner->push($this->uploadList($specs));
+
+        $this->assertSame(['completed', 6], [$result['status'], $result['files_done']]);
+        $this->assertCount(1, $this->requestsFor('staged_upload_batch'), 'six files, one conversation');
+        $this->assertCount(0, $this->requestsFor('staged_upload'), 'no per-file requests for small files');
+        $this->assertSame('file number 3', file_get_contents($this->staging_dir . '/files/small-3.txt'));
+    }
+
+    public function testMixedListBatchesSmallAndChunksLarge(): void
+    {
+        $sizer = new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 512, 'max_bytes' => 512]);
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()), [], null, $sizer);
+
+        $result = $runner->push($this->uploadList([
+            ['id' => 'small-a.txt', 'body' => 'aa'],
+            ['id' => 'large.bin', 'body' => str_repeat('L', 2000)],
+            ['id' => 'small-b.txt', 'body' => 'bb'],
+        ]));
+
+        $this->assertSame(['completed', 3, []], [$result['status'], $result['files_done'], $result['failed']]);
+        $this->assertGreaterThanOrEqual(1, count($this->requestsFor('staged_upload_batch')));
+        $this->assertGreaterThanOrEqual(
+            4,
+            count($this->requestsFor('staged_upload')),
+            'the 2000-byte file streams in 512-byte chunks'
+        );
+        $this->assertSame(str_repeat('L', 2000), file_get_contents($this->staging_dir . '/files/large.bin'));
+    }
+
+    public function testBatchMemberChangedSinceDiffFailsScopedAndContinues(): void
+    {
+        // The volatility discipline holds on the batch path too: a small
+        // file edited between the diff and the upload fails typed and local,
+        // and the rest of its batch still travels.
+        $mtime = 1000;
+        $list = $this->uploadList([
+            ['id' => 'volatile.txt', 'body' => 'original', 'mtime' => $mtime],
+            ['id' => 'stable.txt', 'body' => 'steady'],
+        ]);
+        file_put_contents($this->source_dir . '/volatile.txt', 'rewritten');
+        touch($this->source_dir . '/volatile.txt', $mtime + 10);
+
+        [$runner] = $this->makeRunner($this->transportFor($this->makeEndpoints()));
+        $result = $runner->push($list);
+
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(1, $result['files_done']);
+        $this->assertSame(
+            ['volatile.txt', 'source_changed'],
+            [$result['failed'][0]['artifact_id'], $result['failed'][0]['reason']]
+        );
+        $this->assertSame('steady', file_get_contents($this->staging_dir . '/files/stable.txt'));
+        $this->assertFileDoesNotExist(
+            $this->staging_dir . '/files/volatile.txt',
+            'stale content never travels'
+        );
+    }
+
+    public function testBatchShrinksAfterA413AndCompletes(): void
+    {
+        $specs = [];
+        for ($i = 0; $i < 6; $i++) {
+            $specs[] = ['id' => "cap-{$i}.txt", 'body' => str_repeat( (string) $i, 40)];
+        }
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 700]);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]);
+        [$runner] = $this->makeRunner($this->transportFor($endpoints), [], null, $sizer);
+
+        $result = $runner->push($this->uploadList($specs));
+
+        $this->assertSame(['completed', 6, []], [$result['status'], $result['files_done'], $result['failed']]);
+        $this->assertNotEmpty(array_filter($this->requests, static function (array $request): bool {
+            return $request['http_code'] === 413;
+        }), 'the first oversized batch teaches the sizer');
+        $this->assertGreaterThanOrEqual(2, count($this->requestsFor('staged_upload_batch')), 'repartitioned batches');
+    }
+
+    public function testUnwritableStateDirAbortsTypedBeforeAnyRequest(): void
+    {
+        // A file where the state dir belongs makes mkdir fail: the runner
+        // aborts typed instead of pushing without persistence.
+        $blocker = $this->state_dir . '-blocker';
+        file_put_contents($blocker, 'not a directory');
+        $transport = function (...$args): array {
+            $this->requests[] = ['endpoint' => 'unexpected', 'params' => [], 'http_code' => 0];
+            return ['http_code' => 200, 'body' => '{}', 'error' => null];
+        };
+        $client = new StagedUploadClient([
+            'base_url' => 'https://target.example/?reprint-api',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+            'transport' => $transport,
+            'sleeper' => static function (int $microseconds): void {
+            },
+        ]);
+        $runner = new StagedPushRunner([
+            'state_dir' => $blocker . '/nested',
+            'source_root' => $this->source_dir,
+            'client' => $client,
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+        ]);
+
+        try {
+            $list = $this->uploadList([['id' => 'a.txt', 'body' => 'x']]);
+            $result = $runner->push($list);
+
+            $this->assertSame('aborted', $result['status']);
+            $this->assertSame('state_dir_unwritable', $result['abort_reason']);
+            $this->assertSame([], $this->requests, 'no request may travel without a state dir');
+        } finally {
+            @unlink($blocker);
+        }
+    }
+}

--- a/tests/Import/StagedUploadClientTest.php
+++ b/tests/Import/StagedUploadClientTest.php
@@ -1,0 +1,734 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Artifacts;
+use Site_Export_Staged_Endpoints;
+use StagedUploadClient;
+use UploadChunkSizer;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Drives the real StagedUploadClient against the real staged endpoints and
+ * store in-process: requests are signed by the real HMAC client and verified
+ * by the real HMAC server, only the socket is replaced by a callable.
+ */
+class StagedUploadClientTest extends TestCase
+{
+    private const SECRET = 'staged-upload-client-test-secret';
+
+    private string $staging_dir;
+
+    private string $source_path;
+
+    /** @var array<int, array{endpoint:string, params:array}> */
+    private array $requests = [];
+
+    /** @var int[] */
+    private array $sleeps = [];
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/staged-upload-client-' . $suffix;
+        $this->source_path = sys_get_temp_dir() . '/staged-upload-source-' . $suffix;
+        $this->requests = [];
+        $this->sleeps = [];
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->source_path);
+        $this->removeDir($this->staging_dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
+    {
+        return new Site_Export_Staged_Endpoints(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+        ], $overrides));
+    }
+
+    /**
+     * In-process transport: routes signed requests into the endpoint class
+     * the way the HTTP dispatcher would, recording every call.
+     */
+    private function transportFor(Site_Export_Staged_Endpoints $endpoints): callable
+    {
+        return function (string $method, string $url, array $headers, $body, int $timeout) use ($endpoints): array {
+            parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+            $endpoint = (string) ($params['endpoint'] ?? '');
+            unset($params['endpoint']);
+            $this->requests[] = ['endpoint' => $endpoint, 'params' => $params];
+
+            $server = ['REQUEST_METHOD' => $method];
+            foreach ($headers as $name => $value) {
+                $server['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $value;
+            }
+
+            switch ($endpoint) {
+                case 'staged_upload':
+                    $stream = fopen('php://temp', 'w+b');
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
+                    rewind($stream);
+                    $result = $endpoints->upload($params, $server, $stream);
+                    fclose($stream);
+                    break;
+                case 'staged_finalize':
+                    $result = $endpoints->finalize($params, $server);
+                    break;
+                case 'staged_status':
+                    $result = $endpoints->status($params);
+                    break;
+                case 'staged_discard':
+                    $result = $endpoints->discard($params, $server);
+                    break;
+                case 'staged_upload_batch':
+                    $stream = fopen('php://temp', 'w+b');
+                    if (is_resource($body)) {
+                        rewind($body);
+                        stream_copy_to_stream($body, $stream);
+                    } else {
+                        fwrite($stream, (string) $body);
+                    }
+                    rewind($stream);
+                    $result = $endpoints->upload_batch($params, $server, $stream);
+                    fclose($stream);
+                    break;
+                case 'staged_apply':
+                    $result = $endpoints->apply($params, $server);
+                    break;
+                default:
+                    return ['http_code' => 400, 'body' => '{"error":"unknown endpoint"}', 'error' => null];
+            }
+
+            return [
+                'http_code' => $result['http_code'],
+                'body' => (string) json_encode($result['body']),
+                'error' => null,
+            ];
+        };
+    }
+
+    private function makeClient(callable $transport, array $overrides = []): StagedUploadClient
+    {
+        return new StagedUploadClient(array_merge([
+            'base_url' => 'https://target.example/?reprint-api',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+            'transport' => $transport,
+            'sleeper' => function (int $microseconds): void {
+                $this->sleeps[] = $microseconds;
+            },
+        ], $overrides));
+    }
+
+    private function writeSource(string $body): void
+    {
+        file_put_contents($this->source_path, $body);
+    }
+
+    private function uploadCalls(): array
+    {
+        return array_values(array_filter($this->requests, static function (array $request): bool {
+            return $request['endpoint'] === 'staged_upload';
+        }));
+    }
+
+    // ---------------------------------------------------------------
+    // Happy paths
+    // ---------------------------------------------------------------
+
+    public function testUploadsAMultiChunkArtifactToVerified(): void
+    {
+        $body = str_repeat('0123456789', 6);
+        $this->writeSource($body);
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $progress = [];
+        $result = $client->upload_artifact(
+            'wp-content/uploads/a.bin',
+            $this->source_path,
+            null,
+            static function (int $committed, int $total) use (&$progress): void {
+                $progress[] = [$committed, $total];
+            }
+        );
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame(strlen($body), $result['committed_bytes']);
+        $this->assertSame(
+            $body,
+            file_get_contents($this->staging_dir . '/files/wp-content/uploads/a.bin')
+        );
+        $this->assertCount(8, $this->uploadCalls(), '60 bytes in 8-byte chunks');
+        $offsets = array_column($progress, 0);
+        $sorted = $offsets;
+        sort($sorted);
+        $this->assertSame($sorted, $offsets, 'progress never goes backward');
+        $this->assertSame([strlen($body), strlen($body)], end($progress));
+    }
+
+    public function testResumesFromTheStoreCommittedOffset(): void
+    {
+        $body = str_repeat('resumable-', 6);
+        $this->writeSource($body);
+        // A previous run staged the first 24 bytes.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))
+            ->append('artifact.bin', 0, substr($body, 0, 24));
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame('24', $this->uploadCalls()[0]['params']['offset']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+    }
+
+    public function testZeroByteArtifactVerifiesWithoutUploads(): void
+    {
+        $this->writeSource('');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('empty.txt', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertCount(0, $this->uploadCalls());
+    }
+
+    public function testAlreadyVerifiedArtifactShortCircuits(): void
+    {
+        $body = 'push-me-once';
+        $this->writeSource($body);
+        $transport = $this->transportFor($this->makeEndpoints());
+        $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+        $this->requests = [];
+
+        $again = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame('verified', $again['status']);
+        $this->assertCount(0, $this->uploadCalls());
+
+        $wrong_total = $this->makeClient($transport)
+            ->upload_artifact('artifact.bin', $this->source_path, strlen($body) + 5);
+        $this->assertSame(['failed', 'size_mismatch'], [$wrong_total['status'], $wrong_total['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Response-driven resync
+    // ---------------------------------------------------------------
+
+    public function testLostResponseRetryLandsAsDuplicateAndContinues(): void
+    {
+        $body = str_repeat('abcdefgh', 4);
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+
+        // The second chunk commits server-side but its response is lost.
+        $upload_seen = 0;
+        $transport = function (...$args) use ($base, &$upload_seen): array {
+            $response = $base(...$args);
+            if (strpos($args[1], 'staged_upload') !== false && ++$upload_seen === 2) {
+                return ['http_code' => 0, 'body' => '', 'error' => 'timeout after commit'];
+            }
+            return $response;
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+        $this->assertNotEmpty($this->sleeps, 'the lost response costs one backoff');
+    }
+
+    public function testServerSideDiscardMidTransferResyncsFromZero(): void
+    {
+        $body = str_repeat('resync!!', 5);
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+
+        // Someone discards the artifact on the target between two chunks.
+        $upload_seen = 0;
+        $transport = function (...$args) use ($base, &$upload_seen): array {
+            if (strpos($args[1], 'staged_upload') !== false && ++$upload_seen === 3) {
+                (new Site_Export_Staged_Artifacts($this->staging_dir))->discard('artifact.bin');
+            }
+            return $base(...$args);
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+    }
+
+    // ---------------------------------------------------------------
+    // Chunk-size learning
+    // ---------------------------------------------------------------
+
+    public function test413ShrinksToTheReportedCapAndSucceeds(): void
+    {
+        $body = str_repeat('x', 40);
+        $this->writeSource($body);
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 10]);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 32, 'max_bytes' => 32]);
+        $client = $this->makeClient($this->transportFor($endpoints), ['sizer' => $sizer]);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/artifact.bin'));
+        $this->assertLessThanOrEqual(9, $sizer->chunk_bytes(), 'ceiling learned from the 413');
+    }
+
+    public function testGivesUpWhenTheFloorIsStillTooLarge(): void
+    {
+        $this->writeSource(str_repeat('x', 40));
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 2]);
+        $sizer = new UploadChunkSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 8]);
+        $client = $this->makeClient($this->transportFor($endpoints), ['sizer' => $sizer]);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(
+            ['failed', 'chunk_size_exhausted'],
+            [$result['status'], $result['reason']]
+        );
+        $this->assertLessThan(4, count($this->uploadCalls()), 'no endless probing below the floor');
+    }
+
+    // ---------------------------------------------------------------
+    // Failure classes
+    // ---------------------------------------------------------------
+
+    public function testBusyStoreRetriesThenSucceeds(): void
+    {
+        $body = 'busy-then-fine';
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+
+        $injected = false;
+        $transport = function (...$args) use ($base, &$injected): array {
+            if (!$injected && strpos($args[1], 'staged_upload') !== false) {
+                $injected = true;
+                return [
+                    'http_code' => 423,
+                    'body' => '{"status":"busy","reason":null,"detail":null,"committed_bytes":0}',
+                    'error' => null,
+                ];
+            }
+            return $base(...$args);
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertNotEmpty($this->sleeps);
+    }
+
+    public function testControlPlaneAuthEnvelopeSurfacesAsAuthFailed(): void
+    {
+        // lib.php rejects control-plane requests with its own {error, code}
+        // envelope before any endpoint runs; the client must read that as
+        // an auth failure, not an unexpected response.
+        $envelope = static function (): array {
+            return [
+                'http_code' => 403,
+                'body' => '{"error":"HMAC signature verification failed","code":403}',
+                'error' => null,
+            ];
+        };
+        $client = $this->makeClient($envelope);
+        $this->writeSource('bytes');
+
+        $probe = $client->apply('.manifest.jsonl', true);
+        $this->assertSame(['failed', 'auth_failed'], [$probe['status'], $probe['reason']]);
+
+        $upload = $client->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame(['failed', 'auth_failed'], [$upload['status'], $upload['reason']]);
+
+        $status = $client->status('artifact.bin');
+        $this->assertSame(['failed', 'auth_failed'], [$status['status'], $status['reason']]);
+
+        $discard = $client->discard('artifact.bin');
+        $this->assertSame(['failed', 'auth_failed'], [$discard['status'], $discard['reason']]);
+    }
+
+    public function testWrongSecretFailsFastWithoutRetries(): void
+    {
+        $this->writeSource('some bytes');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [
+            'hmac_client' => new Site_Export_HMAC_Client('not-the-target-secret'),
+        ]);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']]);
+        $this->assertCount(1, $this->uploadCalls(), 'auth failures must not be retried');
+    }
+
+    public function testSourceRewrittenMidUploadFailsTyped(): void
+    {
+        $body = str_repeat('abcd', 8); // 32 bytes: several 8-byte chunks
+        $this->writeSource($body);
+        $base = $this->transportFor($this->makeEndpoints());
+        $rewritten = false;
+        $transport = function (...$args) use ($base, &$rewritten): array {
+            $response = $base(...$args);
+            if (!$rewritten && strpos($args[1], 'staged_upload') !== false) {
+                $rewritten = true;
+                // Same length, new content, future mtime — invisible to
+                // every byte-count check in the pipeline.
+                file_put_contents($this->source_path, str_repeat('zzzz', 8));
+                touch($this->source_path, time() + 10);
+            }
+            return $response;
+        };
+        $client = $this->makeClient($transport);
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(['failed', 'source_changed'], [$result['status'], $result['reason']]);
+        $this->assertFalse(
+            $client->status('artifact.bin')['exists'],
+            'torn staged bytes must be discarded, never verified'
+        );
+    }
+
+    public function testStalePlanMtimeFailsBeforeAnyUpload(): void
+    {
+        $this->writeSource('current content');
+        // Remnants of the older version sit staged on the target.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('artifact.bin', 0, 'old-');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact(
+            'artifact.bin',
+            $this->source_path,
+            null,
+            null,
+            ((int) filemtime($this->source_path)) - 100
+        );
+
+        $this->assertSame(['failed', 'source_changed'], [$result['status'], $result['reason']]);
+        $this->assertCount(0, $this->uploadCalls(), 'a stale plan must not upload');
+        $this->assertFalse($client->status('artifact.bin')['exists'], 'stale remnants are discarded');
+    }
+
+    public function testTransportHardFailureStopsBounded(): void
+    {
+        $this->writeSource(str_repeat('x', 32));
+        $transport = function (...$args): array {
+            parse_str((string) parse_url($args[1], PHP_URL_QUERY), $params);
+            if (($params['endpoint'] ?? '') === 'staged_status') {
+                return [
+                    'http_code' => 200,
+                    'body' => '{"exists":false,"committed_bytes":0,"verified":false}',
+                    'error' => null,
+                ];
+            }
+            $this->requests[] = ['endpoint' => (string) $params['endpoint'], 'params' => $params];
+            return ['http_code' => 0, 'body' => '', 'error' => 'connection refused'];
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame(['failed', 'transport_failed'], [$result['status'], $result['reason']]);
+        $this->assertLessThanOrEqual(
+            6,
+            count($this->uploadCalls()),
+            'bounded by the sizer floor and the consecutive-failure cap'
+        );
+    }
+
+    public function testSourceShorterThanDeclaredTotalFails(): void
+    {
+        $this->writeSource('only-ten-b');
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path, 20);
+
+        $this->assertSame(['failed', 'source_short'], [$result['status'], $result['reason']]);
+    }
+
+    public function testMissingSourceFileFails(): void
+    {
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()));
+
+        $result = $client->upload_artifact('artifact.bin', $this->source_path . '-missing');
+
+        $this->assertSame(['failed', 'source_unreadable'], [$result['status'], $result['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Batched uploads
+    // ---------------------------------------------------------------
+
+    /** Creates one temp file per artifact; returns upload_batch entries. */
+    private function batchFiles(array $map): array
+    {
+        $entries = [];
+        foreach ($map as $artifact_id => $body) {
+            $path = $this->source_path . '-' . md5($artifact_id);
+            file_put_contents($path, $body);
+            $entries[] = [
+                'artifact_id' => $artifact_id,
+                'source_path' => $path,
+                'total_bytes' => strlen($body),
+                'mtime' => (int) filemtime($path),
+            ];
+        }
+        return $entries;
+    }
+
+    public function testUploadBatchVerifiesManyFilesInOneRequest(): void
+    {
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles([
+            'a.txt' => 'aaa',
+            'wp-content/b.bin' => str_repeat('b', 200),
+            'empty.txt' => '',
+        ]);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame('ok', $result['status']);
+        foreach ($files as $file) {
+            $this->assertSame(
+                'verified',
+                $result['per_file'][$file['artifact_id']]['status'],
+                $file['artifact_id']
+            );
+            $this->assertSame(
+                (string) file_get_contents($file['source_path']),
+                (string) file_get_contents($this->staging_dir . '/files/' . $file['artifact_id'])
+            );
+        }
+        $this->assertCount(1, array_filter($this->requests, static function (array $request): bool {
+            return $request['endpoint'] === 'staged_upload_batch';
+        }), 'many files, one conversation');
+    }
+
+    public function testUploadBatchSendsAStreamedRequestBody(): void
+    {
+        $base = $this->transportFor($this->makeEndpoints());
+        $saw_batch_stream = false;
+        $transport = function (string $method, string $url, array $headers, $body, int $timeout) use ($base, &$saw_batch_stream): array {
+            parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+            if (($params['endpoint'] ?? '') === 'staged_upload_batch') {
+                $saw_batch_stream = true;
+                $this->assertTrue(is_resource($body), 'batch body should not be materialized as one PHP string');
+                $stat = fstat($body);
+                $this->assertIsArray($stat);
+                $this->assertSame((string) $stat['size'], $headers['Content-Length'] ?? null);
+            }
+            return $base($method, $url, $headers, $body, $timeout);
+        };
+        $client = $this->makeClient($transport, [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles([
+            'a.txt' => str_repeat('a', 128),
+            'b.txt' => str_repeat('b', 128),
+        ]);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertTrue($saw_batch_stream, 'the test must exercise the batch endpoint');
+    }
+
+    public function testUploadBatchRepartitionsWhenTooLarge(): void
+    {
+        $sizer = new UploadChunkSizer(['floor_bytes' => 16, 'start_bytes' => 256, 'max_bytes' => 256]);
+        $client = $this->makeClient(
+            $this->transportFor($this->makeEndpoints(['max_request_bytes' => 64])),
+            ['sizer' => $sizer]
+        );
+        $files = $this->batchFiles(['big-ish.bin' => str_repeat('x', 200)]);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame(['failed', 'batch_too_large'], [$result['status'], $result['reason']]);
+        $this->assertLessThanOrEqual(57, $sizer->chunk_bytes(), 'the sizer learned the cap');
+    }
+
+    public function testUploadBatchFailsTopLevelRejectedProtocolErrors(): void
+    {
+        $calls = 0;
+        $client = $this->makeClient(static function () use (&$calls): array {
+            $calls++;
+            return [
+                'http_code' => 400,
+                'body' => (string) json_encode([
+                    'status' => 'rejected',
+                    'reason' => 'invalid_batch_frame',
+                    'detail' => 'not json at all',
+                    'results' => [],
+                ]),
+                'error' => null,
+            ];
+        }, [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles(['a.txt' => 'aaa']);
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame(['failed', 'invalid_batch_frame'], [$result['status'], $result['reason']]);
+        $this->assertSame('not json at all', $result['detail']);
+        $this->assertSame(1, $calls, 'malformed batch responses are not retried as sendable files');
+    }
+
+    public function testUploadBatchExcludesAVolatileFileLocally(): void
+    {
+        $client = $this->makeClient($this->transportFor($this->makeEndpoints()), [
+            'sizer' => new UploadChunkSizer(['floor_bytes' => 64, 'start_bytes' => 4096, 'max_bytes' => 4096]),
+        ]);
+        $files = $this->batchFiles(['steady.txt' => 'fine', 'volatile.txt' => 'about to change']);
+        // The plan's mtime no longer matches the file: stale plan.
+        $files[1]['mtime'] = $files[1]['mtime'] - 100;
+
+        $result = $client->upload_batch($files);
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertSame('verified', $result['per_file']['steady.txt']['status']);
+        $this->assertSame(
+            ['failed', 'source_changed'],
+            [$result['per_file']['volatile.txt']['status'], $result['per_file']['volatile.txt']['reason']]
+        );
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/volatile.txt', 'stale content never travels');
+    }
+
+    // ---------------------------------------------------------------
+    // Status and discard passthrough
+    // ---------------------------------------------------------------
+
+    public function testStatusAndDiscardRoundTrip(): void
+    {
+        $body = 'discard-me';
+        $this->writeSource($body);
+        $transport = $this->transportFor($this->makeEndpoints());
+        $client = $this->makeClient($transport);
+        $client->upload_artifact('artifact.bin', $this->source_path);
+
+        $status = $client->status('artifact.bin');
+        $this->assertSame(['ok', true, true], [$status['status'], $status['exists'], $status['verified']]);
+        $this->assertSame(strlen($body), $status['committed_bytes']);
+
+        $this->assertSame('discarded', $client->discard('artifact.bin')['status']);
+        $this->assertFalse($client->status('artifact.bin')['exists']);
+    }
+
+    // ---------------------------------------------------------------
+    // Apply passthrough
+    // ---------------------------------------------------------------
+
+    public function testApplyRoundTripCarriesPreflightFactsAndDeletions(): void
+    {
+        $target_root = $this->staging_dir . '-target';
+        mkdir($target_root, 0700, true);
+        file_put_contents($target_root . '/stale.txt', 'old');
+        $manifest_path = $this->source_path . '-manifest';
+        $endpoints = $this->makeEndpoints(['apply_target_root' => $target_root]);
+        $client = $this->makeClient($this->transportFor($endpoints));
+
+        try {
+            $this->writeSource('fresh');
+            $this->assertSame('verified', $client->upload_artifact('fresh.txt', $this->source_path)['status']);
+
+            $manifest = json_encode(['artifact_id' => 'fresh.txt', 'size' => 5]) . "\n"
+                . json_encode(['artifact_id' => 'stale.txt', 'delete' => true]) . "\n";
+            file_put_contents($manifest_path, $manifest);
+            $this->assertSame('verified', $client->upload_artifact('.m.jsonl', $manifest_path)['status']);
+
+            $probe = $client->apply('.m.jsonl', true);
+            $this->assertSame('ready', $probe['status']);
+            $this->assertIsInt($probe['staging_free_bytes']);
+            $this->assertIsInt($probe['max_request_bytes']);
+
+            $result = $client->apply('.m.jsonl');
+            $this->assertSame(
+                ['applied', 1, 1],
+                [$result['status'], $result['applied'], $result['deleted']]
+            );
+            $this->assertSame('fresh', file_get_contents($target_root . '/fresh.txt'));
+            $this->assertFileDoesNotExist($target_root . '/stale.txt');
+        } finally {
+            @unlink($manifest_path);
+            $this->removeDir($target_root);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Hostile and broken responses
+    // ---------------------------------------------------------------
+
+    public function testHtmlErrorPageInsteadOfJsonFailsTypedWithoutARetryStorm(): void
+    {
+        // Shared hosts interpose HTML error pages (mod_security, WAFs,
+        // maintenance screens). The client must fail typed on the
+        // non-JSON body, not loop and not crash.
+        $this->writeSource('bytes');
+        $html = ['http_code' => 200, 'body' => '<html><h1>Request blocked</h1></html>', 'error' => null];
+
+        // At the status probe: the resume state is unavailable —
+        // typed and classified retryable by the CLI.
+        $calls = 0;
+        $probe_blocked = $this->makeClient(static function (...$args) use (&$calls, $html): array {
+            $calls++;
+            return $html;
+        })->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame(['failed', 'status_unavailable'], [$probe_blocked['status'], $probe_blocked['reason']]);
+        $this->assertLessThan(10, $calls, 'a non-JSON answer must not retry unbounded');
+
+        // Past the probe, at the upload itself: treated like a lost
+        // response — bounded retries with resyncs, then the retryable
+        // transport_failed instead of an opaque crash.
+        $base = $this->transportFor($this->makeEndpoints());
+        $upload_blocked = $this->makeClient(static function (...$args) use ($base, $html): array {
+            return strpos($args[1], 'staged_upload') !== false ? $html : $base(...$args);
+        })->upload_artifact('artifact.bin', $this->source_path);
+        $this->assertSame(['failed', 'transport_failed'], [$upload_blocked['status'], $upload_blocked['reason']]);
+    }
+
+    public function testServerIoErrorSurfacesTyped(): void
+    {
+        // The store answering io_error (disk full, permissions) maps to
+        // the retryable server_io_error, not a generic failure.
+        $this->writeSource('bytes');
+        $transport = static function (...$args): array {
+            return [
+                'http_code' => 500,
+                'body' => '{"status":"rejected","reason":"io_error","detail":"open_lock_file","committed_bytes":0}',
+                'error' => null,
+            ];
+        };
+
+        $result = $this->makeClient($transport)->upload_artifact('artifact.bin', $this->source_path);
+
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('server_io_error', $result['reason']);
+    }
+}

--- a/tests/SiteExportLibraryAuthTest.php
+++ b/tests/SiteExportLibraryAuthTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SiteExportLibraryAuthTest extends TestCase
+{
+    private const LIB_PATH = __DIR__ . '/../reprint-exporter-wp/lib.php';
+
+    public function testLargeBodyStagedEndpointsAuthenticateInTheirHandlers(): void
+    {
+        $script = <<<PHP
+        define('ABSPATH', __DIR__ . '/');
+        define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/');
+        require '{$this->libPath()}';
+
+        echo '__RESULT__' . json_encode([
+            'chunk' => _site_export_endpoint_authenticates_in_handler('staged_upload'),
+            'batch' => _site_export_endpoint_authenticates_in_handler('staged_upload_batch'),
+            'control' => _site_export_endpoint_authenticates_in_handler('staged_status'),
+        ]);
+        PHP;
+
+        $result = json_decode($this->resultJson($this->runScript($script)), true);
+
+        $this->assertSame([
+            'chunk' => true,
+            'batch' => true,
+            'control' => false,
+        ], $result);
+    }
+
+    public function testAuthGateResolvesTheEndpointTheDispatcherWillRun(): void
+    {
+        // The dispatcher merges GET and POST with POST winning, so a request
+        // that names a self-authenticating route in the query string but a
+        // different endpoint in a form body must resolve to the body's
+        // endpoint — otherwise it would skip the default HMAC check and run
+        // an unauthenticated read/control endpoint.
+        $script = <<<PHP
+        define('ABSPATH', __DIR__ . '/');
+        define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/');
+        require '{$this->libPath()}';
+
+        // filter_input() returns the query/form value, or null when absent
+        // and false for a non-scalar (endpoint[]=...).
+        \$bypass = _site_export_resolve_endpoint('staged_upload', 'file_index');
+        echo '__RESULT__' . json_encode([
+            // POST wins, so the gate sees the endpoint that will dispatch.
+            'resolved' => \$bypass,
+            'bypass_skips_auth' => _site_export_endpoint_authenticates_in_handler(\$bypass),
+            // Legitimate data-plane upload: endpoint only in the query string.
+            'query_only' => _site_export_resolve_endpoint('staged_upload', null),
+            // Array endpoint resolves to '' so default auth still runs.
+            'array_endpoint' => _site_export_resolve_endpoint(null, false),
+        ]);
+        PHP;
+
+        $result = json_decode($this->resultJson($this->runScript($script)), true);
+
+        $this->assertSame([
+            'resolved' => 'file_index',
+            'bypass_skips_auth' => false,
+            'query_only' => 'staged_upload',
+            'array_endpoint' => '',
+        ], $result);
+    }
+
+    private function resultJson(string $output): string
+    {
+        $marker = '__RESULT__';
+        $position = strrpos($output, $marker);
+        $this->assertNotFalse($position, $output);
+        return substr($output, $position + strlen($marker));
+    }
+
+    private function libPath(): string
+    {
+        $path = realpath(self::LIB_PATH);
+        $this->assertNotFalse($path);
+        return $path;
+    }
+
+    private function runScript(string $body): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/site-export-library-auth-' . uniqid();
+        mkdir($tmp_dir, 0755, true);
+
+        try {
+            $php_path = $tmp_dir . '/run.php';
+            file_put_contents($php_path, "<?php\n" . $body . "\n");
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open([PHP_BINARY, $php_path], $descriptors, $pipes, $tmp_dir);
+            if (!is_resource($process)) {
+                $this->fail('Failed to spawn PHP subprocess');
+            }
+
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            if (($stdout ?: '') === '') {
+                return $stderr ?: '';
+            }
+            return $stdout;
+        } finally {
+            array_map('unlink', glob($tmp_dir . '/*') ?: []);
+            rmdir($tmp_dir);
+        }
+    }
+}

--- a/tests/StagedApplyTest.php
+++ b/tests/StagedApplyTest.php
@@ -1,0 +1,735 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedApplyTest extends TestCase {
+
+    private string $staging_dir;
+
+    private string $target_root;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/staged-apply-staging-' . $suffix;
+        $this->target_root = sys_get_temp_dir() . '/staged-apply-target-' . $suffix;
+        mkdir($this->target_root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->staging_dir);
+        $this->removeDir($this->target_root);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeApply(array $overrides = []): Site_Export_Staged_Apply
+    {
+        return new Site_Export_Staged_Apply(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'target_root' => $this->target_root,
+        ], $overrides));
+    }
+
+    private function store(): Site_Export_Staged_Artifacts
+    {
+        return new Site_Export_Staged_Artifacts($this->staging_dir);
+    }
+
+    private function stageVerified(string $artifact_id, string $body): void
+    {
+        $store = $this->store();
+        if ($body !== '') {
+            $result = $store->append($artifact_id, 0, $body);
+            assert($result['status'] === 'accepted');
+        }
+        $finalized = $store->finalize($artifact_id, strlen($body));
+        assert($finalized['status'] === 'verified');
+    }
+
+    /**
+     * Stages a manifest listing the given artifacts, returning its id.
+     */
+    private function stageManifest(array $entries, string $manifest_id = '.manifest.jsonl'): string
+    {
+        $lines = '';
+        foreach ($entries as $entry) {
+            $lines .= json_encode($entry) . "\n";
+        }
+        $this->stageVerified($manifest_id, $lines);
+        return $manifest_id;
+    }
+
+    // ---------------------------------------------------------------
+    // The happy window
+    // ---------------------------------------------------------------
+
+    public function testAppliesAVerifiedTransferIntoTheTargetRoot(): void
+    {
+        $this->stageVerified('index.php', '<?php new');
+        $this->stageVerified('wp-content/themes/t/style.css', 'body{}');
+        $this->stageVerified('empty.txt', '');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'index.php', 'size' => 9],
+            ['artifact_id' => 'wp-content/themes/t/style.css', 'size' => 6],
+            ['artifact_id' => 'empty.txt', 'size' => 0],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(3, $result['applied']);
+        $this->assertSame(0, $result['already_applied']);
+        $this->assertSame('<?php new', file_get_contents($this->target_root . '/index.php'));
+        $this->assertSame('body{}', file_get_contents($this->target_root . '/wp-content/themes/t/style.css'));
+        $this->assertSame('', file_get_contents($this->target_root . '/empty.txt'));
+
+        // The transfer is consumed: files, markers, and the manifest.
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/index.php');
+        $this->assertFileDoesNotExist($this->staging_dir . '/verified/index.php');
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/.manifest.jsonl');
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/files/wp-content');
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/verified/wp-content');
+        $this->assertFalse($this->store()->status('index.php')['verified']);
+    }
+
+    public function testReplacesExistingTargetFilesAtomically(): void
+    {
+        mkdir($this->target_root . '/wp-content', 0700, true);
+        file_put_contents($this->target_root . '/wp-content/old.php', 'old content');
+        $this->stageVerified('wp-content/old.php', 'new!');
+        $manifest = $this->stageManifest([['artifact_id' => 'wp-content/old.php', 'size' => 4]]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame('new!', file_get_contents($this->target_root . '/wp-content/old.php'));
+    }
+
+    public function testApplyClearsACursorNamingAConsumedArtifact(): void
+    {
+        $this->stageVerified('artifact.bin', 'payload');
+        // Simulate finalize killed before its best-effort cursor clear.
+        file_put_contents(
+            $this->staging_dir . '/state.json',
+            json_encode(['artifact_id' => 'artifact.bin', 'committed_bytes' => 7])
+        );
+        $manifest = $this->stageManifest([['artifact_id' => 'artifact.bin', 'size' => 7]]);
+
+        $this->assertSame('applied', $this->makeApply()->apply($manifest)['status']);
+
+        $state = json_decode( (string) file_get_contents($this->staging_dir . '/state.json'), true);
+        $this->assertNull($state['artifact_id'], 'a stale cursor must not answer a future upload');
+    }
+
+    // ---------------------------------------------------------------
+    // Same-device requirement
+    // ---------------------------------------------------------------
+
+    public function testCrossDeviceStagingIsRejectedBeforeAnythingMoves(): void
+    {
+        $this->stageVerified('index.php', 'payload');
+        $manifest = $this->stageManifest([['artifact_id' => 'index.php', 'size' => 7]]);
+        $apply = $this->makeApply([
+            // Staging and target report different stat devices.
+            'device_id' => function (string $path): ?int {
+                return strpos($path, 'staged-apply-staging') !== false ? 11 : 22;
+            },
+        ]);
+
+        $result = $apply->apply($manifest);
+
+        $this->assertSame(['rejected', 'cross_device'], [$result['status'], $result['reason']]);
+        $this->assertStringContainsString('device', (string) $result['detail']);
+        $this->assertFileDoesNotExist($this->target_root . '/index.php');
+        $this->assertFileExists($this->staging_dir . '/files/index.php', 'nothing may move');
+
+        // The probe form rejects identically, before any upload happens.
+        $probe = $apply->apply('never-staged-manifest', true);
+        $this->assertSame(['rejected', 'cross_device'], [$probe['status'], $probe['reason']]);
+    }
+
+    public function testCheckOnlyReportsReadyBeforeTheTransferExists(): void
+    {
+        $result = $this->makeApply()->apply('not-yet-staged-manifest', true);
+
+        $this->assertSame('ready', $result['status']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/files');
+    }
+
+    public function testCheckOnlyValidatesAFullTransferWithoutMoving(): void
+    {
+        $this->stageVerified('a.txt', 'aaa');
+        $manifest = $this->stageManifest([['artifact_id' => 'a.txt', 'size' => 3]]);
+
+        $result = $this->makeApply()->apply($manifest, true);
+
+        $this->assertSame('ready', $result['status']);
+        $this->assertFileDoesNotExist($this->target_root . '/a.txt');
+        $this->assertFileExists($this->staging_dir . '/files/a.txt');
+    }
+
+    // ---------------------------------------------------------------
+    // Whole-transfer validation before the first rename
+    // ---------------------------------------------------------------
+
+    public function testUnverifiedArtifactRejectsTheWholeTransfer(): void
+    {
+        $this->stageVerified('good-1.txt', 'aaa');
+        $this->store()->append('half-done.txt', 0, 'bb');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'good-1.txt', 'size' => 3],
+            ['artifact_id' => 'half-done.txt', 'size' => 2],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame(['rejected', 'unverified_artifact'], [$result['status'], $result['reason']]);
+        $this->assertSame('half-done.txt', $result['detail']);
+        $this->assertFileDoesNotExist(
+            $this->target_root . '/good-1.txt',
+            'no partial apply of a half-verified transfer'
+        );
+    }
+
+    public function testMissingArtifactRejectsTheWholeTransfer(): void
+    {
+        $this->stageVerified('present.txt', 'here');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'present.txt', 'size' => 4],
+            ['artifact_id' => 'never-uploaded.txt', 'size' => 9],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame(['rejected', 'missing_artifact'], [$result['status'], $result['reason']]);
+        $this->assertFileDoesNotExist($this->target_root . '/present.txt');
+    }
+
+    public function testManifestProblemsAreTypedRejections(): void
+    {
+        $apply = $this->makeApply();
+
+        $this->stageVerified('torn.jsonl', '{"artifact_id":"x","si');
+        $torn = $apply->apply('torn.jsonl');
+        $this->assertSame(['rejected', 'manifest_invalid'], [$torn['status'], $torn['reason']]);
+
+        $this->stageVerified('selfish.jsonl', json_encode(['artifact_id' => 'selfish.jsonl', 'size' => 1]) . "\n");
+        $selfish = $apply->apply('selfish.jsonl');
+        $this->assertSame('manifest lists itself', $selfish['detail']);
+
+        $this->stageVerified('hostile.jsonl', json_encode(['artifact_id' => '../escape', 'size' => 1]) . "\n");
+        $hostile = $apply->apply('hostile.jsonl');
+        $this->assertStringContainsString('invalid artifact id', (string) $hostile['detail']);
+
+        $unverified = $apply->apply('never-staged.jsonl');
+        $this->assertSame(['rejected', 'manifest_invalid'], [$unverified['status'], $unverified['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Preserve-local policies
+    // ---------------------------------------------------------------
+
+    public function testSkipPolicyLetsAnOccupiedTargetPathWin(): void
+    {
+        file_put_contents($this->target_root . '/index.php', 'local wins');
+        $this->stageVerified('index.php', 'remote bytes');
+        $this->stageVerified('fresh.txt', 'lands');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'index.php', 'size' => 12],
+            ['artifact_id' => 'fresh.txt', 'size' => 5],
+        ]);
+        $apply = $this->makeApply(['on_existing' => 'skip']);
+
+        $result = $apply->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1, $result['applied']);
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame(['index.php'], $result['skipped_paths'], 'callers audit-log the protected paths');
+        $this->assertSame('local wins', file_get_contents($this->target_root . '/index.php'));
+        $this->assertSame('lands', file_get_contents($this->target_root . '/fresh.txt'));
+        $this->assertFileDoesNotExist(
+            $this->staging_dir . '/files/index.php',
+            'protected entries consume their staged bytes'
+        );
+        $this->assertFileDoesNotExist($this->staging_dir . '/verified/index.php');
+    }
+
+    public function testSkipPolicyProtectsDanglingSymlinksAtTheTarget(): void
+    {
+        symlink($this->target_root . '/never-created', $this->target_root . '/link.php');
+        $this->stageVerified('link.php', 'remote');
+        $manifest = $this->stageManifest([['artifact_id' => 'link.php', 'size' => 6]]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
+
+        $this->assertSame(['applied', 1], [$result['status'], $result['skipped']]);
+        $this->assertTrue(is_link($this->target_root . '/link.php'), 'the symlink survives');
+    }
+
+    public function testSymlinkedParentGuardNeverWritesThroughTheLink(): void
+    {
+        // A hosting layout: wp-content/plugins is a symlink to a shared dir.
+        mkdir($this->target_root . '/wp-content', 0700, true);
+        $shared = $this->target_root . '-shared-plugins';
+        mkdir($shared, 0700, true);
+        symlink($shared, $this->target_root . '/wp-content/plugins');
+
+        $this->stageVerified('wp-content/plugins/p/p.php', 'through the link');
+        $this->stageVerified('wp-content/regular.txt', 'fine');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'wp-content/plugins/p/p.php', 'size' => 16],
+            ['artifact_id' => 'wp-content/regular.txt', 'size' => 4],
+        ]);
+
+        try {
+            $result = $this->makeApply(['refuse_symlinked_parents' => true])->apply($manifest);
+
+            $this->assertSame('applied', $result['status']);
+            $this->assertSame(1, $result['applied']);
+            $this->assertSame(1, $result['skipped']);
+            $this->assertSame([], glob($shared . '/*'), 'nothing may appear behind the link');
+            $this->assertSame('fine', file_get_contents($this->target_root . '/wp-content/regular.txt'));
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testSkipPolicyRerunWithNothingStagedStillApplies(): void
+    {
+        file_put_contents($this->target_root . '/protected.php', 'kept');
+        $this->stageVerified('protected.php', 'remote-1');
+        $this->stageVerified('normal.txt', 'moved');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'protected.php', 'size' => 8],
+            ['artifact_id' => 'normal.txt', 'size' => 5],
+        ]);
+        $apply = $this->makeApply(['on_existing' => 'skip']);
+        $this->assertSame('applied', $apply->apply($manifest)['status']);
+
+        // The next transfer lists the protected path again. Nothing is
+        // staged for it and its local size differs from the manifest —
+        // without the policy-first classification this would reject the
+        // whole run as missing_artifact.
+        $this->stageVerified('normal.txt', 'move2');
+        $again = $this->stageManifest([
+            ['artifact_id' => 'protected.php', 'size' => 8],
+            ['artifact_id' => 'normal.txt', 'size' => 5],
+        ], '.manifest-2.jsonl');
+
+        $result = $apply->apply($again);
+
+        // Preserve-local means never overwrite — including files an earlier
+        // run applied. The rerun protects both and consumes the fresh bytes.
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(2, $result['skipped']);
+        $this->assertSame('kept', file_get_contents($this->target_root . '/protected.php'));
+        $this->assertSame('moved', file_get_contents($this->target_root . '/normal.txt'));
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/normal.txt');
+    }
+
+    public function testCheckOnlyReportsProtectedEntriesWithoutConsuming(): void
+    {
+        file_put_contents($this->target_root . '/here.php', 'local');
+        $this->stageVerified('here.php', 'remote');
+        $manifest = $this->stageManifest([['artifact_id' => 'here.php', 'size' => 6]]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest, true);
+
+        $this->assertSame(['ready', 1], [$result['status'], $result['skipped']]);
+        $this->assertFileExists($this->staging_dir . '/files/here.php', 'check_only must not consume');
+    }
+
+    public function testInvalidOnExistingPolicyIsRejectedAtConstruction(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->makeApply(['on_existing' => 'merge']);
+    }
+
+    // ---------------------------------------------------------------
+    // Type swaps between transfers
+    // ---------------------------------------------------------------
+
+    public function testReplacesADirectoryWithAFile(): void
+    {
+        // The previous site version had a directory here; the new one has
+        // a file. Trunk's writer replaces it, so apply must too.
+        mkdir($this->target_root . '/was-a-dir/nested', 0700, true);
+        file_put_contents($this->target_root . '/was-a-dir/nested/old.txt', 'old');
+        $this->stageVerified('was-a-dir', 'now a file');
+        $manifest = $this->stageManifest([['artifact_id' => 'was-a-dir', 'size' => 10]]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame('now a file', file_get_contents($this->target_root . '/was-a-dir'));
+    }
+
+    public function testReplacesASymlinkWithoutFollowingIt(): void
+    {
+        // A symlinked directory occupies the path; replacing it must swap
+        // the link itself and never reach through into the shared target.
+        $shared = $this->target_root . '-shared';
+        mkdir($shared, 0700, true);
+        file_put_contents($shared . '/keep.txt', 'shared content');
+        symlink($shared, $this->target_root . '/linked');
+        $this->stageVerified('linked', 'plain file now');
+        $manifest = $this->stageManifest([['artifact_id' => 'linked', 'size' => 14]]);
+
+        try {
+            $result = $this->makeApply()->apply($manifest);
+
+            $this->assertSame('applied', $result['status']);
+            $this->assertFalse(is_link($this->target_root . '/linked'));
+            $this->assertSame('plain file now', file_get_contents($this->target_root . '/linked'));
+            $this->assertSame(
+                'shared content',
+                file_get_contents($shared . '/keep.txt'),
+                'the link target must survive untouched'
+            );
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testClearsAFileBlockingTheParentChain(): void
+    {
+        // wp-content used to be a file; the new tree needs it as a dir.
+        file_put_contents($this->target_root . '/wp-content', 'blocking file');
+        $this->stageVerified('wp-content/plugins/p.php', '<?php');
+        $manifest = $this->stageManifest([['artifact_id' => 'wp-content/plugins/p.php', 'size' => 5]]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame('<?php', file_get_contents($this->target_root . '/wp-content/plugins/p.php'));
+    }
+
+    // ---------------------------------------------------------------
+    // Deletions
+    // ---------------------------------------------------------------
+
+    public function testDeleteEntriesRemoveFilesDirectoriesAndLinks(): void
+    {
+        file_put_contents($this->target_root . '/stale.php', 'old');
+        mkdir($this->target_root . '/stale-dir/nested', 0700, true);
+        file_put_contents($this->target_root . '/stale-dir/nested/deep.txt', 'old');
+        $shared = $this->target_root . '-shared-del';
+        mkdir($shared, 0700, true);
+        file_put_contents($shared . '/keep.txt', 'shared');
+        symlink($shared, $this->target_root . '/stale-link');
+        $this->stageVerified('fresh.txt', 'new');
+        // An earlier resume staged bytes for a file the remote has since
+        // deleted; the delete pass must consume them with the deletion.
+        $this->stageVerified('stale.php', 'obsolete bytes');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'fresh.txt', 'size' => 3],
+            ['artifact_id' => 'stale.php', 'delete' => true],
+            ['artifact_id' => 'stale-dir', 'delete' => true],
+            ['artifact_id' => 'stale-link', 'delete' => true],
+        ]);
+
+        try {
+            $result = $this->makeApply()->apply($manifest);
+
+            $this->assertSame('applied', $result['status']);
+            $this->assertSame(1, $result['applied']);
+            $this->assertSame(3, $result['deleted']);
+            $this->assertFileDoesNotExist($this->target_root . '/stale.php');
+            $this->assertDirectoryDoesNotExist($this->target_root . '/stale-dir');
+            $this->assertFalse(is_link($this->target_root . '/stale-link'));
+            $this->assertSame(
+                'shared',
+                file_get_contents($shared . '/keep.txt'),
+                'deleting the link must not follow it'
+            );
+            $this->assertSame('new', file_get_contents($this->target_root . '/fresh.txt'));
+            $this->assertFileDoesNotExist(
+                $this->staging_dir . '/files/stale.php',
+                'staged garbage under a deleted id is consumed'
+            );
+            $this->assertFileDoesNotExist($this->staging_dir . '/verified/stale.php');
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testDeletionsRunBeforeMovesRegardlessOfManifestOrder(): void
+    {
+        // The path was a file; the new tree turns it into a directory: the
+        // transfer deletes 'swap' and creates 'swap/new.txt'. Move-first
+        // would build the directory, land the file, and then have the
+        // delete pass tear down the freshly-created tree. The manifest
+        // lists the create first to prove passes, not line order, decide.
+        file_put_contents($this->target_root . '/swap', 'was a file');
+        $this->stageVerified('swap/new.txt', 'dir member');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'swap/new.txt', 'size' => 10],
+            ['artifact_id' => 'swap', 'delete' => true],
+        ]);
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame([1, 1], [$result['applied'], $result['deleted']]);
+        $this->assertSame('dir member', file_get_contents($this->target_root . '/swap/new.txt'));
+    }
+
+    public function testDeletionsAreIdempotentAcrossReruns(): void
+    {
+        file_put_contents($this->target_root . '/goner.txt', 'x');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'goner.txt', 'delete' => true],
+        ]);
+
+        $first = $this->makeApply()->apply($manifest);
+        $this->assertSame(['applied', 1], [$first['status'], $first['deleted']]);
+        $this->assertFileDoesNotExist($this->target_root . '/goner.txt');
+
+        // A kill after apply but before the sender's cache update re-sends
+        // the same deletion; the path being gone already is the done state.
+        $again = $this->stageManifest([
+            ['artifact_id' => 'goner.txt', 'delete' => true],
+        ], '.manifest-2.jsonl');
+        $second = $this->makeApply()->apply($again);
+
+        $this->assertSame('applied', $second['status']);
+        $this->assertSame(0, $second['deleted']);
+        $this->assertSame(1, $second['already_applied']);
+    }
+
+    public function testSkipPolicyDoesNotProtectOwnedDeletions(): void
+    {
+        // Delete entries only ever come from the sender's own ship record
+        // (pull's index, push's cache), so preserve-local — which protects
+        // what the sync never owned — does not stand in their way. This is
+        // trunk's diff-phase behavior: owned files delete under
+        // preserve-local too.
+        file_put_contents($this->target_root . '/shipped-earlier.txt', 'ours');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'shipped-earlier.txt', 'delete' => true],
+        ]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1, $result['deleted']);
+        $this->assertSame(0, $result['skipped']);
+        $this->assertFileDoesNotExist($this->target_root . '/shipped-earlier.txt');
+    }
+
+    public function testSkipPolicyDoesNotProtectOwnedEntries(): void
+    {
+        // An owned entry's occupant is the transfer's own previous copy:
+        // preserve-local must not freeze a file at the version the first
+        // pull shipped. The unowned sibling still gets protected.
+        file_put_contents($this->target_root . '/ours.php', 'v1 from a previous window');
+        file_put_contents($this->target_root . '/theirs.php', 'the user made this');
+        $this->stageVerified('ours.php', 'v2');
+        $this->stageVerified('theirs.php', 'remote bytes');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'ours.php', 'size' => 2, 'owned' => true],
+            ['artifact_id' => 'theirs.php', 'size' => 12],
+        ]);
+
+        $result = $this->makeApply(['on_existing' => 'skip'])->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame([1, 1], [$result['applied'], $result['skipped']]);
+        $this->assertSame(['theirs.php'], $result['skipped_paths']);
+        $this->assertSame('v2', file_get_contents($this->target_root . '/ours.php'));
+        $this->assertSame('the user made this', file_get_contents($this->target_root . '/theirs.php'));
+    }
+
+    public function testSymlinkedParentGuardProtectsDeletions(): void
+    {
+        mkdir($this->target_root . '/wp-content', 0700, true);
+        $shared = $this->target_root . '-shared-linked';
+        mkdir($shared, 0700, true);
+        file_put_contents($shared . '/keep.php', 'shared');
+        symlink($shared, $this->target_root . '/wp-content/plugins');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'wp-content/plugins/keep.php', 'delete' => true],
+        ]);
+
+        try {
+            $result = $this->makeApply(['refuse_symlinked_parents' => true])->apply($manifest);
+
+            $this->assertSame(['applied', 1], [$result['status'], $result['skipped']]);
+            $this->assertSame(0, $result['deleted']);
+            $this->assertSame('shared', file_get_contents($shared . '/keep.php'));
+        } finally {
+            $this->removeDir($shared);
+        }
+    }
+
+    public function testDeletePassIoErrorIsTypedAndRerunResumes(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('permission barriers do not bind as root');
+        }
+        mkdir($this->target_root . '/locked', 0700, true);
+        file_put_contents($this->target_root . '/locked/goner.txt', 'x');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'locked/goner.txt', 'delete' => true],
+        ]);
+
+        // The environment turns hostile mid-transfer: the parent loses its
+        // write bit, so the unlink fails.
+        chmod($this->target_root . '/locked', 0555);
+        try {
+            $result = $this->makeApply()->apply($manifest);
+
+            $this->assertSame(['rejected', 'io_error'], [$result['status'], $result['reason']]);
+            $this->assertStringContainsString('delete: locked/goner.txt', (string) $result['detail']);
+        } finally {
+            chmod($this->target_root . '/locked', 0700);
+        }
+
+        // A rejection consumes nothing; once the operator fixes the
+        // permissions, rerunning the same manifest finishes the window.
+        $second = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $second['status']);
+        $this->assertSame(1, $second['deleted']);
+        $this->assertFileDoesNotExist($this->target_root . '/locked/goner.txt');
+    }
+
+    public function testMalformedDeleteEntriesRejectTheManifest(): void
+    {
+        // delete:false is not a delete, so the entry needs its size.
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'x.txt', 'delete' => false],
+        ]);
+        $result = $this->makeApply()->apply($manifest);
+        $this->assertSame(['rejected', 'manifest_invalid'], [$result['status'], $result['reason']]);
+
+        // Delete ids go through the same path rule as everything else.
+        $this->stageVerified('hostile-delete.jsonl', json_encode(['artifact_id' => '../escape', 'delete' => true]) . "\n");
+        $hostile = $this->makeApply()->apply('hostile-delete.jsonl');
+        $this->assertStringContainsString('invalid artifact id', (string) $hostile['detail']);
+
+        // One verdict per path: a same-id create-plus-delete is ambiguous
+        // on rerun, and neither sender can produce it.
+        $this->stageVerified(
+            'twice.jsonl',
+            json_encode(['artifact_id' => 'x.txt', 'size' => 1]) . "\n"
+                . json_encode(['artifact_id' => 'x.txt', 'delete' => true]) . "\n"
+        );
+        $twice = $this->makeApply()->apply('twice.jsonl');
+        $this->assertStringContainsString('duplicates an artifact id', (string) $twice['detail']);
+    }
+
+    public function testOnProtectedReportsEveryEntryBeyondTheResponseCap(): void
+    {
+        // skipped_paths is a bounded-HTTP-response diagnostic, capped at
+        // 1000. In-process callers reconcile per-entry state through
+        // on_protected, which must see every protected id — an index
+        // catch-up driven by the capped list would silently skip entries
+        // past the cap.
+        $manifest_entries = [];
+        for ($i = 0; $i < 1001; $i++) {
+            $name = sprintf('kept-%04d.txt', $i);
+            file_put_contents($this->target_root . '/' . $name, 'local');
+            $manifest_entries[] = ['artifact_id' => $name, 'size' => 5];
+        }
+        $manifest = $this->stageManifest($manifest_entries);
+
+        $reported = [];
+        $apply = $this->makeApply([
+            'on_existing' => 'skip',
+            'on_protected' => static function (string $artifact_id) use (&$reported): void {
+                $reported[] = $artifact_id;
+            },
+        ]);
+        $result = $apply->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1001, $result['skipped']);
+        $this->assertCount(1000, $result['skipped_paths'], 'the response list stays capped');
+        $this->assertCount(1001, $reported, 'the callback sees every protected entry');
+        $this->assertSame('kept-1000.txt', end($reported));
+    }
+
+    // ---------------------------------------------------------------
+    // Preflight facts on "ready"
+    // ---------------------------------------------------------------
+
+    public function testReadyReportsFreeSpaceForTheSendersPreflight(): void
+    {
+        $result = $this->makeApply()->apply('not-yet-staged', true);
+
+        $this->assertSame('ready', $result['status']);
+        $this->assertIsInt($result['staging_free_bytes']);
+        $this->assertIsInt($result['target_free_bytes']);
+        $this->assertGreaterThan(0, $result['target_free_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Kill windows and contention
+    // ---------------------------------------------------------------
+
+    public function testRerunAfterAKillMidApplyFinishesTheWindow(): void
+    {
+        $this->stageVerified('moved-before-kill.txt', 'first');
+        $this->stageVerified('still-staged.txt', 'second');
+        $manifest = $this->stageManifest([
+            ['artifact_id' => 'moved-before-kill.txt', 'size' => 5],
+            ['artifact_id' => 'still-staged.txt', 'size' => 6],
+        ]);
+
+        // The kill hit between the first rename and its marker unlink.
+        rename(
+            $this->staging_dir . '/files/moved-before-kill.txt',
+            $this->target_root . '/moved-before-kill.txt'
+        );
+
+        $result = $this->makeApply()->apply($manifest);
+
+        $this->assertSame('applied', $result['status']);
+        $this->assertSame(1, $result['applied']);
+        $this->assertSame(1, $result['already_applied']);
+        $this->assertSame('first', file_get_contents($this->target_root . '/moved-before-kill.txt'));
+        $this->assertSame('second', file_get_contents($this->target_root . '/still-staged.txt'));
+        $this->assertFileDoesNotExist(
+            $this->staging_dir . '/verified/moved-before-kill.txt',
+            'the leftover marker is consumed by the rerun'
+        );
+    }
+
+    public function testBusyWhileAWriterHoldsTheStore(): void
+    {
+        $this->stageVerified('a.txt', 'aaa');
+        $manifest = $this->stageManifest([['artifact_id' => 'a.txt', 'size' => 3]]);
+
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $result = $this->makeApply()->apply($manifest);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertSame('busy', $result['status']);
+        $this->assertFileDoesNotExist($this->target_root . '/a.txt');
+    }
+
+    public function testMissingTargetRootIsRejected(): void
+    {
+        $apply = $this->makeApply(['target_root' => $this->target_root . '/never-created']);
+
+        $result = $apply->apply('whatever', true);
+
+        $this->assertSame(['rejected', 'target_missing'], [$result['status'], $result['reason']]);
+    }
+}

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -1,0 +1,714 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedArtifactsTest extends TestCase
+{
+    private string $staging_dir;
+
+    protected function setUp(): void
+    {
+        $this->staging_dir = sys_get_temp_dir() . '/staged-artifacts-test-' . bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->staging_dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeStore(): Site_Export_Staged_Artifacts
+    {
+        return new Site_Export_Staged_Artifacts($this->staging_dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Assembly and finalize
+    // ---------------------------------------------------------------
+
+    public function testSequentialAppendsAssembleAndVerify(): void
+    {
+        $store = $this->makeStore();
+        $body = 'hello staged upload world';
+
+        $first = $store->append('artifact-1', 0, substr($body, 0, 10));
+        $second = $store->append('artifact-1', 10, substr($body, 10));
+
+        $this->assertSame('accepted', $first['status']);
+        $this->assertSame(10, $first['committed_bytes']);
+        $this->assertSame('accepted', $second['status']);
+        $this->assertSame(strlen($body), $second['committed_bytes']);
+
+        $result = $store->finalize('artifact-1', strlen($body));
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($result['path']));
+        $this->assertTrue($store->status('artifact-1')['verified']);
+    }
+
+    public function testCallerDrivenLoopStreamsASourceInBoundedBuffers(): void
+    {
+        $store = $this->makeStore();
+        $body = str_repeat('streamed!', 100000); // ~900 KB, many buffers
+
+        // The endpoint's loop: read the source in bounded buffers, one
+        // append per buffer.
+        $source = fopen('php://temp', 'r+b');
+        fwrite($source, $body);
+        rewind($source);
+        $committed = 0;
+        while (($buffer = fread($source, 65536)) !== false && $buffer !== '') {
+            $result = $store->append('artifact-1', $committed, $buffer);
+            $this->assertSame('accepted', $result['status']);
+            $committed = $result['committed_bytes'];
+        }
+        fclose($source);
+
+        $this->assertSame(strlen($body), $committed);
+        $verified = $store->finalize('artifact-1', strlen($body));
+        $this->assertSame($body, file_get_contents($verified['path']));
+    }
+
+    public function testZeroByteArtifactVerifiesWithoutAppends(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->finalize('empty-artifact', 0);
+
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame('', file_get_contents($result['path']));
+    }
+
+    public function testFinalizeIsIdempotent(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+
+        $again = $store->finalize('artifact-1', 7);
+
+        $this->assertSame('verified', $again['status']);
+    }
+
+    public function testFinalizeOfUnknownArtifactReportsMissing(): void
+    {
+        $store = $this->makeStore();
+
+        $result = $store->finalize('never-uploaded', 5);
+
+        $this->assertSame(['rejected', 'missing'], [$result['status'], $result['reason']]);
+    }
+
+    public function testRefinalizeWithDifferentSizeIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+
+        $result = $store->finalize('artifact-1', 9);
+
+        $this->assertSame(
+            ['rejected', 'size_mismatch', 'verified_record'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+        $this->assertTrue($store->status('artifact-1')['verified']);
+    }
+
+    // ---------------------------------------------------------------
+    // Reentrancy and resume
+    // ---------------------------------------------------------------
+
+    public function testLoopCanStopAfterAnyStepAndResumeInAFreshProcess(): void
+    {
+        $buffers = ['aa', 'bb', 'cc', 'dd'];
+
+        foreach ([0, 1, 2, 3, 4] as $stop_after) {
+            $staging = $this->staging_dir . "/stop-after-{$stop_after}";
+            $first_run = new Site_Export_Staged_Artifacts($staging);
+            for ($i = 0; $i < $stop_after; $i++) {
+                $this->assertSame(
+                    'accepted',
+                    $first_run->append('artifact-1', $i * 2, $buffers[$i])['status']
+                );
+            }
+            unset($first_run); // The driving loop stops; nothing is held.
+
+            // A fresh instance — the next request — resumes from the cursor.
+            $resumed = new Site_Export_Staged_Artifacts($staging);
+            $this->assertSame(
+                $stop_after * 2,
+                $resumed->status('artifact-1')['committed_bytes'],
+                "stopped after {$stop_after} steps"
+            );
+            for ($i = $stop_after; $i < 4; $i++) {
+                $this->assertSame(
+                    'accepted',
+                    $resumed->append('artifact-1', $i * 2, $buffers[$i])['status']
+                );
+            }
+            $verified = $resumed->finalize('artifact-1', 8);
+            $this->assertSame('verified', $verified['status'], "stopped after {$stop_after} steps");
+            $this->assertSame('aabbccdd', file_get_contents($verified['path']));
+        }
+    }
+
+    public function testStoppingInsideAStepDiscardsTheUncommittedTail(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'committed');
+
+        // Simulate a kill after bytes were written but before the cursor
+        // moved: garbage sits beyond committed_bytes in the file.
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'GARBAGE', FILE_APPEND);
+
+        $this->assertSame('accepted', $store->append('artifact-1', 9, '-tail')['status']);
+        $body = 'committed-tail';
+        $result = $store->finalize('artifact-1', strlen($body));
+        $this->assertSame('verified', $result['status']);
+        $this->assertSame($body, file_get_contents($result['path']));
+    }
+
+    public function testResendingCommittedBytesIsADuplicateNoOp(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        $retry = $store->append('artifact-1', 0, 'first');
+
+        $this->assertSame('duplicate', $retry['status']);
+        $this->assertSame(5, $retry['committed_bytes']);
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+    }
+
+    public function testOffsetGapIsRejectedWithCommittedBytesForResync(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        $result = $store->append('artifact-1', 20, 'too-far');
+
+        $this->assertSame('rejected', $result['status']);
+        $this->assertSame('offset_gap', $result['reason']);
+        $this->assertSame(5, $result['committed_bytes']);
+    }
+
+    public function testSwitchingArtifactsRestartsTheAbandonedOne(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-a', 0, 'first');
+
+        // Sequential transfers: an append to another artifact moves the cursor.
+        $this->assertSame('accepted', $store->append('artifact-b', 0, 'bee')['status']);
+
+        $stale = $store->append('artifact-a', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $store->append('artifact-a', 0, 'fresh')['status']);
+    }
+
+    public function testCorruptCommitRecordRestartsTheArtifact(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        file_put_contents($this->staging_dir . '/state.json', 'not json {');
+
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+        $resumed = $store->append('artifact-1', 5, 'second');
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$resumed['status'], $resumed['reason'], $resumed['committed_bytes']]
+        );
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
+    }
+
+    public function testShrunkenStagingFileIsZeroFilledBackToTheCursor(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        // The staging file drifts between requests: something shrinks it
+        // below the committed size. The cursor, not the file, is the
+        // authority — the next append zero-fills back to the committed size.
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
+
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame("fi\0\0\0second", file_get_contents($verified['path']));
+    }
+
+    public function testCursorSurvivingAKilledDiscardRestartsInsteadOfZeroFilling(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        // A discard killed between unlinking the file and clearing the cursor:
+        // state.json still claims 5 committed bytes, but the file is gone.
+        // Recreating and zero-filling to 5 would splice five NUL bytes ahead
+        // of the resumed content and still pass the byte-count finalize.
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        // The store must not trust the phantom prefix: the resume offset no
+        // longer matches, so the sender is told to restart from 0.
+        $gapped = $store->append('artifact-1', 5, 'second');
+        $this->assertSame('rejected', $gapped['status']);
+        $this->assertSame('offset_gap', $gapped['reason']);
+        $this->assertSame(0, $gapped['committed_bytes']);
+
+        // Re-uploading from 0 yields the real bytes — no zero-filled prefix.
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'firstsecond')['status']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    // ---------------------------------------------------------------
+    // Crash recovery: partial states a kill can leave behind
+    // ---------------------------------------------------------------
+
+    public function testEveryCallCanRunInItsOwnProcess(): void
+    {
+        // Each call constructs its own store instance — no shared in-memory
+        // state, as if every step ran in a separate PHP request.
+        $step = fn() => new Site_Export_Staged_Artifacts($this->staging_dir);
+
+        $this->assertSame('accepted', $step()->append('a.txt', 0, 'aaa')['status']);
+        $this->assertSame('accepted', $step()->append('a.txt', 3, 'AAA')['status']);
+        $this->assertSame('verified', $step()->finalize('a.txt', 6)['status']);
+        $this->assertSame('accepted', $step()->append('b.txt', 0, 'bb')['status']);
+        $this->assertSame('verified', $step()->finalize('b.txt', 2)['status']);
+        $this->assertSame('verified', $step()->finalize('empty.txt', 0)['status']);
+
+        $this->assertSame('aaaAAA', file_get_contents($this->staging_dir . '/files/a.txt'));
+        $this->assertSame('bb', file_get_contents($this->staging_dir . '/files/b.txt'));
+        $this->assertTrue($step()->status('a.txt')['verified']);
+    }
+
+    public function testKilledCursorWriteLeavesRecoverableState(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        // Simulate a kill inside write_state: the temp record was written,
+        // the rename never happened, and the appended bytes sit beyond the
+        // still-old cursor.
+        file_put_contents($this->staging_dir . '/state.json.tmp', '{"artifact_id":"artifact-1"');
+        file_put_contents($this->staging_dir . '/files/artifact-1', 'second', FILE_APPEND);
+
+        $this->assertSame(5, $store->status('artifact-1')['committed_bytes']);
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testTornVerifiedRecordIsIgnoredAndRefinalizeRecovers(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-a', 0, 'aaa');
+        $store->finalize('artifact-a', 3);
+        $store->append('artifact-b', 0, 'bbbb');
+
+        // A malformed marker (markers commit by rename, so this means
+        // external interference) must read as not verified.
+        file_put_contents(
+            $this->staging_dir . '/verified/artifact-b',
+            '{"si'
+        );
+
+        $this->assertFalse($store->status('artifact-b')['verified']);
+        $this->assertTrue($store->status('artifact-a')['verified']);
+        $this->assertSame('verified', $store->finalize('artifact-b', 4)['status']);
+        $this->assertTrue($store->status('artifact-b')['verified']);
+    }
+
+    public function testFinalizeKilledBeforeClearingCursorStaysConsistent(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        // Simulate a kill after the verified marker landed but before the
+        // cursor was cleared.
+        mkdir($this->staging_dir . '/verified', 0700, true);
+        file_put_contents(
+            $this->staging_dir . '/verified/artifact-1',
+            json_encode(['size' => 7])
+        );
+
+        $stale = $store->append('artifact-1', 7, 'more');
+        $this->assertSame(['rejected', 'already_verified'], [$stale['status'], $stale['reason']]);
+        $this->assertSame('verified', $store->finalize('artifact-1', 7)['status']);
+        $this->assertSame('accepted', $store->append('artifact-2', 0, 'next')['status']);
+    }
+
+    public function testVerifiedRecordWithoutTheArtifactFileReportsMissing(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $refinalized = $store->finalize('artifact-1', 7);
+
+        $this->assertSame(
+            ['rejected', 'missing', 'verified_record'],
+            [$refinalized['status'], $refinalized['reason'], $refinalized['detail']]
+        );
+
+        // Recovery: discard the orphaned record, then upload from scratch.
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'payload')['status']);
+        $this->assertSame('verified', $store->finalize('artifact-1', 7)['status']);
+    }
+
+    public function testDiscardKilledMidwayIsRetriable(): void
+    {
+        // Window 1: the artifact file was unlinked, the cursor survived.
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
+
+        // Window 2: the cursor was cleared, the verified record survived.
+        $store->finalize('artifact-1', 5);
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertFalse($store->status('artifact-1')['verified']);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'again')['status']);
+    }
+
+    public function testArtifactPathBlockedByAnotherEntryIsATypedError(): void
+    {
+        $store = $this->makeStore();
+
+        // A directory sits where the artifact file should go.
+        $store->append('theme/style.css', 0, 'body{}');
+        $blocked_by_dir = $store->append('theme', 0, 'zip');
+        $this->assertSame(
+            ['rejected', 'io_error', 'open_artifact_file'],
+            [$blocked_by_dir['status'], $blocked_by_dir['reason'], $blocked_by_dir['detail']]
+        );
+
+        // A file sits where a parent directory should go.
+        $store->append('plugin.php', 0, '<?php');
+        $blocked_by_file = $store->append('plugin.php/readme.txt', 0, 'hi');
+        $this->assertSame(
+            ['rejected', 'io_error', 'create_staging_dir'],
+            [$blocked_by_file['status'], $blocked_by_file['reason'], $blocked_by_file['detail']]
+        );
+    }
+
+    public function testUnwritableStagingDirectoryIsATypedError(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        mkdir($this->staging_dir, 0700, true);
+        chmod($this->staging_dir, 0500);
+        $store = $this->makeStore();
+
+        $result = $store->append('artifact-1', 0, 'bytes');
+        $this->assertSame(
+            ['rejected', 'io_error', 'open_lock_file'],
+            [$result['status'], $result['reason'], $result['detail']]
+        );
+
+        // The next run recovers once the environment does.
+        chmod($this->staging_dir, 0700);
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'bytes')['status']);
+    }
+
+    // ---------------------------------------------------------------
+    // Input validation
+    // ---------------------------------------------------------------
+
+    public function testFinalizeRejectsWrongSize(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        $wrong_size = $store->finalize('artifact-1', 99);
+
+        $this->assertSame(['rejected', 'size_mismatch'], [$wrong_size['status'], $wrong_size['reason']]);
+        $this->assertFalse($store->status('artifact-1')['verified']);
+    }
+
+    public function testMalformedOffsetAndBufferAreRejected(): void
+    {
+        $store = $this->makeStore();
+
+        $bad_offset = $store->append('artifact-1', -1, 'bytes');
+        $this->assertSame(['rejected', 'invalid_offset'], [$bad_offset['status'], $bad_offset['reason']]);
+
+        $empty = $store->append('artifact-1', 0, '');
+        $this->assertSame(['rejected', 'empty_body'], [$empty['status'], $empty['reason']]);
+    }
+
+    public function testWritingToAVerifiedArtifactIsRejected(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+
+        $result = $store->append('artifact-1', 7, 'more');
+
+        $this->assertSame(['rejected', 'already_verified'], [$result['status'], $result['reason']]);
+    }
+
+    public function testStagingMirrorsTheArtifactPath(): void
+    {
+        $store = $this->makeStore();
+        $id = 'wp-content/themes/foo/style.css';
+
+        $this->assertSame('accepted', $store->append($id, 0, 'body { }')['status']);
+
+        $this->assertFileExists($this->staging_dir . '/files/' . $id);
+        $this->assertFileExists($this->staging_dir . '/state.json');
+    }
+
+    public function testSiteFilenamesThatLookLikeStagingRecordsStageVerbatim(): void
+    {
+        $store = $this->makeStore();
+
+        // 'lock' and 'files' shadow the store's own scaffolding names;
+        // they must stage under files/ without touching the real lock
+        // file or the artifact tree root.
+        foreach (['index.php', 'index.php.part', 'index.php.meta.json', 'state.json', 'verified', 'verified.tmp', 'lock', 'files'] as $id) {
+            $this->assertSame('accepted', $store->append($id, 0, "body of {$id}")['status']);
+            $verified = $store->finalize($id, strlen("body of {$id}"));
+            $this->assertSame('verified', $verified['status'], "id: {$id}");
+            $this->assertSame("body of {$id}", file_get_contents($this->staging_dir . '/files/' . $id));
+        }
+
+        // The store's own lock file must still be the lock, not an
+        // artifact: concurrency still excludes after staging id 'lock'.
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        $this->assertTrue(flock($holder, LOCK_EX | LOCK_NB), 'the base lock file survives as a lock');
+        $busy = $store->append('another.txt', 0, 'x');
+        $this->assertSame('busy', $busy['status']);
+        flock($holder, LOCK_UN);
+        fclose($holder);
+    }
+
+    public function testDeeplyNestedIdsStageAndDiscardCleanly(): void
+    {
+        // Hosting trees nest far deeper than fixtures; the files/ mirror,
+        // the verified/ marker tree, and discard must all handle it.
+        $store = $this->makeStore();
+        $id = implode('/', array_fill(0, 12, 'd')) . '/deep.txt';
+
+        $this->assertSame('accepted', $store->append($id, 0, 'deep bytes')['status']);
+        $this->assertSame('verified', $store->finalize($id, 10)['status']);
+        $this->assertFileExists($this->staging_dir . '/files/' . $id);
+        $this->assertTrue($store->status($id)['verified']);
+
+        $this->assertTrue($store->discard($id));
+        $this->assertFalse($store->status($id)['exists']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/' . $id);
+    }
+
+    public function testIdsOutsideTheStagingDirAreRejected(): void
+    {
+        $store = $this->makeStore();
+
+        foreach (['../../outside/etc/passwd', '/etc/passwd', 'a/../b', 'a//b', './a', '', 'a\\b', "a\0b"] as $hostile_id) {
+            $result = $store->append($hostile_id, 0, 'bytes');
+            $this->assertSame(
+                ['rejected', 'invalid_artifact_id'],
+                [$result['status'], $result['reason']],
+                "id: {$hostile_id}"
+            );
+            $finalized = $store->finalize($hostile_id, 5);
+            $this->assertSame(
+                ['rejected', 'invalid_artifact_id'],
+                [$finalized['status'], $finalized['reason']],
+                "id: {$hostile_id}"
+            );
+            $this->assertFalse($store->status($hostile_id)['exists'], "id: {$hostile_id}");
+            $this->assertTrue($store->discard($hostile_id), "id: {$hostile_id}");
+        }
+
+        $this->assertDirectoryDoesNotExist(dirname(dirname($this->staging_dir)) . '/outside');
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/etc/passwd');
+    }
+
+    // ---------------------------------------------------------------
+    // Concurrency and lifecycle
+    // ---------------------------------------------------------------
+
+    public function testConcurrentWriterGetsBusy(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+
+        // Hold the lock the way a concurrent writer would.
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+
+        $busy_append = $store->append('artifact-1', 5, 'second');
+        $this->assertSame(['busy', 5], [$busy_append['status'], $busy_append['committed_bytes']]);
+        $busy_finalize = $store->finalize('artifact-1', 5);
+        $this->assertSame(['busy', 5], [$busy_finalize['status'], $busy_finalize['committed_bytes']]);
+        $this->assertFalse($store->discard('artifact-1'));
+
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+    }
+
+    public function testDiscardOfAnUntracedArtifactRespectsTheWriterLock(): void
+    {
+        $store = $this->makeStore();
+        $store->append('other-artifact', 0, 'xx');
+
+        // The first append for artifact-1 is in flight: it holds the lock
+        // but has not yet created the file or moved the cursor. A discard
+        // that answered true here would be contradicted by that append's
+        // commit a moment later.
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+
+        $this->assertFalse($store->discard('artifact-1'));
+
+        flock($holder, LOCK_UN);
+        fclose($holder);
+        $this->assertTrue($store->discard('artifact-1'));
+    }
+
+    public function testDiscardRemovesAllStagedData(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $status = $store->status('artifact-1');
+        $this->assertSame(['exists' => false, 'committed_bytes' => 0, 'verified' => false], $status);
+        $this->assertTrue($store->discard('never-existed'));
+    }
+
+    public function testDiscardBeforeAnyStagingExistsCreatesNothing(): void
+    {
+        $store = $this->makeStore();
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $this->assertDirectoryDoesNotExist($this->staging_dir);
+    }
+
+    public function testDiscardedArtifactRestartsFromScratch(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'first');
+        $store->discard('artifact-1');
+
+        $stale = $store->append('artifact-1', 5, 'second');
+
+        $this->assertSame(
+            ['rejected', 'offset_gap', 0],
+            [$stale['status'], $stale['reason'], $stale['committed_bytes']]
+        );
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
+    }
+
+    public function testDiscardClearsTheCursorWhenTheArtifactFileIsMissing(): void
+    {
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        unlink($this->staging_dir . '/files/artifact-1');
+
+        $this->assertTrue($store->discard('artifact-1'));
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $store->status('artifact-1')
+        );
+    }
+
+    public function testDiscardReportsFailureWhenTheArtifactFileCannotBeRemoved(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        // Unlinking needs write permission on files/, not on the file.
+        chmod($this->staging_dir . '/files', 0500);
+        $this->assertFalse($store->discard('artifact-1'));
+        $this->assertFileExists($this->staging_dir . '/files/artifact-1');
+
+        // Retry until true: the next attempt finishes the cleanup.
+        chmod($this->staging_dir . '/files', 0700);
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+    }
+
+    public function testDiscardReportsFailureWhenTheCursorCannotBeCleared(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+
+        // Clearing the cursor writes state.json.tmp into the staging dir;
+        // the artifact unlink itself only needs write on files/.
+        chmod($this->staging_dir, 0500);
+        $this->assertFalse($store->discard('artifact-1'));
+        $this->assertSame(7, $store->status('artifact-1')['committed_bytes']);
+
+        chmod($this->staging_dir, 0700);
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+    }
+
+    public function testDiscardReportsFailureWhenTheVerifiedRecordCannotBeRemoved(): void
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Permission checks do not bind as root.');
+        }
+
+        $store = $this->makeStore();
+        $store->append('artifact-1', 0, 'payload');
+        $store->finalize('artifact-1', 7);
+
+        // Unlinking the marker needs write permission on verified/.
+        chmod($this->staging_dir . '/verified', 0500);
+        $this->assertFalse($store->discard('artifact-1'));
+        $this->assertTrue($store->status('artifact-1')['verified']);
+
+        chmod($this->staging_dir . '/verified', 0700);
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertFalse($store->status('artifact-1')['verified']);
+    }
+
+    public function testStatusOfUnknownArtifact(): void
+    {
+        $store = $this->makeStore();
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $store->status('unknown')
+        );
+    }
+}

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -1,0 +1,823 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedEndpointsTest extends TestCase {
+
+    private const SECRET = 'staged-endpoints-test-secret';
+
+    private string $staging_dir;
+
+    protected function setUp(): void
+    {
+        $this->staging_dir = sys_get_temp_dir() . '/staged-endpoints-test-' . bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->staging_dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $entry) {
+            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
+        }
+        @rmdir($dir);
+    }
+
+    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
+    {
+        return new Site_Export_Staged_Endpoints(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+        ], $overrides));
+    }
+
+    /**
+     * Headers the way $_SERVER presents them, signed like the HMAC client:
+     * HMAC-SHA256(nonce . timestamp . SHA256(body), secret).
+     */
+    private function signedHeaders(string $body, array $overrides = []): array
+    {
+        $nonce = $overrides['nonce'] ?? bin2hex(random_bytes(16));
+        $timestamp = $overrides['timestamp'] ?? (string) time();
+        $content_hash = $overrides['content_hash'] ?? hash('sha256', $body);
+        $signature = hash_hmac(
+            'sha256',
+            $nonce . $timestamp . $content_hash,
+            $overrides['secret'] ?? self::SECRET
+        );
+
+        return [
+            'REQUEST_METHOD' => 'POST',
+            'HTTP_X_AUTH_SIGNATURE' => $overrides['signature'] ?? $signature,
+            'HTTP_X_AUTH_NONCE' => $nonce,
+            'HTTP_X_AUTH_TIMESTAMP' => $timestamp,
+            'HTTP_X_AUTH_CONTENT_HASH' => $content_hash,
+        ];
+    }
+
+    /** @return resource */
+    private function bodyStream(string $body)
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, $body);
+        rewind($stream);
+        return $stream;
+    }
+
+    private function upload(
+        Site_Export_Staged_Endpoints $endpoints,
+        string $artifact_id,
+        int $offset,
+        string $body,
+        array $header_overrides = []
+    ): array {
+        $stream = $this->bodyStream($body);
+        try {
+            return $endpoints->upload(
+                ['artifact_id' => $artifact_id, 'offset' => $offset],
+                $this->signedHeaders($body, $header_overrides),
+                $stream
+            );
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    private function finalize(Site_Export_Staged_Endpoints $endpoints, string $artifact_id, int $total): array
+    {
+        return $endpoints->finalize(
+            ['artifact_id' => $artifact_id, 'total_bytes' => $total],
+            ['REQUEST_METHOD' => 'POST']
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Upload data plane
+    // ---------------------------------------------------------------
+
+    public function testChunksStageAndFinalizeVerifies(): void
+    {
+        // A small append buffer forces many store steps per chunk.
+        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
+        $body = 'the quick brown fox jumps over the lazy dog';
+        $split = 20;
+
+        $first = $this->upload($endpoints, 'a/b/dump.sql', 0, substr($body, 0, $split));
+        $this->assertSame(200, $first['http_code']);
+        $this->assertSame('accepted', $first['body']['status']);
+        $this->assertSame($split, $first['body']['committed_bytes']);
+
+        $second = $this->upload($endpoints, 'a/b/dump.sql', $split, substr($body, $split));
+        $this->assertSame(strlen($body), $second['body']['committed_bytes']);
+
+        $verified = $this->finalize($endpoints, 'a/b/dump.sql', strlen($body));
+        $this->assertSame(200, $verified['http_code']);
+        $this->assertSame('verified', $verified['body']['status']);
+        $this->assertArrayNotHasKey('path', $verified['body']);
+        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/a/b/dump.sql'));
+    }
+
+    public function testRetriedChunkLandsAsDuplicate(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+
+        // The sender timed out without the response and retries the chunk.
+        $retry = $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+
+        $this->assertSame(200, $retry['http_code']);
+        $this->assertSame('duplicate', $retry['body']['status']);
+        $this->assertSame(10, $retry['body']['committed_bytes']);
+    }
+
+    public function testResentChunkStraddlingTheFrontierAppendsOnlyTheTail(): void
+    {
+        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
+        $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+
+        // After a resync the sender resends from offset 0 with a larger
+        // chunk; only the bytes past the committed frontier may land.
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'abcdefghijKLMNO');
+
+        $this->assertSame(200, $result['http_code']);
+        $this->assertSame('accepted', $result['body']['status']);
+        $this->assertSame(15, $result['body']['committed_bytes']);
+        $this->assertSame(
+            'abcdefghijKLMNO',
+            file_get_contents($this->staging_dir . '/files/artifact-1')
+        );
+    }
+
+    public function testChunkBeyondTheFrontierIsAnOffsetGapWithResumeHint(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'abcde');
+
+        $result = $this->upload($endpoints, 'artifact-1', 50, 'later-bytes');
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('offset_gap', $result['body']['reason']);
+        $this->assertSame(5, $result['body']['committed_bytes']);
+    }
+
+    public function testUploadToAVerifiedArtifactIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $this->finalize($endpoints, 'artifact-1', 7);
+
+        $result = $this->upload($endpoints, 'artifact-1', 7, 'more');
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('already_verified', $result['body']['reason']);
+    }
+
+    public function testEmptyBodyIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, '');
+
+        $this->assertSame(400, $result['http_code']);
+        $this->assertSame('empty_body', $result['body']['reason']);
+    }
+
+    public function testUploadWhileTheStoreIsHeldReportsBusy(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'first');
+
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $result = $this->upload($endpoints, 'artifact-1', 5, 'second');
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertSame(423, $result['http_code']);
+        $this->assertSame('busy', $result['body']['status']);
+        $this->assertSame(5, $result['body']['committed_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Upload authentication: no unverified byte reaches the store
+    // ---------------------------------------------------------------
+
+    public function testUploadWithoutAuthHeadersIsRejectedBeforeTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $stream = $this->bodyStream('payload');
+
+        $result = $endpoints->upload(
+            ['artifact_id' => 'artifact-1', 'offset' => 0],
+            ['REQUEST_METHOD' => 'POST'],
+            $stream
+        );
+        fclose($stream);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('auth_failed', $result['body']['reason']);
+        $this->assertStringContainsString('X-Auth-Signature', $result['body']['detail']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir);
+    }
+
+    public function testUploadWithWrongSignatureIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload', [
+            'signature' => str_repeat('0', 64),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('auth_failed', $result['body']['reason']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir);
+    }
+
+    public function testUploadWithExpiredTimestampIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload', [
+            'timestamp' => (string) ( time() - 3600 ),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('auth_failed', $result['body']['reason']);
+    }
+
+    public function testBodyNotMatchingTheSignedHashNeverReachesTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        // Valid signature over the hash of different bytes: the headers
+        // authenticate, the body does not.
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'actually-sent-bytes', [
+            'content_hash' => hash('sha256', 'the-bytes-that-were-signed'),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertSame('content_hash_mismatch', $result['body']['reason']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
+        $this->assertSame(0, $endpoints->status(['artifact_id' => 'artifact-1'])['body']['committed_bytes']);
+    }
+
+    public function testReplayedRequestIsAbsorbedAsADuplicate(): void
+    {
+        // There is no nonce cache; replay protection is the protocol's
+        // idempotence. A captured append replayed verbatim inside the
+        // timestamp window must land as a duplicate at the same offset —
+        // the frontier does not move and bytes are never doubled.
+        $endpoints = $this->makeEndpoints();
+        $body = 'replayable bytes';
+        $headers = $this->signedHeaders($body);
+
+        $stream = $this->bodyStream($body);
+        $first = $endpoints->upload(['artifact_id' => 'a.txt', 'offset' => 0], $headers, $stream);
+        fclose($stream);
+        $this->assertSame(200, $first['http_code']);
+        $this->assertSame(strlen($body), $first['body']['committed_bytes']);
+
+        // The exact same signed request again — same nonce, same
+        // timestamp, same signature, same body.
+        $stream = $this->bodyStream($body);
+        $replayed = $endpoints->upload(['artifact_id' => 'a.txt', 'offset' => 0], $headers, $stream);
+        fclose($stream);
+
+        $this->assertSame(200, $replayed['http_code']);
+        $this->assertSame('duplicate', $replayed['body']['status']);
+        $this->assertSame(strlen($body), $replayed['body']['committed_bytes'], 'the frontier must not move');
+        $this->assertSame(
+            strlen($body),
+            (int) filesize($this->staging_dir . '/files/a.txt'),
+            'bytes are never doubled'
+        );
+    }
+
+    public function testShortNonceIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->upload($endpoints, 'a.txt', 0, 'bytes', ['nonce' => 'short']);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/a.txt');
+    }
+
+    public function testUploadWithoutAConfiguredSecretIsUnavailable(): void
+    {
+        $endpoints = $this->makeEndpoints(['secret' => null]);
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload');
+
+        $this->assertSame(503, $result['http_code']);
+        $this->assertSame('not_configured', $result['body']['reason']);
+    }
+
+    // ---------------------------------------------------------------
+    // Request-size limits: the chunk sizer's 413 contract
+    // ---------------------------------------------------------------
+
+    public function testBodyOverTheCapIs413WithMaxRequestBytes(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
+
+        $result = $this->upload($endpoints, 'artifact-1', 0, str_repeat('x', 100));
+
+        $this->assertSame(413, $result['http_code']);
+        $this->assertSame('request_too_large', $result['body']['reason']);
+        $this->assertSame(64, $result['body']['max_request_bytes']);
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
+    }
+
+    public function testDeclaredContentLengthOverTheCapIs413BeforeReading(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
+
+        // An empty stream stands in for the body: the declared length alone
+        // must trigger the rejection, before any read happens.
+        $stream = $this->bodyStream('');
+        $headers = $this->signedHeaders('');
+        $headers['CONTENT_LENGTH'] = '5000';
+        $result = $endpoints->upload(
+            ['artifact_id' => 'artifact-1', 'offset' => 0],
+            $headers,
+            $stream
+        );
+        fclose($stream);
+
+        $this->assertSame(413, $result['http_code']);
+        $this->assertSame('request_too_large', $result['body']['reason']);
+        $this->assertSame(64, $result['body']['max_request_bytes']);
+    }
+
+    // ---------------------------------------------------------------
+    // Control plane: finalize, status, discard
+    // ---------------------------------------------------------------
+
+    public function testFinalizeWithWrongTotalIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+
+        $result = $this->finalize($endpoints, 'artifact-1', 99);
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('size_mismatch', $result['body']['reason']);
+    }
+
+    public function testFinalizeOfUnknownArtifactReportsMissing(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->finalize($endpoints, 'never-uploaded', 5);
+
+        $this->assertSame(409, $result['http_code']);
+        $this->assertSame('missing', $result['body']['reason']);
+    }
+
+    public function testFinalizeIsIdempotentAndZeroByteArtifactsVerify(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $this->finalize($endpoints, 'artifact-1', 7);
+
+        $this->assertSame(200, $this->finalize($endpoints, 'artifact-1', 7)['http_code']);
+        $this->assertSame('verified', $this->finalize($endpoints, 'empty.txt', 0)['body']['status']);
+    }
+
+    public function testStatusReportsResumeState(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $unknown = $endpoints->status(['artifact_id' => 'artifact-1']);
+        $this->assertSame(200, $unknown['http_code']);
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            $unknown['body']
+        );
+
+        $this->upload($endpoints, 'artifact-1', 0, 'abcde');
+        $known = $endpoints->status(['artifact_id' => 'artifact-1']);
+        $this->assertSame(
+            ['exists' => true, 'committed_bytes' => 5, 'verified' => false],
+            $known['body']
+        );
+    }
+
+    public function testDiscardReportsHeldStoreAsRetriable(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $busy = $endpoints->discard(
+            ['artifact_id' => 'artifact-1'],
+            ['REQUEST_METHOD' => 'POST']
+        );
+        flock($holder, LOCK_UN);
+        fclose($holder);
+
+        $this->assertSame(423, $busy['http_code']);
+        $this->assertSame(['discarded' => false], $busy['body']);
+
+        $done = $endpoints->discard(
+            ['artifact_id' => 'artifact-1'],
+            ['REQUEST_METHOD' => 'POST']
+        );
+        $this->assertSame(200, $done['http_code']);
+        $this->assertSame(['discarded' => true], $done['body']);
+    }
+
+    // ---------------------------------------------------------------
+    // Apply route
+    // ---------------------------------------------------------------
+
+    public function testApplyRouteProbesThenMovesAVerifiedTransfer(): void
+    {
+        $target_root = $this->staging_dir . '-target';
+        mkdir($target_root, 0700, true);
+        try {
+            $endpoints = $this->makeEndpoints(['apply_target_root' => $target_root]);
+            $this->upload($endpoints, 'wp-content/a.txt', 0, 'applied!');
+            $this->finalize($endpoints, 'wp-content/a.txt', 8);
+            $manifest = json_encode(['artifact_id' => 'wp-content/a.txt', 'size' => 8]) . "\n";
+            $this->upload($endpoints, 'm.jsonl', 0, $manifest);
+            $this->finalize($endpoints, 'm.jsonl', strlen($manifest));
+
+            $probe = $endpoints->apply(
+                ['manifest_id' => 'm.jsonl', 'check_only' => '1'],
+                ['REQUEST_METHOD' => 'POST']
+            );
+            $this->assertSame([200, 'ready'], [$probe['http_code'], $probe['body']['status']]);
+            $this->assertFileDoesNotExist($target_root . '/wp-content/a.txt');
+
+            // "ready" is the sender's preflight: the request cap seeds its
+            // chunk sizer and free space gates the transfer size.
+            $this->assertIsInt($probe['body']['max_request_bytes']);
+            $this->assertGreaterThan(0, $probe['body']['max_request_bytes']);
+            $this->assertIsInt($probe['body']['staging_free_bytes']);
+            $this->assertIsInt($probe['body']['target_free_bytes']);
+
+            $result = $endpoints->apply(['manifest_id' => 'm.jsonl'], ['REQUEST_METHOD' => 'POST']);
+            $this->assertSame(
+                [200, 'applied', 1],
+                [$result['http_code'], $result['body']['status'], $result['body']['applied']]
+            );
+            $this->assertSame('applied!', file_get_contents($target_root . '/wp-content/a.txt'));
+        } finally {
+            $this->removeDir($target_root);
+        }
+    }
+
+    public function testApplyRouteReportsCrossDeviceOnTheProbe(): void
+    {
+        $target_root = $this->staging_dir . '-target';
+        mkdir($target_root, 0700, true);
+        try {
+            $endpoints = $this->makeEndpoints([
+                'apply_target_root' => $target_root,
+                'apply_device_id' => function (string $path): ?int {
+                    return strpos($path, '-target') !== false ? 22 : 11;
+                },
+            ]);
+
+            // No transfer exists yet — the environment verdict alone must
+            // reject, so a sender learns before uploading anything.
+            $probe = $endpoints->apply(
+                ['manifest_id' => 'not-yet-staged', 'check_only' => '1'],
+                ['REQUEST_METHOD' => 'POST']
+            );
+
+            $this->assertSame(409, $probe['http_code']);
+            $this->assertSame('cross_device', $probe['body']['reason']);
+        } finally {
+            $this->removeDir($target_root);
+        }
+    }
+
+    public function testApplyRouteValidatesConfigurationAndMethod(): void
+    {
+        $unconfigured = $this->makeEndpoints();
+        $missing_root = $unconfigured->apply(['manifest_id' => 'm'], ['REQUEST_METHOD' => 'POST']);
+        $this->assertSame(
+            [503, 'not_configured', 'apply_target_root'],
+            [$missing_root['http_code'], $missing_root['body']['reason'], $missing_root['body']['detail']]
+        );
+
+        $configured = $this->makeEndpoints(['apply_target_root' => sys_get_temp_dir()]);
+        $get = $configured->apply(['manifest_id' => 'm'], ['REQUEST_METHOD' => 'GET']);
+        $this->assertSame(405, $get['http_code']);
+
+        $no_manifest = $configured->apply([], ['REQUEST_METHOD' => 'POST']);
+        $this->assertSame([400, 'invalid_manifest_id'], [$no_manifest['http_code'], $no_manifest['body']['reason']]);
+    }
+
+    // ---------------------------------------------------------------
+    // Request validation and server-owned options
+    // ---------------------------------------------------------------
+
+    public function testMutatingRoutesRequirePost(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $get = ['REQUEST_METHOD' => 'GET'];
+
+        $upload = $endpoints->upload(['artifact_id' => 'a', 'offset' => 0], $get, null);
+        $finalize = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 1], $get);
+        $discard = $endpoints->discard(['artifact_id' => 'a'], $get);
+
+        foreach ([$upload, $finalize, $discard] as $result) {
+            $this->assertSame(405, $result['http_code']);
+            $this->assertSame('method_not_allowed', $result['body']['reason']);
+        }
+    }
+
+    public function testMalformedParametersAreRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $post = ['REQUEST_METHOD' => 'POST'];
+
+        $no_id = $endpoints->upload(['offset' => 0], $post, null);
+        $this->assertSame([400, 'invalid_artifact_id'], [$no_id['http_code'], $no_id['body']['reason']]);
+
+        $bad_offset = $endpoints->upload(['artifact_id' => 'a', 'offset' => -1], $post, null);
+        $this->assertSame('invalid_offset', $bad_offset['body']['reason']);
+
+        $bad_total = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 'many'], $post);
+        $this->assertSame('invalid_total', $bad_total['body']['reason']);
+
+        $bad_status_id = $endpoints->status(['artifact_id' => '']);
+        $this->assertSame(400, $bad_status_id['http_code']);
+    }
+
+    public function testClientParametersCannotChooseServerOptions(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_request_bytes' => 1024]);
+        $evil_dir = $this->staging_dir . '-evil';
+        $body = str_repeat('x', 100);
+
+        $stream = $this->bodyStream($body);
+        $result = $endpoints->upload(
+            [
+                'artifact_id' => 'artifact-1',
+                'offset' => 0,
+                // Options are server-owned; parameters with the same names
+                // must be ignored.
+                'staging_dir' => $evil_dir,
+                'max_request_bytes' => 10,
+                'secret' => 'attacker-chosen',
+            ],
+            $this->signedHeaders($body),
+            $stream
+        );
+        fclose($stream);
+
+        $this->assertSame(200, $result['http_code']);
+        $this->assertFileExists($this->staging_dir . '/files/artifact-1');
+        $this->assertDirectoryDoesNotExist($evil_dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Batched uploads: many files, one request
+    // ---------------------------------------------------------------
+
+    /** Builds the length-prefixed frame body for complete files. */
+    private function batchBody(array $files): string
+    {
+        $body = '';
+        foreach ($files as $artifact_id => $payload) {
+            $body .= json_encode([
+                'artifact_id' => $artifact_id,
+                'offset' => 0,
+                'length' => strlen($payload),
+                'total_bytes' => strlen($payload),
+                'final' => true,
+            ]) . "\n" . $payload;
+        }
+        return $body;
+    }
+
+    private function uploadBatch(Site_Export_Staged_Endpoints $endpoints, string $body, array $header_overrides = []): array
+    {
+        $stream = $this->bodyStream($body);
+        try {
+            return $endpoints->upload_batch([], $this->signedHeaders($body, $header_overrides), $stream);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testBatchStagesManyFilesInOneRequest(): void
+    {
+        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 8]);
+        $files = [
+            'index.php' => '<?php // root',
+            'wp-content/uploads/a.bin' => str_repeat('x', 100),
+            'empty.txt' => '',
+        ];
+
+        $result = $this->uploadBatch($endpoints, $this->batchBody($files));
+
+        $this->assertSame(200, $result['http_code'], json_encode($result['body']));
+        $this->assertSame('ok', $result['body']['status']);
+        $this->assertCount(3, $result['body']['results']);
+        foreach ($result['body']['results'] as $file_result) {
+            $this->assertSame('verified', $file_result['status'], json_encode($file_result));
+        }
+        foreach ($files as $artifact_id => $payload) {
+            $this->assertSame($payload, file_get_contents($this->staging_dir . '/files/' . $artifact_id));
+        }
+    }
+
+    public function testBatchRetryIsIdempotent(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $body = $this->batchBody(['a.txt' => 'aaa', 'b.txt' => 'bbbb']);
+        $this->uploadBatch($endpoints, $body);
+
+        // The response was lost; the sender retries the identical batch.
+        $retry = $this->uploadBatch($endpoints, $body);
+
+        $this->assertSame(200, $retry['http_code']);
+        foreach ($retry['body']['results'] as $file_result) {
+            $this->assertSame('verified', $file_result['status']);
+        }
+    }
+
+    public function testBatchRetryWithTruncatedVerifiedPayloadIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $this->uploadBatch($endpoints, $this->batchBody(['a.txt' => 'abcde']));
+        $truncated = json_encode([
+            'artifact_id' => 'a.txt',
+            'offset' => 0,
+            'length' => 5,
+            'total_bytes' => 5,
+            'final' => true,
+        ]) . "\nab";
+
+        $result = $this->uploadBatch($endpoints, $truncated);
+
+        $this->assertSame([400, 'truncated_batch'], [$result['http_code'], $result['body']['reason']]);
+    }
+
+    public function testBatchStopsAtTheFirstBadFrameAndReportsProgress(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $body = $this->batchBody(['good.txt' => 'landed']) . "not json at all\n";
+
+        $result = $this->uploadBatch($endpoints, $body);
+
+        $this->assertSame(400, $result['http_code']);
+        $this->assertSame('invalid_batch_frame', $result['body']['reason']);
+        $this->assertCount(1, $result['body']['results'], 'work before the bad frame is reported');
+        $this->assertSame('verified', $result['body']['results'][0]['status']);
+        $this->assertSame('landed', file_get_contents($this->staging_dir . '/files/good.txt'));
+
+        $truncated = $this->uploadBatch(
+            $endpoints,
+            json_encode(['artifact_id' => 'short.txt', 'offset' => 0, 'length' => 100, 'total_bytes' => 100, 'final' => true]) . "\nonly-a-few"
+        );
+        $this->assertSame([400, 'truncated_batch'], [$truncated['http_code'], $truncated['body']['reason']]);
+    }
+
+    public function testBatchBodyMismatchNeverReachesTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $body = $this->batchBody(['secret.php' => 'attacker bytes']);
+
+        $result = $this->uploadBatch($endpoints, $body, [
+            'content_hash' => hash('sha256', 'what was actually signed'),
+        ]);
+
+        $this->assertSame(403, $result['http_code']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/files');
+    }
+
+    public function testDuplicateIdWithinOneBatchIsIdempotent(): void
+    {
+        // A sender bug or a repartition edge can put the same file into
+        // one request twice. The second frame must land on the verified
+        // short-circuit — never doubled bytes, never a poisoned batch.
+        $endpoints = $this->makeEndpoints();
+        $frame = json_encode([
+            'artifact_id' => 'twice.txt',
+            'offset' => 0,
+            'length' => 5,
+            'total_bytes' => 5,
+            'final' => true,
+        ]) . "\nhello";
+
+        $result = $this->uploadBatch($endpoints, $frame . $frame);
+
+        $this->assertSame(200, $result['http_code'], json_encode($result['body']));
+        $this->assertCount(2, $result['body']['results']);
+        $this->assertSame('verified', $result['body']['results'][0]['status']);
+        $this->assertSame('verified', $result['body']['results'][1]['status']);
+        $this->assertSame('hello', file_get_contents($this->staging_dir . '/files/twice.txt'));
+    }
+
+    public function testHostileFrameFieldsAreTypedRejections(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        // A negative length must not be fed to a read loop.
+        $negative = $this->uploadBatch(
+            $endpoints,
+            json_encode(['artifact_id' => 'n.txt', 'offset' => 0, 'length' => -5, 'total_bytes' => 5, 'final' => true]) . "\nhello"
+        );
+        $this->assertSame(400, $negative['http_code']);
+
+        // A traversal id inside a frame goes through the same path rule
+        // as the single-upload route: the store's typed rejection, and
+        // nothing lands outside the staging dir.
+        $hostile = $this->uploadBatch(
+            $endpoints,
+            json_encode(['artifact_id' => '../escape.txt', 'offset' => 0, 'length' => 5, 'total_bytes' => 5, 'final' => true]) . "\nhello"
+        );
+        $this->assertSame(409, $hostile['http_code']);
+        $this->assertFileDoesNotExist(dirname($this->staging_dir) . '/escape.txt');
+    }
+
+    // ---------------------------------------------------------------
+    // Dispatcher wiring
+    // ---------------------------------------------------------------
+
+    public function testHttpServerRoutesStagedEndpoints(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
+        ]);
+
+        ob_start();
+        $server->handle_request([
+            'get' => ['endpoint' => 'staged_status', 'artifact_id' => 'artifact-1'],
+            'server' => ['REQUEST_METHOD' => 'GET'],
+            'body' => '',
+        ]);
+        $output = ob_get_clean();
+
+        $this->assertSame(
+            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
+            json_decode( (string) $output, true)
+        );
+    }
+
+    public function testStagedRoutesAreAbsentWithoutTheStagedOption(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid endpoint: 'staged_status'");
+
+        $server->dispatch(['endpoint' => 'staged_status']);
+    }
+
+    public function testExplicitHandlersWinOverStagedRegistration(): void
+    {
+        $called = false;
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'staged_status' => function (array $config) use (&$called): void {
+                    $called = true;
+                },
+            ],
+            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
+        ]);
+
+        $server->dispatch(['endpoint' => 'staged_status']);
+
+        $this->assertTrue($called);
+    }
+
+    public function testHandleRequestOnlyReadsTheBodyForJsonContent(): void
+    {
+        $reads = 0;
+        $options = [
+            'handlers' => ['preflight' => static function (array $config): void {}],
+            'body_reader' => function () use (&$reads): string {
+                ++$reads;
+                return '';
+            },
+        ];
+        $server = new Site_Export_HTTP_Server($options);
+
+        $server->handle_request([
+            'get' => ['endpoint' => 'preflight'],
+            'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/octet-stream'],
+        ]);
+        $this->assertSame(0, $reads, 'a raw body must not be buffered for config parsing');
+
+        $server->handle_request([
+            'get' => ['endpoint' => 'preflight'],
+            'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json; charset=utf-8'],
+        ]);
+        $this->assertSame(1, $reads, 'a JSON body still feeds config parsing');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,5 +26,17 @@ if (!class_exists('Site_Export_HTTP_Server', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-http-server.php';
 }
 
+if (!class_exists('Site_Export_Staged_Artifacts', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-artifacts.php';
+}
+
+if (!class_exists('Site_Export_Staged_Endpoints', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-endpoints.php';
+}
+
+if (!class_exists('Site_Export_Staged_Apply', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -1,10 +1,12 @@
-# Stages this PR's perf comment will benchmark.
+# Stages this PR stack's perf comment will benchmark.
 # One stage name per line; comments and blank lines ignored.
 # Both the PR build and the trunk baseline run the same set, so the
-# table shows two like-for-like wall-time numbers per row.
+# table shows like-for-like wall-time numbers per row.
 #
-# This PR loads the Rust wp_mysql_parser PHP.wasm extension for the PR side
-# and leaves it disabled for the trunk baseline. Both sides use the same
-# direct PHP.wasm runner so the wall-time delta isolates the extension.
-playground-sqlite-db-pull
-playground-sqlite-db-apply
+# This stack changes file transfer/apply behavior. Keep the focused benchmark
+# on file movement rather than unrelated database-only Playground SQLite
+# stages. `files-pull` requires preflight state, so benchmark both stages
+# together. Push-specific stages cannot be compared here until push-files exists
+# on the trunk baseline.
+preflight
+files-pull

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -130,6 +130,12 @@
     },
     "edit-locks": {
       "port": 8122
+    },
+    "push-target": {
+      "port": 8123
+    },
+    "push-target-xdev": {
+      "port": 8124
     }
   }
 }

--- a/tests/e2e/tests/import-52-push-files.test.js
+++ b/tests/e2e/tests/import-52-push-files.test.js
@@ -1,0 +1,314 @@
+/**
+ * Test 52: push-files — staged chunk upload and rename-apply
+ *
+ * The reverse direction: the local CLI pushes a tree INTO the served site's
+ * staged artifact store, then staged_apply moves the verified transfer into
+ * the target root by rename. The target serves lib.php WP-less (same
+ * bootstrap as test 44), which is exactly how hosts that route the API from
+ * their own index.php run it.
+ *
+ * Nuances covered:
+ *  - full push to applied, content-identical, including nested paths, an
+ *    empty file, and a multi-chunk file
+ *  - idempotent re-push (cache-skips, apply reports already applied)
+ *  - resume after the client loses ALL local state (server is the truth)
+ *  - resume when a prior apply already moved one staged artifact
+ *  - a same-size edit re-pushes (size checks alone cannot see it)
+ *  - --only pushes a subset and applies only that subset
+ *  - wrong secret fails fast without staging a byte
+ *  - cross-device staging (tmpfs vs disk) rejects before any upload
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, readdirSync, rmSync,
+    mkdirSync, writeFileSync, utimesSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir, runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+/** Writes the WP-less API router that serves the staged endpoints. */
+function writePushRouter(siteDir, stagingDir) {
+    writeFileSync(join(siteDir, 'index.php'), `<?php
+define('ABSPATH', __DIR__ . '/');
+define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/wp-content/plugins/site-export/');
+define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
+define('SITE_EXPORT_STAGING_DIR', '${stagingDir}');
+define('SITE_EXPORT_APPLY_ROOT', __DIR__ . '/applied-site');
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }
+}
+require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';
+_site_export_handle_api_request();
+`);
+}
+
+function provisionOptions(site, stagingDir) {
+    return {
+        db: 'none',
+        files: 'none',
+        afterCreate: async (siteDir) => {
+            mkdirSync(join(siteDir, 'applied-site'), { recursive: true });
+            writePushRouter(siteDir, stagingDir);
+            writeFileSync(
+                join(siteDir, 'wp-content', 'plugins', 'site-export', 'secret.php'),
+                `<?php return 'test-secret-${site}';\n`
+            );
+        },
+        afterPermissions: async (siteDir) => {
+            // PHP-FPM must write staging and the apply root.
+            execSync(`sudo mkdir -p "${join(siteDir, 'applied-site')}"`);
+            execSync(`sudo chmod -R 0777 "${join(siteDir, 'applied-site')}"`);
+        },
+    };
+}
+
+describe('Import: push-files stages and applies a local tree', () => {
+    const site = 'push-target';
+    let siteDir;
+    let appliedRoot;
+    let tempDir;
+    let sourceDir;
+
+    function runPush(extraArgs = [], options = {}) {
+        return runImporter(getSiteUrl(site), tempDir, 'push-files', {
+            secret: getSiteSecret(site),
+            extraArgs,
+            // push-files needs no preflight (its apply probe is the
+            // capability check), and this target serves lib.php WP-less,
+            // where the pull preflight legitimately reports not-ok.
+            skipPreflight: true,
+            ...options,
+        });
+    }
+
+    function freshWorkspace() {
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        tempDir = createTempDir('e2e-push-files');
+        sourceDir = fsRootDir(tempDir);
+        mkdirSync(join(sourceDir, 'wp-content', 'uploads'), { recursive: true });
+        mkdirSync(join(sourceDir, 'wp-content', 'plugins', 'my-plugin'), { recursive: true });
+        writeFileSync(join(sourceDir, 'index.php'), '<?php // pushed root');
+        writeFileSync(join(sourceDir, 'empty.txt'), '');
+        writeFileSync(join(sourceDir, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php'), '<?php // v1');
+        // Several append steps at the endpoint's 256 KiB buffer.
+        writeFileSync(join(sourceDir, 'wp-content', 'uploads', 'big.bin'), 'reprint!'.repeat(80000));
+    }
+
+    function resetTarget() {
+        // Root perms on staging content vary with PHP-FPM's umask; sudo
+        // keeps the reset deterministic.
+        execSync(`sudo rm -rf "${join(siteDir, '.push-staging')}"`);
+        execSync(`sudo rm -rf "${appliedRoot}"`);
+        execSync(`sudo mkdir -p "${appliedRoot}"`);
+        execSync(`sudo chmod 0777 "${appliedRoot}"`);
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, provisionOptions(site, join(getSiteDir(site), '.push-staging')));
+        siteDir = getSiteDir(site);
+        appliedRoot = join(siteDir, 'applied-site');
+    }, 300000);
+
+    afterAll(() => {
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+    });
+
+    it('pushes a tree to applied, content-identical', () => {
+        freshWorkspace();
+        resetTarget();
+
+        const result = runPush(['--apply']);
+
+        assert.equal(result.exitCode, 0, `push failed:\n${result.stderr}\n${result.stdout}`);
+        assert.ok(result.stdout.includes('push_apply'), 'apply summary expected in output');
+        assert.equal(
+            readFileSync(join(appliedRoot, 'index.php'), 'utf-8'),
+            '<?php // pushed root'
+        );
+        assert.equal(
+            readFileSync(join(appliedRoot, 'wp-content', 'uploads', 'big.bin'), 'utf-8'),
+            'reprint!'.repeat(80000),
+            'multi-chunk file must arrive byte-identical'
+        );
+        assert.equal(readFileSync(join(appliedRoot, 'empty.txt'), 'utf-8'), '');
+
+        // The transfer was consumed: nothing left under staging files/.
+        const stagedFiles = join(siteDir, '.push-staging', 'files');
+        const leftovers = existsSync(stagedFiles) ? readdirSync(stagedFiles) : [];
+        assert.deepEqual(leftovers, [], 'apply consumes the staged transfer');
+    }, 120000);
+
+    it('re-pushing the identical tree is an idempotent no-op', () => {
+        const result = runPush(['--apply']);
+
+        assert.equal(result.exitCode, 0, `re-push failed:\n${result.stderr}\n${result.stdout}`);
+        const summary = JSON.parse(result.stdout.slice(result.stdout.lastIndexOf('{\n')));
+        assert.equal(summary.status, 'complete');
+    }, 120000);
+
+    it('resumes after the client loses all local state', () => {
+        freshWorkspace();
+        resetTarget();
+
+        // Stage without applying, then lose every client-side record — the
+        // sizer state and the diff's work lists. The store is the truth.
+        const staged = runPush();
+        assert.equal(staged.exitCode, 0, `staging failed:\n${staged.stderr}\n${staged.stdout}`);
+        for (const name of [
+            '.push-state.json',
+            '.push-source-index.jsonl',
+            '.push-upload-list.jsonl',
+            '.push-deletions.jsonl',
+            '.push-shipped-index.jsonl',
+        ]) {
+            rmSync(join(tempDir, name), { force: true });
+        }
+
+        // The rerun re-confirms every artifact against the store (status +
+        // finalize short-circuits, no byte re-uploads) and applies.
+        const resumed = runPush(['--apply']);
+
+        assert.equal(resumed.exitCode, 0, `resume failed:\n${resumed.stderr}\n${resumed.stdout}`);
+        assert.equal(
+            readFileSync(join(appliedRoot, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php'), 'utf-8'),
+            '<?php // v1'
+        );
+    }, 120000);
+
+    it('finishes an apply window with one file already moved', () => {
+        freshWorkspace();
+        resetTarget();
+
+        const staged = runPush();
+        assert.equal(staged.exitCode, 0, `staging failed:\n${staged.stderr}\n${staged.stdout}`);
+
+        // Simulate a kill after the first rename but before apply could consume
+        // its verified marker. The rerun must treat that artifact as already
+        // applied and continue with the still-staged files.
+        execSync(
+            `sudo mv "${join(siteDir, '.push-staging', 'files', 'index.php')}" "${join(appliedRoot, 'index.php')}"`
+        );
+
+        const result = runPush(['--apply']);
+
+        assert.equal(result.exitCode, 0, `apply rerun failed:\n${result.stderr}\n${result.stdout}`);
+        const summary = JSON.parse(result.stdout.slice(result.stdout.lastIndexOf('{\n')));
+        assert.equal(summary.status, 'complete');
+        assert.equal(summary.already_applied, 1);
+        assert.equal(
+            readFileSync(join(appliedRoot, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php'), 'utf-8'),
+            '<?php // v1'
+        );
+    }, 120000);
+
+    it('a same-size edit re-pushes instead of cache-skipping', () => {
+        freshWorkspace();
+        resetTarget();
+        assert.equal(runPush(['--apply']).exitCode, 0);
+
+        // Same byte length, different content — invisible to size checks.
+        const edited = join(sourceDir, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php');
+        writeFileSync(edited, '<?php // v2');
+        const later = new Date(Date.now() + 5000);
+        utimesSync(edited, later, later);
+
+        const result = runPush(['--apply']);
+
+        assert.equal(result.exitCode, 0, `${result.stderr}\n${result.stdout}`);
+        assert.equal(
+            readFileSync(join(appliedRoot, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php'), 'utf-8'),
+            '<?php // v2',
+            'the target must see the same-size edit'
+        );
+    }, 120000);
+
+    it('--only pushes and applies just the selected subtree', () => {
+        freshWorkspace();
+        resetTarget();
+
+        const result = runPush(['--apply', '--only=wp-content/uploads']);
+
+        assert.equal(result.exitCode, 0, `${result.stderr}\n${result.stdout}`);
+        assert.ok(existsSync(join(appliedRoot, 'wp-content', 'uploads', 'big.bin')));
+        assert.ok(
+            !existsSync(join(appliedRoot, 'index.php')),
+            'out-of-scope files must not apply'
+        );
+    }, 120000);
+
+    it('a wrong secret fails fast without staging a byte', () => {
+        freshWorkspace();
+        resetTarget();
+
+        const result = runImporter(getSiteUrl(site), tempDir, 'push-files', {
+            secret: 'not-the-secret',
+            extraArgs: ['--apply'],
+            autoResume: false,
+            skipPreflight: true,
+        });
+
+        assert.equal(result.exitCode, 1);
+        assert.ok(
+            (result.stdout + result.stderr).includes('auth_failed'),
+            `expected auth_failed:\n${result.stdout}\n${result.stderr}`
+        );
+        const stagedFiles = join(siteDir, '.push-staging', 'files');
+        const staged = existsSync(stagedFiles) ? readdirSync(stagedFiles) : [];
+        assert.deepEqual(staged, [], 'no artifact may stage without the secret');
+    }, 120000);
+});
+
+describe('Import: push-files refuses cross-device staging up front', () => {
+    const site = 'push-target-xdev';
+    // tmpfs — a different stat device than /srv on the CI runner.
+    const xdevStaging = '/dev/shm/reprint-e2e-xdev-staging';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, provisionOptions(site, xdevStaging));
+        tempDir = createTempDir('e2e-push-xdev');
+        mkdirSync(fsRootDir(tempDir), { recursive: true });
+        writeFileSync(join(fsRootDir(tempDir), 'index.php'), '<?php // must never upload');
+    }, 300000);
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+        // PHP-FPM owns the staging scaffolding it created (0700 nginx).
+        execSync(`sudo rm -rf "${xdevStaging}"`);
+    });
+
+    it.skipIf(!existsSync('/dev/shm'))(
+        'rejects before any byte is uploaded',
+        () => {
+            const result = runImporter(getSiteUrl(site), tempDir, 'push-files', {
+                secret: getSiteSecret(site),
+                extraArgs: ['--apply'],
+                autoResume: false,
+                skipPreflight: true,
+            });
+
+            assert.equal(result.exitCode, 1, `${result.stdout}\n${result.stderr}`);
+            assert.ok(
+                (result.stdout + result.stderr).includes('cross_device'),
+                `expected cross_device:\n${result.stdout}\n${result.stderr}`
+            );
+            // The probe rejected before the transfer began: staging holds
+            // no artifact bytes.
+            const files = join(xdevStaging, 'files');
+            const staged = existsSync(files) ? readdirSync(files) : [];
+            assert.deepEqual(staged, [], 'nothing may upload into doomed staging');
+        },
+        120000
+    );
+});

--- a/tests/e2e/tests/import-53-staged-pull.test.js
+++ b/tests/e2e/tests/import-53-staged-pull.test.js
@@ -1,0 +1,75 @@
+/**
+ * Test 53: files-pull --staged-apply against a real WordPress site
+ *
+ * The pull downloads into a staged store under --state-dir and lands in
+ * --fs-root in one rename window at the end — the same staged store and
+ * apply engine push uses, driven from the pull side. The live tree never
+ * holds a half-written file; a mid-transfer failure leaves it untouched.
+ *
+ * The deterministic-interruption, delta, preserve-local, and cross-device
+ * nuances live in the PHPUnit CLI suite (StagedPullCliTest); this scenario
+ * covers the real-site dimension: a full WordPress tree over nginx +
+ * PHP-FPM arrives byte-identical through the staged path.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    assertTreesMatch,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: staged pull applies in one rename window', () => {
+    const site = 'basic';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-staged-pull');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function countStagedFiles() {
+        const staged = join(tempDir, '.pull-staging', 'files');
+        if (!existsSync(staged)) {
+            return 0;
+        }
+        const walk = (dir) => readdirSync(dir, { withFileTypes: true }).reduce(
+            (count, entry) => count + (entry.isDirectory()
+                ? walk(join(dir, entry.name))
+                : 1),
+            0
+        );
+        return walk(staged);
+    }
+
+    it('pulls the full site through staging, byte-identical', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--staged-apply'],
+        });
+
+        assert.equal(result.exitCode, 0, `staged pull failed:\n${result.stderr}\n${result.stdout}`);
+        assert.ok(
+            result.stdout.includes('staged_apply'),
+            `apply summary expected in output:\n${result.stdout.slice(-2000)}`
+        );
+        assertTreesMatch(getSiteDir(site), join(fsRootDir(tempDir), getSiteDir(site)));
+        assert.equal(
+            countStagedFiles(),
+            0,
+            'the apply window consumes the staged transfer'
+        );
+    }, 120000);
+});

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,10 @@
             <file>FileIndexDedupTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>SiteExportLibraryAuthTest.php</file>
+            <file>StagedApplyTest.php</file>
+            <file>StagedArtifactsTest.php</file>
+            <file>StagedEndpointsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>


### PR DESCRIPTION
Consolidates the staged-transfer stack (**#298, #300–#310**) plus a review pass and an architectural collapse into a single PR against `trunk`. Those PRs are being closed in favor of this one.

## What it adds

- **Push** (`push-files`): upload a local tree into a live WordPress target's staging store over the export API, then land it in **one atomic rename window**. New files, changed files, and deletions flip together — the live site never serves a half-written file, and aborting before apply is free.
- **Staged pull** (`files-pull --staged-apply`): the same store and apply engine on the pull side, so a delta arrives whole or not at all.
- **Shared substrate**: a chunked staging store with byte-count integrity and crash-safe cursors, HMAC-authenticated streaming upload/batch endpoints, a resumable upload client, and an atomic apply engine (rename-only, cross-device refused up front, preserve-local policies, opcache eviction).

## Push is an inverted pull

Instead of a parallel implementation, push reuses the code paths already built and tested for pull:

| | Pull | Push |
|---|---|---|
| Source enumeration | remote index (downloaded) | `--fs-root` walk → **same index format** |
| Delta base | local index | **shipped index** (what the target holds) |
| Delta + deletions | sorted-merge diff | **the same `classify_index_pair` merge** |
| Post-apply state | `finalize_index_updates` | **the same** streaming merge |

No separate plan array, no done cache — resume trusts the store the way pull trusts the files already in its fs-root. Deletions and ownership fall out of the diff.

## Configurable path style

`--index-path-style=absolute|relative` (push **and** pull, persisted in state): `absolute` mirrors the whole filesystem layout (can carry paths from outside the document root); `relative` mirrors just the `--fs-root` subtree. Defaults: pull=absolute, push=relative.

## Review fixes folded in

- **Security**: closed an auth-bypass seam (gate read the endpoint from GET while the dispatcher resolved it POST-over-GET).
- **Store**: restart an artifact from 0 when a killed discard left the cursor ahead of a missing file, instead of zero-filling a phantom prefix.
- Deletion derivation excludes plan-builder skips (symlink/unreadable) so a read fault or a dir→symlink swap can't delete live target files.
- Sender streams each chunk through a bounded spool instead of holding it whole in memory.
- Staged pull: persist the `owned` flag across a resumed file; tolerate a re-streamed verified artifact; reindex an own kill-interrupted apply.

## Testing

`composer test` (PHPUnit) + Docker e2e (`import-52-push-files`, `import-53-staged-pull`). PHPStan clean; per-file PHPCS non-increase held.

## Known boundary

Deletions and same-size-edit detection derive from the shipped index, updated at apply. A file edited to the *same byte length* between a stage-only run and a later apply is invisible to the byte-count store — the documented boundary the old done-cache's mtime once covered. Closing it cleanly means putting the mtime in the store's verified marker (small store+endpoint+client addition), noted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)