### PR TITLE
Add --follow-symlinks=DIR, consolidating out-of-scope symlinks

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1090,6 +1090,18 @@ class ImportClient
     private $follow_symlinks = true;
 
     /**
+     * @var string|null Destination directory for escaping (out-of-scope) symlink targets,
+     * nested by the source path. null keeps the default: each symlink target is
+     * mirrored at its own source path underneath --fs-root.
+     *
+     * Usage: --follow-symlinks=<dir>
+     */
+    private $symlink_bundle_directory = null;
+
+    /** @var array|null Cached result of get_export_directories(). */
+    private $export_directories_cache = null;
+
+    /**
      * @var bool When true, ask the server to ship the default-skipped
      * generated content (wp-content/cache, .git, node_modules, etc.).
      *
@@ -1642,6 +1654,13 @@ class ImportClient
             $this->save_state($this->state);
         } elseif (isset($this->import_state()->follow_symlinks)) {
             $this->follow_symlinks = $this->import_state()->follow_symlinks;
+        }
+
+        if (isset($options["symlink_bundle_directory"])) {
+            $this->symlink_bundle_directory = $this->resolve_symlink_bundle_directory($options["symlink_bundle_directory"]);
+            $this->follow_symlinks = true;
+            $this->import_state()->follow_symlinks = true;
+            $this->save_state($this->state);
         }
 
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
@@ -2694,6 +2713,7 @@ class ImportClient
 
         $this->recover_index_updates();
         $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
+        $this->assert_symlink_bundle_directory_unchanged();
 
         // Already completed.
         if ($current_status === "complete") {
@@ -3237,7 +3257,10 @@ class ImportClient
      */
     private function discover_symlink_targets(): void
     {
-        $roots = $this->get_root_directories_from_preflight();
+        // Seed "already covered" from the dirs actually enumerated this run (the
+        // --only prefixes when scoped), not the full preflight roots — otherwise a
+        // narrow --only skips a target under a root but outside its scope.
+        $roots = $this->get_export_directories();
 
         // Collect all indexed directory real paths for containment checks
         $visited = [];
@@ -3492,6 +3515,11 @@ class ImportClient
                 );
                 continue;
             }
+
+            // Repoint through the same seam regular symlink chunks use, so the
+            // link targets wherever the content actually landed (fs-root,
+            // remapped, or bundled) instead of the raw source spelling.
+            $target = $this->map_symlink_target_for_local_mirror($path, $local_path, $target);
 
             // Already correct — skip
             if (is_link($local_path) && readlink($local_path) === $target) {
@@ -8317,7 +8345,11 @@ class ImportClient
     }
 
     /**
-     * Map an absolute remote symlink target to the local fs-root mirror when possible.
+     * Map a remote symlink target to the local fs-root mirror when possible.
+     *
+     * Handles both absolute and relative targets (relative ones are resolved
+     * against the symlink's source directory). In-scope and non-followed targets
+     * keep their original spelling.
      *
      * Example:
      *
@@ -8346,33 +8378,29 @@ class ImportClient
      * With this mapping, the symlink is rewritten to a relative path that resolves to the
      * mirrored local copy under fs-root.
      */
-    private function map_absolute_symlink_target_for_local_mirror(
+    private function map_symlink_target_for_local_mirror(
         string $path,
         string $local_path,
         string $target
     ): string {
-        if (!str_starts_with($target, "/")) {
-            return $target;
-        }
+        // Resolve to an absolute source path (relative targets against the
+        // symlink's source dir) so both spellings are handled the same way.
+        $source_target = str_starts_with($target, "/")
+            ? normalize_path($target)
+            : normalize_path(dirname($path) . "/" . $target);
 
-        $root = $this->get_filesystem_root_path();
-        $normalized_target = normalize_path($target);
-
-        // Already points inside fs-root, keep as-is.
-        if (path_is_within_root($normalized_target, $root)) {
-            return $target;
-        }
-
-        // Only rewrite when symlink-following is enabled and the target path
-        // was actually indexed from the source.
+        // Only rewrite a target whose subtree was actually followed and indexed;
+        // everything else keeps its original (portable) spelling.
         if (
             !$this->follow_symlinks ||
-            !$this->remote_index_contains_path_prefix($normalized_target)
+            !$this->remote_index_contains_path_prefix($source_target)
         ) {
             return $target;
         }
 
-        $mapped_absolute = $root . $normalized_target;
+        // Repoint to wherever the target's content is actually placed,
+        // the same seam file chunks use, so that the link never dangles.
+        $mapped_absolute = $this->remote_path_to_local_path_within_import_root($source_target);
         $mapped_relative = self::compute_relative_path(
             dirname($local_path),
             $mapped_absolute
@@ -8549,6 +8577,62 @@ class ImportClient
             "sha256",
             json_encode($this->pull_only_files_with_path_prefixes, JSON_UNESCAPED_SLASHES),
         );
+    }
+
+    /**
+     * Refuse to run files-pull after the --follow-symlinks bundle directory
+     * changed. Placement of followed content is bound to it, so changing it
+     * mid-state would split content across two layouts. Recorded on the first
+     * run, compared on every run after; --abort resets it.
+     */
+    private function assert_symlink_bundle_directory_unchanged(): void
+    {
+        $fingerprint = $this->symlink_bundle_directory_fingerprint();
+        $previous = $this->import_state()->symlink_bundle_directory_fingerprint ?? null;
+
+        if ($previous !== null && $previous !== $fingerprint) {
+            throw new RuntimeException(
+                "Cannot change the --follow-symlinks bundle directory for an existing files-pull. " .
+                    "Use the original value, or use --abort to start a new files-pull.",
+            );
+        }
+
+        if ($previous === null) {
+            $this->import_state()->symlink_bundle_directory_fingerprint = $fingerprint;
+            $this->save_state($this->state);
+        }
+    }
+
+    /**
+     * Fingerprint of the effective bundle placement root. No bundle directory
+     * (and bare --follow-symlinks) fingerprints as fs-root, which is the
+     * equivalent placement — so switching between those spellings is allowed.
+     */
+    private function symlink_bundle_directory_fingerprint(): string
+    {
+        $effective = $this->symlink_bundle_directory ?? rtrim($this->get_filesystem_root_path(), "/");
+        return hash("sha256", $effective);
+    }
+
+    /**
+     * Resolve the --follow-symlinks=<dir> bundle destination.
+     *
+     * Uses the same target grammar as --remap targets: a :fs-root: path or a raw
+     * absolute path, which must resolve within --fs-root.
+     */
+    private function resolve_symlink_bundle_directory(string $raw): string
+    {
+        $fs_root = rtrim($this->get_filesystem_root_path(), "/");
+        $directory = $this->resolve_token_path($raw, ["fs-root" => $fs_root]);
+
+        if (!path_is_within_root($directory, $fs_root)) {
+            throw new InvalidArgumentException(
+                "--follow-symlinks bundle directory \"{$directory}\" resolves outside --fs-root ({$fs_root}); " .
+                    "it must stay within the destination root",
+            );
+        }
+
+        return $directory;
     }
 
     /**
@@ -8843,6 +8927,13 @@ class ImportClient
                 return $target;
             }
         }
+
+        // A followed target outside the original export scope goes underneath the bundle directory.
+        if ($this->symlink_bundle_directory !== null
+            && !$this->path_is_within_original_export_scope($path)) {
+            return $this->symlink_bundle_directory . $path;
+        }
+
         return $this->get_filesystem_root_path() . $path;
     }
 
@@ -9401,7 +9492,7 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
-        $target_for_local = $this->map_absolute_symlink_target_for_local_mirror(
+        $target_for_local = $this->map_symlink_target_for_local_mirror(
             $path,
             $local_path,
             $target,
@@ -9658,6 +9749,22 @@ class ImportClient
     }
 
     /**
+     * Whether $path falls under one of the ORIGINAL export directories (the
+     * --only prefixes, or the base roots without --only) — i.e. it was going to
+     * be pulled anyway. Evaluated against the pre-follow scope; a followed
+     * target outside all of these is "escaping" and eligible for symlink bundling.
+     */
+    private function path_is_within_original_export_scope(string $path): bool
+    {
+        foreach ($this->get_export_directories() as $root) {
+            if (path_is_within_root($path, $root)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Build the list of directories the server should traverse.
      *
      * Starts from the wp_detect roots (ABSPATH, etc.) and adds
@@ -9669,16 +9776,24 @@ class ImportClient
      */
     private function get_export_directories(): array
     {
+        // Memoized: The inputs (pull_only, remap, preflight) are all set before
+        // the first caller and never change mid-run, so cache on first use.
+        if ($this->export_directories_cache !== null) {
+            return $this->export_directories_cache;
+        }
+
         // With --only, files-pull should enumerate only the selected source path
         // prefixes. Do not add the default roots, remap sources, document root, or
         // auto-prepend/append directories below.
         if (!empty($this->pull_only_files_with_path_prefixes)) {
-            return $this->pull_only_files_with_path_prefixes;
+            $this->export_directories_cache = $this->pull_only_files_with_path_prefixes;
+            return $this->export_directories_cache;
         }
 
         $dirs = $this->get_root_directories_from_preflight();
         if (empty($dirs)) {
-            return [];
+            $this->export_directories_cache = [];
+            return $this->export_directories_cache;
         }
 
         $preflight = $this->import_state()->preflight["data"] ?? [];
@@ -9740,7 +9855,8 @@ class ImportClient
             }
         }
 
-        return $dirs;
+        $this->export_directories_cache = $dirs;
+        return $this->export_directories_cache;
     }
 
     /**
@@ -10827,6 +10943,7 @@ class ImportClient
             "version" => null,
             "webhost" => null,
             "follow_symlinks" => true,
+            "symlink_bundle_directory_fingerprint" => null,
             "fs_root_nonempty_behavior" => "error",
             "filter" => "none",
             "user_agent" => null,
@@ -11688,6 +11805,16 @@ if (
             'flag_value' => true,
             'help' => null,
             'commands' => [],
+        ],
+        [
+            'name' => 'follow-symlinks',
+            'type' => 'value',
+            'target' => 'symlink_bundle_directory',
+            'placeholder' => 'DIR',
+            'help' => 'Follow symlinks, consolidating escaping (out-of-scope) targets into DIR ' .
+                '(a :fs-root: path or an absolute path within --fs-root), nested by source path. ' .
+                'Bare --follow-symlinks is equivalent to --follow-symlinks=:fs-root:.',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
         [
             'name' => 'on-fs-root-nonempty',

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8928,7 +8928,8 @@ class ImportClient
             }
         }
 
-        // A followed target outside the original export scope goes underneath the bundle directory.
+        // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
+        // Use the same bundle mapping for copied content and rewritten symlink targets so the links do not dangle.
         if ($this->symlink_bundle_directory !== null
             && !$this->path_is_within_original_export_scope($path)) {
             return $this->symlink_bundle_directory . $path;

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -346,6 +346,8 @@ class ImportState
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
     public bool $follow_symlinks = true;
+    /** @var string|null Fingerprint of the --follow-symlinks bundle directory; guards resume. */
+    public ?string $symlink_bundle_directory_fingerprint = null;
     public string $fs_root_nonempty_behavior = 'error';
     public string $filter = 'none';
     /** @var string|null User-Agent that worked during preflight. */
@@ -398,6 +400,7 @@ class ImportState
         $state->version = isset($data['version']) ? (string) $data['version'] : null;
         $state->webhost = isset($data['webhost']) ? (string) $data['webhost'] : null;
         $state->follow_symlinks = (bool) ($data['follow_symlinks'] ?? true);
+        $state->symlink_bundle_directory_fingerprint = isset($data['symlink_bundle_directory_fingerprint']) ? (string) $data['symlink_bundle_directory_fingerprint'] : null;
         $state->fs_root_nonempty_behavior = isset($data['fs_root_nonempty_behavior']) ? (string) $data['fs_root_nonempty_behavior'] : 'error';
         $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
         $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
@@ -436,6 +439,7 @@ class ImportState
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
+            'symlink_bundle_directory_fingerprint' => $this->symlink_bundle_directory_fingerprint,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,

--- a/tests/Import/SymlinkBundleTest.php
+++ b/tests/Import/SymlinkBundleTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * --follow-symlinks=<directory> ("symlink bundle") mode: resolving the bundle
+ * destination, classifying escaping vs in-scope paths, and routing placement.
+ */
+class SymlinkBundleTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+    private $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/symlink-bundle-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/srv/htdocs';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+        $this->root = realpath($this->fsRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rrm($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function rrm(string $d): void
+    {
+        if (!is_dir($d)) {
+            return;
+        }
+        foreach (scandir($d) as $i) {
+            if ($i === '.' || $i === '..') {
+                continue;
+            }
+            $p = "$d/$i";
+            (is_dir($p) && !is_link($p)) ? $this->rrm($p) : unlink($p);
+        }
+        rmdir($d);
+    }
+
+    private function newClient(): \ImportClient
+    {
+        return new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    // ── Resolving the bundle destination (:fs-root: grammar, within-root) ──
+
+    private function resolve(string $raw): string
+    {
+        $c = $this->newClient();
+        return (new \ReflectionClass($c))->getMethod('resolve_symlink_bundle_directory')->invoke($c, $raw);
+    }
+
+    public function testFsRootTokenResolvesUnderRoot(): void
+    {
+        $this->assertSame($this->root . '/.symlinks-bundle', $this->resolve(':fs-root:/.symlinks-bundle'));
+    }
+
+    public function testRawAbsoluteWithinRootIsKept(): void
+    {
+        $this->assertSame($this->root . '/.symlinks-bundle', $this->resolve($this->root . '/.symlinks-bundle'));
+    }
+
+    public function testFsRootItselfIsAccepted(): void
+    {
+        // --follow-symlinks=:fs-root: is the identity case (fs-root itself), not an error.
+        $this->assertSame($this->root, $this->resolve(':fs-root:'));
+    }
+
+    public function testOutsideFsRootIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->resolve('/etc/reprint-bundle');
+    }
+
+    public function testRelativeIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->resolve('.symlinks-bundle');
+    }
+
+    // ── "Escaping" classification against the original export scope ──
+
+    private function inScope(array $onlyPrefixes, string $path): bool
+    {
+        $c = $this->newClient();
+        $rc = new \ReflectionClass($c);
+        $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $onlyPrefixes);
+        return $rc->getMethod('path_is_within_original_export_scope')->invoke($c, $path);
+    }
+
+    public function testTargetUnderScopeIsInScope(): void
+    {
+        $this->assertTrue($this->inScope(['/srv/site/wp-content'], '/srv/site/wp-content/plugins/foo'));
+    }
+
+    public function testTargetOutsideScopeEscapes(): void
+    {
+        $this->assertFalse($this->inScope(['/srv/site/wp-content'], '/home/master/shared/foo'));
+    }
+
+    // ── Placement routing (bundle vs default vs remap) ──
+
+    /**
+     * @param string|null $bundleSub Bundle dir as a suffix under fs-root (null = no bundle).
+     * @param array<int,string> $scopePrefixes Original export scope (--only prefixes).
+     * @param array<string,string> $remapRules source => absolute target.
+     */
+    private function placeClient(?string $bundleSub, array $scopePrefixes, array $remapRules = []): \ImportClient
+    {
+        $c = $this->newClient();
+        $rc = new \ReflectionClass($c);
+        $rc->getProperty('symlink_bundle_directory')->setValue($c, $bundleSub === null ? null : $this->root . $bundleSub);
+        $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $scopePrefixes);
+        $rc->getProperty('remap_rules')->setValue($c, $remapRules);
+        return $c;
+    }
+
+    private function place(\ImportClient $c, string $path): string
+    {
+        return (new \ReflectionClass($c))->getMethod('remote_path_to_local_path_within_import_root')->invoke($c, $path);
+    }
+
+    public function testEscapingTargetRoutesIntoBundle(): void
+    {
+        $c = $this->placeClient('/.symlinks-bundle', ['/var/www/html']);
+        $this->assertSame(
+            $this->root . '/.symlinks-bundle/tmp/shared/foo/style.css',
+            $this->place($c, '/tmp/shared/foo/style.css')
+        );
+    }
+
+    public function testInScopePathNotBundled(): void
+    {
+        $c = $this->placeClient('/.symlinks-bundle', ['/var/www/html']);
+        $this->assertSame(
+            $this->root . '/var/www/html/index.php',
+            $this->place($c, '/var/www/html/index.php')
+        );
+    }
+
+    public function testDefaultPlacementWhenNoBundleDirectory(): void
+    {
+        $c = $this->placeClient(null, []);
+        $this->assertSame(
+            $this->root . '/tmp/shared/foo/style.css',
+            $this->place($c, '/tmp/shared/foo/style.css')
+        );
+    }
+
+    // Regression: an escaping root (/shared) that is an ANCESTOR of the scope
+    // (/shared/wp-content) must not bundle the in-scope subtree.
+    public function testAncestorEscapingRootLeavesInScopeContentInPlace(): void
+    {
+        $c = $this->placeClient('/.symlinks-bundle', ['/shared/wp-content']);
+        $this->assertSame(
+            $this->root . '/shared/wp-content/plugins/foo.php',
+            $this->place($c, '/shared/wp-content/plugins/foo.php'),
+            'in-scope content must not be pulled into the bundle'
+        );
+        $this->assertSame(
+            $this->root . '/.symlinks-bundle/shared/other/bar.php',
+            $this->place($c, '/shared/other/bar.php'),
+            'genuinely escaping content is still bundled'
+        );
+    }
+
+    // Regression: an explicit --remap rule wins over bundling, so file placement
+    // and the symlink repoint (which share this seam) agree — no dangling link.
+    public function testRemapWinsOverBundle(): void
+    {
+        $c = $this->placeClient('/.symlinks-bundle', ['/var/www/html'], ['/escaped' => $this->root . '/x']);
+        $this->assertSame(
+            $this->root . '/x/foo',
+            $this->place($c, '/escaped/foo'),
+            'remap target wins; the path is not diverted into the bundle'
+        );
+    }
+
+    // ── Bundle-directory fingerprint guard ──
+
+    private function assertGuard(\ImportClient $c, ?string $bundleDir, ?string $persistedFingerprint): void
+    {
+        $rc = new \ReflectionClass($c);
+        $rc->getProperty('symlink_bundle_directory')->setValue($c, $bundleDir);
+        $rc->getProperty('state')->getValue($c)->symlink_bundle_directory_fingerprint = $persistedFingerprint;
+        $rc->getMethod('assert_symlink_bundle_directory_unchanged')->invoke($c);
+    }
+
+    public function testGuardRejectsChangedBundleDirectory(): void
+    {
+        $c = $this->newClient();
+        $this->expectException(\RuntimeException::class);
+        $this->assertGuard($c, $this->root . '/.bundle-a', hash('sha256', $this->root . '/.bundle-b'));
+    }
+
+    public function testGuardAllowsUnchangedBundleDirectory(): void
+    {
+        $c = $this->newClient();
+        $this->assertGuard($c, $this->root . '/.bundle-a', hash('sha256', $this->root . '/.bundle-a'));
+        $this->addToAssertionCount(1); // no exception == pass
+    }
+
+    public function testGuardRejectsDroppingTheBundleDirectory(): void
+    {
+        // A flag-less run after a bundled pull must error, not silently revert
+        // to default placement.
+        $c = $this->newClient();
+        $this->expectException(\RuntimeException::class);
+        $this->assertGuard($c, null, hash('sha256', $this->root . '/.bundle-a'));
+    }
+
+    public function testGuardTreatsBareFollowAndFsRootAsEquivalent(): void
+    {
+        // Bare --follow-symlinks (no bundle dir) and --follow-symlinks=:fs-root:
+        // fingerprint identically — both place at fs-root.
+        $c = $this->newClient();
+        $this->assertGuard($c, null, hash('sha256', $this->root));
+        $this->assertGuard($c, $this->root, hash('sha256', $this->root));
+        $this->addToAssertionCount(1); // no exception == pass
+    }
+
+    // ── Repoint routes via remap even when the target is spelled within fs-root ──
+    // Overlap case: source docroot == target --fs-root, so an absolute symlink
+    // target falls inside fs-root; a non-identity --remap relocates its content.
+    // The repoint must follow the content to the remapped location, not keep the
+    // verbatim within-fs-root path (which would dangle).
+    public function testWithinFsRootTargetRepointsToRemappedLocation(): void
+    {
+        $c = $this->newClient();
+        $rc = new \ReflectionClass($c);
+        $rc->getProperty('remap_rules')->setValue($c, [$this->root . '/wp-content' => $this->root . '/custom']);
+        $rc->getProperty('follow_symlinks')->setValue($c, true);
+        $target = $this->root . '/wp-content/themes/x'; // realpath-clean, so it is its own cache key
+        // Pretend the target subtree was followed + indexed.
+        $rc->getProperty('remote_index_prefix_cache')->setValue($c, [$target => true]);
+
+        $result = $rc->getMethod('map_symlink_target_for_local_mirror')->invoke(
+            $c,
+            '/src/wp-content/plugins/p/link',            // source symlink path
+            $this->root . '/wp-content/plugins/p/link',  // local path
+            $target                                       // absolute, inside fs-root
+        );
+
+        $this->assertNotSame($target, $result, 'must not keep the verbatim within-fs-root target');
+        $this->assertStringStartsWith('..', $result, 'repoint is a relative path climbing out of plugins/p');
+        $this->assertStringContainsString('custom/themes/x', $result,
+            'repoint follows the content to the remapped custom/ location, not the pre-remap wp-content');
+    }
+
+    // ── Intermediate symlinks are repointed through the placement seam ──
+
+    public function testIntermediateSymlinkRepointsIntoBundle(): void
+    {
+        // In-scope intermediate link whose relative target resolves to an
+        // escaping (bundled) location: the raw target would dangle at
+        // fs-root/opt/data; it must be repointed to the bundle placement.
+        $c = $this->newClient();
+        $rc = new \ReflectionClass($c);
+        $rc->getProperty('symlink_bundle_directory')->setValue($c, $this->root . '/.symlinks-bundle');
+        $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, ['/src/wp-content']);
+        $rc->getProperty('follow_symlinks')->setValue($c, true);
+        $rc->getProperty('remote_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
+
+        $entry = json_encode([
+            'path' => base64_encode('/src/wp-content/data'),
+            'target' => base64_encode('../../../opt/data'),
+            'type' => 'link',
+            'intermediate' => true,
+        ]);
+        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', $entry . "\n");
+
+        $rc->getMethod('recreate_intermediate_symlinks')->invoke($c);
+
+        $link = $this->root . '/src/wp-content/data';
+        $this->assertTrue(is_link($link), 'intermediate link is created');
+        $this->assertStringContainsString('.symlinks-bundle/opt/data', readlink($link),
+            'target is repointed to the bundled placement, not the raw source spelling');
+    }
+}

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -130,6 +130,9 @@
     },
     "edit-locks": {
       "port": 8122
+    },
+    "symlink-bundle": {
+      "port": 8123
     }
   }
 }

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -284,12 +284,19 @@ describe('Import: Follow Symlinks', () => {
 
     // ─── Intermediate symlinks ─────────────────────────────────
 
-    it('intermediate symlink /srv/e2e-via is blocked when target escapes root', () => {
+    it('intermediate symlink /srv/e2e-via is recreated pointing at the local mirror', () => {
+        // Its target (/srv/e2e-external) was followed and mirrored locally, so
+        // the link is repointed within fs-root — same treatment as regular
+        // symlink chunks. Unindexed escaping targets are still blocked.
         const viaPath = join(fsRoot(), '/srv/e2e-via');
         const stat = lstatIfExists(viaPath);
         assert.ok(
-            stat === null || !stat.isSymbolicLink(),
-            `Expected intermediate symlink to be blocked at ${viaPath}`,
+            stat !== null && stat.isSymbolicLink(),
+            `Expected intermediate symlink at ${viaPath}`,
+        );
+        assert.ok(
+            existsSync(join(viaPath, 'dir-target', 'alpha.txt')),
+            'via-link resolves to the mirrored external content',
         );
     });
 

--- a/tests/e2e/tests/import-52-symlink-bundle.test.js
+++ b/tests/e2e/tests/import-52-symlink-bundle.test.js
@@ -1,0 +1,187 @@
+/**
+ * Test 52: symlink bundle — --follow-symlinks=<dir> bundles escaping targets (ARC-1814).
+ *
+ * Covers the {in-scope, escaping} x {relative, absolute} matrix of directory
+ * symlinks under --only + --remap: escaping targets are consolidated into the
+ * bundle (nested by source path, deduped), in-scope targets are left in place.
+ * (Escaping *file* symlinks are a known limitation — not covered here.)
+ *
+ * Run: files-sync --only :wp-content: --remap :wp-content: :fs-root:/wp-content
+ *                 --follow-symlinks=:fs-root:/.symlinks-bundle
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join, relative } from 'node:path';
+import {
+    createTempDir, cleanupTempDir, fsRootDir,
+    getSiteDir, getSiteSecret, getSiteUrl, runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const SHARED_ROOT = '/tmp/e2e-symlink-bundle';
+const SHARED_DIR = join(SHARED_ROOT, 'pub', 'indice');
+const BUNDLED_STYLE = join('.symlinks-bundle', SHARED_ROOT, 'pub', 'indice', 'style.css');
+
+describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping targets', () => {
+    const site = 'symlink-bundle';
+    let tempDir;
+    let tempDir2;
+
+    function prepareSharedTree() {
+        rmSync(SHARED_ROOT, { recursive: true, force: true });
+        mkdirSync(SHARED_DIR, { recursive: true });
+        writeFileSync(join(SHARED_DIR, 'style.css'), '/* Shared indice theme */\n');
+        writeFileSync(join(SHARED_DIR, 'index.php'), '<?php // shared indice theme\n');
+    }
+
+    beforeAll(async () => {
+        execSync(`sudo rm -rf "${getSiteDir(site)}"`, { timeout: 30000 });
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                prepareSharedTree();
+                const themes = join(siteDir, 'wp-content', 'themes');
+                mkdirSync(join(themes, 'indice-real'), { recursive: true });
+                writeFileSync(join(themes, 'indice-real', 'style.css'), '/* in-scope local theme */\n');
+                // The 2x2 matrix of {in-scope, escaping} x {relative, absolute}:
+                for (const [name, target] of [
+                    // escaping (target outside wp-content) — needs bundling
+                    ['indice', SHARED_DIR],                              // escaping, absolute
+                    ['indice2', SHARED_DIR],                             // escaping, absolute (dedup)
+                    ['esc-rel', relative(themes, SHARED_DIR)],           // escaping, relative
+                    // in-scope (target inside wp-content) — must NOT be bundled
+                    ['local', './indice-real'],                         // in-scope, relative
+                    ['abs-local', join(themes, 'indice-real')],         // in-scope, absolute
+                ]) {
+                    const p = join(themes, name);
+                    rmSync(p, { recursive: true, force: true });
+                    symlinkSync(target, p);
+                }
+                // A plugin that symlinks into themes — for the narrow `--only
+                // :wp-content:/plugins` run, themes/indice-real is OUTSIDE the
+                // --only scope but INSIDE the remapped wp-content, so remap (checked
+                // before bundle) should place it at wp-content/themes, not the bundle.
+                const plugin = join(siteDir, 'wp-content', 'plugins', 'cross-plugin');
+                mkdirSync(plugin, { recursive: true });
+                writeFileSync(join(plugin, 'cross-plugin.php'), '<?php // cross plugin\n');
+                symlinkSync('../../themes/indice-real', join(plugin, 'theme-rel'));       // relative
+                symlinkSync(join(themes, 'indice-real'), join(plugin, 'theme-abs'));      // absolute
+            },
+        });
+        prepareSharedTree();
+        tempDir = createTempDir('e2e-symlink-bundle');
+        tempDir2 = createTempDir('e2e-symlink-bundle-narrow');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+        cleanupTempDir(tempDir2);
+        rmSync(SHARED_ROOT, { recursive: true, force: true });
+    });
+
+    const importUrl = () => `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    const fsRoot = () => fsRootDir(tempDir);
+    const fsRoot2 = () => fsRootDir(tempDir2);
+
+    it('files-sync completes with --follow-symlinks=<dir>', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--only', ':wp-content:',
+                '--remap', ':wp-content:', ':fs-root:/wp-content',
+                '--follow-symlinks=:fs-root:/.symlinks-bundle',
+            ],
+        });
+        assert.equal(result.exitCode, 0, `sync failed:\n${result.stdout}\n${result.stderr}`);
+    });
+
+    it('escaping target content lands in the bundle, nested by source path', () => {
+        assert.ok(existsSync(join(fsRoot(), BUNDLED_STYLE)),
+            `expected bundled content at ${join(fsRoot(), BUNDLED_STYLE)}`);
+        assert.ok(readFileSync(join(fsRoot(), BUNDLED_STYLE), 'utf-8').includes('Shared indice theme'));
+    });
+
+    it('escaping content is not left at its source path in the docroot', () => {
+        assert.ok(!existsSync(join(fsRoot(), 'tmp')),
+            'with a bundle directory set, escaping content must not land at fs-root/tmp');
+    });
+
+    it('the escaping symlink resolves into the bundle', () => {
+        const link = join(fsRoot(), 'wp-content', 'themes', 'indice');
+        assert.ok(lstatSync(link).isSymbolicLink(), 'indice is a symlink');
+        assert.ok(existsSync(join(link, 'style.css')), 'indice resolves to bundled style.css');
+    });
+
+    it('dedups: two symlinks to one target share one bundle copy', () => {
+        const link2 = join(fsRoot(), 'wp-content', 'themes', 'indice2');
+        assert.ok(existsSync(join(link2, 'style.css')), 'indice2 also resolves');
+        assert.ok(existsSync(join(fsRoot(), '.symlinks-bundle', SHARED_ROOT, 'pub', 'indice')));
+    });
+
+    it('escaping RELATIVE symlink resolves (into the bundle)', () => {
+        const link = join(fsRoot(), 'wp-content', 'themes', 'esc-rel');
+        assert.ok(lstatSync(link).isSymbolicLink(), 'esc-rel is a symlink');
+        assert.ok(existsSync(join(link, 'style.css')), 'esc-rel resolves to the bundled theme');
+        assert.ok(readFileSync(join(link, 'style.css'), 'utf-8').includes('Shared indice theme'));
+    });
+
+    it('in-scope symlinks (relative AND absolute) are left in place, not bundled', () => {
+        for (const name of ['local', 'abs-local']) {
+            const link = join(fsRoot(), 'wp-content', 'themes', name);
+            assert.ok(lstatSync(link).isSymbolicLink(), `${name} stays a symlink`);
+            assert.ok(existsSync(join(link, 'style.css')), `${name} resolves within wp-content`);
+            assert.ok(readFileSync(join(link, 'style.css'), 'utf-8').includes('in-scope local theme'),
+                `${name} resolves to the in-scope theme`);
+        }
+        assert.ok(!existsSync(join(fsRoot(), '.symlinks-bundle', 'wp-content')),
+            'in-scope targets must not be bundled');
+    });
+
+    // ── Narrow --only: a plugin symlinks into themes (in wp-content, out of --only) ──
+    // themes is OUTSIDE --only :wp-content:/plugins but INSIDE the remapped
+    // wp-content, so remap (checked before bundle) must place it at wp-content/themes,
+    // NOT the bundle — for both relative and absolute spellings.
+    it('narrow --only :wp-content:/plugins files-sync completes', () => {
+        const result = runImporter(importUrl(), tempDir2, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--only', ':wp-content:/plugins',
+                '--remap', ':wp-content:', ':fs-root:/wp-content',
+                '--follow-symlinks=:fs-root:/.symlinks-bundle',
+            ],
+        });
+        assert.equal(result.exitCode, 0, `sync failed:\n${result.stdout}\n${result.stderr}`);
+    });
+
+    it('cross-scope theme target lands under wp-content/themes (remapped), not the bundle', () => {
+        // Followed from a plugin symlink; themes is out of --only but in wp-content.
+        const themeStyle = join(fsRoot2(), 'wp-content', 'themes', 'indice-real', 'style.css');
+        assert.ok(existsSync(themeStyle), `expected remapped theme at ${themeStyle}`);
+        assert.ok(readFileSync(themeStyle, 'utf-8').includes('in-scope local theme'));
+        // It is NOT in the bundle (remap wins over bundling for in-wp-content targets).
+        assert.ok(!existsSync(join(fsRoot2(), '.symlinks-bundle')),
+            'a target inside the remapped wp-content must not be bundled');
+    });
+
+    it('both relative and absolute plugin→theme symlinks resolve', () => {
+        for (const name of ['theme-rel', 'theme-abs']) {
+            const link = join(fsRoot2(), 'wp-content', 'plugins', 'cross-plugin', name);
+            assert.ok(lstatSync(link).isSymbolicLink(), `${name} is a symlink`);
+            assert.ok(readFileSync(join(link, 'style.css'), 'utf-8').includes('in-scope local theme'),
+                `${name} resolves to the remapped theme content`);
+        }
+    });
+
+    it('narrow --only pulls only plugins — unfollowed themes are absent', () => {
+        // themes/indice-real is present (followed via the plugin symlink), but the
+        // other themes (indice, esc-rel, …) live outside --only=plugins and are not
+        // reachable, so they must not be pulled.
+        assert.ok(existsSync(join(fsRoot2(), 'wp-content', 'themes', 'indice-real')),
+            'the followed theme is present');
+        assert.ok(!existsSync(join(fsRoot2(), 'wp-content', 'themes', 'indice')),
+            'unfollowed, out-of-scope themes are not pulled');
+    });
+});


### PR DESCRIPTION
Migrations (especially scoped ones with `--only :wp-content:`) don't have a great option for symlinks that point outside the pulled scope. Bare `--follow-symlinks` pulls the content but mirrors it at its raw source paths, scattered across the docroot. `--no-follow-symlinks` just drops it, leaving dangling links.

This PR adds a destination form: `--follow-symlinks=:fs-root:/.symlinks-bundle`. Escaping targets get followed and consolidated into one private in-tree directory, nested by source path, and their symlinks are repointed there. A scoped wp-content pull ends up self-contained: no dangling links, no junk in the docroot.

**Placement**: remap rules first, then the bundle location if set, then the default fs-root mirror. Anything inside a remapped wp-content lands in the served tree, so the bundle only receives genuinely-external content. Multiple links to one target share a single copy. Relative and absolute targets are handled the same. Bare `--follow-symlinks` is equivalent to `--follow-symlinks=:fs-root:` (the unchanged default), and the value uses the `--remap` target grammar — it must stay within `--fs-root`.

**Resume guard**: the bundle directory is fingerprinted on the first run and checked on every run after. Changing (or dropping) it errors instead of silently splitting placement; `--abort` resets it. Setting a bundle directory also persists `follow_symlinks=true`, so a flag-less delta can't index with follow off and delete previously-followed content.

**Behavior changes** (both previously produced missing content and dangling links):
1. Under a narrow `--only`, followed targets outside the `--only` scope are now pulled. They used to be skipped as "already covered" because they sat under a preflight root, even though the scoped pull never actually downloaded them.
2. Symlinks in the middle of a followed path (e.g. `/srv/wordpress → /wordpress`) are now repointed at the locally-mirrored content, like every other symlink. They used to be skipped whenever their absolute target pointed outside `--fs-root`, even when the content itself had been downloaded.

## Testing

The new `SymlinkBundleTest` (unit) + `import-52-symlink-bundle` (e2e, broad + narrow `--only`) cover lots of cases here.

For manual testing though, the setup would be rather intense. You'll need something like a symlinked plugin that points outside wp-content. Then run `--only :wp-content: --follow-symlinks=:fs-root:/.symlinks-bundle` and ensure the plugin's source ended up in the new bundle location.