### PR TITLE
[Push] Stream staged file chunks in one request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,170 @@
+# AGENTS.md
+
+Working rules for agents in this repository. Every rule below is a
+correction that was actually issued during code review here, or a defect
+class that survived several review rounds before being caught. Follow them
+the first time. Project structure and commands live in CLAUDE.md; this file
+is about how to work.
+
+## Streaming is the point — never buffer
+
+- Never accumulate a request body, a frame plan, or any "send later"
+  structure. A stepping API (`send_chunk()`, `next_chunk()`) must perform
+  its real I/O before returning: when
+  `StagedPushStreamClient::send_chunk()` returns true, the frame has left
+  for the network.
+- The one permissible in-memory unit is a single bounded chunk (a few MiB,
+  the `chunk_bytes` option). Read it, send it, drop it. PHP string
+  assignment is copy-on-write — hand strings over instead of concatenating
+  them (see the outbound frame fields in the push client).
+- Read first, declare after: compute frame headers from the bytes actually
+  read (`strlen($payload)`); never promise a byte count and then try to
+  fulfill it. Short reads then produce smaller frames instead of a poisoned
+  stream.
+- Minimize requests: many chunks of many files travel in one request,
+  resumable by cursor. One-request-per-file or one-request-per-chunk
+  designs are rejected on sight.
+
+## Names carry the correct dimension
+
+- The chunk (in-memory unit) and the request body (what hosts cap) are
+  different dimensions. Never name one after the other. This repo renamed
+  `PushFrameSizer` → `PushRequestSizer`, `chunk_size_exhausted` →
+  `request_size_exhausted`, and the endpoint option `max_request_bytes` →
+  `max_frame_bytes` because each name lied about its dimension.
+- Full descriptive names everywhere; no abbreviations
+  (`$current_base64_path`, never `$cur_b64`). If a name needs "remote" or
+  "local" to be unambiguous, it must contain it.
+
+## Budgets and limits
+
+- Whatever budget you account for must be the budget the remote stack
+  actually enforces. Request-size limits (`post_max_size`,
+  `client_max_body_size`) measure the decoded entity body: frame header
+  lines count toward it, transfer framing and HTTP headers do not.
+- Numbers come from the remote's real configuration — preflight-reported
+  php.ini values seed the ceiling — plus learning from rejections (413s cap
+  it permanently). Web-server limits PHP cannot introspect are learned,
+  never assumed.
+- Adaptive learning needs evidence: an accepted empty request proves
+  nothing about a size being safe to grow from, so it must not record a
+  success.
+
+## Timeouts
+
+- Never a total-transfer timeout: it kills healthy-but-slow bulk transfers.
+  Time out per phase, on lack of progress: connect, stall (zero bytes
+  moving for N seconds), response wait. A slow connection that keeps moving
+  bytes may take as long as it needs.
+
+## Errors, validation, and recoverability
+
+- Every error names the exact violated condition and the observed value, in
+  a human sentence. `throw new InvalidArgumentException('fields')` is the
+  canonical counterexample.
+- Options that are absent get defaults; options that are present but
+  invalid throw. Silently substituting a default hides the caller's
+  mistake. Cast validated numerics — `argv` and state files deliver
+  numeric strings.
+- Classify remote rejections by the protocol's own design: `busy` and
+  `offset_gap` are recoverable (retry with the returned cursor); auth
+  failures and redirects are terminal with pointed messages ("The target
+  redirected to X. Use that address as the push base_url."). "Retry" must
+  never be a terminal status — exhausted retries become `failed`.
+- Cursors and status responses report only what the store has confirmed —
+  never echo a sender's claimed offset back as truth.
+
+## Resume and drift — the hard part
+
+- Any resumable transfer must assume the source changed between sessions.
+  A resumed push must never append new-version bytes behind an old-version
+  prefix — that builds a file no version of the source ever was, and size
+  checks alone will happily verify it.
+- The mechanisms here: the sender persists a source token (size + ctime —
+  the same signals the journal diff keys on; mtime can be backdated by
+  touch(), ctime cannot) alongside every cursor and restarts a changed file
+  at offset 0; the target treats an offset-0 frame for anything it cannot
+  vouch for as a restart (discard, then stage fresh), while verified
+  artifacts replayed at their verified size are skipped.
+- Document the honest gaps where the mechanism is documented: a same-size
+  edit within one timestamp second escapes the token; the diff layer is the
+  deeper net.
+
+## Testing
+
+- Test cross-machine code against real local endpoints (`php -S` running
+  the real router); injected fake transports are rejected. Do more work in
+  the tests rather than adding seams to production code.
+- For any stateful or resumable feature, enumerate the failure taxonomy
+  FIRST (grew / shrank / same-size edit / replay-after-partial-commit /
+  cursor-beyond-EOF / cursor's file deleted from the journal), write the
+  tests, watch them fail for the meaningful assertion, then implement.
+- When asked whether tests would have caught a bug, prove it at the commit
+  boundary: check out the pre-fix implementation files, refresh the vendor
+  mirror, and show the new tests failing against them.
+- Wire-level claims get wire-level proof: a raw TCP listener observing when
+  bytes arrive is how "send_chunk() transmits before returning" and
+  "back-to-back requests reuse the connection" are tested.
+
+## Claims must be verified before they are written
+
+- Never state a guarantee in a docblock, PR description, or review reply
+  without pointing at the line that enforces it. Real defects here were
+  sentences written from memory: "a 409 catches resume-after-change" (true
+  only for verified artifacts), "the token uses the signals the diff
+  trusts" (the diff keys on ctime; the token used mtime).
+- Probe platform behavior empirically instead of assuming, and record the
+  result: PHP's curl binding honors CURL_READFUNC_PAUSE only from 8.1 —
+  on 7.4/8.0 the upload silently truncates (issue #327 has the full
+  write-up); `php -S` never answers 100-continue, so an Expect header
+  stalls every request by the full timeout; libcurl reuses connections
+  across requests only when the curl_multi handle outlives them.
+
+## Abstractions
+
+- Inline single-use helpers; no wrapper classes that only rename a concept.
+  A "transport" callable, a plan-then-send request object, and a processor
+  that materialized a file list were all deleted from this repo. A helper
+  earns its name at two or more callers.
+- No speculative options, hooks, or nullable dependencies "for tests" —
+  `on_before_request` and the optional `hmac_client` were both removed;
+  tests sign requests like every other caller.
+- Mirror how the pipeline already solves a problem before inventing a new
+  scheme: paths travel base64 on every wire and in the journal (JSON is
+  UTF-8-only; file names are arbitrary bytes); change detection keys on
+  ctime + size. Grep first.
+
+## Repo mechanics that will bite you
+
+- Composer's classmap autoloads exporter classes from
+  `vendor/wp-php-toolkit/reprint-exporter/` — a stale mirror silently runs
+  old code under the tests. After editing anything in
+  `packages/reprint-exporter/src/`, copy the file to BOTH
+  `vendor/wp-php-toolkit/reprint-exporter/src/` and
+  `reprint-exporter-wp/vendor/wp-php-toolkit/reprint-exporter/src/`.
+- `packages/reprint-importer/src/lib/upload/` must stay PHP 7.4-PARSEABLE:
+  import.php loads it for pull users on 7.4, and the push client's 8.1
+  requirement is a runtime check in its constructor.
+  PushClientPhpCompatibilityTest enforces this; do not "clean up" the
+  untyped `$max_request_seconds` property into an 8.0 union type.
+- PHPCS: per-file violation counts must not increase. Match each file's
+  existing idiom (including its pre-existing warnings' style) instead of
+  importing your own.
+- Run tests from `tests/` with `../vendor/bin/phpunit <files>`; run
+  `composer analyze -- --memory-limit=1G` and `git diff --check` before
+  committing.
+
+## Writing
+
+- Comments state the mundane real reason, tightly, and must match actual
+  behavior — a docblock that prescribes a courtesy no caller performs is a
+  defect. Update docs in the same commit as the behavior they describe,
+  including the delivery plan (markdown/PUSH-SYNC.md) when a decision
+  changes it.
+- PR descriptions: the first sentence states the observable effect and
+  ideally why; describe concrete triggers and results, never vague causal
+  phrases ("could be found again", "restore more predictably"); the
+  implementation section is optional and high-level; avoid bullet points.
+- When a hard requirement lands on users (push requires PHP 8.1+), write it
+  up thoroughly for an unfamiliar audience (issue #327), link it from the
+  error message and the code, and make the error say exactly what to do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+AGENTS.md holds the working rules distilled from code review in this repo — what to do and what not to do. Read it before writing code; its rules override default instincts.
+
 ## Project Overview
 
 This is a WordPress site export/import system that enables resumable, cursor-based synchronization of both database content and filesystem data over HTTP. The system is designed to work on resource-constrained shared hosting environments by carefully managing memory and execution time.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -205,9 +205,10 @@ Files first, database second, each PR small and stacked in this order:
    the configured storage path; web guards for inside-docroot placement.
 5. **Push journal and local diff** — per-site local baselines, capture and
    overwrite logic, local change and deletion detection.
-6. **Upload endpoint** — the store's HTTP surface plus the sender loop with
-   chunk sizing; deletion manifest staged; `--force-http` with honest help
-   text (the first push networking this flag can gate).
+6. **Push stream endpoint** — the store's HTTP surface plus a sender that
+   streams framed chunks for many files through one authenticated request;
+   deletion manifest staged; `--force-http` with honest help text (the first
+   push networking this flag can gate).
 7. **Package unification** — importer and exporter become one Reprint
    package (lite = serve-only build). Placed here because apply is the
    first piece that needs import-side code running on the remote.
@@ -220,8 +221,8 @@ Files first, database second, each PR small and stacked in this order:
     diff generation and URL rewrite, the apply batch.
 11. **`reprint push`** — the one command that orchestrates plan, confirm,
     transfer, apply, resume.
-12. **Budgets and resumable limits** — upload stays bounded by chunk size and
-    explicit request limits; any endpoint that stops after durable work returns
-    the exact committed state the driver needs to retry. The apply step gets
-    the main budgeted loop: process until a deadline or operation limit, return
-    progress, and let the driver re-enter until complete.
+12. **Budgets and resumable limits** — push stream frames stay bounded by chunk
+    size and explicit frame limits; any endpoint that stops after durable work
+    returns the exact committed state the driver needs to retry. The apply step
+    gets the main budgeted loop: process until a deadline or operation limit,
+    return progress, and let the driver re-enter until complete.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -208,7 +208,14 @@ Files first, database second, each PR small and stacked in this order:
 6. **Push stream endpoint** — the store's HTTP surface plus a sender that
    streams framed chunks for many files through one authenticated request;
    deletion manifest staged; `--force-http` with honest help text (the first
-   push networking this flag can gate).
+   push networking this flag can gate). Decisions this slice locked in:
+   sending streams through libcurl's pause mechanism, which PHP's curl
+   extension supports from 8.1 — so `reprint push` requires PHP 8.1+ (pull
+   keeps 7.4+; the full story is
+   https://github.com/WordPress/reprint/issues/327) — and artifact ids
+   travel base64-encoded in frames, response cursors, and control-plane
+   parameters, because file paths are arbitrary bytes and JSON strings must
+   be UTF-8.
 7. **Package unification** — importer and exporter become one Reprint
    package (lite = serve-only build). Placed here because apply is the
    first piece that needs import-side code running on the remote.
@@ -221,8 +228,11 @@ Files first, database second, each PR small and stacked in this order:
     diff generation and URL rewrite, the apply batch.
 11. **`reprint push`** — the one command that orchestrates plan, confirm,
     transfer, apply, resume.
-12. **Budgets and resumable limits** — push stream frames stay bounded by chunk
-    size and explicit frame limits; any endpoint that stops after durable work
+12. **Budgets and resumable limits** — push requests stay bounded by two
+    budgets of different dimensions: the fixed chunk (the sender's in-memory
+    unit of one read) and the host-learned request body budget that
+    PushRequestSizer sizes from reported php.ini limits and 413s, plus a
+    wall-clock budget per request; any endpoint that stops after durable work
     returns the exact committed state the driver needs to retry. The apply step
     gets the main budgeted loop: process until a deadline or operation limit,
     return progress, and let the driver re-enter until complete.

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -23,6 +23,7 @@
             "src/class-hmac-server.php",
             "src/class-http-server.php",
             "src/class-staged-artifacts.php",
+            "src/class-staged-push-stream-protocol.php",
             "src/class-staged-endpoints.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -50,7 +50,7 @@ final class Site_Export_HTTP_Server {
             $endpoint = (string) ( $get['endpoint'] ?? $post['endpoint'] ?? '' );
             // Data-plane staged routes carry raw bytes and must only be read
             // by their handlers. Other JSON requests still feed config parsing.
-            $body = !in_array($endpoint, ['staged_upload', 'staged_push'], true) && $this->is_json_content_type($server)
+            $body = $endpoint !== 'staged_push' && $this->is_json_content_type($server)
                 ? call_user_func($this->body_reader)
                 : '';
         }
@@ -318,18 +318,6 @@ final class Site_Export_HTTP_Server {
                 try {
                     self::emit_json_response(
                         $endpoints->push_stream($config, $_SERVER, $input === false ? null : $input)
-                    );
-                } finally {
-                    if (is_resource($input)) {
-                        fclose($input);
-                    }
-                }
-            },
-            'staged_upload' => static function (array $config) use ($endpoints): void {
-                $input = @fopen('php://input', 'rb');
-                try {
-                    self::emit_json_response(
-                        $endpoints->upload($config, $_SERVER, $input === false ? null : $input)
                     );
                 } finally {
                     if (is_resource($input)) {

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -48,10 +48,9 @@ final class Site_Export_HTTP_Server {
             $body = (string) $request['body'];
         } else {
             $endpoint = (string) ( $get['endpoint'] ?? $post['endpoint'] ?? '' );
-            // staged_upload parameters live in the query string; its body
-            // is raw artifact bytes and must only be read by the upload
-            // handler. Other JSON requests still feed config parsing.
-            $body = $endpoint !== 'staged_upload' && $this->is_json_content_type($server)
+            // Data-plane staged routes carry raw bytes and must only be read
+            // by their handlers. Other JSON requests still feed config parsing.
+            $body = !in_array($endpoint, ['staged_upload', 'staged_push'], true) && $this->is_json_content_type($server)
                 ? call_user_func($this->body_reader)
                 : '';
         }
@@ -314,6 +313,18 @@ final class Site_Export_HTTP_Server {
      */
     private function register_staged_handlers(Site_Export_Staged_Endpoints $endpoints): void {
         $routes = [
+            'staged_push' => static function (array $config) use ($endpoints): void {
+                $input = @fopen('php://input', 'rb');
+                try {
+                    self::emit_json_response(
+                        $endpoints->push_stream($config, $_SERVER, $input === false ? null : $input)
+                    );
+                } finally {
+                    if (is_resource($input)) {
+                        fclose($input);
+                    }
+                }
+            },
             'staged_upload' => static function (array $config) use ($endpoints): void {
                 $input = @fopen('php://input', 'rb');
                 try {

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -669,10 +669,16 @@ final class Site_Export_Staged_Artifacts {
         if (!is_array($state) || !is_string($state['artifact_id'] ?? null)) {
             return $defaults;
         }
+        // Ids are stored base64 (see write_state); an undecodable record
+        // reads as no state, like any other malformed record.
+        $artifact_id = base64_decode($state['artifact_id'], true);
+        if ($artifact_id === false || $artifact_id === '') {
+            return $defaults;
+        }
 
         $committed_bytes = isset($state['committed_bytes']) ? (int) $state['committed_bytes'] : 0;
         return [
-            'artifact_id' => $state['artifact_id'],
+            'artifact_id' => $artifact_id,
             'committed_bytes' => max(0, $committed_bytes),
         ];
     }
@@ -682,8 +688,12 @@ final class Site_Export_Staged_Artifacts {
         // record or the new one, never a torn file. The temp file sits next
         // to the target so rename stays on the same filesystem.
         $tmp_path = $this->state_path . '.tmp';
+        // The id is stored base64: file names are arbitrary bytes, JSON
+        // strings must be UTF-8, and json_encode() returning false would
+        // otherwise slip through the strlen() comparison below as an empty
+        // record — committed_bytes would silently reset to 0 on every read.
         $json = json_encode([
-            'artifact_id' => $artifact_id,
+            'artifact_id' => $artifact_id !== null ? base64_encode($artifact_id) : null,
             'committed_bytes' => $committed_bytes,
         ]);
         // A short write (disk full) returns a byte count, not false — never

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -15,8 +15,8 @@
  * instead of mutating the live tree for the duration of the transfer.
  *
  * The first consumer is push: bounded frames from an outbound-only local
- * site, sized by PushFrameSizer on the importer side. The pull file
- * writer has the same needs whenever its target is a live site — today it
+ * site, sized by the push client's chunk reads on the importer side. The
+ * pull file writer has the same needs whenever its target is a live site — today it
  * streams downloads straight to their final paths, which is fine for a fresh
  * local directory but not for a web-served tree — so nothing here is
  * upload-specific: sequential offsets match pull's byte-offset resume model.

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -189,7 +189,7 @@ final class Site_Export_Staged_Artifacts {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
                 return [
                     'status' => 'busy',
-                    'reason' => null,
+                    'reason' => 'busy',
                     'detail' => null,
                     'committed_bytes' => $this->status($artifact_id)['committed_bytes'],
                 ];
@@ -362,7 +362,7 @@ final class Site_Export_Staged_Artifacts {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
                 return [
                     'status' => 'busy',
-                    'reason' => null,
+                    'reason' => 'busy',
                     'detail' => null,
                     'committed_bytes' => $this->status($artifact_id)['committed_bytes'],
                     'path' => null,

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -14,8 +14,8 @@
  * moves verified artifacts into place in one short, controlled window
  * instead of mutating the live tree for the duration of the transfer.
  *
- * The first consumer is push: bounded upload requests from an outbound-only
- * local site, sized by UploadChunkSizer on the importer side. The pull file
+ * The first consumer is push: bounded frames from an outbound-only local
+ * site, sized by PushFrameSizer on the importer side. The pull file
  * writer has the same needs whenever its target is a live site — today it
  * streams downloads straight to their final paths, which is fine for a fresh
  * local directory but not for a web-served tree — so nothing here is

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -32,9 +32,11 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * out learns nothing about what landed, retries from its last cursor or
  * asks staged_status for the store's committed offset, and may later
  * resend with shifted boundaries. push_stream therefore compares the store's
- * committed offset with each frame first, absorbs already-committed ranges,
- * skips the committed prefix of a straddling frame, and reports offset_gap
- * with the cursor only when a frame starts beyond the frontier.
+ * committed offset with each frame first, skips the committed prefix of a
+ * straddling mid-file frame, restarts an artifact when the sender begins it
+ * again at offset 0 (the sender only does that when its source changed or
+ * it cannot vouch for the staged prefix), and reports offset_gap with the
+ * cursor only when a frame starts beyond the frontier.
  *
  * Rejections the chunk sizer must learn from are typed for it: a frame
  * over the frame cap is HTTP 413 with max_frame_bytes in the payload,

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -160,10 +160,11 @@ final class Site_Export_Staged_Endpoints {
         $files_verified = 0;
         $cursor = null;
         while (!feof($input)) {
-            $line = Site_Export_Staged_Push_Stream_Protocol::read_header_line($input);
-            if ($line === null) {
+            $line = fgets($input);
+            if ($line === false) {
                 break;
             }
+            $line = rtrim($line, "\r\n");
             try {
                 $frame = Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line);
             } catch (InvalidArgumentException $e) {
@@ -379,27 +380,25 @@ final class Site_Export_Staged_Endpoints {
                 $code = 423;
                 break;
             default:
-                $code = $this->code_for_reason( (string) $result['reason']);
+                switch ((string) $result['reason']) {
+                    case 'io_error':
+                        $code = 500;
+                        break;
+                    case 'offset_gap':
+                    case 'already_verified':
+                    case 'size_mismatch':
+                    case 'missing':
+                        $code = 409;
+                        break;
+                    default:
+                        $code = 400;
+                }
         }
 
         return [
             'http_code' => $code,
             'body' => $result,
         ];
-    }
-
-    private function code_for_reason(string $reason): int {
-        switch ($reason) {
-            case 'io_error':
-                return 500;
-            case 'offset_gap':
-            case 'already_verified':
-            case 'size_mismatch':
-            case 'missing':
-                return 409;
-            default:
-                return 400;
-        }
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -2,29 +2,37 @@
 
 use function WordPress\Reprint\Exporter\parse_size;
 
+if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
+    require_once __DIR__ . '/class-staged-push-stream-protocol.php';
+}
+
 /**
  * HTTP endpoints for the staged artifact store.
  *
- * This is the target side of a push chunk upload: the sender reads its
- * source in bounded chunks (sized by UploadChunkSizer on the importer
- * side) and posts each chunk here, where it accumulates in
- * Site_Export_Staged_Artifacts instead of touching the live site.
+ * This is the target side of a push stream: the sender opens one request,
+ * frames many bounded chunks for many files, and this endpoint commits each
+ * frame into Site_Export_Staged_Artifacts instead of touching the live site.
  *
- * Four routes share the existing endpoint dispatcher:
+ * Five routes share the existing endpoint dispatcher:
  *
- * - staged_upload   (POST, data plane): raw chunk bytes in the request
- *   body, artifact_id and offset in the query string.
+ * - staged_push     (POST, data plane): framed file chunks in one streamed
+ *   request body.
+ * - staged_upload   (POST, data plane, legacy route): raw chunk bytes in the
+ *   request body, artifact_id and offset in the query string.
  * - staged_finalize (POST, control plane): confirm the assembled size.
  * - staged_status   (GET, control plane): resume hint for a sender.
  * - staged_discard  (POST, control plane): drop an artifact; retry
  *   until the response says discarded.
  *
  * Control-plane routes have small bodies and ride the embedding layer's
- * existing HMAC verification, like every other endpoint. staged_upload
- * cannot: that verification buffers the whole request body to hash it,
- * and a chunk can be as large as the sizer's 1 GiB cap. So the upload
- * route authenticates inside the handler, in two steps that keep memory
- * bounded and keep unauthenticated bytes away from the store:
+ * existing HMAC verification, like every other endpoint. staged_push uses
+ * envelope HMAC instead: authenticate method + request target before reading
+ * bytes, then let TLS protect the body. That keeps one push stream as one
+ * request even when it carries many frames for many files.
+ *
+ * The legacy staged_upload route still authenticates each raw chunk body in
+ * two steps that keep memory bounded and keep unauthenticated bytes away from
+ * the store:
  *
  * 1. verify_signed_content_hash() checks the signature, nonce, and
  *    timestamp headers before a single body byte is read. A caller
@@ -265,6 +273,154 @@ final class Site_Export_Staged_Endpoints {
     }
 
     /**
+     * Stage a framed stream of chunks for many artifacts in one request.
+     *
+     * Each frame is one JSON line followed by exactly "bytes" raw bytes:
+     *
+     * {"type":"chunk","artifact_id":"path","offset":0,"bytes":123,"total_bytes":456,"final":false}\n
+     *
+     * A frame commits before the next frame is read. If the request dies after
+     * a commit, the next request may replay from the last sender cursor or from
+     * the beginning; verified artifacts and duplicate ranges are absorbed.
+     *
+     * @param array $config Request parameters.
+     * @param array $headers Request headers/server vars ($_SERVER shape).
+     * @param resource|null $input Request body stream (php://input).
+     * @return array{http_code:int,body:array}
+     */
+    public function push_stream(array $config, array $headers, $input): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        if ($this->secret === null) {
+            return $this->rejected(503, 'not_configured', 'shared_secret');
+        }
+        if (!is_resource($input)) {
+            return $this->rejected(500, 'io_error', 'open_request_body');
+        }
+
+        $request_target = $headers['REQUEST_URI'] ?? null;
+        if (!is_string($request_target) || $request_target === '') {
+            return $this->rejected(400, 'missing_request_target');
+        }
+        $auth_error = (new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance))
+            ->verify_envelope($headers, (string) ( $headers['REQUEST_METHOD'] ?? 'POST' ), $request_target);
+        if ($auth_error !== null) {
+            return $this->rejected(403, 'auth_failed', $auth_error);
+        }
+
+        $files_verified = 0;
+        $cursor = null;
+        while (!feof($input)) {
+            $line = Site_Export_Staged_Push_Stream_Protocol::read_header_line($input);
+            if ($line === null) {
+                break;
+            }
+            try {
+                $frame = Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line);
+            } catch (InvalidArgumentException $e) {
+                return $this->stream_rejected(400, 'invalid_frame', $e->getMessage(), $cursor, $files_verified);
+            }
+            $artifact_id = $frame['artifact_id'];
+            $offset = $frame['offset'];
+            $bytes = $frame['bytes'];
+            $total_bytes = $frame['total_bytes'];
+            $final = $frame['final'];
+            $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => $offset];
+
+            if ($bytes > $this->max_request_bytes) {
+                $response = $this->stream_rejected(413, 'frame_too_large', null, $cursor, $files_verified);
+                $response['body']['max_frame_bytes'] = $this->max_request_bytes;
+                return $response;
+            }
+
+            $status = $this->store->status($artifact_id);
+            if ($status['verified']) {
+                if ($status['committed_bytes'] !== $total_bytes) {
+                    return $this->stream_rejected(409, 'size_mismatch', null, [
+                        'artifact_id' => $artifact_id,
+                        'committed_bytes' => $status['committed_bytes'],
+                    ], $files_verified);
+                }
+                if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $bytes, self::READ_BUFFER_BYTES)) {
+                    return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+                }
+                $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => $status['committed_bytes']];
+                if ($final) {
+                    $files_verified++;
+                }
+                continue;
+            }
+
+            if ($bytes > 0) {
+                $remaining_frame_bytes = $bytes;
+                $append_offset = $offset;
+                while ($remaining_frame_bytes > 0) {
+                    $payload_piece_bytes = min($this->append_buffer_bytes, $remaining_frame_bytes);
+                    $payload_piece = Site_Export_Staged_Push_Stream_Protocol::read_exactly($input, $payload_piece_bytes);
+                    if ($payload_piece === null) {
+                        return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+                    }
+                    $remaining_frame_bytes -= $payload_piece_bytes;
+
+                    while ($payload_piece !== '') {
+                        $append_result = $this->store->append($artifact_id, $append_offset, $payload_piece);
+                        if ($append_result['status'] === 'accepted' || $append_result['status'] === 'duplicate') {
+                            $append_offset = max($append_offset + strlen($payload_piece), (int) $append_result['committed_bytes']);
+                            $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => (int) $append_result['committed_bytes']];
+                            break;
+                        }
+
+                        $committed_bytes = (int) $append_result['committed_bytes'];
+                        if (
+                            $append_result['reason'] === 'offset_gap'
+                            && $committed_bytes > $append_offset
+                            && $committed_bytes < $append_offset + strlen($payload_piece)
+                        ) {
+                            $payload_piece = substr($payload_piece, $committed_bytes - $append_offset);
+                            $append_offset = $committed_bytes;
+                            continue;
+                        }
+
+                        $response = $this->from_store_result($append_result);
+                        $response['body']['cursor'] = [
+                            'artifact_id' => $artifact_id,
+                            'committed_bytes' => $committed_bytes,
+                        ];
+                        $response['body']['files_verified'] = $files_verified;
+                        return $response;
+                    }
+                }
+            }
+
+            if ($final) {
+                $finalize_result = $this->store->finalize($artifact_id, $total_bytes);
+                unset($finalize_result['path']);
+                if ($finalize_result['status'] !== 'verified') {
+                    $response = $this->from_store_result($finalize_result);
+                    $response['body']['cursor'] = $cursor;
+                    $response['body']['files_verified'] = $files_verified;
+                    return $response;
+                }
+                $files_verified++;
+                $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => (int) $finalize_result['committed_bytes']];
+            }
+        }
+
+        return [
+            'http_code' => 200,
+            'body' => [
+                'status' => 'complete',
+                'reason' => null,
+                'detail' => null,
+                'cursor' => $cursor,
+                'files_verified' => $files_verified,
+            ],
+        ];
+    }
+
+    /**
      * Confirm an assembled artifact against its plan-declared size.
      *
      * @return array{http_code:int,body:array}
@@ -390,6 +546,22 @@ final class Site_Export_Staged_Endpoints {
     /**
      * @return array{http_code:int,body:array}
      */
+    private function stream_rejected(int $http_code, string $reason, ?string $detail, ?array $cursor, int $files_verified): array {
+        return [
+            'http_code' => $http_code,
+            'body' => [
+                'status' => 'rejected',
+                'reason' => $reason,
+                'detail' => $detail,
+                'cursor' => $cursor,
+                'files_verified' => $files_verified,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{http_code:int,body:array}
+     */
     private function rejected(int $http_code, string $reason, ?string $detail = null, int $committed_bytes = 0): array {
         return [
             'http_code' => $http_code,
@@ -403,7 +575,7 @@ final class Site_Export_Staged_Endpoints {
     }
 
     /**
-     * The structured too-large rejection UploadChunkSizer::record_too_large()
+     * The structured too-large rejection PushFrameSizer::record_too_large()
      * consumes: HTTP 413 plus the cap it must stay under.
      *
      * @return array{http_code:int,body:array}
@@ -418,4 +590,5 @@ final class Site_Export_Staged_Endpoints {
         $response['body']['max_request_bytes'] = $this->max_request_bytes;
         return $response;
     }
+
 }

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -37,7 +37,7 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * with the cursor only when a frame starts beyond the frontier.
  *
  * Rejections the chunk sizer must learn from are typed for it: a frame
- * over the request cap is HTTP 413 with max_frame_bytes in the payload,
+ * over the frame cap is HTTP 413 with max_frame_bytes in the payload,
  * exactly what record_too_large() consumes. The cap defaults to post_max_size
  * (falling back to the sizer's own 1 GiB hard cap when PHP reports none),
  * because a proxy or PHP itself would refuse larger bodies before this code
@@ -52,7 +52,7 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
 final class Site_Export_Staged_Endpoints {
 
     /** The chunk sizer never sends more than this, so accept up to it. */
-    private const DEFAULT_MAX_REQUEST_BYTES = 1073741824;
+    private const DEFAULT_MAX_FRAME_BYTES = 1073741824;
 
     /** One append() step per this many request-body bytes. */
     private const DEFAULT_APPEND_BUFFER_BYTES = 262144;
@@ -67,7 +67,7 @@ final class Site_Export_Staged_Endpoints {
     private $secret;
 
     /** @var int */
-    private $max_request_bytes;
+    private $max_frame_bytes;
 
     /** @var int */
     private $append_buffer_bytes;
@@ -81,7 +81,7 @@ final class Site_Export_Staged_Endpoints {
      *     Must live outside the web-served tree.
      *   - secret (?string): shared secret for push authentication.
      *     Null leaves pushes answering 503 until one is configured.
-     *   - max_request_bytes (int): push frame body cap; defaults to
+     *   - max_frame_bytes (int): single frame payload cap; defaults to
      *     post_max_size, or 1 GiB when PHP reports no limit.
      *   - append_buffer_bytes (int): request-to-store step size.
      *   - timestamp_tolerance (int): HMAC freshness window in seconds.
@@ -96,17 +96,17 @@ final class Site_Export_Staged_Endpoints {
         $secret = $options['secret'] ?? null;
         $this->secret = is_string($secret) && $secret !== '' ? $secret : null;
 
-        $max_request_bytes_option = $options['max_request_bytes'] ?? null;
-        if (!is_numeric($max_request_bytes_option) || (int) $max_request_bytes_option <= 0) {
+        $max_frame_bytes_option = $options['max_frame_bytes'] ?? null;
+        if (!is_numeric($max_frame_bytes_option) || (int) $max_frame_bytes_option <= 0) {
             $post_max_size = ini_get('post_max_size');
-            $max_request_bytes_option = is_string($post_max_size) && $post_max_size !== ''
+            $max_frame_bytes_option = is_string($post_max_size) && $post_max_size !== ''
                 ? parse_size($post_max_size)
                 : 0;
-            if ($max_request_bytes_option <= 0) {
-                $max_request_bytes_option = self::DEFAULT_MAX_REQUEST_BYTES;
+            if ($max_frame_bytes_option <= 0) {
+                $max_frame_bytes_option = self::DEFAULT_MAX_FRAME_BYTES;
             }
         }
-        $this->max_request_bytes = (int) $max_request_bytes_option;
+        $this->max_frame_bytes = (int) $max_frame_bytes_option;
 
         $append_buffer_bytes_option = $options['append_buffer_bytes'] ?? null;
         $this->append_buffer_bytes = is_numeric($append_buffer_bytes_option) && (int) $append_buffer_bytes_option > 0
@@ -193,9 +193,9 @@ final class Site_Export_Staged_Endpoints {
             // for arbitrary-byte paths.
             $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $offset];
 
-            if ($bytes > $this->max_request_bytes) {
+            if ($bytes > $this->max_frame_bytes) {
                 $response = $this->stream_rejected(413, 'frame_too_large', null, $cursor, $files_verified);
-                $response['body']['max_frame_bytes'] = $this->max_request_bytes;
+                $response['body']['max_frame_bytes'] = $this->max_frame_bytes;
                 return $response;
             }
 

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -13,12 +13,10 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * frames many bounded chunks for many files, and this endpoint commits each
  * frame into Site_Export_Staged_Artifacts instead of touching the live site.
  *
- * Five routes share the existing endpoint dispatcher:
+ * Four routes share the existing endpoint dispatcher:
  *
  * - staged_push     (POST, data plane): framed file chunks in one streamed
  *   request body.
- * - staged_upload   (POST, data plane, legacy route): raw chunk bytes in the
- *   request body, artifact_id and offset in the query string.
  * - staged_finalize (POST, control plane): confirm the assembled size.
  * - staged_status   (GET, control plane): resume hint for a sender.
  * - staged_discard  (POST, control plane): drop an artifact; retry
@@ -30,40 +28,20 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * bytes, then let TLS protect the body. That keeps one push stream as one
  * request even when it carries many frames for many files.
  *
- * The legacy staged_upload route still authenticates each raw chunk body in
- * two steps that keep memory bounded and keep unauthenticated bytes away from
- * the store:
- *
- * 1. verify_signed_content_hash() checks the signature, nonce, and
- *    timestamp headers before a single body byte is read. A caller
- *    without the shared secret is rejected without costing a body read.
- * 2. The body streams into a spool (memory up to a small threshold,
- *    then a temp file) while a SHA-256 digest accumulates. Only when
- *    the digest matches the signed claim does the spool drain into
- *    append(), one bounded buffer per call. A mismatched or oversized
- *    body is discarded with the spool — the store never sees it. The
- *    spool is one extra sequential disk pass over bytes the host
- *    already buffered for the request; that is the price of never
- *    committing an unverified byte.
- *
- * A replayed capture of a signed upload within the timestamp tolerance
- * re-appends bytes the store already committed and comes back
- * "duplicate" — idempotent, same as a sender retry.
- *
  * Chunk retries are the normal case, not an error: a sender that timed
- * out learns nothing about what landed, retries the same chunk, and may
- * later resend with shifted boundaries. The upload route therefore
- * compares the store's committed offset with the chunk's range first,
- * answers "duplicate" for fully-committed ranges, skips the committed
- * prefix of a straddling chunk, and answers offset_gap (with
- * committed_bytes) only when the chunk starts beyond the frontier.
+ * out learns nothing about what landed, retries from its last cursor or
+ * asks staged_status for the store's committed offset, and may later
+ * resend with shifted boundaries. push_stream therefore compares the store's
+ * committed offset with each frame first, absorbs already-committed ranges,
+ * skips the committed prefix of a straddling frame, and reports offset_gap
+ * with the cursor only when a frame starts beyond the frontier.
  *
- * Rejections the chunk sizer must learn from are typed for it: a body
- * over the request cap is HTTP 413 with max_request_bytes in the
- * payload, exactly what record_too_large() consumes. The cap defaults
- * to post_max_size (falling back to the sizer's own 1 GiB hard cap when
- * PHP reports none), because a proxy or PHP itself would refuse larger
- * bodies before this code runs anyway.
+ * Rejections the chunk sizer must learn from are typed for it: a frame
+ * over the request cap is HTTP 413 with max_frame_bytes in the payload,
+ * exactly what record_too_large() consumes. The cap defaults to post_max_size
+ * (falling back to the sizer's own 1 GiB hard cap when PHP reports none),
+ * because a proxy or PHP itself would refuse larger bodies before this code
+ * runs anyway.
  *
  * All options are server-owned. Client config never chooses the staging
  * directory, the secret, or the caps — a request parameter named like
@@ -76,13 +54,10 @@ final class Site_Export_Staged_Endpoints {
     /** The chunk sizer never sends more than this, so accept up to it. */
     private const DEFAULT_MAX_REQUEST_BYTES = 1073741824;
 
-    /** One append() step per this many spooled bytes. */
+    /** One append() step per this many request-body bytes. */
     private const DEFAULT_APPEND_BUFFER_BYTES = 262144;
 
-    /** Spool bytes held in memory before php://temp spills to disk. */
-    private const SPOOL_MEMORY_BYTES = 2097152;
-
-    /** Request-body read size while spooling. */
+    /** Request-body read size while discarding already-committed bytes. */
     private const READ_BUFFER_BYTES = 65536;
 
     /** @var Site_Export_Staged_Artifacts */
@@ -104,11 +79,11 @@ final class Site_Export_Staged_Endpoints {
      * @param array $options Server-owned configuration:
      *   - staging_dir (string, required): passed to the artifact store.
      *     Must live outside the web-served tree.
-     *   - secret (?string): shared secret for upload authentication.
-     *     Null leaves uploads answering 503 until one is configured.
-     *   - max_request_bytes (int): upload body cap; defaults to
+     *   - secret (?string): shared secret for push authentication.
+     *     Null leaves pushes answering 503 until one is configured.
+     *   - max_request_bytes (int): push frame body cap; defaults to
      *     post_max_size, or 1 GiB when PHP reports no limit.
-     *   - append_buffer_bytes (int): spool-to-store step size.
+     *   - append_buffer_bytes (int): request-to-store step size.
      *   - timestamp_tolerance (int): HMAC freshness window in seconds.
      */
     public function __construct(array $options) {
@@ -142,134 +117,6 @@ final class Site_Export_Staged_Endpoints {
         $this->timestamp_tolerance = is_numeric($timestamp_tolerance_option) && (int) $timestamp_tolerance_option > 0
             ? (int) $timestamp_tolerance_option
             : 300;
-    }
-
-    /**
-     * Stage one chunk of an artifact.
-     *
-     * @param array $config Request parameters (artifact_id, offset).
-     * @param array $headers Request headers/server vars ($_SERVER shape).
-     * @param resource|null $input Request body stream (php://input).
-     * @return array{http_code:int,body:array}
-     */
-    public function upload(array $config, array $headers, $input): array {
-        $method_error = $this->require_post($headers);
-        if ($method_error !== null) {
-            return $method_error;
-        }
-
-        $artifact_id = $config['artifact_id'] ?? null;
-        if (!is_string($artifact_id) || $artifact_id === '') {
-            return $this->rejected(400, 'invalid_artifact_id');
-        }
-        $offset = $config['offset'] ?? null;
-        if (!is_numeric($offset) || (int) $offset < 0) {
-            return $this->rejected(400, 'invalid_offset');
-        }
-        $offset = (int) $offset;
-
-        if ($this->secret === null) {
-            return $this->rejected(503, 'not_configured', 'shared_secret');
-        }
-
-        // Headers first: nobody without the secret gets a body read.
-        $hmac_server = new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance);
-        $authentication_result = $hmac_server->verify_signed_content_hash($headers);
-        if ($authentication_result['error'] !== null) {
-            return $this->rejected(403, 'auth_failed', $authentication_result['error']);
-        }
-
-        $declared_length = $headers['CONTENT_LENGTH'] ?? ( $headers['HTTP_CONTENT_LENGTH'] ?? null );
-        if (is_numeric($declared_length) && (int) $declared_length > $this->max_request_bytes) {
-            return $this->too_large($artifact_id);
-        }
-
-        if (!is_resource($input)) {
-            return $this->rejected(500, 'io_error', 'open_request_body');
-        }
-
-        $spool = fopen('php://temp/maxmemory:' . self::SPOOL_MEMORY_BYTES, 'w+b');
-        if ($spool === false) {
-            return $this->rejected(500, 'io_error', 'open_spool');
-        }
-
-        try {
-            $hash_context = hash_init('sha256');
-            $spooled_bytes = 0;
-            while (( $request_body_chunk = fread($input, self::READ_BUFFER_BYTES) ) !== false && $request_body_chunk !== '') {
-                $spooled_bytes += strlen($request_body_chunk);
-                if ($spooled_bytes > $this->max_request_bytes) {
-                    return $this->too_large($artifact_id);
-                }
-                hash_update($hash_context, $request_body_chunk);
-                if (fwrite($spool, $request_body_chunk) !== strlen($request_body_chunk)) {
-                    return $this->rejected(500, 'io_error', 'write_spool');
-                }
-            }
-            if ($request_body_chunk === false && !feof($input)) {
-                return $this->rejected(400, 'body_read_failed');
-            }
-
-            // The signature authenticated the hash claim; this comparison
-            // authenticates the bytes. Nothing reached the store yet.
-            if (!hash_equals( (string) $authentication_result['content_hash'], hash_final($hash_context))) {
-                return $this->rejected(403, 'content_hash_mismatch');
-            }
-
-            if ($spooled_bytes === 0) {
-                return $this->rejected(400, 'empty_body');
-            }
-
-            $status = $this->store->status($artifact_id);
-            if ($status['verified']) {
-                return $this->rejected(409, 'already_verified', null, $status['committed_bytes']);
-            }
-            $committed_bytes = $status['committed_bytes'];
-            if ($committed_bytes >= $offset + $spooled_bytes) {
-                // A retried chunk that fully landed before the sender's
-                // timeout. Nothing to write.
-                return [
-                    'http_code' => 200,
-                    'body' => [
-                        'status' => 'duplicate',
-                        'reason' => null,
-                        'detail' => null,
-                        'committed_bytes' => $committed_bytes,
-                    ],
-                ];
-            }
-            if ($committed_bytes < $offset) {
-                return $this->rejected(409, 'offset_gap', null, $committed_bytes);
-            }
-
-            // A resent chunk may straddle the committed frontier; skip the
-            // prefix the store already has so appends line up with it.
-            rewind($spool);
-            if ($committed_bytes > $offset && fseek($spool, $committed_bytes - $offset) !== 0) {
-                return $this->rejected(500, 'io_error', 'seek_spool');
-            }
-
-            $append_offset = $committed_bytes;
-            while (( $spooled_chunk = fread($spool, $this->append_buffer_bytes) ) !== false && $spooled_chunk !== '') {
-                $append_result = $this->store->append($artifact_id, $append_offset, $spooled_chunk);
-                if ($append_result['status'] !== 'accepted') {
-                    return $this->from_store_result($append_result);
-                }
-                $append_offset = $append_result['committed_bytes'];
-            }
-
-            return [
-                'http_code' => 200,
-                'body' => [
-                    'status' => 'accepted',
-                    'reason' => null,
-                    'detail' => null,
-                    'committed_bytes' => $append_offset,
-                ],
-            ];
-        } finally {
-            fclose($spool);
-        }
     }
 
     /**
@@ -356,6 +203,18 @@ final class Site_Export_Staged_Endpoints {
             if ($bytes > 0) {
                 $remaining_frame_bytes = $bytes;
                 $append_offset = $offset;
+
+                $committed_bytes = (int) $status['committed_bytes'];
+                if ($committed_bytes > $offset) {
+                    $already_committed_bytes = min($bytes, $committed_bytes - $offset);
+                    if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $already_committed_bytes, self::READ_BUFFER_BYTES)) {
+                        return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+                    }
+                    $remaining_frame_bytes -= $already_committed_bytes;
+                    $append_offset += $already_committed_bytes;
+                    $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => $committed_bytes];
+                }
+
                 while ($remaining_frame_bytes > 0) {
                     $payload_piece_bytes = min($this->append_buffer_bytes, $remaining_frame_bytes);
                     $payload_piece = Site_Export_Staged_Push_Stream_Protocol::read_exactly($input, $payload_piece_bytes);
@@ -572,23 +431,6 @@ final class Site_Export_Staged_Endpoints {
                 'committed_bytes' => $committed_bytes,
             ],
         ];
-    }
-
-    /**
-     * The structured too-large rejection PushFrameSizer::record_too_large()
-     * consumes: HTTP 413 plus the cap it must stay under.
-     *
-     * @return array{http_code:int,body:array}
-     */
-    private function too_large(string $artifact_id): array {
-        $response = $this->rejected(
-            413,
-            'request_too_large',
-            null,
-            $this->store->status($artifact_id)['committed_bytes']
-        );
-        $response['body']['max_request_bytes'] = $this->max_request_bytes;
-        return $response;
     }
 
 }

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -128,19 +128,27 @@ final class Site_Export_Staged_Endpoints {
      *
      * A frame commits before the next frame is read. If the request dies after
      * a commit, the next request may replay from the last sender cursor or from
-     * the beginning; verified artifacts and duplicate ranges are absorbed.
+     * the beginning: verified artifacts replayed at their verified size are
+     * skipped, and an offset-0 frame for anything else that holds bytes
+     * restarts the artifact from zero — the sender only starts a file over
+     * when its source changed or it cannot vouch for the staged prefix, and
+     * appending one version behind another would corrupt the artifact.
      *
      * Behavior steps:
      * 1. Read one JSON header line and validate the frame before reading its
      *    payload bytes.
      * 2. Reject frames larger than this endpoint accepts, before consuming the
-     *    oversized payload.
-     * 3. If the artifact is already verified, consume the frame payload only to
-     *    keep the stream aligned with the next JSON header.
-     * 4. If the artifact is partially committed, discard any replayed prefix
-     *    bytes that the store already has and append only the missing suffix.
-     * 5. Append the remaining payload in bounded pieces so one frame cannot
-     *    force the endpoint to hold the full chunk in memory.
+     *    oversized payload. Every rejection cursor reports the store's
+     *    committed count, never the offset the sender claimed.
+     * 3. If the artifact is verified and the frame declares its verified size,
+     *    consume the frame payload only to keep the stream aligned with the
+     *    next JSON header.
+     * 4. If the frame starts at byte 0 and the artifact holds anything else,
+     *    discard the staged bytes and stage this frame fresh.
+     * 5. If the artifact is partially committed and the frame starts mid-file,
+     *    discard any replayed prefix bytes the store already has and append
+     *    only the missing suffix, in bounded pieces so one frame cannot force
+     *    the endpoint to hold the full chunk in memory.
      * 6. Finalize only when the frame marks the artifact final, then report the
      *    latest cursor for the sender to resume from after failures.
      *
@@ -189,9 +197,14 @@ final class Site_Export_Staged_Endpoints {
             $bytes = $frame['bytes'];
             $total_bytes = $frame['total_bytes'];
             $final = $frame['final'];
+
             // Response cursors re-encode the id so responses stay valid JSON
-            // for arbitrary-byte paths.
-            $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $offset];
+            // for arbitrary-byte paths, and they report only what the store
+            // has confirmed — never the offset the sender claims. A rejection
+            // echoing a claimed offset would send the retry to a position the
+            // store never reached.
+            $status = $this->store->status($artifact_id);
+            $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => (int) $status['committed_bytes']];
 
             if ($bytes > $this->max_frame_bytes) {
                 $response = $this->stream_rejected(413, 'frame_too_large', null, $cursor, $files_verified);
@@ -199,32 +212,47 @@ final class Site_Export_Staged_Endpoints {
                 return $response;
             }
 
-            $status = $this->store->status($artifact_id);
-
             /**
-             * Already-verified artifact case.
+             * Already-verified replay case.
              *
              * The sender may replay a request body from the beginning after a
-             * previous request committed and finalized this artifact. The store
-             * must not append or finalize it again, but the frame payload is
-             * still present in the request body. Read and discard those bytes so
-             * the next loop iteration starts at the following JSON header.
+             * previous request committed and finalized this artifact. When the
+             * declared size still matches, the store must not append or
+             * finalize again, but the frame payload is still present in the
+             * request body: read and discard those bytes so the next loop
+             * iteration starts at the following JSON header.
              */
-            if ($status['verified']) {
-                if ($status['committed_bytes'] !== $total_bytes) {
-                    return $this->stream_rejected(409, 'size_mismatch', null, [
-                        'artifact_id' => base64_encode($artifact_id),
-                        'committed_bytes' => $status['committed_bytes'],
-                    ], $files_verified);
-                }
+            if ($status['verified'] && $status['committed_bytes'] === $total_bytes) {
                 if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $bytes, self::READ_BUFFER_BYTES)) {
                     return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
                 }
-                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $status['committed_bytes']];
                 if ($final) {
                     $files_verified++;
                 }
                 continue;
+            }
+
+            /**
+             * Restart case.
+             *
+             * An offset-0 frame for an artifact that already holds bytes means
+             * the sender is pushing the file over: its source changed since
+             * those bytes were staged, or it is replaying after a failure and
+             * cannot vouch for the staged prefix. Drop the staged bytes and
+             * stage this frame fresh — appending a new version behind an old
+             * prefix would build a file no version of the source ever was.
+             */
+            if ($offset === 0 && ($status['verified'] || (int) $status['committed_bytes'] > 0)) {
+                if (!$this->store->discard($artifact_id)) {
+                    return $this->stream_rejected(423, 'busy', null, $cursor, $files_verified);
+                }
+                $status = $this->store->status($artifact_id);
+                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => 0];
+            } elseif ($status['verified']) {
+                // A mid-file frame into a verified artifact of another size:
+                // the source changed but the sender did not restart. Refuse
+                // rather than mix versions; the sender restarts from zero.
+                return $this->stream_rejected(409, 'size_mismatch', null, $cursor, $files_verified);
             }
 
             if ($bytes > 0) {

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -124,7 +124,7 @@ final class Site_Export_Staged_Endpoints {
      *
      * Each frame is one JSON line followed by exactly "bytes" raw bytes:
      *
-     * {"type":"chunk","artifact_id":"path","offset":0,"bytes":123,"total_bytes":456,"final":false}\n
+     * {"type":"chunk","artifact_id":"<base64 of path>","offset":0,"bytes":123,"total_bytes":456,"final":false}\n
      *
      * A frame commits before the next frame is read. If the request dies after
      * a commit, the next request may replay from the last sender cursor or from
@@ -189,7 +189,9 @@ final class Site_Export_Staged_Endpoints {
             $bytes = $frame['bytes'];
             $total_bytes = $frame['total_bytes'];
             $final = $frame['final'];
-            $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => $offset];
+            // Response cursors re-encode the id so responses stay valid JSON
+            // for arbitrary-byte paths.
+            $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $offset];
 
             if ($bytes > $this->max_request_bytes) {
                 $response = $this->stream_rejected(413, 'frame_too_large', null, $cursor, $files_verified);
@@ -211,14 +213,14 @@ final class Site_Export_Staged_Endpoints {
             if ($status['verified']) {
                 if ($status['committed_bytes'] !== $total_bytes) {
                     return $this->stream_rejected(409, 'size_mismatch', null, [
-                        'artifact_id' => $artifact_id,
+                        'artifact_id' => base64_encode($artifact_id),
                         'committed_bytes' => $status['committed_bytes'],
                     ], $files_verified);
                 }
                 if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $bytes, self::READ_BUFFER_BYTES)) {
                     return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
                 }
-                $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => $status['committed_bytes']];
+                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $status['committed_bytes']];
                 if ($final) {
                     $files_verified++;
                 }
@@ -247,7 +249,7 @@ final class Site_Export_Staged_Endpoints {
                     }
                     $remaining_frame_bytes -= $already_committed_bytes;
                     $append_offset += $already_committed_bytes;
-                    $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => $committed_bytes];
+                    $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $committed_bytes];
                 }
 
                 while ($remaining_frame_bytes > 0) {
@@ -272,7 +274,7 @@ final class Site_Export_Staged_Endpoints {
                         $append_result = $this->store->append($artifact_id, $append_offset, $payload_piece);
                         if ($append_result['status'] === 'accepted' || $append_result['status'] === 'duplicate') {
                             $append_offset = max($append_offset + strlen($payload_piece), (int) $append_result['committed_bytes']);
-                            $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => (int) $append_result['committed_bytes']];
+                            $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => (int) $append_result['committed_bytes']];
                             break;
                         }
 
@@ -289,7 +291,7 @@ final class Site_Export_Staged_Endpoints {
 
                         $response = $this->from_store_result($append_result);
                         $response['body']['cursor'] = [
-                            'artifact_id' => $artifact_id,
+                            'artifact_id' => base64_encode($artifact_id),
                             'committed_bytes' => $committed_bytes,
                         ];
                         $response['body']['files_verified'] = $files_verified;
@@ -315,7 +317,7 @@ final class Site_Export_Staged_Endpoints {
                     return $response;
                 }
                 $files_verified++;
-                $cursor = ['artifact_id' => $artifact_id, 'committed_bytes' => (int) $finalize_result['committed_bytes']];
+                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => (int) $finalize_result['committed_bytes']];
             }
         }
 

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -344,8 +344,8 @@ final class Site_Export_Staged_Endpoints {
             return $method_error;
         }
 
-        $artifact_id = $config['artifact_id'] ?? null;
-        if (!is_string($artifact_id) || $artifact_id === '') {
+        $artifact_id = $this->decode_artifact_id_param($config);
+        if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
         $total_bytes = $config['total_bytes'] ?? null;
@@ -365,8 +365,8 @@ final class Site_Export_Staged_Endpoints {
      * @return array{http_code:int,body:array}
      */
     public function status(array $config): array {
-        $artifact_id = $config['artifact_id'] ?? null;
-        if (!is_string($artifact_id) || $artifact_id === '') {
+        $artifact_id = $this->decode_artifact_id_param($config);
+        if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
 
@@ -387,8 +387,8 @@ final class Site_Export_Staged_Endpoints {
             return $method_error;
         }
 
-        $artifact_id = $config['artifact_id'] ?? null;
-        if (!is_string($artifact_id) || $artifact_id === '') {
+        $artifact_id = $this->decode_artifact_id_param($config);
+        if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
 
@@ -404,6 +404,20 @@ final class Site_Export_Staged_Endpoints {
             'http_code' => 200,
             'body' => ['discarded' => true],
         ];
+    }
+
+    /**
+     * Read a control-plane artifact id parameter: base64 in the request —
+     * file paths are arbitrary bytes, the same convention the push stream
+     * frames use — raw path out. Null when missing or not decodable.
+     */
+    private function decode_artifact_id_param(array $config): ?string {
+        $artifact_id = $config['artifact_id'] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === '') {
+            return null;
+        }
+        $artifact_id = base64_decode($artifact_id, true);
+        return $artifact_id === false || $artifact_id === '' ? null : $artifact_id;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -130,6 +130,20 @@ final class Site_Export_Staged_Endpoints {
      * a commit, the next request may replay from the last sender cursor or from
      * the beginning; verified artifacts and duplicate ranges are absorbed.
      *
+     * Behavior steps:
+     * 1. Read one JSON header line and validate the frame before reading its
+     *    payload bytes.
+     * 2. Reject frames larger than this endpoint accepts, before consuming the
+     *    oversized payload.
+     * 3. If the artifact is already verified, consume the frame payload only to
+     *    keep the stream aligned with the next JSON header.
+     * 4. If the artifact is partially committed, discard any replayed prefix
+     *    bytes that the store already has and append only the missing suffix.
+     * 5. Append the remaining payload in bounded pieces so one frame cannot
+     *    force the endpoint to hold the full chunk in memory.
+     * 6. Finalize only when the frame marks the artifact final, then report the
+     *    latest cursor for the sender to resume from after failures.
+     *
      * @param array $config Request parameters.
      * @param array $headers Request headers/server vars ($_SERVER shape).
      * @param resource|null $input Request body stream (php://input).
@@ -184,6 +198,16 @@ final class Site_Export_Staged_Endpoints {
             }
 
             $status = $this->store->status($artifact_id);
+
+            /**
+             * Already-verified artifact case.
+             *
+             * The sender may replay a request body from the beginning after a
+             * previous request committed and finalized this artifact. The store
+             * must not append or finalize it again, but the frame payload is
+             * still present in the request body. Read and discard those bytes so
+             * the next loop iteration starts at the following JSON header.
+             */
             if ($status['verified']) {
                 if ($status['committed_bytes'] !== $total_bytes) {
                     return $this->stream_rejected(409, 'size_mismatch', null, [
@@ -206,6 +230,16 @@ final class Site_Export_Staged_Endpoints {
                 $append_offset = $offset;
 
                 $committed_bytes = (int) $status['committed_bytes'];
+
+                /**
+                 * Partially-committed replay case.
+                 *
+                 * The sender can retry a frame whose prefix was accepted before
+                 * the earlier request failed. Consume the bytes already stored,
+                 * advance the append offset to the first missing byte, and keep
+                 * the cursor at the remote committed position so the sender can
+                 * resume from that boundary if this request fails too.
+                 */
                 if ($committed_bytes > $offset) {
                     $already_committed_bytes = min($bytes, $committed_bytes - $offset);
                     if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $already_committed_bytes, self::READ_BUFFER_BYTES)) {
@@ -225,6 +259,16 @@ final class Site_Export_Staged_Endpoints {
                     $remaining_frame_bytes -= $payload_piece_bytes;
 
                     while ($payload_piece !== '') {
+                        /**
+                         * Append/reconcile case.
+                         *
+                         * A bounded payload piece normally appends once. If the
+                         * store reports that part of this piece was already
+                         * committed, trim that prefix and retry only the suffix;
+                         * this keeps a resumed request moving forward without
+                         * asking the sender to open another request for the same
+                         * frame.
+                         */
                         $append_result = $this->store->append($artifact_id, $append_offset, $payload_piece);
                         if ($append_result['status'] === 'accepted' || $append_result['status'] === 'duplicate') {
                             $append_offset = max($append_offset + strlen($payload_piece), (int) $append_result['committed_bytes']);
@@ -254,6 +298,13 @@ final class Site_Export_Staged_Endpoints {
                 }
             }
 
+            /**
+             * Final frame case.
+             *
+             * Payload bytes are durable before this branch runs. Only frames
+             * marked final ask the store to compare committed bytes with
+             * total_bytes and mark the artifact verified.
+             */
             if ($final) {
                 $finalize_result = $this->store->finalize($artifact_id, $total_bytes);
                 unset($finalize_result['path']);

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -28,6 +28,11 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     /**
      * Decode and validate one chunk frame header.
      *
+     * The artifact_id in the wire frame is base64: file paths are arbitrary
+     * bytes and JSON strings must be UTF-8, so ids travel encoded — the same
+     * convention the pull cursors and the local journal use for paths. The
+     * returned artifact_id is the decoded raw path.
+     *
      * @return array{artifact_id:string,offset:int,bytes:int,total_bytes:int,final:bool}
      */
     public static function decode_chunk_header(string $line): array {
@@ -50,15 +55,20 @@ final class Site_Export_Staged_Push_Stream_Protocol {
         if (!array_key_exists('artifact_id', $frame)) {
             throw new InvalidArgumentException('Missing staged push stream frame field "artifact_id".');
         }
-        if (!is_string($frame['artifact_id'])) {
+        if (!is_string($frame['artifact_id']) || $frame['artifact_id'] === '') {
             throw new InvalidArgumentException(
-                'Expected staged push stream frame field "artifact_id" to be a non-empty string; received ' .
+                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received ' .
                 self::describe_value($frame['artifact_id']) .
                 '.'
             );
         }
-        if ($frame['artifact_id'] === '') {
-            throw new InvalidArgumentException('Expected staged push stream frame field "artifact_id" to be a non-empty string; received an empty string.');
+        $artifact_id = base64_decode($frame['artifact_id'], true);
+        if ($artifact_id === false || $artifact_id === '') {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received ' .
+                self::describe_value($frame['artifact_id']) .
+                '.'
+            );
         }
 
         $offset = self::require_non_negative_integer_field($frame, 'offset');
@@ -88,7 +98,7 @@ final class Site_Export_Staged_Push_Stream_Protocol {
         }
 
         return [
-            'artifact_id' => $frame['artifact_id'],
+            'artifact_id' => $artifact_id,
             'offset' => $offset,
             'bytes' => $bytes,
             'total_bytes' => $total_bytes,

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Shared wire format helpers for staged push streams.
+ *
+ * A staged push stream is a sequence of JSON header lines followed by exactly
+ * the number of raw payload bytes declared by each header. Both the importer
+ * and the exporter use this class so frame shape, validation, and bounded
+ * stream reads stay in one place.
+ */
+final class Site_Export_Staged_Push_Stream_Protocol {
+
+    public const CONTENT_TYPE = 'application/x-reprint-staged-push-stream';
+
+    /**
+     * @return string JSON header line terminated by "\n".
+     */
+    public static function encode_chunk_header(string $artifact_id, int $offset, int $bytes, int $total_bytes, bool $final): string {
+        $line = json_encode([
+            'type' => 'chunk',
+            'artifact_id' => $artifact_id,
+            'offset' => $offset,
+            'bytes' => $bytes,
+            'total_bytes' => $total_bytes,
+            'final' => $final,
+        ], JSON_UNESCAPED_SLASHES);
+        if ($line === false) {
+            throw new RuntimeException('Could not encode staged push stream frame header.');
+        }
+        return $line . "\n";
+    }
+
+    /**
+     * Read the next frame header line from a stream.
+     *
+     * @param resource $input
+     */
+    public static function read_header_line($input): ?string {
+        $line = fgets($input);
+        if ($line === false) {
+            return null;
+        }
+        return rtrim($line, "\r\n");
+    }
+
+    /**
+     * Decode and validate one chunk frame header.
+     *
+     * @return array{artifact_id:string,offset:int,bytes:int,total_bytes:int,final:bool}
+     */
+    public static function decode_chunk_header(string $line): array {
+        $frame = json_decode($line, true);
+        if (!is_array($frame)) {
+            throw new InvalidArgumentException('header_json');
+        }
+
+        $artifact_id = $frame['artifact_id'] ?? null;
+        $offset = $frame['offset'] ?? null;
+        $bytes = $frame['bytes'] ?? null;
+        $total_bytes = $frame['total_bytes'] ?? null;
+        if (
+            ($frame['type'] ?? null) !== 'chunk'
+            || !is_string($artifact_id)
+            || $artifact_id === ''
+            || !is_numeric($offset)
+            || (int) $offset < 0
+            || !is_numeric($bytes)
+            || (int) $bytes < 0
+            || !is_numeric($total_bytes)
+            || (int) $total_bytes < 0
+        ) {
+            throw new InvalidArgumentException('fields');
+        }
+
+        $offset = (int) $offset;
+        $bytes = (int) $bytes;
+        $total_bytes = (int) $total_bytes;
+        if ($offset + $bytes > $total_bytes) {
+            throw new InvalidArgumentException('range_exceeds_total');
+        }
+
+        return [
+            'artifact_id' => $artifact_id,
+            'offset' => $offset,
+            'bytes' => $bytes,
+            'total_bytes' => $total_bytes,
+            'final' => !empty($frame['final']),
+        ];
+    }
+
+    /**
+     * @param resource $input
+     */
+    public static function read_exactly($input, int $bytes): ?string {
+        $data = '';
+        while (strlen($data) < $bytes) {
+            $piece = fread($input, $bytes - strlen($data));
+            if ($piece === false || $piece === '') {
+                return null;
+            }
+            $data .= $piece;
+        }
+        return $data;
+    }
+
+    /**
+     * @param resource $input
+     */
+    public static function discard_exactly($input, int $bytes, int $buffer_bytes): bool {
+        $remaining = $bytes;
+        while ($remaining > 0) {
+            $piece = fread($input, min($buffer_bytes, $remaining));
+            if ($piece === false || $piece === '') {
+                return false;
+            }
+            $remaining -= strlen($piece);
+        }
+        return true;
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -51,40 +51,66 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     public static function decode_chunk_header(string $line): array {
         $frame = json_decode($line, true);
         if (!is_array($frame)) {
-            throw new InvalidArgumentException('header_json');
+            throw new InvalidArgumentException('Expected staged push stream frame header to be a JSON object.');
         }
 
-        $artifact_id = $frame['artifact_id'] ?? null;
-        $offset = $frame['offset'] ?? null;
-        $bytes = $frame['bytes'] ?? null;
-        $total_bytes = $frame['total_bytes'] ?? null;
-        if (
-            ($frame['type'] ?? null) !== 'chunk'
-            || !is_string($artifact_id)
-            || $artifact_id === ''
-            || !is_numeric($offset)
-            || (int) $offset < 0
-            || !is_numeric($bytes)
-            || (int) $bytes < 0
-            || !is_numeric($total_bytes)
-            || (int) $total_bytes < 0
-        ) {
-            throw new InvalidArgumentException('fields');
+        if (!array_key_exists('type', $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "type".');
+        }
+        if ($frame['type'] !== 'chunk') {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "type" to be "chunk"; received ' .
+                self::describe_value($frame['type']) .
+                '.'
+            );
         }
 
-        $offset = (int) $offset;
-        $bytes = (int) $bytes;
-        $total_bytes = (int) $total_bytes;
+        if (!array_key_exists('artifact_id', $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "artifact_id".');
+        }
+        if (!is_string($frame['artifact_id'])) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "artifact_id" to be a non-empty string; received ' .
+                self::describe_value($frame['artifact_id']) .
+                '.'
+            );
+        }
+        if ($frame['artifact_id'] === '') {
+            throw new InvalidArgumentException('Expected staged push stream frame field "artifact_id" to be a non-empty string; received an empty string.');
+        }
+
+        $offset = self::require_non_negative_integer_field($frame, 'offset');
+        $bytes = self::require_non_negative_integer_field($frame, 'bytes');
+        $total_bytes = self::require_non_negative_integer_field($frame, 'total_bytes');
+
+        if (!array_key_exists('final', $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "final".');
+        }
+        if (!is_bool($frame['final'])) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "final" to be a boolean; received ' .
+                self::describe_value($frame['final']) .
+                '.'
+            );
+        }
+
         if ($offset + $bytes > $total_bytes) {
-            throw new InvalidArgumentException('range_exceeds_total');
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Staged push stream frame declares offset %d and %d payload bytes, which exceeds total_bytes %d.',
+                    $offset,
+                    $bytes,
+                    $total_bytes
+                )
+            );
         }
 
         return [
-            'artifact_id' => $artifact_id,
+            'artifact_id' => $frame['artifact_id'],
             'offset' => $offset,
             'bytes' => $bytes,
             'total_bytes' => $total_bytes,
-            'final' => !empty($frame['final']),
+            'final' => $frame['final'],
         ];
     }
 
@@ -116,5 +142,41 @@ final class Site_Export_Staged_Push_Stream_Protocol {
             $remaining -= strlen($piece);
         }
         return true;
+    }
+
+    private static function require_non_negative_integer_field(array $frame, string $field): int {
+        if (!array_key_exists($field, $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "' . $field . '".');
+        }
+        if (!is_int($frame[$field]) || $frame[$field] < 0) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "' . $field . '" to be a non-negative integer; received ' .
+                self::describe_value($frame[$field]) .
+                '.'
+            );
+        }
+        return $frame[$field];
+    }
+
+    private static function describe_value($value): string {
+        if (is_string($value)) {
+            return 'string "' . $value . '"';
+        }
+        if (is_int($value)) {
+            return 'integer ' . $value;
+        }
+        if (is_float($value)) {
+            return 'float ' . $value;
+        }
+        if (is_bool($value)) {
+            return $value ? 'boolean true' : 'boolean false';
+        }
+        if ($value === null) {
+            return 'null';
+        }
+        if (is_array($value)) {
+            return 'array';
+        }
+        return gettype($value);
     }
 }

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -13,24 +13,6 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     public const CONTENT_TYPE = 'application/x-reprint-staged-push-stream';
 
     /**
-     * @return string JSON header line terminated by "\n".
-     */
-    public static function encode_chunk_header(string $artifact_id, int $offset, int $bytes, int $total_bytes, bool $final): string {
-        $line = json_encode([
-            'type' => 'chunk',
-            'artifact_id' => $artifact_id,
-            'offset' => $offset,
-            'bytes' => $bytes,
-            'total_bytes' => $total_bytes,
-            'final' => $final,
-        ], JSON_UNESCAPED_SLASHES);
-        if ($line === false) {
-            throw new RuntimeException('Could not encode staged push stream frame header.');
-        }
-        return $line . "\n";
-    }
-
-    /**
      * Read the next frame header line from a stream.
      *
      * @param resource $input

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -69,7 +69,7 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol')) {
     }
 }
 
-// Adaptive sizing for bounded local-to-remote push stream frames
+// Adaptive sizing for staged push request bodies
 require_once __DIR__ . '/lib/upload/class-push-request-sizer.php';
 
 // One-request push streams into the target's staged artifact store

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -56,8 +56,24 @@ require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
 // Typed state objects for the persisted import state.
 require_once __DIR__ . '/lib/state/class-import-state.php';
 
-// Adaptive sizing for bounded local-to-remote upload chunks (push transfers)
-require_once __DIR__ . '/lib/upload/class-upload-chunk-sizer.php';
+// Shared staged push stream framing used by the sender and the target endpoint.
+if (!class_exists('Site_Export_Staged_Push_Stream_Protocol')) {
+    foreach ([
+        __DIR__ . '/../../reprint-exporter/src/class-staged-push-stream-protocol.php',
+        __DIR__ . '/../../../vendor/wp-php-toolkit/reprint-exporter/src/class-staged-push-stream-protocol.php',
+    ] as $staged_push_stream_protocol_path) {
+        if (file_exists($staged_push_stream_protocol_path)) {
+            require_once $staged_push_stream_protocol_path;
+            break;
+        }
+    }
+}
+
+// Adaptive sizing for bounded local-to-remote push stream frames
+require_once __DIR__ . '/lib/upload/class-push-frame-sizer.php';
+
+// One-request push streams into the target's staged artifact store
+require_once __DIR__ . '/lib/upload/class-staged-push-stream-client.php';
 
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -70,7 +70,7 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol')) {
 }
 
 // Adaptive sizing for bounded local-to-remote push stream frames
-require_once __DIR__ . '/lib/upload/class-push-frame-sizer.php';
+require_once __DIR__ . '/lib/upload/class-push-request-sizer.php';
 
 // One-request push streams into the target's staged artifact store
 require_once __DIR__ . '/lib/upload/class-staged-push-stream-client.php';

--- a/packages/reprint-importer/src/lib/upload/class-push-frame-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-frame-sizer.php
@@ -15,8 +15,10 @@
  *   and frame metadata. A reverse proxy or CDN may still reject earlier, so
  *   the ceiling is an upper bound, not a guarantee.
  * - Without a useful reported limit, frames start at a conservative 32 MiB.
- * - A hard cap (default 1 GiB) bounds every chunk even when the host reports
- *   a larger limit.
+ * - A hard cap (default 128 MiB) bounds every chunk even when the host
+ *   reports a larger limit. The sender reads a whole chunk into memory
+ *   before writing it, so the cap is a memory promise, not just a network
+ *   one.
  * - Accepted chunks double the size toward the ceiling.
  * - The two rejection kinds back off differently because they carry different
  *   evidence. A rejection known to be size-related — HTTP 413 or a structured
@@ -69,8 +71,9 @@ class PushFrameSizer
             // Conservative bootstrap size used until limits teach us more.
             "start_bytes" => 32 * 1024 * 1024,
             // Hard cap: no chunk may exceed this, even when the host reports
-            // a larger limit.
-            "max_bytes" => 1024 * 1024 * 1024,
+            // a larger limit. The sender buffers one whole chunk in memory,
+            // so this is also its memory ceiling.
+            "max_bytes" => 128 * 1024 * 1024,
             // Fraction of a reported limit usable for the chunk payload; the
             // rest absorbs headers, frame metadata, and host quirks.
             "limit_safety_ratio" => 0.9,

--- a/packages/reprint-importer/src/lib/upload/class-push-frame-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-frame-sizer.php
@@ -93,8 +93,11 @@ class PushFrameSizer
         // through the current floor, ceiling, and hard cap before resuming.
         $ceiling = $state["ceiling_bytes"] ?? null;
         $this->ceiling_bytes = is_numeric($ceiling) && (int) $ceiling > 0 ? (int) $ceiling : null;
-        $this->chunk_bytes = $this->clamp_chunk(
-            (int) ($state["chunk_bytes"] ?? $config["start_bytes"]),
+        $state_chunk_bytes = (int) ($state["chunk_bytes"] ?? $config["start_bytes"]);
+        $effective_ceiling = min($this->ceiling_bytes ?? PHP_INT_MAX, $config["max_bytes"]);
+        $this->chunk_bytes = max(
+            $config["floor_bytes"],
+            min(max($effective_ceiling, $config["floor_bytes"]), $state_chunk_bytes),
         );
         $this->growth_holdoff_remaining = max(0, (int) ($state["growth_holdoff_remaining"] ?? 0));
     }
@@ -132,7 +135,7 @@ class PushFrameSizer
         }
 
         if ($smallest === null) {
-            return $this->decision("steady");
+            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
         }
 
         // Limits only lower the ceiling; a later, higher preflight value
@@ -150,16 +153,16 @@ class PushFrameSizer
     {
         if ($this->growth_holdoff_remaining > 0) {
             $this->growth_holdoff_remaining--;
-            return $this->decision("steady");
+            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
         }
 
-        $grown = min($this->chunk_bytes * 2, $this->effective_ceiling());
+        $grown = min($this->chunk_bytes * 2, min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]));
         if ($grown <= $this->chunk_bytes) {
-            return $this->decision("steady");
+            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
         }
 
         $this->chunk_bytes = $grown;
-        return $this->decision("grow");
+        return ["action" => "grow", "chunk_bytes" => $this->chunk_bytes];
     }
 
     /**
@@ -188,7 +191,7 @@ class PushFrameSizer
         }
 
         if ($this->chunk_bytes <= $this->config["floor_bytes"]) {
-            return $this->decision("give_up");
+            return ["action" => "give_up", "chunk_bytes" => $this->chunk_bytes];
         }
 
         return $this->lower_ceiling(max($this->config["floor_bytes"], intdiv($this->chunk_bytes, 2)));
@@ -209,11 +212,11 @@ class PushFrameSizer
         $this->growth_holdoff_remaining = $this->config["growth_holdoff_successes"];
 
         if ($this->chunk_bytes <= $this->config["floor_bytes"]) {
-            return $this->decision("give_up");
+            return ["action" => "give_up", "chunk_bytes" => $this->chunk_bytes];
         }
 
         $this->chunk_bytes = max($this->config["floor_bytes"], intdiv($this->chunk_bytes, 2));
-        return $this->decision("shrink");
+        return ["action" => "shrink", "chunk_bytes" => $this->chunk_bytes];
     }
 
     /**
@@ -242,45 +245,15 @@ class PushFrameSizer
 
         if ($this->ceiling_bytes < $this->config["floor_bytes"]) {
             $this->chunk_bytes = $this->config["floor_bytes"];
-            return $this->decision("give_up");
+            return ["action" => "give_up", "chunk_bytes" => $this->chunk_bytes];
         }
 
         if ($this->chunk_bytes <= $this->ceiling_bytes) {
-            return $this->decision("steady");
+            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
         }
 
         $this->chunk_bytes = $this->ceiling_bytes;
-        return $this->decision("shrink");
+        return ["action" => "shrink", "chunk_bytes" => $this->chunk_bytes];
     }
 
-    /**
-     * Returns the active ceiling after applying the unconditional hard cap.
-     */
-    private function effective_ceiling(): int
-    {
-        return min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]);
-    }
-
-    /**
-     * Normalizes restored state without converting an already-impossible
-     * ceiling into an invalid chunk size.
-     */
-    private function clamp_chunk(int $chunk_bytes): int
-    {
-        return max(
-            $this->config["floor_bytes"],
-            min(max($this->effective_ceiling(), $this->config["floor_bytes"]), $chunk_bytes),
-        );
-    }
-
-    /**
-     * @return array{action:string,chunk_bytes:int}
-     */
-    private function decision(string $action): array
-    {
-        return [
-            "action" => $action,
-            "chunk_bytes" => $this->chunk_bytes,
-        ];
-    }
 }

--- a/packages/reprint-importer/src/lib/upload/class-push-frame-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-frame-sizer.php
@@ -1,49 +1,49 @@
 <?php
 /**
- * Adaptive sizing for bounded local-to-remote upload chunks.
+ * Adaptive sizing for bounded local-to-remote push stream frames.
  *
  * Push moves bytes from an outbound-only local site to a remote WordPress
- * site through PHP request bodies, and most hosts buffer an inbound body
- * before userland code runs (nginx fastcgi_request_buffering, PHP multipart
- * handling). Reprint therefore never streams one large request; it uploads
- * bounded chunks that stay small enough for host buffering to be acceptable.
+ * site through PHP request bodies. The push stream keeps many files inside
+ * one authenticated request, but each file frame still needs a bounded size:
+ * a target may reject a frame before committing it, and the sender must be
+ * able to retry from a cursor with a smaller frame size.
  *
  * This class owns the chunk-size decision:
  *
  * - Remote-reported request limits (post_max_size, upload_max_filesize, and
  *   similar) establish the session ceiling, minus a safety margin for headers
- *   and multipart framing. A reverse proxy or CDN may still reject earlier,
- *   so the ceiling is an upper bound, not a guarantee.
- * - Without a useful reported limit, uploads start at a conservative 32 MiB.
+ *   and frame metadata. A reverse proxy or CDN may still reject earlier, so
+ *   the ceiling is an upper bound, not a guarantee.
+ * - Without a useful reported limit, frames start at a conservative 32 MiB.
  * - A hard cap (default 1 GiB) bounds every chunk even when the host reports
  *   a larger limit.
  * - Accepted chunks double the size toward the ceiling.
  * - The two rejection kinds back off differently because they carry different
  *   evidence. A rejection known to be size-related — HTTP 413 or a structured
  *   "request too large" response — caps the session ceiling permanently, so
- *   growth never retries a size the server already refused. A transport
- *   failure (timeout, reset, empty response) may have nothing to do with
- *   size, and a push session can run for hours over thousands of chunks —
+ *   growth never retries a size the server already refused. An HTTP
+ *   request failure (timeout, reset, empty response) may have nothing to do
+ *   with size, and a push session can run for hours over thousands of chunks —
  *   permanently halving it over one network blip would double the request
- *   count for everything that follows. So a transport failure only halves the
+ *   count for everything that follows. So a request failure only halves the
  *   chunk and holds growth back for a few successes. The accepted cost: a
  *   size-related failure that never surfaces as a 413 is re-probed once per
  *   holdoff window instead of converging.
  * - When even the floor size is rejected, decisions report "give_up" so the
  *   caller can stop with a clear error instead of retrying forever.
  *
- * Callers should retry transient transport errors at the same size first and
- * record a failure only once a size is considered rejected. The decision
+ * Callers should retry transient HTTP request errors at the same size first
+ * and record a failure only once a size is considered rejected. The decision
  * state survives get_state()/constructor round-trips so a resumed session
  * keeps the learned safe chunk size.
  *
  * This is a sibling of AdaptiveTuner, not an extension of it: AdaptiveTuner
  * tunes how much work a pull request asks for so the exporter fits its time
- * budget, driven by server-reported timing and a throughput average. Upload
- * chunks have no timing signal — the only feedback is accept/reject against
- * hard request-size limits — so the two keep separate state and logic.
+ * budget, driven by server-reported timing and a throughput average. Push
+ * frames have no timing signal — the only feedback is accept/reject against
+ * hard size limits — so the two keep separate state and logic.
  */
-class UploadChunkSizer
+class PushFrameSizer
 {
     private array $config;
 
@@ -72,9 +72,9 @@ class UploadChunkSizer
             // a larger limit.
             "max_bytes" => 1024 * 1024 * 1024,
             // Fraction of a reported limit usable for the chunk payload; the
-            // rest absorbs headers, multipart framing, and host quirks.
+            // rest absorbs headers, frame metadata, and host quirks.
             "limit_safety_ratio" => 0.9,
-            // Successful uploads required after a failure before growing again.
+            // Successful frames required after a failure before growing again.
             "growth_holdoff_successes" => 3,
         ];
 
@@ -100,7 +100,7 @@ class UploadChunkSizer
     }
 
     /**
-     * The chunk size the next upload should use, in bytes.
+     * The chunk size the next push stream frame should use, in bytes.
      */
     public function chunk_bytes(): int
     {
@@ -196,7 +196,7 @@ class UploadChunkSizer
 
     /**
      * Record a rejection that may or may not be size-related: timeout, empty
-     * response, connection reset, or similar during an upload.
+     * response, connection reset, or similar during a push stream.
      *
      * Halves the chunk and holds growth back, but does not cap the ceiling —
      * after the holdoff the size may grow back, so one transient failure does
@@ -204,7 +204,7 @@ class UploadChunkSizer
      *
      * @return array{action:string,chunk_bytes:int} Decision summary.
      */
-    public function record_transport_failure(): array
+    public function record_request_failure(): array
     {
         $this->growth_holdoff_remaining = $this->config["growth_holdoff_successes"];
 

--- a/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
@@ -38,10 +38,11 @@
  * - When even the floor size is rejected, decisions report "give_up" so the
  *   caller can stop with a clear error instead of retrying forever.
  *
- * Callers should retry transient HTTP request errors at the same size first
- * and record a failure only once a size is considered rejected. The decision
- * state survives get_state()/constructor round-trips so a resumed session
- * keeps the learned safe request size.
+ * The push client records a request failure immediately when a transfer
+ * breaks — the halve-and-hold-off response above is sized for exactly that:
+ * one blip costs one halving that growth undoes after the holdoff. The
+ * decision state survives get_state()/constructor round-trips so a resumed
+ * session keeps the learned safe request size.
  *
  * This is a sibling of AdaptiveTuner, not an extension of it: AdaptiveTuner
  * tunes how much work a pull request asks for so the exporter fits its time

--- a/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
@@ -12,9 +12,10 @@
  * This class owns the request-body-size decision:
  *
  * - Remote-reported request limits (post_max_size, upload_max_filesize, and
- *   similar) establish the session ceiling, minus a safety margin for headers
- *   and frame metadata. A reverse proxy or CDN may still reject earlier, so
- *   the ceiling is an upper bound, not a guarantee.
+ *   similar) establish the session ceiling, minus a safety margin for host
+ *   quirks and the frame that may straddle the budget edge. A reverse proxy
+ *   or CDN may still reject earlier, so the ceiling is an upper bound, not a
+ *   guarantee.
  * - Without a useful reported limit, request bodies start at a conservative
  *   32 MiB.
  * - A hard cap (default 1 GiB) bounds every request even when the host

--- a/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
@@ -1,56 +1,59 @@
 <?php
 /**
- * Adaptive sizing for bounded local-to-remote push stream frames.
+ * Adaptive sizing for staged push request bodies.
  *
  * Push moves bytes from an outbound-only local site to a remote WordPress
  * site through PHP request bodies. The push stream keeps many files inside
- * one authenticated request, but each file frame still needs a bounded size:
- * a target may reject a frame before committing it, and the sender must be
- * able to retry from a cursor with a smaller frame size.
+ * one authenticated request, but hosts and proxies cap how much a single
+ * request may carry (post_max_size, client_max_body_size, and similar), so
+ * each request body needs a bounded size and the sender must be able to
+ * retry from a cursor with smaller requests.
  *
- * This class owns the chunk-size decision:
+ * This class owns the request-body-size decision:
  *
  * - Remote-reported request limits (post_max_size, upload_max_filesize, and
  *   similar) establish the session ceiling, minus a safety margin for headers
  *   and frame metadata. A reverse proxy or CDN may still reject earlier, so
  *   the ceiling is an upper bound, not a guarantee.
- * - Without a useful reported limit, frames start at a conservative 32 MiB.
- * - A hard cap (default 128 MiB) bounds every chunk even when the host
- *   reports a larger limit. The sender reads a whole chunk into memory
- *   before writing it, so the cap is a memory promise, not just a network
- *   one.
- * - Accepted chunks double the size toward the ceiling.
+ * - Without a useful reported limit, request bodies start at a conservative
+ *   32 MiB.
+ * - A hard cap (default 1 GiB) bounds every request even when the host
+ *   reports a larger limit. The body streams through chunk by chunk, so this
+ *   is not a memory bound — it only keeps single requests from growing
+ *   without end. The in-memory unit is the much smaller chunk the client
+ *   reads per frame; that is unrelated to this class.
+ * - Accepted requests double the size toward the ceiling.
  * - The two rejection kinds back off differently because they carry different
  *   evidence. A rejection known to be size-related — HTTP 413 or a structured
  *   "request too large" response — caps the session ceiling permanently, so
  *   growth never retries a size the server already refused. An HTTP
  *   request failure (timeout, reset, empty response) may have nothing to do
- *   with size, and a push session can run for hours over thousands of chunks —
- *   permanently halving it over one network blip would double the request
- *   count for everything that follows. So a request failure only halves the
- *   chunk and holds growth back for a few successes. The accepted cost: a
- *   size-related failure that never surfaces as a 413 is re-probed once per
- *   holdoff window instead of converging.
+ *   with size, and a push session can run for hours over thousands of
+ *   requests — permanently halving it over one network blip would double the
+ *   request count for everything that follows. So a request failure only
+ *   halves the size and holds growth back for a few successes. The accepted
+ *   cost: a size-related failure that never surfaces as a 413 is re-probed
+ *   once per holdoff window instead of converging.
  * - When even the floor size is rejected, decisions report "give_up" so the
  *   caller can stop with a clear error instead of retrying forever.
  *
  * Callers should retry transient HTTP request errors at the same size first
  * and record a failure only once a size is considered rejected. The decision
  * state survives get_state()/constructor round-trips so a resumed session
- * keeps the learned safe chunk size.
+ * keeps the learned safe request size.
  *
  * This is a sibling of AdaptiveTuner, not an extension of it: AdaptiveTuner
  * tunes how much work a pull request asks for so the exporter fits its time
  * budget, driven by server-reported timing and a throughput average. Push
- * frames have no timing signal — the only feedback is accept/reject against
+ * requests have no timing signal — the only feedback is accept/reject against
  * hard size limits — so the two keep separate state and logic.
  */
-class PushFrameSizer
+class PushRequestSizer
 {
     private array $config;
 
-    /** @var int Current chunk size in bytes. */
-    private int $chunk_bytes;
+    /** @var int Current request body size in bytes. */
+    private int $request_body_bytes;
 
     /** @var int|null Session ceiling in bytes, null while no limit is known. */
     private ?int $ceiling_bytes;
@@ -65,19 +68,19 @@ class PushFrameSizer
     public function __construct(array $config = [], array $state = [])
     {
         $defaults = [
-            // Smallest chunk worth attempting; a rejection at this size ends
-            // the session instead of shrinking further.
+            // Smallest request body worth attempting; a rejection at this
+            // size ends the session instead of shrinking further.
             "floor_bytes" => 1024 * 1024,
             // Conservative bootstrap size used until limits teach us more.
             "start_bytes" => 32 * 1024 * 1024,
-            // Hard cap: no chunk may exceed this, even when the host reports
-            // a larger limit. The sender buffers one whole chunk in memory,
-            // so this is also its memory ceiling.
-            "max_bytes" => 128 * 1024 * 1024,
-            // Fraction of a reported limit usable for the chunk payload; the
+            // Hard cap: no request body may exceed this, even when the host
+            // reports a larger limit. Bodies stream, so this is not a memory
+            // bound — it only keeps single requests from growing without end.
+            "max_bytes" => 1024 * 1024 * 1024,
+            // Fraction of a reported limit usable for the request body; the
             // rest absorbs headers, frame metadata, and host quirks.
             "limit_safety_ratio" => 0.9,
-            // Successful frames required after a failure before growing again.
+            // Successful requests required after a failure before growing again.
             "growth_holdoff_successes" => 3,
         ];
 
@@ -96,21 +99,21 @@ class PushFrameSizer
         // through the current floor, ceiling, and hard cap before resuming.
         $ceiling = $state["ceiling_bytes"] ?? null;
         $this->ceiling_bytes = is_numeric($ceiling) && (int) $ceiling > 0 ? (int) $ceiling : null;
-        $state_chunk_bytes = (int) ($state["chunk_bytes"] ?? $config["start_bytes"]);
+        $state_request_body_bytes = (int) ($state["request_body_bytes"] ?? $config["start_bytes"]);
         $effective_ceiling = min($this->ceiling_bytes ?? PHP_INT_MAX, $config["max_bytes"]);
-        $this->chunk_bytes = max(
+        $this->request_body_bytes = max(
             $config["floor_bytes"],
-            min(max($effective_ceiling, $config["floor_bytes"]), $state_chunk_bytes),
+            min(max($effective_ceiling, $config["floor_bytes"]), $state_request_body_bytes),
         );
         $this->growth_holdoff_remaining = max(0, (int) ($state["growth_holdoff_remaining"] ?? 0));
     }
 
     /**
-     * The chunk size the next push stream frame should use, in bytes.
+     * The body size the next push stream request should stay within, in bytes.
      */
-    public function chunk_bytes(): int
+    public function request_body_bytes(): int
     {
-        return $this->chunk_bytes;
+        return $this->request_body_bytes;
     }
 
     /**
@@ -122,7 +125,7 @@ class PushFrameSizer
      * safety margin, becomes the ceiling.
      *
      * @param array $limit_bytes_list List of int|null limit candidates.
-     * @return array{action:string,chunk_bytes:int} Decision summary.
+     * @return array{action:string,request_body_bytes:int} Decision summary.
      */
     public function apply_reported_limits(array $limit_bytes_list): array
     {
@@ -138,7 +141,7 @@ class PushFrameSizer
         }
 
         if ($smallest === null) {
-            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
+            return ["action" => "steady", "request_body_bytes" => $this->request_body_bytes];
         }
 
         // Limits only lower the ceiling; a later, higher preflight value
@@ -147,25 +150,25 @@ class PushFrameSizer
     }
 
     /**
-     * Record an accepted chunk; grows toward the ceiling unless a recent
+     * Record an accepted request; grows toward the ceiling unless a recent
      * failure is still being held off.
      *
-     * @return array{action:string,chunk_bytes:int} Decision summary.
+     * @return array{action:string,request_body_bytes:int} Decision summary.
      */
     public function record_success(): array
     {
         if ($this->growth_holdoff_remaining > 0) {
             $this->growth_holdoff_remaining--;
-            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
+            return ["action" => "steady", "request_body_bytes" => $this->request_body_bytes];
         }
 
-        $grown = min($this->chunk_bytes * 2, min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]));
-        if ($grown <= $this->chunk_bytes) {
-            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
+        $grown = min($this->request_body_bytes * 2, min($this->ceiling_bytes ?? PHP_INT_MAX, $this->config["max_bytes"]));
+        if ($grown <= $this->request_body_bytes) {
+            return ["action" => "steady", "request_body_bytes" => $this->request_body_bytes];
         }
 
-        $this->chunk_bytes = $grown;
-        return ["action" => "grow", "chunk_bytes" => $this->chunk_bytes];
+        $this->request_body_bytes = $grown;
+        return ["action" => "grow", "request_body_bytes" => $this->request_body_bytes];
     }
 
     /**
@@ -173,11 +176,13 @@ class PushFrameSizer
      * structured request_too_large response.
      *
      * The failed size caps the session ceiling so growth cannot retry it.
-     * When the server reported its actual limit, the ceiling drops below that
-     * limit directly instead of probing downward.
+     * When the server reported its actual limit — the staged_push endpoint's
+     * 413 carries max_frame_bytes, which it derives from its request-size
+     * limits — the ceiling drops below that limit directly instead of
+     * probing downward.
      *
      * @param int|null $reported_max_bytes Server-reported request limit, if any.
-     * @return array{action:string,chunk_bytes:int} Decision summary.
+     * @return array{action:string,request_body_bytes:int} Decision summary.
      */
     public function record_too_large(?int $reported_max_bytes = null): array
     {
@@ -188,57 +193,57 @@ class PushFrameSizer
             if ($decision["action"] !== "steady") {
                 return $decision;
             }
-            // The reported limit did not reduce the chunk, yet this size was
+            // The reported limit did not reduce the size, yet this size was
             // rejected — a proxy in front of PHP can enforce a lower bound
             // than the one PHP reports. Halve so retries make progress.
         }
 
-        if ($this->chunk_bytes <= $this->config["floor_bytes"]) {
-            return ["action" => "give_up", "chunk_bytes" => $this->chunk_bytes];
+        if ($this->request_body_bytes <= $this->config["floor_bytes"]) {
+            return ["action" => "give_up", "request_body_bytes" => $this->request_body_bytes];
         }
 
-        return $this->lower_ceiling(max($this->config["floor_bytes"], intdiv($this->chunk_bytes, 2)));
+        return $this->lower_ceiling(max($this->config["floor_bytes"], intdiv($this->request_body_bytes, 2)));
     }
 
     /**
      * Record a rejection that may or may not be size-related: timeout, empty
      * response, connection reset, or similar during a push stream.
      *
-     * Halves the chunk and holds growth back, but does not cap the ceiling —
+     * Halves the size and holds growth back, but does not cap the ceiling —
      * after the holdoff the size may grow back, so one transient failure does
      * not permanently clamp the session.
      *
-     * @return array{action:string,chunk_bytes:int} Decision summary.
+     * @return array{action:string,request_body_bytes:int} Decision summary.
      */
     public function record_request_failure(): array
     {
         $this->growth_holdoff_remaining = $this->config["growth_holdoff_successes"];
 
-        if ($this->chunk_bytes <= $this->config["floor_bytes"]) {
-            return ["action" => "give_up", "chunk_bytes" => $this->chunk_bytes];
+        if ($this->request_body_bytes <= $this->config["floor_bytes"]) {
+            return ["action" => "give_up", "request_body_bytes" => $this->request_body_bytes];
         }
 
-        $this->chunk_bytes = max($this->config["floor_bytes"], intdiv($this->chunk_bytes, 2));
-        return ["action" => "shrink", "chunk_bytes" => $this->chunk_bytes];
+        $this->request_body_bytes = max($this->config["floor_bytes"], intdiv($this->request_body_bytes, 2));
+        return ["action" => "shrink", "request_body_bytes" => $this->request_body_bytes];
     }
 
     /**
-     * @return array{chunk_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
+     * @return array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
      */
     public function get_state(): array
     {
         return [
-            "chunk_bytes" => $this->chunk_bytes,
+            "request_body_bytes" => $this->request_body_bytes,
             "ceiling_bytes" => $this->ceiling_bytes,
             "growth_holdoff_remaining" => $this->growth_holdoff_remaining,
         ];
     }
 
     /**
-     * Lowers the learned per-session ceiling and shrinks the current chunk
+     * Lowers the learned per-session ceiling and shrinks the current size
      * when it no longer fits.
      *
-     * @return array{action:string,chunk_bytes:int}
+     * @return array{action:string,request_body_bytes:int}
      */
     private function lower_ceiling(int $ceiling): array
     {
@@ -247,16 +252,16 @@ class PushFrameSizer
         }
 
         if ($this->ceiling_bytes < $this->config["floor_bytes"]) {
-            $this->chunk_bytes = $this->config["floor_bytes"];
-            return ["action" => "give_up", "chunk_bytes" => $this->chunk_bytes];
+            $this->request_body_bytes = $this->config["floor_bytes"];
+            return ["action" => "give_up", "request_body_bytes" => $this->request_body_bytes];
         }
 
-        if ($this->chunk_bytes <= $this->ceiling_bytes) {
-            return ["action" => "steady", "chunk_bytes" => $this->chunk_bytes];
+        if ($this->request_body_bytes <= $this->ceiling_bytes) {
+            return ["action" => "steady", "request_body_bytes" => $this->request_body_bytes];
         }
 
-        $this->chunk_bytes = $this->ceiling_bytes;
-        return ["action" => "shrink", "chunk_bytes" => $this->chunk_bytes];
+        $this->request_body_bytes = $this->ceiling_bytes;
+        return ["action" => "shrink", "request_body_bytes" => $this->request_body_bytes];
     }
 
 }

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -167,8 +167,8 @@ class StagedPushStreamClient
      */
     public function push_next_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): array
     {
-        if (!$processor->has_files()) {
-            return $this->result("complete", null, null, null, 0, 0, 0);
+        if ($processor->is_finished_at($cursor ?? $processor->cursor())) {
+            return $this->result("complete", null, null, $cursor ?? $processor->cursor(), 0, 0, 0);
         }
 
         $request = $this->create_request($processor, $cursor, $limits);
@@ -289,11 +289,6 @@ final class StagedPushStreamRequest
         $this->body->finalize();
     }
 
-    public function is_finalized(): bool
-    {
-        return $this->finalized;
-    }
-
     public function has_chunks(): bool
     {
         return $this->body->chunks_planned() > 0;
@@ -370,15 +365,17 @@ final class StagedPushStreamPusher
     {
         $this->client = $client;
         $this->processor = $processor;
+        $max_chunks = $options["max_chunks_per_request"] ?? null;
+        $max_payload_bytes = $options["max_payload_bytes_per_request"] ?? null;
         $this->limits = [
-            "max_chunks" => $this->positive_int_or_null($options["max_chunks_per_request"] ?? null),
-            "max_payload_bytes" => $this->positive_int_or_null($options["max_payload_bytes_per_request"] ?? null),
+            "max_chunks" => is_numeric($max_chunks) && (int) $max_chunks > 0 ? (int) $max_chunks : null,
+            "max_payload_bytes" => is_numeric($max_payload_bytes) && (int) $max_payload_bytes > 0 ? (int) $max_payload_bytes : null,
         ];
         $this->sleeper = $options["sleeper"] ?? static function (int $microseconds): void {
             usleep($microseconds);
         };
         $this->cursor = $processor->cursor();
-        $this->finished = !$processor->has_files() || $processor->is_finished_at($this->cursor);
+        $this->finished = $processor->is_finished_at($this->cursor);
     }
 
     /**
@@ -436,7 +433,8 @@ final class StagedPushStreamPusher
                 $this->result["status"] = "failed";
                 $this->finished = true;
             } else {
-                $this->backoff($this->request_failures);
+                $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $this->request_failures - 1)));
+                call_user_func($this->sleeper, (int) $delay);
             }
             return true;
         }
@@ -463,16 +461,6 @@ final class StagedPushStreamPusher
         return $this->finished;
     }
 
-    private function backoff(int $attempt): void
-    {
-        $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $attempt - 1)));
-        call_user_func($this->sleeper, (int) $delay);
-    }
-
-    private function positive_int_or_null($value): ?int
-    {
-        return is_numeric($value) && (int) $value > 0 ? (int) $value : null;
-    }
 }
 
 /**
@@ -503,11 +491,6 @@ final class StagedPushStreamProcessor
         $this->local_files_root_path = rtrim($local_files_root_path, "/");
         $this->local_paths_to_push_path = $local_paths_to_push_path;
         $this->cursor = $cursor;
-    }
-
-    public function has_files(): bool
-    {
-        return $this->files() !== [];
     }
 
     /** @return array{artifact_id?:string,committed_bytes?:int}|null */
@@ -654,7 +637,9 @@ final class StagedPushRequestBody
         $this->initial_cursor = $cursor;
         $this->max_chunks = $max_chunks !== null ? max(1, $max_chunks) : null;
         $this->max_payload_bytes = $max_payload_bytes !== null ? max(1, $max_payload_bytes) : null;
-        $this->apply_cursor($cursor);
+        $start = $this->cursor_start();
+        $this->file_index = $start["file_index"];
+        $this->offset = $start["offset"];
     }
 
     /**
@@ -666,23 +651,47 @@ final class StagedPushRequestBody
      */
     public function next_chunk(): bool
     {
-        if ($this->finalized || $this->file_index >= count($this->files) || $this->request_limit_reached()) {
+        if ($this->finalized || $this->file_index >= count($this->files)) {
+            return false;
+        }
+        if ($this->max_chunks !== null && count($this->frames) >= $this->max_chunks) {
+            return false;
+        }
+        if ($this->max_payload_bytes !== null && $this->payload_bytes_planned >= $this->max_payload_bytes) {
             return false;
         }
 
         $file = $this->files[$this->file_index];
-        if ($file["total_bytes"] === 0) {
-            $this->frames[] = $this->frame($this->file_index, 0, 0, true);
-            $this->cursor = ["artifact_id" => $file["artifact_id"], "committed_bytes" => 0];
-            $this->file_index++;
-            return true;
+        $offset = $this->offset;
+        $remaining_payload_bytes = $this->max_payload_bytes === null
+            ? PHP_INT_MAX
+            : max(1, $this->max_payload_bytes - $this->payload_bytes_planned);
+        $bytes = $file["total_bytes"] === 0
+            ? 0
+            : min($this->frame_bytes, $file["total_bytes"] - $offset, $remaining_payload_bytes);
+        $final = $offset + $bytes >= $file["total_bytes"];
+
+        $header = json_encode([
+            "type" => "chunk",
+            "artifact_id" => $file["artifact_id"],
+            "offset" => $offset,
+            "bytes" => $bytes,
+            "total_bytes" => $file["total_bytes"],
+            "final" => $final,
+        ], JSON_UNESCAPED_SLASHES);
+        if ($header === false) {
+            throw new RuntimeException("Could not encode staged push stream frame header.");
         }
 
-        $bytes = min($this->frame_bytes, $file["total_bytes"] - $this->offset, $this->remaining_payload_bytes());
-        $final = $this->offset + $bytes >= $file["total_bytes"];
-        $this->frames[] = $this->frame($this->file_index, $this->offset, $bytes, $final);
+        $this->frames[] = [
+            "file_index" => $this->file_index,
+            "offset" => $offset,
+            "bytes" => $bytes,
+            "final" => $final,
+            "header" => $header . "\n",
+        ];
         $this->payload_bytes_planned += $bytes;
-        $this->offset += $bytes;
+        $this->offset = $offset + $bytes;
         $this->cursor = [
             "artifact_id" => $file["artifact_id"],
             "committed_bytes" => $this->offset,
@@ -718,7 +727,7 @@ final class StagedPushRequestBody
 
             if ($this->current_frame_remaining_bytes > 0) {
                 $piece_bytes = min($remaining_output_bytes, $this->current_frame_remaining_bytes);
-                $piece = $this->read_exactly($this->source_handle, $piece_bytes);
+                $piece = Site_Export_Staged_Push_Stream_Protocol::read_exactly($this->source_handle, $piece_bytes);
                 if ($piece === null) {
                     throw new RuntimeException("Source file ended before declared size: " . $this->files[$this->current_frame_file_index]["source_path"]);
                 }
@@ -769,13 +778,6 @@ final class StagedPushRequestBody
         return $this->cursor;
     }
 
-    private function apply_cursor(?array $cursor): void
-    {
-        $start = $this->cursor_start();
-        $this->file_index = $start["file_index"];
-        $this->offset = $start["offset"];
-    }
-
     /** @return array{file_index:int,offset:int} */
     private function cursor_start(): array
     {
@@ -795,18 +797,6 @@ final class StagedPushRequestBody
             }
         }
         return ["file_index" => 0, "offset" => 0];
-    }
-
-    /** @return array{file_index:int,offset:int,bytes:int,final:bool,header:string} */
-    private function frame(int $file_index, int $offset, int $bytes, bool $final): array
-    {
-        return [
-            "file_index" => $file_index,
-            "offset" => $offset,
-            "bytes" => $bytes,
-            "final" => $final,
-            "header" => $this->frame_header($this->files[$file_index], $offset, $bytes, $final),
-        ];
     }
 
     /** @param array{file_index:int,offset:int,bytes:int,final:bool,header:string} $frame */
@@ -834,39 +824,6 @@ final class StagedPushRequestBody
             throw new RuntimeException("Could not seek source file: " . $file["source_path"]);
         }
         $this->current_frame_remaining_bytes = $frame["bytes"];
-    }
-
-    private function request_limit_reached(): bool
-    {
-        if ($this->max_chunks !== null && count($this->frames) >= $this->max_chunks) {
-            return true;
-        }
-        return $this->max_payload_bytes !== null && $this->payload_bytes_planned >= $this->max_payload_bytes;
-    }
-
-    private function remaining_payload_bytes(): int
-    {
-        if ($this->max_payload_bytes === null) {
-            return PHP_INT_MAX;
-        }
-        return max(1, $this->max_payload_bytes - $this->payload_bytes_planned);
-    }
-
-    /** @param array{artifact_id:string,source_path:string,total_bytes:int} $file */
-    private function frame_header(array $file, int $offset, int $bytes, bool $final): string
-    {
-        return Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
-            $file["artifact_id"],
-            $offset,
-            $bytes,
-            $file["total_bytes"],
-            $final
-        );
-    }
-
-    private function read_exactly($source_handle, int $bytes): ?string
-    {
-        return Site_Export_Staged_Push_Stream_Protocol::read_exactly($source_handle, $bytes);
     }
 
     private function close_source(): void

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -8,15 +8,39 @@
  * retried from the last cursor the sender has, or from the beginning with the
  * target absorbing duplicate/verified frames.
  *
- * Bytes are written to the network as the caller advances the request: each
- * StagedPushStreamRequest::next_chunk() call reads the next file range from
- * disk and writes it straight to the request socket before returning. Nothing
- * accumulates a request body in memory — at most one 64 KiB disk read is in
- * flight. Callers decide how many frames go into one request, finalize it,
- * and resume the next request from the cursor.
+ * The client is a pass-through wire. The caller reads a chunk of a file into
+ * memory — at most max_chunk_bytes(), which is why a chunk is the one thing
+ * that may be buffered — and send_chunk() writes the frame header and the
+ * payload straight to the request socket before returning:
+ *
+ *     $client->start_push_request();
+ *     while (...) {
+ *         if ($client->should_finish_request()) {
+ *             $result = $client->finish_request();   // persist $result['cursor']
+ *             $client->start_push_request();
+ *         }
+ *         $payload = fread($source_handle, min($client->capacity_bytes(), $client->max_chunk_bytes()));
+ *         $client->send_chunk([
+ *             'artifact_id' => $artifact_id,
+ *             'offset'      => $offset,
+ *             'total_bytes' => $total_bytes,
+ *             'final'       => $offset + strlen($payload) >= $total_bytes,
+ *             'payload'     => $payload,
+ *         ]);
+ *     }
+ *     $result = $client->finish_request();
+ *
+ * Budgets count as-sent body bytes. Request-size limits (post_max_size,
+ * client_max_body_size and friends) measure the entity body after chunked
+ * transfer-encoding removal, and nothing compresses request bodies, so the
+ * bytes we write are the bytes that get measured — frame header lines count
+ * toward capacity_bytes(), not only payloads.
  */
 class StagedPushStreamClient
 {
+    /** Largest slice handed to one fwrite; bounds the copy cost of partial writes. */
+    private const WRITE_SLICE_BYTES = 1048576;
+
     private string $base_url;
 
     private ?Site_Export_HMAC_Client $hmac_client;
@@ -25,239 +49,19 @@ class StagedPushStreamClient
 
     private int $request_timeout;
 
-    /**
-     * @param array $options
-     *   - base_url (string, required): the export API URL; endpoint is appended
-     *     to its query string.
-     *   - hmac_client (?Site_Export_HMAC_Client): envelope request signer.
-     *   - frame_sizer (?PushFrameSizer): frame-size decisions; defaults to a
-     *     fresh frame sizer. Pass one restored from persisted state to keep
-     *     learned limits.
-     *   - request_timeout (int): seconds without socket progress (one write,
-     *     or the response read) before the request fails.
-     */
-    public function __construct(array $options)
-    {
-        $base_url = $options["base_url"] ?? null;
-        if (!is_string($base_url) || $base_url === "") {
-            throw new InvalidArgumentException("StagedPushStreamClient requires a base_url option.");
-        }
-        $this->base_url = $base_url;
-        $this->hmac_client = $options["hmac_client"] ?? null;
-        $this->frame_sizer = $options["frame_sizer"] ?? new PushFrameSizer();
-        $timeout = $options["request_timeout"] ?? null;
-        $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
-    }
+    /** @var int|float Wall-clock budget per request, in seconds. */
+    private $max_request_seconds;
 
-    /**
-     * Create one staged_push request that the caller advances chunk by chunk.
-     *
-     * The caller owns the nested loop: call StagedPushStreamRequest::next_chunk()
-     * until the request budget or the caller's own budget says to stop, then
-     * hand the request to push_request(). Each next_chunk() call writes that
-     * frame to the network; the connection opens on the first one.
-     *
-     * @param array{max_chunks?:int|null,max_payload_bytes?:int|null} $limits
-     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
-     */
-    public function create_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): StagedPushStreamRequest
-    {
-        $request_url = $this->base_url
-            . (strpos($this->base_url, "?") === false ? "?" : "&")
-            . http_build_query(["endpoint" => "staged_push"]);
-
-        $request_headers = $this->hmac_client !== null
-            ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
-            : [];
-        $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
-        $request_headers["Transfer-Encoding"] = "chunked";
-        $request_headers["Connection"] = "close";
-
-        return new StagedPushStreamRequest(
-            $request_url,
-            $request_headers,
-            $this->request_timeout,
-            $processor->files(),
-            $this->frame_sizer->chunk_bytes(),
-            $cursor ?? $processor->cursor(),
-            $limits["max_chunks"] ?? null,
-            $limits["max_payload_bytes"] ?? null
-        );
-    }
-
-    /**
-     * Finish one staged_push request and return the request-level result.
-     *
-     * The frames themselves were already written to the network by
-     * next_chunk(); this ends the request body, reads the target's response,
-     * and folds it into the retry/cursor decision.
-     *
-     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
-     */
-    public function push_request(StagedPushStreamRequest $request): array
-    {
-        $request->finalize();
-        $response = $request->finish();
-        $request_start_cursor = $request->start_cursor();
-
-        if ($response["http_code"] === 0 && $response["error"] === null) {
-            // No frame was ever written, so no network exchange happened.
-            return $this->result("request_complete", null, null, $request->cursor(), 0, 0, 0);
-        }
-
-        if ($response["error"] !== null) {
-            $decision = $this->frame_sizer->record_request_failure();
-            return $this->result(
-                $decision["action"] === "give_up" ? "failed" : "retry",
-                "request_failed",
-                $response["error"],
-                $request_start_cursor,
-                0,
-                $request->bytes_streamed(),
-                $request->chunks_streamed()
-            );
-        }
-
-        $decoded = json_decode((string) $response["body"], true);
-        if (!is_array($decoded)) {
-            $decision = $this->frame_sizer->record_request_failure();
-            return $this->result(
-                $decision["action"] === "give_up" ? "failed" : "retry",
-                "request_failed",
-                "invalid JSON response (HTTP " . (int) $response["http_code"] . "): " . substr((string) $response["body"], 0, 120),
-                $request_start_cursor,
-                0,
-                $request->bytes_streamed(),
-                $request->chunks_streamed()
-            );
-        }
-
-        if ((int) $response["http_code"] === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
-            $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
-            $decision = $this->frame_sizer->record_too_large(
-                is_numeric($reported_max_frame_bytes) ? (int) $reported_max_frame_bytes : null
-            );
-            return $this->result(
-                $decision["action"] === "give_up" ? "failed" : "retry",
-                $decision["action"] === "give_up" ? "chunk_size_exhausted" : "frame_too_large",
-                null,
-                is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $request_start_cursor,
-                0,
-                $request->bytes_streamed(),
-                $request->chunks_streamed()
-            );
-        }
-
-        if (($decoded["status"] ?? null) !== "complete") {
-            return $this->result(
-                "failed",
-                is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response",
-                is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . (int) $response["http_code"]),
-                is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $request->cursor(),
-                (int) ($decoded["files_verified"] ?? 0),
-                $request->bytes_streamed(),
-                $request->chunks_streamed()
-            );
-        }
-
-        $this->frame_sizer->record_success();
-        return $this->result(
-            "request_complete",
-            null,
-            null,
-            is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null,
-            (int) ($decoded["files_verified"] ?? 0),
-            $request->bytes_streamed(),
-            $request->chunks_streamed()
-        );
-    }
-
-    /**
-     * Convenience wrapper that fills and sends one request.
-     *
-     * Prefer create_request()/push_request() when the caller needs to pause
-     * inside a request after a caller-chosen number of chunks.
-     *
-     * @param array{max_chunks?:int|null,max_payload_bytes?:int|null} $limits
-     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
-     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
-     */
-    public function push_next_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): array
-    {
-        if ($processor->is_finished_at($cursor ?? $processor->cursor())) {
-            return $this->result("complete", null, null, $cursor ?? $processor->cursor(), 0, 0, 0);
-        }
-
-        $request = $this->create_request($processor, $cursor, $limits);
-        while ($request->next_chunk()) {
-            // Fill this request up to the configured request budget.
-        }
-        return $this->push_request($request);
-    }
-
-    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int} */
-    private function result(string $status, ?string $reason, ?string $detail, ?array $cursor, int $files_verified, int $bytes_streamed, int $chunks_streamed): array
-    {
-        return [
-            "status" => $status,
-            "reason" => $reason,
-            "detail" => $detail,
-            "cursor" => $cursor,
-            "files_verified" => $files_verified,
-            "bytes_streamed" => $bytes_streamed,
-            "chunks_streamed" => $chunks_streamed,
-        ];
-    }
-}
-
-/**
- * One live staged_push request.
- *
- * next_chunk() writes the next frame — header line plus the file's byte
- * range — straight to the request socket and only then returns. The socket
- * opens lazily on the first frame, so a request that never pushes a chunk
- * never touches the network. finish() ends the chunked request body and
- * reads the target's response.
- */
-final class StagedPushStreamRequest
-{
-    /** Largest single disk read; also the largest write handed to the socket. */
-    private const DISK_READ_BYTES = 65536;
-
-    private string $request_url;
-
-    /** @var array<string,string> */
-    private array $request_headers;
-
-    private int $request_timeout;
-
-    /** @var array<int,array{artifact_id:string,source_path:string,total_bytes:int}> */
-    private array $files;
-
-    private int $frame_bytes;
-
-    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
-    private ?array $start_cursor;
-
-    private ?int $max_chunks;
-
-    private ?int $max_payload_bytes;
-
-    private int $file_index = 0;
-
-    private int $offset = 0;
-
-    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
-    private ?array $cursor = null;
-
-    private int $chunks_streamed = 0;
-
-    private int $payload_bytes_streamed = 0;
-
-    private bool $finalized = false;
+    private ?int $max_request_body_bytes;
 
     /** @var resource|null */
     private $socket = null;
+
+    private float $request_started_at = 0.0;
+
+    private int $body_bytes_sent = 0;
+
+    private int $chunks_sent = 0;
 
     private ?string $transport_error = null;
 
@@ -273,190 +77,237 @@ final class StagedPushStreamRequest
      */
     private string $early_reply_buffer = "";
 
-    /** @var array{http_code:int,body:string,error:?string}|null */
-    private ?array $final_response = null;
+    private ?string $last_error = null;
 
     /**
-     * @param array<string,string> $request_headers
-     * @param array<int,array{artifact_id:string,source_path:string,total_bytes:int}> $files
-     * @param array{artifact_id?:string,committed_bytes?:int}|null $start_cursor
+     * @param array $options
+     *   - base_url (string, required): the export API URL; endpoint is appended
+     *     to its query string.
+     *   - hmac_client (?Site_Export_HMAC_Client): envelope request signer.
+     *   - frame_sizer (?PushFrameSizer): chunk-size decisions; defaults to a
+     *     fresh frame sizer. Pass one restored from persisted state to keep
+     *     learned limits.
+     *   - request_timeout (int): seconds without socket progress (one write,
+     *     or the response read) before the request fails. Default 120.
+     *   - max_request_seconds (int|float): wall-clock budget per request;
+     *     should_finish_request() turns true once a request is older than
+     *     this. Soft — checked between chunks — so set it with margin below
+     *     the host's execution/proxy limits. Default 30.
+     *   - max_request_body_bytes (?int): body bytes per request, frame
+     *     headers included, after which should_finish_request() turns true.
+     *     Null means requests rotate on time alone.
      */
-    public function __construct(
-        string $request_url,
-        array $request_headers,
-        int $request_timeout,
-        array $files,
-        int $frame_bytes,
-        ?array $start_cursor,
-        ?int $max_chunks = null,
-        ?int $max_payload_bytes = null
-    ) {
-        $this->request_url = $request_url;
-        $this->request_headers = $request_headers;
-        $this->request_timeout = $request_timeout;
-        $this->files = $files;
-        $this->frame_bytes = max(1, $frame_bytes);
-        $this->start_cursor = $start_cursor;
-        $this->max_chunks = $max_chunks !== null ? max(1, $max_chunks) : null;
-        $this->max_payload_bytes = $max_payload_bytes !== null ? max(1, $max_payload_bytes) : null;
-
-        if ($start_cursor !== null && is_string($start_cursor["artifact_id"] ?? null)) {
-            foreach ($files as $index => $file) {
-                if ($file["artifact_id"] !== $start_cursor["artifact_id"]) {
-                    continue;
-                }
-                $committed_bytes = min(max(0, (int) ($start_cursor["committed_bytes"] ?? 0)), $file["total_bytes"]);
-                if ($committed_bytes >= $file["total_bytes"]) {
-                    $this->file_index = $index + 1;
-                } else {
-                    $this->file_index = $index;
-                    $this->offset = $committed_bytes;
-                }
-                break;
-            }
+    public function __construct(array $options)
+    {
+        $base_url = $options["base_url"] ?? null;
+        if (!is_string($base_url) || $base_url === "") {
+            throw new InvalidArgumentException("StagedPushStreamClient requires a base_url option.");
         }
+        $this->base_url = $base_url;
+        $this->hmac_client = $options["hmac_client"] ?? null;
+        $this->frame_sizer = $options["frame_sizer"] ?? new PushFrameSizer();
+        $timeout = $options["request_timeout"] ?? null;
+        $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
+        $max_request_seconds = $options["max_request_seconds"] ?? null;
+        $this->max_request_seconds = is_numeric($max_request_seconds) && $max_request_seconds > 0 ? $max_request_seconds : 30;
+        $max_request_body_bytes = $options["max_request_body_bytes"] ?? null;
+        $this->max_request_body_bytes = is_numeric($max_request_body_bytes) && (int) $max_request_body_bytes > 0
+            ? (int) $max_request_body_bytes
+            : null;
     }
 
     /**
-     * Push one more framed chunk onto the network.
+     * Open a staged_push request: connect, negotiate TLS for https, and write
+     * the signed request head. The request body starts empty; send_chunk()
+     * fills it.
      *
-     * Opens the connection on the first call, then writes the frame header
-     * and the file's byte range for this frame, reading from disk in 64 KiB
-     * pieces. When this returns true, the frame's bytes have been handed to
-     * the socket.
-     *
-     * @return bool Whether a chunk was pushed. False means the request is
-     *              full, the processor has no more chunks, or the exchange
-     *              already ended (transport failure or an early response);
-     *              finish() reports which.
+     * @return bool False when the connection could not be opened;
+     *              get_last_error() says why.
      */
-    public function next_chunk(): bool
+    public function start_push_request(): bool
     {
-        if (
-            $this->finalized
-            || $this->transport_error !== null
-            || $this->target_replied_early
-            || $this->file_index >= count($this->files)
-        ) {
-            return false;
-        }
-        if ($this->max_chunks !== null && $this->chunks_streamed >= $this->max_chunks) {
-            return false;
-        }
-        if ($this->max_payload_bytes !== null && $this->payload_bytes_streamed >= $this->max_payload_bytes) {
-            return false;
+        if ($this->socket !== null) {
+            throw new RuntimeException("A push request is already open; call finish_request() before starting another.");
         }
 
-        if ($this->socket === null && !$this->open_connection()) {
-            return false;
-        }
+        $this->body_bytes_sent = 0;
+        $this->chunks_sent = 0;
+        $this->transport_error = null;
+        $this->target_replied_early = false;
+        $this->early_reply_buffer = "";
+        $this->last_error = null;
 
-        $file = $this->files[$this->file_index];
-        $offset = $this->offset;
-        $remaining_payload_budget = $this->max_payload_bytes === null
-            ? PHP_INT_MAX
-            : max(1, $this->max_payload_bytes - $this->payload_bytes_streamed);
-        $frame_payload_bytes = $file["total_bytes"] === 0
-            ? 0
-            : min($this->frame_bytes, $file["total_bytes"] - $offset, $remaining_payload_budget);
-        $final = $offset + $frame_payload_bytes >= $file["total_bytes"];
+        $request_url = $this->base_url
+            . (strpos($this->base_url, "?") === false ? "?" : "&")
+            . http_build_query(["endpoint" => "staged_push"]);
+        $request_headers = $this->hmac_client !== null
+            ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
+            : [];
+        $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
+        $request_headers["Transfer-Encoding"] = "chunked";
+        $request_headers["Connection"] = "close";
 
-        $frame_header = json_encode([
-            "type" => "chunk",
-            "artifact_id" => $file["artifact_id"],
-            "offset" => $offset,
-            "bytes" => $frame_payload_bytes,
-            "total_bytes" => $file["total_bytes"],
-            "final" => $final,
-        ], JSON_UNESCAPED_SLASHES);
-        if ($frame_header === false) {
-            throw new RuntimeException("Could not encode staged push stream frame header.");
-        }
-
-        if (!$this->write_to_socket($this->encode_body_chunk($frame_header . "\n"))) {
-            return false;
-        }
-
-        if ($frame_payload_bytes > 0) {
-            $source_handle = @fopen($file["source_path"], "rb");
-            if ($source_handle === false) {
-                throw new RuntimeException("Source file is unreadable: " . $file["source_path"]);
+        if (!$this->open_connection($request_url, $request_headers)) {
+            if (is_resource($this->socket)) {
+                fclose($this->socket);
             }
-            if (fseek($source_handle, $offset) !== 0) {
-                fclose($source_handle);
-                throw new RuntimeException("Could not seek source file: " . $file["source_path"]);
-            }
-            $frame_bytes_remaining = $frame_payload_bytes;
-            while ($frame_bytes_remaining > 0) {
-                $piece = fread($source_handle, min(self::DISK_READ_BYTES, $frame_bytes_remaining));
-                if ($piece === false || $piece === "") {
-                    fclose($source_handle);
-                    throw new RuntimeException("Source file ended before its declared size: " . $file["source_path"]);
-                }
-                if (!$this->write_to_socket($this->encode_body_chunk($piece))) {
-                    fclose($source_handle);
-                    return false;
-                }
-                $this->payload_bytes_streamed += strlen($piece);
-                $frame_bytes_remaining -= strlen($piece);
-            }
-            fclose($source_handle);
+            $this->socket = null;
+            $this->last_error = $this->transport_error;
+            $this->transport_error = null;
+            return false;
         }
 
-        $this->chunks_streamed++;
-        $this->offset = $offset + $frame_payload_bytes;
-        $this->cursor = [
-            "artifact_id" => $file["artifact_id"],
-            "committed_bytes" => $this->offset,
-        ];
-        if ($final) {
-            $this->file_index++;
-            $this->offset = 0;
-        }
+        $this->request_started_at = microtime(true);
         return true;
     }
 
     /**
-     * No more chunks will be pushed into this request.
+     * Write one framed chunk — header line, then the payload — straight to
+     * the request socket.
+     *
+     * The payload's length is the frame's byte count; there is no separate
+     * declaration to reconcile. Invalid descriptors throw with the exact
+     * violated condition. Remote conditions do not throw: false means the
+     * wire died or the target replied early, and finish_request() reports
+     * which.
+     *
+     * @param array{artifact_id:string,offset:int,total_bytes:int,final:bool,payload:string} $chunk
      */
-    public function finalize(): void
+    public function send_chunk(array $chunk): bool
     {
-        $this->finalized = true;
+        $artifact_id = $chunk["artifact_id"] ?? null;
+        if (!is_string($artifact_id) || $artifact_id === "") {
+            throw new InvalidArgumentException("Expected chunk field \"artifact_id\" to be a non-empty string.");
+        }
+        $offset = $chunk["offset"] ?? null;
+        if (!is_int($offset) || $offset < 0) {
+            throw new InvalidArgumentException("Expected chunk field \"offset\" to be a non-negative integer for \"" . $artifact_id . "\".");
+        }
+        $total_bytes = $chunk["total_bytes"] ?? null;
+        if (!is_int($total_bytes) || $total_bytes < 0) {
+            throw new InvalidArgumentException("Expected chunk field \"total_bytes\" to be a non-negative integer for \"" . $artifact_id . "\".");
+        }
+        $final = $chunk["final"] ?? null;
+        if (!is_bool($final)) {
+            throw new InvalidArgumentException("Expected chunk field \"final\" to be a boolean for \"" . $artifact_id . "\".");
+        }
+        $payload = $chunk["payload"] ?? null;
+        if (!is_string($payload)) {
+            throw new InvalidArgumentException("Expected chunk field \"payload\" to be a string for \"" . $artifact_id . "\".");
+        }
+        if ($offset + strlen($payload) > $total_bytes) {
+            throw new InvalidArgumentException(
+                "Chunk for \"" . $artifact_id . "\" spans bytes " . $offset . "-" . ($offset + strlen($payload)) . ", which exceeds total_bytes " . $total_bytes . "."
+            );
+        }
+        if ($payload === "" && !$final && $total_bytes > 0) {
+            throw new InvalidArgumentException(
+                "Refusing a zero-byte non-final chunk for \"" . $artifact_id . "\" — the source file is shorter than its declared total_bytes " . $total_bytes . "."
+            );
+        }
+        if ($final && $offset + strlen($payload) !== $total_bytes) {
+            throw new InvalidArgumentException(
+                "Chunk for \"" . $artifact_id . "\" is marked final at byte " . ($offset + strlen($payload)) . " but total_bytes is " . $total_bytes . "."
+            );
+        }
+
+        if ($this->socket === null) {
+            throw new RuntimeException("No push request is open; call start_push_request() before send_chunk().");
+        }
+        if ($this->transport_error !== null || $this->target_replied_early) {
+            return false;
+        }
+
+        $frame_header = json_encode([
+            "type" => "chunk",
+            "artifact_id" => $artifact_id,
+            "offset" => $offset,
+            "bytes" => strlen($payload),
+            "total_bytes" => $total_bytes,
+            "final" => $final,
+        ], JSON_UNESCAPED_SLASHES);
+        if ($frame_header === false) {
+            throw new RuntimeException("Could not encode the staged push stream frame header for \"" . $artifact_id . "\".");
+        }
+        $frame_header .= "\n";
+
+        if (!$this->write_to_socket($this->encode_body_chunk($frame_header))) {
+            return false;
+        }
+        if ($payload !== "" && !$this->write_to_socket($this->encode_body_chunk($payload))) {
+            return false;
+        }
+
+        $this->body_bytes_sent += strlen($frame_header) + strlen($payload);
+        $this->chunks_sent++;
+        return true;
     }
 
     /**
-     * End the request body and read the target's response.
+     * Body bytes the current request still accepts, frame headers included.
+     *
+     * The budget is soft: the caller sizes payloads by it, and the frame
+     * header that rides along may overshoot it by one header line. The frame
+     * sizer's safety margin absorbs that.
+     */
+    public function capacity_bytes(): int
+    {
+        if ($this->max_request_body_bytes === null) {
+            return PHP_INT_MAX;
+        }
+        return max(0, $this->max_request_body_bytes - $this->body_bytes_sent);
+    }
+
+    /**
+     * Largest single chunk the learned frame ceiling allows. This bounds the
+     * caller's fread, so it is also the most memory one chunk may occupy.
+     */
+    public function max_chunk_bytes(): int
+    {
+        return $this->frame_sizer->chunk_bytes();
+    }
+
+    /**
+     * Whether the current request should end now: its byte or time budget is
+     * spent, or the exchange already ended (dead wire or an early response).
+     */
+    public function should_finish_request(): bool
+    {
+        if ($this->socket === null) {
+            throw new RuntimeException("No push request is open; call start_push_request() before should_finish_request().");
+        }
+        return $this->transport_error !== null
+            || $this->target_replied_early
+            || $this->capacity_bytes() === 0
+            || (microtime(true) - $this->request_started_at) > $this->max_request_seconds;
+    }
+
+    /**
+     * End the request body, read the target's response, and fold it into the
+     * retry/cursor decision.
      *
      * Behavior by how the exchange went:
      *
-     * 1. No frame was ever written: returns http_code 0 with no error — no
-     *    network exchange happened.
-     * 2. Normal end: writes the terminating zero-length chunk so the target
+     * 1. Normal end: writes the terminating zero-length chunk so the target
      *    sees a complete body, then reads the response.
-     * 3. The target replied early: skips the terminator (the target already
+     * 2. The target replied early: skips the terminator (the target already
      *    decided) and reads the response that is waiting.
-     * 4. A transport failure interrupted the stream: still tries to read a
+     * 3. A transport failure interrupted the stream: still tries to read a
      *    response — a target that rejected mid-stream (413 from a proxy, auth
      *    failure) breaks our writes but its response carries the reason and a
-     *    resume cursor. Falls back to the original write error when no
-     *    parseable response arrives.
+     *    resume cursor. Falls back to the write error when no parseable
+     *    response arrives.
      *
-     * @return array{http_code:int,body:string,error:?string}
+     * The returned cursor is the server-confirmed one from the response, or
+     * null when no response arrived — resume from the last persisted cursor
+     * or ask staged_status.
+     *
+     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
      */
-    public function finish(): array
+    public function finish_request(): array
     {
-        if ($this->final_response !== null) {
-            return $this->final_response;
-        }
-        $this->finalized = true;
-
         if ($this->socket === null) {
-            $this->final_response = [
-                "http_code" => 0,
-                "body" => "",
-                "error" => $this->transport_error,
-            ];
-            return $this->final_response;
+            throw new RuntimeException("No push request is open; call start_push_request() before finish_request().");
         }
 
         if ($this->transport_error === null && !$this->target_replied_early) {
@@ -468,49 +319,90 @@ final class StagedPushStreamRequest
         fclose($this->socket);
         $this->socket = null;
 
-        $this->final_response = $response ?? [
-            "http_code" => 0,
-            "body" => "",
-            "error" => $write_error ?? $this->transport_error,
+        if ($response === null) {
+            $decision = $this->frame_sizer->record_request_failure();
+            return $this->result(
+                $decision["action"] === "give_up" ? "failed" : "retry",
+                "request_failed",
+                $write_error ?? $this->transport_error
+            );
+        }
+
+        $decoded = json_decode($response["body"], true);
+        if (!is_array($decoded)) {
+            $decision = $this->frame_sizer->record_request_failure();
+            return $this->result(
+                $decision["action"] === "give_up" ? "failed" : "retry",
+                "request_failed",
+                "invalid JSON response (HTTP " . $response["http_code"] . "): " . substr($response["body"], 0, 120)
+            );
+        }
+
+        $response_cursor = is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null;
+
+        if ($response["http_code"] === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
+            $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
+            $decision = $this->frame_sizer->record_too_large(
+                is_numeric($reported_max_frame_bytes) ? (int) $reported_max_frame_bytes : null
+            );
+            return $this->result(
+                $decision["action"] === "give_up" ? "failed" : "retry",
+                $decision["action"] === "give_up" ? "chunk_size_exhausted" : "frame_too_large",
+                null,
+                $response_cursor
+            );
+        }
+
+        if (($decoded["status"] ?? null) !== "complete") {
+            return $this->result(
+                "failed",
+                is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response",
+                is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . $response["http_code"]),
+                $response_cursor,
+                (int) ($decoded["files_verified"] ?? 0)
+            );
+        }
+
+        $this->frame_sizer->record_success();
+        return $this->result("complete", null, null, $response_cursor, (int) ($decoded["files_verified"] ?? 0));
+    }
+
+    /**
+     * Why the last start_push_request() returned false.
+     */
+    public function get_last_error(): ?string
+    {
+        return $this->last_error;
+    }
+
+    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int} */
+    private function result(string $status, ?string $reason, ?string $detail, ?array $cursor = null, int $files_verified = 0): array
+    {
+        return [
+            "status" => $status,
+            "reason" => $reason,
+            "detail" => $detail,
+            "cursor" => $cursor,
+            "files_verified" => $files_verified,
+            "chunks_sent" => $this->chunks_sent,
+            "body_bytes_sent" => $this->body_bytes_sent,
         ];
-        return $this->final_response;
-    }
-
-    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
-    public function start_cursor(): ?array
-    {
-        return $this->start_cursor;
-    }
-
-    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
-    public function cursor(): ?array
-    {
-        return $this->cursor;
-    }
-
-    public function bytes_streamed(): int
-    {
-        return $this->payload_bytes_streamed;
-    }
-
-    public function chunks_streamed(): int
-    {
-        return $this->chunks_streamed;
     }
 
     /**
      * Connect, negotiate TLS for https, and write the request head.
      *
-     * On failure records a transport error and returns false; the connection
-     * error surfaces through finish() like any other request failure.
+     * On failure records a transport error and returns false.
+     *
+     * @param array<string,string> $request_headers
      */
-    private function open_connection(): bool
+    private function open_connection(string $request_url, array $request_headers): bool
     {
-        $url_parts = parse_url($this->request_url);
+        $url_parts = parse_url($request_url);
         $scheme = $url_parts["scheme"] ?? "";
         $host = $url_parts["host"] ?? "";
         if (!in_array($scheme, ["http", "https"], true) || $host === "") {
-            throw new InvalidArgumentException("Staged push requires an http:// or https:// base_url; received " . $this->request_url);
+            throw new InvalidArgumentException("Staged push requires an http:// or https:// base_url; received " . $request_url);
         }
         $is_tls = $scheme === "https";
         $port = isset($url_parts["port"]) ? (int) $url_parts["port"] : ($is_tls ? 443 : 80);
@@ -560,7 +452,7 @@ final class StagedPushStreamRequest
         $default_port = $is_tls ? 443 : 80;
         $head = "POST " . $request_target . " HTTP/1.1\r\n"
             . "Host: " . $host . ($port === $default_port ? "" : ":" . $port) . "\r\n";
-        foreach ($this->request_headers as $header_name => $header_value) {
+        foreach ($request_headers as $header_name => $header_value) {
             $head .= $header_name . ": " . $header_value . "\r\n";
         }
         $head .= "\r\n";
@@ -582,7 +474,7 @@ final class StagedPushStreamRequest
      * Watches for readability in the same select: the target speaking (or
      * closing) before our stream ends means its response decides this request,
      * so sending stops. Returns false on early reply, timeout, or a dead
-     * socket; the specific transport error is recorded for finish().
+     * socket; the specific transport error is recorded for finish_request().
      */
     private function write_to_socket(string $bytes): bool
     {
@@ -614,29 +506,27 @@ final class StagedPushStreamRequest
             if ($ready === 0) {
                 continue;
             }
-            if ($read_sockets !== []) {
-                // Probe whether this is application data. TLS also wakes the
-                // socket for protocol-internal records (e.g. TLS 1.3 session
-                // tickets); reading those yields no bytes and no EOF, and
-                // sending must continue.
-                $probed = fread($this->socket, 1);
-                if ($probed !== false && $probed !== "") {
-                    $this->early_reply_buffer .= $probed;
-                    $this->target_replied_early = true;
-                    return false;
-                }
-                if (feof($this->socket)) {
-                    $this->target_replied_early = true;
-                    return false;
-                }
-                continue;
+
+            // The socket fired; probe for an early reply before writing. Any
+            // buffered application byte means the target's response decides
+            // this request now. TLS also wakes the read side for protocol-
+            // internal records (e.g. TLS 1.3 session tickets); those yield no
+            // bytes and no EOF, and sending continues.
+            $probed = fread($this->socket, 1);
+            if (is_string($probed) && $probed !== "") {
+                $this->early_reply_buffer .= $probed;
+                $this->target_replied_early = true;
+                return false;
+            }
+            if (feof($this->socket)) {
+                $this->target_replied_early = true;
+                return false;
             }
 
-            // @phpstan-ignore deadCode.unreachable (stream_select() empties $read_sockets by reference)
-            $written = @fwrite($this->socket, $unwritten_offset === 0 ? $bytes : substr($bytes, $unwritten_offset));
+            $written = @fwrite($this->socket, substr($bytes, $unwritten_offset, self::WRITE_SLICE_BYTES));
             if ($written === false || $written === 0) {
                 if (feof($this->socket)) {
-                    $this->transport_error = "Connection closed while sending the push stream after " . $this->payload_bytes_streamed . " payload bytes.";
+                    $this->transport_error = "Connection closed while sending the push stream after " . $this->body_bytes_sent . " body bytes.";
                     return false;
                 }
                 // A writable-but-zero write happens during TLS renegotiation;
@@ -652,7 +542,7 @@ final class StagedPushStreamRequest
      * Read and parse the HTTP response. Returns null and records a transport
      * error when no complete response arrives in time.
      *
-     * @return array{http_code:int,body:string,error:?string}|null
+     * @return array{http_code:int,body:string}|null
      */
     private function read_response(): ?array
     {
@@ -716,7 +606,7 @@ final class StagedPushStreamRequest
                 }
                 $body .= substr($chunk, 0, $chunk_size);
             }
-            return ["http_code" => $http_code, "body" => $body, "error" => null];
+            return ["http_code" => $http_code, "body" => $body];
         }
 
         if (isset($response_headers["content-length"])) {
@@ -724,7 +614,7 @@ final class StagedPushStreamRequest
             if ($body === null) {
                 return null;
             }
-            return ["http_code" => $http_code, "body" => $body, "error" => null];
+            return ["http_code" => $http_code, "body" => $body];
         }
 
         // Connection: close without a length — the body ends when the target
@@ -734,7 +624,7 @@ final class StagedPushStreamRequest
             $this->transport_error = "Timed out after " . $this->request_timeout . "s reading the push stream response body.";
             return null;
         }
-        return ["http_code" => $http_code, "body" => $body, "error" => null];
+        return ["http_code" => $http_code, "body" => $body];
     }
 
     /**
@@ -754,270 +644,5 @@ final class StagedPushStreamRequest
             $buffer .= $piece;
         }
         return $buffer;
-    }
-}
-
-/**
- * Cursor-style driver for staged push streams.
- *
- * This mirrors processor and async-client APIs: next_request() opens one
- * network request, the request advances chunk by chunk, finalize_request()
- * sends it, and the caller decides whether to keep looping, persist the
- * cursor, or pause the push.
- */
-final class StagedPushStreamPusher
-{
-    /** Consecutive failed stream requests before the push is abandoned. */
-    private const MAX_REQUEST_RETRIES = 5;
-
-    /** Base backoff between retries, in microseconds. */
-    private const RETRY_BACKOFF_USEC = 250000;
-
-    /** Longest single backoff, in microseconds. */
-    private const MAX_BACKOFF_USEC = 5000000;
-
-    private StagedPushStreamClient $client;
-
-    private StagedPushStreamProcessor $processor;
-
-    /** @var array{max_chunks?:int|null,max_payload_bytes?:int|null} */
-    private array $limits;
-
-    /** @var callable(int):void */
-    private $sleeper;
-
-    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
-    private ?array $cursor;
-
-    /** @var array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}|null */
-    private ?array $result = null;
-
-    private ?StagedPushStreamRequest $request = null;
-
-    private int $request_failures = 0;
-
-    private bool $finished = false;
-
-    /**
-     * @param array $options
-     *   - max_chunks_per_request (?int): stop each request after this many
-     *     framed chunks.
-     *   - max_payload_bytes_per_request (?int): stop each request after this
-     *     many local file bytes, excluding frame headers.
-     *   - sleeper (?callable): fn(int $microseconds), for tests.
-     */
-    public function __construct(StagedPushStreamClient $client, StagedPushStreamProcessor $processor, array $options = [])
-    {
-        $this->client = $client;
-        $this->processor = $processor;
-        $max_chunks = $options["max_chunks_per_request"] ?? null;
-        $max_payload_bytes = $options["max_payload_bytes_per_request"] ?? null;
-        $this->limits = [
-            "max_chunks" => is_numeric($max_chunks) && (int) $max_chunks > 0 ? (int) $max_chunks : null,
-            "max_payload_bytes" => is_numeric($max_payload_bytes) && (int) $max_payload_bytes > 0 ? (int) $max_payload_bytes : null,
-        ];
-        $this->sleeper = $options["sleeper"] ?? static function (int $microseconds): void {
-            usleep($microseconds);
-        };
-        $this->cursor = $processor->cursor();
-        $this->finished = $processor->is_finished_at($this->cursor);
-    }
-
-    /**
-     * Open the next staged_push request.
-     *
-     * @return bool Whether a request is available via get_request().
-     */
-    public function next_request(): bool
-    {
-        if ($this->finished || $this->request !== null) {
-            return false;
-        }
-
-        $this->request = $this->client->create_request($this->processor, $this->cursor, $this->limits);
-        $this->result = null;
-        return true;
-    }
-
-    public function get_request(): ?StagedPushStreamRequest
-    {
-        return $this->request;
-    }
-
-    /**
-     * Finalize and send the current request.
-     *
-     * @return bool Whether a request-level result is available via get_result().
-     */
-    public function finalize_request(): bool
-    {
-        if ($this->request === null) {
-            return false;
-        }
-
-        $result = $this->client->push_request($this->request);
-        $this->request = null;
-        $this->result = $result;
-
-        if ($result["status"] === "request_complete") {
-            $this->request_failures = 0;
-            $this->cursor = is_array($result["cursor"] ?? null) ? $result["cursor"] : $this->cursor;
-            if ($this->processor->is_finished_at($this->cursor)) {
-                $this->result["status"] = "complete";
-                $this->finished = true;
-            } else {
-                $this->result["status"] = "in_progress";
-            }
-            return true;
-        }
-
-        if ($result["status"] === "retry") {
-            $this->request_failures++;
-            $this->cursor = is_array($result["cursor"] ?? null) ? $result["cursor"] : $this->cursor;
-            if ($this->request_failures > self::MAX_REQUEST_RETRIES) {
-                $this->result["status"] = "failed";
-                $this->finished = true;
-            } else {
-                $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $this->request_failures - 1)));
-                call_user_func($this->sleeper, (int) $delay);
-            }
-            return true;
-        }
-
-        $this->cursor = is_array($result["cursor"] ?? null) ? $result["cursor"] : $this->cursor;
-        $this->finished = true;
-        return true;
-    }
-
-    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}|null */
-    public function get_result(): ?array
-    {
-        return $this->result;
-    }
-
-    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
-    public function get_cursor(): ?array
-    {
-        return $this->cursor;
-    }
-
-    public function is_finished(): bool
-    {
-        return $this->finished;
-    }
-
-}
-
-/**
- * Processor-style source for staged push streams.
- *
- * Callers construct this with the local filesystem root, the JSONL list of
- * local paths to push, and the last cursor returned by the target. The client
- * owns HTTP retries and frame sizing; the processor owns local file identity
- * and where a request should start.
- */
-final class StagedPushStreamProcessor
-{
-    private string $local_files_root_path;
-
-    private string $local_paths_to_push_path;
-
-    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
-    private ?array $cursor;
-
-    /** @var array<int,array{artifact_id:string,source_path:string,total_bytes:int}>|null */
-    private ?array $files = null;
-
-    /**
-     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
-     */
-    public function __construct(string $local_files_root_path, string $local_paths_to_push_path, ?array $cursor = null)
-    {
-        $this->local_files_root_path = rtrim($local_files_root_path, "/");
-        $this->local_paths_to_push_path = $local_paths_to_push_path;
-        $this->cursor = $cursor;
-    }
-
-    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
-    public function cursor(): ?array
-    {
-        return $this->cursor;
-    }
-
-    /**
-     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
-     */
-    public function is_finished_at(?array $cursor): bool
-    {
-        $files = $this->files();
-        if ($files === []) {
-            return true;
-        }
-        if (!is_string($cursor["artifact_id"] ?? null)) {
-            return false;
-        }
-        $last_file = $files[count($files) - 1];
-        return $cursor["artifact_id"] === $last_file["artifact_id"]
-            && (int) ($cursor["committed_bytes"] ?? -1) >= $last_file["total_bytes"];
-    }
-
-    /**
-     * The resolved local files to push, in push order.
-     *
-     * @return array<int,array{artifact_id:string,source_path:string,total_bytes:int}>
-     */
-    public function files(): array
-    {
-        if ($this->files !== null) {
-            return $this->files;
-        }
-        if (!is_file($this->local_paths_to_push_path)) {
-            throw new RuntimeException("Cannot open local paths to push: " . $this->local_paths_to_push_path);
-        }
-        $handle = fopen($this->local_paths_to_push_path, "r");
-        if (!$handle) {
-            throw new RuntimeException("Cannot open local paths to push: " . $this->local_paths_to_push_path);
-        }
-
-        $files = [];
-        while (($raw_line = fgets($handle)) !== false) {
-            $raw_line = trim($raw_line);
-            if ($raw_line === "") {
-                continue;
-            }
-            $artifact_id = $this->decode_artifact_id($raw_line);
-            $source_path = $this->local_files_root_path . "/" . $artifact_id;
-            $size = @filesize($source_path);
-            if ($size === false) {
-                fclose($handle);
-                throw new RuntimeException("Source file is unreadable: " . $source_path);
-            }
-            $files[] = [
-                "artifact_id" => $artifact_id,
-                "source_path" => $source_path,
-                "total_bytes" => (int) $size,
-            ];
-        }
-        fclose($handle);
-
-        $this->files = $files;
-        return $this->files;
-    }
-
-    private function decode_artifact_id(string $raw_line): string
-    {
-        try {
-            $decoded_line = json_decode($raw_line, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException("Unexpected local path line, it is not valid JSON: " . substr($raw_line, 0, 120), 0, $exception);
-        }
-        if (!is_array($decoded_line) || !array_key_exists("path", $decoded_line) || !is_string($decoded_line["path"])) {
-            throw new RuntimeException("Invalid local path line: " . substr($raw_line, 0, 120));
-        }
-        $artifact_id = base64_decode($decoded_line["path"], true);
-        if ($artifact_id === false || $artifact_id === "") {
-            throw new RuntimeException("Invalid local path line: " . substr($raw_line, 0, 120));
-        }
-        return $artifact_id;
     }
 }

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -6,9 +6,14 @@
  * framed file chunks. The target commits each frame into
  * Site_Export_Staged_Artifacts as it is read, so a broken connection can be
  * retried from the last cursor the sender has, or from the beginning with the
- * target absorbing duplicate/verified frames. This class exposes request-level
- * control rather than a per-file request API: callers decide how many frames go
- * into one request, finalize it, and resume the next request from the cursor.
+ * target absorbing duplicate/verified frames.
+ *
+ * Bytes are written to the network as the caller advances the request: each
+ * StagedPushStreamRequest::next_chunk() call reads the next file range from
+ * disk and writes it straight to the request socket before returning. Nothing
+ * accumulates a request body in memory — at most one 64 KiB disk read is in
+ * flight. Callers decide how many frames go into one request, finalize it,
+ * and resume the next request from the cursor.
  */
 class StagedPushStreamClient
 {
@@ -20,9 +25,6 @@ class StagedPushStreamClient
 
     private int $request_timeout;
 
-    /** @var callable|null */
-    private $on_before_request;
-
     /**
      * @param array $options
      *   - base_url (string, required): the export API URL; endpoint is appended
@@ -31,8 +33,8 @@ class StagedPushStreamClient
      *   - frame_sizer (?PushFrameSizer): frame-size decisions; defaults to a
      *     fresh frame sizer. Pass one restored from persisted state to keep
      *     learned limits.
-     *   - request_timeout (int): per-request timeout in seconds.
-     *   - on_before_request (?callable): test hook called just before curl runs.
+     *   - request_timeout (int): seconds without socket progress (one write,
+     *     or the response read) before the request fails.
      */
     public function __construct(array $options)
     {
@@ -45,48 +47,63 @@ class StagedPushStreamClient
         $this->frame_sizer = $options["frame_sizer"] ?? new PushFrameSizer();
         $timeout = $options["request_timeout"] ?? null;
         $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
-        $this->on_before_request = $options["on_before_request"] ?? null;
     }
 
     /**
-     * Create one staged_push request that the caller can fill chunk by chunk.
+     * Create one staged_push request that the caller advances chunk by chunk.
      *
-     * The caller owns the nested loop: first start a request, then call
-     * StagedPushStreamRequest::next_chunk() until the request budget or the
-     * caller's own budget says to stop, then finalize and send the request.
+     * The caller owns the nested loop: call StagedPushStreamRequest::next_chunk()
+     * until the request budget or the caller's own budget says to stop, then
+     * hand the request to push_request(). Each next_chunk() call writes that
+     * frame to the network; the connection opens on the first one.
      *
      * @param array{max_chunks?:int|null,max_payload_bytes?:int|null} $limits
      * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
      */
     public function create_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): StagedPushStreamRequest
     {
-        $request_start_cursor = $cursor ?? $processor->cursor();
+        $request_url = $this->base_url
+            . (strpos($this->base_url, "?") === false ? "?" : "&")
+            . http_build_query(["endpoint" => "staged_push"]);
+
+        $request_headers = $this->hmac_client !== null
+            ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
+            : [];
+        $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
+        $request_headers["Transfer-Encoding"] = "chunked";
+        $request_headers["Connection"] = "close";
+
         return new StagedPushStreamRequest(
-            $processor->create_request_body(
-                $this->frame_sizer->chunk_bytes(),
-                $request_start_cursor,
-                $limits["max_chunks"] ?? null,
-                $limits["max_payload_bytes"] ?? null
-            ),
-            $request_start_cursor
+            $request_url,
+            $request_headers,
+            $this->request_timeout,
+            $processor->files(),
+            $this->frame_sizer->chunk_bytes(),
+            $cursor ?? $processor->cursor(),
+            $limits["max_chunks"] ?? null,
+            $limits["max_payload_bytes"] ?? null
         );
     }
 
     /**
-     * Send one finalized staged_push request and return the request-level result.
+     * Finish one staged_push request and return the request-level result.
+     *
+     * The frames themselves were already written to the network by
+     * next_chunk(); this ends the request body, reads the target's response,
+     * and folds it into the retry/cursor decision.
      *
      * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
      */
     public function push_request(StagedPushStreamRequest $request): array
     {
         $request->finalize();
-        if (!$request->has_chunks()) {
+        $response = $request->finish();
+        $request_start_cursor = $request->start_cursor();
+
+        if ($response["http_code"] === 0 && $response["error"] === null) {
+            // No frame was ever written, so no network exchange happened.
             return $this->result("request_complete", null, null, $request->cursor(), 0, 0, 0);
         }
-
-        $body = $request->body();
-        $request_start_cursor = $request->start_cursor();
-        $response = $this->send_stream_request($body);
 
         if ($response["error"] !== null) {
             $decision = $this->frame_sizer->record_request_failure();
@@ -96,8 +113,8 @@ class StagedPushStreamClient
                 $response["error"],
                 $request_start_cursor,
                 0,
-                $body->bytes_streamed(),
-                $body->chunks_streamed()
+                $request->bytes_streamed(),
+                $request->chunks_streamed()
             );
         }
 
@@ -110,8 +127,8 @@ class StagedPushStreamClient
                 "invalid JSON response (HTTP " . (int) $response["http_code"] . "): " . substr((string) $response["body"], 0, 120),
                 $request_start_cursor,
                 0,
-                $body->bytes_streamed(),
-                $body->chunks_streamed()
+                $request->bytes_streamed(),
+                $request->chunks_streamed()
             );
         }
 
@@ -126,8 +143,8 @@ class StagedPushStreamClient
                 null,
                 is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $request_start_cursor,
                 0,
-                $body->bytes_streamed(),
-                $body->chunks_streamed()
+                $request->bytes_streamed(),
+                $request->chunks_streamed()
             );
         }
 
@@ -136,10 +153,10 @@ class StagedPushStreamClient
                 "failed",
                 is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response",
                 is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . (int) $response["http_code"]),
-                is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $body->cursor(),
+                is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $request->cursor(),
                 (int) ($decoded["files_verified"] ?? 0),
-                $body->bytes_streamed(),
-                $body->chunks_streamed()
+                $request->bytes_streamed(),
+                $request->chunks_streamed()
             );
         }
 
@@ -150,8 +167,8 @@ class StagedPushStreamClient
             null,
             is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null,
             (int) ($decoded["files_verified"] ?? 0),
-            $body->bytes_streamed(),
-            $body->chunks_streamed()
+            $request->bytes_streamed(),
+            $request->chunks_streamed()
         );
     }
 
@@ -178,61 +195,6 @@ class StagedPushStreamClient
         return $this->push_request($request);
     }
 
-    /** @return array{http_code:int,body:string,error:?string} */
-    private function send_stream_request(StagedPushRequestBody $body): array
-    {
-        $request_url = $this->base_url
-            . (strpos($this->base_url, "?") === false ? "?" : "&")
-            . http_build_query(["endpoint" => "staged_push"]);
-
-        $request_headers = $this->hmac_client !== null
-            ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
-            : [];
-        $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
-        $request_headers["Transfer-Encoding"] = "chunked";
-        $request_headers["Expect"] = "";
-
-        $header_lines = [];
-        foreach ($request_headers as $name => $value) {
-            $header_lines[] = "{$name}: {$value}";
-        }
-
-        $curl_handle = curl_init($request_url);
-        if (function_exists("reprint_apply_curl_proxy_from_env")) {
-            reprint_apply_curl_proxy_from_env($curl_handle);
-        }
-        if (function_exists("reprint_apply_curl_ca_bundle")) {
-            reprint_apply_curl_ca_bundle($curl_handle);
-        }
-
-        curl_setopt_array($curl_handle, [
-            CURLOPT_UPLOAD => true,
-            CURLOPT_CUSTOMREQUEST => "POST",
-            CURLOPT_HTTPHEADER => $header_lines,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_FOLLOWLOCATION => false,
-            CURLOPT_TIMEOUT => $this->request_timeout,
-            CURLOPT_READFUNCTION => static function ($curl_handle, $stream, int $length) use ($body): string {
-                return $body->read($length);
-            },
-        ]);
-
-        if ($this->on_before_request !== null) {
-            call_user_func($this->on_before_request, $body);
-        }
-
-        $response_body = curl_exec($curl_handle);
-        if ($response_body === false) {
-            $error = curl_error($curl_handle) ?: ("curl errno " . curl_errno($curl_handle));
-            curl_close($curl_handle);
-            return ["http_code" => 0, "body" => "", "error" => $error];
-        }
-        $http_status_code = (int) curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
-        curl_close($curl_handle);
-
-        return ["http_code" => $http_status_code, "body" => (string) $response_body, "error" => null];
-    }
-
     /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int} */
     private function result(string $status, ?string $reason, ?string $detail, ?array $cursor, int $files_verified, int $bytes_streamed, int $chunks_streamed): array
     {
@@ -249,49 +211,269 @@ class StagedPushStreamClient
 }
 
 /**
- * Caller-controlled request builder for one staged push stream request.
+ * One live staged_push request.
+ *
+ * next_chunk() writes the next frame — header line plus the file's byte
+ * range — straight to the request socket and only then returns. The socket
+ * opens lazily on the first frame, so a request that never pushes a chunk
+ * never touches the network. finish() ends the chunked request body and
+ * reads the target's response.
  */
 final class StagedPushStreamRequest
 {
-    private StagedPushRequestBody $body;
+    /** Largest single disk read; also the largest write handed to the socket. */
+    private const DISK_READ_BYTES = 65536;
+
+    private string $request_url;
+
+    /** @var array<string,string> */
+    private array $request_headers;
+
+    private int $request_timeout;
+
+    /** @var array<int,array{artifact_id:string,source_path:string,total_bytes:int}> */
+    private array $files;
+
+    private int $frame_bytes;
 
     /** @var array{artifact_id?:string,committed_bytes?:int}|null */
     private ?array $start_cursor;
 
+    private ?int $max_chunks;
+
+    private ?int $max_payload_bytes;
+
+    private int $file_index = 0;
+
+    private int $offset = 0;
+
+    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
+    private ?array $cursor = null;
+
+    private int $chunks_streamed = 0;
+
+    private int $payload_bytes_streamed = 0;
+
     private bool $finalized = false;
 
+    /** @var resource|null */
+    private $socket = null;
+
+    private ?string $transport_error = null;
+
     /**
+     * The target started responding (or closed) before this stream ended.
+     * Its response decides the request now, so no further bytes are sent.
+     */
+    private bool $target_replied_early = false;
+
+    /**
+     * Response bytes consumed while probing read-readiness during a write;
+     * read_response() treats them as the start of the response head.
+     */
+    private string $early_reply_buffer = "";
+
+    /** @var array{http_code:int,body:string,error:?string}|null */
+    private ?array $final_response = null;
+
+    /**
+     * @param array<string,string> $request_headers
+     * @param array<int,array{artifact_id:string,source_path:string,total_bytes:int}> $files
      * @param array{artifact_id?:string,committed_bytes?:int}|null $start_cursor
      */
-    public function __construct(StagedPushRequestBody $body, ?array $start_cursor)
-    {
-        $this->body = $body;
+    public function __construct(
+        string $request_url,
+        array $request_headers,
+        int $request_timeout,
+        array $files,
+        int $frame_bytes,
+        ?array $start_cursor,
+        ?int $max_chunks = null,
+        ?int $max_payload_bytes = null
+    ) {
+        $this->request_url = $request_url;
+        $this->request_headers = $request_headers;
+        $this->request_timeout = $request_timeout;
+        $this->files = $files;
+        $this->frame_bytes = max(1, $frame_bytes);
         $this->start_cursor = $start_cursor;
+        $this->max_chunks = $max_chunks !== null ? max(1, $max_chunks) : null;
+        $this->max_payload_bytes = $max_payload_bytes !== null ? max(1, $max_payload_bytes) : null;
+
+        if ($start_cursor !== null && is_string($start_cursor["artifact_id"] ?? null)) {
+            foreach ($files as $index => $file) {
+                if ($file["artifact_id"] !== $start_cursor["artifact_id"]) {
+                    continue;
+                }
+                $committed_bytes = min(max(0, (int) ($start_cursor["committed_bytes"] ?? 0)), $file["total_bytes"]);
+                if ($committed_bytes >= $file["total_bytes"]) {
+                    $this->file_index = $index + 1;
+                } else {
+                    $this->file_index = $index;
+                    $this->offset = $committed_bytes;
+                }
+                break;
+            }
+        }
     }
 
     /**
-     * Add one more framed chunk to this request.
+     * Push one more framed chunk onto the network.
      *
-     * @return bool Whether a chunk was added. False means the request is full
-     *              or the processor has no more chunks to send.
+     * Opens the connection on the first call, then writes the frame header
+     * and the file's byte range for this frame, reading from disk in 64 KiB
+     * pieces. When this returns true, the frame's bytes have been handed to
+     * the socket.
+     *
+     * @return bool Whether a chunk was pushed. False means the request is
+     *              full, the processor has no more chunks, or the exchange
+     *              already ended (transport failure or an early response);
+     *              finish() reports which.
      */
     public function next_chunk(): bool
     {
-        if ($this->finalized) {
+        if (
+            $this->finalized
+            || $this->transport_error !== null
+            || $this->target_replied_early
+            || $this->file_index >= count($this->files)
+        ) {
             return false;
         }
-        return $this->body->next_chunk();
+        if ($this->max_chunks !== null && $this->chunks_streamed >= $this->max_chunks) {
+            return false;
+        }
+        if ($this->max_payload_bytes !== null && $this->payload_bytes_streamed >= $this->max_payload_bytes) {
+            return false;
+        }
+
+        if ($this->socket === null && !$this->open_connection()) {
+            return false;
+        }
+
+        $file = $this->files[$this->file_index];
+        $offset = $this->offset;
+        $remaining_payload_budget = $this->max_payload_bytes === null
+            ? PHP_INT_MAX
+            : max(1, $this->max_payload_bytes - $this->payload_bytes_streamed);
+        $frame_payload_bytes = $file["total_bytes"] === 0
+            ? 0
+            : min($this->frame_bytes, $file["total_bytes"] - $offset, $remaining_payload_budget);
+        $final = $offset + $frame_payload_bytes >= $file["total_bytes"];
+
+        $frame_header = json_encode([
+            "type" => "chunk",
+            "artifact_id" => $file["artifact_id"],
+            "offset" => $offset,
+            "bytes" => $frame_payload_bytes,
+            "total_bytes" => $file["total_bytes"],
+            "final" => $final,
+        ], JSON_UNESCAPED_SLASHES);
+        if ($frame_header === false) {
+            throw new RuntimeException("Could not encode staged push stream frame header.");
+        }
+
+        if (!$this->write_to_socket($this->encode_body_chunk($frame_header . "\n"))) {
+            return false;
+        }
+
+        if ($frame_payload_bytes > 0) {
+            $source_handle = @fopen($file["source_path"], "rb");
+            if ($source_handle === false) {
+                throw new RuntimeException("Source file is unreadable: " . $file["source_path"]);
+            }
+            if (fseek($source_handle, $offset) !== 0) {
+                fclose($source_handle);
+                throw new RuntimeException("Could not seek source file: " . $file["source_path"]);
+            }
+            $frame_bytes_remaining = $frame_payload_bytes;
+            while ($frame_bytes_remaining > 0) {
+                $piece = fread($source_handle, min(self::DISK_READ_BYTES, $frame_bytes_remaining));
+                if ($piece === false || $piece === "") {
+                    fclose($source_handle);
+                    throw new RuntimeException("Source file ended before its declared size: " . $file["source_path"]);
+                }
+                if (!$this->write_to_socket($this->encode_body_chunk($piece))) {
+                    fclose($source_handle);
+                    return false;
+                }
+                $this->payload_bytes_streamed += strlen($piece);
+                $frame_bytes_remaining -= strlen($piece);
+            }
+            fclose($source_handle);
+        }
+
+        $this->chunks_streamed++;
+        $this->offset = $offset + $frame_payload_bytes;
+        $this->cursor = [
+            "artifact_id" => $file["artifact_id"],
+            "committed_bytes" => $this->offset,
+        ];
+        if ($final) {
+            $this->file_index++;
+            $this->offset = 0;
+        }
+        return true;
     }
 
+    /**
+     * No more chunks will be pushed into this request.
+     */
     public function finalize(): void
     {
         $this->finalized = true;
-        $this->body->finalize();
     }
 
-    public function has_chunks(): bool
+    /**
+     * End the request body and read the target's response.
+     *
+     * Behavior by how the exchange went:
+     *
+     * 1. No frame was ever written: returns http_code 0 with no error — no
+     *    network exchange happened.
+     * 2. Normal end: writes the terminating zero-length chunk so the target
+     *    sees a complete body, then reads the response.
+     * 3. The target replied early: skips the terminator (the target already
+     *    decided) and reads the response that is waiting.
+     * 4. A transport failure interrupted the stream: still tries to read a
+     *    response — a target that rejected mid-stream (413 from a proxy, auth
+     *    failure) breaks our writes but its response carries the reason and a
+     *    resume cursor. Falls back to the original write error when no
+     *    parseable response arrives.
+     *
+     * @return array{http_code:int,body:string,error:?string}
+     */
+    public function finish(): array
     {
-        return $this->body->chunks_planned() > 0;
+        if ($this->final_response !== null) {
+            return $this->final_response;
+        }
+        $this->finalized = true;
+
+        if ($this->socket === null) {
+            $this->final_response = [
+                "http_code" => 0,
+                "body" => "",
+                "error" => $this->transport_error,
+            ];
+            return $this->final_response;
+        }
+
+        if ($this->transport_error === null && !$this->target_replied_early) {
+            $this->write_to_socket("0\r\n\r\n");
+        }
+
+        $write_error = $this->transport_error;
+        $response = $this->read_response();
+        fclose($this->socket);
+        $this->socket = null;
+
+        $this->final_response = $response ?? [
+            "http_code" => 0,
+            "body" => "",
+            "error" => $write_error ?? $this->transport_error,
+        ];
+        return $this->final_response;
     }
 
     /** @return array{artifact_id?:string,committed_bytes?:int}|null */
@@ -303,12 +485,275 @@ final class StagedPushStreamRequest
     /** @return array{artifact_id?:string,committed_bytes?:int}|null */
     public function cursor(): ?array
     {
-        return $this->body->cursor();
+        return $this->cursor;
     }
 
-    public function body(): StagedPushRequestBody
+    public function bytes_streamed(): int
     {
-        return $this->body;
+        return $this->payload_bytes_streamed;
+    }
+
+    public function chunks_streamed(): int
+    {
+        return $this->chunks_streamed;
+    }
+
+    /**
+     * Connect, negotiate TLS for https, and write the request head.
+     *
+     * On failure records a transport error and returns false; the connection
+     * error surfaces through finish() like any other request failure.
+     */
+    private function open_connection(): bool
+    {
+        $url_parts = parse_url($this->request_url);
+        $scheme = $url_parts["scheme"] ?? "";
+        $host = $url_parts["host"] ?? "";
+        if (!in_array($scheme, ["http", "https"], true) || $host === "") {
+            throw new InvalidArgumentException("Staged push requires an http:// or https:// base_url; received " . $this->request_url);
+        }
+        $is_tls = $scheme === "https";
+        $port = isset($url_parts["port"]) ? (int) $url_parts["port"] : ($is_tls ? 443 : 80);
+
+        $context_options = [];
+        if ($is_tls) {
+            $context_options["ssl"] = ["peer_name" => $host, "SNI_enabled" => true];
+            // Same escape hatch as the pull client's curl path: Playground's
+            // TLS stack may not trust the target's CA. The wizard sets this
+            // env when it hands off; nothing else does.
+            if (getenv("REPRINT_INSECURE_TLS") === "1") {
+                $context_options["ssl"]["verify_peer"] = false;
+                $context_options["ssl"]["verify_peer_name"] = false;
+            }
+        }
+
+        $socket = @stream_socket_client(
+            "tcp://" . $host . ":" . $port,
+            $connect_errno,
+            $connect_error,
+            $this->request_timeout,
+            STREAM_CLIENT_CONNECT,
+            stream_context_create($context_options)
+        );
+        if ($socket === false) {
+            $this->transport_error = "Could not connect to " . $host . ":" . $port . " — " . ($connect_error !== "" ? $connect_error : ("errno " . $connect_errno));
+            return false;
+        }
+        stream_set_timeout($socket, $this->request_timeout);
+
+        if ($is_tls && @stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT) !== true) {
+            $last_error = error_get_last();
+            $this->transport_error = "TLS handshake with " . $host . ":" . $port . " failed — " . (is_array($last_error) ? $last_error["message"] : "unknown error");
+            fclose($socket);
+            return false;
+        }
+
+        // Non-blocking so body writes can watch for an early response in the
+        // same stream_select() that waits for writability.
+        stream_set_blocking($socket, false);
+        $this->socket = $socket;
+
+        $request_target = ($url_parts["path"] ?? "") !== "" ? $url_parts["path"] : "/";
+        if (($url_parts["query"] ?? "") !== "") {
+            $request_target .= "?" . $url_parts["query"];
+        }
+        $default_port = $is_tls ? 443 : 80;
+        $head = "POST " . $request_target . " HTTP/1.1\r\n"
+            . "Host: " . $host . ($port === $default_port ? "" : ":" . $port) . "\r\n";
+        foreach ($this->request_headers as $header_name => $header_value) {
+            $head .= $header_name . ": " . $header_value . "\r\n";
+        }
+        $head .= "\r\n";
+
+        return $this->write_to_socket($head);
+    }
+
+    /**
+     * Wrap raw bytes as one HTTP chunked-transfer-encoding chunk.
+     */
+    private function encode_body_chunk(string $bytes): string
+    {
+        return dechex(strlen($bytes)) . "\r\n" . $bytes . "\r\n";
+    }
+
+    /**
+     * Write bytes to the socket, waiting for writability as needed.
+     *
+     * Watches for readability in the same select: the target speaking (or
+     * closing) before our stream ends means its response decides this request,
+     * so sending stops. Returns false on early reply, timeout, or a dead
+     * socket; the specific transport error is recorded for finish().
+     */
+    private function write_to_socket(string $bytes): bool
+    {
+        $unwritten_offset = 0;
+        $total_bytes = strlen($bytes);
+        $deadline = microtime(true) + $this->request_timeout;
+
+        while ($unwritten_offset < $total_bytes) {
+            $seconds_remaining = $deadline - microtime(true);
+            if ($seconds_remaining <= 0) {
+                $this->transport_error = "Timed out after " . $this->request_timeout . "s waiting to write push stream bytes.";
+                return false;
+            }
+            $read_sockets = [$this->socket];
+            $write_sockets = [$this->socket];
+            $except_sockets = null;
+            $ready = @stream_select(
+                $read_sockets,
+                $write_sockets,
+                $except_sockets,
+                (int) $seconds_remaining,
+                (int) (fmod($seconds_remaining, 1) * 1000000)
+            );
+            if ($ready === false) {
+                $last_error = error_get_last();
+                $this->transport_error = "stream_select() failed while sending the push stream — " . (is_array($last_error) ? $last_error["message"] : "unknown error");
+                return false;
+            }
+            if ($ready === 0) {
+                continue;
+            }
+            if ($read_sockets !== []) {
+                // Probe whether this is application data. TLS also wakes the
+                // socket for protocol-internal records (e.g. TLS 1.3 session
+                // tickets); reading those yields no bytes and no EOF, and
+                // sending must continue.
+                $probed = fread($this->socket, 1);
+                if ($probed !== false && $probed !== "") {
+                    $this->early_reply_buffer .= $probed;
+                    $this->target_replied_early = true;
+                    return false;
+                }
+                if (feof($this->socket)) {
+                    $this->target_replied_early = true;
+                    return false;
+                }
+                continue;
+            }
+
+            // @phpstan-ignore deadCode.unreachable (stream_select() empties $read_sockets by reference)
+            $written = @fwrite($this->socket, $unwritten_offset === 0 ? $bytes : substr($bytes, $unwritten_offset));
+            if ($written === false || $written === 0) {
+                if (feof($this->socket)) {
+                    $this->transport_error = "Connection closed while sending the push stream after " . $this->payload_bytes_streamed . " payload bytes.";
+                    return false;
+                }
+                // A writable-but-zero write happens during TLS renegotiation;
+                // retry until the deadline decides.
+                continue;
+            }
+            $unwritten_offset += $written;
+        }
+        return true;
+    }
+
+    /**
+     * Read and parse the HTTP response. Returns null and records a transport
+     * error when no complete response arrives in time.
+     *
+     * @return array{http_code:int,body:string,error:?string}|null
+     */
+    private function read_response(): ?array
+    {
+        stream_set_blocking($this->socket, true);
+        stream_set_timeout($this->socket, $this->request_timeout);
+
+        $head = $this->early_reply_buffer;
+        while (strpos($head, "\r\n\r\n") === false) {
+            $line = fgets($this->socket);
+            if ($line === false) {
+                $this->transport_error = stream_get_meta_data($this->socket)["timed_out"]
+                    ? "Timed out after " . $this->request_timeout . "s waiting for the push stream response."
+                    : "Connection closed before a push stream response arrived.";
+                return null;
+            }
+            $head .= $line;
+            if (strlen($head) > 65536) {
+                $this->transport_error = "Push stream response headers exceeded 64 KiB.";
+                return null;
+            }
+        }
+
+        if (!preg_match('#^HTTP/\S+\s+(\d{3})#', $head, $status_match)) {
+            $this->transport_error = "Malformed push stream response status line: " . substr($head, 0, 120);
+            return null;
+        }
+        $http_code = (int) $status_match[1];
+
+        $response_headers = [];
+        foreach (explode("\r\n", $head) as $header_line) {
+            $colon_position = strpos($header_line, ":");
+            if ($colon_position !== false) {
+                $response_headers[strtolower(substr($header_line, 0, $colon_position))] = trim(substr($header_line, $colon_position + 1));
+            }
+        }
+
+        if (stripos($response_headers["transfer-encoding"] ?? "", "chunked") !== false) {
+            $body = "";
+            while (true) {
+                $size_line = fgets($this->socket);
+                if ($size_line === false) {
+                    $this->transport_error = "Connection closed inside a chunked push stream response.";
+                    return null;
+                }
+                $chunk_size_hex = trim(explode(";", $size_line, 2)[0]);
+                if ($chunk_size_hex === "" || !ctype_xdigit($chunk_size_hex)) {
+                    $this->transport_error = "Malformed chunked response size line: " . substr($size_line, 0, 40);
+                    return null;
+                }
+                $chunk_size = (int) hexdec($chunk_size_hex);
+                if ($chunk_size === 0) {
+                    // Drain optional trailers up to the blank line.
+                    while (($trailer_line = fgets($this->socket)) !== false && $trailer_line !== "\r\n") {
+                        continue;
+                    }
+                    break;
+                }
+                $chunk = $this->read_from_socket($chunk_size + 2);
+                if ($chunk === null) {
+                    return null;
+                }
+                $body .= substr($chunk, 0, $chunk_size);
+            }
+            return ["http_code" => $http_code, "body" => $body, "error" => null];
+        }
+
+        if (isset($response_headers["content-length"])) {
+            $body = $this->read_from_socket((int) $response_headers["content-length"]);
+            if ($body === null) {
+                return null;
+            }
+            return ["http_code" => $http_code, "body" => $body, "error" => null];
+        }
+
+        // Connection: close without a length — the body ends when the target
+        // closes the connection.
+        $body = stream_get_contents($this->socket);
+        if ($body === false || stream_get_meta_data($this->socket)["timed_out"]) {
+            $this->transport_error = "Timed out after " . $this->request_timeout . "s reading the push stream response body.";
+            return null;
+        }
+        return ["http_code" => $http_code, "body" => $body, "error" => null];
+    }
+
+    /**
+     * Read exactly $bytes from the blocking response socket, or record why not.
+     */
+    private function read_from_socket(int $bytes): ?string
+    {
+        $buffer = "";
+        while (strlen($buffer) < $bytes) {
+            $piece = fread($this->socket, $bytes - strlen($buffer));
+            if ($piece === false || $piece === "") {
+                $this->transport_error = stream_get_meta_data($this->socket)["timed_out"]
+                    ? "Timed out after " . $this->request_timeout . "s reading the push stream response body."
+                    : "Connection closed after " . strlen($buffer) . " of " . $bytes . " expected push stream response body bytes.";
+                return null;
+            }
+            $buffer .= $piece;
+        }
+        return $buffer;
     }
 }
 
@@ -502,14 +947,6 @@ final class StagedPushStreamProcessor
     /**
      * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
      */
-    public function create_request_body(int $frame_bytes, ?array $cursor = null, ?int $max_chunks = null, ?int $max_payload_bytes = null): StagedPushRequestBody
-    {
-        return new StagedPushRequestBody($this->files(), $frame_bytes, $cursor ?? $this->cursor, $max_chunks, $max_payload_bytes);
-    }
-
-    /**
-     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
-     */
     public function is_finished_at(?array $cursor): bool
     {
         $files = $this->files();
@@ -524,8 +961,12 @@ final class StagedPushStreamProcessor
             && (int) ($cursor["committed_bytes"] ?? -1) >= $last_file["total_bytes"];
     }
 
-    /** @return array<int,array{artifact_id:string,source_path:string,total_bytes:int}> */
-    private function files(): array
+    /**
+     * The resolved local files to push, in push order.
+     *
+     * @return array<int,array{artifact_id:string,source_path:string,total_bytes:int}>
+     */
+    public function files(): array
     {
         if ($this->files !== null) {
             return $this->files;
@@ -578,259 +1019,5 @@ final class StagedPushStreamProcessor
             throw new RuntimeException("Invalid local path line: " . substr($raw_line, 0, 120));
         }
         return $artifact_id;
-    }
-}
-
-/**
- * Pull-based request-body producer for one staged push stream.
- */
-final class StagedPushRequestBody
-{
-    /** @var array<int,array{artifact_id:string,source_path:string,total_bytes:int}> */
-    private array $files;
-
-    private int $frame_bytes;
-
-    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
-    private ?array $initial_cursor;
-
-    /** @var array<int,array{file_index:int,offset:int,bytes:int,final:bool,header:string}> */
-    private array $frames = [];
-
-    /** @var array<int,string> */
-    private array $pending = [];
-
-    private int $file_index = 0;
-
-    private int $offset = 0;
-
-    private int $stream_frame_index = 0;
-
-    /** @var resource|null */
-    private $source_handle = null;
-
-    private int $current_frame_remaining_bytes = 0;
-
-    private int $current_frame_file_index = 0;
-
-    private bool $finished = false;
-
-    private bool $finalized = false;
-
-    private int $payload_bytes_planned = 0;
-
-    private int $bytes_streamed = 0;
-
-    private int $chunks_streamed = 0;
-
-    private ?int $max_chunks;
-
-    private ?int $max_payload_bytes;
-
-    private ?array $cursor = null;
-
-    /** @param array<int,array{artifact_id:string,source_path:string,total_bytes:int}> $files */
-    public function __construct(array $files, int $frame_bytes, ?array $cursor, ?int $max_chunks = null, ?int $max_payload_bytes = null)
-    {
-        $this->files = $files;
-        $this->frame_bytes = max(1, $frame_bytes);
-        $this->initial_cursor = $cursor;
-        $this->max_chunks = $max_chunks !== null ? max(1, $max_chunks) : null;
-        $this->max_payload_bytes = $max_payload_bytes !== null ? max(1, $max_payload_bytes) : null;
-        $start = $this->cursor_start();
-        $this->file_index = $start["file_index"];
-        $this->offset = $start["offset"];
-    }
-
-    /**
-     * Plan one more frame for this request body.
-     *
-     * The request still streams from disk through curl later. Planning a frame
-     * only records its header, source path, and byte range so the caller can
-     * decide where a request boundary belongs before the HTTP request starts.
-     */
-    public function next_chunk(): bool
-    {
-        if ($this->finalized || $this->file_index >= count($this->files)) {
-            return false;
-        }
-        if ($this->max_chunks !== null && count($this->frames) >= $this->max_chunks) {
-            return false;
-        }
-        if ($this->max_payload_bytes !== null && $this->payload_bytes_planned >= $this->max_payload_bytes) {
-            return false;
-        }
-
-        $file = $this->files[$this->file_index];
-        $offset = $this->offset;
-        $remaining_payload_bytes = $this->max_payload_bytes === null
-            ? PHP_INT_MAX
-            : max(1, $this->max_payload_bytes - $this->payload_bytes_planned);
-        $bytes = $file["total_bytes"] === 0
-            ? 0
-            : min($this->frame_bytes, $file["total_bytes"] - $offset, $remaining_payload_bytes);
-        $final = $offset + $bytes >= $file["total_bytes"];
-
-        $header = json_encode([
-            "type" => "chunk",
-            "artifact_id" => $file["artifact_id"],
-            "offset" => $offset,
-            "bytes" => $bytes,
-            "total_bytes" => $file["total_bytes"],
-            "final" => $final,
-        ], JSON_UNESCAPED_SLASHES);
-        if ($header === false) {
-            throw new RuntimeException("Could not encode staged push stream frame header.");
-        }
-
-        $this->frames[] = [
-            "file_index" => $this->file_index,
-            "offset" => $offset,
-            "bytes" => $bytes,
-            "final" => $final,
-            "header" => $header . "\n",
-        ];
-        $this->payload_bytes_planned += $bytes;
-        $this->offset = $offset + $bytes;
-        $this->cursor = [
-            "artifact_id" => $file["artifact_id"],
-            "committed_bytes" => $this->offset,
-        ];
-
-        if ($final) {
-            $this->file_index++;
-            $this->offset = 0;
-        }
-        return true;
-    }
-
-    public function finalize(): void
-    {
-        $this->finalized = true;
-    }
-
-    public function read(int $length): string
-    {
-        $out = "";
-        while (strlen($out) < $length && !$this->finished) {
-            $remaining_output_bytes = $length - strlen($out);
-            if ($this->pending !== []) {
-                $piece = array_shift($this->pending);
-                if (strlen($piece) > $remaining_output_bytes) {
-                    $out .= substr($piece, 0, $remaining_output_bytes);
-                    array_unshift($this->pending, substr($piece, $remaining_output_bytes));
-                } else {
-                    $out .= $piece;
-                }
-                continue;
-            }
-
-            if ($this->current_frame_remaining_bytes > 0) {
-                $piece_bytes = min($remaining_output_bytes, $this->current_frame_remaining_bytes);
-                $piece = Site_Export_Staged_Push_Stream_Protocol::read_exactly($this->source_handle, $piece_bytes);
-                if ($piece === null) {
-                    throw new RuntimeException("Source file ended before declared size: " . $this->files[$this->current_frame_file_index]["source_path"]);
-                }
-                $out .= $piece;
-                $this->bytes_streamed += strlen($piece);
-                $this->current_frame_remaining_bytes -= strlen($piece);
-                $this->cursor = [
-                    "artifact_id" => $this->files[$this->current_frame_file_index]["artifact_id"],
-                    "committed_bytes" => $this->frames[$this->stream_frame_index - 1]["offset"] + $this->frames[$this->stream_frame_index - 1]["bytes"] - $this->current_frame_remaining_bytes,
-                ];
-
-                if ($this->current_frame_remaining_bytes === 0) {
-                    $this->close_source();
-                }
-                continue;
-            }
-
-            if ($this->stream_frame_index >= count($this->frames)) {
-                if ($this->finalized) {
-                    $this->finished = true;
-                }
-                break;
-            }
-
-            $this->begin_streaming_frame($this->frames[$this->stream_frame_index]);
-            $this->stream_frame_index++;
-        }
-        return $out;
-    }
-
-    public function bytes_streamed(): int
-    {
-        return $this->bytes_streamed;
-    }
-
-    public function chunks_streamed(): int
-    {
-        return $this->chunks_streamed;
-    }
-
-    public function chunks_planned(): int
-    {
-        return count($this->frames);
-    }
-
-    public function cursor(): ?array
-    {
-        return $this->cursor;
-    }
-
-    /** @return array{file_index:int,offset:int} */
-    private function cursor_start(): array
-    {
-        if ($this->initial_cursor === null || !is_string($this->initial_cursor["artifact_id"] ?? null)) {
-            return ["file_index" => 0, "offset" => 0];
-        }
-        foreach ($this->files as $index => $file) {
-            if ($file["artifact_id"] === $this->initial_cursor["artifact_id"]) {
-                $offset = min(max(0, (int) ($this->initial_cursor["committed_bytes"] ?? 0)), $file["total_bytes"]);
-                if ($offset >= $file["total_bytes"]) {
-                    return ["file_index" => $index + 1, "offset" => 0];
-                }
-                return [
-                    "file_index" => $index,
-                    "offset" => $offset,
-                ];
-            }
-        }
-        return ["file_index" => 0, "offset" => 0];
-    }
-
-    /** @param array{file_index:int,offset:int,bytes:int,final:bool,header:string} $frame */
-    private function begin_streaming_frame(array $frame): void
-    {
-        $this->pending[] = $frame["header"];
-        $this->chunks_streamed++;
-        $this->current_frame_file_index = $frame["file_index"];
-        $this->cursor = [
-            "artifact_id" => $this->files[$frame["file_index"]]["artifact_id"],
-            "committed_bytes" => $frame["offset"],
-        ];
-
-        if ($frame["bytes"] === 0) {
-            return;
-        }
-
-        $file = $this->files[$frame["file_index"]];
-        $this->source_handle = @fopen($file["source_path"], "rb");
-        if ($this->source_handle === false) {
-            throw new RuntimeException("Source file is unreadable: " . $file["source_path"]);
-        }
-        if (fseek($this->source_handle, $frame["offset"]) !== 0) {
-            $this->close_source();
-            throw new RuntimeException("Could not seek source file: " . $file["source_path"]);
-        }
-        $this->current_frame_remaining_bytes = $frame["bytes"];
-    }
-
-    private function close_source(): void
-    {
-        if (is_resource($this->source_handle)) {
-            fclose($this->source_handle);
-        }
-        $this->source_handle = null;
     }
 }

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -6,9 +6,9 @@
  * framed file chunks. The target commits each frame into
  * Site_Export_Staged_Artifacts as it is read, so a broken connection can be
  * retried from the last cursor the sender has, or from the beginning with the
- * target absorbing duplicate/verified frames. This class does not expose a
- * per-file request API: callers pass a staged push stream processor, and
- * the client streams its chunks through one request.
+ * target absorbing duplicate/verified frames. This class exposes request-level
+ * control rather than a per-file request API: callers decide how many frames go
+ * into one request, finalize it, and resume the next request from the cursor.
  */
 class StagedPushStreamClient
 {
@@ -49,29 +49,43 @@ class StagedPushStreamClient
     }
 
     /**
-     * Send one staged_push request and return the request-level result.
+     * Create one staged_push request that the caller can fill chunk by chunk.
      *
-     * The caller owns the loop. A successful request may still leave more local
-     * chunks to send; use StagedPushStreamProcessor::is_finished_at() on the
-     * returned cursor to decide whether to call this again.
+     * The caller owns the nested loop: first start a request, then call
+     * StagedPushStreamRequest::next_chunk() until the request budget or the
+     * caller's own budget says to stop, then finalize and send the request.
      *
      * @param array{max_chunks?:int|null,max_payload_bytes?:int|null} $limits
      * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
+     */
+    public function create_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): StagedPushStreamRequest
+    {
+        $request_start_cursor = $cursor ?? $processor->cursor();
+        return new StagedPushStreamRequest(
+            $processor->create_request_body(
+                $this->frame_sizer->chunk_bytes(),
+                $request_start_cursor,
+                $limits["max_chunks"] ?? null,
+                $limits["max_payload_bytes"] ?? null
+            ),
+            $request_start_cursor
+        );
+    }
+
+    /**
+     * Send one finalized staged_push request and return the request-level result.
+     *
      * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
      */
-    public function push_next_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): array
+    public function push_request(StagedPushStreamRequest $request): array
     {
-        if (!$processor->has_files()) {
-            return $this->result("complete", null, null, null, 0, 0, 0);
+        $request->finalize();
+        if (!$request->has_chunks()) {
+            return $this->result("request_complete", null, null, $request->cursor(), 0, 0, 0);
         }
 
-        $request_start_cursor = $cursor ?? $processor->cursor();
-        $body = $processor->create_request_body(
-            $this->frame_sizer->chunk_bytes(),
-            $request_start_cursor,
-            $limits["max_chunks"] ?? null,
-            $limits["max_payload_bytes"] ?? null
-        );
+        $body = $request->body();
+        $request_start_cursor = $request->start_cursor();
         $response = $this->send_stream_request($body);
 
         if ($response["error"] !== null) {
@@ -139,6 +153,29 @@ class StagedPushStreamClient
             $body->bytes_streamed(),
             $body->chunks_streamed()
         );
+    }
+
+    /**
+     * Convenience wrapper that fills and sends one request.
+     *
+     * Prefer create_request()/push_request() when the caller needs to pause
+     * inside a request after a caller-chosen number of chunks.
+     *
+     * @param array{max_chunks?:int|null,max_payload_bytes?:int|null} $limits
+     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
+     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
+     */
+    public function push_next_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): array
+    {
+        if (!$processor->has_files()) {
+            return $this->result("complete", null, null, null, 0, 0, 0);
+        }
+
+        $request = $this->create_request($processor, $cursor, $limits);
+        while ($request->next_chunk()) {
+            // Fill this request up to the configured request budget.
+        }
+        return $this->push_request($request);
     }
 
     /** @return array{http_code:int,body:string,error:?string} */
@@ -212,11 +249,81 @@ class StagedPushStreamClient
 }
 
 /**
+ * Caller-controlled request builder for one staged push stream request.
+ */
+final class StagedPushStreamRequest
+{
+    private StagedPushRequestBody $body;
+
+    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
+    private ?array $start_cursor;
+
+    private bool $finalized = false;
+
+    /**
+     * @param array{artifact_id?:string,committed_bytes?:int}|null $start_cursor
+     */
+    public function __construct(StagedPushRequestBody $body, ?array $start_cursor)
+    {
+        $this->body = $body;
+        $this->start_cursor = $start_cursor;
+    }
+
+    /**
+     * Add one more framed chunk to this request.
+     *
+     * @return bool Whether a chunk was added. False means the request is full
+     *              or the processor has no more chunks to send.
+     */
+    public function next_chunk(): bool
+    {
+        if ($this->finalized) {
+            return false;
+        }
+        return $this->body->next_chunk();
+    }
+
+    public function finalize(): void
+    {
+        $this->finalized = true;
+        $this->body->finalize();
+    }
+
+    public function is_finalized(): bool
+    {
+        return $this->finalized;
+    }
+
+    public function has_chunks(): bool
+    {
+        return $this->body->chunks_planned() > 0;
+    }
+
+    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
+    public function start_cursor(): ?array
+    {
+        return $this->start_cursor;
+    }
+
+    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
+    public function cursor(): ?array
+    {
+        return $this->body->cursor();
+    }
+
+    public function body(): StagedPushRequestBody
+    {
+        return $this->body;
+    }
+}
+
+/**
  * Cursor-style driver for staged push streams.
  *
- * This mirrors processor and async-client APIs: next_request() advances one
- * network request, get_result() exposes what happened, and the caller decides
- * whether to keep looping, persist the cursor, or pause the push.
+ * This mirrors processor and async-client APIs: next_request() opens one
+ * network request, the request advances chunk by chunk, finalize_request()
+ * sends it, and the caller decides whether to keep looping, persist the
+ * cursor, or pause the push.
  */
 final class StagedPushStreamPusher
 {
@@ -244,6 +351,8 @@ final class StagedPushStreamPusher
 
     /** @var array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}|null */
     private ?array $result = null;
+
+    private ?StagedPushStreamRequest $request = null;
 
     private int $request_failures = 0;
 
@@ -273,17 +382,39 @@ final class StagedPushStreamPusher
     }
 
     /**
-     * Advance the push by one staged_push request.
+     * Open the next staged_push request.
      *
-     * @return bool Whether a request-level result is available via get_result().
+     * @return bool Whether a request is available via get_request().
      */
     public function next_request(): bool
     {
-        if ($this->finished) {
+        if ($this->finished || $this->request !== null) {
             return false;
         }
 
-        $result = $this->client->push_next_request($this->processor, $this->cursor, $this->limits);
+        $this->request = $this->client->create_request($this->processor, $this->cursor, $this->limits);
+        $this->result = null;
+        return true;
+    }
+
+    public function get_request(): ?StagedPushStreamRequest
+    {
+        return $this->request;
+    }
+
+    /**
+     * Finalize and send the current request.
+     *
+     * @return bool Whether a request-level result is available via get_result().
+     */
+    public function finalize_request(): bool
+    {
+        if ($this->request === null) {
+            return false;
+        }
+
+        $result = $this->client->push_request($this->request);
+        $this->request = null;
         $this->result = $result;
 
         if ($result["status"] === "request_complete") {
@@ -480,6 +611,9 @@ final class StagedPushRequestBody
     /** @var array{artifact_id?:string,committed_bytes?:int}|null */
     private ?array $initial_cursor;
 
+    /** @var array<int,array{file_index:int,offset:int,bytes:int,final:bool,header:string}> */
+    private array $frames = [];
+
     /** @var array<int,string> */
     private array $pending = [];
 
@@ -487,14 +621,20 @@ final class StagedPushRequestBody
 
     private int $offset = 0;
 
+    private int $stream_frame_index = 0;
+
     /** @var resource|null */
     private $source_handle = null;
 
     private int $current_frame_remaining_bytes = 0;
 
-    private bool $current_frame_final = false;
+    private int $current_frame_file_index = 0;
 
     private bool $finished = false;
+
+    private bool $finalized = false;
+
+    private int $payload_bytes_planned = 0;
 
     private int $bytes_streamed = 0;
 
@@ -517,6 +657,49 @@ final class StagedPushRequestBody
         $this->apply_cursor($cursor);
     }
 
+    /**
+     * Plan one more frame for this request body.
+     *
+     * The request still streams from disk through curl later. Planning a frame
+     * only records its header, source path, and byte range so the caller can
+     * decide where a request boundary belongs before the HTTP request starts.
+     */
+    public function next_chunk(): bool
+    {
+        if ($this->finalized || $this->file_index >= count($this->files) || $this->request_limit_reached()) {
+            return false;
+        }
+
+        $file = $this->files[$this->file_index];
+        if ($file["total_bytes"] === 0) {
+            $this->frames[] = $this->frame($this->file_index, 0, 0, true);
+            $this->cursor = ["artifact_id" => $file["artifact_id"], "committed_bytes" => 0];
+            $this->file_index++;
+            return true;
+        }
+
+        $bytes = min($this->frame_bytes, $file["total_bytes"] - $this->offset, $this->remaining_payload_bytes());
+        $final = $this->offset + $bytes >= $file["total_bytes"];
+        $this->frames[] = $this->frame($this->file_index, $this->offset, $bytes, $final);
+        $this->payload_bytes_planned += $bytes;
+        $this->offset += $bytes;
+        $this->cursor = [
+            "artifact_id" => $file["artifact_id"],
+            "committed_bytes" => $this->offset,
+        ];
+
+        if ($final) {
+            $this->file_index++;
+            $this->offset = 0;
+        }
+        return true;
+    }
+
+    public function finalize(): void
+    {
+        $this->finalized = true;
+    }
+
     public function read(int $length): string
     {
         $out = "";
@@ -537,27 +720,31 @@ final class StagedPushRequestBody
                 $piece_bytes = min($remaining_output_bytes, $this->current_frame_remaining_bytes);
                 $piece = $this->read_exactly($this->source_handle, $piece_bytes);
                 if ($piece === null) {
-                    throw new RuntimeException("Source file ended before declared size: " . $this->files[$this->file_index]["source_path"]);
+                    throw new RuntimeException("Source file ended before declared size: " . $this->files[$this->current_frame_file_index]["source_path"]);
                 }
                 $out .= $piece;
                 $this->bytes_streamed += strlen($piece);
-                $this->offset += strlen($piece);
                 $this->current_frame_remaining_bytes -= strlen($piece);
                 $this->cursor = [
-                    "artifact_id" => $this->files[$this->file_index]["artifact_id"],
-                    "committed_bytes" => $this->offset,
+                    "artifact_id" => $this->files[$this->current_frame_file_index]["artifact_id"],
+                    "committed_bytes" => $this->frames[$this->stream_frame_index - 1]["offset"] + $this->frames[$this->stream_frame_index - 1]["bytes"] - $this->current_frame_remaining_bytes,
                 ];
 
-                if ($this->current_frame_remaining_bytes === 0 && $this->current_frame_final) {
+                if ($this->current_frame_remaining_bytes === 0) {
                     $this->close_source();
-                    $this->file_index++;
-                    $this->offset = 0;
-                    $this->current_frame_final = false;
                 }
                 continue;
             }
 
-            $this->begin_next_frame();
+            if ($this->stream_frame_index >= count($this->frames)) {
+                if ($this->finalized) {
+                    $this->finished = true;
+                }
+                break;
+            }
+
+            $this->begin_streaming_frame($this->frames[$this->stream_frame_index]);
+            $this->stream_frame_index++;
         }
         return $out;
     }
@@ -570,6 +757,11 @@ final class StagedPushRequestBody
     public function chunks_streamed(): int
     {
         return $this->chunks_streamed;
+    }
+
+    public function chunks_planned(): int
+    {
+        return count($this->frames);
     }
 
     public function cursor(): ?array
@@ -605,48 +797,51 @@ final class StagedPushRequestBody
         return ["file_index" => 0, "offset" => 0];
     }
 
-    private function begin_next_frame(): void
+    /** @return array{file_index:int,offset:int,bytes:int,final:bool,header:string} */
+    private function frame(int $file_index, int $offset, int $bytes, bool $final): array
     {
-        if ($this->file_index >= count($this->files) || $this->request_limit_reached()) {
+        return [
+            "file_index" => $file_index,
+            "offset" => $offset,
+            "bytes" => $bytes,
+            "final" => $final,
+            "header" => $this->frame_header($this->files[$file_index], $offset, $bytes, $final),
+        ];
+    }
+
+    /** @param array{file_index:int,offset:int,bytes:int,final:bool,header:string} $frame */
+    private function begin_streaming_frame(array $frame): void
+    {
+        $this->pending[] = $frame["header"];
+        $this->chunks_streamed++;
+        $this->current_frame_file_index = $frame["file_index"];
+        $this->cursor = [
+            "artifact_id" => $this->files[$frame["file_index"]]["artifact_id"],
+            "committed_bytes" => $frame["offset"],
+        ];
+
+        if ($frame["bytes"] === 0) {
+            return;
+        }
+
+        $file = $this->files[$frame["file_index"]];
+        $this->source_handle = @fopen($file["source_path"], "rb");
+        if ($this->source_handle === false) {
+            throw new RuntimeException("Source file is unreadable: " . $file["source_path"]);
+        }
+        if (fseek($this->source_handle, $frame["offset"]) !== 0) {
             $this->close_source();
-            $this->finished = true;
-            return;
-        }
-
-        $file = $this->files[$this->file_index];
-        if ($this->source_handle === null && $file["total_bytes"] > 0) {
-            $this->source_handle = @fopen($file["source_path"], "rb");
-            if ($this->source_handle === false) {
-                throw new RuntimeException("Source file is unreadable: " . $file["source_path"]);
-            }
-        }
-
-        if ($file["total_bytes"] === 0) {
-            $this->pending[] = $this->frame_header($file, 0, 0, true);
-            $this->chunks_streamed++;
-            $this->cursor = ["artifact_id" => $file["artifact_id"], "committed_bytes" => 0];
-            $this->file_index++;
-            return;
-        }
-
-        $bytes = min($this->frame_bytes, $file["total_bytes"] - $this->offset, $this->remaining_payload_bytes());
-        if (fseek($this->source_handle, $this->offset) !== 0) {
             throw new RuntimeException("Could not seek source file: " . $file["source_path"]);
         }
-
-        $final = $this->offset + $bytes >= $file["total_bytes"];
-        $this->pending[] = $this->frame_header($file, $this->offset, $bytes, $final);
-        $this->chunks_streamed++;
-        $this->current_frame_remaining_bytes = $bytes;
-        $this->current_frame_final = $final;
+        $this->current_frame_remaining_bytes = $frame["bytes"];
     }
 
     private function request_limit_reached(): bool
     {
-        if ($this->max_chunks !== null && $this->chunks_streamed >= $this->max_chunks) {
+        if ($this->max_chunks !== null && count($this->frames) >= $this->max_chunks) {
             return true;
         }
-        return $this->max_payload_bytes !== null && $this->bytes_streamed >= $this->max_payload_bytes;
+        return $this->max_payload_bytes !== null && $this->payload_bytes_planned >= $this->max_payload_bytes;
     }
 
     private function remaining_payload_bytes(): int
@@ -654,7 +849,7 @@ final class StagedPushRequestBody
         if ($this->max_payload_bytes === null) {
             return PHP_INT_MAX;
         }
-        return max(1, $this->max_payload_bytes - $this->bytes_streamed);
+        return max(1, $this->max_payload_bytes - $this->payload_bytes_planned);
     }
 
     /** @param array{artifact_id:string,source_path:string,total_bytes:int} $file */

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -5,8 +5,13 @@
  * A push stream is one authenticated HTTP request whose body is a sequence of
  * framed file chunks. The target commits each frame into
  * Site_Export_Staged_Artifacts as it is read, so a broken connection can be
- * retried from the last cursor the sender has, or from the beginning with the
- * target absorbing duplicate/verified frames.
+ * retried from the last cursor the sender has, or from the beginning: the
+ * target skips replayed files it already verified and restarts partially
+ * staged ones from zero, so a source file that changed between requests can
+ * never end up half old version, half new. Callers persist the source token
+ * (size and mtime) alongside each cursor and restart a file at offset 0 when
+ * the file on disk no longer matches it — the reference loop in
+ * StagedPushStreamClientTest::pushOnce() shows both halves.
  *
  * The client is a pass-through wire. The caller reads a chunk of a file into
  * memory — at most next_chunk_body_bytes(), which is why a chunk is the one
@@ -238,7 +243,9 @@ class StagedPushStreamClient
         if ($max_request_seconds !== null && (!is_numeric($max_request_seconds) || $max_request_seconds <= 0)) {
             throw new InvalidArgumentException("Expected option \"max_request_seconds\" to be a positive number; received " . json_encode($max_request_seconds) . ".");
         }
-        $this->max_request_seconds = $max_request_seconds ?? 30;
+        // The + cast turns numeric strings (CLI flags, state files) into the
+        // int|float the property declares.
+        $this->max_request_seconds = $max_request_seconds !== null ? +$max_request_seconds : 30;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -61,7 +61,23 @@ class StagedPushStreamClient
 
     private PushRequestSizer $request_sizer;
 
-    private int $request_timeout;
+    /** Seconds to establish the connection and get the request head out. */
+    private int $connect_timeout;
+
+    /**
+     * Seconds without a single byte moving before the transfer is declared
+     * dead. Only stalls trip this — a slow connection that keeps moving
+     * bytes never does, no matter how long the request takes.
+     */
+    private int $stall_timeout;
+
+    /**
+     * Seconds to wait for the response after the body is finished. A
+     * separate phase with no progress signal: request-buffering stacks do
+     * all their frame processing here, so this needs room proportional to
+     * how much one request carries.
+     */
+    private int $response_timeout;
 
     /** @var int|float Wall-clock budget per request, in seconds. */
     private $max_request_seconds;
@@ -90,6 +106,14 @@ class StagedPushStreamClient
      */
     private bool $curl_requested_body = false;
 
+    /**
+     * Total bytes libcurl has consumed from the read callback; the progress
+     * signal the stall timeout watches. libcurl only asks for more after
+     * writing the previous piece toward the socket, so consumption tracks
+     * actual transmission at upload-buffer granularity.
+     */
+    private int $outbound_consumed_bytes = 0;
+
     private bool $transfer_finished = false;
 
     private ?string $transfer_error = null;
@@ -112,9 +136,16 @@ class StagedPushStreamClient
      *     to keep learned limits.
      *   - chunk_bytes (int): in-memory unit of one caller fread; unrelated
      *     to the request body budget. Default 4 MiB.
-     *   - request_timeout (int): seconds without transfer progress (opening
-     *     the request, handing one chunk to libcurl, or the response read)
-     *     before the request fails. Default 120.
+     *   - connect_timeout (int): seconds to establish the connection and
+     *     send the request head. Default 30.
+     *   - stall_timeout (int): seconds without a single byte moving while
+     *     sending before the request fails. Slow connections that keep
+     *     moving bytes never trip this; there is deliberately no total
+     *     transfer timeout, so a large request over a slow link runs as
+     *     long as it keeps progressing. Default 60.
+     *   - response_timeout (int): seconds to wait for the response after
+     *     the body is finished — the phase where request-buffering hosts
+     *     process every frame at once. Default 300.
      *   - max_request_seconds (int|float): wall-clock budget per request;
      *     should_finish_request() turns true once a request is older than
      *     this. Soft — checked between chunks — so set it with margin below
@@ -144,8 +175,12 @@ class StagedPushStreamClient
         $this->request_sizer = $options["request_sizer"] ?? new PushRequestSizer();
         $chunk_bytes = $options["chunk_bytes"] ?? null;
         $this->chunk_bytes = is_numeric($chunk_bytes) && (int) $chunk_bytes > 0 ? (int) $chunk_bytes : 4 * 1024 * 1024;
-        $timeout = $options["request_timeout"] ?? null;
-        $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
+        $connect_timeout = $options["connect_timeout"] ?? null;
+        $this->connect_timeout = is_numeric($connect_timeout) && (int) $connect_timeout > 0 ? (int) $connect_timeout : 30;
+        $stall_timeout = $options["stall_timeout"] ?? null;
+        $this->stall_timeout = is_numeric($stall_timeout) && (int) $stall_timeout > 0 ? (int) $stall_timeout : 60;
+        $response_timeout = $options["response_timeout"] ?? null;
+        $this->response_timeout = is_numeric($response_timeout) && (int) $response_timeout > 0 ? (int) $response_timeout : 300;
         $max_request_seconds = $options["max_request_seconds"] ?? null;
         $this->max_request_seconds = is_numeric($max_request_seconds) && $max_request_seconds > 0 ? $max_request_seconds : 30;
     }
@@ -166,6 +201,7 @@ class StagedPushStreamClient
 
         $this->outbound_bytes = "";
         $this->outbound_offset = 0;
+        $this->outbound_consumed_bytes = 0;
         $this->body_complete = false;
         $this->curl_requested_body = false;
         $this->transfer_finished = false;
@@ -205,15 +241,17 @@ class StagedPushStreamClient
             CURLOPT_HTTPHEADER => $header_lines,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => false,
-            CURLOPT_CONNECTTIMEOUT => $this->request_timeout,
-            // Total lifetime of one request, including caller time between
-            // chunks; keep it above max_request_seconds plus response time.
-            CURLOPT_TIMEOUT => $this->request_timeout,
+            CURLOPT_CONNECTTIMEOUT => $this->connect_timeout,
+            // Deliberately no CURLOPT_TIMEOUT: a total-transfer cap kills
+            // healthy-but-slow bulk uploads. Each phase has its own bound —
+            // connect_timeout, the stall watch in send_chunk(), and
+            // response_timeout in finish_request().
             CURLOPT_READFUNCTION => function ($curl_handle, $stream, int $length) {
                 $this->curl_requested_body = true;
                 if ($this->outbound_offset < strlen($this->outbound_bytes)) {
                     $piece = substr($this->outbound_bytes, $this->outbound_offset, $length);
                     $this->outbound_offset += strlen($piece);
+                    $this->outbound_consumed_bytes += strlen($piece);
                     if ($this->outbound_offset >= strlen($this->outbound_bytes)) {
                         $this->outbound_bytes = "";
                         $this->outbound_offset = 0;
@@ -233,10 +271,10 @@ class StagedPushStreamClient
         // Drive the transfer until the head is out — libcurl asking for body
         // bytes proves it — so connection and TLS failures surface here, not
         // in the middle of the caller's chunk loop.
-        $deadline = microtime(true) + $this->request_timeout;
+        $deadline = microtime(true) + $this->connect_timeout;
         while (!$this->curl_requested_body && !$this->transfer_finished) {
             if (microtime(true) > $deadline) {
-                $this->transfer_error = "Timed out after " . $this->request_timeout . "s opening the push stream request.";
+                $this->transfer_error = "Timed out after " . $this->connect_timeout . "s opening the push stream request.";
                 break;
             }
             $this->pump_transfer();
@@ -333,10 +371,18 @@ class StagedPushStreamClient
         $this->outbound_bytes = $frame_header . $payload;
         $this->outbound_offset = 0;
         curl_pause($this->curl_handle, CURLPAUSE_CONT);
-        $deadline = microtime(true) + $this->request_timeout;
+
+        // The stall watch fails only on zero progress: every byte libcurl
+        // consumes resets the clock, so a slow connection that keeps moving
+        // can take as long as it needs.
+        $consumed_at_last_progress = $this->outbound_consumed_bytes;
+        $last_progress_at = microtime(true);
         while ($this->outbound_bytes !== "" && !$this->transfer_finished) {
-            if (microtime(true) > $deadline) {
-                $this->transfer_error = "Timed out after " . $this->request_timeout . "s sending push stream bytes.";
+            if ($this->outbound_consumed_bytes !== $consumed_at_last_progress) {
+                $consumed_at_last_progress = $this->outbound_consumed_bytes;
+                $last_progress_at = microtime(true);
+            } elseif (microtime(true) - $last_progress_at > $this->stall_timeout) {
+                $this->transfer_error = "The push stream stalled: no bytes moved for " . $this->stall_timeout . "s while sending a chunk of \"" . $artifact_id . "\".";
                 $this->transfer_finished = true;
                 break;
             }
@@ -415,10 +461,10 @@ class StagedPushStreamClient
         if (!$this->transfer_finished) {
             $this->body_complete = true;
             curl_pause($this->curl_handle, CURLPAUSE_CONT);
-            $deadline = microtime(true) + $this->request_timeout;
+            $deadline = microtime(true) + $this->response_timeout;
             while (!$this->transfer_finished) {
                 if (microtime(true) > $deadline) {
-                    $this->transfer_error = "Timed out after " . $this->request_timeout . "s waiting for the push stream response.";
+                    $this->transfer_error = "No response arrived within " . $this->response_timeout . "s of finishing the push stream body.";
                     break;
                 }
                 $this->pump_transfer();

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -13,6 +13,9 @@
  * thing that may be buffered — and send_chunk() sends it over the network
  * before returning:
  *
+ *     // Open the request only once the first chunk exists — an empty
+ *     // source should not cost a network exchange (the reference loop in
+ *     // StagedPushStreamClientTest::pushOnce() shows the lazy shape).
  *     $client->start_push_request();
  *     while (...) {
  *         if ($client->should_finish_request()) {
@@ -100,7 +103,14 @@ class StagedPushStreamClient
     /** @var resource|object|null curl easy handle for the open request */
     private $curl_handle = null;
 
-    /** @var resource|object|null curl multi handle driving the open request */
+    /**
+     * curl multi handle driving requests. Outlives individual requests on
+     * purpose: libcurl's connection cache lives on the multi handle, so
+     * back-to-back requests reuse the TCP/TLS connection instead of paying
+     * a fresh handshake per rotation.
+     *
+     * @var resource|object|null
+     */
     private $multi_handle = null;
 
     /**
@@ -270,8 +280,13 @@ class StagedPushStreamClient
         foreach ($request_headers as $header_name => $header_value) {
             $header_lines[] = $header_name . ": " . $header_value;
         }
-        // Suppress Expect: 100-continue; waiting for the interim response
-        // would stall the first chunk for nothing.
+        // Suppress Expect: 100-continue (older libcurls add it for chunked
+        // uploads). The 100-continue dance would spare a misconfigured push
+        // from uploading a body the target is about to refuse — but servers
+        // that never answer the interim 100 (php -S among them) cost a full
+        // Expect timeout stall on every request, while the wasted body is
+        // bounded by one request budget and happens once before the push
+        // stops with a pointed error.
         $header_lines[] = "Expect:";
 
         $this->curl_handle = curl_init($request_url);
@@ -338,13 +353,17 @@ class StagedPushStreamClient
             },
         ]);
 
-        // One curl_multi handle per request, holding a single transfer.
-        // Multi is not for concurrency here: unlike curl_exec(), which
-        // blocks until the whole exchange is over, curl_multi_exec()
-        // performs one small slice of work and returns. That is what lets
-        // send_chunk() feed a frame, pump until libcurl consumed it, and
-        // hand control back to the caller while the request stays open.
-        $this->multi_handle = curl_multi_init();
+        // One transfer at a time in one long-lived curl_multi handle. Multi
+        // is not for concurrency here: unlike curl_exec(), which blocks
+        // until the whole exchange is over, curl_multi_exec() performs one
+        // small slice of work and returns. That is what lets send_chunk()
+        // feed a frame, pump until libcurl consumed it, and hand control
+        // back to the caller while the request stays open. The handle
+        // itself lives as long as the client so requests reuse connections
+        // (see the property docblock).
+        if ($this->multi_handle === null) {
+            $this->multi_handle = curl_multi_init();
+        }
         curl_multi_add_handle($this->multi_handle, $this->curl_handle);
 
         // Drive the transfer until the head is out — libcurl asking for body
@@ -361,9 +380,7 @@ class StagedPushStreamClient
         if (!$this->curl_requested_body) {
             $this->last_error = $this->transfer_error ?? "The push stream request ended before the request head was sent.";
             curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
-            curl_multi_close($this->multi_handle);
             $this->curl_handle = null;
-            $this->multi_handle = null;
             return false;
         }
 
@@ -573,10 +590,10 @@ class StagedPushStreamClient
         $http_code = (int) curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
         $redirect_url = (string) curl_getinfo($this->curl_handle, CURLINFO_REDIRECT_URL);
         $response_body = (string) curl_multi_getcontent($this->curl_handle);
+        // The easy handle is done; the multi handle stays for the next
+        // request so its connection cache can hand the connection back.
         curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
-        curl_multi_close($this->multi_handle);
         $this->curl_handle = null;
-        $this->multi_handle = null;
 
         // A redirect is a configuration problem, not a transient failure or
         // a size signal: the usual case is an http:// base_url on a site
@@ -615,7 +632,7 @@ class StagedPushStreamClient
         }
 
         if ($http_code === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
-            $reported_limit_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
+            $reported_limit_bytes = $decoded["max_frame_bytes"] ?? null;
             $decision = $this->request_sizer->record_too_large(
                 is_numeric($reported_limit_bytes) ? (int) $reported_limit_bytes : null
             );

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -9,7 +9,7 @@
  * target absorbing duplicate/verified frames.
  *
  * The client is a pass-through wire. The caller reads a chunk of a file into
- * memory — at most max_chunk_bytes(), which is why a chunk is the one thing
+ * memory — at most next_chunk_bytes(), which is why a chunk is the one thing
  * that may be buffered — and send_chunk() writes the frame header and the
  * payload straight to the request socket before returning:
  *
@@ -19,7 +19,7 @@
  *             $result = $client->finish_request();   // persist $result['cursor']
  *             $client->start_push_request();
  *         }
- *         $payload = fread($source_handle, min($client->capacity_bytes(), $client->max_chunk_bytes()));
+ *         $payload = fread($source_handle, $client->next_chunk_bytes());
  *         $client->send_chunk([
  *             'artifact_id' => $artifact_id,
  *             'offset'      => $offset,
@@ -31,13 +31,14 @@
  *     $result = $client->finish_request();
  *
  * Two sizes govern the loop, and they are different dimensions. The chunk
- * (max_chunk_bytes()) is the small fixed in-memory unit of one fread. The
- * request body budget (capacity_bytes()) is what hosts and proxies actually
- * limit — post_max_size, client_max_body_size and friends measure the entity
- * body after chunked transfer-encoding removal, and nothing compresses
- * request bodies, so the bytes we write are the bytes that get measured.
- * That budget is learned per host by PushRequestSizer and counts frame
- * header lines alongside payloads.
+ * is the small fixed in-memory unit of one fread. The request body budget
+ * is what hosts and proxies actually limit — post_max_size,
+ * client_max_body_size and friends measure the entity body after chunked
+ * transfer-encoding removal, and nothing compresses request bodies, so the
+ * bytes we write are the bytes that get measured. That budget is learned
+ * per host by PushRequestSizer and counts frame header lines alongside
+ * payloads. next_chunk_bytes() folds both into the one number a caller's
+ * fread needs.
  */
 class StagedPushStreamClient
 {
@@ -245,25 +246,21 @@ class StagedPushStreamClient
     }
 
     /**
-     * Body bytes the current request still accepts, frame headers included.
+     * How many bytes the caller's next fread should ask for.
      *
-     * This is the host-learned request body budget draining toward zero. It
-     * is soft: the caller sizes payloads by it, and the frame header that
-     * rides along may overshoot it by one header line. The sizer's safety
-     * margin absorbs that.
+     * The fixed chunk size — the in-memory unit — bounded by what remains of
+     * the host-learned request body budget, which counts as-sent body bytes,
+     * frame headers included. Returns 0 when the request is full;
+     * should_finish_request() is already true then. Near the end of a file
+     * fread simply returns fewer bytes and the smaller frame is correct, so
+     * callers need no min() of their own. The budget is soft: the frame
+     * header riding along with the last chunk may overshoot it by one header
+     * line, which the sizer's safety margin absorbs.
      */
-    public function capacity_bytes(): int
+    public function next_chunk_bytes(): int
     {
-        return max(0, $this->request_sizer->request_body_bytes() - $this->body_bytes_sent);
-    }
-
-    /**
-     * The in-memory unit: how many bytes one caller fread may hold. Much
-     * smaller than the request body a stream carries across many chunks.
-     */
-    public function max_chunk_bytes(): int
-    {
-        return $this->chunk_bytes;
+        $remaining_body_budget = max(0, $this->request_sizer->request_body_bytes() - $this->body_bytes_sent);
+        return min($this->chunk_bytes, $remaining_body_budget);
     }
 
     /**
@@ -277,7 +274,7 @@ class StagedPushStreamClient
         }
         return $this->transport_error !== null
             || $this->target_replied_early
-            || $this->capacity_bytes() === 0
+            || $this->next_chunk_bytes() === 0
             || (microtime(true) - $this->request_started_at) > $this->max_request_seconds;
     }
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -42,6 +42,12 @@
  * silently truncates, so the constructor refuses to run there. The full
  * story: https://github.com/WordPress/reprint/issues/327
  *
+ * That 8.1 requirement is runtime-only on purpose: import.php requires this
+ * file for every command, including pull on PHP 7.4, so the file itself must
+ * stay parseable by 7.4 — no 8.x syntax (which is also why
+ * $max_request_seconds is untyped: int|float property types are PHP 8.0).
+ * PushClientPhpCompatibilityTest enforces this.
+ *
  * Two sizes govern the loop, and they are different dimensions. The chunk
  * is the small fixed in-memory unit of one fread. The request body budget
  * is what hosts and proxies actually limit — post_max_size,
@@ -79,7 +85,13 @@ class StagedPushStreamClient
      */
     private int $response_timeout;
 
-    /** @var int|float Wall-clock budget per request, in seconds. */
+    /**
+     * Wall-clock budget per request, in seconds. Untyped because this file
+     * must stay PHP 7.4-parseable (class docblock) and int|float property
+     * types are PHP 8.0 syntax.
+     *
+     * @var int|float
+     */
     private $max_request_seconds;
 
     /** @var int In-memory unit of one caller fread, in bytes. */
@@ -188,16 +200,35 @@ class StagedPushStreamClient
         }
         $this->hmac_client = $hmac_client;
         $this->request_sizer = $options["request_sizer"] ?? new PushRequestSizer();
+
+        // Absent options get defaults; present-but-invalid options throw —
+        // silently substituting a default would hide the caller's mistake
+        // until it surfaces as puzzling runtime behavior.
         $chunk_bytes = $options["chunk_bytes"] ?? null;
-        $this->chunk_bytes = is_numeric($chunk_bytes) && (int) $chunk_bytes > 0 ? (int) $chunk_bytes : 4 * 1024 * 1024;
+        if ($chunk_bytes !== null && (!is_numeric($chunk_bytes) || (int) $chunk_bytes <= 0)) {
+            throw new InvalidArgumentException("Expected option \"chunk_bytes\" to be a positive integer; received " . json_encode($chunk_bytes) . ".");
+        }
+        $this->chunk_bytes = $chunk_bytes !== null ? (int) $chunk_bytes : 4 * 1024 * 1024;
         $connect_timeout = $options["connect_timeout"] ?? null;
-        $this->connect_timeout = is_numeric($connect_timeout) && (int) $connect_timeout > 0 ? (int) $connect_timeout : 30;
+        if ($connect_timeout !== null && (!is_numeric($connect_timeout) || (int) $connect_timeout <= 0)) {
+            throw new InvalidArgumentException("Expected option \"connect_timeout\" to be a positive integer; received " . json_encode($connect_timeout) . ".");
+        }
+        $this->connect_timeout = $connect_timeout !== null ? (int) $connect_timeout : 30;
         $stall_timeout = $options["stall_timeout"] ?? null;
-        $this->stall_timeout = is_numeric($stall_timeout) && (int) $stall_timeout > 0 ? (int) $stall_timeout : 60;
+        if ($stall_timeout !== null && (!is_numeric($stall_timeout) || (int) $stall_timeout <= 0)) {
+            throw new InvalidArgumentException("Expected option \"stall_timeout\" to be a positive integer; received " . json_encode($stall_timeout) . ".");
+        }
+        $this->stall_timeout = $stall_timeout !== null ? (int) $stall_timeout : 60;
         $response_timeout = $options["response_timeout"] ?? null;
-        $this->response_timeout = is_numeric($response_timeout) && (int) $response_timeout > 0 ? (int) $response_timeout : 300;
+        if ($response_timeout !== null && (!is_numeric($response_timeout) || (int) $response_timeout <= 0)) {
+            throw new InvalidArgumentException("Expected option \"response_timeout\" to be a positive integer; received " . json_encode($response_timeout) . ".");
+        }
+        $this->response_timeout = $response_timeout !== null ? (int) $response_timeout : 300;
         $max_request_seconds = $options["max_request_seconds"] ?? null;
-        $this->max_request_seconds = is_numeric($max_request_seconds) && $max_request_seconds > 0 ? $max_request_seconds : 30;
+        if ($max_request_seconds !== null && (!is_numeric($max_request_seconds) || $max_request_seconds <= 0)) {
+            throw new InvalidArgumentException("Expected option \"max_request_seconds\" to be a positive number; received " . json_encode($max_request_seconds) . ".");
+        }
+        $this->max_request_seconds = $max_request_seconds ?? 30;
     }
 
     /**
@@ -474,6 +505,9 @@ class StagedPushStreamClient
      */
     public function next_chunk_body_bytes(): int
     {
+        if ($this->curl_handle === null) {
+            throw new RuntimeException("No push request is open; call start_push_request() before next_chunk_body_bytes().");
+        }
         $remaining_body_budget = max(0, $this->request_sizer->request_body_bytes() - $this->body_bytes_sent);
         return min($this->chunk_bytes, $remaining_body_budget);
     }
@@ -550,13 +584,13 @@ class StagedPushStreamClient
         $response_cursor = is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null;
 
         if ($http_code === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
-            $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
+            $reported_limit_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
             $decision = $this->request_sizer->record_too_large(
-                is_numeric($reported_max_frame_bytes) ? (int) $reported_max_frame_bytes : null
+                is_numeric($reported_limit_bytes) ? (int) $reported_limit_bytes : null
             );
             return $this->result(
                 $decision["action"] === "give_up" ? "failed" : "retry",
-                $decision["action"] === "give_up" ? "chunk_size_exhausted" : "frame_too_large",
+                $decision["action"] === "give_up" ? "request_size_exhausted" : "frame_too_large",
                 null,
                 $response_cursor
             );
@@ -572,7 +606,12 @@ class StagedPushStreamClient
             );
         }
 
-        $this->request_sizer->record_success();
+        // A success only teaches the sizer something when the request
+        // carried bytes: "the host accepted an empty body" is no evidence
+        // that the current size is safe to grow from.
+        if ($this->chunks_sent > 0) {
+            $this->request_sizer->record_success();
+        }
         return $this->result("complete", null, null, $response_cursor, (int) ($decoded["files_verified"] ?? 0));
     }
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -30,11 +30,14 @@
  *     }
  *     $result = $client->finish_request();
  *
- * Budgets count as-sent body bytes. Request-size limits (post_max_size,
- * client_max_body_size and friends) measure the entity body after chunked
- * transfer-encoding removal, and nothing compresses request bodies, so the
- * bytes we write are the bytes that get measured — frame header lines count
- * toward capacity_bytes(), not only payloads.
+ * Two sizes govern the loop, and they are different dimensions. The chunk
+ * (max_chunk_bytes()) is the small fixed in-memory unit of one fread. The
+ * request body budget (capacity_bytes()) is what hosts and proxies actually
+ * limit — post_max_size, client_max_body_size and friends measure the entity
+ * body after chunked transfer-encoding removal, and nothing compresses
+ * request bodies, so the bytes we write are the bytes that get measured.
+ * That budget is learned per host by PushRequestSizer and counts frame
+ * header lines alongside payloads.
  */
 class StagedPushStreamClient
 {
@@ -45,14 +48,15 @@ class StagedPushStreamClient
 
     private ?Site_Export_HMAC_Client $hmac_client;
 
-    private PushFrameSizer $frame_sizer;
+    private PushRequestSizer $request_sizer;
 
     private int $request_timeout;
 
     /** @var int|float Wall-clock budget per request, in seconds. */
     private $max_request_seconds;
 
-    private ?int $max_request_body_bytes;
+    /** @var int In-memory unit of one caller fread, in bytes. */
+    private int $chunk_bytes;
 
     /** @var resource|null */
     private $socket = null;
@@ -84,18 +88,17 @@ class StagedPushStreamClient
      *   - base_url (string, required): the export API URL; endpoint is appended
      *     to its query string.
      *   - hmac_client (?Site_Export_HMAC_Client): envelope request signer.
-     *   - frame_sizer (?PushFrameSizer): chunk-size decisions; defaults to a
-     *     fresh frame sizer. Pass one restored from persisted state to keep
-     *     learned limits.
+     *   - request_sizer (?PushRequestSizer): request-body-size decisions;
+     *     defaults to a fresh sizer. Pass one restored from persisted state
+     *     to keep learned limits.
+     *   - chunk_bytes (int): in-memory unit of one caller fread; unrelated
+     *     to the request body budget. Default 4 MiB.
      *   - request_timeout (int): seconds without socket progress (one write,
      *     or the response read) before the request fails. Default 120.
      *   - max_request_seconds (int|float): wall-clock budget per request;
      *     should_finish_request() turns true once a request is older than
      *     this. Soft — checked between chunks — so set it with margin below
      *     the host's execution/proxy limits. Default 30.
-     *   - max_request_body_bytes (?int): body bytes per request, frame
-     *     headers included, after which should_finish_request() turns true.
-     *     Null means requests rotate on time alone.
      */
     public function __construct(array $options)
     {
@@ -105,15 +108,13 @@ class StagedPushStreamClient
         }
         $this->base_url = $base_url;
         $this->hmac_client = $options["hmac_client"] ?? null;
-        $this->frame_sizer = $options["frame_sizer"] ?? new PushFrameSizer();
+        $this->request_sizer = $options["request_sizer"] ?? new PushRequestSizer();
+        $chunk_bytes = $options["chunk_bytes"] ?? null;
+        $this->chunk_bytes = is_numeric($chunk_bytes) && (int) $chunk_bytes > 0 ? (int) $chunk_bytes : 4 * 1024 * 1024;
         $timeout = $options["request_timeout"] ?? null;
         $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
         $max_request_seconds = $options["max_request_seconds"] ?? null;
         $this->max_request_seconds = is_numeric($max_request_seconds) && $max_request_seconds > 0 ? $max_request_seconds : 30;
-        $max_request_body_bytes = $options["max_request_body_bytes"] ?? null;
-        $this->max_request_body_bytes = is_numeric($max_request_body_bytes) && (int) $max_request_body_bytes > 0
-            ? (int) $max_request_body_bytes
-            : null;
     }
 
     /**
@@ -246,25 +247,23 @@ class StagedPushStreamClient
     /**
      * Body bytes the current request still accepts, frame headers included.
      *
-     * The budget is soft: the caller sizes payloads by it, and the frame
-     * header that rides along may overshoot it by one header line. The frame
-     * sizer's safety margin absorbs that.
+     * This is the host-learned request body budget draining toward zero. It
+     * is soft: the caller sizes payloads by it, and the frame header that
+     * rides along may overshoot it by one header line. The sizer's safety
+     * margin absorbs that.
      */
     public function capacity_bytes(): int
     {
-        if ($this->max_request_body_bytes === null) {
-            return PHP_INT_MAX;
-        }
-        return max(0, $this->max_request_body_bytes - $this->body_bytes_sent);
+        return max(0, $this->request_sizer->request_body_bytes() - $this->body_bytes_sent);
     }
 
     /**
-     * Largest single chunk the learned frame ceiling allows. This bounds the
-     * caller's fread, so it is also the most memory one chunk may occupy.
+     * The in-memory unit: how many bytes one caller fread may hold. Much
+     * smaller than the request body a stream carries across many chunks.
      */
     public function max_chunk_bytes(): int
     {
-        return $this->frame_sizer->chunk_bytes();
+        return $this->chunk_bytes;
     }
 
     /**
@@ -320,7 +319,7 @@ class StagedPushStreamClient
         $this->socket = null;
 
         if ($response === null) {
-            $decision = $this->frame_sizer->record_request_failure();
+            $decision = $this->request_sizer->record_request_failure();
             return $this->result(
                 $decision["action"] === "give_up" ? "failed" : "retry",
                 "request_failed",
@@ -330,7 +329,7 @@ class StagedPushStreamClient
 
         $decoded = json_decode($response["body"], true);
         if (!is_array($decoded)) {
-            $decision = $this->frame_sizer->record_request_failure();
+            $decision = $this->request_sizer->record_request_failure();
             return $this->result(
                 $decision["action"] === "give_up" ? "failed" : "retry",
                 "request_failed",
@@ -342,7 +341,7 @@ class StagedPushStreamClient
 
         if ($response["http_code"] === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
             $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
-            $decision = $this->frame_sizer->record_too_large(
+            $decision = $this->request_sizer->record_too_large(
                 is_numeric($reported_max_frame_bytes) ? (int) $reported_max_frame_bytes : null
             );
             return $this->result(
@@ -363,7 +362,7 @@ class StagedPushStreamClient
             );
         }
 
-        $this->frame_sizer->record_success();
+        $this->request_sizer->record_success();
         return $this->result("complete", null, null, $response_cursor, (int) ($decoded["files_verified"] ?? 0));
     }
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -9,7 +9,7 @@
  * target absorbing duplicate/verified frames.
  *
  * The client is a pass-through wire. The caller reads a chunk of a file into
- * memory — at most next_chunk_bytes(), which is why a chunk is the one thing
+ * memory — at most next_chunk_body_bytes(), which is why a chunk is the one thing
  * that may be buffered — and send_chunk() writes the frame header and the
  * payload straight to the request socket before returning:
  *
@@ -19,7 +19,7 @@
  *             $result = $client->finish_request();   // persist $result['cursor']
  *             $client->start_push_request();
  *         }
- *         $payload = fread($source_handle, $client->next_chunk_bytes());
+ *         $payload = fread($source_handle, $client->next_chunk_body_bytes());
  *         $client->send_chunk([
  *             'artifact_id' => $artifact_id,
  *             'offset'      => $offset,
@@ -33,12 +33,12 @@
  * Two sizes govern the loop, and they are different dimensions. The chunk
  * is the small fixed in-memory unit of one fread. The request body budget
  * is what hosts and proxies actually limit — post_max_size,
- * client_max_body_size and friends measure the entity body after chunked
- * transfer-encoding removal, and nothing compresses request bodies, so the
- * bytes we write are the bytes that get measured. That budget is learned
- * per host by PushRequestSizer and counts frame header lines alongside
- * payloads. next_chunk_bytes() folds both into the one number a caller's
- * fread needs.
+ * client_max_body_size and friends measure the entity body, and nothing
+ * compresses request bodies, so the bytes we write are the bytes that get
+ * measured. That budget is learned per host by PushRequestSizer and charges
+ * everything the body carries: frame header lines, payloads, and the
+ * chunked transfer-encoding framing around them. next_chunk_body_bytes()
+ * folds both sizes into the one number a caller's fread needs.
  */
 class StagedPushStreamClient
 {
@@ -233,14 +233,19 @@ class StagedPushStreamClient
         }
         $frame_header .= "\n";
 
-        if (!$this->write_to_socket($this->encode_body_chunk($frame_header))) {
+        // Account the encoded wire bytes — frame header, payload, and the
+        // chunked transfer-encoding size lines and CRLFs around each — so
+        // body_bytes_sent equals what the request body actually carries.
+        $encoded_frame_header = $this->encode_body_chunk($frame_header);
+        if (!$this->write_to_socket($encoded_frame_header)) {
             return false;
         }
-        if ($payload !== "" && !$this->write_to_socket($this->encode_body_chunk($payload))) {
+        $encoded_payload = $payload === "" ? "" : $this->encode_body_chunk($payload);
+        if ($encoded_payload !== "" && !$this->write_to_socket($encoded_payload)) {
             return false;
         }
 
-        $this->body_bytes_sent += strlen($frame_header) + strlen($payload);
+        $this->body_bytes_sent += strlen($encoded_frame_header) + strlen($encoded_payload);
         $this->chunks_sent++;
         return true;
     }
@@ -249,15 +254,17 @@ class StagedPushStreamClient
      * How many bytes the caller's next fread should ask for.
      *
      * The fixed chunk size — the in-memory unit — bounded by what remains of
-     * the host-learned request body budget, which counts as-sent body bytes,
-     * frame headers included. Returns 0 when the request is full;
-     * should_finish_request() is already true then. Near the end of a file
-     * fread simply returns fewer bytes and the smaller frame is correct, so
-     * callers need no min() of their own. The budget is soft: the frame
-     * header riding along with the last chunk may overshoot it by one header
-     * line, which the sizer's safety margin absorbs.
+     * the host-learned request body budget. That budget counts every byte
+     * the request body carries: frame header lines, payloads, and the
+     * chunked transfer-encoding size lines and CRLFs around them — hence
+     * "body bytes", not just payload bytes. Returns 0 when the request is
+     * full; should_finish_request() is already true then. Near the end of a
+     * file fread simply returns fewer bytes and the smaller frame is
+     * correct, so callers need no min() of their own. The budget is soft:
+     * the header and framing riding along with the last chunk may overshoot
+     * it by one frame's overhead, which the sizer's safety margin absorbs.
      */
-    public function next_chunk_bytes(): int
+    public function next_chunk_body_bytes(): int
     {
         $remaining_body_budget = max(0, $this->request_sizer->request_body_bytes() - $this->body_bytes_sent);
         return min($this->chunk_bytes, $remaining_body_budget);
@@ -274,7 +281,7 @@ class StagedPushStreamClient
         }
         return $this->transport_error !== null
             || $this->target_replied_early
-            || $this->next_chunk_bytes() === 0
+            || $this->next_chunk_body_bytes() === 0
             || (microtime(true) - $this->request_started_at) > $this->max_request_seconds;
     }
 

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -9,9 +9,12 @@
  * target skips replayed files it already verified and restarts partially
  * staged ones from zero, so a source file that changed between requests can
  * never end up half old version, half new. Callers persist the source token
- * (size and mtime) alongside each cursor and restart a file at offset 0 when
- * the file on disk no longer matches it — the reference loop in
- * StagedPushStreamClientTest::pushOnce() shows both halves.
+ * (size and ctime — the signals the push journal's own diff keys on)
+ * alongside each cursor and restart a file at offset 0 when the file on disk
+ * no longer matches it; a same-size edit within the same timestamp second
+ * escapes the token, and the diff layer's change detection is the deeper
+ * net. The reference loop in StagedPushStreamClientTest::pushOnce() shows
+ * both halves.
  *
  * The client is a pass-through wire. The caller reads a chunk of a file into
  * memory — at most next_chunk_body_bytes(), which is why a chunk is the one
@@ -652,9 +655,16 @@ class StagedPushStreamClient
         }
 
         if (($decoded["status"] ?? null) !== "complete") {
+            $reason = is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response";
+            // The protocol designs these two as recoverable, not fatal:
+            // busy is the store's retry-until-free lock contract, and
+            // offset_gap arrives with the store's own cursor to resume
+            // from. Neither says anything about request size, so the
+            // sizer records nothing.
+            $retryable = $reason === "busy" || $reason === "offset_gap";
             return $this->result(
-                "failed",
-                is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response",
+                $retryable ? "retry" : "failed",
+                $reason,
                 is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . $http_code),
                 $response_cursor,
                 (int) ($decoded["files_verified"] ?? 0)

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -57,7 +57,7 @@ class StagedPushStreamClient
 {
     private string $base_url;
 
-    private ?Site_Export_HMAC_Client $hmac_client;
+    private Site_Export_HMAC_Client $hmac_client;
 
     private PushRequestSizer $request_sizer;
 
@@ -91,11 +91,20 @@ class StagedPushStreamClient
     /** @var resource|object|null curl multi handle driving the open request */
     private $multi_handle = null;
 
-    /** Bytes handed to send_chunk() that libcurl has not consumed yet. */
-    private string $outbound_bytes = "";
+    /**
+     * The current frame, waiting for libcurl to consume it. Held as two
+     * fields instead of one concatenated string on purpose: PHP string
+     * assignment is copy-on-write, so taking the caller's payload here
+     * allocates nothing — the only real copies are the substr() pieces the
+     * read callback returns, which is the smallest handoff PHP's callback
+     * API allows.
+     */
+    private string $outbound_frame_header = "";
 
-    /** How far into $outbound_bytes libcurl's read callback has consumed. */
-    private int $outbound_offset = 0;
+    private string $outbound_payload = "";
+
+    /** How far into $outbound_payload libcurl's read callback has consumed. */
+    private int $outbound_payload_offset = 0;
 
     /** The read callback signals end-of-body when this is true. */
     private bool $body_complete = false;
@@ -130,7 +139,9 @@ class StagedPushStreamClient
      * @param array $options
      *   - base_url (string, required): the export API URL; endpoint is appended
      *     to its query string.
-     *   - hmac_client (?Site_Export_HMAC_Client): envelope request signer.
+     *   - hmac_client (Site_Export_HMAC_Client, required): signs every
+     *     request; the staged endpoints reject unsigned requests before
+     *     reading the body, so there is no unauthenticated push.
      *   - request_sizer (?PushRequestSizer): request-body-size decisions;
      *     defaults to a fresh sizer. Pass one restored from persisted state
      *     to keep learned limits.
@@ -171,7 +182,11 @@ class StagedPushStreamClient
             throw new InvalidArgumentException("StagedPushStreamClient requires a base_url option.");
         }
         $this->base_url = $base_url;
-        $this->hmac_client = $options["hmac_client"] ?? null;
+        $hmac_client = $options["hmac_client"] ?? null;
+        if (!$hmac_client instanceof Site_Export_HMAC_Client) {
+            throw new InvalidArgumentException("StagedPushStreamClient requires an hmac_client option; the staged endpoints reject unsigned requests.");
+        }
+        $this->hmac_client = $hmac_client;
         $this->request_sizer = $options["request_sizer"] ?? new PushRequestSizer();
         $chunk_bytes = $options["chunk_bytes"] ?? null;
         $this->chunk_bytes = is_numeric($chunk_bytes) && (int) $chunk_bytes > 0 ? (int) $chunk_bytes : 4 * 1024 * 1024;
@@ -199,8 +214,9 @@ class StagedPushStreamClient
             throw new RuntimeException("A push request is already open; call finish_request() before starting another.");
         }
 
-        $this->outbound_bytes = "";
-        $this->outbound_offset = 0;
+        $this->outbound_frame_header = "";
+        $this->outbound_payload = "";
+        $this->outbound_payload_offset = 0;
         $this->outbound_consumed_bytes = 0;
         $this->body_complete = false;
         $this->curl_requested_body = false;
@@ -210,12 +226,13 @@ class StagedPushStreamClient
         $this->chunks_sent = 0;
         $this->last_error = null;
 
+        // Signing covers the method and the URL (path + query), so it can
+        // happen before the body exists — the body itself is not signed;
+        // the X-Auth-Content-Hash header says so explicitly.
         $request_url = $this->base_url
             . (strpos($this->base_url, "?") === false ? "?" : "&")
             . http_build_query(["endpoint" => "staged_push"]);
-        $request_headers = $this->hmac_client !== null
-            ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
-            : [];
+        $request_headers = $this->hmac_client->get_envelope_auth_headers("POST", $request_url);
         $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
 
         $header_lines = [];
@@ -227,6 +244,12 @@ class StagedPushStreamClient
         $header_lines[] = "Expect:";
 
         $this->curl_handle = curl_init($request_url);
+        // Same environment knobs as every pull request: ALL_PROXY routes
+        // the transfer through a proxy even on hosts that strip the process
+        // environment libcurl would otherwise read it from, and the CA
+        // helper covers Playground's WASM curl, which cannot see
+        // openssl.cafile. Both are documented where they are defined, in
+        // import.php.
         if (function_exists("reprint_apply_curl_proxy_from_env")) {
             reprint_apply_curl_proxy_from_env($this->curl_handle);
         }
@@ -235,7 +258,8 @@ class StagedPushStreamClient
         }
         curl_setopt_array($this->curl_handle, [
             // Upload with no declared size: libcurl picks the transfer
-            // framing (chunked on HTTP/1.1, DATA frames on HTTP/2).
+            // framing (chunked on HTTP/1.1, DATA frames on HTTP/2). UPLOAD
+            // defaults the verb to PUT; the export API routes POST.
             CURLOPT_UPLOAD => true,
             CURLOPT_CUSTOMREQUEST => "POST",
             CURLOPT_HTTPHEADER => $header_lines,
@@ -246,15 +270,33 @@ class StagedPushStreamClient
             // healthy-but-slow bulk uploads. Each phase has its own bound —
             // connect_timeout, the stall watch in send_chunk(), and
             // response_timeout in finish_request().
+            //
+            // libcurl drives the upload by asking: whenever the socket can
+            // take more data, it calls this function for up to $length bytes
+            // ($length is libcurl's upload buffer, typically 64 KiB). Three
+            // possible answers:
+            //   - a piece of the current frame: the header line first, then
+            //     the payload, sliced to $length;
+            //   - "": the body is complete, libcurl ends the request;
+            //   - CURL_READFUNC_PAUSE: nothing to send right now, but the
+            //     body is not over — libcurl parks the upload until
+            //     send_chunk() supplies the next frame and unpauses. This
+            //     constant is why push needs PHP 8.1+ (class docblock).
             CURLOPT_READFUNCTION => function ($curl_handle, $stream, int $length) {
                 $this->curl_requested_body = true;
-                if ($this->outbound_offset < strlen($this->outbound_bytes)) {
-                    $piece = substr($this->outbound_bytes, $this->outbound_offset, $length);
-                    $this->outbound_offset += strlen($piece);
+                if ($this->outbound_frame_header !== "") {
+                    $piece = substr($this->outbound_frame_header, 0, $length);
+                    $this->outbound_frame_header = (string) substr($this->outbound_frame_header, strlen($piece));
                     $this->outbound_consumed_bytes += strlen($piece);
-                    if ($this->outbound_offset >= strlen($this->outbound_bytes)) {
-                        $this->outbound_bytes = "";
-                        $this->outbound_offset = 0;
+                    return $piece;
+                }
+                if ($this->outbound_payload_offset < strlen($this->outbound_payload)) {
+                    $piece = substr($this->outbound_payload, $this->outbound_payload_offset, $length);
+                    $this->outbound_payload_offset += strlen($piece);
+                    $this->outbound_consumed_bytes += strlen($piece);
+                    if ($this->outbound_payload_offset >= strlen($this->outbound_payload)) {
+                        $this->outbound_payload = "";
+                        $this->outbound_payload_offset = 0;
                     }
                     return $piece;
                 }
@@ -265,6 +307,12 @@ class StagedPushStreamClient
             },
         ]);
 
+        // One curl_multi handle per request, holding a single transfer.
+        // Multi is not for concurrency here: unlike curl_exec(), which
+        // blocks until the whole exchange is over, curl_multi_exec()
+        // performs one small slice of work and returns. That is what lets
+        // send_chunk() feed a frame, pump until libcurl consumed it, and
+        // hand control back to the caller while the request stays open.
         $this->multi_handle = curl_multi_init();
         curl_multi_add_handle($this->multi_handle, $this->curl_handle);
 
@@ -312,6 +360,12 @@ class StagedPushStreamClient
      */
     public function send_chunk(array $chunk): bool
     {
+        // This mirrors the target's own frame validation, so a bad
+        // descriptor fails here — naming the exact field — instead of after
+        // uploading it. The last two checks are protocol invariants no type
+        // system covers: a zero-byte non-final frame means the source file
+        // shrank under the caller, and a final frame must land exactly on
+        // total_bytes or the target will 409 after staging the bytes.
         $artifact_id = $chunk["artifact_id"] ?? null;
         if (!is_string($artifact_id) || $artifact_id === "") {
             throw new InvalidArgumentException("Expected chunk field \"artifact_id\" to be a non-empty string.");
@@ -368,8 +422,11 @@ class StagedPushStreamClient
         }
         $frame_header .= "\n";
 
-        $this->outbound_bytes = $frame_header . $payload;
-        $this->outbound_offset = 0;
+        // Copy-on-write assignments: neither line copies the payload bytes.
+        // Unpausing tells libcurl to start calling the read callback again.
+        $this->outbound_frame_header = $frame_header;
+        $this->outbound_payload = $payload;
+        $this->outbound_payload_offset = 0;
         curl_pause($this->curl_handle, CURLPAUSE_CONT);
 
         // The stall watch fails only on zero progress: every byte libcurl
@@ -377,7 +434,7 @@ class StagedPushStreamClient
         // can take as long as it needs.
         $consumed_at_last_progress = $this->outbound_consumed_bytes;
         $last_progress_at = microtime(true);
-        while ($this->outbound_bytes !== "" && !$this->transfer_finished) {
+        while (($this->outbound_frame_header !== "" || $this->outbound_payload !== "") && !$this->transfer_finished) {
             if ($this->outbound_consumed_bytes !== $consumed_at_last_progress) {
                 $consumed_at_last_progress = $this->outbound_consumed_bytes;
                 $last_progress_at = microtime(true);
@@ -388,11 +445,12 @@ class StagedPushStreamClient
             }
             $this->pump_transfer();
         }
-        if ($this->outbound_bytes !== "") {
+        if ($this->outbound_frame_header !== "" || $this->outbound_payload !== "") {
             // The transfer ended mid-frame; drop the leftover so the read
             // callback cannot leak stale bytes into a later pump.
-            $this->outbound_bytes = "";
-            $this->outbound_offset = 0;
+            $this->outbound_frame_header = "";
+            $this->outbound_payload = "";
+            $this->outbound_payload_offset = 0;
             return false;
         }
 
@@ -527,8 +585,14 @@ class StagedPushStreamClient
     }
 
     /**
-     * One curl_multi step: perform pending transfer work, harvest the
-     * completion message, and wait briefly for socket activity.
+     * One curl_multi step. curl_multi_exec() performs whatever transfer
+     * work the socket allows right now — writing queued upload bytes,
+     * reading response bytes — and returns without blocking. When the
+     * transfer ends, curl_multi_info_read() delivers exactly one DONE
+     * message carrying the result code; that is the only place libcurl
+     * reports how the transfer ended, so it is harvested here into
+     * $transfer_finished/$transfer_error. The select waits up to 50 ms for
+     * socket readiness so callers can loop on this without busy-spinning.
      */
     private function pump_transfer(): void
     {

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -34,9 +34,9 @@
  * request stays open between chunks: send_chunk() hands the frame to curl's
  * read callback and pumps the transfer until libcurl has consumed every
  * byte. libcurl writes to the socket as it consumes, so when send_chunk()
- * returns true the frame has left for the network — at most libcurl's
- * upload buffer (64 KiB) sits between this process and the socket, never a
- * request body. Between chunks the read callback returns
+ * returns true the frame has left for the network — what trails behind is
+ * libcurl's upload buffer (64 KiB) and the kernel's socket send buffer,
+ * never a request body. Between chunks the read callback returns
  * CURL_READFUNC_PAUSE, which PHP's curl extension only supports since
  * PHP 8.1 — on 7.4/8.0 that return is misread as end-of-body and the upload
  * silently truncates, so the constructor refuses to run there. The full
@@ -379,10 +379,13 @@ class StagedPushStreamClient
      * libcurl's read callback and the transfer is pumped until libcurl has
      * consumed every byte and written it toward the socket. When this
      * returns true the frame is on the network, not queued in this process;
-     * at most libcurl's 64 KiB upload buffer trails behind.
+     * libcurl's 64 KiB upload buffer and the kernel's socket send buffer
+     * trail behind — buffers, never a request body.
      *
      * The payload's length is the frame's byte count; there is no separate
-     * declaration to reconcile. Invalid descriptors throw with the exact
+     * declaration to reconcile. The artifact_id may be arbitrary bytes —
+     * file names are not guaranteed UTF-8 — and travels base64-encoded
+     * inside the JSON frame header. Invalid descriptors throw with the exact
      * violated condition. Remote conditions do not throw: false means the
      * transfer ended early — dead connection or the target already
      * responded — and finish_request() reports which.
@@ -442,7 +445,11 @@ class StagedPushStreamClient
 
         $frame_header = json_encode([
             "type" => "chunk",
-            "artifact_id" => $artifact_id,
+            // File paths are arbitrary bytes and JSON strings must be UTF-8,
+            // so the id travels base64-encoded — the same convention the
+            // journal and the pull cursors use. json_encode would return
+            // false on a raw non-UTF-8 name.
+            "artifact_id" => base64_encode($artifact_id),
             "offset" => $offset,
             "bytes" => strlen($payload),
             "total_bytes" => $total_bytes,
@@ -564,11 +571,26 @@ class StagedPushStreamClient
         }
 
         $http_code = (int) curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
+        $redirect_url = (string) curl_getinfo($this->curl_handle, CURLINFO_REDIRECT_URL);
         $response_body = (string) curl_multi_getcontent($this->curl_handle);
         curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
         curl_multi_close($this->multi_handle);
         $this->curl_handle = null;
         $this->multi_handle = null;
+
+        // A redirect is a configuration problem, not a transient failure or
+        // a size signal: the usual case is an http:// base_url on a site
+        // that forces https. Name the target instead of retrying into it —
+        // the request cannot replay its streamed body through a redirect.
+        if (in_array($http_code, [301, 302, 303, 307, 308], true)) {
+            return $this->result(
+                "failed",
+                "redirected",
+                $redirect_url !== ""
+                    ? "The target redirected to \"" . $redirect_url . "\". Use that address as the push base_url."
+                    : "The target answered HTTP " . $http_code . " without a Location header."
+            );
+        }
 
         $decoded = json_decode($response_body, true);
         if (!is_array($decoded)) {
@@ -582,6 +604,15 @@ class StagedPushStreamClient
         }
 
         $response_cursor = is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null;
+        if ($response_cursor !== null) {
+            // The wire carries the id base64-encoded (see send_chunk); hand
+            // callers the raw path back. A cursor that does not decode is as
+            // useless as none — callers fall back to their persisted cursor.
+            $decoded_artifact_id = base64_decode((string) ($response_cursor["artifact_id"] ?? ""), true);
+            $response_cursor = $decoded_artifact_id !== false && $decoded_artifact_id !== ""
+                ? ["artifact_id" => $decoded_artifact_id, "committed_bytes" => (int) ($response_cursor["committed_bytes"] ?? 0)]
+                : null;
+        }
 
         if ($http_code === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
             $reported_limit_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -9,9 +9,9 @@
  * target absorbing duplicate/verified frames.
  *
  * The client is a pass-through wire. The caller reads a chunk of a file into
- * memory — at most next_chunk_body_bytes(), which is why a chunk is the one thing
- * that may be buffered — and send_chunk() writes the frame header and the
- * payload straight to the request socket before returning:
+ * memory — at most next_chunk_body_bytes(), which is why a chunk is the one
+ * thing that may be buffered — and send_chunk() sends it over the network
+ * before returning:
  *
  *     $client->start_push_request();
  *     while (...) {
@@ -30,21 +30,31 @@
  *     }
  *     $result = $client->finish_request();
  *
+ * The transfer runs through libcurl, driven with the curl_multi API so the
+ * request stays open between chunks: send_chunk() hands the frame to curl's
+ * read callback and pumps the transfer until libcurl has consumed every
+ * byte. libcurl writes to the socket as it consumes, so when send_chunk()
+ * returns true the frame has left for the network — at most libcurl's
+ * upload buffer (64 KiB) sits between this process and the socket, never a
+ * request body. Between chunks the read callback returns
+ * CURL_READFUNC_PAUSE, which PHP's curl extension only supports since
+ * PHP 8.1 — on 7.4/8.0 that return is misread as end-of-body and the upload
+ * silently truncates, so the constructor refuses to run there. The full
+ * story: https://github.com/WordPress/reprint/issues/327
+ *
  * Two sizes govern the loop, and they are different dimensions. The chunk
  * is the small fixed in-memory unit of one fread. The request body budget
  * is what hosts and proxies actually limit — post_max_size,
  * client_max_body_size and friends measure the entity body, and nothing
  * compresses request bodies, so the bytes we write are the bytes that get
  * measured. That budget is learned per host by PushRequestSizer and charges
- * everything the body carries: frame header lines, payloads, and the
- * chunked transfer-encoding framing around them. next_chunk_body_bytes()
- * folds both sizes into the one number a caller's fread needs.
+ * frame header lines alongside payloads; the transfer framing around them
+ * is libcurl's business (chunked on HTTP/1.1, DATA frames on HTTP/2) and
+ * rides in the sizer's safety margin. next_chunk_body_bytes() folds both
+ * sizes into the one number a caller's fread needs.
  */
 class StagedPushStreamClient
 {
-    /** Largest slice handed to one fwrite; bounds the copy cost of partial writes. */
-    private const WRITE_SLICE_BYTES = 1048576;
-
     private string $base_url;
 
     private ?Site_Export_HMAC_Client $hmac_client;
@@ -59,28 +69,36 @@ class StagedPushStreamClient
     /** @var int In-memory unit of one caller fread, in bytes. */
     private int $chunk_bytes;
 
-    /** @var resource|null */
-    private $socket = null;
+    /** @var resource|object|null curl easy handle for the open request */
+    private $curl_handle = null;
+
+    /** @var resource|object|null curl multi handle driving the open request */
+    private $multi_handle = null;
+
+    /** Bytes handed to send_chunk() that libcurl has not consumed yet. */
+    private string $outbound_bytes = "";
+
+    /** How far into $outbound_bytes libcurl's read callback has consumed. */
+    private int $outbound_offset = 0;
+
+    /** The read callback signals end-of-body when this is true. */
+    private bool $body_complete = false;
+
+    /**
+     * libcurl asked the read callback for body bytes — the request head is
+     * out and the connection is established.
+     */
+    private bool $curl_requested_body = false;
+
+    private bool $transfer_finished = false;
+
+    private ?string $transfer_error = null;
 
     private float $request_started_at = 0.0;
 
     private int $body_bytes_sent = 0;
 
     private int $chunks_sent = 0;
-
-    private ?string $transport_error = null;
-
-    /**
-     * The target started responding (or closed) before this stream ended.
-     * Its response decides the request now, so no further bytes are sent.
-     */
-    private bool $target_replied_early = false;
-
-    /**
-     * Response bytes consumed while probing read-readiness during a write;
-     * read_response() treats them as the start of the response head.
-     */
-    private string $early_reply_buffer = "";
 
     private ?string $last_error = null;
 
@@ -94,8 +112,9 @@ class StagedPushStreamClient
      *     to keep learned limits.
      *   - chunk_bytes (int): in-memory unit of one caller fread; unrelated
      *     to the request body budget. Default 4 MiB.
-     *   - request_timeout (int): seconds without socket progress (one write,
-     *     or the response read) before the request fails. Default 120.
+     *   - request_timeout (int): seconds without transfer progress (opening
+     *     the request, handing one chunk to libcurl, or the response read)
+     *     before the request fails. Default 120.
      *   - max_request_seconds (int|float): wall-clock budget per request;
      *     should_finish_request() turns true once a request is older than
      *     this. Soft — checked between chunks — so set it with margin below
@@ -103,6 +122,19 @@ class StagedPushStreamClient
      */
     public function __construct(array $options)
     {
+        if (PHP_VERSION_ID < 80100) {
+            // Before 8.1, ext/curl only honors string returns from the read
+            // callback: CURL_READFUNC_PAUSE falls through to 0, libcurl
+            // reads that as end-of-body, and the upload silently truncates.
+            throw new RuntimeException(
+                "reprint push requires PHP 8.1 or newer: streaming request bodies through curl needs"
+                . " CURL_READFUNC_PAUSE support, which PHP's curl extension added in 8.1 — on older PHP"
+                . " the pause return is misread as end-of-body and the upload silently truncates."
+                . " Current PHP is " . PHP_VERSION . "."
+                . " See https://github.com/WordPress/reprint/issues/327 for the full story."
+            );
+        }
+
         $base_url = $options["base_url"] ?? null;
         if (!is_string($base_url) || $base_url === "") {
             throw new InvalidArgumentException("StagedPushStreamClient requires a base_url option.");
@@ -119,24 +151,27 @@ class StagedPushStreamClient
     }
 
     /**
-     * Open a staged_push request: connect, negotiate TLS for https, and write
-     * the signed request head. The request body starts empty; send_chunk()
-     * fills it.
+     * Open a staged_push request: connect and send the signed request head,
+     * returning once libcurl asks for body bytes. The request body starts
+     * empty; send_chunk() fills it.
      *
      * @return bool False when the connection could not be opened;
      *              get_last_error() says why.
      */
     public function start_push_request(): bool
     {
-        if ($this->socket !== null) {
+        if ($this->curl_handle !== null) {
             throw new RuntimeException("A push request is already open; call finish_request() before starting another.");
         }
 
+        $this->outbound_bytes = "";
+        $this->outbound_offset = 0;
+        $this->body_complete = false;
+        $this->curl_requested_body = false;
+        $this->transfer_finished = false;
+        $this->transfer_error = null;
         $this->body_bytes_sent = 0;
         $this->chunks_sent = 0;
-        $this->transport_error = null;
-        $this->target_replied_early = false;
-        $this->early_reply_buffer = "";
         $this->last_error = null;
 
         $request_url = $this->base_url
@@ -146,16 +181,72 @@ class StagedPushStreamClient
             ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
             : [];
         $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
-        $request_headers["Transfer-Encoding"] = "chunked";
-        $request_headers["Connection"] = "close";
 
-        if (!$this->open_connection($request_url, $request_headers)) {
-            if (is_resource($this->socket)) {
-                fclose($this->socket);
+        $header_lines = [];
+        foreach ($request_headers as $header_name => $header_value) {
+            $header_lines[] = $header_name . ": " . $header_value;
+        }
+        // Suppress Expect: 100-continue; waiting for the interim response
+        // would stall the first chunk for nothing.
+        $header_lines[] = "Expect:";
+
+        $this->curl_handle = curl_init($request_url);
+        if (function_exists("reprint_apply_curl_proxy_from_env")) {
+            reprint_apply_curl_proxy_from_env($this->curl_handle);
+        }
+        if (function_exists("reprint_apply_curl_ca_bundle")) {
+            reprint_apply_curl_ca_bundle($this->curl_handle);
+        }
+        curl_setopt_array($this->curl_handle, [
+            // Upload with no declared size: libcurl picks the transfer
+            // framing (chunked on HTTP/1.1, DATA frames on HTTP/2).
+            CURLOPT_UPLOAD => true,
+            CURLOPT_CUSTOMREQUEST => "POST",
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_CONNECTTIMEOUT => $this->request_timeout,
+            // Total lifetime of one request, including caller time between
+            // chunks; keep it above max_request_seconds plus response time.
+            CURLOPT_TIMEOUT => $this->request_timeout,
+            CURLOPT_READFUNCTION => function ($curl_handle, $stream, int $length) {
+                $this->curl_requested_body = true;
+                if ($this->outbound_offset < strlen($this->outbound_bytes)) {
+                    $piece = substr($this->outbound_bytes, $this->outbound_offset, $length);
+                    $this->outbound_offset += strlen($piece);
+                    if ($this->outbound_offset >= strlen($this->outbound_bytes)) {
+                        $this->outbound_bytes = "";
+                        $this->outbound_offset = 0;
+                    }
+                    return $piece;
+                }
+                if ($this->body_complete) {
+                    return "";
+                }
+                return CURL_READFUNC_PAUSE;
+            },
+        ]);
+
+        $this->multi_handle = curl_multi_init();
+        curl_multi_add_handle($this->multi_handle, $this->curl_handle);
+
+        // Drive the transfer until the head is out — libcurl asking for body
+        // bytes proves it — so connection and TLS failures surface here, not
+        // in the middle of the caller's chunk loop.
+        $deadline = microtime(true) + $this->request_timeout;
+        while (!$this->curl_requested_body && !$this->transfer_finished) {
+            if (microtime(true) > $deadline) {
+                $this->transfer_error = "Timed out after " . $this->request_timeout . "s opening the push stream request.";
+                break;
             }
-            $this->socket = null;
-            $this->last_error = $this->transport_error;
-            $this->transport_error = null;
+            $this->pump_transfer();
+        }
+        if (!$this->curl_requested_body) {
+            $this->last_error = $this->transfer_error ?? "The push stream request ended before the request head was sent.";
+            curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
+            curl_multi_close($this->multi_handle);
+            $this->curl_handle = null;
+            $this->multi_handle = null;
             return false;
         }
 
@@ -164,14 +255,20 @@ class StagedPushStreamClient
     }
 
     /**
-     * Write one framed chunk — header line, then the payload — straight to
-     * the request socket.
+     * Send one framed chunk — header line, then the payload — over the
+     * network.
+     *
+     * This performs the actual network transmission: the frame is handed to
+     * libcurl's read callback and the transfer is pumped until libcurl has
+     * consumed every byte and written it toward the socket. When this
+     * returns true the frame is on the network, not queued in this process;
+     * at most libcurl's 64 KiB upload buffer trails behind.
      *
      * The payload's length is the frame's byte count; there is no separate
      * declaration to reconcile. Invalid descriptors throw with the exact
      * violated condition. Remote conditions do not throw: false means the
-     * wire died or the target replied early, and finish_request() reports
-     * which.
+     * transfer ended early — dead connection or the target already
+     * responded — and finish_request() reports which.
      *
      * @param array{artifact_id:string,offset:int,total_bytes:int,final:bool,payload:string} $chunk
      */
@@ -213,10 +310,10 @@ class StagedPushStreamClient
             );
         }
 
-        if ($this->socket === null) {
+        if ($this->curl_handle === null) {
             throw new RuntimeException("No push request is open; call start_push_request() before send_chunk().");
         }
-        if ($this->transport_error !== null || $this->target_replied_early) {
+        if ($this->transfer_finished) {
             return false;
         }
 
@@ -233,19 +330,27 @@ class StagedPushStreamClient
         }
         $frame_header .= "\n";
 
-        // Account the encoded wire bytes — frame header, payload, and the
-        // chunked transfer-encoding size lines and CRLFs around each — so
-        // body_bytes_sent equals what the request body actually carries.
-        $encoded_frame_header = $this->encode_body_chunk($frame_header);
-        if (!$this->write_to_socket($encoded_frame_header)) {
-            return false;
+        $this->outbound_bytes = $frame_header . $payload;
+        $this->outbound_offset = 0;
+        curl_pause($this->curl_handle, CURLPAUSE_CONT);
+        $deadline = microtime(true) + $this->request_timeout;
+        while ($this->outbound_bytes !== "" && !$this->transfer_finished) {
+            if (microtime(true) > $deadline) {
+                $this->transfer_error = "Timed out after " . $this->request_timeout . "s sending push stream bytes.";
+                $this->transfer_finished = true;
+                break;
+            }
+            $this->pump_transfer();
         }
-        $encoded_payload = $payload === "" ? "" : $this->encode_body_chunk($payload);
-        if ($encoded_payload !== "" && !$this->write_to_socket($encoded_payload)) {
+        if ($this->outbound_bytes !== "") {
+            // The transfer ended mid-frame; drop the leftover so the read
+            // callback cannot leak stale bytes into a later pump.
+            $this->outbound_bytes = "";
+            $this->outbound_offset = 0;
             return false;
         }
 
-        $this->body_bytes_sent += strlen($encoded_frame_header) + strlen($encoded_payload);
+        $this->body_bytes_sent += strlen($frame_header) + strlen($payload);
         $this->chunks_sent++;
         return true;
     }
@@ -254,15 +359,14 @@ class StagedPushStreamClient
      * How many bytes the caller's next fread should ask for.
      *
      * The fixed chunk size — the in-memory unit — bounded by what remains of
-     * the host-learned request body budget. That budget counts every byte
-     * the request body carries: frame header lines, payloads, and the
-     * chunked transfer-encoding size lines and CRLFs around them — hence
-     * "body bytes", not just payload bytes. Returns 0 when the request is
-     * full; should_finish_request() is already true then. Near the end of a
-     * file fread simply returns fewer bytes and the smaller frame is
-     * correct, so callers need no min() of their own. The budget is soft:
-     * the header and framing riding along with the last chunk may overshoot
-     * it by one frame's overhead, which the sizer's safety margin absorbs.
+     * the host-learned request body budget. That budget is denominated in
+     * entity-body bytes, the dimension request-size limits measure: frame
+     * header lines and payloads. Returns 0 when the request is full;
+     * should_finish_request() is already true then. Near the end of a file
+     * fread simply returns fewer bytes and the smaller frame is correct, so
+     * callers need no min() of their own. The budget is soft: the header
+     * riding along with the last chunk may overshoot it by one line, which
+     * the sizer's safety margin absorbs.
      */
     public function next_chunk_body_bytes(): int
     {
@@ -272,15 +376,15 @@ class StagedPushStreamClient
 
     /**
      * Whether the current request should end now: its byte or time budget is
-     * spent, or the exchange already ended (dead wire or an early response).
+     * spent, or the transfer already ended (dead connection or an early
+     * response).
      */
     public function should_finish_request(): bool
     {
-        if ($this->socket === null) {
+        if ($this->curl_handle === null) {
             throw new RuntimeException("No push request is open; call start_push_request() before should_finish_request().");
         }
-        return $this->transport_error !== null
-            || $this->target_replied_early
+        return $this->transfer_finished
             || $this->next_chunk_body_bytes() === 0
             || (microtime(true) - $this->request_started_at) > $this->max_request_seconds;
     }
@@ -289,17 +393,12 @@ class StagedPushStreamClient
      * End the request body, read the target's response, and fold it into the
      * retry/cursor decision.
      *
-     * Behavior by how the exchange went:
-     *
-     * 1. Normal end: writes the terminating zero-length chunk so the target
-     *    sees a complete body, then reads the response.
-     * 2. The target replied early: skips the terminator (the target already
-     *    decided) and reads the response that is waiting.
-     * 3. A transport failure interrupted the stream: still tries to read a
-     *    response — a target that rejected mid-stream (413 from a proxy, auth
-     *    failure) breaks our writes but its response carries the reason and a
-     *    resume cursor. Falls back to the write error when no parseable
-     *    response arrives.
+     * The read callback reports end-of-body to libcurl, the transfer is
+     * pumped to completion, and the response is interpreted. When the
+     * transfer broke mid-stream, a parseable response still wins over the
+     * transport error — a target that rejected mid-stream (413 from a proxy,
+     * auth failure) breaks the upload but its response carries the reason
+     * and a resume cursor.
      *
      * The returned cursor is the server-confirmed one from the response, or
      * null when no response arrived — resume from the last persisted cursor
@@ -309,41 +408,44 @@ class StagedPushStreamClient
      */
     public function finish_request(): array
     {
-        if ($this->socket === null) {
+        if ($this->curl_handle === null) {
             throw new RuntimeException("No push request is open; call start_push_request() before finish_request().");
         }
 
-        if ($this->transport_error === null && !$this->target_replied_early) {
-            $this->write_to_socket("0\r\n\r\n");
+        if (!$this->transfer_finished) {
+            $this->body_complete = true;
+            curl_pause($this->curl_handle, CURLPAUSE_CONT);
+            $deadline = microtime(true) + $this->request_timeout;
+            while (!$this->transfer_finished) {
+                if (microtime(true) > $deadline) {
+                    $this->transfer_error = "Timed out after " . $this->request_timeout . "s waiting for the push stream response.";
+                    break;
+                }
+                $this->pump_transfer();
+            }
         }
 
-        $write_error = $this->transport_error;
-        $response = $this->read_response();
-        fclose($this->socket);
-        $this->socket = null;
+        $http_code = (int) curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
+        $response_body = (string) curl_multi_getcontent($this->curl_handle);
+        curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
+        curl_multi_close($this->multi_handle);
+        $this->curl_handle = null;
+        $this->multi_handle = null;
 
-        if ($response === null) {
-            $decision = $this->request_sizer->record_request_failure();
-            return $this->result(
-                $decision["action"] === "give_up" ? "failed" : "retry",
-                "request_failed",
-                $write_error ?? $this->transport_error
-            );
-        }
-
-        $decoded = json_decode($response["body"], true);
+        $decoded = json_decode($response_body, true);
         if (!is_array($decoded)) {
             $decision = $this->request_sizer->record_request_failure();
             return $this->result(
                 $decision["action"] === "give_up" ? "failed" : "retry",
                 "request_failed",
-                "invalid JSON response (HTTP " . $response["http_code"] . "): " . substr($response["body"], 0, 120)
+                $this->transfer_error
+                    ?? "invalid JSON response (HTTP " . $http_code . "): " . substr($response_body, 0, 120)
             );
         }
 
         $response_cursor = is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null;
 
-        if ($response["http_code"] === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
+        if ($http_code === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
             $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
             $decision = $this->request_sizer->record_too_large(
                 is_numeric($reported_max_frame_bytes) ? (int) $reported_max_frame_bytes : null
@@ -360,7 +462,7 @@ class StagedPushStreamClient
             return $this->result(
                 "failed",
                 is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response",
-                is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . $response["http_code"]),
+                is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . $http_code),
                 $response_cursor,
                 (int) ($decoded["files_verified"] ?? 0)
             );
@@ -378,6 +480,30 @@ class StagedPushStreamClient
         return $this->last_error;
     }
 
+    /**
+     * One curl_multi step: perform pending transfer work, harvest the
+     * completion message, and wait briefly for socket activity.
+     */
+    private function pump_transfer(): void
+    {
+        do {
+            $status = curl_multi_exec($this->multi_handle, $active_transfers);
+        } while ($status === CURLM_CALL_MULTI_PERFORM);
+
+        while (($message = curl_multi_info_read($this->multi_handle)) !== false) {
+            if ($message["msg"] === CURLMSG_DONE) {
+                $this->transfer_finished = true;
+                if ($message["result"] !== CURLE_OK) {
+                    $this->transfer_error = curl_error($this->curl_handle) ?: curl_strerror((int) $message["result"]);
+                }
+            }
+        }
+
+        if (!$this->transfer_finished) {
+            curl_multi_select($this->multi_handle, 0.05);
+        }
+    }
+
     /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int} */
     private function result(string $status, ?string $reason, ?string $detail, ?array $cursor = null, int $files_verified = 0): array
     {
@@ -390,262 +516,5 @@ class StagedPushStreamClient
             "chunks_sent" => $this->chunks_sent,
             "body_bytes_sent" => $this->body_bytes_sent,
         ];
-    }
-
-    /**
-     * Connect, negotiate TLS for https, and write the request head.
-     *
-     * On failure records a transport error and returns false.
-     *
-     * @param array<string,string> $request_headers
-     */
-    private function open_connection(string $request_url, array $request_headers): bool
-    {
-        $url_parts = parse_url($request_url);
-        $scheme = $url_parts["scheme"] ?? "";
-        $host = $url_parts["host"] ?? "";
-        if (!in_array($scheme, ["http", "https"], true) || $host === "") {
-            throw new InvalidArgumentException("Staged push requires an http:// or https:// base_url; received " . $request_url);
-        }
-        $is_tls = $scheme === "https";
-        $port = isset($url_parts["port"]) ? (int) $url_parts["port"] : ($is_tls ? 443 : 80);
-
-        $context_options = [];
-        if ($is_tls) {
-            $context_options["ssl"] = ["peer_name" => $host, "SNI_enabled" => true];
-            // Same escape hatch as the pull client's curl path: Playground's
-            // TLS stack may not trust the target's CA. The wizard sets this
-            // env when it hands off; nothing else does.
-            if (getenv("REPRINT_INSECURE_TLS") === "1") {
-                $context_options["ssl"]["verify_peer"] = false;
-                $context_options["ssl"]["verify_peer_name"] = false;
-            }
-        }
-
-        $socket = @stream_socket_client(
-            "tcp://" . $host . ":" . $port,
-            $connect_errno,
-            $connect_error,
-            $this->request_timeout,
-            STREAM_CLIENT_CONNECT,
-            stream_context_create($context_options)
-        );
-        if ($socket === false) {
-            $this->transport_error = "Could not connect to " . $host . ":" . $port . " — " . ($connect_error !== "" ? $connect_error : ("errno " . $connect_errno));
-            return false;
-        }
-        stream_set_timeout($socket, $this->request_timeout);
-
-        if ($is_tls && @stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT) !== true) {
-            $last_error = error_get_last();
-            $this->transport_error = "TLS handshake with " . $host . ":" . $port . " failed — " . (is_array($last_error) ? $last_error["message"] : "unknown error");
-            fclose($socket);
-            return false;
-        }
-
-        // Non-blocking so body writes can watch for an early response in the
-        // same stream_select() that waits for writability.
-        stream_set_blocking($socket, false);
-        $this->socket = $socket;
-
-        $request_target = ($url_parts["path"] ?? "") !== "" ? $url_parts["path"] : "/";
-        if (($url_parts["query"] ?? "") !== "") {
-            $request_target .= "?" . $url_parts["query"];
-        }
-        $default_port = $is_tls ? 443 : 80;
-        $head = "POST " . $request_target . " HTTP/1.1\r\n"
-            . "Host: " . $host . ($port === $default_port ? "" : ":" . $port) . "\r\n";
-        foreach ($request_headers as $header_name => $header_value) {
-            $head .= $header_name . ": " . $header_value . "\r\n";
-        }
-        $head .= "\r\n";
-
-        return $this->write_to_socket($head);
-    }
-
-    /**
-     * Wrap raw bytes as one HTTP chunked-transfer-encoding chunk.
-     */
-    private function encode_body_chunk(string $bytes): string
-    {
-        return dechex(strlen($bytes)) . "\r\n" . $bytes . "\r\n";
-    }
-
-    /**
-     * Write bytes to the socket, waiting for writability as needed.
-     *
-     * Watches for readability in the same select: the target speaking (or
-     * closing) before our stream ends means its response decides this request,
-     * so sending stops. Returns false on early reply, timeout, or a dead
-     * socket; the specific transport error is recorded for finish_request().
-     */
-    private function write_to_socket(string $bytes): bool
-    {
-        $unwritten_offset = 0;
-        $total_bytes = strlen($bytes);
-        $deadline = microtime(true) + $this->request_timeout;
-
-        while ($unwritten_offset < $total_bytes) {
-            $seconds_remaining = $deadline - microtime(true);
-            if ($seconds_remaining <= 0) {
-                $this->transport_error = "Timed out after " . $this->request_timeout . "s waiting to write push stream bytes.";
-                return false;
-            }
-            $read_sockets = [$this->socket];
-            $write_sockets = [$this->socket];
-            $except_sockets = null;
-            $ready = @stream_select(
-                $read_sockets,
-                $write_sockets,
-                $except_sockets,
-                (int) $seconds_remaining,
-                (int) (fmod($seconds_remaining, 1) * 1000000)
-            );
-            if ($ready === false) {
-                $last_error = error_get_last();
-                $this->transport_error = "stream_select() failed while sending the push stream — " . (is_array($last_error) ? $last_error["message"] : "unknown error");
-                return false;
-            }
-            if ($ready === 0) {
-                continue;
-            }
-
-            // The socket fired; probe for an early reply before writing. Any
-            // buffered application byte means the target's response decides
-            // this request now. TLS also wakes the read side for protocol-
-            // internal records (e.g. TLS 1.3 session tickets); those yield no
-            // bytes and no EOF, and sending continues.
-            $probed = fread($this->socket, 1);
-            if (is_string($probed) && $probed !== "") {
-                $this->early_reply_buffer .= $probed;
-                $this->target_replied_early = true;
-                return false;
-            }
-            if (feof($this->socket)) {
-                $this->target_replied_early = true;
-                return false;
-            }
-
-            $written = @fwrite($this->socket, substr($bytes, $unwritten_offset, self::WRITE_SLICE_BYTES));
-            if ($written === false || $written === 0) {
-                if (feof($this->socket)) {
-                    $this->transport_error = "Connection closed while sending the push stream after " . $this->body_bytes_sent . " body bytes.";
-                    return false;
-                }
-                // A writable-but-zero write happens during TLS renegotiation;
-                // retry until the deadline decides.
-                continue;
-            }
-            $unwritten_offset += $written;
-        }
-        return true;
-    }
-
-    /**
-     * Read and parse the HTTP response. Returns null and records a transport
-     * error when no complete response arrives in time.
-     *
-     * @return array{http_code:int,body:string}|null
-     */
-    private function read_response(): ?array
-    {
-        stream_set_blocking($this->socket, true);
-        stream_set_timeout($this->socket, $this->request_timeout);
-
-        $head = $this->early_reply_buffer;
-        while (strpos($head, "\r\n\r\n") === false) {
-            $line = fgets($this->socket);
-            if ($line === false) {
-                $this->transport_error = stream_get_meta_data($this->socket)["timed_out"]
-                    ? "Timed out after " . $this->request_timeout . "s waiting for the push stream response."
-                    : "Connection closed before a push stream response arrived.";
-                return null;
-            }
-            $head .= $line;
-            if (strlen($head) > 65536) {
-                $this->transport_error = "Push stream response headers exceeded 64 KiB.";
-                return null;
-            }
-        }
-
-        if (!preg_match('#^HTTP/\S+\s+(\d{3})#', $head, $status_match)) {
-            $this->transport_error = "Malformed push stream response status line: " . substr($head, 0, 120);
-            return null;
-        }
-        $http_code = (int) $status_match[1];
-
-        $response_headers = [];
-        foreach (explode("\r\n", $head) as $header_line) {
-            $colon_position = strpos($header_line, ":");
-            if ($colon_position !== false) {
-                $response_headers[strtolower(substr($header_line, 0, $colon_position))] = trim(substr($header_line, $colon_position + 1));
-            }
-        }
-
-        if (stripos($response_headers["transfer-encoding"] ?? "", "chunked") !== false) {
-            $body = "";
-            while (true) {
-                $size_line = fgets($this->socket);
-                if ($size_line === false) {
-                    $this->transport_error = "Connection closed inside a chunked push stream response.";
-                    return null;
-                }
-                $chunk_size_hex = trim(explode(";", $size_line, 2)[0]);
-                if ($chunk_size_hex === "" || !ctype_xdigit($chunk_size_hex)) {
-                    $this->transport_error = "Malformed chunked response size line: " . substr($size_line, 0, 40);
-                    return null;
-                }
-                $chunk_size = (int) hexdec($chunk_size_hex);
-                if ($chunk_size === 0) {
-                    // Drain optional trailers up to the blank line.
-                    while (($trailer_line = fgets($this->socket)) !== false && $trailer_line !== "\r\n") {
-                        continue;
-                    }
-                    break;
-                }
-                $chunk = $this->read_from_socket($chunk_size + 2);
-                if ($chunk === null) {
-                    return null;
-                }
-                $body .= substr($chunk, 0, $chunk_size);
-            }
-            return ["http_code" => $http_code, "body" => $body];
-        }
-
-        if (isset($response_headers["content-length"])) {
-            $body = $this->read_from_socket((int) $response_headers["content-length"]);
-            if ($body === null) {
-                return null;
-            }
-            return ["http_code" => $http_code, "body" => $body];
-        }
-
-        // Connection: close without a length — the body ends when the target
-        // closes the connection.
-        $body = stream_get_contents($this->socket);
-        if ($body === false || stream_get_meta_data($this->socket)["timed_out"]) {
-            $this->transport_error = "Timed out after " . $this->request_timeout . "s reading the push stream response body.";
-            return null;
-        }
-        return ["http_code" => $http_code, "body" => $body];
-    }
-
-    /**
-     * Read exactly $bytes from the blocking response socket, or record why not.
-     */
-    private function read_from_socket(int $bytes): ?string
-    {
-        $buffer = "";
-        while (strlen($buffer) < $bytes) {
-            $piece = fread($this->socket, $bytes - strlen($buffer));
-            if ($piece === false || $piece === "") {
-                $this->transport_error = stream_get_meta_data($this->socket)["timed_out"]
-                    ? "Timed out after " . $this->request_timeout . "s reading the push stream response body."
-                    : "Connection closed after " . strlen($buffer) . " of " . $bytes . " expected push stream response body bytes.";
-                return null;
-            }
-            $buffer .= $piece;
-        }
-        return $buffer;
     }
 }

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -1,0 +1,684 @@
+<?php
+/**
+ * Sender for the staged push stream endpoint.
+ *
+ * A push stream is one authenticated HTTP request whose body is a sequence of
+ * framed file chunks. The target commits each frame into
+ * Site_Export_Staged_Artifacts as it is read, so a broken connection can be
+ * retried from the last cursor the sender has, or from the beginning with the
+ * target absorbing duplicate/verified frames. This class does not expose a
+ * per-file request API: callers pass a staged push stream processor, and
+ * the client streams its chunks through one request.
+ */
+class StagedPushStreamClient
+{
+    private string $base_url;
+
+    private ?Site_Export_HMAC_Client $hmac_client;
+
+    private PushFrameSizer $frame_sizer;
+
+    private int $request_timeout;
+
+    /** @var callable|null */
+    private $on_before_request;
+
+    /**
+     * @param array $options
+     *   - base_url (string, required): the export API URL; endpoint is appended
+     *     to its query string.
+     *   - hmac_client (?Site_Export_HMAC_Client): envelope request signer.
+     *   - frame_sizer (?PushFrameSizer): frame-size decisions; defaults to a
+     *     fresh frame sizer. Pass one restored from persisted state to keep
+     *     learned limits.
+     *   - request_timeout (int): per-request timeout in seconds.
+     *   - on_before_request (?callable): test hook called just before curl runs.
+     */
+    public function __construct(array $options)
+    {
+        $base_url = $options["base_url"] ?? null;
+        if (!is_string($base_url) || $base_url === "") {
+            throw new InvalidArgumentException("StagedPushStreamClient requires a base_url option.");
+        }
+        $this->base_url = $base_url;
+        $this->hmac_client = $options["hmac_client"] ?? null;
+        $this->frame_sizer = $options["frame_sizer"] ?? new PushFrameSizer();
+        $timeout = $options["request_timeout"] ?? null;
+        $this->request_timeout = is_numeric($timeout) && (int) $timeout > 0 ? (int) $timeout : 120;
+        $this->on_before_request = $options["on_before_request"] ?? null;
+    }
+
+    /**
+     * Send one staged_push request and return the request-level result.
+     *
+     * The caller owns the loop. A successful request may still leave more local
+     * chunks to send; use StagedPushStreamProcessor::is_finished_at() on the
+     * returned cursor to decide whether to call this again.
+     *
+     * @param array{max_chunks?:int|null,max_payload_bytes?:int|null} $limits
+     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
+     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
+     */
+    public function push_next_request(StagedPushStreamProcessor $processor, ?array $cursor = null, array $limits = []): array
+    {
+        if (!$processor->has_files()) {
+            return $this->result("complete", null, null, null, 0, 0, 0);
+        }
+
+        $request_start_cursor = $cursor ?? $processor->cursor();
+        $body = $processor->create_request_body(
+            $this->frame_sizer->chunk_bytes(),
+            $request_start_cursor,
+            $limits["max_chunks"] ?? null,
+            $limits["max_payload_bytes"] ?? null
+        );
+        $response = $this->send_stream_request($body);
+
+        if ($response["error"] !== null) {
+            $decision = $this->frame_sizer->record_request_failure();
+            return $this->result(
+                $decision["action"] === "give_up" ? "failed" : "retry",
+                "request_failed",
+                $response["error"],
+                $request_start_cursor,
+                0,
+                $body->bytes_streamed(),
+                $body->chunks_streamed()
+            );
+        }
+
+        $decoded = json_decode((string) $response["body"], true);
+        if (!is_array($decoded)) {
+            $decision = $this->frame_sizer->record_request_failure();
+            return $this->result(
+                $decision["action"] === "give_up" ? "failed" : "retry",
+                "request_failed",
+                "invalid JSON response (HTTP " . (int) $response["http_code"] . "): " . substr((string) $response["body"], 0, 120),
+                $request_start_cursor,
+                0,
+                $body->bytes_streamed(),
+                $body->chunks_streamed()
+            );
+        }
+
+        if ((int) $response["http_code"] === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
+            $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? ($decoded["max_request_bytes"] ?? null);
+            $decision = $this->frame_sizer->record_too_large(
+                is_numeric($reported_max_frame_bytes) ? (int) $reported_max_frame_bytes : null
+            );
+            return $this->result(
+                $decision["action"] === "give_up" ? "failed" : "retry",
+                $decision["action"] === "give_up" ? "chunk_size_exhausted" : "frame_too_large",
+                null,
+                is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $request_start_cursor,
+                0,
+                $body->bytes_streamed(),
+                $body->chunks_streamed()
+            );
+        }
+
+        if (($decoded["status"] ?? null) !== "complete") {
+            return $this->result(
+                "failed",
+                is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response",
+                is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . (int) $response["http_code"]),
+                is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : $body->cursor(),
+                (int) ($decoded["files_verified"] ?? 0),
+                $body->bytes_streamed(),
+                $body->chunks_streamed()
+            );
+        }
+
+        $this->frame_sizer->record_success();
+        return $this->result(
+            "request_complete",
+            null,
+            null,
+            is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null,
+            (int) ($decoded["files_verified"] ?? 0),
+            $body->bytes_streamed(),
+            $body->chunks_streamed()
+        );
+    }
+
+    /** @return array{http_code:int,body:string,error:?string} */
+    private function send_stream_request(StagedPushRequestBody $body): array
+    {
+        $request_url = $this->base_url
+            . (strpos($this->base_url, "?") === false ? "?" : "&")
+            . http_build_query(["endpoint" => "staged_push"]);
+
+        $request_headers = $this->hmac_client !== null
+            ? $this->hmac_client->get_envelope_auth_headers("POST", $request_url)
+            : [];
+        $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
+        $request_headers["Transfer-Encoding"] = "chunked";
+        $request_headers["Expect"] = "";
+
+        $header_lines = [];
+        foreach ($request_headers as $name => $value) {
+            $header_lines[] = "{$name}: {$value}";
+        }
+
+        $curl_handle = curl_init($request_url);
+        if (function_exists("reprint_apply_curl_proxy_from_env")) {
+            reprint_apply_curl_proxy_from_env($curl_handle);
+        }
+        if (function_exists("reprint_apply_curl_ca_bundle")) {
+            reprint_apply_curl_ca_bundle($curl_handle);
+        }
+
+        curl_setopt_array($curl_handle, [
+            CURLOPT_UPLOAD => true,
+            CURLOPT_CUSTOMREQUEST => "POST",
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_TIMEOUT => $this->request_timeout,
+            CURLOPT_READFUNCTION => static function ($curl_handle, $stream, int $length) use ($body): string {
+                return $body->read($length);
+            },
+        ]);
+
+        if ($this->on_before_request !== null) {
+            call_user_func($this->on_before_request, $body);
+        }
+
+        $response_body = curl_exec($curl_handle);
+        if ($response_body === false) {
+            $error = curl_error($curl_handle) ?: ("curl errno " . curl_errno($curl_handle));
+            curl_close($curl_handle);
+            return ["http_code" => 0, "body" => "", "error" => $error];
+        }
+        $http_status_code = (int) curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
+        curl_close($curl_handle);
+
+        return ["http_code" => $http_status_code, "body" => (string) $response_body, "error" => null];
+    }
+
+    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int} */
+    private function result(string $status, ?string $reason, ?string $detail, ?array $cursor, int $files_verified, int $bytes_streamed, int $chunks_streamed): array
+    {
+        return [
+            "status" => $status,
+            "reason" => $reason,
+            "detail" => $detail,
+            "cursor" => $cursor,
+            "files_verified" => $files_verified,
+            "bytes_streamed" => $bytes_streamed,
+            "chunks_streamed" => $chunks_streamed,
+        ];
+    }
+}
+
+/**
+ * Cursor-style driver for staged push streams.
+ *
+ * This mirrors processor and async-client APIs: next_request() advances one
+ * network request, get_result() exposes what happened, and the caller decides
+ * whether to keep looping, persist the cursor, or pause the push.
+ */
+final class StagedPushStreamPusher
+{
+    /** Consecutive failed stream requests before the push is abandoned. */
+    private const MAX_REQUEST_RETRIES = 5;
+
+    /** Base backoff between retries, in microseconds. */
+    private const RETRY_BACKOFF_USEC = 250000;
+
+    /** Longest single backoff, in microseconds. */
+    private const MAX_BACKOFF_USEC = 5000000;
+
+    private StagedPushStreamClient $client;
+
+    private StagedPushStreamProcessor $processor;
+
+    /** @var array{max_chunks?:int|null,max_payload_bytes?:int|null} */
+    private array $limits;
+
+    /** @var callable(int):void */
+    private $sleeper;
+
+    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
+    private ?array $cursor;
+
+    /** @var array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}|null */
+    private ?array $result = null;
+
+    private int $request_failures = 0;
+
+    private bool $finished = false;
+
+    /**
+     * @param array $options
+     *   - max_chunks_per_request (?int): stop each request after this many
+     *     framed chunks.
+     *   - max_payload_bytes_per_request (?int): stop each request after this
+     *     many local file bytes, excluding frame headers.
+     *   - sleeper (?callable): fn(int $microseconds), for tests.
+     */
+    public function __construct(StagedPushStreamClient $client, StagedPushStreamProcessor $processor, array $options = [])
+    {
+        $this->client = $client;
+        $this->processor = $processor;
+        $this->limits = [
+            "max_chunks" => $this->positive_int_or_null($options["max_chunks_per_request"] ?? null),
+            "max_payload_bytes" => $this->positive_int_or_null($options["max_payload_bytes_per_request"] ?? null),
+        ];
+        $this->sleeper = $options["sleeper"] ?? static function (int $microseconds): void {
+            usleep($microseconds);
+        };
+        $this->cursor = $processor->cursor();
+        $this->finished = !$processor->has_files() || $processor->is_finished_at($this->cursor);
+    }
+
+    /**
+     * Advance the push by one staged_push request.
+     *
+     * @return bool Whether a request-level result is available via get_result().
+     */
+    public function next_request(): bool
+    {
+        if ($this->finished) {
+            return false;
+        }
+
+        $result = $this->client->push_next_request($this->processor, $this->cursor, $this->limits);
+        $this->result = $result;
+
+        if ($result["status"] === "request_complete") {
+            $this->request_failures = 0;
+            $this->cursor = is_array($result["cursor"] ?? null) ? $result["cursor"] : $this->cursor;
+            if ($this->processor->is_finished_at($this->cursor)) {
+                $this->result["status"] = "complete";
+                $this->finished = true;
+            } else {
+                $this->result["status"] = "in_progress";
+            }
+            return true;
+        }
+
+        if ($result["status"] === "retry") {
+            $this->request_failures++;
+            $this->cursor = is_array($result["cursor"] ?? null) ? $result["cursor"] : $this->cursor;
+            if ($this->request_failures > self::MAX_REQUEST_RETRIES) {
+                $this->result["status"] = "failed";
+                $this->finished = true;
+            } else {
+                $this->backoff($this->request_failures);
+            }
+            return true;
+        }
+
+        $this->cursor = is_array($result["cursor"] ?? null) ? $result["cursor"] : $this->cursor;
+        $this->finished = true;
+        return true;
+    }
+
+    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}|null */
+    public function get_result(): ?array
+    {
+        return $this->result;
+    }
+
+    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
+    public function get_cursor(): ?array
+    {
+        return $this->cursor;
+    }
+
+    public function is_finished(): bool
+    {
+        return $this->finished;
+    }
+
+    private function backoff(int $attempt): void
+    {
+        $delay = min(self::MAX_BACKOFF_USEC, self::RETRY_BACKOFF_USEC * (2 ** max(0, $attempt - 1)));
+        call_user_func($this->sleeper, (int) $delay);
+    }
+
+    private function positive_int_or_null($value): ?int
+    {
+        return is_numeric($value) && (int) $value > 0 ? (int) $value : null;
+    }
+}
+
+/**
+ * Processor-style source for staged push streams.
+ *
+ * Callers construct this with the local filesystem root, the JSONL list of
+ * local paths to push, and the last cursor returned by the target. The client
+ * owns HTTP retries and frame sizing; the processor owns local file identity
+ * and where a request should start.
+ */
+final class StagedPushStreamProcessor
+{
+    private string $local_files_root_path;
+
+    private string $local_paths_to_push_path;
+
+    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
+    private ?array $cursor;
+
+    /** @var array<int,array{artifact_id:string,source_path:string,total_bytes:int}>|null */
+    private ?array $files = null;
+
+    /**
+     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
+     */
+    public function __construct(string $local_files_root_path, string $local_paths_to_push_path, ?array $cursor = null)
+    {
+        $this->local_files_root_path = rtrim($local_files_root_path, "/");
+        $this->local_paths_to_push_path = $local_paths_to_push_path;
+        $this->cursor = $cursor;
+    }
+
+    public function has_files(): bool
+    {
+        return $this->files() !== [];
+    }
+
+    /** @return array{artifact_id?:string,committed_bytes?:int}|null */
+    public function cursor(): ?array
+    {
+        return $this->cursor;
+    }
+
+    /**
+     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
+     */
+    public function create_request_body(int $frame_bytes, ?array $cursor = null, ?int $max_chunks = null, ?int $max_payload_bytes = null): StagedPushRequestBody
+    {
+        return new StagedPushRequestBody($this->files(), $frame_bytes, $cursor ?? $this->cursor, $max_chunks, $max_payload_bytes);
+    }
+
+    /**
+     * @param array{artifact_id?:string,committed_bytes?:int}|null $cursor
+     */
+    public function is_finished_at(?array $cursor): bool
+    {
+        $files = $this->files();
+        if ($files === []) {
+            return true;
+        }
+        if (!is_string($cursor["artifact_id"] ?? null)) {
+            return false;
+        }
+        $last_file = $files[count($files) - 1];
+        return $cursor["artifact_id"] === $last_file["artifact_id"]
+            && (int) ($cursor["committed_bytes"] ?? -1) >= $last_file["total_bytes"];
+    }
+
+    /** @return array<int,array{artifact_id:string,source_path:string,total_bytes:int}> */
+    private function files(): array
+    {
+        if ($this->files !== null) {
+            return $this->files;
+        }
+        if (!is_file($this->local_paths_to_push_path)) {
+            throw new RuntimeException("Cannot open local paths to push: " . $this->local_paths_to_push_path);
+        }
+        $handle = fopen($this->local_paths_to_push_path, "r");
+        if (!$handle) {
+            throw new RuntimeException("Cannot open local paths to push: " . $this->local_paths_to_push_path);
+        }
+
+        $files = [];
+        while (($raw_line = fgets($handle)) !== false) {
+            $raw_line = trim($raw_line);
+            if ($raw_line === "") {
+                continue;
+            }
+            $artifact_id = $this->decode_artifact_id($raw_line);
+            $source_path = $this->local_files_root_path . "/" . $artifact_id;
+            $size = @filesize($source_path);
+            if ($size === false) {
+                fclose($handle);
+                throw new RuntimeException("Source file is unreadable: " . $source_path);
+            }
+            $files[] = [
+                "artifact_id" => $artifact_id,
+                "source_path" => $source_path,
+                "total_bytes" => (int) $size,
+            ];
+        }
+        fclose($handle);
+
+        $this->files = $files;
+        return $this->files;
+    }
+
+    private function decode_artifact_id(string $raw_line): string
+    {
+        try {
+            $decoded_line = json_decode($raw_line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException("Unexpected local path line, it is not valid JSON: " . substr($raw_line, 0, 120), 0, $exception);
+        }
+        if (!is_array($decoded_line) || !array_key_exists("path", $decoded_line) || !is_string($decoded_line["path"])) {
+            throw new RuntimeException("Invalid local path line: " . substr($raw_line, 0, 120));
+        }
+        $artifact_id = base64_decode($decoded_line["path"], true);
+        if ($artifact_id === false || $artifact_id === "") {
+            throw new RuntimeException("Invalid local path line: " . substr($raw_line, 0, 120));
+        }
+        return $artifact_id;
+    }
+}
+
+/**
+ * Pull-based request-body producer for one staged push stream.
+ */
+final class StagedPushRequestBody
+{
+    /** @var array<int,array{artifact_id:string,source_path:string,total_bytes:int}> */
+    private array $files;
+
+    private int $frame_bytes;
+
+    /** @var array{artifact_id?:string,committed_bytes?:int}|null */
+    private ?array $initial_cursor;
+
+    /** @var array<int,string> */
+    private array $pending = [];
+
+    private int $file_index = 0;
+
+    private int $offset = 0;
+
+    /** @var resource|null */
+    private $source_handle = null;
+
+    private int $current_frame_remaining_bytes = 0;
+
+    private bool $current_frame_final = false;
+
+    private bool $finished = false;
+
+    private int $bytes_streamed = 0;
+
+    private int $chunks_streamed = 0;
+
+    private ?int $max_chunks;
+
+    private ?int $max_payload_bytes;
+
+    private ?array $cursor = null;
+
+    /** @param array<int,array{artifact_id:string,source_path:string,total_bytes:int}> $files */
+    public function __construct(array $files, int $frame_bytes, ?array $cursor, ?int $max_chunks = null, ?int $max_payload_bytes = null)
+    {
+        $this->files = $files;
+        $this->frame_bytes = max(1, $frame_bytes);
+        $this->initial_cursor = $cursor;
+        $this->max_chunks = $max_chunks !== null ? max(1, $max_chunks) : null;
+        $this->max_payload_bytes = $max_payload_bytes !== null ? max(1, $max_payload_bytes) : null;
+        $this->apply_cursor($cursor);
+    }
+
+    public function read(int $length): string
+    {
+        $out = "";
+        while (strlen($out) < $length && !$this->finished) {
+            $remaining_output_bytes = $length - strlen($out);
+            if ($this->pending !== []) {
+                $piece = array_shift($this->pending);
+                if (strlen($piece) > $remaining_output_bytes) {
+                    $out .= substr($piece, 0, $remaining_output_bytes);
+                    array_unshift($this->pending, substr($piece, $remaining_output_bytes));
+                } else {
+                    $out .= $piece;
+                }
+                continue;
+            }
+
+            if ($this->current_frame_remaining_bytes > 0) {
+                $piece_bytes = min($remaining_output_bytes, $this->current_frame_remaining_bytes);
+                $piece = $this->read_exactly($this->source_handle, $piece_bytes);
+                if ($piece === null) {
+                    throw new RuntimeException("Source file ended before declared size: " . $this->files[$this->file_index]["source_path"]);
+                }
+                $out .= $piece;
+                $this->bytes_streamed += strlen($piece);
+                $this->offset += strlen($piece);
+                $this->current_frame_remaining_bytes -= strlen($piece);
+                $this->cursor = [
+                    "artifact_id" => $this->files[$this->file_index]["artifact_id"],
+                    "committed_bytes" => $this->offset,
+                ];
+
+                if ($this->current_frame_remaining_bytes === 0 && $this->current_frame_final) {
+                    $this->close_source();
+                    $this->file_index++;
+                    $this->offset = 0;
+                    $this->current_frame_final = false;
+                }
+                continue;
+            }
+
+            $this->begin_next_frame();
+        }
+        return $out;
+    }
+
+    public function bytes_streamed(): int
+    {
+        return $this->bytes_streamed;
+    }
+
+    public function chunks_streamed(): int
+    {
+        return $this->chunks_streamed;
+    }
+
+    public function cursor(): ?array
+    {
+        return $this->cursor;
+    }
+
+    private function apply_cursor(?array $cursor): void
+    {
+        $start = $this->cursor_start();
+        $this->file_index = $start["file_index"];
+        $this->offset = $start["offset"];
+    }
+
+    /** @return array{file_index:int,offset:int} */
+    private function cursor_start(): array
+    {
+        if ($this->initial_cursor === null || !is_string($this->initial_cursor["artifact_id"] ?? null)) {
+            return ["file_index" => 0, "offset" => 0];
+        }
+        foreach ($this->files as $index => $file) {
+            if ($file["artifact_id"] === $this->initial_cursor["artifact_id"]) {
+                $offset = min(max(0, (int) ($this->initial_cursor["committed_bytes"] ?? 0)), $file["total_bytes"]);
+                if ($offset >= $file["total_bytes"]) {
+                    return ["file_index" => $index + 1, "offset" => 0];
+                }
+                return [
+                    "file_index" => $index,
+                    "offset" => $offset,
+                ];
+            }
+        }
+        return ["file_index" => 0, "offset" => 0];
+    }
+
+    private function begin_next_frame(): void
+    {
+        if ($this->file_index >= count($this->files) || $this->request_limit_reached()) {
+            $this->close_source();
+            $this->finished = true;
+            return;
+        }
+
+        $file = $this->files[$this->file_index];
+        if ($this->source_handle === null && $file["total_bytes"] > 0) {
+            $this->source_handle = @fopen($file["source_path"], "rb");
+            if ($this->source_handle === false) {
+                throw new RuntimeException("Source file is unreadable: " . $file["source_path"]);
+            }
+        }
+
+        if ($file["total_bytes"] === 0) {
+            $this->pending[] = $this->frame_header($file, 0, 0, true);
+            $this->chunks_streamed++;
+            $this->cursor = ["artifact_id" => $file["artifact_id"], "committed_bytes" => 0];
+            $this->file_index++;
+            return;
+        }
+
+        $bytes = min($this->frame_bytes, $file["total_bytes"] - $this->offset, $this->remaining_payload_bytes());
+        if (fseek($this->source_handle, $this->offset) !== 0) {
+            throw new RuntimeException("Could not seek source file: " . $file["source_path"]);
+        }
+
+        $final = $this->offset + $bytes >= $file["total_bytes"];
+        $this->pending[] = $this->frame_header($file, $this->offset, $bytes, $final);
+        $this->chunks_streamed++;
+        $this->current_frame_remaining_bytes = $bytes;
+        $this->current_frame_final = $final;
+    }
+
+    private function request_limit_reached(): bool
+    {
+        if ($this->max_chunks !== null && $this->chunks_streamed >= $this->max_chunks) {
+            return true;
+        }
+        return $this->max_payload_bytes !== null && $this->bytes_streamed >= $this->max_payload_bytes;
+    }
+
+    private function remaining_payload_bytes(): int
+    {
+        if ($this->max_payload_bytes === null) {
+            return PHP_INT_MAX;
+        }
+        return max(1, $this->max_payload_bytes - $this->bytes_streamed);
+    }
+
+    /** @param array{artifact_id:string,source_path:string,total_bytes:int} $file */
+    private function frame_header(array $file, int $offset, int $bytes, bool $final): string
+    {
+        return Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
+            $file["artifact_id"],
+            $offset,
+            $bytes,
+            $file["total_bytes"],
+            $final
+        );
+    }
+
+    private function read_exactly($source_handle, int $bytes): ?string
+    {
+        return Site_Export_Staged_Push_Stream_Protocol::read_exactly($source_handle, $bytes);
+    }
+
+    private function close_source(): void
+    {
+        if (is_resource($this->source_handle)) {
+            fclose($this->source_handle);
+        }
+        $this->source_handle = null;
+    }
+}

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * import.php requires the upload lib for every command, including pull on
+ * PHP 7.4 — the push client's PHP 8.1 requirement is enforced at runtime in
+ * its constructor, not at parse time. This scan fails when 8.x-only syntax
+ * sneaks into the upload lib and would fatal 7.4 pull users at require time.
+ * The repo-wide lint:php:compat covers the same files but currently fails on
+ * unrelated pre-existing findings, so this narrow scan is the enforced
+ * regression check.
+ */
+class PushClientPhpCompatibilityTest extends TestCase
+{
+    public function testUploadLibStaysParseableOnPhp74(): void
+    {
+        $phpcs_path = realpath(__DIR__ . '/../../vendor/bin/phpcs');
+        $upload_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/upload');
+        $this->assertNotFalse($phpcs_path, 'vendor/bin/phpcs is missing; run composer install');
+        $this->assertNotFalse($upload_lib_path);
+
+        exec(
+            escapeshellarg($phpcs_path)
+                . ' --standard=PHPCompatibility --runtime-set testVersion 7.4- -q '
+                . escapeshellarg($upload_lib_path) . ' 2>&1',
+            $scan_output,
+            $scan_exit_code
+        );
+
+        $this->assertSame(0, $scan_exit_code, implode("\n", $scan_output));
+    }
+}

--- a/tests/Import/PushFrameSizerTest.php
+++ b/tests/Import/PushFrameSizerTest.php
@@ -92,10 +92,11 @@ class PushFrameSizerTest extends TestCase
         $sizer->record_success();
         $sizer->record_success();
 
-        $ceiling = (int) (256 * self::MIB * 0.9);
-        $this->assertSame($ceiling, $sizer->chunk_bytes());
+        // The 128 MiB hard cap binds before the reported 256M * 0.9 ceiling:
+        // one whole chunk is buffered in sender memory, so growth stops there.
+        $this->assertSame(128 * self::MIB, $sizer->chunk_bytes());
         $this->assertSame('steady', $sizer->record_success()['action']);
-        $this->assertSame($ceiling, $sizer->chunk_bytes());
+        $this->assertSame(128 * self::MIB, $sizer->chunk_bytes());
     }
 
     public function testGrowthWithoutLimitsStopsAtConfiguredMax(): void
@@ -116,7 +117,7 @@ class PushFrameSizerTest extends TestCase
             $sizer->record_success();
         }
 
-        $this->assertSame(1024 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(128 * self::MIB, $sizer->chunk_bytes());
     }
 
     // ---------------------------------------------------------------

--- a/tests/Import/PushFrameSizerTest.php
+++ b/tests/Import/PushFrameSizerTest.php
@@ -3,11 +3,11 @@
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
-use UploadChunkSizer;
+use PushFrameSizer;
 
 require_once __DIR__ . '/../../importer/import.php';
 
-class UploadChunkSizerTest extends TestCase
+class PushFrameSizerTest extends TestCase
 {
     private const MIB = 1024 * 1024;
 
@@ -17,14 +17,14 @@ class UploadChunkSizerTest extends TestCase
 
     public function testStartsAtConservativeBootstrapSizeWithoutLimits(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $this->assertSame(32 * self::MIB, $sizer->chunk_bytes());
     }
 
     public function testReportedLimitAboveChunkKeepsCurrentSize(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->apply_reported_limits([256 * self::MIB, null, 128 * self::MIB]);
 
@@ -34,7 +34,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testSmallestReportedLimitClampsChunkWithSafetyMargin(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->apply_reported_limits([64 * self::MIB, 8 * self::MIB]);
 
@@ -44,7 +44,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testUnknownLimitValuesAreIgnored(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->apply_reported_limits([null, 0, -1]);
 
@@ -54,7 +54,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testLaterHigherReportedLimitDoesNotRaiseTheCeiling(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
         $sizer->apply_reported_limits([8 * self::MIB]);
 
         // A re-preflight reporting a raised limit must not undo what the
@@ -69,7 +69,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testReportedLimitBelowFloorGivesUp(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->apply_reported_limits([512 * 1024]);
 
@@ -83,7 +83,7 @@ class UploadChunkSizerTest extends TestCase
     public function testSuccessDoublesTowardReportedLimit(): void
     {
         // A host reporting 256M must not stay capped at the 32 MiB bootstrap.
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
         $sizer->apply_reported_limits([256 * self::MIB]);
 
         $this->assertSame('grow', $sizer->record_success()['action']);
@@ -100,7 +100,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testGrowthWithoutLimitsStopsAtConfiguredMax(): void
     {
-        $sizer = new UploadChunkSizer(["max_bytes" => 64 * self::MIB]);
+        $sizer = new PushFrameSizer(["max_bytes" => 64 * self::MIB]);
 
         $sizer->record_success();
         $this->assertSame(64 * self::MIB, $sizer->chunk_bytes());
@@ -109,7 +109,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testHardCapAppliesEvenWhenHostReportsALargerLimit(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
         $sizer->apply_reported_limits([4 * 1024 * self::MIB]);
 
         for ($i = 0; $i < 10; $i++) {
@@ -125,7 +125,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testTooLargeWithServerReportedLimitDropsBelowIt(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->record_too_large(16 * self::MIB);
 
@@ -137,7 +137,7 @@ class UploadChunkSizerTest extends TestCase
     {
         // A proxy can reject at a lower bound than the limit PHP reports, so
         // a rejected size must never be retried unchanged.
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->record_too_large(512 * self::MIB);
 
@@ -147,7 +147,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testTooLargeWithoutReportedLimitHalves(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
 
         $decision = $sizer->record_too_large();
 
@@ -157,7 +157,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testGrowthNeverRetriesARefusedSize(): void
     {
-        $sizer = new UploadChunkSizer(["growth_holdoff_successes" => 1]);
+        $sizer = new PushFrameSizer(["growth_holdoff_successes" => 1]);
         $sizer->record_too_large(); // 32 MiB refused, ceiling capped at 16 MiB
 
         $sizer->record_success(); // absorbs the holdoff
@@ -170,7 +170,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testTooLargeBetweenFloorAndTwiceFloorStillTriesTheFloor(): void
     {
-        $sizer = new UploadChunkSizer(["start_bytes" => 3 * 512 * 1024]); // 1.5 MiB
+        $sizer = new PushFrameSizer(["start_bytes" => 3 * 512 * 1024]); // 1.5 MiB
 
         $decision = $sizer->record_too_large();
 
@@ -180,7 +180,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testTooLargeAtFloorGivesUp(): void
     {
-        $sizer = new UploadChunkSizer(["start_bytes" => self::MIB]);
+        $sizer = new PushFrameSizer(["start_bytes" => self::MIB]);
 
         $decision = $sizer->record_too_large();
 
@@ -189,14 +189,14 @@ class UploadChunkSizerTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // Transport failures
+    // HTTP request failures
     // ---------------------------------------------------------------
 
-    public function testTransportFailureHalvesWithoutCappingTheCeiling(): void
+    public function testRequestFailureHalvesWithoutCappingTheCeiling(): void
     {
-        $sizer = new UploadChunkSizer(["growth_holdoff_successes" => 2]);
+        $sizer = new PushFrameSizer(["growth_holdoff_successes" => 2]);
 
-        $decision = $sizer->record_transport_failure();
+        $decision = $sizer->record_request_failure();
         $this->assertSame('shrink', $decision['action']);
         $this->assertSame(16 * self::MIB, $sizer->chunk_bytes());
 
@@ -209,11 +209,11 @@ class UploadChunkSizerTest extends TestCase
         $this->assertSame(64 * self::MIB, $sizer->chunk_bytes());
     }
 
-    public function testTransportFailureAtFloorGivesUp(): void
+    public function testRequestFailureAtFloorGivesUp(): void
     {
-        $sizer = new UploadChunkSizer(["start_bytes" => self::MIB]);
+        $sizer = new PushFrameSizer(["start_bytes" => self::MIB]);
 
-        $this->assertSame('give_up', $sizer->record_transport_failure()['action']);
+        $this->assertSame('give_up', $sizer->record_request_failure()['action']);
     }
 
     // ---------------------------------------------------------------
@@ -222,11 +222,11 @@ class UploadChunkSizerTest extends TestCase
 
     public function testStateSurvivesRoundTrip(): void
     {
-        $sizer = new UploadChunkSizer();
+        $sizer = new PushFrameSizer();
         $sizer->apply_reported_limits([64 * self::MIB]);
         $sizer->record_too_large();
 
-        $resumed = new UploadChunkSizer([], $sizer->get_state());
+        $resumed = new PushFrameSizer([], $sizer->get_state());
 
         $this->assertSame($sizer->chunk_bytes(), $resumed->chunk_bytes());
         $this->assertSame($sizer->get_state(), $resumed->get_state());
@@ -240,7 +240,7 @@ class UploadChunkSizerTest extends TestCase
 
     public function testRestoredStateIsClampedToConfiguredBounds(): void
     {
-        $sizer = new UploadChunkSizer(
+        $sizer = new PushFrameSizer(
             ["max_bytes" => 64 * self::MIB],
             ["chunk_bytes" => PHP_INT_MAX, "ceiling_bytes" => -5, "growth_holdoff_remaining" => -2],
         );

--- a/tests/Import/PushRequestSizerTest.php
+++ b/tests/Import/PushRequestSizerTest.php
@@ -3,11 +3,11 @@
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
-use PushFrameSizer;
+use PushRequestSizer;
 
 require_once __DIR__ . '/../../importer/import.php';
 
-class PushFrameSizerTest extends TestCase
+class PushRequestSizerTest extends TestCase
 {
     private const MIB = 1024 * 1024;
 
@@ -17,44 +17,44 @@ class PushFrameSizerTest extends TestCase
 
     public function testStartsAtConservativeBootstrapSizeWithoutLimits(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
-        $this->assertSame(32 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(32 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testReportedLimitAboveChunkKeepsCurrentSize(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->apply_reported_limits([256 * self::MIB, null, 128 * self::MIB]);
 
         $this->assertSame('steady', $decision['action']);
-        $this->assertSame(32 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(32 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testSmallestReportedLimitClampsChunkWithSafetyMargin(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->apply_reported_limits([64 * self::MIB, 8 * self::MIB]);
 
         $this->assertSame('shrink', $decision['action']);
-        $this->assertSame((int) (8 * self::MIB * 0.9), $sizer->chunk_bytes());
+        $this->assertSame((int) (8 * self::MIB * 0.9), $sizer->request_body_bytes());
     }
 
     public function testUnknownLimitValuesAreIgnored(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->apply_reported_limits([null, 0, -1]);
 
         $this->assertSame('steady', $decision['action']);
-        $this->assertSame(32 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(32 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testLaterHigherReportedLimitDoesNotRaiseTheCeiling(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
         $sizer->apply_reported_limits([8 * self::MIB]);
 
         // A re-preflight reporting a raised limit must not undo what the
@@ -64,12 +64,12 @@ class PushFrameSizerTest extends TestCase
             $sizer->record_success();
         }
 
-        $this->assertSame((int) (8 * self::MIB * 0.9), $sizer->chunk_bytes());
+        $this->assertSame((int) (8 * self::MIB * 0.9), $sizer->request_body_bytes());
     }
 
     public function testReportedLimitBelowFloorGivesUp(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->apply_reported_limits([512 * 1024]);
 
@@ -83,41 +83,40 @@ class PushFrameSizerTest extends TestCase
     public function testSuccessDoublesTowardReportedLimit(): void
     {
         // A host reporting 256M must not stay capped at the 32 MiB bootstrap.
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
         $sizer->apply_reported_limits([256 * self::MIB]);
 
         $this->assertSame('grow', $sizer->record_success()['action']);
-        $this->assertSame(64 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(64 * self::MIB, $sizer->request_body_bytes());
 
         $sizer->record_success();
         $sizer->record_success();
 
-        // The 128 MiB hard cap binds before the reported 256M * 0.9 ceiling:
-        // one whole chunk is buffered in sender memory, so growth stops there.
-        $this->assertSame(128 * self::MIB, $sizer->chunk_bytes());
+        $ceiling = (int) (256 * self::MIB * 0.9);
+        $this->assertSame($ceiling, $sizer->request_body_bytes());
         $this->assertSame('steady', $sizer->record_success()['action']);
-        $this->assertSame(128 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame($ceiling, $sizer->request_body_bytes());
     }
 
     public function testGrowthWithoutLimitsStopsAtConfiguredMax(): void
     {
-        $sizer = new PushFrameSizer(["max_bytes" => 64 * self::MIB]);
+        $sizer = new PushRequestSizer(["max_bytes" => 64 * self::MIB]);
 
         $sizer->record_success();
-        $this->assertSame(64 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(64 * self::MIB, $sizer->request_body_bytes());
         $this->assertSame('steady', $sizer->record_success()['action']);
     }
 
     public function testHardCapAppliesEvenWhenHostReportsALargerLimit(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
         $sizer->apply_reported_limits([4 * 1024 * self::MIB]);
 
         for ($i = 0; $i < 10; $i++) {
             $sizer->record_success();
         }
 
-        $this->assertSame(128 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(1024 * self::MIB, $sizer->request_body_bytes());
     }
 
     // ---------------------------------------------------------------
@@ -126,39 +125,39 @@ class PushFrameSizerTest extends TestCase
 
     public function testTooLargeWithServerReportedLimitDropsBelowIt(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->record_too_large(16 * self::MIB);
 
         $this->assertSame('shrink', $decision['action']);
-        $this->assertSame((int) (16 * self::MIB * 0.9), $sizer->chunk_bytes());
+        $this->assertSame((int) (16 * self::MIB * 0.9), $sizer->request_body_bytes());
     }
 
-    public function testTooLargeWithReportedLimitAboveCurrentChunkStillShrinks(): void
+    public function testTooLargeWithReportedLimitAboveCurrentSizeStillShrinks(): void
     {
         // A proxy can reject at a lower bound than the limit PHP reports, so
         // a rejected size must never be retried unchanged.
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->record_too_large(512 * self::MIB);
 
         $this->assertSame('shrink', $decision['action']);
-        $this->assertSame(16 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(16 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testTooLargeWithoutReportedLimitHalves(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
 
         $decision = $sizer->record_too_large();
 
         $this->assertSame('shrink', $decision['action']);
-        $this->assertSame(16 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(16 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testGrowthNeverRetriesARefusedSize(): void
     {
-        $sizer = new PushFrameSizer(["growth_holdoff_successes" => 1]);
+        $sizer = new PushRequestSizer(["growth_holdoff_successes" => 1]);
         $sizer->record_too_large(); // 32 MiB refused, ceiling capped at 16 MiB
 
         $sizer->record_success(); // absorbs the holdoff
@@ -166,27 +165,27 @@ class PushFrameSizerTest extends TestCase
             $sizer->record_success();
         }
 
-        $this->assertSame(16 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(16 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testTooLargeBetweenFloorAndTwiceFloorStillTriesTheFloor(): void
     {
-        $sizer = new PushFrameSizer(["start_bytes" => 3 * 512 * 1024]); // 1.5 MiB
+        $sizer = new PushRequestSizer(["start_bytes" => 3 * 512 * 1024]); // 1.5 MiB
 
         $decision = $sizer->record_too_large();
 
         $this->assertSame('shrink', $decision['action']);
-        $this->assertSame(self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(self::MIB, $sizer->request_body_bytes());
     }
 
     public function testTooLargeAtFloorGivesUp(): void
     {
-        $sizer = new PushFrameSizer(["start_bytes" => self::MIB]);
+        $sizer = new PushRequestSizer(["start_bytes" => self::MIB]);
 
         $decision = $sizer->record_too_large();
 
         $this->assertSame('give_up', $decision['action']);
-        $this->assertSame(self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(self::MIB, $sizer->request_body_bytes());
     }
 
     // ---------------------------------------------------------------
@@ -195,11 +194,11 @@ class PushFrameSizerTest extends TestCase
 
     public function testRequestFailureHalvesWithoutCappingTheCeiling(): void
     {
-        $sizer = new PushFrameSizer(["growth_holdoff_successes" => 2]);
+        $sizer = new PushRequestSizer(["growth_holdoff_successes" => 2]);
 
         $decision = $sizer->record_request_failure();
         $this->assertSame('shrink', $decision['action']);
-        $this->assertSame(16 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(16 * self::MIB, $sizer->request_body_bytes());
 
         // Two successes absorb the holdoff, then growth resumes past the
         // failed size — a transient timeout must not clamp the session.
@@ -207,12 +206,12 @@ class PushFrameSizerTest extends TestCase
         $this->assertSame('steady', $sizer->record_success()['action']);
         $this->assertSame('grow', $sizer->record_success()['action']);
         $sizer->record_success();
-        $this->assertSame(64 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(64 * self::MIB, $sizer->request_body_bytes());
     }
 
     public function testRequestFailureAtFloorGivesUp(): void
     {
-        $sizer = new PushFrameSizer(["start_bytes" => self::MIB]);
+        $sizer = new PushRequestSizer(["start_bytes" => self::MIB]);
 
         $this->assertSame('give_up', $sizer->record_request_failure()['action']);
     }
@@ -223,30 +222,30 @@ class PushFrameSizerTest extends TestCase
 
     public function testStateSurvivesRoundTrip(): void
     {
-        $sizer = new PushFrameSizer();
+        $sizer = new PushRequestSizer();
         $sizer->apply_reported_limits([64 * self::MIB]);
         $sizer->record_too_large();
 
-        $resumed = new PushFrameSizer([], $sizer->get_state());
+        $resumed = new PushRequestSizer([], $sizer->get_state());
 
-        $this->assertSame($sizer->chunk_bytes(), $resumed->chunk_bytes());
+        $this->assertSame($sizer->request_body_bytes(), $resumed->request_body_bytes());
         $this->assertSame($sizer->get_state(), $resumed->get_state());
 
         // The learned ceiling still constrains growth after the resume.
         for ($i = 0; $i < 8; $i++) {
             $resumed->record_success();
         }
-        $this->assertSame(16 * self::MIB, $resumed->chunk_bytes());
+        $this->assertSame(16 * self::MIB, $resumed->request_body_bytes());
     }
 
     public function testRestoredStateIsClampedToConfiguredBounds(): void
     {
-        $sizer = new PushFrameSizer(
+        $sizer = new PushRequestSizer(
             ["max_bytes" => 64 * self::MIB],
-            ["chunk_bytes" => PHP_INT_MAX, "ceiling_bytes" => -5, "growth_holdoff_remaining" => -2],
+            ["request_body_bytes" => PHP_INT_MAX, "ceiling_bytes" => -5, "growth_holdoff_remaining" => -2],
         );
 
-        $this->assertSame(64 * self::MIB, $sizer->chunk_bytes());
+        $this->assertSame(64 * self::MIB, $sizer->request_body_bytes());
         $state = $sizer->get_state();
         $this->assertNull($state['ceiling_bytes']);
         $this->assertSame(0, $state['growth_holdoff_remaining']);

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -615,10 +615,10 @@ class StagedPushStreamClientTest extends TestCase
         $local_paths_to_push = $this->writeLocalPathsToPush(['drift-grow.bin']);
         $resume_cursor = $this->pushFirstBytes($client, 'drift-grow.bin', $old_content, 4, $source_path);
 
-        // The file changes before the next session: longer and different.
+        // The file changes before the next session: longer and different —
+        // the size alone betrays it.
         $new_content = str_repeat('n', 16);
         file_put_contents($source_path, $new_content);
-        touch($source_path, ((int) $resume_cursor['source_mtime']) + 5);
         clearstatcache();
 
         $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
@@ -635,10 +635,12 @@ class StagedPushStreamClientTest extends TestCase
         $local_paths_to_push = $this->writeLocalPathsToPush(['drift-edit.bin']);
         $resume_cursor = $this->pushFirstBytes($client, 'drift-edit.bin', $old_content, 4, $source_path);
 
-        // Same byte count, different bytes — only the mtime betrays the edit.
+        // Same byte count, different bytes — only the ctime betrays the
+        // edit, so the rewrite must land in a later timestamp second (ctime
+        // cannot be set the way touch() sets mtime).
+        usleep(1100000);
         $new_content = str_repeat('n', 12);
         file_put_contents($source_path, $new_content);
-        touch($source_path, ((int) $resume_cursor['source_mtime']) + 5);
         clearstatcache();
 
         $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
@@ -659,7 +661,6 @@ class StagedPushStreamClientTest extends TestCase
         // would leave the target holding 8 stale bytes and this push lying.
         $new_content = str_repeat('n', 6);
         file_put_contents($source_path, $new_content);
-        touch($source_path, ((int) $resume_cursor['source_mtime']) + 5);
         clearstatcache();
 
         $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
@@ -689,10 +690,10 @@ class StagedPushStreamClientTest extends TestCase
     /**
      * Session one: push the first $bytes_to_push bytes of $content, then
      * stop, returning the resume cursor the reference loop would persist —
-     * the server cursor plus the source token (size and mtime) it saves
+     * the server cursor plus the source token (size and ctime) it saves
      * alongside.
      *
-     * @return array{artifact_id:string,committed_bytes:int,total_bytes:int,source_mtime:int}
+     * @return array{artifact_id:string,committed_bytes:int,total_bytes:int,source_ctime:int}
      */
     private function pushFirstBytes(StagedPushStreamClient $client, string $artifact_id, string $content, int $bytes_to_push, string $source_path): array
     {
@@ -710,10 +711,64 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result));
         $this->assertSame($bytes_to_push, $first_result['cursor']['committed_bytes']);
 
+        clearstatcache();
         return $first_result['cursor'] + [
             'total_bytes' => strlen($content),
-            'source_mtime' => (int) filemtime($source_path),
+            'source_ctime' => (int) stat($source_path)['ctime'],
         ];
+    }
+
+    public function testAStoreLockCollisionIsRetryableNotFatal(): void
+    {
+        $this->writeSource('locked.bin', str_repeat('l', 4));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['locked.bin']);
+
+        // Create the store scaffolding, then hold its lock the way a
+        // concurrent writer would. The store's answer is its documented
+        // retry-until-free contract, not a push-ending failure.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('scaffold.bin', 0, 'x');
+        $lock_holder = fopen($this->staging_dir . '/lock', 'r+b');
+        $this->assertNotFalse($lock_holder);
+        $this->assertTrue(flock($lock_holder, LOCK_EX));
+
+        $held_result = $this->pushOnce($client, $local_paths_to_push, null);
+        $this->assertSame(['retry', 'busy'], [$held_result['status'], $held_result['reason']], (string) json_encode($held_result));
+
+        flock($lock_holder, LOCK_UN);
+        fclose($lock_holder);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(str_repeat('l', 4), file_get_contents($this->staging_dir . '/files/locked.bin'));
+    }
+
+    public function testAStaleCursorBeyondTheStoreFrontierRetriesFromTheStoreCursor(): void
+    {
+        $content = str_repeat('g', 8);
+        $source_path = $this->writeSource('gapped.bin', $content);
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['gapped.bin']);
+        clearstatcache();
+        $source_stat = stat($source_path);
+        $this->assertNotFalse($source_stat);
+
+        // The cursor claims 4 committed bytes and its source token matches
+        // the file, but the staging directory was wiped: the store holds
+        // nothing. The server answers offset_gap with its own cursor — the
+        // push must resume from that cursor, not die.
+        $stale_cursor = [
+            'artifact_id' => 'gapped.bin',
+            'committed_bytes' => 4,
+            'total_bytes' => 8,
+            'source_ctime' => (int) $source_stat['ctime'],
+        ];
+
+        $result = $this->pushAll($client, $local_paths_to_push, $stale_cursor);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame($content, file_get_contents($this->staging_dir . '/files/gapped.bin'));
+        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen(), 'one gap rejection, one clean resume from the store cursor');
     }
 
     public function testBackToBackRequestsReuseTheConnection(): void
@@ -941,17 +996,20 @@ PHP_ROUTER);
             $this->assertNotFalse($source_handle);
             $source_stat = fstat($source_handle);
             $total_bytes = (int) $source_stat['size'];
-            $source_mtime = (int) $source_stat['mtime'];
+            $source_ctime = (int) $source_stat['ctime'];
 
             // The cursor's source token remembers the file the staged bytes
-            // came from. Any change — size or mtime — means those bytes are
-            // another version: restart the file at zero so the target
-            // re-stages it instead of appending one version behind another.
+            // came from. Any change — size or ctime, the same signals the
+            // journal's diff keys on — means those bytes are another version:
+            // restart the file at zero so the target re-stages it instead of
+            // appending one version behind another. A same-size edit within
+            // the same timestamp second escapes this token; the diff layer's
+            // own change detection is the deeper net.
             if (
                 $resuming_this_file
                 && (
                     (isset($cursor['total_bytes']) && (int) $cursor['total_bytes'] !== $total_bytes)
-                    || (isset($cursor['source_mtime']) && (int) $cursor['source_mtime'] !== $source_mtime)
+                    || (isset($cursor['source_ctime']) && (int) $cursor['source_ctime'] !== $source_ctime)
                 )
             ) {
                 $offset = 0;
@@ -980,7 +1038,7 @@ PHP_ROUTER);
                     if ($result['status'] !== 'complete') {
                         fclose($source_handle);
                         fclose($journal_handle);
-                        return $this->withSourceToken($result, $artifact_id, $total_bytes, $source_mtime);
+                        return $this->withSourceToken($result, $artifact_id, $total_bytes, $source_ctime);
                     }
                     if (false === $client->start_push_request()) {
                         fclose($source_handle);
@@ -1003,7 +1061,7 @@ PHP_ROUTER);
                 ])) {
                     fclose($source_handle);
                     fclose($journal_handle);
-                    return $this->withSourceToken($client->finish_request(), $artifact_id, $total_bytes, $source_mtime);
+                    return $this->withSourceToken($client->finish_request(), $artifact_id, $total_bytes, $source_ctime);
                 }
 
                 $offset += strlen($payload);
@@ -1028,19 +1086,19 @@ PHP_ROUTER);
                 'body_bytes_sent' => 0,
             ];
         }
-        return $this->withSourceToken($client->finish_request(), $artifact_id, $total_bytes, $source_mtime);
+        return $this->withSourceToken($client->finish_request(), $artifact_id, $total_bytes, $source_ctime);
     }
 
     /**
      * Attach the source token the reference loop persists alongside a server
-     * cursor: the size and mtime of the file whose bytes the cursor counts.
+     * cursor: the size and ctime of the file whose bytes the cursor counts.
      * A later resume compares them against the file on disk and restarts the
      * file when they differ.
      */
-    private function withSourceToken(array $result, string $artifact_id, int $total_bytes, int $source_mtime): array
+    private function withSourceToken(array $result, string $artifact_id, int $total_bytes, int $source_ctime): array
     {
         if (is_array($result['cursor'] ?? null) && ($result['cursor']['artifact_id'] ?? null) === $artifact_id) {
-            $result['cursor'] += ['total_bytes' => $total_bytes, 'source_mtime' => $source_mtime];
+            $result['cursor'] += ['total_bytes' => $total_bytes, 'source_ctime' => $source_ctime];
         }
         return $result;
     }

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -184,9 +184,13 @@ class StagedPushStreamClientTest extends TestCase
             'final' => false,
         ], JSON_UNESCAPED_SLASHES) . "\n";
         // Budget for one full frame plus 3 spare bytes, so the value of
-        // next_chunk_bytes() after the first chunk reveals whether the frame
-        // header was charged against the budget alongside the payload.
-        $request_body_budget = strlen($first_frame_header) + 4 + 3;
+        // next_chunk_body_bytes() after the first chunk reveals whether the
+        // frame header and the chunked transfer-encoding framing were charged
+        // against the budget alongside the payload. Each write travels as one
+        // transfer-encoding chunk: hex size line, CRLF, bytes, CRLF.
+        $first_frame_wire_bytes = strlen(dechex(strlen($first_frame_header))) + 2 + strlen($first_frame_header) + 2;
+        $first_payload_wire_bytes = strlen(dechex(4)) + 2 + 4 + 2;
+        $request_body_budget = $first_frame_wire_bytes + $first_payload_wire_bytes + 3;
         $client = $this->makeClient([
             'request_sizer' => new PushRequestSizer([
                 'floor_bytes' => 4,
@@ -205,7 +209,7 @@ class StagedPushStreamClientTest extends TestCase
             'payload' => 'yyyy',
         ]));
 
-        $this->assertSame(3, $client->next_chunk_bytes(), 'the frame header was charged against the budget, not only the payload');
+        $this->assertSame(3, $client->next_chunk_body_bytes(), 'the frame header and transfer-encoding framing were charged against the budget, not only the payload');
         $this->assertFalse($client->should_finish_request());
 
         $this->assertTrue($client->send_chunk([
@@ -215,7 +219,7 @@ class StagedPushStreamClientTest extends TestCase
             'final' => false,
             'payload' => 'yyy',
         ]));
-        $this->assertSame(0, $client->next_chunk_bytes(), 'the second frame header spends the rest of the budget');
+        $this->assertSame(0, $client->next_chunk_body_bytes(), 'the second frame header spends the rest of the budget');
         $this->assertTrue($client->should_finish_request());
 
         $rotation_result = $client->finish_request();
@@ -369,7 +373,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
         $this->assertSame(2, $result['chunks_sent']);
-        $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers');
+        $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers and transfer-encoding framing');
     }
 
     public function testInvalidChunksThrowSpecificErrors(): void
@@ -488,7 +492,7 @@ PHP_ROUTER);
     /**
      * One pass over the journal from $cursor: the caller loop the client is
      * designed for. Streams journal lines, reads each file in pieces sized by
-     * next_chunk_bytes(), and rotates requests when the client says to.
+     * next_chunk_body_bytes(), and rotates requests when the client says to.
      *
      * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
      */
@@ -544,7 +548,7 @@ PHP_ROUTER);
 
                 $payload = $total_bytes === 0
                     ? ''
-                    : (string) fread($source_handle, $client->next_chunk_bytes());
+                    : (string) fread($source_handle, $client->next_chunk_body_bytes());
                 $final = $offset + strlen($payload) >= $total_bytes;
 
                 if (!$client->send_chunk([

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -175,8 +175,24 @@ class StagedPushStreamClientTest extends TestCase
     public function testBodyBudgetCountsFrameHeadersWhenRotatingRequests(): void
     {
         $this->writeSource('budget.bin', str_repeat('y', 10));
+        $first_frame_header = json_encode([
+            'type' => 'chunk',
+            'artifact_id' => 'budget.bin',
+            'offset' => 0,
+            'bytes' => 4,
+            'total_bytes' => 10,
+            'final' => false,
+        ], JSON_UNESCAPED_SLASHES) . "\n";
+        // Budget for one full frame plus 3 spare bytes, so the value of
+        // next_chunk_bytes() after the first chunk reveals whether the frame
+        // header was charged against the budget alongside the payload.
+        $request_body_budget = strlen($first_frame_header) + 4 + 3;
         $client = $this->makeClient([
-            'request_sizer' => new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 150, 'max_bytes' => 150]),
+            'request_sizer' => new PushRequestSizer([
+                'floor_bytes' => 4,
+                'start_bytes' => $request_body_budget,
+                'max_bytes' => $request_body_budget,
+            ]),
         ]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['budget.bin']);
 
@@ -189,19 +205,7 @@ class StagedPushStreamClientTest extends TestCase
             'payload' => 'yyyy',
         ]));
 
-        $sent_frame_header = json_encode([
-            'type' => 'chunk',
-            'artifact_id' => 'budget.bin',
-            'offset' => 0,
-            'bytes' => 4,
-            'total_bytes' => 10,
-            'final' => false,
-        ], JSON_UNESCAPED_SLASHES) . "\n";
-        $this->assertSame(
-            150 - strlen($sent_frame_header) - 4,
-            $client->capacity_bytes(),
-            'capacity accounts for the frame header, not only the payload'
-        );
+        $this->assertSame(3, $client->next_chunk_bytes(), 'the frame header was charged against the budget, not only the payload');
         $this->assertFalse($client->should_finish_request());
 
         $this->assertTrue($client->send_chunk([
@@ -209,13 +213,14 @@ class StagedPushStreamClientTest extends TestCase
             'offset' => 4,
             'total_bytes' => 10,
             'final' => false,
-            'payload' => 'yyyy',
+            'payload' => 'yyy',
         ]));
-        $this->assertSame(0, $client->capacity_bytes(), 'the second frame header spends the rest of the budget');
+        $this->assertSame(0, $client->next_chunk_bytes(), 'the second frame header spends the rest of the budget');
         $this->assertTrue($client->should_finish_request());
 
         $rotation_result = $client->finish_request();
         $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result));
+        $this->assertSame(['artifact_id' => 'budget.bin', 'committed_bytes' => 7], $rotation_result['cursor']);
 
         $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
 
@@ -483,8 +488,7 @@ PHP_ROUTER);
     /**
      * One pass over the journal from $cursor: the caller loop the client is
      * designed for. Streams journal lines, reads each file in pieces sized by
-     * capacity_bytes()/max_chunk_bytes(), and rotates requests when the
-     * client says to.
+     * next_chunk_bytes(), and rotates requests when the client says to.
      *
      * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
      */
@@ -540,7 +544,7 @@ PHP_ROUTER);
 
                 $payload = $total_bytes === 0
                     ? ''
-                    : (string) fread($source_handle, min($total_bytes - $offset, $client->capacity_bytes(), $client->max_chunk_bytes()));
+                    : (string) fread($source_handle, $client->next_chunk_bytes());
                 $final = $offset + strlen($payload) >= $total_bytes;
 
                 if (!$client->send_chunk([

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -243,6 +243,53 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertLessThanOrEqual(5, $sizer->chunk_bytes());
     }
 
+    public function testNextChunkWritesBytesToTheNetworkBeforeTheRequestIsFinalized(): void
+    {
+        // A raw TCP listener instead of the shared endpoint server, so the
+        // test can observe exactly when request bytes reach the network.
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($listener, (string) $errstr);
+        $listener_address = stream_socket_get_name($listener, false);
+
+        $this->writeSource('streamed.bin', str_repeat('s', 8));
+        $client = new StagedPushStreamClient([
+            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 2, 'start_bytes' => 4, 'max_bytes' => 4]),
+        ]);
+        $processor = new StagedPushStreamProcessor($this->source_dir, $this->writeLocalPathsToPush(['streamed.bin']));
+        $request = $client->create_request($processor);
+
+        $pending_connections = [$listener];
+        $write_sockets = null;
+        $except_sockets = null;
+        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 0), 'creating a request must not open a connection');
+
+        $this->assertTrue($request->next_chunk());
+        $connection = stream_socket_accept($listener, 5);
+        $this->assertNotFalse($connection);
+        $received = $this->readAvailableBytes($connection);
+
+        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_push HTTP/1.1', $received);
+        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":0,"bytes":4', $received);
+        $this->assertStringContainsString('ssss', $received, 'the first frame payload is on the wire before the request is finalized');
+        $this->assertStringNotContainsString("0\r\n\r\n", $received, 'the request body is still open');
+
+        $this->assertTrue($request->next_chunk());
+        $received .= $this->readAvailableBytes($connection);
+        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":4,"bytes":4', $received);
+        $this->assertSame(2, substr_count($received, 'ssss'), 'the second frame payload followed without finalizing');
+
+        // Drop the connection without responding: the failure must surface as
+        // a retryable request-level result, not an exception.
+        fclose($connection);
+        fclose($listener);
+        $result = $client->push_request($request);
+
+        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(2, $result['chunks_streamed']);
+        $this->assertSame(8, $result['bytes_streamed']);
+    }
+
     public function testWrongSecretFailsBeforeReadingTheBody(): void
     {
         $this->writeSource('secret.bin', 'secret');
@@ -352,6 +399,31 @@ PHP_ROUTER);
             'bytes_streamed' => 0,
             'chunks_streamed' => 0,
         ];
+    }
+
+    /**
+     * Read whatever bytes have already arrived on the connection, allowing a
+     * brief settle so kernel-buffered writes from the client become visible.
+     */
+    private function readAvailableBytes($connection): string
+    {
+        stream_set_blocking($connection, false);
+        $received = '';
+        $last_data_at = microtime(true);
+        $deadline = microtime(true) + 2.0;
+        while (microtime(true) < $deadline) {
+            $piece = fread($connection, 65536);
+            if (is_string($piece) && $piece !== '') {
+                $received .= $piece;
+                $last_data_at = microtime(true);
+                continue;
+            }
+            if ($received !== '' && microtime(true) - $last_data_at > 0.1) {
+                break;
+            }
+            usleep(5000);
+        }
+        return $received;
     }
 
     private function writeSource(string $name, string $body): string

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -118,7 +118,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(2, $result['files_verified']);
         $this->assertSame(str_repeat('a', 10), file_get_contents($this->staging_dir . '/files/wp-content/uploads/first.bin'));
         $this->assertSame(str_repeat('bc', 7), file_get_contents($this->staging_dir . '/files/wp-content/uploads/second.bin'));
@@ -138,7 +138,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push, ['artifact_id' => 'second.bin', 'committed_bytes' => 4]);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertFileDoesNotExist($this->staging_dir . '/files/first.bin', 'cursor skips files before the resumed artifact');
         $this->assertSame(str_repeat('b', 12), file_get_contents($this->staging_dir . '/files/second.bin'));
         $this->assertSame(['staged_push'], $this->endpointsSeen());
@@ -160,14 +160,14 @@ class StagedPushStreamClientTest extends TestCase
         ]));
         $first_result = $client->finish_request();
 
-        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result));
+        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(1, $first_result['chunks_sent']);
         $this->assertSame(['artifact_id' => 'chunked.bin', 'committed_bytes' => 4], $first_result['cursor']);
         $this->assertSame(str_repeat('x', 4), file_get_contents($this->staging_dir . '/files/chunked.bin'));
 
         $result = $this->pushAll($client, $local_paths_to_push, $first_result['cursor']);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(str_repeat('x', 12), file_get_contents($this->staging_dir . '/files/chunked.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
@@ -221,12 +221,12 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertTrue($client->should_finish_request());
 
         $rotation_result = $client->finish_request();
-        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result));
+        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(['artifact_id' => 'budget.bin', 'committed_bytes' => 7], $rotation_result['cursor']);
 
         $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(str_repeat('y', 10), file_get_contents($this->staging_dir . '/files/budget.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
@@ -249,11 +249,11 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertTrue($client->should_finish_request(), 'an open request older than max_request_seconds asks to be finished');
 
         $rotation_result = $client->finish_request();
-        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result));
+        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result, JSON_INVALID_UTF8_SUBSTITUTE));
 
         $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(str_repeat('t', 8), file_get_contents($this->staging_dir . '/files/timed.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
@@ -278,7 +278,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(str_repeat('a', 8), file_get_contents($this->staging_dir . '/files/first.bin'));
         $this->assertSame(str_repeat('b', 8), file_get_contents($this->staging_dir . '/files/second.bin'));
         $this->assertSame(['staged_push'], $this->endpointsSeen());
@@ -295,7 +295,7 @@ class StagedPushStreamClientTest extends TestCase
         $push_started_at = microtime(true);
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertGreaterThan(0.25, microtime(true) - $push_started_at, 'the retry after the 413 backed off before re-hitting the host');
         $this->assertSame(str_repeat('x', 20), file_get_contents($this->staging_dir . '/files/large.bin'));
         // The 413 caps the body budget at the reported 6 * 0.9 = 5 bytes, so
@@ -315,7 +315,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertFileDoesNotExist($this->staging_dir . '/files/secret.bin');
         $this->assertSame(['staged_push'], $this->endpointsSeen());
     }
@@ -374,7 +374,7 @@ class StagedPushStreamClientTest extends TestCase
         fclose($listener);
         $result = $client->finish_request();
 
-        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(2, $result['chunks_sent']);
         $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers');
     }
@@ -417,7 +417,7 @@ class StagedPushStreamClientTest extends TestCase
         fclose($connection);
         fclose($listener);
 
-        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertStringContainsString('no bytes moved for 1s', (string) $result['detail']);
     }
 
@@ -463,7 +463,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame(['failed', 'request_size_exhausted'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(['failed', 'request_size_exhausted'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
     }
 
     public function testEmptyRequestsDoNotGrowTheBodyBudget(): void
@@ -556,7 +556,7 @@ class StagedPushStreamClientTest extends TestCase
         // replay from the top, not skim past everything and report success.
         $result = $this->pushAll($client, $local_paths_to_push, ['artifact_id' => 'deleted-since.bin', 'committed_bytes' => 4]);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(2, $result['files_verified']);
         $this->assertSame(str_repeat('k', 6), file_get_contents($this->staging_dir . '/files/kept-one.bin'));
         $this->assertSame(str_repeat('K', 6), file_get_contents($this->staging_dir . '/files/kept-two.bin'));
@@ -569,7 +569,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(0, $result['chunks_sent']);
         $this->assertSame([], $this->endpointsSeen(), 'an empty journal must not cost a network exchange');
     }
@@ -602,7 +602,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $client->finish_request();
 
-        $this->assertSame(['failed', 'redirected'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(['failed', 'redirected'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertStringContainsString('https://example.com/?reprint-api=1&endpoint=staged_push', (string) $result['detail']);
         $this->assertStringContainsString('Use that address as the push base_url', (string) $result['detail']);
     }
@@ -623,7 +623,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-grow.bin'), 'no byte of the old version may survive under the new one');
     }
 
@@ -645,7 +645,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-edit.bin'), 'no byte of the old version may survive under the new one');
     }
 
@@ -665,7 +665,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(1, $result['files_verified']);
         $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-shrink.bin'));
     }
@@ -683,7 +683,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/replayed.bin'));
     }
 
@@ -708,7 +708,7 @@ class StagedPushStreamClientTest extends TestCase
             ]));
         }
         $first_result = $client->finish_request();
-        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result));
+        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame($bytes_to_push, $first_result['cursor']['committed_bytes']);
 
         clearstatcache();
@@ -733,13 +733,13 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertTrue(flock($lock_holder, LOCK_EX));
 
         $held_result = $this->pushOnce($client, $local_paths_to_push, null);
-        $this->assertSame(['retry', 'busy'], [$held_result['status'], $held_result['reason']], (string) json_encode($held_result));
+        $this->assertSame(['retry', 'busy'], [$held_result['status'], $held_result['reason']], (string) json_encode($held_result, JSON_INVALID_UTF8_SUBSTITUTE));
 
         flock($lock_holder, LOCK_UN);
         fclose($lock_holder);
 
         $result = $this->pushAll($client, $local_paths_to_push);
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(str_repeat('l', 4), file_get_contents($this->staging_dir . '/files/locked.bin'));
     }
 
@@ -766,7 +766,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push, $stale_cursor);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame($content, file_get_contents($this->staging_dir . '/files/gapped.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen(), 'one gap rejection, one clean resume from the store cursor');
     }
@@ -827,7 +827,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(1, $result['files_verified']);
         $this->assertSame(str_repeat('e', 10), file_get_contents($this->staging_dir . '/files/' . $emoji_artifact_id));
     }
@@ -845,7 +845,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
         $this->assertSame(1, $result['files_verified']);
         $this->assertSame(str_repeat('n', 6), file_get_contents($this->staging_dir . '/files/' . $non_utf8_artifact_id));
     }

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Site_Export_HMAC_Client;
 use Site_Export_Staged_Artifacts;
 use StagedPushStreamClient;
-use PushFrameSizer;
+use PushRequestSizer;
 
 require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
 
@@ -175,7 +175,9 @@ class StagedPushStreamClientTest extends TestCase
     public function testBodyBudgetCountsFrameHeadersWhenRotatingRequests(): void
     {
         $this->writeSource('budget.bin', str_repeat('y', 10));
-        $client = $this->makeClient(['max_request_body_bytes' => 150]);
+        $client = $this->makeClient([
+            'request_sizer' => new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 150, 'max_bytes' => 150]),
+        ]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['budget.bin']);
 
         $this->assertTrue($client->start_push_request());
@@ -258,7 +260,7 @@ class StagedPushStreamClientTest extends TestCase
         $store->finalize('first.bin', 8);
         $store->append('second.bin', 0, str_repeat('b', 4));
         $client = $this->makeClient([
-            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+            'chunk_bytes' => 8,
         ]);
         $local_paths_to_push = $this->writeLocalPathsToPush([
             'first.bin',
@@ -273,20 +275,23 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertSame(['staged_push'], $this->endpointsSeen());
     }
 
-    public function testFrameTooLargeShrinksAndRetriesTheStream(): void
+    public function testFrameTooLargeShrinksTheBodyBudgetAndRetries(): void
     {
         $this->writeSource('large.bin', str_repeat('x', 20));
         $this->configureEndpoint(['max_request_bytes' => 6]);
-        $sizer = new PushFrameSizer(['floor_bytes' => 4, 'start_bytes' => 12, 'max_bytes' => 12]);
-        $client = $this->makeClient(['frame_sizer' => $sizer]);
+        $sizer = new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 12, 'max_bytes' => 12]);
+        $client = $this->makeClient(['request_sizer' => $sizer, 'chunk_bytes' => 12]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['large.bin']);
 
         $result = $this->pushAll($client, $local_paths_to_push);
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(str_repeat('x', 20), file_get_contents($this->staging_dir . '/files/large.bin'));
-        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
-        $this->assertLessThanOrEqual(5, $sizer->chunk_bytes());
+        // The 413 caps the body budget at the reported 6 * 0.9 = 5 bytes, so
+        // after the rejected first request the remaining 20 bytes travel as
+        // four one-frame requests, chunks sized down to the capacity.
+        $this->assertSame(array_fill(0, 5, 'staged_push'), $this->endpointsSeen());
+        $this->assertLessThanOrEqual(5, $sizer->request_body_bytes());
     }
 
     public function testWrongSecretFailsBeforeReadingTheBody(): void
@@ -314,7 +319,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $client = new StagedPushStreamClient([
             'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
-            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 2, 'start_bytes' => 4, 'max_bytes' => 4]),
+            'chunk_bytes' => 4,
         ]);
 
         $pending_connections = [$listener];
@@ -452,7 +457,7 @@ PHP_ROUTER);
         return new StagedPushStreamClient(array_merge([
             'base_url' => self::$base_url,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 4]),
+            'chunk_bytes' => 4,
         ], $overrides));
     }
 

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -2,19 +2,21 @@
 
 namespace ImportTests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Site_Export_HMAC_Client;
 use Site_Export_Staged_Artifacts;
 use StagedPushStreamClient;
-use StagedPushStreamProcessor;
-use StagedPushStreamPusher;
 use PushFrameSizer;
 
 require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
 
 /**
- * Drives the push stream client over curl against a local PHP server that
- * dispatches the real staged endpoint routes.
+ * Drives the push stream client against a local PHP server that dispatches
+ * the real staged endpoint routes. The pushAll()/pushOnce() helpers are the
+ * reference caller loop: stream the local-paths journal line by line, read
+ * each file in budget-sized pieces, rotate requests when the client says so,
+ * and retry from the server-confirmed cursor.
  */
 class StagedPushStreamClientTest extends TestCase
 {
@@ -31,9 +33,6 @@ class StagedPushStreamClientTest extends TestCase
 
     private string $staging_dir;
     private string $source_dir;
-
-    /** @var int[] */
-    private array $sleeps = [];
 
     public static function setUpBeforeClass(): void
     {
@@ -97,7 +96,6 @@ class StagedPushStreamClientTest extends TestCase
         $this->staging_dir = sys_get_temp_dir() . '/staged-push-stream-' . $suffix;
         $this->source_dir = sys_get_temp_dir() . '/staged-push-source-' . $suffix;
         mkdir($this->source_dir, 0700, true);
-        $this->sleeps = [];
         @unlink(self::$request_log_path);
         $this->configureEndpoint();
     }
@@ -118,9 +116,9 @@ class StagedPushStreamClientTest extends TestCase
             'wp-content/uploads/second.bin',
         ]);
 
-        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+        $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(2, $result['files_verified']);
         $this->assertSame(str_repeat('a', 10), file_get_contents($this->staging_dir . '/files/wp-content/uploads/first.bin'));
         $this->assertSame(str_repeat('bc', 7), file_get_contents($this->staging_dir . '/files/wp-content/uploads/second.bin'));
@@ -137,11 +135,10 @@ class StagedPushStreamClientTest extends TestCase
             'first.bin',
             'second.bin',
         ]);
-        $cursor = ['artifact_id' => 'second.bin', 'committed_bytes' => 4];
 
-        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push, $cursor));
+        $result = $this->pushAll($client, $local_paths_to_push, ['artifact_id' => 'second.bin', 'committed_bytes' => 4]);
 
-        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertFileDoesNotExist($this->staging_dir . '/files/first.bin', 'cursor skips files before the resumed artifact');
         $this->assertSame(str_repeat('b', 12), file_get_contents($this->staging_dir . '/files/second.bin'));
         $this->assertSame(['staged_push'], $this->endpointsSeen());
@@ -152,54 +149,103 @@ class StagedPushStreamClientTest extends TestCase
         $this->writeSource('chunked.bin', str_repeat('x', 12));
         $client = $this->makeClient();
         $local_paths_to_push = $this->writeLocalPathsToPush(['chunked.bin']);
-        $processor = new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push);
-        $pusher = new StagedPushStreamPusher($client, $processor, [
-            'sleeper' => function (int $microseconds): void {
-                $this->sleeps[] = $microseconds;
-            },
-        ]);
 
-        $this->assertTrue($pusher->next_request());
-        $request = $pusher->get_request();
-        $this->assertNotNull($request);
-        $this->assertTrue($request->next_chunk());
-        $request->finalize();
-        $this->assertTrue($pusher->finalize_request());
-        $first_result = $pusher->get_result();
+        $this->assertTrue($client->start_push_request());
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'chunked.bin',
+            'offset' => 0,
+            'total_bytes' => 12,
+            'final' => false,
+            'payload' => str_repeat('x', 4),
+        ]));
+        $first_result = $client->finish_request();
 
-        $this->assertSame('in_progress', $first_result['status'], var_export($first_result, true));
-        $this->assertSame(1, $first_result['chunks_streamed']);
-        $this->assertSame(['artifact_id' => 'chunked.bin', 'committed_bytes' => 4], $pusher->get_cursor());
+        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result));
+        $this->assertSame(1, $first_result['chunks_sent']);
+        $this->assertSame(['artifact_id' => 'chunked.bin', 'committed_bytes' => 4], $first_result['cursor']);
         $this->assertSame(str_repeat('x', 4), file_get_contents($this->staging_dir . '/files/chunked.bin'));
 
-        while ($pusher->next_request()) {
-            $request = $pusher->get_request();
-            $this->assertNotNull($request);
-            while ($request->next_chunk()) {
-                // Keep filling the current request until its configured budget is exhausted.
-            }
-            $this->assertTrue($pusher->finalize_request());
-        }
+        $result = $this->pushAll($client, $local_paths_to_push, $first_result['cursor']);
 
-        $this->assertSame('complete', $pusher->get_result()['status'], var_export($pusher->get_result(), true));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(str_repeat('x', 12), file_get_contents($this->staging_dir . '/files/chunked.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
 
-    public function testPayloadByteLimitStartsNewRequestsAsNeeded(): void
+    public function testBodyBudgetCountsFrameHeadersWhenRotatingRequests(): void
     {
-        $this->writeSource('byte-budget.bin', str_repeat('y', 10));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['byte-budget.bin']);
+        $this->writeSource('budget.bin', str_repeat('y', 10));
+        $client = $this->makeClient(['max_request_body_bytes' => 150]);
+        $local_paths_to_push = $this->writeLocalPathsToPush(['budget.bin']);
 
-        $result = $this->runPusher(
-            $client,
-            new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push),
-            ['max_payload_bytes_per_request' => 5]
+        $this->assertTrue($client->start_push_request());
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'budget.bin',
+            'offset' => 0,
+            'total_bytes' => 10,
+            'final' => false,
+            'payload' => 'yyyy',
+        ]));
+
+        $sent_frame_header = json_encode([
+            'type' => 'chunk',
+            'artifact_id' => 'budget.bin',
+            'offset' => 0,
+            'bytes' => 4,
+            'total_bytes' => 10,
+            'final' => false,
+        ], JSON_UNESCAPED_SLASHES) . "\n";
+        $this->assertSame(
+            150 - strlen($sent_frame_header) - 4,
+            $client->capacity_bytes(),
+            'capacity accounts for the frame header, not only the payload'
         );
+        $this->assertFalse($client->should_finish_request());
 
-        $this->assertSame('complete', $result['status'], var_export($result, true));
-        $this->assertSame(str_repeat('y', 10), file_get_contents($this->staging_dir . '/files/byte-budget.bin'));
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'budget.bin',
+            'offset' => 4,
+            'total_bytes' => 10,
+            'final' => false,
+            'payload' => 'yyyy',
+        ]));
+        $this->assertSame(0, $client->capacity_bytes(), 'the second frame header spends the rest of the budget');
+        $this->assertTrue($client->should_finish_request());
+
+        $rotation_result = $client->finish_request();
+        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result));
+
+        $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(str_repeat('y', 10), file_get_contents($this->staging_dir . '/files/budget.bin'));
+        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
+    }
+
+    public function testTimeBudgetRotatesRequests(): void
+    {
+        $this->writeSource('timed.bin', str_repeat('t', 8));
+        $client = $this->makeClient(['max_request_seconds' => 0.05]);
+        $local_paths_to_push = $this->writeLocalPathsToPush(['timed.bin']);
+
+        $this->assertTrue($client->start_push_request());
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'timed.bin',
+            'offset' => 0,
+            'total_bytes' => 8,
+            'final' => false,
+            'payload' => 'tttt',
+        ]));
+        usleep(80000);
+        $this->assertTrue($client->should_finish_request(), 'an open request older than max_request_seconds asks to be finished');
+
+        $rotation_result = $client->finish_request();
+        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result));
+
+        $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(str_repeat('t', 8), file_get_contents($this->staging_dir . '/files/timed.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
 
@@ -219,9 +265,9 @@ class StagedPushStreamClientTest extends TestCase
             'second.bin',
         ]);
 
-        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+        $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(str_repeat('a', 8), file_get_contents($this->staging_dir . '/files/first.bin'));
         $this->assertSame(str_repeat('b', 8), file_get_contents($this->staging_dir . '/files/second.bin'));
         $this->assertSame(['staged_push'], $this->endpointsSeen());
@@ -235,59 +281,12 @@ class StagedPushStreamClientTest extends TestCase
         $client = $this->makeClient(['frame_sizer' => $sizer]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['large.bin']);
 
-        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+        $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(str_repeat('x', 20), file_get_contents($this->staging_dir . '/files/large.bin'));
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
         $this->assertLessThanOrEqual(5, $sizer->chunk_bytes());
-    }
-
-    public function testNextChunkWritesBytesToTheNetworkBeforeTheRequestIsFinalized(): void
-    {
-        // A raw TCP listener instead of the shared endpoint server, so the
-        // test can observe exactly when request bytes reach the network.
-        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
-        $this->assertNotFalse($listener, (string) $errstr);
-        $listener_address = stream_socket_get_name($listener, false);
-
-        $this->writeSource('streamed.bin', str_repeat('s', 8));
-        $client = new StagedPushStreamClient([
-            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
-            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 2, 'start_bytes' => 4, 'max_bytes' => 4]),
-        ]);
-        $processor = new StagedPushStreamProcessor($this->source_dir, $this->writeLocalPathsToPush(['streamed.bin']));
-        $request = $client->create_request($processor);
-
-        $pending_connections = [$listener];
-        $write_sockets = null;
-        $except_sockets = null;
-        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 0), 'creating a request must not open a connection');
-
-        $this->assertTrue($request->next_chunk());
-        $connection = stream_socket_accept($listener, 5);
-        $this->assertNotFalse($connection);
-        $received = $this->readAvailableBytes($connection);
-
-        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_push HTTP/1.1', $received);
-        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":0,"bytes":4', $received);
-        $this->assertStringContainsString('ssss', $received, 'the first frame payload is on the wire before the request is finalized');
-        $this->assertStringNotContainsString("0\r\n\r\n", $received, 'the request body is still open');
-
-        $this->assertTrue($request->next_chunk());
-        $received .= $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":4,"bytes":4', $received);
-        $this->assertSame(2, substr_count($received, 'ssss'), 'the second frame payload followed without finalizing');
-
-        // Drop the connection without responding: the failure must surface as
-        // a retryable request-level result, not an exception.
-        fclose($connection);
-        fclose($listener);
-        $result = $client->push_request($request);
-
-        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
-        $this->assertSame(2, $result['chunks_streamed']);
-        $this->assertSame(8, $result['bytes_streamed']);
     }
 
     public function testWrongSecretFailsBeforeReadingTheBody(): void
@@ -298,11 +297,97 @@ class StagedPushStreamClientTest extends TestCase
         ]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['secret.bin']);
 
-        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+        $result = $this->pushAll($client, $local_paths_to_push);
 
-        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']], var_export($result, true));
+        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
         $this->assertFileDoesNotExist($this->staging_dir . '/files/secret.bin');
         $this->assertSame(['staged_push'], $this->endpointsSeen());
+    }
+
+    public function testSendChunkWritesBytesToTheNetworkBeforeTheRequestIsFinalized(): void
+    {
+        // A raw TCP listener instead of the shared endpoint server, so the
+        // test can observe exactly when request bytes reach the network.
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($listener, (string) $errstr);
+        $listener_address = stream_socket_get_name($listener, false);
+
+        $client = new StagedPushStreamClient([
+            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 2, 'start_bytes' => 4, 'max_bytes' => 4]),
+        ]);
+
+        $pending_connections = [$listener];
+        $write_sockets = null;
+        $except_sockets = null;
+        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 0), 'constructing a client must not open a connection');
+
+        $this->assertTrue($client->start_push_request());
+        $connection = stream_socket_accept($listener, 5);
+        $this->assertNotFalse($connection);
+        $received = $this->readAvailableBytes($connection);
+        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_push HTTP/1.1', $received, 'the request head is on the wire right after start_push_request()');
+
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'streamed.bin',
+            'offset' => 0,
+            'total_bytes' => 8,
+            'final' => false,
+            'payload' => 'ssss',
+        ]));
+        $received .= $this->readAvailableBytes($connection);
+        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":0,"bytes":4', $received);
+        $this->assertStringContainsString('ssss', $received, 'the first frame payload is on the wire before the request is finalized');
+        $this->assertStringNotContainsString("0\r\n\r\n", $received, 'the request body is still open');
+
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'streamed.bin',
+            'offset' => 4,
+            'total_bytes' => 8,
+            'final' => true,
+            'payload' => 'ssss',
+        ]));
+        $received .= $this->readAvailableBytes($connection);
+        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":4,"bytes":4', $received);
+        $this->assertSame(2, substr_count($received, 'ssss'), 'the second frame payload followed without finalizing');
+
+        // Drop the connection without responding: the failure must surface as
+        // a retryable request-level result, not an exception.
+        fclose($connection);
+        fclose($listener);
+        $result = $client->finish_request();
+
+        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertSame(2, $result['chunks_sent']);
+        $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers');
+    }
+
+    public function testInvalidChunksThrowSpecificErrors(): void
+    {
+        $client = $this->makeClient();
+        $invalid_chunks = [
+            [
+                ['artifact_id' => 'a.bin', 'offset' => 8, 'total_bytes' => 10, 'final' => false, 'payload' => 'zzzz'],
+                'Chunk for "a.bin" spans bytes 8-12, which exceeds total_bytes 10.',
+            ],
+            [
+                ['artifact_id' => 'a.bin', 'offset' => 4, 'total_bytes' => 10, 'final' => false, 'payload' => ''],
+                'Refusing a zero-byte non-final chunk for "a.bin" — the source file is shorter than its declared total_bytes 10.',
+            ],
+            [
+                ['artifact_id' => 'a.bin', 'offset' => 4, 'total_bytes' => 10, 'final' => true, 'payload' => 'zz'],
+                'Chunk for "a.bin" is marked final at byte 6 but total_bytes is 10.',
+            ],
+        ];
+
+        foreach ($invalid_chunks as [$chunk, $expected_message]) {
+            try {
+                $client->send_chunk($chunk);
+                $this->fail('Expected an InvalidArgumentException for: ' . (string) json_encode($chunk));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertSame($expected_message, $exception->getMessage());
+            }
+        }
     }
 
     private static function writeRouter(): void
@@ -372,32 +457,122 @@ PHP_ROUTER);
     }
 
     /**
-     * @param array{max_chunks_per_request?:int,max_payload_bytes_per_request?:int} $options
-     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
+     * Push everything, retrying failed requests from the server-confirmed
+     * cursor the way the push command will.
+     *
+     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
      */
-    private function runPusher(StagedPushStreamClient $client, StagedPushStreamProcessor $processor, array $options = []): array
+    private function pushAll(StagedPushStreamClient $client, string $local_paths_to_push, ?array $cursor = null): array
     {
-        $pusher = new StagedPushStreamPusher($client, $processor, array_merge([
-            'sleeper' => function (int $microseconds): void {
-                $this->sleeps[] = $microseconds;
-            },
-        ], $options));
-        while ($pusher->next_request()) {
-            $request = $pusher->get_request();
-            $this->assertNotNull($request);
-            while ($request->next_chunk()) {
-                // The caller owns this inner loop and may finalize after any chunk.
+        $result = null;
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $result = $this->pushOnce($client, $local_paths_to_push, $cursor);
+            if ($result['status'] !== 'retry') {
+                return $result;
             }
-            $this->assertTrue($pusher->finalize_request());
+            $cursor = $result['cursor'];
         }
-        return $pusher->get_result() ?? [
-            'status' => 'complete',
-            'reason' => null,
-            'detail' => null,
-            'cursor' => null,
+        return $result;
+    }
+
+    /**
+     * One pass over the journal from $cursor: the caller loop the client is
+     * designed for. Streams journal lines, reads each file in pieces sized by
+     * capacity_bytes()/max_chunk_bytes(), and rotates requests when the
+     * client says to.
+     *
+     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
+     */
+    private function pushOnce(StagedPushStreamClient $client, string $local_paths_to_push, ?array $cursor): array
+    {
+        $journal_handle = fopen($local_paths_to_push, 'r');
+        $this->assertNotFalse($journal_handle);
+        if (false === $client->start_push_request()) {
+            fclose($journal_handle);
+            return $this->startFailureResult($client, $cursor);
+        }
+
+        $skipping_to_cursor = is_array($cursor) && isset($cursor['artifact_id']);
+        while (($journal_line = fgets($journal_handle)) !== false) {
+            $journal_line = trim($journal_line);
+            if ($journal_line === '') {
+                continue;
+            }
+            $decoded_line = json_decode($journal_line, true, 512, JSON_THROW_ON_ERROR);
+            $artifact_id = (string) base64_decode((string) $decoded_line['path'], true);
+
+            if ($skipping_to_cursor && $artifact_id !== $cursor['artifact_id']) {
+                continue;
+            }
+            $offset = $skipping_to_cursor ? (int) $cursor['committed_bytes'] : 0;
+            $skipping_to_cursor = false;
+
+            $source_handle = fopen($this->source_dir . '/' . $artifact_id, 'rb');
+            $this->assertNotFalse($source_handle);
+            $total_bytes = fstat($source_handle)['size'];
+            if ($total_bytes > 0 && $offset >= $total_bytes) {
+                fclose($source_handle);
+                continue;
+            }
+            if ($offset > 0) {
+                fseek($source_handle, $offset);
+            }
+
+            while (true) {
+                if ($client->should_finish_request()) {
+                    $result = $client->finish_request();
+                    if ($result['status'] !== 'complete') {
+                        fclose($source_handle);
+                        fclose($journal_handle);
+                        return $result;
+                    }
+                    if (false === $client->start_push_request()) {
+                        fclose($source_handle);
+                        fclose($journal_handle);
+                        return $this->startFailureResult($client, $result['cursor']);
+                    }
+                }
+
+                $payload = $total_bytes === 0
+                    ? ''
+                    : (string) fread($source_handle, min($total_bytes - $offset, $client->capacity_bytes(), $client->max_chunk_bytes()));
+                $final = $offset + strlen($payload) >= $total_bytes;
+
+                if (!$client->send_chunk([
+                    'artifact_id' => $artifact_id,
+                    'offset' => $offset,
+                    'total_bytes' => $total_bytes,
+                    'final' => $final,
+                    'payload' => $payload,
+                ])) {
+                    fclose($source_handle);
+                    fclose($journal_handle);
+                    return $client->finish_request();
+                }
+
+                $offset += strlen($payload);
+                if ($final) {
+                    break;
+                }
+            }
+            fclose($source_handle);
+        }
+        fclose($journal_handle);
+
+        return $client->finish_request();
+    }
+
+    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int} */
+    private function startFailureResult(StagedPushStreamClient $client, ?array $cursor): array
+    {
+        return [
+            'status' => 'retry',
+            'reason' => 'request_failed',
+            'detail' => $client->get_last_error(),
+            'cursor' => $cursor,
             'files_verified' => 0,
-            'bytes_streamed' => 0,
-            'chunks_streamed' => 0,
+            'chunks_sent' => 0,
+            'body_bytes_sent' => 0,
         ];
     }
 

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -326,6 +326,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $client = new StagedPushStreamClient([
             'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 4,
         ]);
 
@@ -386,6 +387,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $client = new StagedPushStreamClient([
             'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 8 * 1024 * 1024,
             'stall_timeout' => 1,
         ]);

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -258,8 +258,10 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
 
-    public function testRetryFromTheBeginningSkipsAlreadyVerifiedFilesAndDuplicateBytes(): void
+    public function testRetryFromTheBeginningSkipsVerifiedFilesAndRestartsPartialOnes(): void
     {
+        // first.bin is verified and gets skipped on replay; second.bin holds
+        // 4 unvouched-for bytes, so the replay restarts it from zero.
         $this->writeSource('first.bin', str_repeat('a', 8));
         $this->writeSource('second.bin', str_repeat('b', 8));
         $store = new Site_Export_Staged_Artifacts($this->staging_dir);
@@ -605,6 +607,115 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertStringContainsString('Use that address as the push base_url', (string) $result['detail']);
     }
 
+    public function testResumeAfterTheSourceGrewRestartsTheFile(): void
+    {
+        $old_content = str_repeat('o', 12);
+        $source_path = $this->writeSource('drift-grow.bin', $old_content);
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['drift-grow.bin']);
+        $resume_cursor = $this->pushFirstBytes($client, 'drift-grow.bin', $old_content, 4, $source_path);
+
+        // The file changes before the next session: longer and different.
+        $new_content = str_repeat('n', 16);
+        file_put_contents($source_path, $new_content);
+        touch($source_path, ((int) $resume_cursor['source_mtime']) + 5);
+        clearstatcache();
+
+        $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-grow.bin'), 'no byte of the old version may survive under the new one');
+    }
+
+    public function testResumeAfterASameSizeEditRestartsTheFile(): void
+    {
+        $old_content = str_repeat('o', 12);
+        $source_path = $this->writeSource('drift-edit.bin', $old_content);
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['drift-edit.bin']);
+        $resume_cursor = $this->pushFirstBytes($client, 'drift-edit.bin', $old_content, 4, $source_path);
+
+        // Same byte count, different bytes — only the mtime betrays the edit.
+        $new_content = str_repeat('n', 12);
+        file_put_contents($source_path, $new_content);
+        touch($source_path, ((int) $resume_cursor['source_mtime']) + 5);
+        clearstatcache();
+
+        $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-edit.bin'), 'no byte of the old version may survive under the new one');
+    }
+
+    public function testResumeCursorBeyondAShrunkenFileRestartsTheFile(): void
+    {
+        $old_content = str_repeat('o', 12);
+        $source_path = $this->writeSource('drift-shrink.bin', $old_content);
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['drift-shrink.bin']);
+        $resume_cursor = $this->pushFirstBytes($client, 'drift-shrink.bin', $old_content, 8, $source_path);
+
+        // The file shrank below the committed offset. Skipping it as "done"
+        // would leave the target holding 8 stale bytes and this push lying.
+        $new_content = str_repeat('n', 6);
+        file_put_contents($source_path, $new_content);
+        touch($source_path, ((int) $resume_cursor['source_mtime']) + 5);
+        clearstatcache();
+
+        $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(1, $result['files_verified']);
+        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-shrink.bin'));
+    }
+
+    public function testFullReplayAfterAPartialCommitRewritesChangedBytes(): void
+    {
+        // 4 bytes of an earlier version are staged; the retry has no cursor
+        // (a transport failure lost it) and replays from the top with the
+        // file's current content. The staged prefix must not survive.
+        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('replayed.bin', 0, 'OOOO');
+        $new_content = 'NNNN' . str_repeat('n', 8);
+        $this->writeSource('replayed.bin', $new_content);
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['replayed.bin']);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/replayed.bin'));
+    }
+
+    /**
+     * Session one: push the first $bytes_to_push bytes of $content, then
+     * stop, returning the resume cursor the reference loop would persist —
+     * the server cursor plus the source token (size and mtime) it saves
+     * alongside.
+     *
+     * @return array{artifact_id:string,committed_bytes:int,total_bytes:int,source_mtime:int}
+     */
+    private function pushFirstBytes(StagedPushStreamClient $client, string $artifact_id, string $content, int $bytes_to_push, string $source_path): array
+    {
+        $this->assertTrue($client->start_push_request());
+        for ($offset = 0; $offset < $bytes_to_push; $offset += 4) {
+            $this->assertTrue($client->send_chunk([
+                'artifact_id' => $artifact_id,
+                'offset' => $offset,
+                'total_bytes' => strlen($content),
+                'final' => false,
+                'payload' => substr($content, $offset, 4),
+            ]));
+        }
+        $first_result = $client->finish_request();
+        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result));
+        $this->assertSame($bytes_to_push, $first_result['cursor']['committed_bytes']);
+
+        return $first_result['cursor'] + [
+            'total_bytes' => strlen($content),
+            'source_mtime' => (int) filemtime($source_path),
+        ];
+    }
+
     public function testBackToBackRequestsReuseTheConnection(): void
     {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
@@ -777,7 +888,9 @@ PHP_ROUTER);
     /**
      * One pass over the journal from $cursor: the caller loop the client is
      * designed for. Streams journal lines, reads each file in pieces sized by
-     * next_chunk_body_bytes(), and rotates requests when the client says to.
+     * next_chunk_body_bytes(), rotates requests when the client says to, and
+     * persists a source token (size and mtime) with every cursor so a resume
+     * restarts any file that changed since its bytes were staged.
      *
      * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
      */
@@ -820,12 +933,30 @@ PHP_ROUTER);
             if ($skipping_to_cursor && $artifact_id !== $cursor['artifact_id']) {
                 continue;
             }
-            $offset = $skipping_to_cursor ? (int) $cursor['committed_bytes'] : 0;
+            $resuming_this_file = $skipping_to_cursor;
+            $offset = $resuming_this_file ? (int) $cursor['committed_bytes'] : 0;
             $skipping_to_cursor = false;
 
             $source_handle = fopen($this->source_dir . '/' . $artifact_id, 'rb');
             $this->assertNotFalse($source_handle);
-            $total_bytes = fstat($source_handle)['size'];
+            $source_stat = fstat($source_handle);
+            $total_bytes = (int) $source_stat['size'];
+            $source_mtime = (int) $source_stat['mtime'];
+
+            // The cursor's source token remembers the file the staged bytes
+            // came from. Any change — size or mtime — means those bytes are
+            // another version: restart the file at zero so the target
+            // re-stages it instead of appending one version behind another.
+            if (
+                $resuming_this_file
+                && (
+                    (isset($cursor['total_bytes']) && (int) $cursor['total_bytes'] !== $total_bytes)
+                    || (isset($cursor['source_mtime']) && (int) $cursor['source_mtime'] !== $source_mtime)
+                )
+            ) {
+                $offset = 0;
+            }
+
             if ($total_bytes > 0 && $offset >= $total_bytes) {
                 fclose($source_handle);
                 continue;
@@ -849,7 +980,7 @@ PHP_ROUTER);
                     if ($result['status'] !== 'complete') {
                         fclose($source_handle);
                         fclose($journal_handle);
-                        return $result;
+                        return $this->withSourceToken($result, $artifact_id, $total_bytes, $source_mtime);
                     }
                     if (false === $client->start_push_request()) {
                         fclose($source_handle);
@@ -872,7 +1003,7 @@ PHP_ROUTER);
                 ])) {
                     fclose($source_handle);
                     fclose($journal_handle);
-                    return $client->finish_request();
+                    return $this->withSourceToken($client->finish_request(), $artifact_id, $total_bytes, $source_mtime);
                 }
 
                 $offset += strlen($payload);
@@ -897,7 +1028,21 @@ PHP_ROUTER);
                 'body_bytes_sent' => 0,
             ];
         }
-        return $client->finish_request();
+        return $this->withSourceToken($client->finish_request(), $artifact_id, $total_bytes, $source_mtime);
+    }
+
+    /**
+     * Attach the source token the reference loop persists alongside a server
+     * cursor: the size and mtime of the file whose bytes the cursor counts.
+     * A later resume compares them against the file on disk and restarts the
+     * file when they differ.
+     */
+    private function withSourceToken(array $result, string $artifact_id, int $total_bytes, int $source_mtime): array
+    {
+        if (is_array($result['cursor'] ?? null) && ($result['cursor']['artifact_id'] ?? null) === $artifact_id) {
+            $result['cursor'] += ['total_bytes' => $total_bytes, 'source_mtime' => $source_mtime];
+        }
+        return $result;
     }
 
     /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int} */

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -290,9 +290,11 @@ class StagedPushStreamClientTest extends TestCase
         $client = $this->makeClient(['request_sizer' => $sizer, 'chunk_bytes' => 12]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['large.bin']);
 
+        $push_started_at = microtime(true);
         $result = $this->pushAll($client, $local_paths_to_push);
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertGreaterThan(0.25, microtime(true) - $push_started_at, 'the retry after the 413 backed off before re-hitting the host');
         $this->assertSame(str_repeat('x', 20), file_get_contents($this->staging_dir . '/files/large.bin'));
         // The 413 caps the body budget at the reported 6 * 0.9 = 5 bytes, so
         // after the rejected first request the remaining 20 bytes travel as
@@ -758,6 +760,11 @@ PHP_ROUTER);
     {
         $result = null;
         for ($attempt = 0; $attempt < 5; $attempt++) {
+            if ($attempt > 0) {
+                // Back off before retrying — the command must too; a
+                // struggling host should not be re-hit at full speed.
+                usleep(min(5000000, 250000 * (2 ** ($attempt - 1))));
+            }
             $result = $this->pushOnce($client, $local_paths_to_push, $cursor);
             if ($result['status'] !== 'retry') {
                 return $result;

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -285,7 +285,7 @@ class StagedPushStreamClientTest extends TestCase
     public function testFrameTooLargeShrinksTheBodyBudgetAndRetries(): void
     {
         $this->writeSource('large.bin', str_repeat('x', 20));
-        $this->configureEndpoint(['max_request_bytes' => 6]);
+        $this->configureEndpoint(['max_frame_bytes' => 6]);
         $sizer = new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 12, 'max_bytes' => 12]);
         $client = $this->makeClient(['request_sizer' => $sizer, 'chunk_bytes' => 12]);
         $local_paths_to_push = $this->writeLocalPathsToPush(['large.bin']);
@@ -451,7 +451,7 @@ class StagedPushStreamClientTest extends TestCase
         // The target caps frames at 3 bytes; the sizer cannot shrink the
         // 4-byte body budget below its own floor, so the push must give up —
         // and the reason names the request-size dimension, not the chunk.
-        $this->configureEndpoint(['max_request_bytes' => 3]);
+        $this->configureEndpoint(['max_frame_bytes' => 3]);
         $client = $this->makeClient([
             'request_sizer' => new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 4]),
         ]);
@@ -603,6 +603,53 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertStringContainsString('Use that address as the push base_url', (string) $result['detail']);
     }
 
+    public function testBackToBackRequestsReuseTheConnection(): void
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($listener, (string) $errstr);
+        $listener_address = stream_socket_get_name($listener, false);
+
+        $client = new StagedPushStreamClient([
+            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 4,
+        ]);
+        $keep_alive_response = static function (): string {
+            $response_body = json_encode(['status' => 'complete', 'cursor' => null, 'files_verified' => 1]);
+            return "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response_body) . "\r\n\r\n" . $response_body;
+        };
+
+        $this->assertTrue($client->start_push_request());
+        $connection = stream_socket_accept($listener, 5);
+        $this->assertNotFalse($connection);
+        $this->readAvailableBytes($connection);
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'reuse.bin',
+            'offset' => 0,
+            'total_bytes' => 4,
+            'final' => true,
+            'payload' => 'rrrr',
+        ]));
+        $this->readAvailableBytes($connection);
+        fwrite($connection, $keep_alive_response());
+        $this->assertSame('complete', $client->finish_request()['status']);
+
+        // The second request must ride the connection libcurl cached on the
+        // client's long-lived multi handle, not open a new one.
+        $this->assertTrue($client->start_push_request());
+        $pending_connections = [$listener];
+        $write_sockets = null;
+        $except_sockets = null;
+        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 200000), 'the second request must not open a new connection');
+        $second_request_head = $this->readAvailableBytes($connection);
+        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_push HTTP/1.1', $second_request_head, 'the second request head travels on the reused connection');
+
+        fwrite($connection, $keep_alive_response());
+        $this->assertSame('complete', $client->finish_request()['status']);
+        fclose($connection);
+        fclose($listener);
+    }
+
     public function testEmojiFileNameRoundTrips(): void
     {
         $emoji_artifact_id = "wp-content/uploads/\u{1F4F7} photo.bin";
@@ -675,7 +722,7 @@ file_put_contents(
     'staged' => [
         'staging_dir' => (string) \$config['staging_dir'],
         'secret' => (string) \$config['secret'],
-        'max_request_bytes' => (int) ( \$config['max_request_bytes'] ?? 1073741824 ),
+        'max_frame_bytes' => (int) ( \$config['max_frame_bytes'] ?? 1073741824 ),
     ],
 ]);
 \$server->handle_request();
@@ -688,7 +735,7 @@ PHP_ROUTER);
         file_put_contents(self::$config_path, json_encode(array_merge([
             'staging_dir' => $this->staging_dir,
             'secret' => self::SECRET,
-            'max_request_bytes' => 1073741824,
+            'max_frame_bytes' => 1073741824,
         ], $overrides)));
     }
 
@@ -740,8 +787,12 @@ PHP_ROUTER);
         if ($skipping_to_cursor) {
             $cursor_artifact_in_journal = false;
             while (($journal_line = fgets($journal_handle)) !== false) {
-                $decoded_line = json_decode(trim($journal_line), true);
-                if (is_array($decoded_line) && base64_decode((string) ($decoded_line['path'] ?? ''), true) === $cursor['artifact_id']) {
+                $journal_line = trim($journal_line);
+                if ($journal_line === '') {
+                    continue;
+                }
+                $decoded_line = json_decode($journal_line, true, 512, JSON_THROW_ON_ERROR);
+                if (base64_decode((string) ($decoded_line['path'] ?? ''), true) === $cursor['artifact_id']) {
                     $cursor_artifact_in_journal = true;
                     break;
                 }

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -374,6 +374,47 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers');
     }
 
+    public function testStalledConnectionFailsAfterStallTimeoutWhileSlowProgressDoesNot(): void
+    {
+        // A listener that accepts the connection and then never reads: the
+        // kernel and libcurl buffers absorb a few hundred KiB, after which
+        // zero bytes move. The stall watch must fail the request; a total
+        // timeout would instead have killed any slow-but-healthy transfer.
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($listener, (string) $errstr);
+        $listener_address = stream_socket_get_name($listener, false);
+
+        $client = new StagedPushStreamClient([
+            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'chunk_bytes' => 8 * 1024 * 1024,
+            'stall_timeout' => 1,
+        ]);
+
+        $this->assertTrue($client->start_push_request());
+        $connection = stream_socket_accept($listener, 5);
+        $this->assertNotFalse($connection);
+        // Do not read from $connection: the pipe backs up and stalls.
+
+        $stalled_send_started_at = microtime(true);
+        $sent = $client->send_chunk([
+            'artifact_id' => 'stalled.bin',
+            'offset' => 0,
+            'total_bytes' => 8 * 1024 * 1024,
+            'final' => true,
+            'payload' => str_repeat('s', 8 * 1024 * 1024),
+        ]);
+
+        $this->assertFalse($sent, 'a stalled connection must fail the chunk');
+        $this->assertGreaterThan(1.0, microtime(true) - $stalled_send_started_at, 'the stall watch waited out its window first');
+
+        $result = $client->finish_request();
+        fclose($connection);
+        fclose($listener);
+
+        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertStringContainsString('no bytes moved for 1s', (string) $result['detail']);
+    }
+
     public function testInvalidChunksThrowSpecificErrors(): void
     {
         $client = $this->makeClient();

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -177,7 +177,7 @@ class StagedPushStreamClientTest extends TestCase
         $this->writeSource('budget.bin', str_repeat('y', 10));
         $first_frame_header = json_encode([
             'type' => 'chunk',
-            'artifact_id' => 'budget.bin',
+            'artifact_id' => base64_encode('budget.bin'),
             'offset' => 0,
             'bytes' => 4,
             'total_bytes' => 10,
@@ -349,7 +349,7 @@ class StagedPushStreamClientTest extends TestCase
             'payload' => 'ssss',
         ]));
         $received .= $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":0,"bytes":4', $received);
+        $this->assertStringContainsString('"artifact_id":"c3RyZWFtZWQuYmlu","offset":0,"bytes":4', $received);
         $this->assertStringContainsString('ssss', $received, 'the first frame payload is on the wire before the request is finalized');
         $this->assertStringNotContainsString("0\r\n\r\n", $received, 'the request body is still open');
 
@@ -361,7 +361,7 @@ class StagedPushStreamClientTest extends TestCase
             'payload' => 'ssss',
         ]));
         $received .= $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('"artifact_id":"streamed.bin","offset":4,"bytes":4', $received);
+        $this->assertStringContainsString('"artifact_id":"c3RyZWFtZWQuYmlu","offset":4,"bytes":4', $received);
         $this->assertSame(2, substr_count($received, 'ssss'), 'the second frame payload followed without finalizing');
 
         // Drop the connection without responding: the failure must surface as
@@ -540,6 +540,101 @@ class StagedPushStreamClientTest extends TestCase
         }
     }
 
+    public function testResumeCursorForADeletedFileReplaysFromTheTop(): void
+    {
+        $this->writeSource('kept-one.bin', str_repeat('k', 6));
+        $this->writeSource('kept-two.bin', str_repeat('K', 6));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['kept-one.bin', 'kept-two.bin']);
+
+        // The cursor points at a file that was deleted locally after the
+        // last push, so a rebuilt journal no longer lists it. The push must
+        // replay from the top, not skim past everything and report success.
+        $result = $this->pushAll($client, $local_paths_to_push, ['artifact_id' => 'deleted-since.bin', 'committed_bytes' => 4]);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(2, $result['files_verified']);
+        $this->assertSame(str_repeat('k', 6), file_get_contents($this->staging_dir . '/files/kept-one.bin'));
+        $this->assertSame(str_repeat('K', 6), file_get_contents($this->staging_dir . '/files/kept-two.bin'));
+    }
+
+    public function testEmptyJournalPushesNothingWithoutANetworkRequest(): void
+    {
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush([]);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(0, $result['chunks_sent']);
+        $this->assertSame([], $this->endpointsSeen(), 'an empty journal must not cost a network exchange');
+    }
+
+    public function testRedirectResponseNamesTheTargetInsteadOfRetrying(): void
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($listener, (string) $errstr);
+        $listener_address = stream_socket_get_name($listener, false);
+
+        $client = new StagedPushStreamClient([
+            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 4,
+        ]);
+
+        $this->assertTrue($client->start_push_request());
+        $connection = stream_socket_accept($listener, 5);
+        $this->assertNotFalse($connection);
+        // The usual misconfiguration: an http:// base_url on a site that
+        // forces https. Answer like such a site would.
+        fwrite(
+            $connection,
+            "HTTP/1.1 301 Moved Permanently\r\n"
+            . "Location: https://example.com/?reprint-api=1&endpoint=staged_push\r\n"
+            . "Content-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+
+        $this->assertSame(['failed', 'redirected'], [$result['status'], $result['reason']], (string) json_encode($result));
+        $this->assertStringContainsString('https://example.com/?reprint-api=1&endpoint=staged_push', (string) $result['detail']);
+        $this->assertStringContainsString('Use that address as the push base_url', (string) $result['detail']);
+    }
+
+    public function testEmojiFileNameRoundTrips(): void
+    {
+        $emoji_artifact_id = "wp-content/uploads/\u{1F4F7} photo.bin";
+        $this->writeSource($emoji_artifact_id, str_repeat('e', 10));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush([$emoji_artifact_id]);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(1, $result['files_verified']);
+        $this->assertSame(str_repeat('e', 10), file_get_contents($this->staging_dir . '/files/' . $emoji_artifact_id));
+    }
+
+    public function testNonUtf8FileNameRoundTrips(): void
+    {
+        // Latin-1 "café" plus a stray 0xFF: bytes json_encode cannot carry
+        // raw, which is why artifact ids travel base64 on the wire.
+        $non_utf8_artifact_id = "caf\xE9-\xFF.bin";
+        if (@file_put_contents($this->source_dir . '/' . $non_utf8_artifact_id, str_repeat('n', 6)) === false) {
+            $this->markTestSkipped('This filesystem rejects non-UTF-8 file names (APFS does; ext4 allows them).');
+        }
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush([$non_utf8_artifact_id]);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(1, $result['files_verified']);
+        $this->assertSame(str_repeat('n', 6), file_get_contents($this->staging_dir . '/files/' . $non_utf8_artifact_id));
+    }
+
     private static function writeRouter(): void
     {
         $import_path = addslashes(realpath(__DIR__ . '/../../packages/reprint-importer/src/import.php'));
@@ -636,12 +731,26 @@ PHP_ROUTER);
     {
         $journal_handle = fopen($local_paths_to_push, 'r');
         $this->assertNotFalse($journal_handle);
-        if (false === $client->start_push_request()) {
-            fclose($journal_handle);
-            return $this->startFailureResult($client, $cursor);
+
+        // A journal rebuilt since the cursor was saved may no longer contain
+        // the cursor's file (deleted locally). Skimming for a line that never
+        // comes would push nothing and report success, so check first —
+        // replaying from the top is safe, the target absorbs committed frames.
+        $skipping_to_cursor = is_array($cursor) && isset($cursor['artifact_id']);
+        if ($skipping_to_cursor) {
+            $cursor_artifact_in_journal = false;
+            while (($journal_line = fgets($journal_handle)) !== false) {
+                $decoded_line = json_decode(trim($journal_line), true);
+                if (is_array($decoded_line) && base64_decode((string) ($decoded_line['path'] ?? ''), true) === $cursor['artifact_id']) {
+                    $cursor_artifact_in_journal = true;
+                    break;
+                }
+            }
+            rewind($journal_handle);
+            $skipping_to_cursor = $cursor_artifact_in_journal;
         }
 
-        $skipping_to_cursor = is_array($cursor) && isset($cursor['artifact_id']);
+        $request_open = false;
         while (($journal_line = fgets($journal_handle)) !== false) {
             $journal_line = trim($journal_line);
             if ($journal_line === '') {
@@ -668,7 +777,16 @@ PHP_ROUTER);
             }
 
             while (true) {
-                if ($client->should_finish_request()) {
+                // Open the request only once there is a chunk to push, so an
+                // empty journal never costs a network exchange.
+                if (!$request_open) {
+                    if (false === $client->start_push_request()) {
+                        fclose($source_handle);
+                        fclose($journal_handle);
+                        return $this->startFailureResult($client, $cursor);
+                    }
+                    $request_open = true;
+                } elseif ($client->should_finish_request()) {
                     $result = $client->finish_request();
                     if ($result['status'] !== 'complete') {
                         fclose($source_handle);
@@ -708,6 +826,19 @@ PHP_ROUTER);
         }
         fclose($journal_handle);
 
+        if (!$request_open) {
+            // Nothing needed pushing; report completion without having
+            // touched the network.
+            return [
+                'status' => 'complete',
+                'reason' => null,
+                'detail' => null,
+                'cursor' => $cursor,
+                'files_verified' => 0,
+                'chunks_sent' => 0,
+                'body_bytes_sent' => 0,
+            ];
+        }
         return $client->finish_request();
     }
 

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -445,6 +445,101 @@ class StagedPushStreamClientTest extends TestCase
         }
     }
 
+    public function testGivingUpOnRequestSizeReportsRequestSizeExhausted(): void
+    {
+        $this->writeSource('giveup.bin', str_repeat('g', 8));
+        // The target caps frames at 3 bytes; the sizer cannot shrink the
+        // 4-byte body budget below its own floor, so the push must give up —
+        // and the reason names the request-size dimension, not the chunk.
+        $this->configureEndpoint(['max_request_bytes' => 3]);
+        $client = $this->makeClient([
+            'request_sizer' => new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 4]),
+        ]);
+        $local_paths_to_push = $this->writeLocalPathsToPush(['giveup.bin']);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+
+        $this->assertSame(['failed', 'request_size_exhausted'], [$result['status'], $result['reason']], (string) json_encode($result));
+    }
+
+    public function testEmptyRequestsDoNotGrowTheBodyBudget(): void
+    {
+        $sizer = new PushRequestSizer([
+            'floor_bytes' => 4,
+            'start_bytes' => 8,
+            'max_bytes' => 32,
+            'growth_holdoff_successes' => 0,
+        ]);
+        $client = $this->makeClient(['request_sizer' => $sizer]);
+
+        // Requests that carried nothing teach the sizer nothing.
+        $this->assertTrue($client->start_push_request());
+        $this->assertSame('complete', $client->finish_request()['status']);
+        $this->assertTrue($client->start_push_request());
+        $this->assertSame('complete', $client->finish_request()['status']);
+        $this->assertSame(8, $sizer->request_body_bytes(), 'accepting an empty body is no evidence the size is safe to grow');
+
+        // A request that carried bytes grows the budget as before.
+        $this->writeSource('grow.bin', 'gggg');
+        $this->assertTrue($client->start_push_request());
+        $this->assertTrue($client->send_chunk([
+            'artifact_id' => 'grow.bin',
+            'offset' => 0,
+            'total_bytes' => 4,
+            'final' => true,
+            'payload' => 'gggg',
+        ]));
+        $this->assertSame('complete', $client->finish_request()['status']);
+        $this->assertSame(16, $sizer->request_body_bytes());
+    }
+
+    public function testInvalidOptionsThrowSpecificErrors(): void
+    {
+        $invalid_options = [
+            [['chunk_bytes' => 0], 'Expected option "chunk_bytes" to be a positive integer; received 0.'],
+            [['stall_timeout' => 'soon'], 'Expected option "stall_timeout" to be a positive integer; received "soon".'],
+            [['max_request_seconds' => -1], 'Expected option "max_request_seconds" to be a positive number; received -1.'],
+        ];
+
+        foreach ($invalid_options as [$options, $expected_message]) {
+            try {
+                $this->makeClient($options);
+                $this->fail('Expected an InvalidArgumentException for: ' . (string) json_encode($options));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertSame($expected_message, $exception->getMessage());
+            }
+        }
+    }
+
+    public function testEveryRequestMethodThrowsWithoutAnOpenRequest(): void
+    {
+        $client = $this->makeClient();
+        $method_calls = [
+            'next_chunk_body_bytes' => static fn (StagedPushStreamClient $client) => $client->next_chunk_body_bytes(),
+            'should_finish_request' => static fn (StagedPushStreamClient $client) => $client->should_finish_request(),
+            'finish_request' => static fn (StagedPushStreamClient $client) => $client->finish_request(),
+            'send_chunk' => static fn (StagedPushStreamClient $client) => $client->send_chunk([
+                'artifact_id' => 'a.bin',
+                'offset' => 0,
+                'total_bytes' => 4,
+                'final' => true,
+                'payload' => 'aaaa',
+            ]),
+        ];
+
+        foreach ($method_calls as $method_name => $method_call) {
+            try {
+                $method_call($client);
+                $this->fail('Expected a RuntimeException from ' . $method_name . '() without an open request');
+            } catch (\RuntimeException $exception) {
+                $this->assertSame(
+                    'No push request is open; call start_push_request() before ' . $method_name . '().',
+                    $exception->getMessage()
+                );
+            }
+        }
+    }
+
     private static function writeRouter(): void
     {
         $import_path = addslashes(realpath(__DIR__ . '/../../packages/reprint-importer/src/import.php'));

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -185,12 +185,10 @@ class StagedPushStreamClientTest extends TestCase
         ], JSON_UNESCAPED_SLASHES) . "\n";
         // Budget for one full frame plus 3 spare bytes, so the value of
         // next_chunk_body_bytes() after the first chunk reveals whether the
-        // frame header and the chunked transfer-encoding framing were charged
-        // against the budget alongside the payload. Each write travels as one
-        // transfer-encoding chunk: hex size line, CRLF, bytes, CRLF.
-        $first_frame_wire_bytes = strlen(dechex(strlen($first_frame_header))) + 2 + strlen($first_frame_header) + 2;
-        $first_payload_wire_bytes = strlen(dechex(4)) + 2 + 4 + 2;
-        $request_body_budget = $first_frame_wire_bytes + $first_payload_wire_bytes + 3;
+        // frame header was charged against the budget alongside the payload.
+        // The budget is denominated in entity-body bytes; the transfer
+        // framing around them is libcurl's business.
+        $request_body_budget = strlen($first_frame_header) + 4 + 3;
         $client = $this->makeClient([
             'request_sizer' => new PushRequestSizer([
                 'floor_bytes' => 4,
@@ -209,7 +207,7 @@ class StagedPushStreamClientTest extends TestCase
             'payload' => 'yyyy',
         ]));
 
-        $this->assertSame(3, $client->next_chunk_body_bytes(), 'the frame header and transfer-encoding framing were charged against the budget, not only the payload');
+        $this->assertSame(3, $client->next_chunk_body_bytes(), 'the frame header was charged against the budget, not only the payload');
         $this->assertFalse($client->should_finish_request());
 
         $this->assertTrue($client->send_chunk([
@@ -373,7 +371,7 @@ class StagedPushStreamClientTest extends TestCase
 
         $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result));
         $this->assertSame(2, $result['chunks_sent']);
-        $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers and transfer-encoding framing');
+        $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers');
     }
 
     public function testInvalidChunksThrowSpecificErrors(): void

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Artifacts;
+use StagedPushStreamClient;
+use StagedPushStreamProcessor;
+use StagedPushStreamPusher;
+use PushFrameSizer;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+/**
+ * Drives the push stream client over curl against a local PHP server that
+ * dispatches the real staged endpoint routes.
+ */
+class StagedPushStreamClientTest extends TestCase
+{
+    private const SECRET = 'staged-push-stream-client-test-secret';
+
+    private static string $server_root;
+    private static string $router_path;
+    private static string $config_path;
+    private static string $request_log_path;
+    private static string $base_url;
+
+    /** @var resource|null */
+    private static $server_process = null;
+
+    private string $staging_dir;
+    private string $source_dir;
+
+    /** @var int[] */
+    private array $sleeps = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        self::$server_root = sys_get_temp_dir() . '/staged-push-stream-site-' . $suffix;
+        self::$router_path = self::$server_root . '/router.php';
+        self::$config_path = self::$server_root . '/endpoint-config.json';
+        self::$request_log_path = self::$server_root . '/requests.jsonl';
+        mkdir(self::$server_root, 0700, true);
+        self::writeRouter();
+
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if ($socket === false) {
+            self::fail('Could not reserve a local test port: ' . $errstr);
+        }
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        $port = (int) substr(strrchr((string) $address, ':'), 1);
+        self::$base_url = 'http://127.0.0.1:' . $port . '/?reprint-api=1';
+
+        self::$server_process = proc_open(
+            [PHP_BINARY, '-n', '-S', '127.0.0.1:' . $port, '-t', self::$server_root, self::$router_path],
+            [0 => ['pipe', 'r'], 1 => ['file', self::$server_root . '/server.log', 'a'], 2 => ['file', self::$server_root . '/server.log', 'a']],
+            $pipes,
+            self::$server_root
+        );
+        if (!is_resource(self::$server_process)) {
+            self::fail('Could not start the local staged endpoint server.');
+        }
+        fclose($pipes[0]);
+
+        $ready = false;
+        for ($attempt = 0; $attempt < 50; $attempt++) {
+            if (@file_get_contents('http://127.0.0.1:' . $port . '/__ping') === 'ok') {
+                $ready = true;
+                break;
+            }
+            usleep(100000);
+        }
+        if (!$ready) {
+            self::tearDownAfterClass();
+            self::fail('The local staged endpoint server did not start.');
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (is_resource(self::$server_process)) {
+            proc_terminate(self::$server_process);
+            proc_close(self::$server_process);
+            self::$server_process = null;
+        }
+        if (isset(self::$server_root)) {
+            self::removeDirectory(self::$server_root);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->staging_dir = sys_get_temp_dir() . '/staged-push-stream-' . $suffix;
+        $this->source_dir = sys_get_temp_dir() . '/staged-push-source-' . $suffix;
+        mkdir($this->source_dir, 0700, true);
+        $this->sleeps = [];
+        @unlink(self::$request_log_path);
+        $this->configureEndpoint();
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeDirectory($this->staging_dir);
+        self::removeDirectory($this->source_dir);
+    }
+
+    public function testStreamsManyFilesThroughOneRequest(): void
+    {
+        $this->writeSource('wp-content/uploads/first.bin', str_repeat('a', 10));
+        $this->writeSource('wp-content/uploads/second.bin', str_repeat('bc', 7));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush([
+            'wp-content/uploads/first.bin',
+            'wp-content/uploads/second.bin',
+        ]);
+
+        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+
+        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame(2, $result['files_verified']);
+        $this->assertSame(str_repeat('a', 10), file_get_contents($this->staging_dir . '/files/wp-content/uploads/first.bin'));
+        $this->assertSame(str_repeat('bc', 7), file_get_contents($this->staging_dir . '/files/wp-content/uploads/second.bin'));
+        $this->assertSame(['staged_push'], $this->endpointsSeen(), 'all file chunks travel through one request');
+    }
+
+    public function testCursorCanResumeMidFileInTheNextPushStream(): void
+    {
+        $this->writeSource('first.bin', str_repeat('a', 12));
+        $this->writeSource('second.bin', str_repeat('b', 12));
+        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('second.bin', 0, str_repeat('b', 4));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush([
+            'first.bin',
+            'second.bin',
+        ]);
+        $cursor = ['artifact_id' => 'second.bin', 'committed_bytes' => 4];
+
+        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push, $cursor));
+
+        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/first.bin', 'cursor skips files before the resumed artifact');
+        $this->assertSame(str_repeat('b', 12), file_get_contents($this->staging_dir . '/files/second.bin'));
+        $this->assertSame(['staged_push'], $this->endpointsSeen());
+    }
+
+    public function testCallerCanPauseAfterOneChunkAndResumeFromTheCursor(): void
+    {
+        $this->writeSource('chunked.bin', str_repeat('x', 12));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['chunked.bin']);
+        $processor = new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push);
+        $pusher = new StagedPushStreamPusher($client, $processor, [
+            'max_chunks_per_request' => 1,
+            'sleeper' => function (int $microseconds): void {
+                $this->sleeps[] = $microseconds;
+            },
+        ]);
+
+        $this->assertTrue($pusher->next_request());
+        $first_result = $pusher->get_result();
+
+        $this->assertSame('in_progress', $first_result['status'], var_export($first_result, true));
+        $this->assertSame(1, $first_result['chunks_streamed']);
+        $this->assertSame(['artifact_id' => 'chunked.bin', 'committed_bytes' => 4], $pusher->get_cursor());
+        $this->assertSame(str_repeat('x', 4), file_get_contents($this->staging_dir . '/files/chunked.bin'));
+
+        while ($pusher->next_request()) {
+            // Keep advancing one request at a time until the pusher reports completion.
+        }
+
+        $this->assertSame('complete', $pusher->get_result()['status'], var_export($pusher->get_result(), true));
+        $this->assertSame(str_repeat('x', 12), file_get_contents($this->staging_dir . '/files/chunked.bin'));
+        $this->assertSame(['staged_push', 'staged_push', 'staged_push'], $this->endpointsSeen());
+    }
+
+    public function testPayloadByteLimitStartsNewRequestsAsNeeded(): void
+    {
+        $this->writeSource('byte-budget.bin', str_repeat('y', 10));
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['byte-budget.bin']);
+
+        $result = $this->runPusher(
+            $client,
+            new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push),
+            ['max_payload_bytes_per_request' => 5]
+        );
+
+        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame(str_repeat('y', 10), file_get_contents($this->staging_dir . '/files/byte-budget.bin'));
+        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
+    }
+
+    public function testRetryFromTheBeginningSkipsAlreadyVerifiedFilesAndDuplicateBytes(): void
+    {
+        $this->writeSource('first.bin', str_repeat('a', 8));
+        $this->writeSource('second.bin', str_repeat('b', 8));
+        $store = new Site_Export_Staged_Artifacts($this->staging_dir);
+        $store->append('first.bin', 0, str_repeat('a', 8));
+        $store->finalize('first.bin', 8);
+        $store->append('second.bin', 0, str_repeat('b', 4));
+        $client = $this->makeClient([
+            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 4, 'start_bytes' => 8, 'max_bytes' => 8]),
+        ]);
+        $local_paths_to_push = $this->writeLocalPathsToPush([
+            'first.bin',
+            'second.bin',
+        ]);
+
+        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+
+        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame(str_repeat('a', 8), file_get_contents($this->staging_dir . '/files/first.bin'));
+        $this->assertSame(str_repeat('b', 8), file_get_contents($this->staging_dir . '/files/second.bin'));
+        $this->assertSame(['staged_push'], $this->endpointsSeen());
+    }
+
+    public function testFrameTooLargeShrinksAndRetriesTheStream(): void
+    {
+        $this->writeSource('large.bin', str_repeat('x', 20));
+        $this->configureEndpoint(['max_request_bytes' => 6]);
+        $sizer = new PushFrameSizer(['floor_bytes' => 4, 'start_bytes' => 12, 'max_bytes' => 12]);
+        $client = $this->makeClient(['frame_sizer' => $sizer]);
+        $local_paths_to_push = $this->writeLocalPathsToPush(['large.bin']);
+
+        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+
+        $this->assertSame('complete', $result['status'], var_export($result, true));
+        $this->assertSame(str_repeat('x', 20), file_get_contents($this->staging_dir . '/files/large.bin'));
+        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
+        $this->assertLessThanOrEqual(5, $sizer->chunk_bytes());
+    }
+
+    public function testWrongSecretFailsBeforeReadingTheBody(): void
+    {
+        $this->writeSource('secret.bin', 'secret');
+        $client = $this->makeClient([
+            'hmac_client' => new Site_Export_HMAC_Client('wrong-secret'),
+        ]);
+        $local_paths_to_push = $this->writeLocalPathsToPush(['secret.bin']);
+
+        $result = $this->runPusher($client, new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push));
+
+        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']], var_export($result, true));
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/secret.bin');
+        $this->assertSame(['staged_push'], $this->endpointsSeen());
+    }
+
+    private static function writeRouter(): void
+    {
+        $import_path = addslashes(realpath(__DIR__ . '/../../packages/reprint-importer/src/import.php'));
+        $config_path = addslashes(self::$config_path);
+        $request_log_path = addslashes(self::$request_log_path);
+
+        file_put_contents(self::$router_path, <<<PHP_ROUTER
+<?php
+// PHP 8.1 emits the required CLI script's shebang; keep test HTTP responses clean.
+ob_start();
+require_once '{$import_path}';
+ob_end_clean();
+
+if (parse_url(\$_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__ping') {
+    echo 'ok';
+    return true;
+}
+
+\$config = json_decode((string) file_get_contents('{$config_path}'), true);
+if (!is_array(\$config)) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'missing endpoint config']);
+    return true;
+}
+
+file_put_contents(
+    '{$request_log_path}',
+    json_encode([
+        'endpoint' => (string) ( \$_GET['endpoint'] ?? '' ),
+        'method' => \$_SERVER['REQUEST_METHOD'] ?? '',
+        'content_length' => \$_SERVER['CONTENT_LENGTH'] ?? null,
+    ]) . "\n",
+    FILE_APPEND
+);
+
+\$server = new Site_Export_HTTP_Server([
+    'staged' => [
+        'staging_dir' => (string) \$config['staging_dir'],
+        'secret' => (string) \$config['secret'],
+        'max_request_bytes' => (int) ( \$config['max_request_bytes'] ?? 1073741824 ),
+    ],
+]);
+\$server->handle_request();
+return true;
+PHP_ROUTER);
+    }
+
+    private function configureEndpoint(array $overrides = []): void
+    {
+        file_put_contents(self::$config_path, json_encode(array_merge([
+            'staging_dir' => $this->staging_dir,
+            'secret' => self::SECRET,
+            'max_request_bytes' => 1073741824,
+        ], $overrides)));
+    }
+
+    private function makeClient(array $overrides = []): StagedPushStreamClient
+    {
+        return new StagedPushStreamClient(array_merge([
+            'base_url' => self::$base_url,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'frame_sizer' => new PushFrameSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 4]),
+        ], $overrides));
+    }
+
+    /**
+     * @param array{max_chunks_per_request?:int,max_payload_bytes_per_request?:int} $options
+     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,bytes_streamed:int,chunks_streamed:int}
+     */
+    private function runPusher(StagedPushStreamClient $client, StagedPushStreamProcessor $processor, array $options = []): array
+    {
+        $pusher = new StagedPushStreamPusher($client, $processor, array_merge([
+            'sleeper' => function (int $microseconds): void {
+                $this->sleeps[] = $microseconds;
+            },
+        ], $options));
+        while ($pusher->next_request()) {
+            // The caller owns this loop and may break after any request.
+        }
+        return $pusher->get_result() ?? [
+            'status' => 'complete',
+            'reason' => null,
+            'detail' => null,
+            'cursor' => null,
+            'files_verified' => 0,
+            'bytes_streamed' => 0,
+            'chunks_streamed' => 0,
+        ];
+    }
+
+    private function writeSource(string $name, string $body): string
+    {
+        $path = $this->source_dir . '/' . $name;
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0700, true);
+        }
+        file_put_contents($path, $body);
+        return $path;
+    }
+
+    /** @param string[] $artifact_ids */
+    private function writeLocalPathsToPush(array $artifact_ids): string
+    {
+        $path = $this->source_dir . '/local-paths-to-push.jsonl';
+        $body = '';
+        foreach ($artifact_ids as $artifact_id) {
+            $body .= json_encode(['path' => base64_encode($artifact_id)], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        }
+        file_put_contents($path, $body);
+        return $path;
+    }
+
+    /** @return string[] */
+    private function endpointsSeen(): array
+    {
+        if (!file_exists(self::$request_log_path)) {
+            return [];
+        }
+        $endpoints = [];
+        foreach (file(self::$request_log_path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                $endpoints[] = (string) ($decoded['endpoint'] ?? '');
+            }
+        }
+        return $endpoints;
+    }
+
+    private static function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        foreach (glob($directory . '/*') ?: [] as $directory_entry) {
+            is_dir($directory_entry) ? self::removeDirectory($directory_entry) : @unlink($directory_entry);
+        }
+        @rmdir($directory);
+    }
+}

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -154,13 +154,17 @@ class StagedPushStreamClientTest extends TestCase
         $local_paths_to_push = $this->writeLocalPathsToPush(['chunked.bin']);
         $processor = new StagedPushStreamProcessor($this->source_dir, $local_paths_to_push);
         $pusher = new StagedPushStreamPusher($client, $processor, [
-            'max_chunks_per_request' => 1,
             'sleeper' => function (int $microseconds): void {
                 $this->sleeps[] = $microseconds;
             },
         ]);
 
         $this->assertTrue($pusher->next_request());
+        $request = $pusher->get_request();
+        $this->assertNotNull($request);
+        $this->assertTrue($request->next_chunk());
+        $request->finalize();
+        $this->assertTrue($pusher->finalize_request());
         $first_result = $pusher->get_result();
 
         $this->assertSame('in_progress', $first_result['status'], var_export($first_result, true));
@@ -169,12 +173,17 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertSame(str_repeat('x', 4), file_get_contents($this->staging_dir . '/files/chunked.bin'));
 
         while ($pusher->next_request()) {
-            // Keep advancing one request at a time until the pusher reports completion.
+            $request = $pusher->get_request();
+            $this->assertNotNull($request);
+            while ($request->next_chunk()) {
+                // Keep filling the current request until its configured budget is exhausted.
+            }
+            $this->assertTrue($pusher->finalize_request());
         }
 
         $this->assertSame('complete', $pusher->get_result()['status'], var_export($pusher->get_result(), true));
         $this->assertSame(str_repeat('x', 12), file_get_contents($this->staging_dir . '/files/chunked.bin'));
-        $this->assertSame(['staged_push', 'staged_push', 'staged_push'], $this->endpointsSeen());
+        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
     }
 
     public function testPayloadByteLimitStartsNewRequestsAsNeeded(): void
@@ -327,7 +336,12 @@ PHP_ROUTER);
             },
         ], $options));
         while ($pusher->next_request()) {
-            // The caller owns this loop and may break after any request.
+            $request = $pusher->get_request();
+            $this->assertNotNull($request);
+            while ($request->next_chunk()) {
+                // The caller owns this inner loop and may finalize after any chunk.
+            }
+            $this->assertTrue($pusher->finalize_request());
         }
         return $pusher->get_result() ?? [
             'status' => 'complete',

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -547,6 +547,22 @@ final class StagedArtifactsTest extends TestCase
     // Concurrency and lifecycle
     // ---------------------------------------------------------------
 
+    public function testStateFileRecordsArtifactIdsBase64(): void
+    {
+        $store = $this->makeStore();
+        $store->append('plain.bin', 0, 'abcd');
+
+        // File names are arbitrary bytes and JSON strings must be UTF-8 —
+        // a raw non-UTF-8 id would make json_encode() return false and the
+        // state record would silently become an empty file, resetting
+        // committed_bytes to 0 on every read. Ids travel base64 in the
+        // state file, like everywhere else on the wire and in the journal.
+        $state = json_decode((string) file_get_contents($this->staging_dir . '/state.json'), true);
+        $this->assertSame(base64_encode('plain.bin'), $state['artifact_id']);
+        $this->assertSame(4, $state['committed_bytes']);
+        $this->assertSame(4, $store->status('plain.bin')['committed_bytes'], 'the id round-trips back out of the state file');
+    }
+
     public function testConcurrentWriterGetsBusy(): void
     {
         $store = $this->makeStore();

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -557,9 +557,9 @@ final class StagedArtifactsTest extends TestCase
         flock($holder, LOCK_EX);
 
         $busy_append = $store->append('artifact-1', 5, 'second');
-        $this->assertSame(['busy', 5], [$busy_append['status'], $busy_append['committed_bytes']]);
+        $this->assertSame(['busy', 'busy', 5], [$busy_append['status'], $busy_append['reason'], $busy_append['committed_bytes']]);
         $busy_finalize = $store->finalize('artifact-1', 5);
-        $this->assertSame(['busy', 5], [$busy_finalize['status'], $busy_finalize['committed_bytes']]);
+        $this->assertSame(['busy', 'busy', 5], [$busy_finalize['status'], $busy_finalize['reason'], $busy_finalize['committed_bytes']]);
         $this->assertFalse($store->discard('artifact-1'));
 
         flock($holder, LOCK_UN);

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -337,6 +337,57 @@ final class StagedEndpointsTest extends TestCase {
     // Request validation and server-owned options
     // ---------------------------------------------------------------
 
+    public function testOversizedFrameCursorReportsOnlyStoreCommittedBytes(): void
+    {
+        $endpoints = $this->makeEndpoints(['max_frame_bytes' => 6]);
+
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'claimed.bin', 'offset' => 4, 'bytes' => str_repeat('x', 10), 'total_bytes' => 20, 'final' => false],
+        ]);
+
+        $this->assertSame(413, $result['http_code']);
+        $this->assertSame(
+            ['artifact_id' => base64_encode('claimed.bin'), 'committed_bytes' => 0],
+            $result['body']['cursor'],
+            'a rejection cursor must report what the store confirmed, not what the sender claimed'
+        );
+    }
+
+    public function testOffsetZeroFrameRestartsAnUnverifiedArtifact(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('restarted.bin', 0, 'AAAA');
+
+        // A frame starting at byte 0 means the sender is pushing the file
+        // over — it cannot vouch for the staged prefix. The old bytes must
+        // not survive underneath the new ones.
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'restarted.bin', 'offset' => 0, 'bytes' => 'BBBBBBBB', 'total_bytes' => 8, 'final' => true],
+        ]);
+
+        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
+        $this->assertSame(1, $result['body']['files_verified']);
+        $this->assertSame('BBBBBBBB', file_get_contents($this->staging_dir . '/files/restarted.bin'));
+    }
+
+    public function testOffsetZeroFrameWithANewTotalRestartsAVerifiedArtifact(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $store = new Site_Export_Staged_Artifacts($this->staging_dir);
+        $store->append('reverified.bin', 0, str_repeat('A', 8));
+        $store->finalize('reverified.bin', 8);
+
+        // The source changed after verification; the sender restarts the
+        // file with its new size. Refusing forever would deadlock the push.
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'reverified.bin', 'offset' => 0, 'bytes' => 'CCCCCC', 'total_bytes' => 6, 'final' => true],
+        ]);
+
+        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
+        $this->assertSame(1, $result['body']['files_verified']);
+        $this->assertSame('CCCCCC', file_get_contents($this->staging_dir . '/files/reverified.bin'));
+    }
+
     public function testMutatingRoutesRequirePost(): void
     {
         $endpoints = $this->makeEndpoints();

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -259,7 +259,7 @@ final class StagedEndpointsTest extends TestCase {
     private function finalize(Site_Export_Staged_Endpoints $endpoints, string $artifact_id, int $total): array
     {
         return $endpoints->finalize(
-            ['artifact_id' => $artifact_id, 'total_bytes' => $total],
+            ['artifact_id' => base64_encode($artifact_id), 'total_bytes' => $total],
             ['REQUEST_METHOD' => 'POST']
         );
     }
@@ -289,7 +289,7 @@ final class StagedEndpointsTest extends TestCase {
     {
         $endpoints = $this->makeEndpoints();
 
-        $unknown = $endpoints->status(['artifact_id' => 'artifact-1']);
+        $unknown = $endpoints->status(['artifact_id' => base64_encode('artifact-1')]);
         $this->assertSame(200, $unknown['http_code']);
         $this->assertSame(
             ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
@@ -299,7 +299,7 @@ final class StagedEndpointsTest extends TestCase {
         $this->push($endpoints, [
             ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcde', 'total_bytes' => 10, 'final' => false],
         ]);
-        $known = $endpoints->status(['artifact_id' => 'artifact-1']);
+        $known = $endpoints->status(['artifact_id' => base64_encode('artifact-1')]);
         $this->assertSame(
             ['exists' => true, 'committed_bytes' => 5, 'verified' => false],
             $known['body']
@@ -316,7 +316,7 @@ final class StagedEndpointsTest extends TestCase {
         $holder = fopen($this->staging_dir . '/lock', 'r+b');
         flock($holder, LOCK_EX);
         $busy = $endpoints->discard(
-            ['artifact_id' => 'artifact-1'],
+            ['artifact_id' => base64_encode('artifact-1')],
             ['REQUEST_METHOD' => 'POST']
         );
         flock($holder, LOCK_UN);
@@ -326,7 +326,7 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame(['discarded' => false], $busy['body']);
 
         $done = $endpoints->discard(
-            ['artifact_id' => 'artifact-1'],
+            ['artifact_id' => base64_encode('artifact-1')],
             ['REQUEST_METHOD' => 'POST']
         );
         $this->assertSame(200, $done['http_code']);
@@ -359,11 +359,16 @@ final class StagedEndpointsTest extends TestCase {
         $endpoints = $this->makeEndpoints();
         $post = ['REQUEST_METHOD' => 'POST'];
 
-        $bad_total = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 'many'], $post);
+        $bad_total = $endpoints->finalize(['artifact_id' => base64_encode('a'), 'total_bytes' => 'many'], $post);
         $this->assertSame('invalid_total', $bad_total['body']['reason']);
 
         $bad_status_id = $endpoints->status(['artifact_id' => '']);
         $this->assertSame(400, $bad_status_id['http_code']);
+
+        // Control-plane ids travel base64, like push stream frames.
+        $undecodable_status_id = $endpoints->status(['artifact_id' => '!!!not-base64!!!']);
+        $this->assertSame(400, $undecodable_status_id['http_code']);
+        $this->assertSame('invalid_artifact_id', $undecodable_status_id['body']['reason']);
     }
 
     public function testClientParametersCannotChooseServerOptions(): void
@@ -397,7 +402,7 @@ final class StagedEndpointsTest extends TestCase {
 
         ob_start();
         $server->handle_request([
-            'get' => ['endpoint' => 'staged_status', 'artifact_id' => 'artifact-1'],
+            'get' => ['endpoint' => 'staged_status', 'artifact_id' => base64_encode('artifact-1')],
             'server' => ['REQUEST_METHOD' => 'GET'],
             'body' => '',
         ]);

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -192,7 +192,7 @@ final class StagedEndpointsTest extends TestCase {
 
     public function testPushStreamBodyOverTheCapIs413WithMaxFrameBytes(): void
     {
-        $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
+        $endpoints = $this->makeEndpoints(['max_frame_bytes' => 64]);
 
         $result = $this->push($endpoints, [
             ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => str_repeat('x', 100), 'total_bytes' => 100, 'final' => true],
@@ -368,7 +368,7 @@ final class StagedEndpointsTest extends TestCase {
 
     public function testClientParametersCannotChooseServerOptions(): void
     {
-        $endpoints = $this->makeEndpoints(['max_request_bytes' => 1024]);
+        $endpoints = $this->makeEndpoints(['max_frame_bytes' => 1024]);
         $evil_dir = $this->staging_dir . '-evil';
         $result = $this->push($endpoints, [
             ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => str_repeat('x', 100), 'total_bytes' => 100, 'final' => true],
@@ -376,7 +376,7 @@ final class StagedEndpointsTest extends TestCase {
             // Options are server-owned; parameters with the same names
             // must be ignored.
             'staging_dir' => $evil_dir,
-            'max_request_bytes' => 10,
+            'max_frame_bytes' => 10,
             'secret' => 'attacker-chosen',
         ]);
 

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -575,7 +575,7 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame(1, $reads, 'a JSON body still feeds config parsing');
     }
 
-    public function testHandleRequestDoesNotBufferStagedUploadBodies(): void
+    public function testHandleRequestDoesNotBufferStagedDataPlaneBodies(): void
     {
         $reads = 0;
         $server = new Site_Export_HTTP_Server([
@@ -586,27 +586,40 @@ final class StagedEndpointsTest extends TestCase {
             },
         ]);
 
-        $previous_request_method = $_SERVER['REQUEST_METHOD'] ?? null;
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-        ob_start();
-        try {
-            $server->handle_request([
-                'get' => ['endpoint' => 'staged_upload', 'artifact_id' => 'artifact-1', 'offset' => 0],
-                'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json'],
-            ]);
-            $output = ob_get_clean();
-        } finally {
-            if (ob_get_level() > 0) {
-                ob_end_clean();
+        foreach ([
+            ['endpoint' => 'staged_upload', 'artifact_id' => 'artifact-1', 'offset' => 0],
+            ['endpoint' => 'staged_push'],
+        ] as $request_query) {
+            $previous_request_method = $_SERVER['REQUEST_METHOD'] ?? null;
+            $previous_request_uri = $_SERVER['REQUEST_URI'] ?? null;
+            $_SERVER['REQUEST_METHOD'] = 'POST';
+            $_SERVER['REQUEST_URI'] = '/?endpoint=' . $request_query['endpoint'];
+            $buffer_level = ob_get_level();
+            ob_start();
+            try {
+                $server->handle_request([
+                    'get' => $request_query,
+                    'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json'],
+                ]);
+                $output = ob_get_clean();
+            } finally {
+                while (ob_get_level() > $buffer_level) {
+                    ob_end_clean();
+                }
+                if ($previous_request_method === null) {
+                    unset($_SERVER['REQUEST_METHOD']);
+                } else {
+                    $_SERVER['REQUEST_METHOD'] = $previous_request_method;
+                }
+                if ($previous_request_uri === null) {
+                    unset($_SERVER['REQUEST_URI']);
+                } else {
+                    $_SERVER['REQUEST_URI'] = $previous_request_uri;
+                }
             }
-            if ($previous_request_method === null) {
-                unset($_SERVER['REQUEST_METHOD']);
-            } else {
-                $_SERVER['REQUEST_METHOD'] = $previous_request_method;
-            }
-        }
 
-        $this->assertSame(0, $reads, 'staged_upload body bytes must only be read by the upload handler');
-        $this->assertSame('auth_failed', json_decode( (string) $output, true)['reason']);
+            $this->assertSame(0, $reads, $request_query['endpoint'] . ' body bytes must only be read by the staged handler');
+            $this->assertSame('auth_failed', json_decode( (string) $output, true)['reason']);
+        }
     }
 }

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -63,7 +63,7 @@ final class StagedEndpointsTest extends TestCase {
         foreach ($frames as $frame) {
             $header = json_encode([
                 'type' => 'chunk',
-                'artifact_id' => $frame['artifact_id'],
+                'artifact_id' => base64_encode($frame['artifact_id']),
                 'offset' => $frame['offset'],
                 'bytes' => strlen($frame['bytes']),
                 'total_bytes' => $frame['total_bytes'],
@@ -110,7 +110,7 @@ final class StagedEndpointsTest extends TestCase {
 
         $this->assertSame(200, $result['http_code']);
         $this->assertSame('complete', $result['body']['status']);
-        $this->assertSame(['artifact_id' => 'a/b/dump.sql', 'committed_bytes' => strlen($body)], $result['body']['cursor']);
+        $this->assertSame(['artifact_id' => base64_encode('a/b/dump.sql'), 'committed_bytes' => strlen($body)], $result['body']['cursor']);
         $this->assertSame(1, $result['body']['files_verified']);
         $this->assertSame($body, file_get_contents($this->staging_dir . '/files/a/b/dump.sql'));
     }
@@ -126,7 +126,7 @@ final class StagedEndpointsTest extends TestCase {
 
         $this->assertSame(200, $retry['http_code']);
         $this->assertSame('complete', $retry['body']['status']);
-        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 10], $retry['body']['cursor']);
+        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 10], $retry['body']['cursor']);
         $this->assertSame(1, $retry['body']['files_verified']);
         $this->assertSame('abcdefghij', file_get_contents($this->staging_dir . '/files/artifact-1'));
     }
@@ -145,7 +145,7 @@ final class StagedEndpointsTest extends TestCase {
         ]);
 
         $this->assertSame(200, $result['http_code']);
-        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 15], $result['body']['cursor']);
+        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 15], $result['body']['cursor']);
         $this->assertSame('abcdefghijKLMNO', file_get_contents($this->staging_dir . '/files/artifact-1'));
     }
 
@@ -162,7 +162,7 @@ final class StagedEndpointsTest extends TestCase {
 
         $this->assertSame(409, $result['http_code']);
         $this->assertSame('offset_gap', $result['body']['reason']);
-        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 5], $result['body']['cursor']);
+        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 5], $result['body']['cursor']);
     }
 
     public function testPushStreamRejectsWrongSecretBeforeTheStore(): void
@@ -221,13 +221,13 @@ final class StagedEndpointsTest extends TestCase {
 
         $this->assertSame(423, $result['http_code']);
         $this->assertSame('busy', $result['body']['status']);
-        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 5], $result['body']['cursor']);
+        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 5], $result['body']['cursor']);
     }
 
     public function testMalformedPushFrameIsRejected(): void
     {
         $endpoints = $this->makeEndpoints();
-        $stream = $this->bodyStream(json_encode(['type' => 'chunk', 'artifact_id' => 'a', 'offset' => 5, 'bytes' => 1, 'total_bytes' => 3, 'final' => false]) . "\nX");
+        $stream = $this->bodyStream(json_encode(['type' => 'chunk', 'artifact_id' => base64_encode('a'), 'offset' => 5, 'bytes' => 1, 'total_bytes' => 3, 'final' => false]) . "\nX");
         try {
             $result = $endpoints->push_stream([], $this->pushHeaders(), $stream);
         } finally {

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 final class StagedEndpointsTest extends TestCase {
 
     private const SECRET = 'staged-endpoints-test-secret';
+    private const PUSH_TARGET = '/?endpoint=staged_push';
 
     private string $staging_dir;
 
@@ -37,30 +38,6 @@ final class StagedEndpointsTest extends TestCase {
         ], $overrides));
     }
 
-    /**
-     * Headers the way $_SERVER presents them, signed like the HMAC client:
-     * HMAC-SHA256(nonce . timestamp . SHA256(body), secret).
-     */
-    private function signedHeaders(string $body, array $overrides = []): array
-    {
-        $nonce = $overrides['nonce'] ?? bin2hex(random_bytes(16));
-        $timestamp = $overrides['timestamp'] ?? (string) time();
-        $content_hash = $overrides['content_hash'] ?? hash('sha256', $body);
-        $signature = hash_hmac(
-            'sha256',
-            $nonce . $timestamp . $content_hash,
-            $overrides['secret'] ?? self::SECRET
-        );
-
-        return [
-            'REQUEST_METHOD' => 'POST',
-            'HTTP_X_AUTH_SIGNATURE' => $overrides['signature'] ?? $signature,
-            'HTTP_X_AUTH_NONCE' => $nonce,
-            'HTTP_X_AUTH_TIMESTAMP' => $timestamp,
-            'HTTP_X_AUTH_CONTENT_HASH' => $content_hash,
-        ];
-    }
-
     /** @return resource */
     private function bodyStream(string $body)
     {
@@ -70,290 +47,192 @@ final class StagedEndpointsTest extends TestCase {
         return $stream;
     }
 
-    private function upload(
-        Site_Export_Staged_Endpoints $endpoints,
-        string $artifact_id,
-        int $offset,
-        string $body,
-        array $header_overrides = []
-    ): array {
-        $stream = $this->bodyStream($body);
-        try {
-            return $endpoints->upload(
-                ['artifact_id' => $artifact_id, 'offset' => $offset],
-                $this->signedHeaders($body, $header_overrides),
-                $stream
+    private function pushHeaders(string $secret = self::SECRET, array $overrides = []): array
+    {
+        $headers = (new Site_Export_HMAC_Client($secret))->get_envelope_auth_headers('POST', self::PUSH_TARGET);
+        return array_merge([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => self::PUSH_TARGET,
+        ], $headers, $overrides);
+    }
+
+    /** @param array<int,array{artifact_id:string,offset:int,bytes:string,total_bytes:int,final:bool}> $frames */
+    private function pushBody(array $frames): string
+    {
+        $body = '';
+        foreach ($frames as $frame) {
+            $body .= Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
+                $frame['artifact_id'],
+                $frame['offset'],
+                strlen($frame['bytes']),
+                $frame['total_bytes'],
+                $frame['final']
             );
+            $body .= $frame['bytes'];
+        }
+        return $body;
+    }
+
+    /** @param array<int,array{artifact_id:string,offset:int,bytes:string,total_bytes:int,final:bool}> $frames */
+    private function push(
+        Site_Export_Staged_Endpoints $endpoints,
+        array $frames,
+        array $headers = [],
+        array $config = []
+    ): array {
+        $stream = $this->bodyStream($this->pushBody($frames));
+        try {
+            return $endpoints->push_stream($config, $headers ?: $this->pushHeaders(), $stream);
         } finally {
             fclose($stream);
         }
     }
 
-    private function finalize(Site_Export_Staged_Endpoints $endpoints, string $artifact_id, int $total): array
-    {
-        return $endpoints->finalize(
-            ['artifact_id' => $artifact_id, 'total_bytes' => $total],
-            ['REQUEST_METHOD' => 'POST']
-        );
-    }
-
     // ---------------------------------------------------------------
-    // Upload data plane
+    // Push data plane
     // ---------------------------------------------------------------
 
-    public function testChunksStageAndFinalizeVerifies(): void
+    public function testPushStreamStagesManyChunksAndFinalizes(): void
     {
-        // A small append buffer forces many store steps per chunk.
+        // A small append buffer forces many store steps per frame.
         $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
         $body = 'the quick brown fox jumps over the lazy dog';
         $split = 20;
 
-        $first = $this->upload($endpoints, 'a/b/dump.sql', 0, substr($body, 0, $split));
-        $this->assertSame(200, $first['http_code']);
-        $this->assertSame('accepted', $first['body']['status']);
-        $this->assertSame($split, $first['body']['committed_bytes']);
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'a/b/dump.sql', 'offset' => 0, 'bytes' => substr($body, 0, $split), 'total_bytes' => strlen($body), 'final' => false],
+            ['artifact_id' => 'a/b/dump.sql', 'offset' => $split, 'bytes' => substr($body, $split), 'total_bytes' => strlen($body), 'final' => true],
+        ]);
 
-        $second = $this->upload($endpoints, 'a/b/dump.sql', $split, substr($body, $split));
-        $this->assertSame(strlen($body), $second['body']['committed_bytes']);
-
-        $verified = $this->finalize($endpoints, 'a/b/dump.sql', strlen($body));
-        $this->assertSame(200, $verified['http_code']);
-        $this->assertSame('verified', $verified['body']['status']);
-        $this->assertArrayNotHasKey('path', $verified['body']);
+        $this->assertSame(200, $result['http_code']);
+        $this->assertSame('complete', $result['body']['status']);
+        $this->assertSame(['artifact_id' => 'a/b/dump.sql', 'committed_bytes' => strlen($body)], $result['body']['cursor']);
+        $this->assertSame(1, $result['body']['files_verified']);
         $this->assertSame($body, file_get_contents($this->staging_dir . '/files/a/b/dump.sql'));
     }
 
-    public function testRetriedChunkLandsAsDuplicate(): void
+    public function testPushStreamRetryAbsorbsDuplicateBytes(): void
     {
         $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+        $frame = ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcdefghij', 'total_bytes' => 10, 'final' => true];
+        $this->push($endpoints, [$frame]);
 
-        // The sender timed out without the response and retries the chunk.
-        $retry = $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+        // The sender timed out without the response and retries from the same cursor.
+        $retry = $this->push($endpoints, [$frame]);
 
         $this->assertSame(200, $retry['http_code']);
-        $this->assertSame('duplicate', $retry['body']['status']);
-        $this->assertSame(10, $retry['body']['committed_bytes']);
+        $this->assertSame('complete', $retry['body']['status']);
+        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 10], $retry['body']['cursor']);
+        $this->assertSame(1, $retry['body']['files_verified']);
+        $this->assertSame('abcdefghij', file_get_contents($this->staging_dir . '/files/artifact-1'));
     }
 
-    public function testResentChunkStraddlingTheFrontierAppendsOnlyTheTail(): void
+    public function testPushStreamStraddlingFrameAppendsOnlyTheTail(): void
     {
         $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
-        $this->upload($endpoints, 'artifact-1', 0, 'abcdefghij');
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcdefghij', 'total_bytes' => 15, 'final' => false],
+        ]);
 
         // After a resync the sender resends from offset 0 with a larger
-        // chunk; only the bytes past the committed frontier may land.
-        $result = $this->upload($endpoints, 'artifact-1', 0, 'abcdefghijKLMNO');
+        // frame; only the bytes past the committed frontier may land.
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcdefghijKLMNO', 'total_bytes' => 15, 'final' => true],
+        ]);
 
         $this->assertSame(200, $result['http_code']);
-        $this->assertSame('accepted', $result['body']['status']);
-        $this->assertSame(15, $result['body']['committed_bytes']);
-        $this->assertSame(
-            'abcdefghijKLMNO',
-            file_get_contents($this->staging_dir . '/files/artifact-1')
-        );
+        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 15], $result['body']['cursor']);
+        $this->assertSame('abcdefghijKLMNO', file_get_contents($this->staging_dir . '/files/artifact-1'));
     }
 
-    public function testChunkBeyondTheFrontierIsAnOffsetGapWithResumeHint(): void
+    public function testPushStreamFrameBeyondTheFrontierIsAnOffsetGapWithResumeHint(): void
     {
         $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'abcde');
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcde', 'total_bytes' => 20, 'final' => false],
+        ]);
 
-        $result = $this->upload($endpoints, 'artifact-1', 50, 'later-bytes');
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 50, 'bytes' => 'later-bytes', 'total_bytes' => 100, 'final' => false],
+        ]);
 
         $this->assertSame(409, $result['http_code']);
         $this->assertSame('offset_gap', $result['body']['reason']);
-        $this->assertSame(5, $result['body']['committed_bytes']);
+        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 5], $result['body']['cursor']);
     }
 
-    public function testUploadToAVerifiedArtifactIsRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'payload');
-        $this->finalize($endpoints, 'artifact-1', 7);
-
-        $result = $this->upload($endpoints, 'artifact-1', 7, 'more');
-
-        $this->assertSame(409, $result['http_code']);
-        $this->assertSame('already_verified', $result['body']['reason']);
-    }
-
-    public function testEmptyBodyIsRejected(): void
+    public function testPushStreamRejectsWrongSecretBeforeTheStore(): void
     {
         $endpoints = $this->makeEndpoints();
 
-        $result = $this->upload($endpoints, 'artifact-1', 0, '');
-
-        $this->assertSame(400, $result['http_code']);
-        $this->assertSame('empty_body', $result['body']['reason']);
-    }
-
-    public function testUploadWhileTheStoreIsHeldReportsBusy(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'first');
-
-        $holder = fopen($this->staging_dir . '/lock', 'r+b');
-        flock($holder, LOCK_EX);
-        $result = $this->upload($endpoints, 'artifact-1', 5, 'second');
-        flock($holder, LOCK_UN);
-        fclose($holder);
-
-        $this->assertSame(423, $result['http_code']);
-        $this->assertSame('busy', $result['body']['status']);
-        $this->assertSame(5, $result['body']['committed_bytes']);
-    }
-
-    // ---------------------------------------------------------------
-    // Upload authentication: no unverified byte reaches the store
-    // ---------------------------------------------------------------
-
-    public function testUploadWithoutAuthHeadersIsRejectedBeforeTheStore(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $stream = $this->bodyStream('payload');
-
-        $result = $endpoints->upload(
-            ['artifact_id' => 'artifact-1', 'offset' => 0],
-            ['REQUEST_METHOD' => 'POST'],
-            $stream
-        );
-        fclose($stream);
-
-        $this->assertSame(403, $result['http_code']);
-        $this->assertSame('auth_failed', $result['body']['reason']);
-        $this->assertStringContainsString('X-Auth-Signature', $result['body']['detail']);
-        $this->assertDirectoryDoesNotExist($this->staging_dir);
-    }
-
-    public function testUploadWithWrongSignatureIsRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload', [
-            'signature' => str_repeat('0', 64),
-        ]);
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'secret.bin', 'offset' => 0, 'bytes' => 'secret', 'total_bytes' => 6, 'final' => true],
+        ], $this->pushHeaders('wrong-secret'));
 
         $this->assertSame(403, $result['http_code']);
         $this->assertSame('auth_failed', $result['body']['reason']);
         $this->assertDirectoryDoesNotExist($this->staging_dir);
     }
 
-    public function testUploadWithExpiredTimestampIsRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload', [
-            'timestamp' => (string) ( time() - 3600 ),
-        ]);
-
-        $this->assertSame(403, $result['http_code']);
-        $this->assertSame('auth_failed', $result['body']['reason']);
-    }
-
-    public function testBodyNotMatchingTheSignedHashNeverReachesTheStore(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        // Valid signature over the hash of different bytes: the headers
-        // authenticate, the body does not.
-        $result = $this->upload($endpoints, 'artifact-1', 0, 'actually-sent-bytes', [
-            'content_hash' => hash('sha256', 'the-bytes-that-were-signed'),
-        ]);
-
-        $this->assertSame(403, $result['http_code']);
-        $this->assertSame('content_hash_mismatch', $result['body']['reason']);
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
-        $this->assertSame(0, $endpoints->status(['artifact_id' => 'artifact-1'])['body']['committed_bytes']);
-    }
-
-    public function testReplayedRequestIsAbsorbedAsADuplicate(): void
-    {
-        // There is no nonce cache; replay protection is the protocol's
-        // idempotence. A captured append replayed verbatim inside the
-        // timestamp window must land as a duplicate at the same offset —
-        // the frontier does not move and bytes are never doubled.
-        $endpoints = $this->makeEndpoints();
-        $body = 'replayable bytes';
-        $headers = $this->signedHeaders($body);
-
-        $stream = $this->bodyStream($body);
-        $first = $endpoints->upload(['artifact_id' => 'a.txt', 'offset' => 0], $headers, $stream);
-        fclose($stream);
-        $this->assertSame(200, $first['http_code']);
-        $this->assertSame(strlen($body), $first['body']['committed_bytes']);
-
-        // The exact same signed request again — same nonce, same
-        // timestamp, same signature, same body.
-        $stream = $this->bodyStream($body);
-        $replayed = $endpoints->upload(['artifact_id' => 'a.txt', 'offset' => 0], $headers, $stream);
-        fclose($stream);
-
-        $this->assertSame(200, $replayed['http_code']);
-        $this->assertSame('duplicate', $replayed['body']['status']);
-        $this->assertSame(strlen($body), $replayed['body']['committed_bytes'], 'the frontier must not move');
-        $this->assertSame(
-            strlen($body),
-            (int) filesize($this->staging_dir . '/files/a.txt'),
-            'bytes are never doubled'
-        );
-    }
-
-    public function testShortNonceIsRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $result = $this->upload($endpoints, 'a.txt', 0, 'bytes', ['nonce' => 'short']);
-
-        $this->assertSame(403, $result['http_code']);
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/a.txt');
-    }
-
-    public function testUploadWithoutAConfiguredSecretIsUnavailable(): void
+    public function testPushStreamWithoutAConfiguredSecretIsUnavailable(): void
     {
         $endpoints = $this->makeEndpoints(['secret' => null]);
 
-        $result = $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 7, 'final' => true],
+        ]);
 
         $this->assertSame(503, $result['http_code']);
         $this->assertSame('not_configured', $result['body']['reason']);
     }
 
-    // ---------------------------------------------------------------
-    // Request-size limits: the chunk sizer's 413 contract
-    // ---------------------------------------------------------------
-
-    public function testBodyOverTheCapIs413WithMaxRequestBytes(): void
+    public function testPushStreamBodyOverTheCapIs413WithMaxFrameBytes(): void
     {
         $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
 
-        $result = $this->upload($endpoints, 'artifact-1', 0, str_repeat('x', 100));
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => str_repeat('x', 100), 'total_bytes' => 100, 'final' => true],
+        ]);
 
         $this->assertSame(413, $result['http_code']);
-        $this->assertSame('request_too_large', $result['body']['reason']);
-        $this->assertSame(64, $result['body']['max_request_bytes']);
+        $this->assertSame('frame_too_large', $result['body']['reason']);
+        $this->assertSame(64, $result['body']['max_frame_bytes']);
         $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
     }
 
-    public function testDeclaredContentLengthOverTheCapIs413BeforeReading(): void
+    public function testPushStreamWhileTheStoreIsHeldReportsBusy(): void
     {
-        $endpoints = $this->makeEndpoints(['max_request_bytes' => 64]);
+        $endpoints = $this->makeEndpoints();
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'first', 'total_bytes' => 11, 'final' => false],
+        ]);
 
-        // An empty stream stands in for the body: the declared length alone
-        // must trigger the rejection, before any read happens.
-        $stream = $this->bodyStream('');
-        $headers = $this->signedHeaders('');
-        $headers['CONTENT_LENGTH'] = '5000';
-        $result = $endpoints->upload(
-            ['artifact_id' => 'artifact-1', 'offset' => 0],
-            $headers,
-            $stream
-        );
-        fclose($stream);
+        $holder = fopen($this->staging_dir . '/lock', 'r+b');
+        flock($holder, LOCK_EX);
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 5, 'bytes' => 'second', 'total_bytes' => 11, 'final' => true],
+        ]);
+        flock($holder, LOCK_UN);
+        fclose($holder);
 
-        $this->assertSame(413, $result['http_code']);
-        $this->assertSame('request_too_large', $result['body']['reason']);
-        $this->assertSame(64, $result['body']['max_request_bytes']);
+        $this->assertSame(423, $result['http_code']);
+        $this->assertSame('busy', $result['body']['status']);
+        $this->assertSame(['artifact_id' => 'artifact-1', 'committed_bytes' => 5], $result['body']['cursor']);
+    }
+
+    public function testMalformedPushFrameIsRejected(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $stream = $this->bodyStream(json_encode(['type' => 'chunk', 'artifact_id' => 'a', 'offset' => 5, 'bytes' => 1, 'total_bytes' => 3, 'final' => false]) . "\nX");
+        try {
+            $result = $endpoints->push_stream([], $this->pushHeaders(), $stream);
+        } finally {
+            fclose($stream);
+        }
+
+        $this->assertSame(400, $result['http_code']);
+        $this->assertSame('invalid_frame', $result['body']['reason']);
+        $this->assertSame('range_exceeds_total', $result['body']['detail']);
     }
 
     // ---------------------------------------------------------------
@@ -363,12 +242,22 @@ final class StagedEndpointsTest extends TestCase {
     public function testFinalizeWithWrongTotalIsRejected(): void
     {
         $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 10, 'final' => false],
+        ]);
 
         $result = $this->finalize($endpoints, 'artifact-1', 99);
 
         $this->assertSame(409, $result['http_code']);
         $this->assertSame('size_mismatch', $result['body']['reason']);
+    }
+
+    private function finalize(Site_Export_Staged_Endpoints $endpoints, string $artifact_id, int $total): array
+    {
+        return $endpoints->finalize(
+            ['artifact_id' => $artifact_id, 'total_bytes' => $total],
+            ['REQUEST_METHOD' => 'POST']
+        );
     }
 
     public function testFinalizeOfUnknownArtifactReportsMissing(): void
@@ -384,8 +273,9 @@ final class StagedEndpointsTest extends TestCase {
     public function testFinalizeIsIdempotentAndZeroByteArtifactsVerify(): void
     {
         $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'payload');
-        $this->finalize($endpoints, 'artifact-1', 7);
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 7, 'final' => true],
+        ]);
 
         $this->assertSame(200, $this->finalize($endpoints, 'artifact-1', 7)['http_code']);
         $this->assertSame('verified', $this->finalize($endpoints, 'empty.txt', 0)['body']['status']);
@@ -402,7 +292,9 @@ final class StagedEndpointsTest extends TestCase {
             $unknown['body']
         );
 
-        $this->upload($endpoints, 'artifact-1', 0, 'abcde');
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcde', 'total_bytes' => 10, 'final' => false],
+        ]);
         $known = $endpoints->status(['artifact_id' => 'artifact-1']);
         $this->assertSame(
             ['exists' => true, 'committed_bytes' => 5, 'verified' => false],
@@ -413,7 +305,9 @@ final class StagedEndpointsTest extends TestCase {
     public function testDiscardReportsHeldStoreAsRetriable(): void
     {
         $endpoints = $this->makeEndpoints();
-        $this->upload($endpoints, 'artifact-1', 0, 'payload');
+        $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 7, 'final' => true],
+        ]);
 
         $holder = fopen($this->staging_dir . '/lock', 'r+b');
         flock($holder, LOCK_EX);
@@ -443,12 +337,14 @@ final class StagedEndpointsTest extends TestCase {
     {
         $endpoints = $this->makeEndpoints();
         $get = ['REQUEST_METHOD' => 'GET'];
+        $stream = $this->bodyStream('');
 
-        $upload = $endpoints->upload(['artifact_id' => 'a', 'offset' => 0], $get, null);
+        $push = $endpoints->push_stream([], $get, $stream);
+        fclose($stream);
         $finalize = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 1], $get);
         $discard = $endpoints->discard(['artifact_id' => 'a'], $get);
 
-        foreach ([$upload, $finalize, $discard] as $result) {
+        foreach ([$push, $finalize, $discard] as $result) {
             $this->assertSame(405, $result['http_code']);
             $this->assertSame('method_not_allowed', $result['body']['reason']);
         }
@@ -458,12 +354,6 @@ final class StagedEndpointsTest extends TestCase {
     {
         $endpoints = $this->makeEndpoints();
         $post = ['REQUEST_METHOD' => 'POST'];
-
-        $no_id = $endpoints->upload(['offset' => 0], $post, null);
-        $this->assertSame([400, 'invalid_artifact_id'], [$no_id['http_code'], $no_id['body']['reason']]);
-
-        $bad_offset = $endpoints->upload(['artifact_id' => 'a', 'offset' => -1], $post, null);
-        $this->assertSame('invalid_offset', $bad_offset['body']['reason']);
 
         $bad_total = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 'many'], $post);
         $this->assertSame('invalid_total', $bad_total['body']['reason']);
@@ -476,23 +366,15 @@ final class StagedEndpointsTest extends TestCase {
     {
         $endpoints = $this->makeEndpoints(['max_request_bytes' => 1024]);
         $evil_dir = $this->staging_dir . '-evil';
-        $body = str_repeat('x', 100);
-
-        $stream = $this->bodyStream($body);
-        $result = $endpoints->upload(
-            [
-                'artifact_id' => 'artifact-1',
-                'offset' => 0,
-                // Options are server-owned; parameters with the same names
-                // must be ignored.
-                'staging_dir' => $evil_dir,
-                'max_request_bytes' => 10,
-                'secret' => 'attacker-chosen',
-            ],
-            $this->signedHeaders($body),
-            $stream
-        );
-        fclose($stream);
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => str_repeat('x', 100), 'total_bytes' => 100, 'final' => true],
+        ], [], [
+            // Options are server-owned; parameters with the same names
+            // must be ignored.
+            'staging_dir' => $evil_dir,
+            'max_request_bytes' => 10,
+            'secret' => 'attacker-chosen',
+        ]);
 
         $this->assertSame(200, $result['http_code']);
         $this->assertFileExists($this->staging_dir . '/files/artifact-1');
@@ -575,51 +457,46 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame(1, $reads, 'a JSON body still feeds config parsing');
     }
 
-    public function testHandleRequestDoesNotBufferStagedDataPlaneBodies(): void
+    public function testHandleRequestDoesNotBufferStagedPushBodies(): void
     {
         $reads = 0;
         $server = new Site_Export_HTTP_Server([
             'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
             'body_reader' => function () use (&$reads): string {
                 ++$reads;
-                return 'this would buffer the raw upload';
+                return 'this would buffer the raw push body';
             },
         ]);
 
-        foreach ([
-            ['endpoint' => 'staged_upload', 'artifact_id' => 'artifact-1', 'offset' => 0],
-            ['endpoint' => 'staged_push'],
-        ] as $request_query) {
-            $previous_request_method = $_SERVER['REQUEST_METHOD'] ?? null;
-            $previous_request_uri = $_SERVER['REQUEST_URI'] ?? null;
-            $_SERVER['REQUEST_METHOD'] = 'POST';
-            $_SERVER['REQUEST_URI'] = '/?endpoint=' . $request_query['endpoint'];
-            $buffer_level = ob_get_level();
-            ob_start();
-            try {
-                $server->handle_request([
-                    'get' => $request_query,
-                    'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json'],
-                ]);
-                $output = ob_get_clean();
-            } finally {
-                while (ob_get_level() > $buffer_level) {
-                    ob_end_clean();
-                }
-                if ($previous_request_method === null) {
-                    unset($_SERVER['REQUEST_METHOD']);
-                } else {
-                    $_SERVER['REQUEST_METHOD'] = $previous_request_method;
-                }
-                if ($previous_request_uri === null) {
-                    unset($_SERVER['REQUEST_URI']);
-                } else {
-                    $_SERVER['REQUEST_URI'] = $previous_request_uri;
-                }
+        $previous_request_method = $_SERVER['REQUEST_METHOD'] ?? null;
+        $previous_request_uri = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI'] = self::PUSH_TARGET;
+        $buffer_level = ob_get_level();
+        ob_start();
+        try {
+            $server->handle_request([
+                'get' => ['endpoint' => 'staged_push'],
+                'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json'],
+            ]);
+            $output = ob_get_clean();
+        } finally {
+            while (ob_get_level() > $buffer_level) {
+                ob_end_clean();
             }
-
-            $this->assertSame(0, $reads, $request_query['endpoint'] . ' body bytes must only be read by the staged handler');
-            $this->assertSame('auth_failed', json_decode( (string) $output, true)['reason']);
+            if ($previous_request_method === null) {
+                unset($_SERVER['REQUEST_METHOD']);
+            } else {
+                $_SERVER['REQUEST_METHOD'] = $previous_request_method;
+            }
+            if ($previous_request_uri === null) {
+                unset($_SERVER['REQUEST_URI']);
+            } else {
+                $_SERVER['REQUEST_URI'] = $previous_request_uri;
+            }
         }
+
+        $this->assertSame(0, $reads, 'staged_push body bytes must only be read by the staged handler');
+        $this->assertSame('auth_failed', json_decode( (string) $output, true)['reason']);
     }
 }

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -61,14 +61,18 @@ final class StagedEndpointsTest extends TestCase {
     {
         $body = '';
         foreach ($frames as $frame) {
-            $body .= Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
-                $frame['artifact_id'],
-                $frame['offset'],
-                strlen($frame['bytes']),
-                $frame['total_bytes'],
-                $frame['final']
-            );
-            $body .= $frame['bytes'];
+            $header = json_encode([
+                'type' => 'chunk',
+                'artifact_id' => $frame['artifact_id'],
+                'offset' => $frame['offset'],
+                'bytes' => strlen($frame['bytes']),
+                'total_bytes' => $frame['total_bytes'],
+                'final' => $frame['final'],
+            ], JSON_UNESCAPED_SLASHES);
+            if ($header === false) {
+                throw new RuntimeException('Could not encode staged push stream frame header.');
+            }
+            $body .= $header . "\n" . $frame['bytes'];
         }
         return $body;
     }

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -232,7 +232,7 @@ final class StagedEndpointsTest extends TestCase {
 
         $this->assertSame(400, $result['http_code']);
         $this->assertSame('invalid_frame', $result['body']['reason']);
-        $this->assertSame('range_exceeds_total', $result['body']['detail']);
+        $this->assertStringContainsString('offset 5 and 1 payload bytes, which exceeds total_bytes 3', $result['body']['detail']);
     }
 
     // ---------------------------------------------------------------

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -26,7 +26,7 @@ final class StagedPushStreamProtocolTest extends TestCase
     public function testChunkHeaderValidationRejectsRangesOutsideTheDeclaredFile(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('range_exceeds_total');
+        $this->expectExceptionMessage('offset 8 and 4 payload bytes, which exceeds total_bytes 10');
 
         Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(json_encode([
             'type' => 'chunk',
@@ -36,6 +36,43 @@ final class StagedPushStreamProtocolTest extends TestCase
             'total_bytes' => 10,
             'final' => true,
         ], JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @dataProvider invalidChunkHeaderProvider
+     */
+    public function testChunkHeaderValidationNamesTheExactInvalidField(array $header, string $expected_message): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expected_message);
+
+        Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(json_encode($header, JSON_UNESCAPED_SLASHES));
+    }
+
+    public static function invalidChunkHeaderProvider(): array
+    {
+        return [
+            'missing type' => [
+                ['artifact_id' => 'file.txt', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
+                'Missing staged push stream frame field "type".',
+            ],
+            'empty artifact id' => [
+                ['type' => 'chunk', 'artifact_id' => '', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
+                'Expected staged push stream frame field "artifact_id" to be a non-empty string; received an empty string.',
+            ],
+            'negative offset' => [
+                ['type' => 'chunk', 'artifact_id' => 'file.txt', 'offset' => -1, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
+                'Expected staged push stream frame field "offset" to be a non-negative integer; received integer -1.',
+            ],
+            'string byte count' => [
+                ['type' => 'chunk', 'artifact_id' => 'file.txt', 'offset' => 0, 'bytes' => '1', 'total_bytes' => 1, 'final' => false],
+                'Expected staged push stream frame field "bytes" to be a non-negative integer; received string "1".',
+            ],
+            'missing final flag' => [
+                ['type' => 'chunk', 'artifact_id' => 'file.txt', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1],
+                'Missing staged push stream frame field "final".',
+            ],
+        ];
     }
 
     public function testReadAndDiscardUseTheSameBoundedStreamHelpers(): void

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedPushStreamProtocolTest extends TestCase
+{
+    public function testChunkHeadersRoundTripThroughTheSharedCodec(): void
+    {
+        $line = Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
+            'wp-content/uploads/photo.jpg',
+            10,
+            5,
+            20,
+            false
+        );
+
+        $this->assertSame([
+            'artifact_id' => 'wp-content/uploads/photo.jpg',
+            'offset' => 10,
+            'bytes' => 5,
+            'total_bytes' => 20,
+            'final' => false,
+        ], Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(rtrim($line, "\n")));
+    }
+
+    public function testChunkHeaderValidationRejectsRangesOutsideTheDeclaredFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('range_exceeds_total');
+
+        Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(json_encode([
+            'type' => 'chunk',
+            'artifact_id' => 'file.txt',
+            'offset' => 8,
+            'bytes' => 4,
+            'total_bytes' => 10,
+            'final' => true,
+        ], JSON_UNESCAPED_SLASHES));
+    }
+
+    public function testReadAndDiscardUseTheSameBoundedStreamHelpers(): void
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, "abc\ndefghijk");
+        rewind($stream);
+
+        $this->assertSame('abc', Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream));
+        $this->assertSame('def', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 3));
+        $this->assertTrue(Site_Export_Staged_Push_Stream_Protocol::discard_exactly($stream, 3, 2));
+        $this->assertSame('jk', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 2));
+
+        fclose($stream);
+    }
+}

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -4,15 +4,16 @@ use PHPUnit\Framework\TestCase;
 
 final class StagedPushStreamProtocolTest extends TestCase
 {
-    public function testChunkHeadersRoundTripThroughTheSharedCodec(): void
+    public function testChunkHeadersDecodeFromJsonLines(): void
     {
-        $line = Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
-            'wp-content/uploads/photo.jpg',
-            10,
-            5,
-            20,
-            false
-        );
+        $line = json_encode([
+            'type' => 'chunk',
+            'artifact_id' => 'wp-content/uploads/photo.jpg',
+            'offset' => 10,
+            'bytes' => 5,
+            'total_bytes' => 20,
+            'final' => false,
+        ], JSON_UNESCAPED_SLASHES);
 
         $this->assertSame([
             'artifact_id' => 'wp-content/uploads/photo.jpg',
@@ -20,7 +21,7 @@ final class StagedPushStreamProtocolTest extends TestCase
             'bytes' => 5,
             'total_bytes' => 20,
             'final' => false,
-        ], Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(rtrim($line, "\n")));
+        ], Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line));
     }
 
     public function testChunkHeaderValidationRejectsRangesOutsideTheDeclaredFile(): void
@@ -81,7 +82,7 @@ final class StagedPushStreamProtocolTest extends TestCase
         fwrite($stream, "abc\ndefghijk");
         rewind($stream);
 
-        $this->assertSame('abc', Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream));
+        $this->assertSame("abc\n", fgets($stream));
         $this->assertSame('def', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 3));
         $this->assertTrue(Site_Export_Staged_Push_Stream_Protocol::discard_exactly($stream, 3, 2));
         $this->assertSame('jk', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 2));

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -8,13 +8,15 @@ final class StagedPushStreamProtocolTest extends TestCase
     {
         $line = json_encode([
             'type' => 'chunk',
-            'artifact_id' => 'wp-content/uploads/photo.jpg',
+            'artifact_id' => base64_encode('wp-content/uploads/photo.jpg'),
             'offset' => 10,
             'bytes' => 5,
             'total_bytes' => 20,
             'final' => false,
         ], JSON_UNESCAPED_SLASHES);
 
+        // The wire carries the id base64-encoded; decoding hands back the
+        // raw path.
         $this->assertSame([
             'artifact_id' => 'wp-content/uploads/photo.jpg',
             'offset' => 10,
@@ -31,7 +33,7 @@ final class StagedPushStreamProtocolTest extends TestCase
 
         Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(json_encode([
             'type' => 'chunk',
-            'artifact_id' => 'file.txt',
+            'artifact_id' => base64_encode('file.txt'),
             'offset' => 8,
             'bytes' => 4,
             'total_bytes' => 10,
@@ -54,23 +56,27 @@ final class StagedPushStreamProtocolTest extends TestCase
     {
         return [
             'missing type' => [
-                ['artifact_id' => 'file.txt', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
+                ['artifact_id' => base64_encode('file.txt'), 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
                 'Missing staged push stream frame field "type".',
             ],
             'empty artifact id' => [
                 ['type' => 'chunk', 'artifact_id' => '', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
-                'Expected staged push stream frame field "artifact_id" to be a non-empty string; received an empty string.',
+                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received string "".',
+            ],
+            'artifact id that is not base64' => [
+                ['type' => 'chunk', 'artifact_id' => '!!!not-base64!!!', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
+                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received string "!!!not-base64!!!".',
             ],
             'negative offset' => [
-                ['type' => 'chunk', 'artifact_id' => 'file.txt', 'offset' => -1, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
+                ['type' => 'chunk', 'artifact_id' => base64_encode('file.txt'), 'offset' => -1, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
                 'Expected staged push stream frame field "offset" to be a non-negative integer; received integer -1.',
             ],
             'string byte count' => [
-                ['type' => 'chunk', 'artifact_id' => 'file.txt', 'offset' => 0, 'bytes' => '1', 'total_bytes' => 1, 'final' => false],
+                ['type' => 'chunk', 'artifact_id' => base64_encode('file.txt'), 'offset' => 0, 'bytes' => '1', 'total_bytes' => 1, 'final' => false],
                 'Expected staged push stream frame field "bytes" to be a non-negative integer; received string "1".',
             ],
             'missing final flag' => [
-                ['type' => 'chunk', 'artifact_id' => 'file.txt', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1],
+                ['type' => 'chunk', 'artifact_id' => base64_encode('file.txt'), 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1],
                 'Missing staged push stream frame field "final".',
             ],
         ];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,10 @@ if (!class_exists('Site_Export_Staged_Artifacts', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-artifacts.php';
 }
 
+if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-push-stream-protocol.php';
+}
+
 if (!class_exists('Site_Export_Staged_Endpoints', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-endpoints.php';
 }


### PR DESCRIPTION
## What it does

This adds `StagedPushStreamClient`, the importer-side sender that pushes file chunks to the remote site.

With this PR, Reprint can move local file bytes into a remote site's staging area end to end:

* read files in bounded chunks (one chunk is all that ever sits in memory)
* stream them through requests sized to what the target host actually enforces (a per-host body budget learned from reported php.ini limits and 413s)
* rotate requests before host execution windows expire
* recover from crashes, stalls, store lock contention, wiped staging directories, and source files that changed mid-push.

Like on import, a resumed file that no longer matches its cursor restarts from zero instead of mixing versions. File names of any byte encoding round-trip (ids travel base64 end to end).

This PR **does not implement** the `reprint push` command, the confirmation step, and applying staged artifacts to the live tree are later stack slices.

Push requires PHP 8.1+ because that's when CURL_READFUNC_PAUSE support was introduced. That's what allows us to stream one file through a request body and then return to the loop and stream another file. Pull keeps its 7.4+ support.

Before this PR, the exporter's staged store was reachable only through a per-chunk `staged_upload` route — one HTTP request per chunk of each file, with no sender-side code at all. A real site is hundreds of thousands of chunks, so per-request overhead (TLS handshake, auth, PHP boot) dominates transfer time, and an interrupted push had no resume story beyond re-uploading. That route is removed: one streamed request carrying many frames amortizes the overhead, the server commits each frame as it arrives, and the cursor/restart semantics make interruption the normal case instead of a failure mode.

## Usage

```php
$client = new StagedPushStreamClient([
    'base_url'    => 'https://example.com/?reprint-api=1',
    'hmac_client' => new Site_Export_HMAC_Client($shared_secret),
]);

$journal_handle = fopen($state_dir . '/local-paths-to-push.jsonl', 'r');
$client->start_push_request();
while (($journal_line = fgets($journal_handle)) !== false) {
    $artifact_id = base64_decode(json_decode(trim($journal_line), true, 512, JSON_THROW_ON_ERROR)['path'], true);
    $source_handle = fopen($local_files_root . '/' . $artifact_id, 'rb');
    $source_stat = fstat($source_handle);
    $offset = 0;

    while (true) {
        if ($client->should_finish_request()) {   // body budget spent, or the request is old
            $result = $client->finish_request();
            // The size+ctime token makes a later resume restart this file if it changed.
            persist_cursor($result['cursor'] + ['total_bytes' => $source_stat['size'], 'source_ctime' => $source_stat['ctime']]);
            $client->start_push_request();
        }

        $payload = $source_stat['size'] === 0 ? '' : fread($source_handle, $client->next_chunk_body_bytes());
        $client->send_chunk([
            'artifact_id' => $artifact_id,
            'offset'      => $offset,
            'total_bytes' => $source_stat['size'],
            'final'       => $offset + strlen($payload) >= $source_stat['size'],
            'payload'     => $payload,
        ]);
        $offset += strlen($payload);
        if ($offset >= $source_stat['size']) {
            break;
        }
    }
    fclose($source_handle);
}
fclose($journal_handle);
$result = $client->finish_request();
```

`finish_request()` returns `{status, reason, detail, cursor, files_verified, chunks_sent, body_bytes_sent}`. `retry` means back off and run the pass again from the returned cursor; `failed` means stop and read `detail`. Resuming is this same loop started with a saved cursor: continue at `committed_bytes` while the persisted size and ctime still match the file on disk, restart the file at offset 0 when they don't. The complete loop — resume skim, restarts, retry backoff, lazy request open — is `StagedPushStreamClientTest::pushOnce()`.

## Testing instructions

```bash
cd tests && ../vendor/bin/phpunit StagedEndpointsTest.php StagedPushStreamProtocolTest.php StagedArtifactsTest.php Import/StagedPushStreamClientTest.php Import/PushRequestSizerTest.php Import/PushClientPhpCompatibilityTest.php --colors=never
composer analyze -- --memory-limit=1G
git diff --check
```

The client tests run against a local PHP server dispatching the real staged endpoint routes. Raw TCP listeners prove the wire-level claims (bytes arrive per `send_chunk()`, connections are reused, stalls fail while slow progress doesn't), and the seven drift-scenario tests were written first and fail against the pre-fix implementation.
