### PR TITLE
[Push] Use local-only baselines for push planning

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -79,9 +79,13 @@ Each baseline is a copy of a file index in the `.import-index.jsonl` format
 the pull path already reads and writes — one JSON object per line, sorted by
 path.
 
-The remote baseline is captured by a scoped reindex that runs *after* apply —
-apply itself changes remote ctimes, and without this refresh the next push
-would report everything we just wrote as drift.
+The remote baseline must stay a full last-synced remote index. Apply itself
+changes remote ctimes, so the paths written by a successful push need a
+post-apply refresh, but a scoped refresh cannot replace the whole baseline. If
+the push only reindexes the paths it touched, those scoped entries must be
+merged into the previous full remote baseline while preserving untouched
+entries. Otherwise a later push of a different path would compare against an
+incomplete remote history.
 
 The first push to a site has no baselines: everything is "changed locally",
 nothing can be checked for drift, and the summary says so. ctime is trusted

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -7,27 +7,21 @@ the end maps it to a PR stack.
 
 ## Shape of a push
 
-1. The local machine knows what changed locally since its last sync with this
-   remote (files, deletions, database rows), by comparing against baselines it
-   stored at the end of that sync.
-2. It asks the remote to reindex just the paths (later: rows) the local
-   changes touch, and compares the result against the remote baseline from
-   the last sync. That reveals remote drift — files someone changed on the
-   remote that this push would overwrite.
-3. It shows a summary: changed locally, changed on the remote (within the
-   pushed scope), deletions. The user confirms. Conflicts are file-level and
-   row-level; the only resolutions are "override" and "skip". We never show
-   line-level or field-level diffs.
-4. It transfers everything into a staging area on the remote — file bytes,
+1. The local machine knows what changed locally since its last push to this
+   remote (files, deletions, database rows), by comparing against the local
+   baselines it stored at the end of that push.
+2. It shows a summary of local uploads and deletions. The user confirms that
+   local should win for those paths and rows.
+3. It transfers everything into a staging area on the remote — file bytes,
    a deletion manifest, and (phase two) the database diff. The transfer is
    resumable at byte granularity.
-5. It drives the apply step with repeated commands until done. The remote
+4. It drives the apply step with repeated commands until done. The remote
    moves staged files into place, executes deletions, applies the database
    diff, and fixes symlinks — inside a maintenance window that lasts seconds,
    not the length of the transfer.
-6. It runs one more scoped reindex and stores the results as the new
-   baselines. The push is complete only after this step; a crashed push is
-   re-driven from the top and converges.
+5. It stores the current local indexes as the new local baselines. The push is
+   complete only after this step; a crashed push is re-driven from the top and
+   converges.
 
 Both sides act only when the local machine calls: no worker, no polling, no
 sessions. The remote is a passive authenticated API.
@@ -58,48 +52,36 @@ of buffering pain. Signing cost is constant per request regardless of payload
 size. The secret travels in no URL and no body, so it never lands in an
 access log.
 
-## Change detection: each machine compared against itself
+## Change detection: local machine compared against itself
 
-ctime is machine-local, so we never compare a local timestamp to a remote
-one. Each side is compared only against its own past:
-
-- "changed on my machine since the last sync" — local index now vs the local
-  baseline,
-- "changed on the remote since the last sync" — remote index now (scoped to
-  the pushed paths) vs the remote baseline.
+ctime is machine-local, so push never compares a local timestamp to a remote
+one. It only answers "what changed locally since my last successful push to
+this remote" by comparing the current local indexes against local baselines.
 
 The local machine keeps one set of baselines **per remote site**, overwritten
 after each successful apply:
 
     <state-dir>/push/<site>/last-sync-local-files.jsonl
-    <state-dir>/push/<site>/last-sync-remote-files.jsonl
     <state-dir>/push/<site>/last-sync-local-rows.jsonl   (phase two)
 
-Each baseline is a copy of a file index in the `.import-index.jsonl` format
-the pull path already reads and writes — one JSON object per line, sorted by
-path.
+Each file baseline is a copy of a local file index in the `.import-index.jsonl`
+format the pull path already reads and writes — one JSON object per line,
+sorted by path.
 
-The remote baseline must stay a full last-synced remote index. Apply itself
-changes remote ctimes, so the paths written by a successful push need a
-post-apply refresh, but a scoped refresh cannot replace the whole baseline. If
-the push only reindexes the paths it touched, those scoped entries must be
-merged into the previous full remote baseline while preserving untouched
-entries. Otherwise a later push of a different path would compare against an
-incomplete remote history.
+The first push to a site has no baselines: every current local file counts as
+changed, and no local deletion can be detected yet.
 
-The first push to a site has no baselines: everything is "changed locally",
-nothing can be checked for drift, and the summary says so. ctime is trusted
-as-is; events that bump it without changing content (chmod, restores, host
-migrations) produce false drift warnings, and "override" is how the user
-moves past them.
+Push is intentionally local-wins. If a developer edited the remote site
+outside Reprint, a later push of the same path or row overwrites that remote
+edit. This keeps push as a simple deployment tool instead of a conflict
+manager.
 
 ## Deletions
 
-Local deletions since the last sync come out of the baseline comparison. They
+Local deletions since the last push come out of the baseline comparison. They
 travel as a deletion manifest — itself a staged artifact, uploaded through
 the same store as file bytes — and the apply step executes the unlinks inside
-the same window as the moves. Remote deletions since the last sync appear in
-the drift summary.
+the same window as the moves.
 
 ## The staging store
 
@@ -147,13 +129,11 @@ Order:
    (`$upgrading = 0` for us, `time()` for everyone else). WordPress's own
    rule that a `.maintenance` file older than 10 minutes is ignored stays
    intact, so an interrupted apply can never leave the site down for good.
-3. **Recheck, now that web writes are frozen:** the apply command carries the
-   expected `(path, ctime, size)` tuples; the remote re-verifies them and
-   refuses with a fresh conflict list instead of overwriting drift.
-4. **Swap:** journaled `.new`/`.bak` renames, deletion unlinks, the database
+3. **Swap:** journaled `.new`/`.bak` renames, deletion unlinks, the database
    batch, symlink fixes. The window contains renames and a row batch —
    seconds, independent of payload size.
-5. **Maintenance off**, scoped reindex, baselines updated.
+4. **Maintenance off**, local baselines updated by the driver after apply
+   completes.
 
 If the driver dies mid-apply: WordPress stops honoring the `.maintenance`
 file after 10 minutes on its own, the journal is resumable by the next apply
@@ -182,14 +162,10 @@ that replaces tables. The mechanics mirror the file design:
 
 - A **row index** — `(table, primary key, row hash)` — plays the role
   `(path, ctime, size)` plays for files. The local machine keeps the row
-  index from the last sync as a baseline; diffing against it yields the
+  index from the last push as a baseline; diffing against it yields the
   upsert and delete sets.
-- The remote exposes a row-index endpoint scoped to the touched primary
-  keys, cursor-paginated the same way the dump producer already walks
-  tables, for drift detection.
-- Conflicts are row-level: a serialized option conflicts as a whole row, and
-  the resolutions are override or skip. Rows inserted on both sides with the
-  same primary key are conflicts; we do not remap keys.
+- Push is local-wins for rows too. Rows changed on the remote outside Reprint
+  are overwritten when the local diff touches the same primary key.
 - The diff stream passes through the URL rewriter in the local-to-remote
   direction before staging.
 - Volatile rows are excluded by default (transients, sessions, cron), the
@@ -204,13 +180,12 @@ Stated here so nobody rediscovers them as surprises:
 - **Same-size corruption is invisible.** Transfers are verified by byte
   count only. Corruption that preserves length passes. We decided detection
   is not worth hashing multi-gigabyte artifacts inside PHP time limits.
-- **ctime produces false drift** after chmod, restores, or host migrations.
-  The cost is a noisy summary, not wrong data; "override" moves past it.
+- **Remote edits are overwritten.** Push is a local-wins deployment tool, not
+  a bidirectional conflict resolver. Developers who edit the remote site
+  outside Reprint are responsible for pulling or preserving those changes
+  before pushing over them.
 - **Shell and cron can write during the maintenance window.** Maintenance
-  blocks web requests; it cannot block SSH or system cron. The recheck runs
-  after freezing web writes; what happens under it from a shell is accepted.
-- **Conflicts are whole-file and whole-row.** No line or field granularity,
-  by design.
+  blocks web requests; it cannot block SSH or system cron.
 - **A sender that abandons a failed discard and re-uploads anyway** can end
   up with a zero-filled prefix that passes the size check. The discard
   retry rule exists precisely to make this unreachable.
@@ -228,23 +203,20 @@ Files first, database second, each PR small and stacked in this order:
    the closed #298).
 4. **Reprint-storage exclusions** — indexer and deletion-sync hard-exclude
    the configured storage path; web guards for inside-docroot placement.
-5. **Push journal and local diff** — per-site baselines, capture and
+5. **Push journal and local diff** — per-site local baselines, capture and
    overwrite logic, local change and deletion detection.
-6. **Scoped remote reindex and drift summary** — path-scoped index requests,
-   baseline comparison, the summary/confirm UX.
-7. **Upload endpoint** — the store's HTTP surface plus the sender loop with
+6. **Upload endpoint** — the store's HTTP surface plus the sender loop with
    chunk sizing; deletion manifest staged; `--force-http` with honest help
    text (the first push networking this flag can gate).
-8. **Package unification** — importer and exporter become one Reprint
+7. **Package unification** — importer and exporter become one Reprint
    package (lite = serve-only build). Placed here because apply is the
    first piece that needs import-side code running on the remote.
-9. **Apply engine, files** — journaled swaps, copy-first, the whitelisted
-   maintenance file, the recheck, unfinished-journal completion, post-apply
-   reindex. Reuses the apply code already built in PR #277 (the journaled
-   `.new`/`.bak` swaps and the copy-first flow); the relay around that code
-   is dropped.
-10. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
-11. **Row index and database diff** — the row index producer and endpoint,
-    local row baselines, diff generation and URL rewrite, the apply batch.
-12. **`reprint push`** — the one command that orchestrates plan, confirm,
+8. **Apply engine, files** — journaled swaps, copy-first, the whitelisted
+   maintenance file, unfinished-journal completion. Reuses the apply code
+   already built in PR #277 (the journaled `.new`/`.bak` swaps and the
+   copy-first flow); the relay around that code is dropped.
+9. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
+10. **Row index and database diff** — the local row index, row baseline,
+    diff generation and URL rewrite, the apply batch.
+11. **`reprint push`** — the one command that orchestrates plan, confirm,
     transfer, apply, resume.

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Per-remote-site memory of the last completed push: the baselines.
+ * Per-remote-site memory of the last completed push: the local baseline.
  *
  * ctime is machine-local, so push never compares a local timestamp against
  * a remote one. Each machine is compared against its own past instead
@@ -8,12 +8,11 @@
  * on the local machine, one directory per remote site:
  *
  *     <state-dir>/push/<site>/last-sync-local-files.jsonl
- *     <state-dir>/push/<site>/last-sync-remote-files.jsonl
  *
- * Each baseline is a copy of a file index in the same format as
+ * The baseline is a copy of a file index in the same format as
  * .import-index.jsonl: one JSON object per line with a base64-encoded path
  * plus ctime, size, and type, sorted by decoded path. The push driver
- * captures both at the end of a successful push. A capture writes a
+ * captures it at the end of a successful push. A capture writes a
  * temporary file and renames it into place, so a killed process never
  * leaves a truncated baseline for the next push to trust — until the
  * rename lands, the previous baseline stays in effect.
@@ -40,13 +39,6 @@
  * With no baseline yet — the first push to a site — every current entry
  * counts as changed and no deletion can be detected.
  *
- * diff_remote_files() answers "did the remote change any path this push is
- * about to touch". Its current index input must be the scoped remote reindex
- * for local_paths_to_push plus local_paths_to_delete. The stored remote
- * baseline must still be the full last-synced remote index; this class filters
- * it to the current local scope before comparison, so unrelated remote changes
- * do not block a push.
- *
  * Producing the current index is the caller's job; this class only
  * compares and stores. The lists belong to the run that produced them:
  * a resumed push reruns the diff (one cheap local pass) rather than
@@ -59,30 +51,18 @@ class PushJournal
     /** @var string Copy of the local file index from the last completed push. */
     public string $local_files_baseline_path;
 
-    /** @var string Copy of the remote file index from the last completed push. */
-    public string $remote_files_baseline_path;
-
     /** @var string JSONL file of local paths to push, written by diff_local_files(). */
     public string $local_paths_to_push;
 
     /** @var string JSONL file of local paths whose deletion should be pushed, written by diff_local_files(). */
     public string $local_paths_to_delete;
 
-    /** @var string JSONL file of scoped remote paths changed since the remote baseline. */
-    public string $remote_paths_changed_since_last_sync;
-
-    /** @var string JSONL file of scoped remote paths deleted since the remote baseline. */
-    public string $remote_paths_deleted_since_last_sync;
-
     public function __construct(string $state_dir, string $site_url)
     {
         $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
         $this->local_files_baseline_path = $this->site_dir . "/last-sync-local-files.jsonl";
-        $this->remote_files_baseline_path = $this->site_dir . "/last-sync-remote-files.jsonl";
         $this->local_paths_to_push = $this->site_dir . "/local-paths-to-push.jsonl";
         $this->local_paths_to_delete = $this->site_dir . "/local-paths-to-delete.jsonl";
-        $this->remote_paths_changed_since_last_sync = $this->site_dir . "/remote-paths-changed-since-last-sync.jsonl";
-        $this->remote_paths_deleted_since_last_sync = $this->site_dir . "/remote-paths-deleted-since-last-sync.jsonl";
     }
 
     /**
@@ -134,22 +114,6 @@ class PushJournal
     }
 
     /**
-     * Store a copy of the full remote file index as the new remote baseline.
-     *
-     * The index must cover the whole remote tree, not only the paths touched
-     * by the latest push. diff_remote_files() treats a path absent from this
-     * baseline as absent from the remote at the last sync, so replacing the
-     * baseline with a scoped reindex would make a later push of different
-     * paths compare against an incomplete history. If the push driver only
-     * has a scoped post-apply reindex, it must merge those scoped entries into
-     * the previous full remote baseline instead of calling this method.
-     */
-    public function capture_full_remote_files_baseline(string $index_file): void
-    {
-        $this->replace_file($this->remote_files_baseline_path, $index_file);
-    }
-
-    /**
      * Compare the current local index against the local baseline and write
      * the local paths to push and local paths to delete, replacing any lists
      * from an earlier run.
@@ -174,292 +138,100 @@ class PushJournal
         }
         $this->ensure_site_dir();
 
-        return $this->diff_index_files(
-            $current_index_file,
-            is_file($this->local_files_baseline_path) ? $this->local_files_baseline_path : null,
-            $this->local_paths_to_push,
-            $this->local_paths_to_delete,
-            true
-        );
-    }
-
-    /**
-     * Compare a scoped current remote index against the remote baseline and
-     * write the remote paths that changed or disappeared since the last sync.
-     *
-     * The scoped current remote index must contain exactly the paths from the
-     * local push/delete lists that still exist on the remote. The stored
-     * remote baseline must be the full last-synced remote index; the method
-     * filters it to those same local paths before the merge, so a remote edit
-     * outside the pushed scope cannot become a false conflict.
-     *
-     * If there is no remote baseline yet, this is the first push to the site:
-     * drift cannot be detected, stale drift lists are replaced with empty
-     * files, and baseline_missing is true for the summary UI.
-     *
-     * @return array{changed: int, deleted: int, baseline_missing: bool} Entry counts, for the push summary.
-     */
-    public function diff_remote_files(string $current_remote_index_file): array
-    {
-        if (!is_file($current_remote_index_file)) {
-            throw new RuntimeException("Cannot diff, the current remote index file is missing: {$current_remote_index_file}");
-        }
-        $this->ensure_site_dir();
-
-        if (!is_file($this->local_paths_to_push)) {
-            throw new RuntimeException("Cannot diff remote drift, local_paths_to_push is missing: {$this->local_paths_to_push}");
-        }
-        if (!is_file($this->local_paths_to_delete)) {
-            throw new RuntimeException("Cannot diff remote drift, local_paths_to_delete is missing: {$this->local_paths_to_delete}");
-        }
-
-        if (!is_file($this->remote_files_baseline_path)) {
-            $this->write_empty_jsonl($this->remote_paths_changed_since_last_sync);
-            $this->write_empty_jsonl($this->remote_paths_deleted_since_last_sync);
-            return ["changed" => 0, "deleted" => 0, "baseline_missing" => true];
-        }
-
-        $scoped_last_synced_remote_index = $this->site_dir . "/last-synced-remote-index-for-local-paths.jsonl.tmp";
-        $this->write_scoped_last_synced_remote_index($scoped_last_synced_remote_index);
-        try {
-            $counts = $this->diff_index_files(
-                $current_remote_index_file,
-                $scoped_last_synced_remote_index,
-                $this->remote_paths_changed_since_last_sync,
-                $this->remote_paths_deleted_since_last_sync,
-                false
-            );
-        } finally {
-            if (is_file($scoped_last_synced_remote_index)) {
-                unlink($scoped_last_synced_remote_index);
-            }
-        }
-
-        return [
-            "changed" => $counts["changed"],
-            "deleted" => $counts["deleted"],
-            "baseline_missing" => false,
-        ];
-    }
-
-    /**
-     * Compare two sorted index files and write {"path": <base64>} lists for
-     * entries that changed or disappeared.
-     *
-     * @return array{changed: int, deleted: int}
-     */
-    private function diff_index_files(
-        string $current_index_file,
-        ?string $previous_index_file,
-        string $changed_paths_file,
-        string $deleted_paths_file,
-        bool $missing_previous_index_marks_current_changed
-    ): array {
-        $current_index_handle = fopen($current_index_file, "r");
-        if (!$current_index_handle) {
+        $current_handle = fopen($current_index_file, "r");
+        if (!$current_handle) {
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
-        $previous_index_handle = null;
-        if ($previous_index_file !== null && is_file($previous_index_file)) {
-            $previous_index_handle = fopen($previous_index_file, "r");
-            if (!$previous_index_handle) {
-                fclose($current_index_handle);
-                throw new RuntimeException("Failed to open the previous index: {$previous_index_file}");
+        $baseline_handle = null;
+        if (is_file($this->local_files_baseline_path)) {
+            $baseline_handle = fopen($this->local_files_baseline_path, "r");
+            if (!$baseline_handle) {
+                fclose($current_handle);
+                throw new RuntimeException("Failed to open the local baseline: {$this->local_files_baseline_path}");
             }
         }
 
-        $changed_paths_tmp = $changed_paths_file . ".tmp";
-        $changed_paths_handle = fopen($changed_paths_tmp, "w");
-        if (!$changed_paths_handle) {
-            fclose($current_index_handle);
-            if ($previous_index_handle) {
-                fclose($previous_index_handle);
+        $local_paths_to_push_tmp = $this->local_paths_to_push . ".tmp";
+        $paths_to_push_handle = fopen($local_paths_to_push_tmp, "w");
+        if (!$paths_to_push_handle) {
+            fclose($current_handle);
+            if ($baseline_handle) {
+                fclose($baseline_handle);
             }
-            throw new RuntimeException("Failed to open changed paths list for writing: {$changed_paths_tmp}");
+            throw new RuntimeException("Failed to open local_paths_to_push for writing: {$local_paths_to_push_tmp}");
         }
-        $deleted_paths_tmp = $deleted_paths_file . ".tmp";
-        $deleted_paths_handle = fopen($deleted_paths_tmp, "w");
-        if (!$deleted_paths_handle) {
-            fclose($current_index_handle);
-            if ($previous_index_handle) {
-                fclose($previous_index_handle);
+        $local_paths_to_delete_tmp = $this->local_paths_to_delete . ".tmp";
+        $paths_to_delete_handle = fopen($local_paths_to_delete_tmp, "w");
+        if (!$paths_to_delete_handle) {
+            fclose($current_handle);
+            if ($baseline_handle) {
+                fclose($baseline_handle);
             }
-            fclose($changed_paths_handle);
-            throw new RuntimeException("Failed to open deleted paths list for writing: {$deleted_paths_tmp}");
+            fclose($paths_to_push_handle);
+            throw new RuntimeException("Failed to open local_paths_to_delete for writing: {$local_paths_to_delete_tmp}");
         }
 
         $changed = 0;
         $deleted = 0;
-        $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
-        $this->read_line($previous_index_handle, $previous_index_entry, $previous_index_path, $previous_index_base64_path);
-        while ($current_entry !== null || $previous_index_entry !== null) {
+        $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
+        $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+        while ($current_entry !== null || $baseline_entry !== null) {
             // base64 does not preserve byte order ('0' sorts before 'A' in
             // ASCII but encodes a higher value), so ordering has to use the
             // decoded paths.
-            if ($previous_index_entry === null) {
+            if ($baseline_entry === null) {
                 $order = -1;
             } elseif ($current_entry === null) {
                 $order = 1;
             } else {
-                $order = strcmp($current_path, $previous_index_path);
+                $order = strcmp($current_path, $baseline_path);
             }
 
             if ($order < 0) {
                 // Only in the current index: new since the last push.
-                if ($previous_index_handle || $missing_previous_index_marks_current_changed) {
-                    $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                    if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
-                        throw new RuntimeException("Short write on changed paths list, is the disk full?");
-                    }
-                    $changed++;
+                $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                if (fwrite($paths_to_push_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on local_paths_to_push, is the disk full?");
                 }
-                $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
+                $changed++;
+                $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
             } elseif ($order > 0) {
-                // Only in the previous index: deleted since the last push.
-                $out = json_encode(["path" => $previous_index_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                if (fwrite($deleted_paths_handle, $out) !== strlen($out)) {
-                    throw new RuntimeException("Short write on deleted paths list, is the disk full?");
+                // Only in the baseline: deleted since the last push.
+                $out = json_encode(["path" => $baseline_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                if (fwrite($paths_to_delete_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on local_paths_to_delete, is the disk full?");
                 }
                 $deleted++;
-                $this->read_line($previous_index_handle, $previous_index_entry, $previous_index_path, $previous_index_base64_path);
+                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
             } else {
                 // Same path on both sides. Decoded JSON array comparison keeps
                 // field order and slash escaping out of change detection. A
                 // writer field change would mark everything changed once (a
                 // wasted re-upload, never a missed one).
-                if ($current_entry != $previous_index_entry) {
+                if ($current_entry != $baseline_entry) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                    if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
-                        throw new RuntimeException("Short write on changed paths list, is the disk full?");
+                    if (fwrite($paths_to_push_handle, $out) !== strlen($out)) {
+                        throw new RuntimeException("Short write on local_paths_to_push, is the disk full?");
                     }
                     $changed++;
                 }
-                $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
-                $this->read_line($previous_index_handle, $previous_index_entry, $previous_index_path, $previous_index_base64_path);
+                $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
+                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
             }
         }
 
-        fclose($current_index_handle);
-        if ($previous_index_handle) {
-            fclose($previous_index_handle);
+        fclose($current_handle);
+        if ($baseline_handle) {
+            fclose($baseline_handle);
         }
-        if (!fclose($changed_paths_handle) || !rename($changed_paths_tmp, $changed_paths_file)) {
-            throw new RuntimeException("Failed to move changed paths list into place: {$changed_paths_file}");
+        if (!fclose($paths_to_push_handle) || !rename($local_paths_to_push_tmp, $this->local_paths_to_push)) {
+            throw new RuntimeException("Failed to move local_paths_to_push into place: {$this->local_paths_to_push}");
         }
-        if (!fclose($deleted_paths_handle) || !rename($deleted_paths_tmp, $deleted_paths_file)) {
-            throw new RuntimeException("Failed to move deleted paths list into place: {$deleted_paths_file}");
+        if (!fclose($paths_to_delete_handle) || !rename($local_paths_to_delete_tmp, $this->local_paths_to_delete)) {
+            throw new RuntimeException("Failed to move local_paths_to_delete into place: {$this->local_paths_to_delete}");
         }
 
         return ["changed" => $changed, "deleted" => $deleted];
-    }
-
-    /**
-     * Write the last-synced remote index entries for paths this push will touch.
-     *
-     * local_paths_to_push and local_paths_to_delete are already sorted by
-     * decoded path because diff_local_files() writes them during a merge over
-     * the sorted local index. The last-synced remote index is sorted the same
-     * way. This merge keeps memory constant and ignores last-synced remote
-     * entries outside the local push scope.
-     */
-    private function write_scoped_last_synced_remote_index(string $scoped_last_synced_remote_index_path): void
-    {
-        $last_synced_remote_index_handle = fopen($this->remote_files_baseline_path, "r");
-        if (!$last_synced_remote_index_handle) {
-            throw new RuntimeException("Failed to open the last-synced remote index: {$this->remote_files_baseline_path}");
-        }
-        $local_paths_to_push_handle = fopen($this->local_paths_to_push, "r");
-        if (!$local_paths_to_push_handle) {
-            fclose($last_synced_remote_index_handle);
-            throw new RuntimeException("Failed to open local_paths_to_push: {$this->local_paths_to_push}");
-        }
-        $local_paths_to_delete_handle = fopen($this->local_paths_to_delete, "r");
-        if (!$local_paths_to_delete_handle) {
-            fclose($last_synced_remote_index_handle);
-            fclose($local_paths_to_push_handle);
-            throw new RuntimeException("Failed to open local_paths_to_delete: {$this->local_paths_to_delete}");
-        }
-        $scoped_last_synced_remote_index_handle = fopen($scoped_last_synced_remote_index_path, "w");
-        if (!$scoped_last_synced_remote_index_handle) {
-            fclose($last_synced_remote_index_handle);
-            fclose($local_paths_to_push_handle);
-            fclose($local_paths_to_delete_handle);
-            throw new RuntimeException("Failed to open scoped last-synced remote index for writing: {$scoped_last_synced_remote_index_path}");
-        }
-
-        $last_local_scope_path = null;
-        $this->read_line($last_synced_remote_index_handle, $last_synced_remote_entry, $last_synced_remote_path, $last_synced_remote_base64_path);
-        $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
-        $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
-
-        while ($last_synced_remote_entry !== null && ($local_path_to_push_entry !== null || $local_path_to_delete_entry !== null)) {
-            if ($local_path_to_push_entry !== null && ($local_path_to_delete_entry === null || strcmp($local_path_to_push, $local_path_to_delete) <= 0)) {
-                $local_scope_path = $local_path_to_push;
-            } else {
-                $local_scope_path = $local_path_to_delete;
-            }
-
-            if ($local_scope_path === $last_local_scope_path) {
-                if ($local_path_to_push === $local_scope_path) {
-                    $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
-                }
-                if ($local_path_to_delete === $local_scope_path) {
-                    $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
-                }
-                continue;
-            }
-
-            $order = strcmp($last_synced_remote_path, $local_scope_path);
-            if ($order < 0) {
-                $this->read_line($last_synced_remote_index_handle, $last_synced_remote_entry, $last_synced_remote_path, $last_synced_remote_base64_path);
-                continue;
-            }
-            if ($order > 0) {
-                $last_local_scope_path = $local_scope_path;
-                if ($local_path_to_push === $local_scope_path) {
-                    $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
-                }
-                if ($local_path_to_delete === $local_scope_path) {
-                    $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
-                }
-                continue;
-            }
-
-            $line = json_encode($last_synced_remote_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-            if (fwrite($scoped_last_synced_remote_index_handle, $line) !== strlen($line)) {
-                throw new RuntimeException("Short write on scoped last-synced remote index, is the disk full?");
-            }
-            $last_local_scope_path = $local_scope_path;
-            $this->read_line($last_synced_remote_index_handle, $last_synced_remote_entry, $last_synced_remote_path, $last_synced_remote_base64_path);
-            if ($local_path_to_push === $local_scope_path) {
-                $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
-            }
-            if ($local_path_to_delete === $local_scope_path) {
-                $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
-            }
-        }
-
-        fclose($last_synced_remote_index_handle);
-        fclose($local_paths_to_push_handle);
-        fclose($local_paths_to_delete_handle);
-        if (!fclose($scoped_last_synced_remote_index_handle)) {
-            throw new RuntimeException("Failed to close scoped last-synced remote index: {$scoped_last_synced_remote_index_path}");
-        }
-    }
-
-    /**
-     * Atomically replace a JSONL list with an empty file.
-     */
-    private function write_empty_jsonl(string $jsonl_path): void
-    {
-        $tmp = $jsonl_path . ".tmp";
-        $handle = fopen($tmp, "w");
-        if (!$handle) {
-            throw new RuntimeException("Failed to open empty JSONL temp file for writing: {$tmp}");
-        }
-        if (!fclose($handle) || !rename($tmp, $jsonl_path)) {
-            throw new RuntimeException("Failed to move empty JSONL file into place: {$jsonl_path}");
-        }
     }
 
     /**
@@ -506,18 +278,18 @@ class PushJournal
      * Copy an index file over a baseline: temp file in the same directory,
      * then rename, so readers only ever see the old or the new baseline.
      */
-    private function replace_file(string $target_baseline_path, string $source_index_file): void
+    private function replace_file(string $target, string $source_index_file): void
     {
         if (!is_file($source_index_file)) {
             throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$source_index_file}");
         }
         $this->ensure_site_dir();
-        $tmp = $target_baseline_path . ".tmp";
+        $tmp = $target . ".tmp";
         if (!copy($source_index_file, $tmp)) {
             throw new RuntimeException("Failed to copy the index into a baseline temp file: {$tmp}");
         }
-        if (!rename($tmp, $target_baseline_path)) {
-            throw new RuntimeException("Failed to move the baseline into place: {$target_baseline_path}");
+        if (!rename($tmp, $target)) {
+            throw new RuntimeException("Failed to move the baseline into place: {$target}");
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -250,15 +250,15 @@ class PushJournal
         string $deleted_paths_file,
         bool $missing_baseline_marks_current_changed
     ): array {
-        $current_handle = fopen($current_index_file, "r");
-        if (!$current_handle) {
+        $current_index_handle = fopen($current_index_file, "r");
+        if (!$current_index_handle) {
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
-        $baseline_handle = null;
+        $baseline_index_handle = null;
         if ($baseline_index_file !== null && is_file($baseline_index_file)) {
-            $baseline_handle = fopen($baseline_index_file, "r");
-            if (!$baseline_handle) {
-                fclose($current_handle);
+            $baseline_index_handle = fopen($baseline_index_file, "r");
+            if (!$baseline_index_handle) {
+                fclose($current_index_handle);
                 throw new RuntimeException("Failed to open the baseline index: {$baseline_index_file}");
             }
         }
@@ -266,18 +266,18 @@ class PushJournal
         $changed_paths_tmp = $changed_paths_file . ".tmp";
         $changed_paths_handle = fopen($changed_paths_tmp, "w");
         if (!$changed_paths_handle) {
-            fclose($current_handle);
-            if ($baseline_handle) {
-                fclose($baseline_handle);
+            fclose($current_index_handle);
+            if ($baseline_index_handle) {
+                fclose($baseline_index_handle);
             }
             throw new RuntimeException("Failed to open changed paths list for writing: {$changed_paths_tmp}");
         }
         $deleted_paths_tmp = $deleted_paths_file . ".tmp";
         $deleted_paths_handle = fopen($deleted_paths_tmp, "w");
         if (!$deleted_paths_handle) {
-            fclose($current_handle);
-            if ($baseline_handle) {
-                fclose($baseline_handle);
+            fclose($current_index_handle);
+            if ($baseline_index_handle) {
+                fclose($baseline_index_handle);
             }
             fclose($changed_paths_handle);
             throw new RuntimeException("Failed to open deleted paths list for writing: {$deleted_paths_tmp}");
@@ -285,58 +285,58 @@ class PushJournal
 
         $changed = 0;
         $deleted = 0;
-        $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
-        $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
-        while ($current_entry !== null || $baseline_entry !== null) {
+        $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
+        $this->read_line($baseline_index_handle, $baseline_index_entry, $baseline_index_path, $baseline_index_base64_path);
+        while ($current_entry !== null || $baseline_index_entry !== null) {
             // base64 does not preserve byte order ('0' sorts before 'A' in
             // ASCII but encodes a higher value), so ordering has to use the
             // decoded paths.
-            if ($baseline_entry === null) {
+            if ($baseline_index_entry === null) {
                 $order = -1;
             } elseif ($current_entry === null) {
                 $order = 1;
             } else {
-                $order = strcmp($current_path, $baseline_path);
+                $order = strcmp($current_path, $baseline_index_path);
             }
 
             if ($order < 0) {
                 // Only in the current index: new since the last push.
-                if ($baseline_handle || $missing_baseline_marks_current_changed) {
+                if ($baseline_index_handle || $missing_baseline_marks_current_changed) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                     if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
                         throw new RuntimeException("Short write on changed paths list, is the disk full?");
                     }
                     $changed++;
                 }
-                $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
+                $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
             } elseif ($order > 0) {
                 // Only in the baseline: deleted since the last push.
-                $out = json_encode(["path" => $baseline_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                $out = json_encode(["path" => $baseline_index_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                 if (fwrite($deleted_paths_handle, $out) !== strlen($out)) {
                     throw new RuntimeException("Short write on deleted paths list, is the disk full?");
                 }
                 $deleted++;
-                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+                $this->read_line($baseline_index_handle, $baseline_index_entry, $baseline_index_path, $baseline_index_base64_path);
             } else {
                 // Same path on both sides. Decoded JSON array comparison keeps
                 // field order and slash escaping out of change detection. A
                 // writer field change would mark everything changed once (a
                 // wasted re-upload, never a missed one).
-                if ($current_entry != $baseline_entry) {
+                if ($current_entry != $baseline_index_entry) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                     if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
                         throw new RuntimeException("Short write on changed paths list, is the disk full?");
                     }
                     $changed++;
                 }
-                $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
-                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+                $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
+                $this->read_line($baseline_index_handle, $baseline_index_entry, $baseline_index_path, $baseline_index_base64_path);
             }
         }
 
-        fclose($current_handle);
-        if ($baseline_handle) {
-            fclose($baseline_handle);
+        fclose($current_index_handle);
+        if ($baseline_index_handle) {
+            fclose($baseline_index_handle);
         }
         if (!fclose($changed_paths_handle) || !rename($changed_paths_tmp, $changed_paths_file)) {
             throw new RuntimeException("Failed to move changed paths list into place: {$changed_paths_file}");
@@ -357,103 +357,103 @@ class PushJournal
      * merge keeps memory constant and ignores remote baseline entries outside
      * the local push scope.
      */
-    private function write_scoped_remote_baseline(string $target): void
+    private function write_scoped_remote_baseline(string $scoped_remote_baseline_path): void
     {
-        $baseline_handle = fopen($this->remote_files_baseline_path, "r");
-        if (!$baseline_handle) {
+        $remote_baseline_handle = fopen($this->remote_files_baseline_path, "r");
+        if (!$remote_baseline_handle) {
             throw new RuntimeException("Failed to open the remote baseline: {$this->remote_files_baseline_path}");
         }
-        $paths_to_push_handle = fopen($this->local_paths_to_push, "r");
-        if (!$paths_to_push_handle) {
-            fclose($baseline_handle);
+        $local_paths_to_push_handle = fopen($this->local_paths_to_push, "r");
+        if (!$local_paths_to_push_handle) {
+            fclose($remote_baseline_handle);
             throw new RuntimeException("Failed to open local_paths_to_push: {$this->local_paths_to_push}");
         }
-        $paths_to_delete_handle = fopen($this->local_paths_to_delete, "r");
-        if (!$paths_to_delete_handle) {
-            fclose($baseline_handle);
-            fclose($paths_to_push_handle);
+        $local_paths_to_delete_handle = fopen($this->local_paths_to_delete, "r");
+        if (!$local_paths_to_delete_handle) {
+            fclose($remote_baseline_handle);
+            fclose($local_paths_to_push_handle);
             throw new RuntimeException("Failed to open local_paths_to_delete: {$this->local_paths_to_delete}");
         }
-        $target_handle = fopen($target, "w");
-        if (!$target_handle) {
-            fclose($baseline_handle);
-            fclose($paths_to_push_handle);
-            fclose($paths_to_delete_handle);
-            throw new RuntimeException("Failed to open scoped remote baseline for writing: {$target}");
+        $scoped_remote_baseline_handle = fopen($scoped_remote_baseline_path, "w");
+        if (!$scoped_remote_baseline_handle) {
+            fclose($remote_baseline_handle);
+            fclose($local_paths_to_push_handle);
+            fclose($local_paths_to_delete_handle);
+            throw new RuntimeException("Failed to open scoped remote baseline for writing: {$scoped_remote_baseline_path}");
         }
 
-        $last_scope_path = null;
-        $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
-        $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
-        $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+        $last_local_scope_path = null;
+        $this->read_line($remote_baseline_handle, $remote_baseline_entry, $remote_baseline_path, $remote_baseline_base64_path);
+        $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
+        $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
 
-        while ($baseline_entry !== null && ($path_to_push_entry !== null || $path_to_delete_entry !== null)) {
-            if ($path_to_push_entry !== null && ($path_to_delete_entry === null || strcmp($path_to_push, $path_to_delete) <= 0)) {
-                $scope_path = $path_to_push;
+        while ($remote_baseline_entry !== null && ($local_path_to_push_entry !== null || $local_path_to_delete_entry !== null)) {
+            if ($local_path_to_push_entry !== null && ($local_path_to_delete_entry === null || strcmp($local_path_to_push, $local_path_to_delete) <= 0)) {
+                $local_scope_path = $local_path_to_push;
             } else {
-                $scope_path = $path_to_delete;
+                $local_scope_path = $local_path_to_delete;
             }
 
-            if ($scope_path === $last_scope_path) {
-                if ($path_to_push === $scope_path) {
-                    $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+            if ($local_scope_path === $last_local_scope_path) {
+                if ($local_path_to_push === $local_scope_path) {
+                    $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
                 }
-                if ($path_to_delete === $scope_path) {
-                    $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+                if ($local_path_to_delete === $local_scope_path) {
+                    $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
                 }
                 continue;
             }
 
-            $order = strcmp($baseline_path, $scope_path);
+            $order = strcmp($remote_baseline_path, $local_scope_path);
             if ($order < 0) {
-                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+                $this->read_line($remote_baseline_handle, $remote_baseline_entry, $remote_baseline_path, $remote_baseline_base64_path);
                 continue;
             }
             if ($order > 0) {
-                $last_scope_path = $scope_path;
-                if ($path_to_push === $scope_path) {
-                    $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+                $last_local_scope_path = $local_scope_path;
+                if ($local_path_to_push === $local_scope_path) {
+                    $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
                 }
-                if ($path_to_delete === $scope_path) {
-                    $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+                if ($local_path_to_delete === $local_scope_path) {
+                    $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
                 }
                 continue;
             }
 
-            $line = json_encode($baseline_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-            if (fwrite($target_handle, $line) !== strlen($line)) {
+            $line = json_encode($remote_baseline_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            if (fwrite($scoped_remote_baseline_handle, $line) !== strlen($line)) {
                 throw new RuntimeException("Short write on scoped remote baseline, is the disk full?");
             }
-            $last_scope_path = $scope_path;
-            $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
-            if ($path_to_push === $scope_path) {
-                $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+            $last_local_scope_path = $local_scope_path;
+            $this->read_line($remote_baseline_handle, $remote_baseline_entry, $remote_baseline_path, $remote_baseline_base64_path);
+            if ($local_path_to_push === $local_scope_path) {
+                $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
             }
-            if ($path_to_delete === $scope_path) {
-                $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+            if ($local_path_to_delete === $local_scope_path) {
+                $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
             }
         }
 
-        fclose($baseline_handle);
-        fclose($paths_to_push_handle);
-        fclose($paths_to_delete_handle);
-        if (!fclose($target_handle)) {
-            throw new RuntimeException("Failed to close scoped remote baseline: {$target}");
+        fclose($remote_baseline_handle);
+        fclose($local_paths_to_push_handle);
+        fclose($local_paths_to_delete_handle);
+        if (!fclose($scoped_remote_baseline_handle)) {
+            throw new RuntimeException("Failed to close scoped remote baseline: {$scoped_remote_baseline_path}");
         }
     }
 
     /**
      * Atomically replace a JSONL list with an empty file.
      */
-    private function write_empty_jsonl(string $target): void
+    private function write_empty_jsonl(string $jsonl_path): void
     {
-        $tmp = $target . ".tmp";
+        $tmp = $jsonl_path . ".tmp";
         $handle = fopen($tmp, "w");
         if (!$handle) {
             throw new RuntimeException("Failed to open empty JSONL temp file for writing: {$tmp}");
         }
-        if (!fclose($handle) || !rename($tmp, $target)) {
-            throw new RuntimeException("Failed to move empty JSONL file into place: {$target}");
+        if (!fclose($handle) || !rename($tmp, $jsonl_path)) {
+            throw new RuntimeException("Failed to move empty JSONL file into place: {$jsonl_path}");
         }
     }
 
@@ -501,18 +501,18 @@ class PushJournal
      * Copy an index file over a baseline: temp file in the same directory,
      * then rename, so readers only ever see the old or the new baseline.
      */
-    private function replace_file(string $target, string $source_index_file): void
+    private function replace_file(string $scoped_remote_baseline_path, string $source_index_file): void
     {
         if (!is_file($source_index_file)) {
             throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$source_index_file}");
         }
         $this->ensure_site_dir();
-        $tmp = $target . ".tmp";
+        $tmp = $scoped_remote_baseline_path . ".tmp";
         if (!copy($source_index_file, $tmp)) {
             throw new RuntimeException("Failed to copy the index into a baseline temp file: {$tmp}");
         }
-        if (!rename($tmp, $target)) {
-            throw new RuntimeException("Failed to move the baseline into place: {$target}");
+        if (!rename($tmp, $scoped_remote_baseline_path)) {
+            throw new RuntimeException("Failed to move the baseline into place: {$scoped_remote_baseline_path}");
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -214,19 +214,19 @@ class PushJournal
             return ["changed" => 0, "deleted" => 0, "baseline_missing" => true];
         }
 
-        $scoped_remote_baseline = $this->site_dir . "/remote-baseline-for-local-paths.jsonl.tmp";
-        $this->write_scoped_remote_baseline($scoped_remote_baseline);
+        $scoped_last_synced_remote_index = $this->site_dir . "/last-synced-remote-index-for-local-paths.jsonl.tmp";
+        $this->write_scoped_last_synced_remote_index($scoped_last_synced_remote_index);
         try {
             $counts = $this->diff_index_files(
                 $current_remote_index_file,
-                $scoped_remote_baseline,
+                $scoped_last_synced_remote_index,
                 $this->remote_paths_changed_since_last_sync,
                 $this->remote_paths_deleted_since_last_sync,
                 false
             );
         } finally {
-            if (is_file($scoped_remote_baseline)) {
-                unlink($scoped_remote_baseline);
+            if (is_file($scoped_last_synced_remote_index)) {
+                unlink($scoped_last_synced_remote_index);
             }
         }
 
@@ -245,21 +245,21 @@ class PushJournal
      */
     private function diff_index_files(
         string $current_index_file,
-        ?string $baseline_index_file,
+        ?string $previous_index_file,
         string $changed_paths_file,
         string $deleted_paths_file,
-        bool $missing_baseline_marks_current_changed
+        bool $missing_previous_index_marks_current_changed
     ): array {
         $current_index_handle = fopen($current_index_file, "r");
         if (!$current_index_handle) {
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
-        $baseline_index_handle = null;
-        if ($baseline_index_file !== null && is_file($baseline_index_file)) {
-            $baseline_index_handle = fopen($baseline_index_file, "r");
-            if (!$baseline_index_handle) {
+        $previous_index_handle = null;
+        if ($previous_index_file !== null && is_file($previous_index_file)) {
+            $previous_index_handle = fopen($previous_index_file, "r");
+            if (!$previous_index_handle) {
                 fclose($current_index_handle);
-                throw new RuntimeException("Failed to open the baseline index: {$baseline_index_file}");
+                throw new RuntimeException("Failed to open the previous index: {$previous_index_file}");
             }
         }
 
@@ -267,8 +267,8 @@ class PushJournal
         $changed_paths_handle = fopen($changed_paths_tmp, "w");
         if (!$changed_paths_handle) {
             fclose($current_index_handle);
-            if ($baseline_index_handle) {
-                fclose($baseline_index_handle);
+            if ($previous_index_handle) {
+                fclose($previous_index_handle);
             }
             throw new RuntimeException("Failed to open changed paths list for writing: {$changed_paths_tmp}");
         }
@@ -276,8 +276,8 @@ class PushJournal
         $deleted_paths_handle = fopen($deleted_paths_tmp, "w");
         if (!$deleted_paths_handle) {
             fclose($current_index_handle);
-            if ($baseline_index_handle) {
-                fclose($baseline_index_handle);
+            if ($previous_index_handle) {
+                fclose($previous_index_handle);
             }
             fclose($changed_paths_handle);
             throw new RuntimeException("Failed to open deleted paths list for writing: {$deleted_paths_tmp}");
@@ -286,22 +286,22 @@ class PushJournal
         $changed = 0;
         $deleted = 0;
         $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
-        $this->read_line($baseline_index_handle, $baseline_index_entry, $baseline_index_path, $baseline_index_base64_path);
-        while ($current_entry !== null || $baseline_index_entry !== null) {
+        $this->read_line($previous_index_handle, $previous_index_entry, $previous_index_path, $previous_index_base64_path);
+        while ($current_entry !== null || $previous_index_entry !== null) {
             // base64 does not preserve byte order ('0' sorts before 'A' in
             // ASCII but encodes a higher value), so ordering has to use the
             // decoded paths.
-            if ($baseline_index_entry === null) {
+            if ($previous_index_entry === null) {
                 $order = -1;
             } elseif ($current_entry === null) {
                 $order = 1;
             } else {
-                $order = strcmp($current_path, $baseline_index_path);
+                $order = strcmp($current_path, $previous_index_path);
             }
 
             if ($order < 0) {
                 // Only in the current index: new since the last push.
-                if ($baseline_index_handle || $missing_baseline_marks_current_changed) {
+                if ($previous_index_handle || $missing_previous_index_marks_current_changed) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                     if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
                         throw new RuntimeException("Short write on changed paths list, is the disk full?");
@@ -310,19 +310,19 @@ class PushJournal
                 }
                 $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
             } elseif ($order > 0) {
-                // Only in the baseline: deleted since the last push.
-                $out = json_encode(["path" => $baseline_index_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                // Only in the previous index: deleted since the last push.
+                $out = json_encode(["path" => $previous_index_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                 if (fwrite($deleted_paths_handle, $out) !== strlen($out)) {
                     throw new RuntimeException("Short write on deleted paths list, is the disk full?");
                 }
                 $deleted++;
-                $this->read_line($baseline_index_handle, $baseline_index_entry, $baseline_index_path, $baseline_index_base64_path);
+                $this->read_line($previous_index_handle, $previous_index_entry, $previous_index_path, $previous_index_base64_path);
             } else {
                 // Same path on both sides. Decoded JSON array comparison keeps
                 // field order and slash escaping out of change detection. A
                 // writer field change would mark everything changed once (a
                 // wasted re-upload, never a missed one).
-                if ($current_entry != $baseline_index_entry) {
+                if ($current_entry != $previous_index_entry) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                     if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
                         throw new RuntimeException("Short write on changed paths list, is the disk full?");
@@ -330,13 +330,13 @@ class PushJournal
                     $changed++;
                 }
                 $this->read_line($current_index_handle, $current_entry, $current_path, $current_base64_path);
-                $this->read_line($baseline_index_handle, $baseline_index_entry, $baseline_index_path, $baseline_index_base64_path);
+                $this->read_line($previous_index_handle, $previous_index_entry, $previous_index_path, $previous_index_base64_path);
             }
         }
 
         fclose($current_index_handle);
-        if ($baseline_index_handle) {
-            fclose($baseline_index_handle);
+        if ($previous_index_handle) {
+            fclose($previous_index_handle);
         }
         if (!fclose($changed_paths_handle) || !rename($changed_paths_tmp, $changed_paths_file)) {
             throw new RuntimeException("Failed to move changed paths list into place: {$changed_paths_file}");
@@ -349,45 +349,45 @@ class PushJournal
     }
 
     /**
-     * Write the remote baseline entries for paths this push will touch.
+     * Write the last-synced remote index entries for paths this push will touch.
      *
      * local_paths_to_push and local_paths_to_delete are already sorted by
      * decoded path because diff_local_files() writes them during a merge over
-     * the sorted local index. The remote baseline is sorted the same way. This
-     * merge keeps memory constant and ignores remote baseline entries outside
-     * the local push scope.
+     * the sorted local index. The last-synced remote index is sorted the same
+     * way. This merge keeps memory constant and ignores last-synced remote
+     * entries outside the local push scope.
      */
-    private function write_scoped_remote_baseline(string $scoped_remote_baseline_path): void
+    private function write_scoped_last_synced_remote_index(string $scoped_last_synced_remote_index_path): void
     {
-        $remote_baseline_handle = fopen($this->remote_files_baseline_path, "r");
-        if (!$remote_baseline_handle) {
-            throw new RuntimeException("Failed to open the remote baseline: {$this->remote_files_baseline_path}");
+        $last_synced_remote_index_handle = fopen($this->remote_files_baseline_path, "r");
+        if (!$last_synced_remote_index_handle) {
+            throw new RuntimeException("Failed to open the last-synced remote index: {$this->remote_files_baseline_path}");
         }
         $local_paths_to_push_handle = fopen($this->local_paths_to_push, "r");
         if (!$local_paths_to_push_handle) {
-            fclose($remote_baseline_handle);
+            fclose($last_synced_remote_index_handle);
             throw new RuntimeException("Failed to open local_paths_to_push: {$this->local_paths_to_push}");
         }
         $local_paths_to_delete_handle = fopen($this->local_paths_to_delete, "r");
         if (!$local_paths_to_delete_handle) {
-            fclose($remote_baseline_handle);
+            fclose($last_synced_remote_index_handle);
             fclose($local_paths_to_push_handle);
             throw new RuntimeException("Failed to open local_paths_to_delete: {$this->local_paths_to_delete}");
         }
-        $scoped_remote_baseline_handle = fopen($scoped_remote_baseline_path, "w");
-        if (!$scoped_remote_baseline_handle) {
-            fclose($remote_baseline_handle);
+        $scoped_last_synced_remote_index_handle = fopen($scoped_last_synced_remote_index_path, "w");
+        if (!$scoped_last_synced_remote_index_handle) {
+            fclose($last_synced_remote_index_handle);
             fclose($local_paths_to_push_handle);
             fclose($local_paths_to_delete_handle);
-            throw new RuntimeException("Failed to open scoped remote baseline for writing: {$scoped_remote_baseline_path}");
+            throw new RuntimeException("Failed to open scoped last-synced remote index for writing: {$scoped_last_synced_remote_index_path}");
         }
 
         $last_local_scope_path = null;
-        $this->read_line($remote_baseline_handle, $remote_baseline_entry, $remote_baseline_path, $remote_baseline_base64_path);
+        $this->read_line($last_synced_remote_index_handle, $last_synced_remote_entry, $last_synced_remote_path, $last_synced_remote_base64_path);
         $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
         $this->read_line($local_paths_to_delete_handle, $local_path_to_delete_entry, $local_path_to_delete, $local_path_to_delete_base64);
 
-        while ($remote_baseline_entry !== null && ($local_path_to_push_entry !== null || $local_path_to_delete_entry !== null)) {
+        while ($last_synced_remote_entry !== null && ($local_path_to_push_entry !== null || $local_path_to_delete_entry !== null)) {
             if ($local_path_to_push_entry !== null && ($local_path_to_delete_entry === null || strcmp($local_path_to_push, $local_path_to_delete) <= 0)) {
                 $local_scope_path = $local_path_to_push;
             } else {
@@ -404,9 +404,9 @@ class PushJournal
                 continue;
             }
 
-            $order = strcmp($remote_baseline_path, $local_scope_path);
+            $order = strcmp($last_synced_remote_path, $local_scope_path);
             if ($order < 0) {
-                $this->read_line($remote_baseline_handle, $remote_baseline_entry, $remote_baseline_path, $remote_baseline_base64_path);
+                $this->read_line($last_synced_remote_index_handle, $last_synced_remote_entry, $last_synced_remote_path, $last_synced_remote_base64_path);
                 continue;
             }
             if ($order > 0) {
@@ -420,12 +420,12 @@ class PushJournal
                 continue;
             }
 
-            $line = json_encode($remote_baseline_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-            if (fwrite($scoped_remote_baseline_handle, $line) !== strlen($line)) {
-                throw new RuntimeException("Short write on scoped remote baseline, is the disk full?");
+            $line = json_encode($last_synced_remote_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            if (fwrite($scoped_last_synced_remote_index_handle, $line) !== strlen($line)) {
+                throw new RuntimeException("Short write on scoped last-synced remote index, is the disk full?");
             }
             $last_local_scope_path = $local_scope_path;
-            $this->read_line($remote_baseline_handle, $remote_baseline_entry, $remote_baseline_path, $remote_baseline_base64_path);
+            $this->read_line($last_synced_remote_index_handle, $last_synced_remote_entry, $last_synced_remote_path, $last_synced_remote_base64_path);
             if ($local_path_to_push === $local_scope_path) {
                 $this->read_line($local_paths_to_push_handle, $local_path_to_push_entry, $local_path_to_push, $local_path_to_push_base64);
             }
@@ -434,11 +434,11 @@ class PushJournal
             }
         }
 
-        fclose($remote_baseline_handle);
+        fclose($last_synced_remote_index_handle);
         fclose($local_paths_to_push_handle);
         fclose($local_paths_to_delete_handle);
-        if (!fclose($scoped_remote_baseline_handle)) {
-            throw new RuntimeException("Failed to close scoped remote baseline: {$scoped_remote_baseline_path}");
+        if (!fclose($scoped_last_synced_remote_index_handle)) {
+            throw new RuntimeException("Failed to close scoped last-synced remote index: {$scoped_last_synced_remote_index_path}");
         }
     }
 
@@ -501,18 +501,18 @@ class PushJournal
      * Copy an index file over a baseline: temp file in the same directory,
      * then rename, so readers only ever see the old or the new baseline.
      */
-    private function replace_file(string $scoped_remote_baseline_path, string $source_index_file): void
+    private function replace_file(string $target_baseline_path, string $source_index_file): void
     {
         if (!is_file($source_index_file)) {
             throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$source_index_file}");
         }
         $this->ensure_site_dir();
-        $tmp = $scoped_remote_baseline_path . ".tmp";
+        $tmp = $target_baseline_path . ".tmp";
         if (!copy($source_index_file, $tmp)) {
             throw new RuntimeException("Failed to copy the index into a baseline temp file: {$tmp}");
         }
-        if (!rename($tmp, $scoped_remote_baseline_path)) {
-            throw new RuntimeException("Failed to move the baseline into place: {$scoped_remote_baseline_path}");
+        if (!rename($tmp, $target_baseline_path)) {
+            throw new RuntimeException("Failed to move the baseline into place: {$target_baseline_path}");
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -201,17 +201,17 @@ class PushJournal
         }
         $this->ensure_site_dir();
 
-        if (!is_file($this->remote_files_baseline_path)) {
-            $this->write_empty_jsonl($this->remote_paths_changed_since_last_sync);
-            $this->write_empty_jsonl($this->remote_paths_deleted_since_last_sync);
-            return ["changed" => 0, "deleted" => 0, "baseline_missing" => true];
-        }
-
         if (!is_file($this->local_paths_to_push)) {
             throw new RuntimeException("Cannot diff remote drift, local_paths_to_push is missing: {$this->local_paths_to_push}");
         }
         if (!is_file($this->local_paths_to_delete)) {
             throw new RuntimeException("Cannot diff remote drift, local_paths_to_delete is missing: {$this->local_paths_to_delete}");
+        }
+
+        if (!is_file($this->remote_files_baseline_path)) {
+            $this->write_empty_jsonl($this->remote_paths_changed_since_last_sync);
+            $this->write_empty_jsonl($this->remote_paths_deleted_since_last_sync);
+            return ["changed" => 0, "deleted" => 0, "baseline_missing" => true];
         }
 
         $scoped_remote_baseline = $this->site_dir . "/remote-baseline-for-local-paths.jsonl.tmp";
@@ -395,17 +395,12 @@ class PushJournal
             }
 
             if ($scope_path === $last_scope_path) {
-                $this->advance_scope_path(
-                    $scope_path,
-                    $paths_to_push_handle,
-                    $path_to_push_entry,
-                    $path_to_push,
-                    $path_to_push_base64,
-                    $paths_to_delete_handle,
-                    $path_to_delete_entry,
-                    $path_to_delete,
-                    $path_to_delete_base64
-                );
+                if ($path_to_push === $scope_path) {
+                    $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+                }
+                if ($path_to_delete === $scope_path) {
+                    $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+                }
                 continue;
             }
 
@@ -416,17 +411,12 @@ class PushJournal
             }
             if ($order > 0) {
                 $last_scope_path = $scope_path;
-                $this->advance_scope_path(
-                    $scope_path,
-                    $paths_to_push_handle,
-                    $path_to_push_entry,
-                    $path_to_push,
-                    $path_to_push_base64,
-                    $paths_to_delete_handle,
-                    $path_to_delete_entry,
-                    $path_to_delete,
-                    $path_to_delete_base64
-                );
+                if ($path_to_push === $scope_path) {
+                    $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+                }
+                if ($path_to_delete === $scope_path) {
+                    $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+                }
                 continue;
             }
 
@@ -436,17 +426,12 @@ class PushJournal
             }
             $last_scope_path = $scope_path;
             $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
-            $this->advance_scope_path(
-                $scope_path,
-                $paths_to_push_handle,
-                $path_to_push_entry,
-                $path_to_push,
-                $path_to_push_base64,
-                $paths_to_delete_handle,
-                $path_to_delete_entry,
-                $path_to_delete,
-                $path_to_delete_base64
-            );
+            if ($path_to_push === $scope_path) {
+                $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+            }
+            if ($path_to_delete === $scope_path) {
+                $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+            }
         }
 
         fclose($baseline_handle);
@@ -454,33 +439,6 @@ class PushJournal
         fclose($paths_to_delete_handle);
         if (!fclose($target_handle)) {
             throw new RuntimeException("Failed to close scoped remote baseline: {$target}");
-        }
-    }
-
-    /**
-     * Advance both local scope lists past one decoded path.
-     *
-     * @param resource $paths_to_push_handle
-     * @param array<string, mixed>|null $path_to_push_entry
-     * @param resource $paths_to_delete_handle
-     * @param array<string, mixed>|null $path_to_delete_entry
-     */
-    private function advance_scope_path(
-        string $scope_path,
-        $paths_to_push_handle,
-        ?array &$path_to_push_entry,
-        ?string &$path_to_push,
-        ?string &$path_to_push_base64,
-        $paths_to_delete_handle,
-        ?array &$path_to_delete_entry,
-        ?string &$path_to_delete,
-        ?string &$path_to_delete_base64
-    ): void {
-        if ($path_to_push === $scope_path) {
-            $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
-        }
-        if ($path_to_delete === $scope_path) {
-            $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -40,6 +40,12 @@
  * With no baseline yet — the first push to a site — every current entry
  * counts as changed and no deletion can be detected.
  *
+ * diff_remote_files() answers "did the remote change any path this push is
+ * about to touch". Its current index input must be the scoped remote reindex
+ * for local_paths_to_push plus local_paths_to_delete. The remote baseline is
+ * filtered to that same scope before comparison, so unrelated remote changes
+ * do not block a push.
+ *
  * Producing the current index is the caller's job; this class only
  * compares and stores. The lists belong to the run that produced them:
  * a resumed push reruns the diff (one cheap local pass) rather than
@@ -61,6 +67,12 @@ class PushJournal
     /** @var string JSONL file of local paths whose deletion should be pushed, written by diff_local_files(). */
     public string $local_paths_to_delete;
 
+    /** @var string JSONL file of scoped remote paths changed since the remote baseline. */
+    public string $remote_paths_changed_since_last_sync;
+
+    /** @var string JSONL file of scoped remote paths deleted since the remote baseline. */
+    public string $remote_paths_deleted_since_last_sync;
+
     public function __construct(string $state_dir, string $site_url)
     {
         $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
@@ -68,6 +80,8 @@ class PushJournal
         $this->remote_files_baseline_path = $this->site_dir . "/last-sync-remote-files.jsonl";
         $this->local_paths_to_push = $this->site_dir . "/local-paths-to-push.jsonl";
         $this->local_paths_to_delete = $this->site_dir . "/local-paths-to-delete.jsonl";
+        $this->remote_paths_changed_since_last_sync = $this->site_dir . "/remote-paths-changed-since-last-sync.jsonl";
+        $this->remote_paths_deleted_since_last_sync = $this->site_dir . "/remote-paths-deleted-since-last-sync.jsonl";
     }
 
     /**
@@ -155,37 +169,118 @@ class PushJournal
         }
         $this->ensure_site_dir();
 
+        return $this->diff_index_files(
+            $current_index_file,
+            is_file($this->local_files_baseline_path) ? $this->local_files_baseline_path : null,
+            $this->local_paths_to_push,
+            $this->local_paths_to_delete,
+            true
+        );
+    }
+
+    /**
+     * Compare a scoped current remote index against the remote baseline and
+     * write the remote paths that changed or disappeared since the last sync.
+     *
+     * The scoped current remote index must contain exactly the paths from the
+     * local push/delete lists that still exist on the remote. The method
+     * filters the stored remote baseline to those same local paths before the
+     * merge, so a remote edit outside the pushed scope cannot become a false
+     * conflict.
+     *
+     * If there is no remote baseline yet, this is the first push to the site:
+     * drift cannot be detected, stale drift lists are replaced with empty
+     * files, and baseline_missing is true for the summary UI.
+     *
+     * @return array{changed: int, deleted: int, baseline_missing: bool} Entry counts, for the push summary.
+     */
+    public function diff_remote_files(string $current_remote_index_file): array
+    {
+        if (!is_file($current_remote_index_file)) {
+            throw new RuntimeException("Cannot diff, the current remote index file is missing: {$current_remote_index_file}");
+        }
+        $this->ensure_site_dir();
+
+        if (!is_file($this->remote_files_baseline_path)) {
+            $this->write_empty_jsonl($this->remote_paths_changed_since_last_sync);
+            $this->write_empty_jsonl($this->remote_paths_deleted_since_last_sync);
+            return ["changed" => 0, "deleted" => 0, "baseline_missing" => true];
+        }
+
+        if (!is_file($this->local_paths_to_push)) {
+            throw new RuntimeException("Cannot diff remote drift, local_paths_to_push is missing: {$this->local_paths_to_push}");
+        }
+        if (!is_file($this->local_paths_to_delete)) {
+            throw new RuntimeException("Cannot diff remote drift, local_paths_to_delete is missing: {$this->local_paths_to_delete}");
+        }
+
+        $scoped_remote_baseline = $this->site_dir . "/remote-baseline-for-local-paths.jsonl.tmp";
+        $this->write_scoped_remote_baseline($scoped_remote_baseline);
+        try {
+            $counts = $this->diff_index_files(
+                $current_remote_index_file,
+                $scoped_remote_baseline,
+                $this->remote_paths_changed_since_last_sync,
+                $this->remote_paths_deleted_since_last_sync,
+                false
+            );
+        } finally {
+            if (is_file($scoped_remote_baseline)) {
+                unlink($scoped_remote_baseline);
+            }
+        }
+
+        return [
+            "changed" => $counts["changed"],
+            "deleted" => $counts["deleted"],
+            "baseline_missing" => false,
+        ];
+    }
+
+    /**
+     * Compare two sorted index files and write {"path": <base64>} lists for
+     * entries that changed or disappeared.
+     *
+     * @return array{changed: int, deleted: int}
+     */
+    private function diff_index_files(
+        string $current_index_file,
+        ?string $baseline_index_file,
+        string $changed_paths_file,
+        string $deleted_paths_file,
+        bool $missing_baseline_marks_current_changed
+    ): array {
         $current_handle = fopen($current_index_file, "r");
         if (!$current_handle) {
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
         $baseline_handle = null;
-        if (is_file($this->local_files_baseline_path)) {
-            $baseline_handle = fopen($this->local_files_baseline_path, "r");
+        if ($baseline_index_file !== null && is_file($baseline_index_file)) {
+            $baseline_handle = fopen($baseline_index_file, "r");
             if (!$baseline_handle) {
                 fclose($current_handle);
-                throw new RuntimeException("Failed to open the local baseline: {$this->local_files_baseline_path}");
+                throw new RuntimeException("Failed to open the baseline index: {$baseline_index_file}");
             }
         }
 
-        $local_paths_to_push_tmp = $this->local_paths_to_push . ".tmp";
-        $paths_to_push_handle = fopen($local_paths_to_push_tmp, "w");
-        if (!$paths_to_push_handle) {
+        $changed_paths_tmp = $changed_paths_file . ".tmp";
+        $changed_paths_handle = fopen($changed_paths_tmp, "w");
+        if (!$changed_paths_handle) {
             fclose($current_handle);
             if ($baseline_handle) {
                 fclose($baseline_handle);
             }
-            throw new RuntimeException("Failed to open local_paths_to_push for writing: {$local_paths_to_push_tmp}");
+            throw new RuntimeException("Failed to open changed paths list for writing: {$changed_paths_tmp}");
         }
-        $local_paths_to_delete_tmp = $this->local_paths_to_delete . ".tmp";
-        $paths_to_delete_handle = fopen($local_paths_to_delete_tmp, "w");
-        if (!$paths_to_delete_handle) {
+        $deleted_paths_tmp = $deleted_paths_file . ".tmp";
+        $deleted_paths_handle = fopen($deleted_paths_tmp, "w");
+        if (!$deleted_paths_handle) {
             fclose($current_handle);
             if ($baseline_handle) {
                 fclose($baseline_handle);
             }
-            fclose($paths_to_push_handle);
-            throw new RuntimeException("Failed to open local_paths_to_delete for writing: {$local_paths_to_delete_tmp}");
+            fclose($changed_paths_handle);
+            throw new RuntimeException("Failed to open deleted paths list for writing: {$deleted_paths_tmp}");
         }
 
         $changed = 0;
@@ -206,17 +301,19 @@ class PushJournal
 
             if ($order < 0) {
                 // Only in the current index: new since the last push.
-                $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                if (fwrite($paths_to_push_handle, $out) !== strlen($out)) {
-                    throw new RuntimeException("Short write on local_paths_to_push, is the disk full?");
+                if ($baseline_handle || $missing_baseline_marks_current_changed) {
+                    $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                    if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
+                        throw new RuntimeException("Short write on changed paths list, is the disk full?");
+                    }
+                    $changed++;
                 }
-                $changed++;
                 $this->read_line($current_handle, $current_entry, $current_path, $current_base64_path);
             } elseif ($order > 0) {
                 // Only in the baseline: deleted since the last push.
                 $out = json_encode(["path" => $baseline_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                if (fwrite($paths_to_delete_handle, $out) !== strlen($out)) {
-                    throw new RuntimeException("Short write on local_paths_to_delete, is the disk full?");
+                if (fwrite($deleted_paths_handle, $out) !== strlen($out)) {
+                    throw new RuntimeException("Short write on deleted paths list, is the disk full?");
                 }
                 $deleted++;
                 $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
@@ -227,8 +324,8 @@ class PushJournal
                 // wasted re-upload, never a missed one).
                 if ($current_entry != $baseline_entry) {
                     $out = json_encode(["path" => $current_base64_path], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-                    if (fwrite($paths_to_push_handle, $out) !== strlen($out)) {
-                        throw new RuntimeException("Short write on local_paths_to_push, is the disk full?");
+                    if (fwrite($changed_paths_handle, $out) !== strlen($out)) {
+                        throw new RuntimeException("Short write on changed paths list, is the disk full?");
                     }
                     $changed++;
                 }
@@ -241,14 +338,165 @@ class PushJournal
         if ($baseline_handle) {
             fclose($baseline_handle);
         }
-        if (!fclose($paths_to_push_handle) || !rename($local_paths_to_push_tmp, $this->local_paths_to_push)) {
-            throw new RuntimeException("Failed to move local_paths_to_push into place: {$this->local_paths_to_push}");
+        if (!fclose($changed_paths_handle) || !rename($changed_paths_tmp, $changed_paths_file)) {
+            throw new RuntimeException("Failed to move changed paths list into place: {$changed_paths_file}");
         }
-        if (!fclose($paths_to_delete_handle) || !rename($local_paths_to_delete_tmp, $this->local_paths_to_delete)) {
-            throw new RuntimeException("Failed to move local_paths_to_delete into place: {$this->local_paths_to_delete}");
+        if (!fclose($deleted_paths_handle) || !rename($deleted_paths_tmp, $deleted_paths_file)) {
+            throw new RuntimeException("Failed to move deleted paths list into place: {$deleted_paths_file}");
         }
 
         return ["changed" => $changed, "deleted" => $deleted];
+    }
+
+    /**
+     * Write the remote baseline entries for paths this push will touch.
+     *
+     * local_paths_to_push and local_paths_to_delete are already sorted by
+     * decoded path because diff_local_files() writes them during a merge over
+     * the sorted local index. The remote baseline is sorted the same way. This
+     * merge keeps memory constant and ignores remote baseline entries outside
+     * the local push scope.
+     */
+    private function write_scoped_remote_baseline(string $target): void
+    {
+        $baseline_handle = fopen($this->remote_files_baseline_path, "r");
+        if (!$baseline_handle) {
+            throw new RuntimeException("Failed to open the remote baseline: {$this->remote_files_baseline_path}");
+        }
+        $paths_to_push_handle = fopen($this->local_paths_to_push, "r");
+        if (!$paths_to_push_handle) {
+            fclose($baseline_handle);
+            throw new RuntimeException("Failed to open local_paths_to_push: {$this->local_paths_to_push}");
+        }
+        $paths_to_delete_handle = fopen($this->local_paths_to_delete, "r");
+        if (!$paths_to_delete_handle) {
+            fclose($baseline_handle);
+            fclose($paths_to_push_handle);
+            throw new RuntimeException("Failed to open local_paths_to_delete: {$this->local_paths_to_delete}");
+        }
+        $target_handle = fopen($target, "w");
+        if (!$target_handle) {
+            fclose($baseline_handle);
+            fclose($paths_to_push_handle);
+            fclose($paths_to_delete_handle);
+            throw new RuntimeException("Failed to open scoped remote baseline for writing: {$target}");
+        }
+
+        $last_scope_path = null;
+        $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+        $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+        $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+
+        while ($baseline_entry !== null && ($path_to_push_entry !== null || $path_to_delete_entry !== null)) {
+            if ($path_to_push_entry !== null && ($path_to_delete_entry === null || strcmp($path_to_push, $path_to_delete) <= 0)) {
+                $scope_path = $path_to_push;
+            } else {
+                $scope_path = $path_to_delete;
+            }
+
+            if ($scope_path === $last_scope_path) {
+                $this->advance_scope_path(
+                    $scope_path,
+                    $paths_to_push_handle,
+                    $path_to_push_entry,
+                    $path_to_push,
+                    $path_to_push_base64,
+                    $paths_to_delete_handle,
+                    $path_to_delete_entry,
+                    $path_to_delete,
+                    $path_to_delete_base64
+                );
+                continue;
+            }
+
+            $order = strcmp($baseline_path, $scope_path);
+            if ($order < 0) {
+                $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+                continue;
+            }
+            if ($order > 0) {
+                $last_scope_path = $scope_path;
+                $this->advance_scope_path(
+                    $scope_path,
+                    $paths_to_push_handle,
+                    $path_to_push_entry,
+                    $path_to_push,
+                    $path_to_push_base64,
+                    $paths_to_delete_handle,
+                    $path_to_delete_entry,
+                    $path_to_delete,
+                    $path_to_delete_base64
+                );
+                continue;
+            }
+
+            $line = json_encode($baseline_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            if (fwrite($target_handle, $line) !== strlen($line)) {
+                throw new RuntimeException("Short write on scoped remote baseline, is the disk full?");
+            }
+            $last_scope_path = $scope_path;
+            $this->read_line($baseline_handle, $baseline_entry, $baseline_path, $baseline_base64_path);
+            $this->advance_scope_path(
+                $scope_path,
+                $paths_to_push_handle,
+                $path_to_push_entry,
+                $path_to_push,
+                $path_to_push_base64,
+                $paths_to_delete_handle,
+                $path_to_delete_entry,
+                $path_to_delete,
+                $path_to_delete_base64
+            );
+        }
+
+        fclose($baseline_handle);
+        fclose($paths_to_push_handle);
+        fclose($paths_to_delete_handle);
+        if (!fclose($target_handle)) {
+            throw new RuntimeException("Failed to close scoped remote baseline: {$target}");
+        }
+    }
+
+    /**
+     * Advance both local scope lists past one decoded path.
+     *
+     * @param resource $paths_to_push_handle
+     * @param array<string, mixed>|null $path_to_push_entry
+     * @param resource $paths_to_delete_handle
+     * @param array<string, mixed>|null $path_to_delete_entry
+     */
+    private function advance_scope_path(
+        string $scope_path,
+        $paths_to_push_handle,
+        ?array &$path_to_push_entry,
+        ?string &$path_to_push,
+        ?string &$path_to_push_base64,
+        $paths_to_delete_handle,
+        ?array &$path_to_delete_entry,
+        ?string &$path_to_delete,
+        ?string &$path_to_delete_base64
+    ): void {
+        if ($path_to_push === $scope_path) {
+            $this->read_line($paths_to_push_handle, $path_to_push_entry, $path_to_push, $path_to_push_base64);
+        }
+        if ($path_to_delete === $scope_path) {
+            $this->read_line($paths_to_delete_handle, $path_to_delete_entry, $path_to_delete, $path_to_delete_base64);
+        }
+    }
+
+    /**
+     * Atomically replace a JSONL list with an empty file.
+     */
+    private function write_empty_jsonl(string $target): void
+    {
+        $tmp = $target . ".tmp";
+        $handle = fopen($tmp, "w");
+        if (!$handle) {
+            throw new RuntimeException("Failed to open empty JSONL temp file for writing: {$tmp}");
+        }
+        if (!fclose($handle) || !rename($tmp, $target)) {
+            throw new RuntimeException("Failed to move empty JSONL file into place: {$target}");
+        }
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -42,8 +42,9 @@
  *
  * diff_remote_files() answers "did the remote change any path this push is
  * about to touch". Its current index input must be the scoped remote reindex
- * for local_paths_to_push plus local_paths_to_delete. The remote baseline is
- * filtered to that same scope before comparison, so unrelated remote changes
+ * for local_paths_to_push plus local_paths_to_delete. The stored remote
+ * baseline must still be the full last-synced remote index; this class filters
+ * it to the current local scope before comparison, so unrelated remote changes
  * do not block a push.
  *
  * Producing the current index is the caller's job; this class only
@@ -133,13 +134,17 @@ class PushJournal
     }
 
     /**
-     * Store a copy of the remote file index as the new remote baseline.
+     * Store a copy of the full remote file index as the new remote baseline.
      *
-     * Captured from the scoped reindex that runs after apply — apply itself
-     * changes remote ctimes, so without this refresh the next push would
-     * report everything it just wrote as remote drift.
+     * The index must cover the whole remote tree, not only the paths touched
+     * by the latest push. diff_remote_files() treats a path absent from this
+     * baseline as absent from the remote at the last sync, so replacing the
+     * baseline with a scoped reindex would make a later push of different
+     * paths compare against an incomplete history. If the push driver only
+     * has a scoped post-apply reindex, it must merge those scoped entries into
+     * the previous full remote baseline instead of calling this method.
      */
-    public function capture_remote_files_baseline(string $index_file): void
+    public function capture_full_remote_files_baseline(string $index_file): void
     {
         $this->replace_file($this->remote_files_baseline_path, $index_file);
     }
@@ -183,10 +188,10 @@ class PushJournal
      * write the remote paths that changed or disappeared since the last sync.
      *
      * The scoped current remote index must contain exactly the paths from the
-     * local push/delete lists that still exist on the remote. The method
-     * filters the stored remote baseline to those same local paths before the
-     * merge, so a remote edit outside the pushed scope cannot become a false
-     * conflict.
+     * local push/delete lists that still exist on the remote. The stored
+     * remote baseline must be the full last-synced remote index; the method
+     * filters it to those same local paths before the merge, so a remote edit
+     * outside the pushed scope cannot become a false conflict.
      *
      * If there is no remote baseline yet, this is the first push to the site:
      * drift cannot be detected, stale drift lists are replaced with empty

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -7,14 +7,15 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-journal.php';
 
 /**
- * Coverage for PushJournal: per-remote-site baselines and the local diff.
+ * Coverage for PushJournal: per-remote-site baselines and file diffs.
  *
  * The diff drives real uploads and deletions later in a push, so the tests
  * pin the classification exactly: new, ctime-changed, size-changed,
  * type-changed, deleted, unchanged — plus the two boundary situations
  * (no baseline yet; stale lists from an earlier run), the encoding
  * round-trip for paths that need base64 in the first place, and the JSON
- * parsing behavior that keeps the diff independent from field order.
+ * parsing behavior that keeps the diff independent from field order, and the
+ * scoped remote drift comparison that only checks paths a push will touch.
  */
 final class PushJournalTest extends TestCase
 {
@@ -284,6 +285,73 @@ final class PushJournalTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('current index file is missing');
         $this->makeJournal()->diff_local_files($this->tempDir . '/no-such-index.jsonl');
+    }
+
+    // ------------------------------------------------------------------
+    //  Remote drift
+    // ------------------------------------------------------------------
+
+    public function testRemoteDiffReportsOnlyDriftInTheLocalPushScope(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'changed-remotely.txt' => [100, 5, 'file'],
+            'deleted-locally.txt' => [100, 5, 'file'],
+            'deleted-remotely.txt' => [100, 5, 'file'],
+            'unchanged.txt' => [100, 5, 'file'],
+        ]));
+        $journal->capture_remote_files_baseline($this->writeIndex([
+            'changed-remotely.txt' => [200, 5, 'file'],
+            'deleted-locally.txt' => [200, 5, 'file'],
+            'deleted-remotely.txt' => [200, 5, 'file'],
+            'unchanged.txt' => [200, 5, 'file'],
+            'unrelated-remote-change.txt' => [200, 5, 'file'],
+        ]));
+
+        $journal->diff_local_files($this->writeIndex([
+            'changed-remotely.txt' => [101, 5, 'file'],
+            'deleted-remotely.txt' => [101, 5, 'file'],
+            'unchanged.txt' => [100, 5, 'file'],
+        ]));
+
+        $counts = $journal->diff_remote_files($this->writeIndex([
+            'changed-remotely.txt' => [201, 5, 'file'],
+            'deleted-locally.txt' => [200, 5, 'file'],
+        ]));
+
+        $this->assertSame(['changed' => 1, 'deleted' => 1, 'baseline_missing' => false], $counts);
+        $this->assertSame(['changed-remotely.txt'], $this->listPaths($journal->remote_paths_changed_since_last_sync));
+        $this->assertSame(['deleted-remotely.txt'], $this->listPaths($journal->remote_paths_deleted_since_last_sync));
+    }
+
+    public function testRemoteDiffCannotCheckDriftBeforeTheFirstRemoteBaseline(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->diff_local_files($this->writeIndex([
+            'first-push.txt' => [100, 5, 'file'],
+        ]));
+
+        $counts = $journal->diff_remote_files($this->writeIndex([
+            'first-push.txt' => [200, 5, 'file'],
+        ]));
+
+        $this->assertSame(['changed' => 0, 'deleted' => 0, 'baseline_missing' => true], $counts);
+        $this->assertSame([], $this->listPaths($journal->remote_paths_changed_since_last_sync));
+        $this->assertSame([], $this->listPaths($journal->remote_paths_deleted_since_last_sync));
+    }
+
+    public function testRemoteDiffRequiresTheLocalDiffLists(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_remote_files_baseline($this->writeIndex([
+            'a.txt' => [100, 5, 'file'],
+        ]));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('local_paths_to_push is missing');
+        $journal->diff_remote_files($this->writeIndex([
+            'a.txt' => [101, 5, 'file'],
+        ]));
     }
 
     // ------------------------------------------------------------------

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -14,8 +14,8 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push
  * type-changed, deleted, unchanged — plus the two boundary situations
  * (no baseline yet; stale lists from an earlier run), the encoding
  * round-trip for paths that need base64 in the first place, and the JSON
- * parsing behavior that keeps the diff independent from field order, and the
- * scoped remote drift comparison that only checks paths a push will touch.
+ * parsing behavior that keeps the diff independent from field order, plus
+ * the scoped remote drift comparison that only checks paths a push will touch.
  */
 final class PushJournalTest extends TestCase
 {
@@ -346,6 +346,17 @@ final class PushJournalTest extends TestCase
         $journal->capture_remote_files_baseline($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('local_paths_to_push is missing');
+        $journal->diff_remote_files($this->writeIndex([
+            'a.txt' => [101, 5, 'file'],
+        ]));
+    }
+
+    public function testRemoteDiffRequiresTheLocalDiffListsBeforeFirstRemoteBaseline(): void
+    {
+        $journal = $this->makeJournal();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('local_paths_to_push is missing');

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -7,15 +7,14 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-journal.php';
 
 /**
- * Coverage for PushJournal: per-remote-site baselines and file diffs.
+ * Coverage for PushJournal: per-remote-site baselines and the local diff.
  *
  * The diff drives real uploads and deletions later in a push, so the tests
  * pin the classification exactly: new, ctime-changed, size-changed,
  * type-changed, deleted, unchanged — plus the two boundary situations
  * (no baseline yet; stale lists from an earlier run), the encoding
  * round-trip for paths that need base64 in the first place, and the JSON
- * parsing behavior that keeps the diff independent from field order, plus
- * the scoped remote drift comparison that only checks paths a push will touch.
+ * parsing behavior that keeps the diff independent from field order.
  */
 final class PushJournalTest extends TestCase
 {
@@ -94,17 +93,6 @@ final class PushJournalTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('index file is missing');
         $this->makeJournal()->capture_local_files_baseline($this->tempDir . '/no-such-index.jsonl');
-    }
-
-    public function testLocalAndRemoteBaselinesAreSeparateFiles(): void
-    {
-        $journal = $this->makeJournal();
-        $journal->capture_local_files_baseline($this->writeIndex(['a' => [1, 1, 'file']]));
-        $journal->capture_full_remote_files_baseline($this->writeIndex(['b' => [2, 2, 'file']]));
-
-        $this->assertNotSame($journal->local_files_baseline_path, $journal->remote_files_baseline_path);
-        $this->assertSame(['a'], $this->listPaths($journal->local_files_baseline_path));
-        $this->assertSame(['b'], $this->listPaths($journal->remote_files_baseline_path));
     }
 
     // ------------------------------------------------------------------
@@ -285,119 +273,6 @@ final class PushJournalTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('current index file is missing');
         $this->makeJournal()->diff_local_files($this->tempDir . '/no-such-index.jsonl');
-    }
-
-    // ------------------------------------------------------------------
-    //  Remote drift
-    // ------------------------------------------------------------------
-
-    public function testRemoteDiffReportsOnlyDriftInTheLocalPushScope(): void
-    {
-        $journal = $this->makeJournal();
-        $journal->capture_local_files_baseline($this->writeIndex([
-            'changed-remotely.txt' => [100, 5, 'file'],
-            'deleted-locally.txt' => [100, 5, 'file'],
-            'deleted-remotely.txt' => [100, 5, 'file'],
-            'unchanged.txt' => [100, 5, 'file'],
-        ]));
-        $journal->capture_full_remote_files_baseline($this->writeIndex([
-            'changed-remotely.txt' => [200, 5, 'file'],
-            'deleted-locally.txt' => [200, 5, 'file'],
-            'deleted-remotely.txt' => [200, 5, 'file'],
-            'unchanged.txt' => [200, 5, 'file'],
-            'unrelated-remote-change.txt' => [200, 5, 'file'],
-        ]));
-
-        $journal->diff_local_files($this->writeIndex([
-            'changed-remotely.txt' => [101, 5, 'file'],
-            'deleted-remotely.txt' => [101, 5, 'file'],
-            'unchanged.txt' => [100, 5, 'file'],
-        ]));
-
-        $counts = $journal->diff_remote_files($this->writeIndex([
-            'changed-remotely.txt' => [201, 5, 'file'],
-            'deleted-locally.txt' => [200, 5, 'file'],
-        ]));
-
-        $this->assertSame(['changed' => 1, 'deleted' => 1, 'baseline_missing' => false], $counts);
-        $this->assertSame(['changed-remotely.txt'], $this->listPaths($journal->remote_paths_changed_since_last_sync));
-        $this->assertSame(['deleted-remotely.txt'], $this->listPaths($journal->remote_paths_deleted_since_last_sync));
-    }
-
-    public function testRemoteDiffCanCheckDifferentLocalScopesAgainstOneFullRemoteBaseline(): void
-    {
-        $journal = $this->makeJournal();
-        $journal->capture_local_files_baseline($this->writeIndex([
-            'first-scope.txt' => [100, 5, 'file'],
-            'second-scope.txt' => [100, 5, 'file'],
-        ]));
-        $journal->capture_full_remote_files_baseline($this->writeIndex([
-            'first-scope.txt' => [200, 5, 'file'],
-            'second-scope.txt' => [200, 5, 'file'],
-        ]));
-
-        $journal->diff_local_files($this->writeIndex([
-            'first-scope.txt' => [101, 5, 'file'],
-            'second-scope.txt' => [100, 5, 'file'],
-        ]));
-        $this->assertSame(
-            ['changed' => 0, 'deleted' => 0, 'baseline_missing' => false],
-            $journal->diff_remote_files($this->writeIndex([
-                'first-scope.txt' => [200, 5, 'file'],
-            ]))
-        );
-
-        $journal->diff_local_files($this->writeIndex([
-            'first-scope.txt' => [100, 5, 'file'],
-            'second-scope.txt' => [101, 5, 'file'],
-        ]));
-        $this->assertSame(
-            ['changed' => 0, 'deleted' => 0, 'baseline_missing' => false],
-            $journal->diff_remote_files($this->writeIndex([
-                'second-scope.txt' => [200, 5, 'file'],
-            ]))
-        );
-    }
-
-    public function testRemoteDiffCannotCheckDriftBeforeTheFirstRemoteBaseline(): void
-    {
-        $journal = $this->makeJournal();
-        $journal->diff_local_files($this->writeIndex([
-            'first-push.txt' => [100, 5, 'file'],
-        ]));
-
-        $counts = $journal->diff_remote_files($this->writeIndex([
-            'first-push.txt' => [200, 5, 'file'],
-        ]));
-
-        $this->assertSame(['changed' => 0, 'deleted' => 0, 'baseline_missing' => true], $counts);
-        $this->assertSame([], $this->listPaths($journal->remote_paths_changed_since_last_sync));
-        $this->assertSame([], $this->listPaths($journal->remote_paths_deleted_since_last_sync));
-    }
-
-    public function testRemoteDiffRequiresTheLocalDiffLists(): void
-    {
-        $journal = $this->makeJournal();
-        $journal->capture_full_remote_files_baseline($this->writeIndex([
-            'a.txt' => [100, 5, 'file'],
-        ]));
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('local_paths_to_push is missing');
-        $journal->diff_remote_files($this->writeIndex([
-            'a.txt' => [101, 5, 'file'],
-        ]));
-    }
-
-    public function testRemoteDiffRequiresTheLocalDiffListsBeforeFirstRemoteBaseline(): void
-    {
-        $journal = $this->makeJournal();
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('local_paths_to_push is missing');
-        $journal->diff_remote_files($this->writeIndex([
-            'a.txt' => [101, 5, 'file'],
-        ]));
     }
 
     // ------------------------------------------------------------------

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -100,7 +100,7 @@ final class PushJournalTest extends TestCase
     {
         $journal = $this->makeJournal();
         $journal->capture_local_files_baseline($this->writeIndex(['a' => [1, 1, 'file']]));
-        $journal->capture_remote_files_baseline($this->writeIndex(['b' => [2, 2, 'file']]));
+        $journal->capture_full_remote_files_baseline($this->writeIndex(['b' => [2, 2, 'file']]));
 
         $this->assertNotSame($journal->local_files_baseline_path, $journal->remote_files_baseline_path);
         $this->assertSame(['a'], $this->listPaths($journal->local_files_baseline_path));
@@ -300,7 +300,7 @@ final class PushJournalTest extends TestCase
             'deleted-remotely.txt' => [100, 5, 'file'],
             'unchanged.txt' => [100, 5, 'file'],
         ]));
-        $journal->capture_remote_files_baseline($this->writeIndex([
+        $journal->capture_full_remote_files_baseline($this->writeIndex([
             'changed-remotely.txt' => [200, 5, 'file'],
             'deleted-locally.txt' => [200, 5, 'file'],
             'deleted-remotely.txt' => [200, 5, 'file'],
@@ -324,6 +324,41 @@ final class PushJournalTest extends TestCase
         $this->assertSame(['deleted-remotely.txt'], $this->listPaths($journal->remote_paths_deleted_since_last_sync));
     }
 
+    public function testRemoteDiffCanCheckDifferentLocalScopesAgainstOneFullRemoteBaseline(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'first-scope.txt' => [100, 5, 'file'],
+            'second-scope.txt' => [100, 5, 'file'],
+        ]));
+        $journal->capture_full_remote_files_baseline($this->writeIndex([
+            'first-scope.txt' => [200, 5, 'file'],
+            'second-scope.txt' => [200, 5, 'file'],
+        ]));
+
+        $journal->diff_local_files($this->writeIndex([
+            'first-scope.txt' => [101, 5, 'file'],
+            'second-scope.txt' => [100, 5, 'file'],
+        ]));
+        $this->assertSame(
+            ['changed' => 0, 'deleted' => 0, 'baseline_missing' => false],
+            $journal->diff_remote_files($this->writeIndex([
+                'first-scope.txt' => [200, 5, 'file'],
+            ]))
+        );
+
+        $journal->diff_local_files($this->writeIndex([
+            'first-scope.txt' => [100, 5, 'file'],
+            'second-scope.txt' => [101, 5, 'file'],
+        ]));
+        $this->assertSame(
+            ['changed' => 0, 'deleted' => 0, 'baseline_missing' => false],
+            $journal->diff_remote_files($this->writeIndex([
+                'second-scope.txt' => [200, 5, 'file'],
+            ]))
+        );
+    }
+
     public function testRemoteDiffCannotCheckDriftBeforeTheFirstRemoteBaseline(): void
     {
         $journal = $this->makeJournal();
@@ -343,7 +378,7 @@ final class PushJournalTest extends TestCase
     public function testRemoteDiffRequiresTheLocalDiffLists(): void
     {
         $journal = $this->makeJournal();
-        $journal->capture_remote_files_baseline($this->writeIndex([
+        $journal->capture_full_remote_files_baseline($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
 


### PR DESCRIPTION
When a developer runs `reprint push`, the plan now compares the current local site only against the local baseline from the previous successful push, so push stays a local-wins deployment flow instead of trying to detect remote edits.

## What it does

The push design now reports local uploads and local deletions, asks the developer to confirm that local should win for those paths and rows, and then updates the local baselines after apply completes. Remote edits to the same files or rows are overwritten by the confirmed push; developers who edit the remote site outside Reprint need to pull or preserve those changes before pushing over them.

`PushJournal` now stores only the local file baseline and the local upload/delete lists. The remote baseline path and capture method are gone because the simplified plan no longer keeps remote index state between pushes.

## Rationale

The remote-drift version needed a remote index before push, another remote index after apply, and merge rules that kept a full remote baseline valid across different push scopes. If the developer pushed one set of paths now and a different set later, an incomplete remote baseline could make the next comparison wrong unless every later PR preserved that extra state correctly.

For this tool, that state is not worth carrying. Push is a deployment command: the local diff decides what will be applied, and remote changes made outside Reprint are outside the contract of this PR.

## Testing instructions

```bash
php -l packages/reprint-importer/src/lib/push/class-push-journal.php
php -l tests/Import/PushJournalTest.php
cd tests && ../vendor/bin/phpunit Import/PushJournalTest.php
composer analyze -- --memory-limit=1G
git diff --check
```
