### PR TITLE
[Push] Introduce file chunk stream writer

### DIFF
--- a/packages/reprint-exporter/src/class-file-chunk-stream-writer.php
+++ b/packages/reprint-exporter/src/class-file-chunk-stream-writer.php
@@ -1,0 +1,159 @@
+<?php
+
+use function WordPress\Reprint\Exporter\json_encode_or_throw;
+
+/**
+ * Writes file-transfer chunks into the multipart stream used by file_fetch.
+ */
+final class Site_Export_File_Chunk_Stream_Writer
+{
+    private $stream;
+
+    private string $boundary;
+
+    public function __construct($stream, string $boundary)
+    {
+        $this->stream = $stream;
+        $this->boundary = $boundary;
+    }
+
+    public function write_progress(array $progress, string $cursor): void
+    {
+        $this->write_json_part('progress', $progress, [
+            'X-Cursor' => base64_encode($cursor),
+        ]);
+    }
+
+    public function write_metadata(?string $filesystem_root): void
+    {
+        $metadata = [
+            'filesystem_root' => base64_encode($filesystem_root ?? ''),
+        ];
+        $this->write_json_part('metadata', $metadata, [
+            'X-Filesystem-Root' => base64_encode($filesystem_root ?? ''),
+        ]);
+    }
+
+    public function write_directory(array $chunk, string $cursor): void
+    {
+        $headers = [
+            'X-Cursor' => base64_encode($cursor),
+            'X-Directory-Path' => base64_encode($chunk['path']),
+        ];
+        if (isset($chunk['ctime'])) {
+            $headers['X-Directory-Ctime'] = (string) $chunk['ctime'];
+        }
+        $this->write_empty_part('directory', $headers);
+    }
+
+    public function write_symlink(array $chunk, string $cursor): void
+    {
+        $this->write_empty_part('symlink', [
+            'X-Cursor' => base64_encode($cursor),
+            'X-Symlink-Path' => base64_encode($chunk['path']),
+            'X-Symlink-Target' => base64_encode($chunk['target']),
+            'X-Symlink-Ctime' => (string) $chunk['ctime'],
+        ]);
+    }
+
+    public function write_index(array $chunk, string $cursor): void
+    {
+        $this->write_empty_part('index', [
+            'X-Cursor' => base64_encode($cursor),
+            'X-Index-Path' => base64_encode($chunk['path']),
+            'X-File-Ctime' => (string) $chunk['ctime'],
+            'X-File-Size' => (string) $chunk['size'],
+        ]);
+    }
+
+    public function write_missing(array $chunk, string $cursor): void
+    {
+        $this->write_empty_part('missing', [
+            'X-Cursor' => base64_encode($cursor),
+            'X-File-Path' => base64_encode($chunk['path']),
+        ]);
+    }
+
+    public function write_error(array $payload, string $cursor): void
+    {
+        $this->write_json_part('error', $payload, [
+            'X-Cursor' => base64_encode($cursor),
+        ]);
+    }
+
+    public function write_file(array $chunk, string $cursor): void
+    {
+        $data = $chunk['data'];
+        $headers = [
+            'X-Cursor' => base64_encode($cursor),
+            'X-File-Path' => base64_encode($chunk['path']),
+            'X-File-Size' => (string) $chunk['size'],
+            'X-File-Ctime' => (string) $chunk['ctime'],
+            'X-Chunk-Offset' => (string) $chunk['offset'],
+            'X-Chunk-Size' => (string) strlen($data),
+            'X-First-Chunk' => $chunk['is_first_chunk'] ? '1' : '0',
+            'X-Last-Chunk' => $chunk['is_last_chunk'] ? '1' : '0',
+        ];
+        if (!empty($chunk['file_changed'])) {
+            $headers['X-File-Changed'] = '1';
+            if ($chunk['change_ctime'] !== null) {
+                $headers['X-File-Change-Ctime'] = (string) $chunk['change_ctime'];
+            }
+            if ($chunk['change_size'] !== null) {
+                $headers['X-File-Change-Size'] = (string) $chunk['change_size'];
+            }
+        }
+        $this->write_part('file', 'application/octet-stream', $headers, $data);
+    }
+
+    public function write_completion(array $stats): void
+    {
+        $this->write_empty_part('completion', [
+            'X-Status' => (string) $stats['status'],
+            'X-Chunks-Processed' => (string) $stats['chunks_processed'],
+            'X-Files-Completed' => (string) $stats['files_completed'],
+            'X-Bytes-Processed' => (string) $stats['bytes_processed'],
+            'X-Memory-Used' => (string) $stats['memory_used'],
+            'X-Memory-Limit' => (string) $stats['memory_limit'],
+            'X-Time-Elapsed' => (string) $stats['time_elapsed'],
+        ]);
+        $this->stream->write("--{$this->boundary}--\r\n");
+    }
+
+    private function write_json_part(string $chunk_type, array $payload, array $headers): void
+    {
+        $json = json_encode_or_throw($payload);
+        $this->write_part($chunk_type, 'application/json', $headers, $json);
+    }
+
+    private function write_empty_part(string $chunk_type, array $headers): void
+    {
+        $this->write_part($chunk_type, 'application/octet-stream', $headers, '');
+    }
+
+    private function write_part(string $chunk_type, string $content_type, array $headers, string $body): void
+    {
+        $this->stream->write(
+            "--{$this->boundary}\r\n" .
+            "Content-Type: {$content_type}\r\n" .
+            "Content-Length: " . strlen($body) . "\r\n" .
+            "X-Chunk-Type: {$chunk_type}\r\n" .
+            $this->format_headers($headers) .
+            "\r\n"
+        );
+        if ($body !== '') {
+            $this->stream->write($body);
+        }
+        $this->stream->write("\r\n");
+        $this->stream->sync();
+    }
+
+    private function format_headers(array $headers): string
+    {
+        $lines = '';
+        foreach ($headers as $name => $value) {
+            $lines .= $name . ': ' . $value . "\r\n";
+        }
+        return $lines;
+    }
+}

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -570,6 +570,7 @@ if (getenv('SITE_EXPORT_TEST_MODE')) {
 
 require_once __DIR__ . "/class-mysql-dump-producer.php";
 require_once __DIR__ . "/class-file-tree-producer.php";
+require_once __DIR__ . "/class-file-chunk-stream-writer.php";
 
 /**
  * Prepares the PHP environment for streaming by disabling output buffering,
@@ -2198,6 +2199,7 @@ function stream_file_producer(
     $aborted = false;
     $abort_payload = null;
     $last_cursor = "";
+    $writer = new Site_Export_File_Chunk_Stream_Writer($gz, $boundary);
 
     // -- Stream chunks from the producer --
     // The producer yields file data, directories, symlinks, index entries,
@@ -2206,19 +2208,9 @@ function stream_file_producer(
     // until the producer is exhausted or the resource budget runs out.
     try {
         $initial_progress = $producer->get_progress();
-        $initial_progress_json = json_encode_or_throw($initial_progress);
         $initial_cursor = $producer->get_reentrancy_cursor();
         $last_cursor = $initial_cursor;
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/json\r\n" .
-            "Content-Length: " . strlen($initial_progress_json) . "\r\n" .
-            "X-Chunk-Type: progress\r\n" .
-            "X-Cursor: " . base64_encode($initial_cursor) . "\r\n" .
-            "\r\n" .
-            $initial_progress_json . "\r\n",
-        );
-        $gz->sync();
+        $writer->write_progress($initial_progress, $initial_cursor);
         while (true) {
             if (
                 !$budget->has_remaining()
@@ -2236,21 +2228,7 @@ function stream_file_producer(
 
             if (!$metadata_sent && $progress["phase"] === "streaming") {
                 $filesystem_root = $producer->get_filesystem_root();
-                $metadata = [
-                    "filesystem_root" => base64_encode($filesystem_root ?? ""),
-                ];
-                $metadata_json = json_encode_or_throw($metadata);
-
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($metadata_json) . "\r\n" .
-                    "X-Chunk-Type: metadata\r\n" .
-                    "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
-                    "\r\n" .
-                    $metadata_json . "\r\n",
-                );
-                $gz->sync();
+                $writer->write_metadata($filesystem_root);
 
                 $metadata_sent = true;
             }
@@ -2258,20 +2236,10 @@ function stream_file_producer(
             if ($chunk === null) {
                 $now = microtime(true);
                 if ($iterations === 1 || $now - $last_progress_output >= 3.0) {
-                    $progress_json = json_encode_or_throw($progress);
                     $cursor = $producer->get_reentrancy_cursor();
                     $last_cursor = $cursor;
 
-                    $gz->write(
-                        "--{$boundary}\r\n" .
-                        "Content-Type: application/json\r\n" .
-                        "Content-Length: " . strlen($progress_json) . "\r\n" .
-                        "X-Chunk-Type: progress\r\n" .
-                        "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                        "\r\n" .
-                        $progress_json . "\r\n",
-                    );
-                    $gz->sync();
+                    $writer->write_progress($progress, $cursor);
 
                     $last_progress_output = $now;
                 }
@@ -2284,55 +2252,13 @@ function stream_file_producer(
             $last_cursor = $cursor;
 
             if ($chunk_type === "directory") {
-                $part =
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: directory\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-Directory-Path: " . base64_encode($chunk["path"]) . "\r\n";
-                if (isset($chunk["ctime"])) {
-                    $part .= "X-Directory-Ctime: " . $chunk["ctime"] . "\r\n";
-                }
-                $gz->write($part . "\r\n\r\n");
-                $gz->sync();
+                $writer->write_directory($chunk, $cursor);
             } elseif ($chunk_type === "symlink") {
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: symlink\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-Symlink-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "X-Symlink-Target: " . base64_encode($chunk["target"]) . "\r\n" .
-                    "X-Symlink-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "\r\n\r\n",
-                );
-                $gz->sync();
+                $writer->write_symlink($chunk, $cursor);
             } elseif ($chunk_type === "index") {
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: index\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-Index-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "X-File-Size: " . $chunk["size"] . "\r\n" .
-                    "\r\n\r\n",
-                );
-                $gz->sync();
+                $writer->write_index($chunk, $cursor);
             } elseif ($chunk_type === "missing") {
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: missing\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "\r\n\r\n",
-                );
-                $gz->sync();
+                $writer->write_missing($chunk, $cursor);
             } elseif ($chunk_type === "error") {
                 $payload = [
                     "error_type" => $chunk["error_type"] ?? "unknown",
@@ -2345,17 +2271,7 @@ function stream_file_producer(
                 if (isset($chunk["actual_ctime"])) {
                     $payload["actual_ctime"] = $chunk["actual_ctime"];
                 }
-                $json = json_encode_or_throw($payload);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n",
-                );
-                $gz->sync();
+                $writer->write_error($payload, $cursor);
             } else {
                 // E2E test hook: before file chunk is emitted
                 if (getenv('SITE_EXPORT_TEST_MODE')) {
@@ -2371,34 +2287,7 @@ function stream_file_producer(
                     $files_completed++;
                 }
 
-                $data = $chunk["data"];
-
-                $headers =
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: " . strlen($data) . "\r\n" .
-                    "X-Chunk-Type: file\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "X-File-Size: " . $chunk["size"] . "\r\n" .
-                    "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "X-Chunk-Offset: " . $chunk["offset"] . "\r\n" .
-                    "X-Chunk-Size: " . strlen($data) . "\r\n" .
-                    "X-First-Chunk: " . ($chunk["is_first_chunk"] ? "1" : "0") . "\r\n" .
-                    "X-Last-Chunk: " . ($chunk["is_last_chunk"] ? "1" : "0") . "\r\n";
-                if (!empty($chunk["file_changed"])) {
-                    $headers .= "X-File-Changed: 1\r\n";
-                    if ($chunk["change_ctime"] !== null) {
-                        $headers .= "X-File-Change-Ctime: " . $chunk["change_ctime"] . "\r\n";
-                    }
-                    if ($chunk["change_size"] !== null) {
-                        $headers .= "X-File-Change-Size: " . $chunk["change_size"] . "\r\n";
-                    }
-                }
-                $gz->write($headers . "\r\n");
-                $gz->write($data);
-                $gz->write("\r\n");
-                $gz->sync();
+                $writer->write_file($chunk, $cursor);
             }
         }
     } catch (Throwable $e) {
@@ -2418,17 +2307,7 @@ function stream_file_producer(
         //        chunk as data. We should try and backfill the output up to the
         //        previous content-length value if possible.
         if ($abort_payload !== null) {
-            $json = json_encode_or_throw($abort_payload);
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/json\r\n" .
-                "Content-Length: " . strlen($json) . "\r\n" .
-                "X-Chunk-Type: error\r\n" .
-                "X-Cursor: " . base64_encode($last_cursor) . "\r\n" .
-                "\r\n" .
-                $json . "\r\n",
-            );
-            $gz->sync();
+            $writer->write_error($abort_payload, $last_cursor);
         }
 
         $progress = $producer->get_progress();
@@ -2446,22 +2325,15 @@ function stream_file_producer(
                 "chunks={$chunks_processed}, files={$files_completed}, bytes={$bytes_processed}",
         );
 
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/octet-stream\r\n" .
-            "Content-Length: 0\r\n" .
-            "X-Chunk-Type: completion\r\n" .
-            "X-Status: {$status}\r\n" .
-            "X-Chunks-Processed: {$chunks_processed}\r\n" .
-            "X-Files-Completed: {$files_completed}\r\n" .
-            "X-Bytes-Processed: {$bytes_processed}\r\n" .
-            "X-Memory-Used: " . memory_get_peak_usage(true) . "\r\n" .
-            "X-Memory-Limit: " . $budget->max_memory . "\r\n" .
-            "X-Time-Elapsed: " . (microtime(true) - $budget->start_time) . "\r\n" .
-            "\r\n" .
-            "\r\n" .
-            "--{$boundary}--\r\n",
-        );
+        $writer->write_completion([
+            "status" => $status,
+            "chunks_processed" => $chunks_processed,
+            "files_completed" => $files_completed,
+            "bytes_processed" => $bytes_processed,
+            "memory_used" => memory_get_peak_usage(true),
+            "memory_limit" => $budget->max_memory,
+            "time_elapsed" => microtime(true) - $budget->start_time,
+        ]);
         $gz->finish();
     } catch (\Throwable $e) {
         error_log("Export: failed to write completion chunk: " . $e->getMessage());

--- a/tests/FileChunkStreamWriterTest.php
+++ b/tests/FileChunkStreamWriterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-exporter/src/utils.php';
+require_once __DIR__ . '/../packages/reprint-exporter/src/class-file-chunk-stream-writer.php';
+
+final class FileChunkStreamWriterTest extends TestCase
+{
+    public function testWritesFilePartWithMultipartHeaders(): void
+    {
+        $stream = new TestFileChunkOutputStream();
+        $writer = new Site_Export_File_Chunk_Stream_Writer($stream, 'boundary');
+
+        $writer->write_file([
+            'data' => 'hello',
+            'path' => 'wp-content/uploads/a.txt',
+            'size' => 12,
+            'ctime' => 123,
+            'offset' => 7,
+            'is_first_chunk' => false,
+            'is_last_chunk' => true,
+        ], 'cursor-value');
+
+        $this->assertSame(
+            "--boundary\r\n" .
+            "Content-Type: application/octet-stream\r\n" .
+            "Content-Length: 5\r\n" .
+            "X-Chunk-Type: file\r\n" .
+            "X-Cursor: " . base64_encode('cursor-value') . "\r\n" .
+            "X-File-Path: " . base64_encode('wp-content/uploads/a.txt') . "\r\n" .
+            "X-File-Size: 12\r\n" .
+            "X-File-Ctime: 123\r\n" .
+            "X-Chunk-Offset: 7\r\n" .
+            "X-Chunk-Size: 5\r\n" .
+            "X-First-Chunk: 0\r\n" .
+            "X-Last-Chunk: 1\r\n" .
+            "\r\n" .
+            "hello\r\n",
+            $stream->body
+        );
+        $this->assertSame(1, $stream->syncs);
+    }
+}
+
+final class TestFileChunkOutputStream
+{
+    public string $body = '';
+
+    public int $syncs = 0;
+
+    public function write(string $body): void
+    {
+        $this->body .= $body;
+    }
+
+    public function sync(): void
+    {
+        $this->syncs++;
+    }
+}


### PR DESCRIPTION
## What it does

File fetch responses now write multipart transfer chunks through a named stream writer, which keeps the export loop focused on producer progress instead of constructing each part inline.

## Rationale

The export response and staged push request both describe the same transfer concepts: metadata, file chunks, directory and symlink entries, missing paths, progress, errors, and completion. Giving that serialization one writer makes the current export path easier to read and gives the next stacked PR an API it can use for push request bodies.

## Implementation

`Site_Export_File_Chunk_Stream_Writer` owns multipart headers, body writes, and final boundary emission. `stream_file_producer()` still owns iteration, budget checks, counters, cursor advancement, and test hooks.

## Testing instructions

Run:

```bash
composer analyze -- --memory-limit=1G
cd tests && ../vendor/bin/phpunit FileChunkStreamWriterTest.php FileSyncProducer --colors=never
```
