### PR TITLE
Add envelope-only HMAC for unsigned payloads

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -96,8 +96,10 @@ the drift summary.
 ## The staging store
 
 The staging area is `Site_Export_Staged_Artifacts` as built: artifact bytes
-at plain target-relative paths under `files/`, a rename-atomic cursor in
-`state.json`, an append-only `verified.jsonl`, one `lock` file. The caller
+at plain target-relative paths under `files/`, a cursor in `state.json`
+(replaced by writing a temp file and renaming it, so readers never see a
+half-written record), one small verified marker per finished artifact under
+`verified/`, and one `lock` file. The caller
 drives the loop — one `append()` per buffer, individually committed, so the
 transfer can stop after any step and resume from `committed_bytes` in a new
 request. `finalize()` checks the assembled size against the size declared in
@@ -208,8 +210,9 @@ Files first, database second, each PR small and stacked in this order:
 
 1. **Design doc** — this file.
 2. **Envelope auth** — headers-only HMAC for data routes: the
-   UNSIGNED-PAYLOAD sentinel with method and request target bound into the
-   signature.
+   X-Auth-Content-Hash header carries the literal string UNSIGNED-PAYLOAD,
+   and the signature covers the method and request target instead of a
+   body hash.
 3. **Staged artifact store** — already built (PR #298); rebases here.
 4. **Reprint-storage exclusions** — indexer and deletion-sync hard-exclude
    the configured storage path; web guards for inside-docroot placement.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -51,8 +51,8 @@ what it gives up: over plain HTTP an active attacker can read and modify
 transferred content; the flag only keeps the shared secret off the wire and
 limits replay.
 
-Every request carries an HMAC over the envelope only — method, path,
-timestamp, nonce. Payloads are not signed and not hashed: TLS already
+Every request carries an HMAC signature over exactly four values — the
+HTTP method, the URL's path and query, a timestamp, and a random nonce. Payloads are not signed and not hashed: TLS already
 guarantees their integrity, and signing streams was the single biggest source
 of buffering pain. Signing cost is constant per request regardless of payload
 size. The secret travels in no URL and no body, so it never lands in an

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -131,8 +131,9 @@ Order:
    siblings next to their targets. The site runs normally throughout.
 2. **Maintenance on.** We write the `.maintenance` file ourselves, and since
    WordPress executes that file, ours whitelists reprint API requests
-   (`$upgrading = 0` for us, `time()` for everyone else). Core's built-in
-   10-minute expiry stays intact as the dead-man switch.
+   (`$upgrading = 0` for us, `time()` for everyone else). WordPress's own
+   rule that a `.maintenance` file older than 10 minutes is ignored stays
+   intact, so an interrupted apply can never leave the site down for good.
 3. **Recheck, now that web writes are frozen:** the apply command carries the
    expected `(path, ctime, size)` tuples; the remote re-verifies them and
    refuses with a fresh conflict list instead of overwriting drift.
@@ -141,10 +142,10 @@ Order:
    seconds, independent of payload size.
 5. **Maintenance off**, scoped reindex, baselines updated.
 
-If the driver dies mid-apply: core expires maintenance after 10 minutes, the
-journal is resumable by the next apply command, and any authenticated push
-request that notices an incomplete journal finishes it before doing its own
-work (a lazy janitor — no worker, no cron).
+If the driver dies mid-apply: WordPress stops honoring the `.maintenance`
+file after 10 minutes on its own, the journal is resumable by the next apply
+command, and any authenticated push request that notices an unfinished
+journal finishes it before doing its own work — no worker or cron needed.
 
 **The reprint plugin's own directory is never touched by apply.** It is
 excluded from swaps and deletions and reported as excluded in the summary.
@@ -220,9 +221,11 @@ Files first, database second, each PR small and stacked in this order:
 8. **Package unification** — importer and exporter become one Reprint
    package (lite = serve-only build). Placed here because apply is the
    first piece that needs import-side code running on the remote.
-9. **Apply engine, files** — journaled swaps, copy-first, maintenance
-   whitelist, recheck, janitor, post-apply reindex. Harvests the apply
-   primitives from PR #277; the relay around them is dropped.
+9. **Apply engine, files** — journaled swaps, copy-first, the whitelisted
+   maintenance file, the recheck, unfinished-journal completion, post-apply
+   reindex. Reuses the apply code already built in PR #277 (the journaled
+   `.new`/`.bak` swaps and the copy-first flow); the relay around that code
+   is dropped.
 10. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
 11. **Row index and database diff** — the row index producer and endpoint,
     local row baselines, diff generation and URL rewrite, the apply batch.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -206,8 +206,9 @@ Stated here so nobody rediscovers them as surprises:
 Files first, database second, each PR small and stacked in this order:
 
 1. **Design doc** — this file.
-2. **Envelope auth** — headers-only HMAC for data routes, `--force-http`
-   with honest help text.
+2. **Envelope auth** — headers-only HMAC for data routes: the
+   UNSIGNED-PAYLOAD sentinel with method and request target bound into the
+   signature.
 3. **Staged artifact store** — already built (PR #298); rebases here.
 4. **Reprint-storage exclusions** — indexer and deletion-sync hard-exclude
    the configured storage path; web guards for inside-docroot placement.
@@ -216,7 +217,8 @@ Files first, database second, each PR small and stacked in this order:
 6. **Scoped remote reindex and drift summary** — path-scoped index requests,
    baseline comparison, the summary/confirm UX.
 7. **Upload endpoint** — the store's HTTP surface plus the sender loop with
-   chunk sizing; deletion manifest staged.
+   chunk sizing; deletion manifest staged; `--force-http` with honest help
+   text (the first push networking this flag can gate).
 8. **Package unification** — importer and exporter become one Reprint
    package (lite = serve-only build). Placed here because apply is the
    first piece that needs import-side code running on the remote.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -1,0 +1,230 @@
+# Push Sync
+
+Push local changes to a remote WordPress site: files and database, driven
+entirely from the local machine, resumable at every step, never leaving the
+remote half-applied. This document is the agreed design; the delivery plan at
+the end maps it to a PR stack.
+
+## Shape of a push
+
+1. The local machine knows what changed locally since its last sync with this
+   remote (files, deletions, database rows), by comparing against baselines it
+   stored at the end of that sync.
+2. It asks the remote to reindex just the paths (later: rows) the local
+   changes touch, and compares the result against the remote baseline from
+   the last sync. That reveals remote drift — files someone changed on the
+   remote that this push would overwrite.
+3. It shows a summary: changed locally, changed on the remote (within the
+   pushed scope), deletions. The user confirms. Conflicts are file-level and
+   row-level; the only resolutions are "override" and "skip". We never show
+   line-level or field-level diffs.
+4. It transfers everything into a staging area on the remote — file bytes,
+   a deletion manifest, and (phase two) the database diff. The transfer is
+   resumable at byte granularity.
+5. It drives the apply step with repeated commands until done. The remote
+   moves staged files into place, executes deletions, applies the database
+   diff, and fixes symlinks — inside a maintenance window that lasts seconds,
+   not the length of the transfer.
+6. It runs one more scoped reindex and stores the results as the new
+   baselines. The push is complete only after this step; a crashed push is
+   re-driven from the top and converges.
+
+Both sides act only when the local machine calls: no worker, no polling, no
+sessions. The remote is a passive authenticated API.
+
+## Peers and packages
+
+There is one package: Reprint. Every peer ships the same code with three
+capabilities:
+
+- **serve** — index and fetch endpoints (today's export surface),
+- **apply** — staging store, apply engine, database batch,
+- **drive** — the CLI that runs syncs.
+
+"Reprint lite" is a serve-only build for peers that only ever get pulled
+from. The WordPress plugin ships the full package.
+
+## Transport and authentication
+
+HTTPS is required. `--force-http` opts out explicitly, and its help text says
+what it gives up: over plain HTTP an active attacker can read and modify
+transferred content; the flag only keeps the shared secret off the wire and
+limits replay.
+
+Every request carries an HMAC over the envelope only — method, path,
+timestamp, nonce. Payloads are not signed and not hashed: TLS already
+guarantees their integrity, and signing streams was the single biggest source
+of buffering pain. Signing cost is constant per request regardless of payload
+size. The secret travels in no URL and no body, so it never lands in an
+access log.
+
+## Change detection: each machine compared against itself
+
+ctime is machine-local, so we never compare a local timestamp to a remote
+one. Each side is compared only against its own past:
+
+- "changed on my machine since the last sync" — local index now vs the local
+  baseline,
+- "changed on the remote since the last sync" — remote index now (scoped to
+  the pushed paths) vs the remote baseline.
+
+The local machine keeps one set of baselines **per remote site**, overwritten
+after each successful apply:
+
+    <state-dir>/push/<site>/last-sync-local-files.tsv
+    <state-dir>/push/<site>/last-sync-remote-files.tsv
+    <state-dir>/push/<site>/last-sync-local-rows.tsv   (phase two)
+
+The remote baseline is captured by a scoped reindex that runs *after* apply —
+apply itself changes remote ctimes, and without this refresh the next push
+would report everything we just wrote as drift.
+
+The first push to a site has no baselines: everything is "changed locally",
+nothing can be checked for drift, and the summary says so. ctime is trusted
+as-is; events that bump it without changing content (chmod, restores, host
+migrations) produce false drift warnings, and "override" is how the user
+moves past them.
+
+## Deletions
+
+Local deletions since the last sync come out of the baseline comparison. They
+travel as a deletion manifest — itself a staged artifact, uploaded through
+the same store as file bytes — and the apply step executes the unlinks inside
+the same window as the moves. Remote deletions since the last sync appear in
+the drift summary.
+
+## The staging store
+
+The staging area is `Site_Export_Staged_Artifacts` as built: artifact bytes
+at plain target-relative paths under `files/`, a rename-atomic cursor in
+`state.json`, an append-only `verified.jsonl`, one `lock` file. The caller
+drives the loop — one `append()` per buffer, individually committed, so the
+transfer can stop after any step and resume from `committed_bytes` in a new
+request. `finalize()` checks the assembled size against the size declared in
+the plan; nothing re-reads or hashes artifacts.
+
+Driver rule: **a discard that did not return true must be retried until it
+does** — before re-uploading an artifact and before starting a fresh push
+over leftovers. A half-finished discard leaves states that only another
+discard cleans up.
+
+## Where reprint stores its own data on the remote
+
+The remote is configured with one storage path for everything reprint keeps:
+the staging area and any apply bookkeeping. Preferably outside the document
+root. When the host only allows writing inside the document root:
+
+- the file indexer hard-excludes the configured path — it never appears in
+  any index, so it is never synced in either direction,
+- the deletion step refuses to touch anything under it,
+- best-effort web guards are written into it (`.htaccess` deny-all and an
+  empty `index.php`), since anything under the document root is otherwise
+  servable.
+
+## Apply
+
+Remote-side, journaled, idempotent, driven by repeated commands until done.
+Order:
+
+1. **Copy-first, outside maintenance:** static assets (uploads, media) move
+   to their final paths; PHP, plugins, and themes are materialized as `.new`
+   siblings next to their targets. The site runs normally throughout.
+2. **Maintenance on.** We write the `.maintenance` file ourselves, and since
+   WordPress executes that file, ours whitelists reprint API requests
+   (`$upgrading = 0` for us, `time()` for everyone else). Core's built-in
+   10-minute expiry stays intact as the dead-man switch.
+3. **Recheck, now that web writes are frozen:** the apply command carries the
+   expected `(path, ctime, size)` tuples; the remote re-verifies them and
+   refuses with a fresh conflict list instead of overwriting drift.
+4. **Swap:** journaled `.new`/`.bak` renames, deletion unlinks, the database
+   batch, symlink fixes. The window contains renames and a row batch —
+   seconds, independent of payload size.
+5. **Maintenance off**, scoped reindex, baselines updated.
+
+If the driver dies mid-apply: core expires maintenance after 10 minutes, the
+journal is resumable by the next apply command, and any authenticated push
+request that notices an incomplete journal finishes it before doing its own
+work (a lazy janitor — no worker, no cron).
+
+**The reprint plugin's own directory is never touched by apply.** It is
+excluded from swaps and deletions and reported as excluded in the summary.
+Updating reprint itself is a separate concern, never part of a sync.
+
+## Escape hatch: apply without booting WordPress
+
+Normally the endpoint runs through the WordPress boot because it is
+convenient. But an apply step can break that boot — a fatal in a half-swapped
+plugin — so the same endpoint is also reachable as a standalone PHP file that
+never loads WordPress: it reads database credentials from `wp-config.php`
+directly and operates on the filesystem and database with reprint's own code.
+The driver falls back to it automatically when the normal route stops
+answering sensibly. This is what makes apply failures recoverable from the
+outside instead of requiring SSH.
+
+## Database diff (phase two)
+
+The database is pushed as a diff — INSERT, UPDATE, DELETE — never as a dump
+that replaces tables. The mechanics mirror the file design:
+
+- A **row index** — `(table, primary key, row hash)` — plays the role
+  `(path, ctime, size)` plays for files. The local machine keeps the row
+  index from the last sync as a baseline; diffing against it yields the
+  upsert and delete sets.
+- The remote exposes a row-index endpoint scoped to the touched primary
+  keys, cursor-paginated the same way the dump producer already walks
+  tables, for drift detection.
+- Conflicts are row-level: a serialized option conflicts as a whole row, and
+  the resolutions are override or skip. Rows inserted on both sides with the
+  same primary key are conflicts; we do not remap keys.
+- The diff stream passes through the URL rewriter in the local-to-remote
+  direction before staging.
+- Volatile rows are excluded by default (transients, sessions, cron), the
+  same way volatile files are handled in pull.
+- The batch executes inside the apply maintenance window, bounded and
+  resumable like every other step.
+
+## Accepted limitations
+
+Stated here so nobody rediscovers them as surprises:
+
+- **Same-size corruption is invisible.** Transfers are verified by byte
+  count only. Corruption that preserves length passes. We decided detection
+  is not worth hashing multi-gigabyte artifacts inside PHP time limits.
+- **ctime produces false drift** after chmod, restores, or host migrations.
+  The cost is a noisy summary, not wrong data; "override" moves past it.
+- **Shell and cron can write during the maintenance window.** Maintenance
+  blocks web requests; it cannot block SSH or system cron. The recheck runs
+  after freezing web writes; what happens under it from a shell is accepted.
+- **Conflicts are whole-file and whole-row.** No line or field granularity,
+  by design.
+- **A sender that abandons a failed discard and re-uploads anyway** can end
+  up with a zero-filled prefix that passes the size check. The discard
+  retry rule exists precisely to make this unreachable.
+
+## Delivery plan
+
+Files first, database second, each PR small and stacked in this order:
+
+1. **Design doc** — this file.
+2. **Envelope auth** — headers-only HMAC for data routes, `--force-http`
+   with honest help text.
+3. **Staged artifact store** — already built (PR #298); rebases here.
+4. **Reprint-storage exclusions** — indexer and deletion-sync hard-exclude
+   the configured storage path; web guards for inside-docroot placement.
+5. **Push journal and local diff** — per-site baselines, capture and
+   overwrite logic, local change and deletion detection.
+6. **Scoped remote reindex and drift summary** — path-scoped index requests,
+   baseline comparison, the summary/confirm UX.
+7. **Upload endpoint** — the store's HTTP surface plus the sender loop with
+   chunk sizing; deletion manifest staged.
+8. **Package unification** — importer and exporter become one Reprint
+   package (lite = serve-only build). Placed here because apply is the
+   first piece that needs import-side code running on the remote.
+9. **Apply engine, files** — journaled swaps, copy-first, maintenance
+   whitelist, recheck, janitor, post-apply reindex. Harvests the apply
+   primitives from PR #277; the relay around them is dropped.
+10. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
+11. **Row index and database diff** — the row index producer and endpoint,
+    local row baselines, diff generation and URL rewrite, the apply batch.
+12. **`reprint push`** — the one command that orchestrates plan, confirm,
+    transfer, apply, resume.

--- a/packages/reprint-exporter/src/class-hmac-client.php
+++ b/packages/reprint-exporter/src/class-hmac-client.php
@@ -82,7 +82,8 @@ class Site_Export_HMAC_Client {
      * request to a digest: the server verifies the timestamp, nonce, and HMAC
      * over X-Auth-Content-Hash before it computes or compares any body hash.
      *
-     * This is intended for small control-plane requests. Large data transfers
+     * This is intended for small command requests such as preflight or plan
+     * confirmation. Large data transfers
      * should use an authenticated session and per-chunk hashes instead of
      * HMAC-signing one large request body.
      *

--- a/packages/reprint-exporter/src/class-hmac-client.php
+++ b/packages/reprint-exporter/src/class-hmac-client.php
@@ -45,8 +45,9 @@
 class Site_Export_HMAC_Client {
 
     /**
-     * Content-hash sentinel for requests whose payload is deliberately
-     * unsigned. Must match Site_Export_HMAC_Server::UNSIGNED_PAYLOAD.
+     * Value of the X-Auth-Content-Hash header when the request body is
+     * deliberately not signed: this literal string stands where a body hash
+     * would otherwise be. Must match Site_Export_HMAC_Server::UNSIGNED_PAYLOAD.
      */
     public const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
 
@@ -116,13 +117,14 @@ class Site_Export_HMAC_Client {
     }
 
     /**
-     * Returns X-Auth-* headers that sign only the request envelope.
+     * Returns X-Auth-* headers for a request whose body is not signed.
      *
-     * The signature binds the method and request target instead of a body
-     * digest, so a payload of any size streams through without buffering or
-     * hashing, and a captured envelope cannot be replayed against another
-     * route. Payload integrity belongs to TLS; over --force-http a tampered
-     * body is accepted — that is the flag's documented trade.
+     * The signature covers the method and the request target instead of a
+     * body hash, so a body of any size streams through without either side
+     * hashing it, and captured auth headers still cannot be reused for a
+     * different endpoint or method. Protecting the body from tampering is
+     * TLS's job — over --force-http a tampered body would be accepted,
+     * which is what that flag's help text warns about.
      *
      * Signature = HMAC-SHA256(nonce + timestamp + "UNSIGNED-PAYLOAD\n" + METHOD + "\n" + target, secret)
      *

--- a/packages/reprint-exporter/src/class-hmac-client.php
+++ b/packages/reprint-exporter/src/class-hmac-client.php
@@ -44,6 +44,12 @@
  */
 class Site_Export_HMAC_Client {
 
+    /**
+     * Content-hash sentinel for requests whose payload is deliberately
+     * unsigned. Must match Site_Export_HMAC_Server::UNSIGNED_PAYLOAD.
+     */
+    public const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
+
     /** @var string */
     private $secret;
 
@@ -107,6 +113,45 @@ class Site_Export_HMAC_Client {
             'X-Auth-Timestamp' => $timestamp,
             'X-Auth-Content-Hash' => $content_hash,
         ];
+    }
+
+    /**
+     * Returns X-Auth-* headers that sign only the request envelope.
+     *
+     * The signature binds the method and request target instead of a body
+     * digest, so a payload of any size streams through without buffering or
+     * hashing, and a captured envelope cannot be replayed against another
+     * route. Payload integrity belongs to TLS; over --force-http a tampered
+     * body is accepted — that is the flag's documented trade.
+     *
+     * Signature = HMAC-SHA256(nonce + timestamp + "UNSIGNED-PAYLOAD\n" + METHOD + "\n" + target, secret)
+     *
+     * @param string $method Uppercased into the signature (GET, POST, ...).
+     * @param string $url    Full request URL; only path and query are signed.
+     */
+    public function get_envelope_auth_headers(string $method, string $url): array {
+        $nonce = $this->generate_nonce();
+        $timestamp = $this->get_timestamp();
+        $message = $nonce . $timestamp . self::UNSIGNED_PAYLOAD . "\n" . strtoupper($method) . "\n" . self::request_target($url);
+
+        return [
+            'X-Auth-Signature' => hash_hmac('sha256', $message, $this->secret),
+            'X-Auth-Nonce' => $nonce,
+            'X-Auth-Timestamp' => $timestamp,
+            'X-Auth-Content-Hash' => self::UNSIGNED_PAYLOAD,
+        ];
+    }
+
+    /**
+     * Normalizes a URL to the "path?query" form both sides sign — the same
+     * shape PHP exposes as $_SERVER['REQUEST_URI'] on the receiving end.
+     */
+    public static function request_target(string $url): string {
+        $path = parse_url($url, PHP_URL_PATH);
+        $query = parse_url($url, PHP_URL_QUERY);
+        $target = is_string($path) && $path !== '' ? $path : '/';
+
+        return is_string($query) && $query !== '' ? $target . '?' . $query : $target;
     }
 
     /** Returns auth headers formatted for CURLOPT_HTTPHEADER (["Name: value", ...]). */

--- a/packages/reprint-exporter/src/class-hmac-client.php
+++ b/packages/reprint-exporter/src/class-hmac-client.php
@@ -120,9 +120,9 @@ class Site_Export_HMAC_Client {
     /**
      * Returns X-Auth-* headers for a request whose body is not signed.
      *
-     * The signature covers the method and the request target instead of a
-     * body hash, so a body of any size streams through without either side
-     * hashing it, and captured auth headers still cannot be reused for a
+     * The signature covers the nonce, the timestamp, the method, and the
+     * request target instead of a body hash, so a body of any size streams
+     * through without either side hashing it, and captured auth headers still cannot be reused for a
      * different endpoint or method. Protecting the body from tampering is
      * TLS's job — over --force-http a tampered body would be accepted,
      * which is what that flag's help text warns about.

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -10,8 +10,9 @@
 final class Site_Export_HMAC_Server {
 
     /**
-     * Content-hash sentinel for requests whose payload is deliberately
-     * unsigned. Must match Site_Export_HMAC_Client::UNSIGNED_PAYLOAD.
+     * Value of the X-Auth-Content-Hash header when the request body is
+     * deliberately not signed: this literal string stands where a body hash
+     * would otherwise be. Must match Site_Export_HMAC_Client::UNSIGNED_PAYLOAD.
      */
     public const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
 
@@ -141,21 +142,28 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
-     * Verify a request whose payload is deliberately unsigned.
+     * Verify a request whose body is deliberately not signed.
      *
-     * The signature binds the envelope — nonce, timestamp, method, and
-     * request target — and the content-hash header must carry the literal
-     * UNSIGNED-PAYLOAD sentinel. An envelope signature therefore never
-     * passes body verification and a body signature never passes here.
-     * Payload integrity belongs to TLS; data-plane routes opt into this so
-     * streams flow without buffering or hashing.
+     * Instead of a body hash, the signature covers the request itself:
+     * nonce, timestamp, HTTP method, and the request target (the
+     * "path?query" part of the URL). A request body of any size can then
+     * stream through without either side hashing it, and a captured set of
+     * auth headers still cannot be reused for a different endpoint or
+     * method. Protecting the body from tampering is TLS's job.
+     *
+     * The X-Auth-Content-Hash header must be the literal string
+     * UNSIGNED-PAYLOAD. Because of that, headers signed for this check can
+     * never pass the body-signed checks and vice versa — the two signatures
+     * are computed over strings that can never be equal. Each route decides
+     * which check it calls, so a client cannot pick the weaker one for a
+     * control-plane route.
      *
      * @param string $request_target The "path?query" form of the request URL.
      */
     public function verify_envelope(array $headers, string $method, string $request_target, ?float $now = null): ?string {
         $auth = $this->collect_auth_headers($headers);
         if ($auth['content_hash'] !== self::UNSIGNED_PAYLOAD) {
-            return 'Envelope verification requires the UNSIGNED-PAYLOAD content hash sentinel';
+            return 'Envelope verification requires the literal UNSIGNED-PAYLOAD content hash';
         }
 
         $freshness_error = $this->verify_freshness($auth, $now);
@@ -214,9 +222,10 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
-     * Checks header presence, timestamp tolerance, and nonce length — the
-     * scheme-independent half of verification. Signature checks differ per
-     * scheme and stay with their callers.
+     * Checks header presence, timestamp tolerance, and nonce length —
+     * everything except the signature. Body-signed and envelope-signed
+     * requests compute their signatures over different strings, so each
+     * caller does its own signature check after this passes.
      */
     private function verify_freshness(array $auth, ?float $now = null): ?string {
         $signature = $auth['signature'];

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -30,7 +30,7 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
-     * Verify a bounded control-plane request.
+     * Verify a small command request with a bounded body.
      *
      * HMAC is the guard for small protocol commands such as preflight, session
      * start, plan confirmation, and abort/resume. Large data uploads should use
@@ -155,8 +155,8 @@ final class Site_Export_HMAC_Server {
      * UNSIGNED-PAYLOAD. Because of that, headers signed for this check can
      * never pass the body-signed checks and vice versa — the two signatures
      * are computed over strings that can never be equal. Each route decides
-     * which check it calls, so a client cannot pick the weaker one for a
-     * control-plane route.
+     * which check it calls, so a client cannot make a command endpoint
+     * that requires verify_control_request() accept this body-less check.
      *
      * @param string $request_target The "path?query" form of the request URL.
      */
@@ -185,7 +185,7 @@ final class Site_Export_HMAC_Server {
      *
      * Returns null on success, or an error string on failure. This legacy
      * convenience path buffers php://input and should only be used for small
-     * request bodies. New control-plane routes should bound the body and call
+     * request bodies. New command endpoints should bound the body and call
      * verify_control_request(). Large data routes should not use whole-body
      * HMAC verification.
      */

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -144,9 +144,9 @@ final class Site_Export_HMAC_Server {
     /**
      * Verify a request whose body is deliberately not signed.
      *
-     * Instead of a body hash, the signature covers the request itself:
-     * nonce, timestamp, HTTP method, and the request target (the
-     * "path?query" part of the URL). A request body of any size can then
+     * Instead of a body hash, the signature covers exactly four values:
+     * the nonce, the timestamp, the HTTP method, and the request target
+     * (the "path?query" part of the URL). A request body of any size can then
      * stream through without either side hashing it, and a captured set of
      * auth headers still cannot be reused for a different endpoint or
      * method. Protecting the body from tampering is TLS's job.

--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -9,6 +9,12 @@
  */
 final class Site_Export_HMAC_Server {
 
+    /**
+     * Content-hash sentinel for requests whose payload is deliberately
+     * unsigned. Must match Site_Export_HMAC_Client::UNSIGNED_PAYLOAD.
+     */
+    public const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
+
     private const DEFAULT_MAX_CONTROL_BODY_BYTES = 1048576;
 
     /** @var string */
@@ -135,6 +141,38 @@ final class Site_Export_HMAC_Server {
     }
 
     /**
+     * Verify a request whose payload is deliberately unsigned.
+     *
+     * The signature binds the envelope — nonce, timestamp, method, and
+     * request target — and the content-hash header must carry the literal
+     * UNSIGNED-PAYLOAD sentinel. An envelope signature therefore never
+     * passes body verification and a body signature never passes here.
+     * Payload integrity belongs to TLS; data-plane routes opt into this so
+     * streams flow without buffering or hashing.
+     *
+     * @param string $request_target The "path?query" form of the request URL.
+     */
+    public function verify_envelope(array $headers, string $method, string $request_target, ?float $now = null): ?string {
+        $auth = $this->collect_auth_headers($headers);
+        if ($auth['content_hash'] !== self::UNSIGNED_PAYLOAD) {
+            return 'Envelope verification requires the UNSIGNED-PAYLOAD content hash sentinel';
+        }
+
+        $freshness_error = $this->verify_freshness($auth, $now);
+        if ($freshness_error !== null) {
+            return $freshness_error;
+        }
+
+        $message = $auth['nonce'] . $auth['timestamp'] . self::UNSIGNED_PAYLOAD . "\n" . strtoupper($method) . "\n" . $request_target;
+        $expected_signature = hash_hmac('sha256', $message, $this->secret);
+        if (!hash_equals($expected_signature, $auth['signature'])) {
+            return 'HMAC signature verification failed';
+        }
+
+        return null;
+    }
+
+    /**
      * Verify the current PHP request using superglobals.
      *
      * Returns null on success, or an error string on failure. This legacy
@@ -162,6 +200,25 @@ final class Site_Export_HMAC_Server {
     }
 
     private function verify_auth_headers(array $auth, ?float $now = null): ?string {
+        $freshness_error = $this->verify_freshness($auth, $now);
+        if ($freshness_error !== null) {
+            return $freshness_error;
+        }
+
+        $expected_signature = hash_hmac('sha256', $auth['nonce'] . $auth['timestamp'] . $auth['content_hash'], $this->secret);
+        if (!hash_equals($expected_signature, $auth['signature'])) {
+            return 'HMAC signature verification failed';
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks header presence, timestamp tolerance, and nonce length — the
+     * scheme-independent half of verification. Signature checks differ per
+     * scheme and stay with their callers.
+     */
+    private function verify_freshness(array $auth, ?float $now = null): ?string {
         $signature = $auth['signature'];
         $nonce = $auth['nonce'];
         $timestamp = $auth['timestamp'];
@@ -197,11 +254,6 @@ final class Site_Export_HMAC_Server {
 
         if (strlen($nonce) < 16) {
             return 'Nonce must be at least 16 characters';
-        }
-
-        $expected_signature = hash_hmac('sha256', $nonce . $timestamp . $signed_content_hash, $this->secret);
-        if (!hash_equals($expected_signature, $signature)) {
-            return 'HMAC signature verification failed';
         }
 
         return null;

--- a/tests/HmacServerTest.php
+++ b/tests/HmacServerTest.php
@@ -245,13 +245,13 @@ final class HmacServerTest extends TestCase
         );
     }
 
-    public function testEnvelopeRequiresTheSentinel(): void
+    public function testEnvelopeRequiresTheUnsignedPayloadHeader(): void
     {
         $headers = $this->buildHeadersForBody('{"command":"push"}');
         $server = new Site_Export_HMAC_Server(self::SECRET);
 
         $this->assertSame(
-            'Envelope verification requires the UNSIGNED-PAYLOAD content hash sentinel',
+            'Envelope verification requires the literal UNSIGNED-PAYLOAD content hash',
             $server->verify_envelope($headers, 'POST', '/?endpoint=push-append', 1700000001.0)
         );
     }

--- a/tests/HmacServerTest.php
+++ b/tests/HmacServerTest.php
@@ -212,6 +212,91 @@ final class HmacServerTest extends TestCase
         );
     }
 
+    public function testEnvelopeSignedRequestVerifies(): void
+    {
+        $client = new Site_Export_HMAC_Client(self::SECRET);
+        $url = 'https://example.com/?reprint-api&endpoint=push-append&artifact=a.txt';
+        $headers = $client->get_envelope_auth_headers('POST', $url);
+        $server = new Site_Export_HMAC_Server(self::SECRET);
+
+        $this->assertNull($server->verify_envelope(
+            $headers,
+            'post', // Method casing must not matter.
+            '/?reprint-api&endpoint=push-append&artifact=a.txt',
+            (float) $headers['X-Auth-Timestamp']
+        ));
+    }
+
+    public function testEnvelopeRejectsAnotherRouteOrMethod(): void
+    {
+        $client = new Site_Export_HMAC_Client(self::SECRET);
+        $headers = $client->get_envelope_auth_headers('POST', 'https://example.com/?endpoint=push-append');
+        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $now = (float) $headers['X-Auth-Timestamp'];
+
+        $this->assertSame(
+            'HMAC signature verification failed',
+            $server->verify_envelope($headers, 'POST', '/?endpoint=push-apply', $now),
+            'A captured envelope must not replay against a different route.'
+        );
+        $this->assertSame(
+            'HMAC signature verification failed',
+            $server->verify_envelope($headers, 'DELETE', '/?endpoint=push-append', $now)
+        );
+    }
+
+    public function testEnvelopeRequiresTheSentinel(): void
+    {
+        $headers = $this->buildHeadersForBody('{"command":"push"}');
+        $server = new Site_Export_HMAC_Server(self::SECRET);
+
+        $this->assertSame(
+            'Envelope verification requires the UNSIGNED-PAYLOAD content hash sentinel',
+            $server->verify_envelope($headers, 'POST', '/?endpoint=push-append', 1700000001.0)
+        );
+    }
+
+    public function testEnvelopeHeadersDoNotPassBodyVerification(): void
+    {
+        $client = new Site_Export_HMAC_Client(self::SECRET);
+        $headers = $client->get_envelope_auth_headers('POST', 'https://example.com/?endpoint=push-append');
+        $server = new Site_Export_HMAC_Server(self::SECRET);
+
+        $this->assertSame(
+            'HMAC signature verification failed',
+            $server->verify($headers, 'any-body', [], (float) $headers['X-Auth-Timestamp'])
+        );
+    }
+
+    public function testEnvelopeExpiredTimestampIsRejected(): void
+    {
+        $client = new Site_Export_HMAC_Client(self::SECRET);
+        $headers = $client->get_envelope_auth_headers('POST', 'https://example.com/?endpoint=push-append');
+        $server = new Site_Export_HMAC_Server(self::SECRET);
+
+        $result = $server->verify_envelope(
+            $headers,
+            'POST',
+            '/?endpoint=push-append',
+            (float) $headers['X-Auth-Timestamp'] + 301.0
+        );
+
+        $this->assertStringContainsString('Request timestamp expired', (string) $result);
+    }
+
+    public function testRequestTargetNormalization(): void
+    {
+        $this->assertSame(
+            '/?reprint-api&endpoint=push-append',
+            Site_Export_HMAC_Client::request_target('https://example.com/?reprint-api&endpoint=push-append')
+        );
+        $this->assertSame(
+            '/wp/index.php?a=1',
+            Site_Export_HMAC_Client::request_target('http://example.com:8080/wp/index.php?a=1#frag')
+        );
+        $this->assertSame('/', Site_Export_HMAC_Client::request_target('https://example.com'));
+    }
+
     private function buildHeadersForBody(
         string $body,
         string $timestamp = '1700000000.000000',


### PR DESCRIPTION
Part of #276.

Step 2 of the push stack (#315).

## What it does

Adds `HMAC(nonce + timestamp + UNSIGNED-PAYLOAD + method + path?query)` authentication support for requests with large bodies. `UNSIGNED-PAYLOAD` means the literal string `UNSIGNED-PAYLOAD`.

The previous way way of HMACing the entire request body is kept for now for backwards compatibility, and may eventually be removed in favor of this one.

## Why

Push uploads are large. Hashing a 512MB on both sides just to sign it costs a full extra read of the data, and #293 already had to fight the buffering this causes. Over HTTPS the body hash also buys nothing: TLS already guarantees nobody modified the body in transit.

With this PR, we lose full-body verification. If a request is somehow captured, it may be replayed with a different body for a limited time. This seems acceptable, since requests are transmitted between trusted sites over HTTPS. 

## Implementation

- **A body-signed request can never pass the envelope check, and envelope headers can never pass a body-signed check.** The two signatures are computed over strings that can never be equal: one contains a 64-character hex hash exactly where the other contains `UNSIGNED-PAYLOAD` plus the method and path.
- **The server route picks which check runs.** The command endpoints (preflight, plan confirmation, and similar) keep calling `verify_control_request()`, so a client cannot talk them into the body-less check.
`--force-http` (arriving with the first push networking, stack step 7) is the one situation where an unsigned body is a real loss — on plain HTTP someone in the middle could alter the body. Its help text will say exactly that.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit HmacServerTest.php
composer analyze
```

Tests cover: a signed request verifies (method case does not matter); captured headers fail against a different route or verb; a body-signed request fails the envelope check and envelope headers fail the body-signed check; expired timestamps fail; URL normalization.




