### PR TITLE
[Push] Reserve a safe artifact id for the deletion manifest

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -83,6 +83,17 @@ travel as a deletion manifest — itself a staged artifact, uploaded through
 the same store as file bytes — and the apply step executes the unlinks inside
 the same window as the moves.
 
+The manifest is staged at one reserved artifact id, `.reprint/deletions.jsonl`,
+whose content is the `local-paths-to-delete.jsonl` the journal produces. To
+keep that namespace trustworthy, the exporter refuses any sender-named
+artifact under the top-level `.reprint/` segment except that one id — on the
+push stream and on the `finalize`/`status`/`discard` control routes alike
+(`reserved_artifact_id`, HTTP 400). So a site that happens to hold a
+`.reprint/` file cannot overwrite the manifest, and apply can trust that
+everything under `.reprint/` is reprint's own. The staging code that actually
+writes the manifest lands with the push command; this reservation is in place
+ahead of it so the namespace is clean from the first push.
+
 ## The staging store
 
 The staging area is `Site_Export_Staged_Artifacts` as built: artifact bytes

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -208,7 +208,7 @@ final class Site_Export_Staged_Endpoints {
             // deletion manifest (or hide as another .reprint/ artifact apply
             // would then trust). The one deletion-manifest id is allowed
             // through and stages like any other artifact.
-            if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+            if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
                 return $this->stream_rejected(
                     400,
                     'reserved_artifact_id',
@@ -396,7 +396,7 @@ final class Site_Export_Staged_Endpoints {
         if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
-        if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+        if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
             return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
         }
         $total_bytes = $config['total_bytes'] ?? null;
@@ -420,7 +420,7 @@ final class Site_Export_Staged_Endpoints {
         if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
-        if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+        if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
             return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
         }
 
@@ -445,7 +445,7 @@ final class Site_Export_Staged_Endpoints {
         if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
-        if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+        if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
             return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
         }
 

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -62,6 +62,9 @@ final class Site_Export_Staged_Endpoints {
     /** Request-body read size while discarding already-committed bytes. */
     private const READ_BUFFER_BYTES = 65536;
 
+    /** Detail returned when a control-plane call names the reserved namespace. */
+    private const RESERVED_NAMESPACE_MESSAGE = 'This artifact id is in reprint\'s reserved ".reprint/" namespace; only the deletion manifest may be written there.';
+
     /** @var Site_Export_Staged_Artifacts */
     private $store;
 
@@ -199,6 +202,21 @@ final class Site_Export_Staged_Endpoints {
             $bytes = $frame['bytes'];
             $total_bytes = $frame['total_bytes'];
             $final = $frame['final'];
+
+            // Refuse frames that name reprint's reserved namespace before the
+            // store is touched, so a pushed file can never overwrite the
+            // deletion manifest (or hide as another .reprint/ artifact apply
+            // would then trust). The one deletion-manifest id is allowed
+            // through and stages like any other artifact.
+            if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+                return $this->stream_rejected(
+                    400,
+                    'reserved_artifact_id',
+                    'The artifact id "' . $artifact_id . '" is in reprint\'s reserved ".reprint/" namespace; only the deletion manifest may be written there.',
+                    ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => 0],
+                    $files_verified
+                );
+            }
 
             // Response cursors re-encode the id so responses stay valid JSON
             // for arbitrary-byte paths, and they report only what the store
@@ -378,6 +396,9 @@ final class Site_Export_Staged_Endpoints {
         if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
         }
+        if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+            return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
+        }
         $total_bytes = $config['total_bytes'] ?? null;
         if (!is_numeric($total_bytes) || (int) $total_bytes < 0) {
             return $this->rejected(400, 'invalid_total');
@@ -398,6 +419,9 @@ final class Site_Export_Staged_Endpoints {
         $artifact_id = $this->decode_artifact_id_param($config);
         if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
+        }
+        if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+            return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
         }
 
         return [
@@ -420,6 +444,9 @@ final class Site_Export_Staged_Endpoints {
         $artifact_id = $this->decode_artifact_id_param($config);
         if ($artifact_id === null) {
             return $this->rejected(400, 'invalid_artifact_id');
+        }
+        if (Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)) {
+            return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
         }
 
         if (!$this->store->discard($artifact_id)) {

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -13,6 +13,38 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     public const CONTENT_TYPE = 'application/x-reprint-staged-push-stream';
 
     /**
+     * Top-level path segment reprint reserves for its own staged bookkeeping.
+     * A sender's file artifacts may never land here — see
+     * is_forbidden_sender_artifact_id() — so the apply step can trust that
+     * everything under it is reprint's own, not pushed site content.
+     */
+    public const RESERVED_NAMESPACE_SEGMENT = '.reprint';
+
+    /**
+     * The one artifact id inside the reserved namespace a sender is allowed
+     * to write: the list of paths deleted locally since the last push, staged
+     * like any other artifact so apply can unlink them in its window. Content
+     * is the local-paths-to-delete.jsonl the push journal produces.
+     */
+    public const DELETION_MANIFEST_ARTIFACT_ID = '.reprint/deletions.jsonl';
+
+    /**
+     * Whether a sender-named artifact id intrudes on reprint's reserved
+     * namespace. True for the bare reserved segment and anything beneath it,
+     * except the one deletion-manifest id a sender may legitimately write.
+     *
+     * The check is on the first path segment, not a raw string prefix, so
+     * a real site file like ".reprintfoo" or "wp-content/.reprint/x" is not
+     * caught — only the top-level ".reprint" namespace is.
+     */
+    public static function is_forbidden_sender_artifact_id(string $artifact_id): bool {
+        if ($artifact_id === self::DELETION_MANIFEST_ARTIFACT_ID) {
+            return false;
+        }
+        return explode('/', $artifact_id, 2)[0] === self::RESERVED_NAMESPACE_SEGMENT;
+    }
+
+    /**
      * Read the next frame header line from a stream.
      *
      * @param resource $input

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -15,7 +15,7 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     /**
      * Top-level path segment reprint reserves for its own staged bookkeeping.
      * A sender's file artifacts may never land here — see
-     * is_forbidden_sender_artifact_id() — so the apply step can trust that
+     * is_reserved_sender_artifact_id() — so the apply step can trust that
      * everything under it is reprint's own, not pushed site content.
      */
     public const RESERVED_NAMESPACE_SEGMENT = '.reprint';
@@ -37,7 +37,7 @@ final class Site_Export_Staged_Push_Stream_Protocol {
      * a real site file like ".reprintfoo" or "wp-content/.reprint/x" is not
      * caught — only the top-level ".reprint" namespace is.
      */
-    public static function is_forbidden_sender_artifact_id(string $artifact_id): bool {
+    public static function is_reserved_sender_artifact_id(string $artifact_id): bool {
         if ($artifact_id === self::DELETION_MANIFEST_ARTIFACT_ID) {
             return false;
         }

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -320,6 +320,21 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertSame(['staged_push'], $this->endpointsSeen());
     }
 
+    public function testAFileInTheReservedNamespaceIsRejectedOverTheWire(): void
+    {
+        // A local site that happens to hold a .reprint/ file: the push must
+        // be refused end to end, not silently written into reprint's own
+        // namespace where apply would later trust it.
+        $this->writeSource('.reprint/evil.bin', 'x');
+        $client = $this->makeClient();
+        $local_paths_to_push = $this->writeLocalPathsToPush(['.reprint/evil.bin']);
+
+        $result = $this->pushAll($client, $local_paths_to_push);
+
+        $this->assertSame(['failed', 'reserved_artifact_id'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/.reprint/evil.bin');
+    }
+
     public function testSendChunkWritesBytesToTheNetworkBeforeTheRequestIsFinalized(): void
     {
         // A raw TCP listener instead of the shared endpoint server, so the

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -239,6 +239,57 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertStringContainsString('offset 5 and 1 payload bytes, which exceeds total_bytes 3', $result['body']['detail']);
     }
 
+    public function testPushStreamRejectsAReservedNamespaceFrameBeforeTheStore(): void
+    {
+        $endpoints = $this->makeEndpoints();
+
+        $result = $this->push($endpoints, [
+            ['artifact_id' => '.reprint/evil.txt', 'offset' => 0, 'bytes' => 'x', 'total_bytes' => 1, 'final' => true],
+        ]);
+
+        $this->assertSame(400, $result['http_code']);
+        $this->assertSame('reserved_artifact_id', $result['body']['reason']);
+        $this->assertStringContainsString('.reprint/', $result['body']['detail']);
+        // The store never saw it: nothing was written under files/.reprint/.
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/.reprint/evil.txt');
+        $this->assertSame(['artifact_id' => base64_encode('.reprint/evil.txt'), 'committed_bytes' => 0], $result['body']['cursor']);
+    }
+
+    public function testPushStreamAcceptsTheDeletionManifestId(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $manifest = json_encode(['path' => base64_encode('wp-content/gone.txt')]) . "\n";
+
+        $result = $this->push($endpoints, [
+            ['artifact_id' => '.reprint/deletions.jsonl', 'offset' => 0, 'bytes' => $manifest, 'total_bytes' => strlen($manifest), 'final' => true],
+        ]);
+
+        // The one reserved id a sender may write stages like any artifact.
+        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
+        $this->assertSame('complete', $result['body']['status']);
+        $this->assertSame(1, $result['body']['files_verified']);
+        $this->assertSame($manifest, file_get_contents($this->staging_dir . '/files/.reprint/deletions.jsonl'));
+    }
+
+    public function testControlPlaneRoutesRefuseTheReservedNamespace(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        $reserved = base64_encode('.reprint/evil.txt');
+
+        $finalize = $endpoints->finalize(['artifact_id' => $reserved, 'total_bytes' => 1], ['REQUEST_METHOD' => 'POST']);
+        $status = $endpoints->status(['artifact_id' => $reserved]);
+        $discard = $endpoints->discard(['artifact_id' => $reserved], ['REQUEST_METHOD' => 'POST']);
+
+        foreach (['finalize' => $finalize, 'status' => $status, 'discard' => $discard] as $route => $result) {
+            $this->assertSame(400, $result['http_code'], $route);
+            $this->assertSame('reserved_artifact_id', $result['body']['reason'], $route);
+        }
+
+        // The manifest id passes the gate on the control plane too.
+        $manifest_status = $endpoints->status(['artifact_id' => base64_encode('.reprint/deletions.jsonl')]);
+        $this->assertSame(200, $manifest_status['http_code']);
+    }
+
     // ---------------------------------------------------------------
     // Control plane: finalize, status, discard
     // ---------------------------------------------------------------

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -33,7 +33,7 @@ final class StagedPushStreamProtocolTest extends TestCase
     {
         $this->assertSame(
             $forbidden,
-            Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)
+            Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)
         );
     }
 

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -26,6 +26,30 @@ final class StagedPushStreamProtocolTest extends TestCase
         ], Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line));
     }
 
+    /**
+     * @dataProvider reservedArtifactIdProvider
+     */
+    public function testReservedNamespaceGuardsEveryReprintIdButTheManifest(string $artifact_id, bool $forbidden): void
+    {
+        $this->assertSame(
+            $forbidden,
+            Site_Export_Staged_Push_Stream_Protocol::is_forbidden_sender_artifact_id($artifact_id)
+        );
+    }
+
+    public static function reservedArtifactIdProvider(): array
+    {
+        return [
+            'the deletion manifest is the one allowed reserved id' => ['.reprint/deletions.jsonl', false],
+            'a sibling in the namespace is forbidden' => ['.reprint/evil.jsonl', true],
+            'a nested path in the namespace is forbidden' => ['.reprint/sub/dir/file', true],
+            'the bare namespace segment is forbidden' => ['.reprint', true],
+            'a real file that merely starts with the segment is allowed' => ['.reprintfoo', false],
+            'a nested .reprint below a real dir is allowed' => ['wp-content/.reprint/x', false],
+            'an ordinary site file is allowed' => ['wp-content/uploads/photo.jpg', false],
+        ];
+    }
+
     public function testChunkHeaderValidationRejectsRangesOutsideTheDeclaredFile(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Why

The deletion manifest will stage as an ordinary artifact at a fixed id, `.reprint/deletions.jsonl` — but an artifact id is just a path a sender picks, so nothing stops a pushed file from naming that id (or any `.reprint/` path) and overwriting the manifest, or planting content in reprint's namespace that apply later trusts as its own.

## What

The exporter now refuses any sender-named artifact whose first path segment is `.reprint`, except the one manifest id — on the push stream and on `finalize`/`status`/`discard` alike (`reserved_artifact_id`, HTTP 400), before the store is touched. It's a first-segment check, so `.reprintfoo` and `wp-content/.reprint/x` are unaffected. This lands ahead of the staging code (which comes with the push command) so the namespace is clean from the first push.

## Testing

```bash
cd tests && ../vendor/bin/phpunit StagedPushStreamProtocolTest.php StagedEndpointsTest.php Import/StagedPushStreamClientTest.php --colors=never
```

Helper unit tests over the edge cases; endpoint rejects a reserved frame and accepts the manifest id on data and control planes; one end-to-end test pushes a real `.reprint/evil.bin` over curl and gets `failed`/`reserved_artifact_id`, nothing written. Proven failing-first — with the gate stubbed to allow everything, the six forbidden-case assertions fail, the allowed cases stay green.
