### PR TITLE
[Push] Document push endpoint budgeting

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -220,3 +220,8 @@ Files first, database second, each PR small and stacked in this order:
     diff generation and URL rewrite, the apply batch.
 11. **`reprint push`** — the one command that orchestrates plan, confirm,
     transfer, apply, resume.
+12. **Budgets and resumable limits** — upload stays bounded by chunk size and
+    explicit request limits; any endpoint that stops after durable work returns
+    the exact committed state the driver needs to retry. The apply step gets
+    the main budgeted loop: process until a deadline or operation limit, return
+    progress, and let the driver re-enter until complete.


### PR DESCRIPTION
This adds the deferred budgeting slice to the push implementation plan so the delivery stack records how staged endpoints and apply should become bounded later.

The plan keeps upload bounded by chunk size and request limits, requires budget-stopped endpoints to return the exact durable state needed for retry, and calls out apply as the main resumable budgeted loop.

## Testing instructions

```bash
git diff --check
```
