### PR TITLE
Push journal: per-site baselines and the local file diff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,8 @@ The exporter must scan both roots (document root + ABSPATH) without infinite loo
 ## Common Gotchas
 
 - **Cursor encoding**: Producers work with JSON strings. export.php handles base64 encoding for HTTP. Never pass base64 to producer constructors.
+- **Variable names**: Use full, descriptive names for domain values. Do not abbreviate to save characters (for example, prefer `$current_base64_path` over `$cur_b64`).
+- **JSON/JSONL parsing**: Parse JSON as JSON and validate semantic fields. Do not match prefixes, slice by fixed offsets, or depend on JSON field order or escaping.
 - **Memory limits**: Large dataset tests require at least 512MB PHP memory_limit
 - **Execution time**: LargeDatasetReentrancyTest processes 200,000+ rows and may take 30-60 seconds
 - **MySQL version**: Minimum MySQL 5.7 required (for JSON type support)

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -71,9 +71,13 @@ one. Each side is compared only against its own past:
 The local machine keeps one set of baselines **per remote site**, overwritten
 after each successful apply:
 
-    <state-dir>/push/<site>/last-sync-local-files.tsv
-    <state-dir>/push/<site>/last-sync-remote-files.tsv
-    <state-dir>/push/<site>/last-sync-local-rows.tsv   (phase two)
+    <state-dir>/push/<site>/last-sync-local-files.jsonl
+    <state-dir>/push/<site>/last-sync-remote-files.jsonl
+    <state-dir>/push/<site>/last-sync-local-rows.jsonl   (phase two)
+
+Each baseline is a copy of a file index in the `.import-index.jsonl` format
+the pull path already reads and writes — one JSON object per line, sorted by
+path.
 
 The remote baseline is captured by a scoped reindex that runs *after* apply —
 apply itself changes remote ctimes, and without this refresh the next push

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -19,19 +19,25 @@
  * rename lands, the previous baseline stays in effect.
  *
  * diff_local_files() answers "what changed on this machine since the last
- * push to this site". It walks the current index and the local baseline
- * together — both are sorted by path, so one pass suffices, the same merge
- * diff_indexes_and_build_fetch_list() in import.php runs against a remote
- * index — and writes two lists into the site directory:
+ * push to this site". It streams the current index and the local baseline
+ * together — both are sorted by path, so one pass suffices — and writes
+ * two lists into the site directory:
  *
  *     upload-list.jsonl     paths new since the baseline, or whose ctime,
  *                           size, or type differs
  *     deletion-list.jsonl   paths in the baseline but gone from the index
  *
- * Both lists hold one {"path": <base64>} object per line, the same shape
- * as .import-download-list.jsonl. They carry no sizes or types on purpose:
- * the files are local, so the upload step reads the filesystem when it
- * stages them instead of trusting a snapshot that may already be stale.
+ * The diff works on raw lines and never touches a JSON function. Index
+ * lines always start with {"path":"<base64>" — every index writer in
+ * import.php puts the path field first — so the path comes out of the
+ * line by position. Ordering compares decoded paths; two entries with the
+ * same path count as unchanged only when their lines are byte-identical,
+ * which holds because both files come from the same writer. Output lines
+ * reuse the base64 substring as-is, producing the .import-download-list.jsonl
+ * shape: one {"path": <base64>} object per line. The lists carry no sizes
+ * or types on purpose — the files are local, so the upload step reads the
+ * filesystem when it stages them instead of trusting a snapshot that may
+ * already be stale.
  *
  * With no baseline yet — the first push to a site — every current entry
  * counts as changed and no deletion can be detected.
@@ -136,12 +142,12 @@ class PushJournal
      * upload-list.jsonl and deletion-list.jsonl, replacing any lists from
      * an earlier run.
      *
-     * Both inputs are sorted by decoded path, so this is a single merge
-     * pass: a path only in the current index is new, a path in both with
-     * a different ctime, size, or type has changed (both go to the upload
-     * list), a path only in the baseline was deleted. Unchanged paths
-     * produce no output. Each list is written to a temporary file and
-     * renamed into place, so a killed run never leaves a torn line behind.
+     * A single merge pass over the two path-sorted files: a path only in
+     * the current index is new, a path in both whose lines differ has
+     * changed (both go to the upload list), a path only in the baseline
+     * was deleted. Unchanged paths produce no output. Each list is written
+     * to a temporary file and renamed into place, so a killed run never
+     * leaves a torn line behind.
      *
      * @return array{changed: int, deleted: int} Entry counts, for the push summary.
      */
@@ -187,38 +193,50 @@ class PushJournal
 
         $changed = 0;
         $deleted = 0;
-        $current = $this->read_index_line($current_handle);
-        $baseline = $this->read_index_line($baseline_handle);
-        while ($current !== null || $baseline !== null) {
-            if ($baseline === null) {
+        $this->read_line($current_handle, $cur_line, $cur_path, $cur_b64);
+        $this->read_line($baseline_handle, $base_line, $base_path, $base_b64);
+        while ($cur_line !== null || $base_line !== null) {
+            // base64 does not preserve byte order ('0' sorts before 'A' in
+            // ASCII but encodes a higher value), so ordering has to use the
+            // decoded paths.
+            if ($base_line === null) {
                 $order = -1;
-            } elseif ($current === null) {
+            } elseif ($cur_line === null) {
                 $order = 1;
             } else {
-                $order = strcmp($current["path"], $baseline["path"]);
+                $order = strcmp($cur_path, $base_path);
             }
 
             if ($order < 0) {
                 // Only in the current index: new since the last push.
-                $this->append_path_line($upload_handle, $current["path"]);
+                $out = '{"path":"' . $cur_b64 . "\"}\n";
+                if (fwrite($upload_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on the upload list, is the disk full?");
+                }
                 $changed++;
-                $current = $this->read_index_line($current_handle);
+                $this->read_line($current_handle, $cur_line, $cur_path, $cur_b64);
             } elseif ($order > 0) {
                 // Only in the baseline: deleted since the last push.
-                $this->append_path_line($deletion_handle, $baseline["path"]);
+                $out = '{"path":"' . $base_b64 . "\"}\n";
+                if (fwrite($deletion_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on the deletion list, is the disk full?");
+                }
                 $deleted++;
-                $baseline = $this->read_index_line($baseline_handle);
+                $this->read_line($baseline_handle, $base_line, $base_path, $base_b64);
             } else {
-                if (
-                    $current["ctime"] !== $baseline["ctime"] ||
-                    $current["size"] !== $baseline["size"] ||
-                    $current["type"] !== $baseline["type"]
-                ) {
-                    $this->append_path_line($upload_handle, $current["path"]);
+                // Same path on both sides. Same writer, same fields — so a
+                // changed ctime, size, or type is exactly a changed line.
+                // A writer format change would mark everything changed once
+                // (a wasted re-upload, never a missed one).
+                if ($cur_line !== $base_line) {
+                    $out = '{"path":"' . $cur_b64 . "\"}\n";
+                    if (fwrite($upload_handle, $out) !== strlen($out)) {
+                        throw new RuntimeException("Short write on the upload list, is the disk full?");
+                    }
                     $changed++;
                 }
-                $current = $this->read_index_line($current_handle);
-                $baseline = $this->read_index_line($baseline_handle);
+                $this->read_line($current_handle, $cur_line, $cur_path, $cur_b64);
+                $this->read_line($baseline_handle, $base_line, $base_path, $base_b64);
             }
         }
 
@@ -234,6 +252,47 @@ class PushJournal
         }
 
         return ["changed" => $changed, "deleted" => $deleted];
+    }
+
+    /**
+     * Read the next index line and pull the path out of it by position,
+     * without decoding the JSON.
+     *
+     * Index lines start with {"path":"<base64>" — every index writer in
+     * import.php emits the path field first, and base64 never contains a
+     * quote or a backslash, so the first quote after the prefix ends the
+     * encoded path. Anything else is not an index file and stops the diff.
+     *
+     * All three out-parameters become null at end of file: $line is the
+     * raw line, $path the decoded path (for ordering), $b64 the encoded
+     * path (reused verbatim in output lines).
+     *
+     * @param resource|null $handle
+     */
+    private function read_line($handle, ?string &$line, ?string &$path, ?string &$b64): void
+    {
+        $line = null;
+        $path = null;
+        $b64 = null;
+        if (!$handle) {
+            return;
+        }
+        $raw = fgets($handle);
+        if ($raw === false) {
+            return;
+        }
+        if (strncmp($raw, '{"path":"', 9) !== 0) {
+            throw new RuntimeException('Unexpected index line, it does not start with {"path":" — ' . substr($raw, 0, 120));
+        }
+        $quote = strpos($raw, '"', 9);
+        $encoded = $quote === false ? "" : substr($raw, 9, $quote - 9);
+        $decoded = $encoded === "" ? false : base64_decode($encoded, true);
+        if ($decoded === false || $decoded === "") {
+            throw new RuntimeException("Invalid index path in line: " . substr($raw, 0, 120));
+        }
+        $line = $raw;
+        $path = $decoded;
+        $b64 = $encoded;
     }
 
     /**
@@ -259,66 +318,6 @@ class PushJournal
     {
         if (!is_dir($this->site_dir) && !@mkdir($this->site_dir, 0755, true) && !is_dir($this->site_dir)) {
             throw new RuntimeException("Failed to create the push journal directory: {$this->site_dir}");
-        }
-    }
-
-    /**
-     * Read the next entry from a sorted index file, skipping blank lines.
-     *
-     * Mirrors read_index_line()/parse_index_line() in import.php, minus
-     * their path validation: the baselines are this class's own files, and
-     * everything that later acts on these paths — the upload step, the
-     * remote staging store — validates them again at that boundary.
-     *
-     * @param resource|null $handle
-     * @return array{path: string, ctime: int, size: int, type: string}|null
-     */
-    private function read_index_line($handle): ?array
-    {
-        if (!$handle) {
-            return null;
-        }
-        while (($line = fgets($handle)) !== false) {
-            $line = trim($line);
-            if ($line === "") {
-                continue;
-            }
-            $data = json_decode($line, true);
-            if (!is_array($data)) {
-                throw new RuntimeException("Invalid index line: " . substr($line, 0, 120));
-            }
-            $path_encoded = $data["path"] ?? "";
-            $path = is_string($path_encoded) ? base64_decode($path_encoded, true) : false;
-            if ($path === false || $path === "") {
-                throw new RuntimeException("Invalid index path in line: " . substr($line, 0, 120));
-            }
-            return [
-                "path" => $path,
-                "ctime" => (int) ($data["ctime"] ?? 0),
-                "size" => (int) ($data["size"] ?? 0),
-                "type" => (string) ($data["type"] ?? "file"),
-            ];
-        }
-        return null;
-    }
-
-    /**
-     * Write one {"path": <base64>} line — the .import-download-list.jsonl
-     * shape. The byte-count check is there because a silently short write
-     * (disk full) would drop a path from a list that drives real uploads
-     * and deletions.
-     *
-     * @param resource $handle
-     */
-    private function append_path_line($handle, string $path): void
-    {
-        $line = json_encode(["path" => base64_encode($path)], JSON_UNESCAPED_SLASHES);
-        if ($line === false) {
-            throw new RuntimeException("Failed to encode a list line for path: {$path}");
-        }
-        $written = fwrite($handle, $line . "\n");
-        if ($written !== strlen($line) + 1) {
-            throw new RuntimeException("Short write on a push list, is the disk full?");
         }
     }
 }

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -23,9 +23,10 @@
  * together — both are sorted by path, so one pass suffices — and writes
  * two lists into the site directory:
  *
- *     upload-list.jsonl     paths new since the baseline, or whose ctime,
- *                           size, or type differs
- *     deletion-list.jsonl   paths in the baseline but gone from the index
+ *     local-paths-to-push.jsonl    paths new since the baseline, or whose
+ *                                  ctime, size, or type differs
+ *     local-paths-to-delete.jsonl  paths in the baseline but gone from the
+ *                                  current index
  *
  * The diff parses one JSON line at a time from each input. Ordering compares
  * decoded paths; two entries with the same path count as unchanged when their
@@ -54,19 +55,19 @@ class PushJournal
     /** @var string Copy of the remote file index from the last completed push. */
     public string $remote_files_baseline_path;
 
-    /** @var string Paths to upload, written by diff_local_files(). */
-    public string $upload_list_path;
+    /** @var string JSONL file of local paths to push, written by diff_local_files(). */
+    public string $local_paths_to_push;
 
-    /** @var string Paths deleted locally since the baseline, written by diff_local_files(). */
-    public string $deletion_list_path;
+    /** @var string JSONL file of local paths whose deletion should be pushed, written by diff_local_files(). */
+    public string $local_paths_to_delete;
 
     public function __construct(string $state_dir, string $site_url)
     {
         $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
         $this->local_files_baseline_path = $this->site_dir . "/last-sync-local-files.jsonl";
         $this->remote_files_baseline_path = $this->site_dir . "/last-sync-remote-files.jsonl";
-        $this->upload_list_path = $this->site_dir . "/upload-list.jsonl";
-        $this->deletion_list_path = $this->site_dir . "/deletion-list.jsonl";
+        $this->local_paths_to_push = $this->site_dir . "/local-paths-to-push.jsonl";
+        $this->local_paths_to_delete = $this->site_dir . "/local-paths-to-delete.jsonl";
     }
 
     /**
@@ -131,15 +132,15 @@ class PushJournal
 
     /**
      * Compare the current local index against the local baseline and write
-     * upload-list.jsonl and deletion-list.jsonl, replacing any lists from
-     * an earlier run.
+     * the local paths to push and local paths to delete, replacing any lists
+     * from an earlier run.
      *
      * A single merge pass over the two path-sorted files: a path only in
      * the current index is new, a path in both whose lines differ has
-     * changed (both go to the upload list), a path only in the baseline
-     * was deleted. Unchanged paths produce no output. Each list is written
-     * to a temporary file and renamed into place, so a killed run never
-     * leaves a torn line behind.
+     * changed (both go to local_paths_to_push), a path only in the baseline
+     * was deleted (it goes to local_paths_to_delete). Unchanged paths produce
+     * no output. Each list is written to a temporary file and renamed into
+     * place, so a killed run never leaves a torn line behind.
      *
      * Memory stays constant however large the site is: the merge holds one
      * line from each input file and the lists go straight to disk, so an
@@ -167,24 +168,24 @@ class PushJournal
             }
         }
 
-        $upload_tmp = $this->upload_list_path . ".tmp";
-        $upload_handle = fopen($upload_tmp, "w");
-        if (!$upload_handle) {
+        $local_paths_to_push_tmp = $this->local_paths_to_push . ".tmp";
+        $paths_to_push_handle = fopen($local_paths_to_push_tmp, "w");
+        if (!$paths_to_push_handle) {
             fclose($current_handle);
             if ($baseline_handle) {
                 fclose($baseline_handle);
             }
-            throw new RuntimeException("Failed to open the upload list for writing: {$upload_tmp}");
+            throw new RuntimeException("Failed to open local_paths_to_push for writing: {$local_paths_to_push_tmp}");
         }
-        $deletion_tmp = $this->deletion_list_path . ".tmp";
-        $deletion_handle = fopen($deletion_tmp, "w");
-        if (!$deletion_handle) {
+        $local_paths_to_delete_tmp = $this->local_paths_to_delete . ".tmp";
+        $paths_to_delete_handle = fopen($local_paths_to_delete_tmp, "w");
+        if (!$paths_to_delete_handle) {
             fclose($current_handle);
             if ($baseline_handle) {
                 fclose($baseline_handle);
             }
-            fclose($upload_handle);
-            throw new RuntimeException("Failed to open the deletion list for writing: {$deletion_tmp}");
+            fclose($paths_to_push_handle);
+            throw new RuntimeException("Failed to open local_paths_to_delete for writing: {$local_paths_to_delete_tmp}");
         }
 
         $changed = 0;
@@ -206,16 +207,16 @@ class PushJournal
             if ($order < 0) {
                 // Only in the current index: new since the last push.
                 $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                if (fwrite($upload_handle, $out) !== strlen($out)) {
-                    throw new RuntimeException("Short write on the upload list, is the disk full?");
+                if (fwrite($paths_to_push_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on local_paths_to_push, is the disk full?");
                 }
                 $changed++;
                 $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
             } elseif ($order > 0) {
                 // Only in the baseline: deleted since the last push.
                 $out = json_encode(["path" => $baseline_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                if (fwrite($deletion_handle, $out) !== strlen($out)) {
-                    throw new RuntimeException("Short write on the deletion list, is the disk full?");
+                if (fwrite($paths_to_delete_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on local_paths_to_delete, is the disk full?");
                 }
                 $deleted++;
                 $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
@@ -226,8 +227,8 @@ class PushJournal
                 // wasted re-upload, never a missed one).
                 if ($current_entry != $baseline_entry) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                    if (fwrite($upload_handle, $out) !== strlen($out)) {
-                        throw new RuntimeException("Short write on the upload list, is the disk full?");
+                    if (fwrite($paths_to_push_handle, $out) !== strlen($out)) {
+                        throw new RuntimeException("Short write on local_paths_to_push, is the disk full?");
                     }
                     $changed++;
                 }
@@ -240,11 +241,11 @@ class PushJournal
         if ($baseline_handle) {
             fclose($baseline_handle);
         }
-        if (!fclose($upload_handle) || !rename($upload_tmp, $this->upload_list_path)) {
-            throw new RuntimeException("Failed to move the upload list into place: {$this->upload_list_path}");
+        if (!fclose($paths_to_push_handle) || !rename($local_paths_to_push_tmp, $this->local_paths_to_push)) {
+            throw new RuntimeException("Failed to move local_paths_to_push into place: {$this->local_paths_to_push}");
         }
-        if (!fclose($deletion_handle) || !rename($deletion_tmp, $this->deletion_list_path)) {
-            throw new RuntimeException("Failed to move the deletion list into place: {$this->deletion_list_path}");
+        if (!fclose($paths_to_delete_handle) || !rename($local_paths_to_delete_tmp, $this->local_paths_to_delete)) {
+            throw new RuntimeException("Failed to move local_paths_to_delete into place: {$this->local_paths_to_delete}");
         }
 
         return ["changed" => $changed, "deleted" => $deleted];

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -51,9 +51,16 @@ class PushJournal
 {
     private string $site_dir;
 
+    /** @var string Copy of the local file index from the last completed push. */
     public string $local_files_baseline_path;
+
+    /** @var string Copy of the remote file index from the last completed push. */
     public string $remote_files_baseline_path;
+
+    /** @var string Paths to upload, written by diff_local_files(). */
     public string $upload_list_path;
+
+    /** @var string Paths deleted locally since the baseline, written by diff_local_files(). */
     public string $deletion_list_path;
 
     public function __construct(string $state_dir, string $site_url)
@@ -101,11 +108,25 @@ class PushJournal
         return $slug === "" ? $hash : "{$slug}-{$hash}";
     }
 
+    /**
+     * Store a copy of the local file index as the new local baseline.
+     *
+     * The push driver calls this at the end of a successful push; from then
+     * on "changed locally" means "different from this index". The copy is
+     * atomic (temp file + rename) and the source file is left untouched.
+     */
     public function capture_local_files_baseline(string $index_file): void
     {
         $this->replace_file($this->local_files_baseline_path, $index_file);
     }
 
+    /**
+     * Store a copy of the remote file index as the new remote baseline.
+     *
+     * Captured from the scoped reindex that runs after apply — apply itself
+     * changes remote ctimes, so without this refresh the next push would
+     * report everything it just wrote as remote drift.
+     */
     public function capture_remote_files_baseline(string $index_file): void
     {
         $this->replace_file($this->remote_files_baseline_path, $index_file);
@@ -122,6 +143,10 @@ class PushJournal
      * was deleted. Unchanged paths produce no output. Each list is written
      * to a temporary file and renamed into place, so a killed run never
      * leaves a torn line behind.
+     *
+     * Memory stays constant however large the site is: the merge holds one
+     * line from each input file and the lists go straight to disk, so an
+     * index with a million entries costs the same as one with ten.
      *
      * @return array{changed: int, deleted: int} Entry counts, for the push summary.
      */

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Per-remote-site memory of the last completed push: the baselines.
+ *
+ * ctime is machine-local, so push never compares a local timestamp against
+ * a remote one. Each machine is compared against its own past instead
+ * (markdown/PUSH-SYNC.md, "Change detection"). This class stores that past
+ * on the local machine, one directory per remote site:
+ *
+ *     <state-dir>/push/<site>/last-sync-local-files.jsonl
+ *     <state-dir>/push/<site>/last-sync-remote-files.jsonl
+ *
+ * Each baseline is a copy of a file index in the same format as
+ * .import-index.jsonl: one JSON object per line with a base64-encoded path
+ * plus ctime, size, and type, sorted by decoded path. The push driver
+ * captures both at the end of a successful push. A capture writes a
+ * temporary file and renames it into place, so a killed process never
+ * leaves a truncated baseline for the next push to trust — until the
+ * rename lands, the previous baseline stays in effect.
+ *
+ * diff_local_files() answers "what changed on this machine since the last
+ * push to this site". It walks the current index and the local baseline
+ * together — both are sorted by path, so one pass suffices, the same merge
+ * diff_indexes_and_build_fetch_list() in import.php runs against a remote
+ * index — and writes two lists into the site directory:
+ *
+ *     upload-list.jsonl     paths new since the baseline, or whose ctime,
+ *                           size, or type differs
+ *     deletion-list.jsonl   paths in the baseline but gone from the index
+ *
+ * Both lists hold one {"path": <base64>} object per line, the same shape
+ * as .import-download-list.jsonl. They carry no sizes or types on purpose:
+ * the files are local, so the upload step reads the filesystem when it
+ * stages them instead of trusting a snapshot that may already be stale.
+ *
+ * With no baseline yet — the first push to a site — every current entry
+ * counts as changed and no deletion can be detected.
+ *
+ * Producing the current index is the caller's job; this class only
+ * compares and stores. The lists belong to the run that produced them:
+ * a resumed push reruns the diff (one cheap local pass) rather than
+ * trusting lists from an earlier run.
+ */
+class PushJournal
+{
+    private string $site_dir;
+
+    public function __construct(string $state_dir, string $site_url)
+    {
+        $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
+    }
+
+    /**
+     * Directory name for a remote site URL: a readable slug plus a short
+     * hash. "https://Example.com/blog/" becomes "example.com-blog-<hash>".
+     *
+     * Host, port, and path identify the site; scheme, credentials, query,
+     * and fragment do not (http and https reach the same files). The slug
+     * keeps the directory recognizable when someone lists <state-dir>/push;
+     * the hash tells apart URLs whose slugs collide, like a site on port
+     * 8080 next to one on 8081.
+     */
+    public static function site_key(string $site_url): string
+    {
+        $site_url = trim($site_url);
+        $parts = parse_url($site_url);
+        if ((!is_array($parts) || empty($parts["host"])) && strpos($site_url, "//") === false) {
+            // A bare "example.com/blog" parses as all-path; retry it as a
+            // host-relative URL.
+            $parts = parse_url("//" . $site_url);
+        }
+        if (!is_array($parts) || empty($parts["host"]) || !is_string($parts["host"])) {
+            throw new RuntimeException("Cannot derive a push site key, the URL has no host: {$site_url}");
+        }
+        $host = strtolower($parts["host"]);
+        $port = isset($parts["port"]) ? ":" . $parts["port"] : "";
+        $path = isset($parts["path"]) && is_string($parts["path"]) ? rtrim($parts["path"], "/") : "";
+        $normalized = $host . $port . $path;
+
+        $slug = trim((string) preg_replace("/[^a-z0-9.]+/", "-", strtolower($normalized)), "-.");
+        // Directory names have length limits; the hash carries identity,
+        // so a long slug can be cut without risking collisions.
+        $slug = substr($slug, 0, 60);
+        $hash = substr(sha1($normalized), 0, 8);
+
+        return $slug === "" ? $hash : "{$slug}-{$hash}";
+    }
+
+    public function site_dir(): string
+    {
+        return $this->site_dir;
+    }
+
+    public function local_files_baseline_path(): string
+    {
+        return $this->site_dir . "/last-sync-local-files.jsonl";
+    }
+
+    public function remote_files_baseline_path(): string
+    {
+        return $this->site_dir . "/last-sync-remote-files.jsonl";
+    }
+
+    public function has_local_files_baseline(): bool
+    {
+        return is_file($this->local_files_baseline_path());
+    }
+
+    public function has_remote_files_baseline(): bool
+    {
+        return is_file($this->remote_files_baseline_path());
+    }
+
+    public function capture_local_files_baseline(string $index_file): void
+    {
+        $this->replace_file($this->local_files_baseline_path(), $index_file);
+    }
+
+    public function capture_remote_files_baseline(string $index_file): void
+    {
+        $this->replace_file($this->remote_files_baseline_path(), $index_file);
+    }
+
+    public function upload_list_path(): string
+    {
+        return $this->site_dir . "/upload-list.jsonl";
+    }
+
+    public function deletion_list_path(): string
+    {
+        return $this->site_dir . "/deletion-list.jsonl";
+    }
+
+    /**
+     * Compare the current local index against the local baseline and write
+     * upload-list.jsonl and deletion-list.jsonl, replacing any lists from
+     * an earlier run.
+     *
+     * Both inputs are sorted by decoded path, so this is a single merge
+     * pass: a path only in the current index is new, a path in both with
+     * a different ctime, size, or type has changed (both go to the upload
+     * list), a path only in the baseline was deleted. Unchanged paths
+     * produce no output. Each list is written to a temporary file and
+     * renamed into place, so a killed run never leaves a torn line behind.
+     *
+     * @return array{changed: int, deleted: int} Entry counts, for the push summary.
+     */
+    public function diff_local_files(string $current_index_file): array
+    {
+        if (!is_file($current_index_file)) {
+            throw new RuntimeException("Cannot diff, the current index file is missing: {$current_index_file}");
+        }
+        $this->ensure_site_dir();
+
+        $current_handle = fopen($current_index_file, "r");
+        if (!$current_handle) {
+            throw new RuntimeException("Failed to open the current index: {$current_index_file}");
+        }
+        $baseline_handle = null;
+        if ($this->has_local_files_baseline()) {
+            $baseline_handle = fopen($this->local_files_baseline_path(), "r");
+            if (!$baseline_handle) {
+                fclose($current_handle);
+                throw new RuntimeException("Failed to open the local baseline: {$this->local_files_baseline_path()}");
+            }
+        }
+
+        $upload_tmp = $this->upload_list_path() . ".tmp";
+        $upload_handle = fopen($upload_tmp, "w");
+        if (!$upload_handle) {
+            fclose($current_handle);
+            if ($baseline_handle) {
+                fclose($baseline_handle);
+            }
+            throw new RuntimeException("Failed to open the upload list for writing: {$upload_tmp}");
+        }
+        $deletion_tmp = $this->deletion_list_path() . ".tmp";
+        $deletion_handle = fopen($deletion_tmp, "w");
+        if (!$deletion_handle) {
+            fclose($current_handle);
+            if ($baseline_handle) {
+                fclose($baseline_handle);
+            }
+            fclose($upload_handle);
+            throw new RuntimeException("Failed to open the deletion list for writing: {$deletion_tmp}");
+        }
+
+        $changed = 0;
+        $deleted = 0;
+        $current = $this->read_index_line($current_handle);
+        $baseline = $this->read_index_line($baseline_handle);
+        while ($current !== null || $baseline !== null) {
+            if ($baseline === null) {
+                $order = -1;
+            } elseif ($current === null) {
+                $order = 1;
+            } else {
+                $order = strcmp($current["path"], $baseline["path"]);
+            }
+
+            if ($order < 0) {
+                // Only in the current index: new since the last push.
+                $this->append_path_line($upload_handle, $current["path"]);
+                $changed++;
+                $current = $this->read_index_line($current_handle);
+            } elseif ($order > 0) {
+                // Only in the baseline: deleted since the last push.
+                $this->append_path_line($deletion_handle, $baseline["path"]);
+                $deleted++;
+                $baseline = $this->read_index_line($baseline_handle);
+            } else {
+                if (
+                    $current["ctime"] !== $baseline["ctime"] ||
+                    $current["size"] !== $baseline["size"] ||
+                    $current["type"] !== $baseline["type"]
+                ) {
+                    $this->append_path_line($upload_handle, $current["path"]);
+                    $changed++;
+                }
+                $current = $this->read_index_line($current_handle);
+                $baseline = $this->read_index_line($baseline_handle);
+            }
+        }
+
+        fclose($current_handle);
+        if ($baseline_handle) {
+            fclose($baseline_handle);
+        }
+        if (!fclose($upload_handle) || !rename($upload_tmp, $this->upload_list_path())) {
+            throw new RuntimeException("Failed to move the upload list into place: {$this->upload_list_path()}");
+        }
+        if (!fclose($deletion_handle) || !rename($deletion_tmp, $this->deletion_list_path())) {
+            throw new RuntimeException("Failed to move the deletion list into place: {$this->deletion_list_path()}");
+        }
+
+        return ["changed" => $changed, "deleted" => $deleted];
+    }
+
+    /**
+     * Copy an index file over a baseline: temp file in the same directory,
+     * then rename, so readers only ever see the old or the new baseline.
+     */
+    private function replace_file(string $target, string $source_index_file): void
+    {
+        if (!is_file($source_index_file)) {
+            throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$source_index_file}");
+        }
+        $this->ensure_site_dir();
+        $tmp = $target . ".tmp";
+        if (!copy($source_index_file, $tmp)) {
+            throw new RuntimeException("Failed to copy the index into a baseline temp file: {$tmp}");
+        }
+        if (!rename($tmp, $target)) {
+            throw new RuntimeException("Failed to move the baseline into place: {$target}");
+        }
+    }
+
+    private function ensure_site_dir(): void
+    {
+        if (!is_dir($this->site_dir) && !@mkdir($this->site_dir, 0755, true) && !is_dir($this->site_dir)) {
+            throw new RuntimeException("Failed to create the push journal directory: {$this->site_dir}");
+        }
+    }
+
+    /**
+     * Read the next entry from a sorted index file, skipping blank lines.
+     *
+     * Mirrors read_index_line()/parse_index_line() in import.php, minus
+     * their path validation: the baselines are this class's own files, and
+     * everything that later acts on these paths — the upload step, the
+     * remote staging store — validates them again at that boundary.
+     *
+     * @param resource|null $handle
+     * @return array{path: string, ctime: int, size: int, type: string}|null
+     */
+    private function read_index_line($handle): ?array
+    {
+        if (!$handle) {
+            return null;
+        }
+        while (($line = fgets($handle)) !== false) {
+            $line = trim($line);
+            if ($line === "") {
+                continue;
+            }
+            $data = json_decode($line, true);
+            if (!is_array($data)) {
+                throw new RuntimeException("Invalid index line: " . substr($line, 0, 120));
+            }
+            $path_encoded = $data["path"] ?? "";
+            $path = is_string($path_encoded) ? base64_decode($path_encoded, true) : false;
+            if ($path === false || $path === "") {
+                throw new RuntimeException("Invalid index path in line: " . substr($line, 0, 120));
+            }
+            return [
+                "path" => $path,
+                "ctime" => (int) ($data["ctime"] ?? 0),
+                "size" => (int) ($data["size"] ?? 0),
+                "type" => (string) ($data["type"] ?? "file"),
+            ];
+        }
+        return null;
+    }
+
+    /**
+     * Write one {"path": <base64>} line — the .import-download-list.jsonl
+     * shape. The byte-count check is there because a silently short write
+     * (disk full) would drop a path from a list that drives real uploads
+     * and deletions.
+     *
+     * @param resource $handle
+     */
+    private function append_path_line($handle, string $path): void
+    {
+        $line = json_encode(["path" => base64_encode($path)], JSON_UNESCAPED_SLASHES);
+        if ($line === false) {
+            throw new RuntimeException("Failed to encode a list line for path: {$path}");
+        }
+        $written = fwrite($handle, $line . "\n");
+        if ($written !== strlen($line) + 1) {
+            throw new RuntimeException("Short write on a push list, is the disk full?");
+        }
+    }
+}

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -27,17 +27,14 @@
  *                           size, or type differs
  *     deletion-list.jsonl   paths in the baseline but gone from the index
  *
- * The diff works on raw lines and never touches a JSON function. Index
- * lines always start with {"path":"<base64>" — every index writer in
- * import.php puts the path field first — so the path comes out of the
- * line by position. Ordering compares decoded paths; two entries with the
- * same path count as unchanged only when their lines are byte-identical,
- * which holds because both files come from the same writer. Output lines
- * reuse the base64 substring as-is, producing the .import-download-list.jsonl
- * shape: one {"path": <base64>} object per line. The lists carry no sizes
- * or types on purpose — the files are local, so the upload step reads the
- * filesystem when it stages them instead of trusting a snapshot that may
- * already be stale.
+ * The diff parses one JSON line at a time from each input. Ordering compares
+ * decoded paths; two entries with the same path count as unchanged when their
+ * decoded JSON objects match, so JSON field order or escaping changes do not
+ * affect the diff. Output lines carry only the base64 path, producing the
+ * .import-download-list.jsonl shape: one {"path": <base64>} object per line.
+ * The lists carry no sizes or types on purpose — the files are local, so the
+ * upload step reads the filesystem when it stages them instead of trusting a
+ * snapshot that may already be stale.
  *
  * With no baseline yet — the first push to a site — every current entry
  * counts as changed and no deletion can be detected.
@@ -192,50 +189,50 @@ class PushJournal
 
         $changed = 0;
         $deleted = 0;
-        $this->read_line($current_handle, $cur_line, $cur_path, $cur_b64);
-        $this->read_line($baseline_handle, $base_line, $base_path, $base_b64);
-        while ($cur_line !== null || $base_line !== null) {
+        $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
+        $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+        while ($current_entry !== null || $baseline_entry !== null) {
             // base64 does not preserve byte order ('0' sorts before 'A' in
             // ASCII but encodes a higher value), so ordering has to use the
             // decoded paths.
-            if ($base_line === null) {
+            if ($baseline_entry === null) {
                 $order = -1;
-            } elseif ($cur_line === null) {
+            } elseif ($current_entry === null) {
                 $order = 1;
             } else {
-                $order = strcmp($cur_path, $base_path);
+                $order = strcmp($current_path, $baseline_path);
             }
 
             if ($order < 0) {
                 // Only in the current index: new since the last push.
-                $out = '{"path":"' . $cur_b64 . "\"}\n";
+                $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                 if (fwrite($upload_handle, $out) !== strlen($out)) {
                     throw new RuntimeException("Short write on the upload list, is the disk full?");
                 }
                 $changed++;
-                $this->read_line($current_handle, $cur_line, $cur_path, $cur_b64);
+                $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
             } elseif ($order > 0) {
                 // Only in the baseline: deleted since the last push.
-                $out = '{"path":"' . $base_b64 . "\"}\n";
+                $out = json_encode(["path" => $baseline_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                 if (fwrite($deletion_handle, $out) !== strlen($out)) {
                     throw new RuntimeException("Short write on the deletion list, is the disk full?");
                 }
                 $deleted++;
-                $this->read_line($baseline_handle, $base_line, $base_path, $base_b64);
+                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
             } else {
-                // Same path on both sides. Same writer, same fields — so a
-                // changed ctime, size, or type is exactly a changed line.
-                // A writer format change would mark everything changed once
-                // (a wasted re-upload, never a missed one).
-                if ($cur_line !== $base_line) {
-                    $out = '{"path":"' . $cur_b64 . "\"}\n";
+                // Same path on both sides. Decoded JSON array comparison keeps
+                // field order and slash escaping out of change detection. A
+                // writer field change would mark everything changed once (a
+                // wasted re-upload, never a missed one).
+                if ($current_entry != $baseline_entry) {
+                    $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                     if (fwrite($upload_handle, $out) !== strlen($out)) {
                         throw new RuntimeException("Short write on the upload list, is the disk full?");
                     }
                     $changed++;
                 }
-                $this->read_line($current_handle, $cur_line, $cur_path, $cur_b64);
-                $this->read_line($baseline_handle, $base_line, $base_path, $base_b64);
+                $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
+                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
             }
         }
 
@@ -254,44 +251,43 @@ class PushJournal
     }
 
     /**
-     * Read the next index line and pull the path out of it by position,
-     * without decoding the JSON.
+     * Read the next index line and parse its JSON object.
      *
-     * Index lines start with {"path":"<base64>" — every index writer in
-     * import.php emits the path field first, and base64 never contains a
-     * quote or a backslash, so the first quote after the prefix ends the
-     * encoded path. Anything else is not an index file and stops the diff.
-     *
-     * All three out-parameters become null at end of file: $line is the
-     * raw line, $path the decoded path (for ordering), $b64 the encoded
-     * path (reused verbatim in output lines).
+     * All three out-parameters become null at end of file: $entry is the
+     * decoded index object, $path the decoded path (for ordering),
+     * $base64_path the encoded path (reused in output lines).
      *
      * @param resource|null $handle
+     * @param array<string, mixed>|null $entry
      */
-    private function read_line($handle, ?string &$line, ?string &$path, ?string &$b64): void
+    private function read_line($handle, ?array &$entry, ?string &$path, ?string &$base64_path): void
     {
-        $line = null;
+        $entry = null;
         $path = null;
-        $b64 = null;
+        $base64_path = null;
         if (!$handle) {
             return;
         }
-        $raw = fgets($handle);
-        if ($raw === false) {
+        $raw_line = fgets($handle);
+        if ($raw_line === false) {
             return;
         }
-        if (strncmp($raw, '{"path":"', 9) !== 0) {
-            throw new RuntimeException('Unexpected index line, it does not start with {"path":" — ' . substr($raw, 0, 120));
+
+        try {
+            $decoded_entry = json_decode($raw_line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException("Unexpected index line, it is not valid JSON: " . substr($raw_line, 0, 120), 0, $exception);
         }
-        $quote = strpos($raw, '"', 9);
-        $encoded = $quote === false ? "" : substr($raw, 9, $quote - 9);
-        $decoded = $encoded === "" ? false : base64_decode($encoded, true);
-        if ($decoded === false || $decoded === "") {
-            throw new RuntimeException("Invalid index path in line: " . substr($raw, 0, 120));
+        if (!is_array($decoded_entry) || !array_key_exists("path", $decoded_entry) || !is_string($decoded_entry["path"])) {
+            throw new RuntimeException("Invalid index path in line: " . substr($raw_line, 0, 120));
         }
-        $line = $raw;
-        $path = $decoded;
-        $b64 = $encoded;
+        $decoded_path = base64_decode($decoded_entry["path"], true);
+        if ($decoded_path === false || $decoded_path === "") {
+            throw new RuntimeException("Invalid index path in line: " . substr($raw_line, 0, 120));
+        }
+        $entry = $decoded_entry;
+        $path = $decoded_path;
+        $base64_path = $decoded_entry["path"];
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -92,11 +92,6 @@ class PushJournal
         return $slug === "" ? $hash : "{$slug}-{$hash}";
     }
 
-    public function site_dir(): string
-    {
-        return $this->site_dir;
-    }
-
     public function local_files_baseline_path(): string
     {
         return $this->site_dir . "/last-sync-local-files.jsonl";
@@ -105,16 +100,6 @@ class PushJournal
     public function remote_files_baseline_path(): string
     {
         return $this->site_dir . "/last-sync-remote-files.jsonl";
-    }
-
-    public function has_local_files_baseline(): bool
-    {
-        return is_file($this->local_files_baseline_path());
-    }
-
-    public function has_remote_files_baseline(): bool
-    {
-        return is_file($this->remote_files_baseline_path());
     }
 
     public function capture_local_files_baseline(string $index_file): void
@@ -162,12 +147,13 @@ class PushJournal
         if (!$current_handle) {
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
+        $baseline_path = $this->local_files_baseline_path();
         $baseline_handle = null;
-        if ($this->has_local_files_baseline()) {
-            $baseline_handle = fopen($this->local_files_baseline_path(), "r");
+        if (is_file($baseline_path)) {
+            $baseline_handle = fopen($baseline_path, "r");
             if (!$baseline_handle) {
                 fclose($current_handle);
-                throw new RuntimeException("Failed to open the local baseline: {$this->local_files_baseline_path()}");
+                throw new RuntimeException("Failed to open the local baseline: {$baseline_path}");
             }
         }
 

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -51,9 +51,18 @@ class PushJournal
 {
     private string $site_dir;
 
+    public string $local_files_baseline_path;
+    public string $remote_files_baseline_path;
+    public string $upload_list_path;
+    public string $deletion_list_path;
+
     public function __construct(string $state_dir, string $site_url)
     {
         $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
+        $this->local_files_baseline_path = $this->site_dir . "/last-sync-local-files.jsonl";
+        $this->remote_files_baseline_path = $this->site_dir . "/last-sync-remote-files.jsonl";
+        $this->upload_list_path = $this->site_dir . "/upload-list.jsonl";
+        $this->deletion_list_path = $this->site_dir . "/deletion-list.jsonl";
     }
 
     /**
@@ -92,34 +101,14 @@ class PushJournal
         return $slug === "" ? $hash : "{$slug}-{$hash}";
     }
 
-    public function local_files_baseline_path(): string
-    {
-        return $this->site_dir . "/last-sync-local-files.jsonl";
-    }
-
-    public function remote_files_baseline_path(): string
-    {
-        return $this->site_dir . "/last-sync-remote-files.jsonl";
-    }
-
     public function capture_local_files_baseline(string $index_file): void
     {
-        $this->replace_file($this->local_files_baseline_path(), $index_file);
+        $this->replace_file($this->local_files_baseline_path, $index_file);
     }
 
     public function capture_remote_files_baseline(string $index_file): void
     {
-        $this->replace_file($this->remote_files_baseline_path(), $index_file);
-    }
-
-    public function upload_list_path(): string
-    {
-        return $this->site_dir . "/upload-list.jsonl";
-    }
-
-    public function deletion_list_path(): string
-    {
-        return $this->site_dir . "/deletion-list.jsonl";
+        $this->replace_file($this->remote_files_baseline_path, $index_file);
     }
 
     /**
@@ -147,17 +136,16 @@ class PushJournal
         if (!$current_handle) {
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
-        $baseline_path = $this->local_files_baseline_path();
         $baseline_handle = null;
-        if (is_file($baseline_path)) {
-            $baseline_handle = fopen($baseline_path, "r");
+        if (is_file($this->local_files_baseline_path)) {
+            $baseline_handle = fopen($this->local_files_baseline_path, "r");
             if (!$baseline_handle) {
                 fclose($current_handle);
-                throw new RuntimeException("Failed to open the local baseline: {$baseline_path}");
+                throw new RuntimeException("Failed to open the local baseline: {$this->local_files_baseline_path}");
             }
         }
 
-        $upload_tmp = $this->upload_list_path() . ".tmp";
+        $upload_tmp = $this->upload_list_path . ".tmp";
         $upload_handle = fopen($upload_tmp, "w");
         if (!$upload_handle) {
             fclose($current_handle);
@@ -166,7 +154,7 @@ class PushJournal
             }
             throw new RuntimeException("Failed to open the upload list for writing: {$upload_tmp}");
         }
-        $deletion_tmp = $this->deletion_list_path() . ".tmp";
+        $deletion_tmp = $this->deletion_list_path . ".tmp";
         $deletion_handle = fopen($deletion_tmp, "w");
         if (!$deletion_handle) {
             fclose($current_handle);
@@ -230,11 +218,11 @@ class PushJournal
         if ($baseline_handle) {
             fclose($baseline_handle);
         }
-        if (!fclose($upload_handle) || !rename($upload_tmp, $this->upload_list_path())) {
-            throw new RuntimeException("Failed to move the upload list into place: {$this->upload_list_path()}");
+        if (!fclose($upload_handle) || !rename($upload_tmp, $this->upload_list_path)) {
+            throw new RuntimeException("Failed to move the upload list into place: {$this->upload_list_path}");
         }
-        if (!fclose($deletion_handle) || !rename($deletion_tmp, $this->deletion_list_path())) {
-            throw new RuntimeException("Failed to move the deletion list into place: {$this->deletion_list_path()}");
+        if (!fclose($deletion_handle) || !rename($deletion_tmp, $this->deletion_list_path)) {
+            throw new RuntimeException("Failed to move the deletion list into place: {$this->deletion_list_path}");
         }
 
         return ["changed" => $changed, "deleted" => $deleted];

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -69,12 +69,12 @@ final class PushJournalTest extends TestCase
     public function testCaptureCreatesAndOverwritesTheBaseline(): void
     {
         $journal = $this->makeJournal();
-        $this->assertFalse($journal->has_local_files_baseline());
+        $this->assertFileDoesNotExist($journal->local_files_baseline_path());
 
         $journal->capture_local_files_baseline($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
-        $this->assertTrue($journal->has_local_files_baseline());
+        $this->assertFileExists($journal->local_files_baseline_path());
         $this->assertFileDoesNotExist($journal->local_files_baseline_path() . '.tmp');
 
         // A second capture replaces the first: diffing an index identical
@@ -100,11 +100,9 @@ final class PushJournalTest extends TestCase
         $journal->capture_local_files_baseline($this->writeIndex(['a' => [1, 1, 'file']]));
         $journal->capture_remote_files_baseline($this->writeIndex(['b' => [2, 2, 'file']]));
 
-        $this->assertTrue($journal->has_local_files_baseline());
-        $this->assertTrue($journal->has_remote_files_baseline());
         $this->assertNotSame($journal->local_files_baseline_path(), $journal->remote_files_baseline_path());
-        $this->assertSame(['a'], $this->indexPaths($journal->local_files_baseline_path()));
-        $this->assertSame(['b'], $this->indexPaths($journal->remote_files_baseline_path()));
+        $this->assertSame(['a'], $this->listPaths($journal->local_files_baseline_path()));
+        $this->assertSame(['b'], $this->listPaths($journal->remote_files_baseline_path()));
     }
 
     // ------------------------------------------------------------------
@@ -317,16 +315,6 @@ final class PushJournalTest extends TestCase
             $paths[] = base64_decode($data['path'], true);
         }
         return $paths;
-    }
-
-    /**
-     * Decode the paths from a baseline (full index lines).
-     *
-     * @return list<string>
-     */
-    private function indexPaths(string $file): array
-    {
-        return $this->listPaths($file);
     }
 
     private function recursiveDelete(string $dir): void

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -12,8 +12,9 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push
  * The diff drives real uploads and deletions later in a push, so the tests
  * pin the classification exactly: new, ctime-changed, size-changed,
  * type-changed, deleted, unchanged — plus the two boundary situations
- * (no baseline yet; stale lists from an earlier run) and the encoding
- * round-trip for paths that need base64 in the first place.
+ * (no baseline yet; stale lists from an earlier run), the encoding
+ * round-trip for paths that need base64 in the first place, and the JSON
+ * parsing behavior that keeps the diff independent from field order.
  */
 final class PushJournalTest extends TestCase
 {
@@ -227,11 +228,34 @@ final class PushJournalTest extends TestCase
         );
     }
 
+    public function testDiffParsesJsonWithoutDependingOnFieldOrderOrEscaping(): void
+    {
+        $journal = $this->makeJournal();
+        $path = 'wp-content/???';
+        $base64Path = base64_encode($path);
+        $baseline = $this->tempDir . '/baseline-shape.jsonl';
+        $current = $this->tempDir . '/current-shape.jsonl';
+
+        file_put_contents(
+            $baseline,
+            json_encode(['path' => $base64Path, 'ctime' => 100, 'size' => 5, 'type' => 'file'], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+        );
+        file_put_contents(
+            $current,
+            json_encode(['type' => 'file', 'size' => 5, 'ctime' => 100, 'path' => $base64Path], JSON_THROW_ON_ERROR) . "\n"
+        );
+
+        $journal->capture_local_files_baseline($baseline);
+
+        $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($current));
+        $this->assertSame([], $this->listPaths($journal->upload_list_path));
+        $this->assertSame([], $this->listPaths($journal->deletion_list_path));
+    }
+
     public function testDiffRejectsLinesTheIndexWritersDoNotProduce(): void
     {
-        // The diff reads paths out of raw lines by position, so it accepts
-        // exactly what the index writers emit — anything else (including a
-        // blank line) means the file is not an index and the diff stops.
+        // A blank line means the file is not a JSONL index and the diff
+        // stops instead of silently skipping a possibly-corrupt entry.
         $journal = $this->makeJournal();
         $garbage = $this->tempDir . '/garbage.jsonl';
         file_put_contents(
@@ -240,7 +264,7 @@ final class PushJournalTest extends TestCase
         );
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected index line');
+        $this->expectExceptionMessage('not valid JSON');
         $journal->diff_local_files($garbage);
     }
 
@@ -292,9 +316,7 @@ final class PushJournalTest extends TestCase
 
     private function indexLine(string $path, int $ctime, int $size, string $type): string
     {
-        // JSON_UNESCAPED_SLASHES matters: the real index writers use it, and
-        // the diff reads the base64 path out of the raw line, where an
-        // escaped slash would not decode.
+        // Match the real index writers so fixtures use production-shaped JSON.
         return json_encode(
             ['path' => base64_encode($path), 'ctime' => $ctime, 'size' => $size, 'type' => $type],
             JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -122,13 +122,13 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['changed' => 3, 'deleted' => 0], $counts);
         $this->assertSame(
             ['index.php', 'wp-content', 'wp-content/themes/foo/style.css'],
-            $this->listPaths($journal->upload_list_path)
+            $this->listPaths($journal->local_paths_to_push)
         );
-        $this->assertSame([], $this->listPaths($journal->deletion_list_path));
+        $this->assertSame([], $this->listPaths($journal->local_paths_to_delete));
 
         // Pin the exact bytes: one {"path": <base64>} object per line, the
         // .import-download-list.jsonl shape.
-        $firstLine = strtok((string) file_get_contents($journal->upload_list_path), "\n");
+        $firstLine = strtok((string) file_get_contents($journal->local_paths_to_push), "\n");
         $this->assertSame('{"path":"' . base64_encode('index.php') . '"}', $firstLine);
     }
 
@@ -142,8 +142,8 @@ final class PushJournalTest extends TestCase
         $journal->capture_local_files_baseline($index);
 
         $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($index));
-        $this->assertSame([], $this->listPaths($journal->upload_list_path));
-        $this->assertSame([], $this->listPaths($journal->deletion_list_path));
+        $this->assertSame([], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame([], $this->listPaths($journal->local_paths_to_delete));
     }
 
     public function testCtimeSizeOrTypeChangeEachMarkThePathChanged(): void
@@ -166,7 +166,7 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['changed' => 3, 'deleted' => 0], $counts);
         $this->assertSame(
             ['ctime-bump.txt', 'size-bump.txt', 'type-swap'],
-            $this->listPaths($journal->upload_list_path)
+            $this->listPaths($journal->local_paths_to_push)
         );
     }
 
@@ -187,8 +187,8 @@ final class PushJournalTest extends TestCase
 
         $this->assertSame(['changed' => 2, 'deleted' => 1], $counts);
         // Output order follows the sorted index order.
-        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($journal->upload_list_path));
-        $this->assertSame(['deleted.txt'], $this->listPaths($journal->deletion_list_path));
+        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame(['deleted.txt'], $this->listPaths($journal->local_paths_to_delete));
     }
 
     public function testDiffReplacesListsFromAnEarlierRun(): void
@@ -196,16 +196,16 @@ final class PushJournalTest extends TestCase
         $journal = $this->makeJournal();
         $index = $this->writeIndex(['a.txt' => [100, 5, 'file']]);
 
-        // First run, no baseline: a.txt lands on the upload list.
+        // First run, no baseline: a.txt lands in local_paths_to_push.
         $journal->diff_local_files($index);
-        $this->assertSame(['a.txt'], $this->listPaths($journal->upload_list_path));
+        $this->assertSame(['a.txt'], $this->listPaths($journal->local_paths_to_push));
 
         // Capture and rerun: the old list must be replaced, not appended to.
         $journal->capture_local_files_baseline($index);
         $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($index));
-        $this->assertSame([], $this->listPaths($journal->upload_list_path));
-        $this->assertFileDoesNotExist($journal->upload_list_path . '.tmp');
-        $this->assertFileDoesNotExist($journal->deletion_list_path . '.tmp');
+        $this->assertSame([], $this->listPaths($journal->local_paths_to_push));
+        $this->assertFileDoesNotExist($journal->local_paths_to_push . '.tmp');
+        $this->assertFileDoesNotExist($journal->local_paths_to_delete . '.tmp');
     }
 
     public function testPathsThatNeedBase64SurviveTheRoundTrip(): void
@@ -224,7 +224,7 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['changed' => 2, 'deleted' => 0], $counts);
         $this->assertEqualsCanonicalizing(
             [$weird, $utf8],
-            $this->listPaths($journal->upload_list_path)
+            $this->listPaths($journal->local_paths_to_push)
         );
     }
 
@@ -248,8 +248,8 @@ final class PushJournalTest extends TestCase
         $journal->capture_local_files_baseline($baseline);
 
         $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($current));
-        $this->assertSame([], $this->listPaths($journal->upload_list_path));
-        $this->assertSame([], $this->listPaths($journal->deletion_list_path));
+        $this->assertSame([], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame([], $this->listPaths($journal->local_paths_to_delete));
     }
 
     public function testDiffRejectsLinesTheIndexWritersDoNotProduce(): void
@@ -324,7 +324,7 @@ final class PushJournalTest extends TestCase
     }
 
     /**
-     * Decode the paths from an upload/deletion list ({"path": <base64>} lines).
+     * Decode a {"path": <base64>} JSONL list.
      *
      * @return list<string>
      */

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-journal.php';
+
+/**
+ * Coverage for PushJournal: per-remote-site baselines and the local diff.
+ *
+ * The diff drives real uploads and deletions later in a push, so the tests
+ * pin the classification exactly: new, ctime-changed, size-changed,
+ * type-changed, deleted, unchanged — plus the two boundary situations
+ * (no baseline yet; stale lists from an earlier run) and the encoding
+ * round-trip for paths that need base64 in the first place.
+ */
+final class PushJournalTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/push-journal-test-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    //  Site keys
+    // ------------------------------------------------------------------
+
+    public function testSiteKeyIdentifiesTheSiteNotTheUrlSpelling(): void
+    {
+        $canonical = PushJournal::site_key('https://example.com/blog');
+
+        // Spelling variants of the same site map to the same directory.
+        $this->assertSame($canonical, PushJournal::site_key('http://example.com/blog'));
+        $this->assertSame($canonical, PushJournal::site_key('https://EXAMPLE.com/blog/'));
+        $this->assertSame($canonical, PushJournal::site_key('https://example.com/blog?preview=1'));
+        $this->assertSame($canonical, PushJournal::site_key('example.com/blog'));
+
+        // Different sites map to different directories.
+        $this->assertNotSame($canonical, PushJournal::site_key('https://example.com'));
+        $this->assertNotSame($canonical, PushJournal::site_key('https://example.com:8080/blog'));
+        $this->assertNotSame($canonical, PushJournal::site_key('https://example.org/blog'));
+
+        // The slug part stays readable.
+        $this->assertStringStartsWith('example.com-blog-', $canonical);
+    }
+
+    public function testSiteKeyRejectsUrlsWithoutAHost(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('no host');
+        PushJournal::site_key('/just/a/path');
+    }
+
+    // ------------------------------------------------------------------
+    //  Baselines
+    // ------------------------------------------------------------------
+
+    public function testCaptureCreatesAndOverwritesTheBaseline(): void
+    {
+        $journal = $this->makeJournal();
+        $this->assertFalse($journal->has_local_files_baseline());
+
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'a.txt' => [100, 5, 'file'],
+        ]));
+        $this->assertTrue($journal->has_local_files_baseline());
+        $this->assertFileDoesNotExist($journal->local_files_baseline_path() . '.tmp');
+
+        // A second capture replaces the first: diffing an index identical
+        // to the second capture reports no changes.
+        $second = $this->writeIndex(['b.txt' => [200, 9, 'file']]);
+        $journal->capture_local_files_baseline($second);
+        $this->assertSame(
+            ['changed' => 0, 'deleted' => 0],
+            $journal->diff_local_files($second)
+        );
+    }
+
+    public function testCaptureRequiresTheIndexFileToExist(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('index file is missing');
+        $this->makeJournal()->capture_local_files_baseline($this->tempDir . '/no-such-index.jsonl');
+    }
+
+    public function testLocalAndRemoteBaselinesAreSeparateFiles(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex(['a' => [1, 1, 'file']]));
+        $journal->capture_remote_files_baseline($this->writeIndex(['b' => [2, 2, 'file']]));
+
+        $this->assertTrue($journal->has_local_files_baseline());
+        $this->assertTrue($journal->has_remote_files_baseline());
+        $this->assertNotSame($journal->local_files_baseline_path(), $journal->remote_files_baseline_path());
+        $this->assertSame(['a'], $this->indexPaths($journal->local_files_baseline_path()));
+        $this->assertSame(['b'], $this->indexPaths($journal->remote_files_baseline_path()));
+    }
+
+    // ------------------------------------------------------------------
+    //  Local diff
+    // ------------------------------------------------------------------
+
+    public function testFirstPushTreatsEveryEntryAsChanged(): void
+    {
+        $journal = $this->makeJournal();
+        $counts = $journal->diff_local_files($this->writeIndex([
+            'index.php' => [100, 10, 'file'],
+            'wp-content' => [100, 0, 'dir'],
+            'wp-content/themes/foo/style.css' => [150, 20, 'file'],
+        ]));
+
+        $this->assertSame(['changed' => 3, 'deleted' => 0], $counts);
+        $this->assertSame(
+            ['index.php', 'wp-content', 'wp-content/themes/foo/style.css'],
+            $this->listPaths($journal->upload_list_path())
+        );
+        $this->assertSame([], $this->listPaths($journal->deletion_list_path()));
+    }
+
+    public function testUnchangedIndexProducesEmptyLists(): void
+    {
+        $journal = $this->makeJournal();
+        $index = $this->writeIndex([
+            'a.txt' => [100, 5, 'file'],
+            'b/c.txt' => [200, 7, 'file'],
+        ]);
+        $journal->capture_local_files_baseline($index);
+
+        $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($index));
+        $this->assertSame([], $this->listPaths($journal->upload_list_path()));
+        $this->assertSame([], $this->listPaths($journal->deletion_list_path()));
+    }
+
+    public function testCtimeSizeOrTypeChangeEachMarkThePathChanged(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'ctime-bump.txt' => [100, 5, 'file'],
+            'size-bump.txt' => [100, 5, 'file'],
+            'type-swap' => [100, 5, 'file'],
+            'same.txt' => [100, 5, 'file'],
+        ]));
+
+        $counts = $journal->diff_local_files($this->writeIndex([
+            'ctime-bump.txt' => [101, 5, 'file'],
+            'size-bump.txt' => [100, 6, 'file'],
+            'type-swap' => [100, 5, 'link'],
+            'same.txt' => [100, 5, 'file'],
+        ]));
+
+        $this->assertSame(['changed' => 3, 'deleted' => 0], $counts);
+        $this->assertSame(
+            ['ctime-bump.txt', 'size-bump.txt', 'type-swap'],
+            $this->listPaths($journal->upload_list_path())
+        );
+    }
+
+    public function testNewChangedDeletedAndUnchangedTogether(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'changed.txt' => [100, 5, 'file'],
+            'deleted.txt' => [100, 5, 'file'],
+            'unchanged.txt' => [100, 5, 'file'],
+        ]));
+
+        $counts = $journal->diff_local_files($this->writeIndex([
+            'added.txt' => [300, 3, 'file'],
+            'changed.txt' => [200, 5, 'file'],
+            'unchanged.txt' => [100, 5, 'file'],
+        ]));
+
+        $this->assertSame(['changed' => 2, 'deleted' => 1], $counts);
+        // Output order follows the sorted index order.
+        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($journal->upload_list_path()));
+        $this->assertSame(['deleted.txt'], $this->listPaths($journal->deletion_list_path()));
+    }
+
+    public function testDiffReplacesListsFromAnEarlierRun(): void
+    {
+        $journal = $this->makeJournal();
+        $index = $this->writeIndex(['a.txt' => [100, 5, 'file']]);
+
+        // First run, no baseline: a.txt lands on the upload list.
+        $journal->diff_local_files($index);
+        $this->assertSame(['a.txt'], $this->listPaths($journal->upload_list_path()));
+
+        // Capture and rerun: the old list must be replaced, not appended to.
+        $journal->capture_local_files_baseline($index);
+        $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($index));
+        $this->assertSame([], $this->listPaths($journal->upload_list_path()));
+        $this->assertFileDoesNotExist($journal->upload_list_path() . '.tmp');
+        $this->assertFileDoesNotExist($journal->deletion_list_path() . '.tmp');
+    }
+
+    public function testPathsThatNeedBase64SurviveTheRoundTrip(): void
+    {
+        // A newline in a filename is the reason the index encodes paths at
+        // all; the non-ASCII name checks the bytes pass through untouched.
+        $weird = "wp-content/uploads/line\nbreak.png";
+        $utf8 = 'wp-content/uploads/naïve-café.jpg';
+
+        $journal = $this->makeJournal();
+        $counts = $journal->diff_local_files($this->writeIndex([
+            $weird => [100, 5, 'file'],
+            $utf8 => [100, 6, 'file'],
+        ]));
+
+        $this->assertSame(['changed' => 2, 'deleted' => 0], $counts);
+        $this->assertEqualsCanonicalizing(
+            [$weird, $utf8],
+            $this->listPaths($journal->upload_list_path())
+        );
+    }
+
+    public function testDiffSkipsBlankLinesAndRejectsGarbage(): void
+    {
+        $journal = $this->makeJournal();
+
+        $withBlanks = $this->tempDir . '/with-blanks.jsonl';
+        file_put_contents(
+            $withBlanks,
+            $this->indexLine('a.txt', 100, 5, 'file') . "\n\n" .
+            $this->indexLine('b.txt', 100, 5, 'file') . "\n"
+        );
+        $this->assertSame(['changed' => 2, 'deleted' => 0], $journal->diff_local_files($withBlanks));
+
+        $garbage = $this->tempDir . '/garbage.jsonl';
+        file_put_contents($garbage, "not json at all\n");
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid index line');
+        $journal->diff_local_files($garbage);
+    }
+
+    public function testDiffRejectsAnUndecodablePath(): void
+    {
+        $journal = $this->makeJournal();
+        $bad = $this->tempDir . '/bad-path.jsonl';
+        file_put_contents($bad, '{"path":"%%%not-base64%%%","ctime":1,"size":1,"type":"file"}' . "\n");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid index path');
+        $journal->diff_local_files($bad);
+    }
+
+    public function testDiffRequiresTheCurrentIndexToExist(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('current index file is missing');
+        $this->makeJournal()->diff_local_files($this->tempDir . '/no-such-index.jsonl');
+    }
+
+    // ------------------------------------------------------------------
+    //  Helpers
+    // ------------------------------------------------------------------
+
+    private function makeJournal(): PushJournal
+    {
+        return new PushJournal($this->tempDir . '/state', 'https://example.com/');
+    }
+
+    /**
+     * Write a sorted index file. Entries map path => [ctime, size, type];
+     * the helper sorts by path bytes, matching how real index files are
+     * stored.
+     *
+     * @param array<string, array{0: int, 1: int, 2: string}> $entries
+     */
+    private function writeIndex(array $entries): string
+    {
+        uksort($entries, 'strcmp');
+        $lines = '';
+        foreach ($entries as $path => [$ctime, $size, $type]) {
+            $lines .= $this->indexLine($path, $ctime, $size, $type) . "\n";
+        }
+        $file = $this->tempDir . '/index-' . uniqid() . '.jsonl';
+        file_put_contents($file, $lines);
+        return $file;
+    }
+
+    private function indexLine(string $path, int $ctime, int $size, string $type): string
+    {
+        return json_encode(
+            ['path' => base64_encode($path), 'ctime' => $ctime, 'size' => $size, 'type' => $type],
+            JSON_THROW_ON_ERROR
+        );
+    }
+
+    /**
+     * Decode the paths from an upload/deletion list ({"path": <base64>} lines).
+     *
+     * @return list<string>
+     */
+    private function listPaths(string $file): array
+    {
+        $this->assertFileExists($file);
+        $paths = [];
+        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $paths[] = base64_decode($data['path'], true);
+        }
+        return $paths;
+    }
+
+    /**
+     * Decode the paths from a baseline (full index lines).
+     *
+     * @return list<string>
+     */
+    private function indexPaths(string $file): array
+    {
+        return $this->listPaths($file);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->recursiveDelete($path);
+                continue;
+            }
+            unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -126,6 +126,11 @@ final class PushJournalTest extends TestCase
             $this->listPaths($journal->upload_list_path())
         );
         $this->assertSame([], $this->listPaths($journal->deletion_list_path()));
+
+        // Pin the exact bytes: one {"path": <base64>} object per line, the
+        // .import-download-list.jsonl shape.
+        $firstLine = strtok((string) file_get_contents($journal->upload_list_path()), "\n");
+        $this->assertSame('{"path":"' . base64_encode('index.php') . '"}', $firstLine);
     }
 
     public function testUnchangedIndexProducesEmptyLists(): void
@@ -224,22 +229,20 @@ final class PushJournalTest extends TestCase
         );
     }
 
-    public function testDiffSkipsBlankLinesAndRejectsGarbage(): void
+    public function testDiffRejectsLinesTheIndexWritersDoNotProduce(): void
     {
+        // The diff reads paths out of raw lines by position, so it accepts
+        // exactly what the index writers emit — anything else (including a
+        // blank line) means the file is not an index and the diff stops.
         $journal = $this->makeJournal();
-
-        $withBlanks = $this->tempDir . '/with-blanks.jsonl';
-        file_put_contents(
-            $withBlanks,
-            $this->indexLine('a.txt', 100, 5, 'file') . "\n\n" .
-            $this->indexLine('b.txt', 100, 5, 'file') . "\n"
-        );
-        $this->assertSame(['changed' => 2, 'deleted' => 0], $journal->diff_local_files($withBlanks));
-
         $garbage = $this->tempDir . '/garbage.jsonl';
-        file_put_contents($garbage, "not json at all\n");
+        file_put_contents(
+            $garbage,
+            $this->indexLine('a.txt', 100, 5, 'file') . "\n\nnot json at all\n"
+        );
+
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid index line');
+        $this->expectExceptionMessage('Unexpected index line');
         $journal->diff_local_files($garbage);
     }
 
@@ -291,9 +294,12 @@ final class PushJournalTest extends TestCase
 
     private function indexLine(string $path, int $ctime, int $size, string $type): string
     {
+        // JSON_UNESCAPED_SLASHES matters: the real index writers use it, and
+        // the diff reads the base64 path out of the raw line, where an
+        // escaped slash would not decode.
         return json_encode(
             ['path' => base64_encode($path), 'ctime' => $ctime, 'size' => $size, 'type' => $type],
-            JSON_THROW_ON_ERROR
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
         );
     }
 

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -69,13 +69,13 @@ final class PushJournalTest extends TestCase
     public function testCaptureCreatesAndOverwritesTheBaseline(): void
     {
         $journal = $this->makeJournal();
-        $this->assertFileDoesNotExist($journal->local_files_baseline_path());
+        $this->assertFileDoesNotExist($journal->local_files_baseline_path);
 
         $journal->capture_local_files_baseline($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
-        $this->assertFileExists($journal->local_files_baseline_path());
-        $this->assertFileDoesNotExist($journal->local_files_baseline_path() . '.tmp');
+        $this->assertFileExists($journal->local_files_baseline_path);
+        $this->assertFileDoesNotExist($journal->local_files_baseline_path . '.tmp');
 
         // A second capture replaces the first: diffing an index identical
         // to the second capture reports no changes.
@@ -100,9 +100,9 @@ final class PushJournalTest extends TestCase
         $journal->capture_local_files_baseline($this->writeIndex(['a' => [1, 1, 'file']]));
         $journal->capture_remote_files_baseline($this->writeIndex(['b' => [2, 2, 'file']]));
 
-        $this->assertNotSame($journal->local_files_baseline_path(), $journal->remote_files_baseline_path());
-        $this->assertSame(['a'], $this->listPaths($journal->local_files_baseline_path()));
-        $this->assertSame(['b'], $this->listPaths($journal->remote_files_baseline_path()));
+        $this->assertNotSame($journal->local_files_baseline_path, $journal->remote_files_baseline_path);
+        $this->assertSame(['a'], $this->listPaths($journal->local_files_baseline_path));
+        $this->assertSame(['b'], $this->listPaths($journal->remote_files_baseline_path));
     }
 
     // ------------------------------------------------------------------
@@ -121,13 +121,13 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['changed' => 3, 'deleted' => 0], $counts);
         $this->assertSame(
             ['index.php', 'wp-content', 'wp-content/themes/foo/style.css'],
-            $this->listPaths($journal->upload_list_path())
+            $this->listPaths($journal->upload_list_path)
         );
-        $this->assertSame([], $this->listPaths($journal->deletion_list_path()));
+        $this->assertSame([], $this->listPaths($journal->deletion_list_path));
 
         // Pin the exact bytes: one {"path": <base64>} object per line, the
         // .import-download-list.jsonl shape.
-        $firstLine = strtok((string) file_get_contents($journal->upload_list_path()), "\n");
+        $firstLine = strtok((string) file_get_contents($journal->upload_list_path), "\n");
         $this->assertSame('{"path":"' . base64_encode('index.php') . '"}', $firstLine);
     }
 
@@ -141,8 +141,8 @@ final class PushJournalTest extends TestCase
         $journal->capture_local_files_baseline($index);
 
         $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($index));
-        $this->assertSame([], $this->listPaths($journal->upload_list_path()));
-        $this->assertSame([], $this->listPaths($journal->deletion_list_path()));
+        $this->assertSame([], $this->listPaths($journal->upload_list_path));
+        $this->assertSame([], $this->listPaths($journal->deletion_list_path));
     }
 
     public function testCtimeSizeOrTypeChangeEachMarkThePathChanged(): void
@@ -165,7 +165,7 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['changed' => 3, 'deleted' => 0], $counts);
         $this->assertSame(
             ['ctime-bump.txt', 'size-bump.txt', 'type-swap'],
-            $this->listPaths($journal->upload_list_path())
+            $this->listPaths($journal->upload_list_path)
         );
     }
 
@@ -186,8 +186,8 @@ final class PushJournalTest extends TestCase
 
         $this->assertSame(['changed' => 2, 'deleted' => 1], $counts);
         // Output order follows the sorted index order.
-        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($journal->upload_list_path()));
-        $this->assertSame(['deleted.txt'], $this->listPaths($journal->deletion_list_path()));
+        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($journal->upload_list_path));
+        $this->assertSame(['deleted.txt'], $this->listPaths($journal->deletion_list_path));
     }
 
     public function testDiffReplacesListsFromAnEarlierRun(): void
@@ -197,14 +197,14 @@ final class PushJournalTest extends TestCase
 
         // First run, no baseline: a.txt lands on the upload list.
         $journal->diff_local_files($index);
-        $this->assertSame(['a.txt'], $this->listPaths($journal->upload_list_path()));
+        $this->assertSame(['a.txt'], $this->listPaths($journal->upload_list_path));
 
         // Capture and rerun: the old list must be replaced, not appended to.
         $journal->capture_local_files_baseline($index);
         $this->assertSame(['changed' => 0, 'deleted' => 0], $journal->diff_local_files($index));
-        $this->assertSame([], $this->listPaths($journal->upload_list_path()));
-        $this->assertFileDoesNotExist($journal->upload_list_path() . '.tmp');
-        $this->assertFileDoesNotExist($journal->deletion_list_path() . '.tmp');
+        $this->assertSame([], $this->listPaths($journal->upload_list_path));
+        $this->assertFileDoesNotExist($journal->upload_list_path . '.tmp');
+        $this->assertFileDoesNotExist($journal->deletion_list_path . '.tmp');
     }
 
     public function testPathsThatNeedBase64SurviveTheRoundTrip(): void
@@ -223,7 +223,7 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['changed' => 2, 'deleted' => 0], $counts);
         $this->assertEqualsCanonicalizing(
             [$weird, $utf8],
-            $this->listPaths($journal->upload_list_path())
+            $this->listPaths($journal->upload_list_path)
         );
     }
 


### PR DESCRIPTION
## What it does

Adds `PushJournal` (`packages/reprint-importer/src/lib/push/class-push-journal.php`): the local machine's memory of its last completed push to each remote site, and the comparison that turns that memory into work lists.

- One directory per remote site under `<state-dir>/push/<site>/`, named by a readable slug plus a short hash of the site URL (`example.com-blog-a1b2c3d4`).
- `capture_local_files_baseline()` / `capture_remote_files_baseline()` copy an index file into the journal — temp file + rename, so a killed process never leaves a truncated baseline behind.
- `diff_local_files()` compares the current local index against the local baseline and writes `upload-list.jsonl` (paths new since the baseline, or whose ctime, size, or type changed) and `deletion-list.jsonl` (paths gone since the baseline). It returns the two counts for the push summary.

Step 5 of the delivery plan in `markdown/PUSH-SYNC.md`. Nothing calls it yet — the upload loop (step 7) and `reprint push` (step 12) will. Based on trunk, independent of #318.

## Rationale

ctime is machine-local, so push never compares a local timestamp against a remote one; each machine is compared against its own past. The journal stores that past, and the diff answers "what changed on this machine since the last push to this site". With no baseline yet (the first push), every entry counts as changed and no deletion can be detected — exactly what the design doc promises for first pushes.

The formats reuse what pull already has instead of inventing new ones:

- Baselines are byte-for-byte copies of index files in the `.import-index.jsonl` format (one JSON object per line, base64 path + ctime + size + type, sorted by path).
- The work lists use the `.import-download-list.jsonl` shape: one `{"path": <base64>}` object per line.
- The lists carry no sizes or types on purpose. The files are local, so the upload step will read the filesystem when it stages them, rather than trusting a snapshot that may already be stale.

The design doc named these files `.tsv`; the index machinery this reuses is JSON-lines, so the doc now says `.jsonl` — one format everywhere instead of a converter.

## Implementation

`diff_local_files()` is a merge join over the two path-sorted files — one pass, constant memory, and no JSON functions anywhere in the loop:

- Index lines always start with `{"path":"<base64>"` — every index writer in `import.php` puts the path field first — so the diff pulls the encoded path out of each raw line by position (`strncmp`/`strpos`/`substr`) and decodes only that. base64 does not preserve byte order ('0' sorts before 'A' in ASCII but encodes a higher value), so the merge orders by decoded path.
- A path present on both sides counts as unchanged only when the two lines are byte-identical. Both files come from the same writer, so a changed ctime, size, or type is exactly a changed line. A writer format change would at worst mark everything changed once — a wasted re-upload, never a missed one.
- Output lines reuse the base64 substring verbatim (`'{"path":"' . $b64 . '"}'`), byte-identical to what the download-list writer produces with `json_encode` + `JSON_UNESCAPED_SLASHES`.
- Classification: path only in the current index → upload list; same path, different line → upload list; path only in the baseline → deletion list.

Every output file is written to a temp file and renamed into place. Short writes throw instead of passing silently, because a dropped line here would mean a file that never uploads or a deletion that never executes. A line that does not match the writers' format stops the diff with an error — these are our own state files, so anything else is corruption, not input to tolerate.

`site_key()` treats host, port, and path as the site's identity; scheme, query, and credentials are ignored (http and https reach the same files). The slug keeps the directory recognizable; the sha1 prefix tells apart URLs whose slugs collide.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit Import/PushJournalTest.php
```

14 tests: the full classification (new / ctime / size / type / deleted / unchanged), first-push behavior, stale lists replaced on rerun, base64 round-trip for a filename with a newline and a UTF-8 name, rejection of lines the index writers do not produce, undecodable-path rejection, missing-input errors, site-key normalization, and a byte-level pin of the output line format. The file sits in `tests/Import/`, which the Import Tests suite picks up automatically.
