### PR TITLE
[Push] Expose authenticated typed-operation sessions

### DIFF
--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -7,6 +7,15 @@ use function WordPress\Reprint\Exporter\parse_size;
  */
 final class Site_Export_HTTP_Server {
 
+    /** Reserved session route names. */
+    public const STAGED_SESSION_ENDPOINTS = [
+        'staged_session_create',
+        'staged_session_push',
+        'staged_session_advance',
+        'staged_session_status',
+        'staged_session_discard',
+    ];
+
     /** @var array<string, callable> */
     private $handlers;
 
@@ -22,6 +31,15 @@ final class Site_Export_HTTP_Server {
     /** @var string|null */
     private $default_directory;
 
+    /** @var string|null Server-owned path excluded from file indexes. */
+    private $storage_path;
+
+    /** @var Site_Export_Staged_Endpoints|null */
+    private $staged_endpoints;
+
+    /** @var array<string,bool> Session routes authenticated before parsing. */
+    private $staged_envelope_endpoints = [];
+
     /** @var string[] Endpoints dispatched without a resource budget. */
     private $no_budget_endpoints = ['preflight'];
 
@@ -34,23 +52,131 @@ final class Site_Export_HTTP_Server {
         };
         $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
         $this->default_directory = $options['default_directory'] ?? null;
+        $this->staged_endpoints = null;
 
-        if (isset($options['staged']) && is_array($options['staged'])) {
-            $this->register_staged_handlers(new Site_Export_Staged_Endpoints($options['staged']));
+        $staged_options = isset($options['staged']) && is_array($options['staged'])
+            ? $options['staged']
+            : null;
+        $has_explicit_storage_path = array_key_exists('storage_path', $options);
+        $has_staged_storage_path = $staged_options !== null && array_key_exists('staging_dir', $staged_options);
+        $explicit_storage_path = $has_explicit_storage_path
+            ? self::normalize_storage_path($options['storage_path'], 'The HTTP server storage_path')
+            : null;
+        $staged_storage_path = $has_staged_storage_path
+            ? self::normalize_storage_path($staged_options['staging_dir'], 'The HTTP server staged.staging_dir')
+            : null;
+        if ($staged_options !== null && $has_explicit_storage_path && !$has_staged_storage_path) {
+            throw new InvalidArgumentException('The HTTP server storage_path cannot replace a missing staged.staging_dir.');
         }
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not HTML output.
+        if (
+            $explicit_storage_path !== null
+            && $staged_storage_path !== null
+            && $explicit_storage_path !== $staged_storage_path
+        ) {
+            throw new InvalidArgumentException(
+                'The HTTP server storage_path must match staged.staging_dir when both are configured; observed '
+                . $explicit_storage_path . ' and ' . $staged_storage_path . '.'
+            );
+        }
+        $this->storage_path = $staged_storage_path ?? $explicit_storage_path;
+
+        if ($staged_options !== null) {
+            if ($staged_storage_path !== null) {
+                $staged_options['staging_dir'] = $staged_storage_path;
+            }
+            $this->staged_endpoints = new Site_Export_Staged_Endpoints($staged_options);
+            $this->register_staged_handlers($this->staged_endpoints);
+        }
+    }
+
+    /**
+     * Keep the HTTP server and its host integration on one storage-path
+     * invariant before either lets the path affect a file index.
+     *
+     * @param mixed $storage_path
+     */
+    public static function normalize_storage_path($storage_path, string $option_name): string {
+        if (!is_string($storage_path)) {
+            throw new InvalidArgumentException(
+                $option_name . ' must be a string; observed ' . gettype($storage_path) . '.'
+            );
+        }
+        if ($storage_path === '' || $storage_path[0] !== '/' || strpos($storage_path, "\0") !== false) {
+            throw new InvalidArgumentException(
+                $option_name . ' must be an absolute non-empty path without NUL bytes; observed base64 '
+                . base64_encode($storage_path) . '.'
+            );
+        }
+        foreach (explode('/', $storage_path) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException(
+                    $option_name . ' must not contain dot segments; observed base64 '
+                    . base64_encode($storage_path) . '.'
+                );
+            }
+        }
+        $storage_path = rtrim($storage_path, '/');
+        if ($storage_path === '') {
+            throw new InvalidArgumentException($option_name . ' must not be the filesystem root; observed /.');
+        }
+        if (is_link($storage_path)) {
+            throw new InvalidArgumentException(
+                $option_name . ' must not be a symlink; observed base64 ' . base64_encode($storage_path) . '.'
+            );
+        }
+        $existing_path = $storage_path;
+        while (!file_exists($existing_path) && !is_link($existing_path)) {
+            $parent_path = dirname($existing_path);
+            if ($parent_path === $existing_path) {
+                break;
+            }
+            $existing_path = $parent_path;
+        }
+        if (!is_dir($existing_path)) {
+            throw new InvalidArgumentException(
+                $option_name . ' must not be blocked by a non-directory path; observed base64 '
+                . base64_encode($existing_path) . '.'
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        return $storage_path;
     }
 
     public function handle_request(array $request = []): void {
         $server = $request['server'] ?? $_SERVER;
         $get = $request['get'] ?? $_GET;
         $post = $request['post'] ?? $_POST;
+        if (!$this->pre_authenticate_staged_query($get, $server)) {
+            return;
+        }
+        $post_endpoint = $post['endpoint'] ?? null;
+        if (
+            is_string($post_endpoint)
+            && isset($this->staged_envelope_endpoints[$post_endpoint])
+            && ( $get['endpoint'] ?? null ) !== $post_endpoint
+        ) {
+            $this->reject_staged_endpoint_outside_query($post_endpoint);
+            return;
+        }
         if (array_key_exists('body', $request)) {
             $body = (string) $request['body'];
         } else {
-            $endpoint = (string) ( $get['endpoint'] ?? $post['endpoint'] ?? '' );
-            // Data-plane staged routes carry raw bytes and must only be read
-            // by their handlers. Other JSON requests still feed config parsing.
-            $body = $endpoint !== 'staged_push' && $this->is_json_content_type($server)
+            // The query endpoint is what plugin authentication sees. It must
+            // therefore also win dispatch selection; a form body cannot turn
+            // an envelope-authenticated staged route into another endpoint.
+            $endpoint = $get['endpoint'] ?? $post['endpoint'] ?? '';
+            $endpoint = is_string($endpoint) ? $endpoint : '';
+            // Staged session parameters live in the signed request target,
+            // never a JSON body. Do not read any session body here: push owns
+            // its raw stream, and control routes must authenticate before an
+            // untrusted body can be buffered. Other JSON requests still feed
+            // config parsing.
+            // Older senders may still upload a large staged_push body. The
+            // route is retired, but its rejection must not buffer that body.
+            $body = $endpoint !== 'staged_push'
+                && !self::is_staged_session_endpoint($endpoint)
+                && $this->is_json_content_type($server)
                 ? call_user_func($this->body_reader)
                 : '';
         }
@@ -60,8 +186,21 @@ final class Site_Export_HTTP_Server {
             $server,
             $body
         );
+        $selected_endpoint = $config['endpoint'] ?? null;
+        if (
+            is_string($selected_endpoint)
+            && isset($this->staged_envelope_endpoints[$selected_endpoint])
+            && ( $get['endpoint'] ?? null ) !== $selected_endpoint
+        ) {
+            $this->reject_staged_endpoint_outside_query($selected_endpoint);
+            return;
+        }
         $config = $this->normalize_config($config, $server);
         $this->dispatch($config);
+    }
+
+    public static function is_staged_session_endpoint(string $endpoint): bool {
+        return in_array($endpoint, self::STAGED_SESSION_ENDPOINTS, true);
     }
 
     /**
@@ -161,15 +300,34 @@ final class Site_Export_HTTP_Server {
      */
     public function parse_http_config(array $get = [], array $post = [], array $server = [], string $body = ''): array {
         $config = [];
-        $params = array_merge($get, $post);
+        $json_data = [];
 
         $content_type = $server['CONTENT_TYPE'] ?? '';
         $content_type_main = strtolower(trim((string) strtok((string) $content_type, ';')));
         if ($content_type_main === 'application/json' && $body !== '') {
-            $json_data = json_decode($body, true);
-            if (is_array($json_data)) {
-                $params = array_merge($json_data, $params);
+            $decoded_json = json_decode($body, true);
+            if (is_array($decoded_json)) {
+                $json_data = $decoded_json;
             }
+        }
+
+        $endpoint = null;
+        foreach ([$get, $post, $json_data] as $parameters) {
+            if (!array_key_exists('endpoint', $parameters)) {
+                continue;
+            }
+            if (!is_string($parameters['endpoint'])) {
+                throw new InvalidArgumentException('endpoint parameter must be a string.');
+            }
+            if ($endpoint !== null && $parameters['endpoint'] !== $endpoint) {
+                throw new InvalidArgumentException('endpoint parameter must match in the request target and body.');
+            }
+            $endpoint = $parameters['endpoint'];
+        }
+
+        $params = array_merge($json_data, $get, $post);
+        if ($endpoint !== null) {
+            $params['endpoint'] = $endpoint;
         }
 
         foreach ($params as $key => $value) {
@@ -215,6 +373,14 @@ final class Site_Export_HTTP_Server {
             !isset($config['directory'])
         ) {
             $config['directory'] = $this->default_directory;
+        }
+
+        // A peer must not hide an arbitrary target subtree from file_index.
+        // The server either supplies its own storage path or removes the
+        // request parameter entirely.
+        unset($config['storage_path']);
+        if ($this->storage_path !== null) {
+            $config['storage_path'] = $this->storage_path;
         }
 
         if (!isset($config['cursor']) && isset($server[$this->cursor_header_name])) {
@@ -306,18 +472,22 @@ final class Site_Export_HTTP_Server {
     }
 
     /**
-     * Wire the staged artifact routes to the shared dispatcher.
+     * Wire direct staged-apply session routes to the shared dispatcher.
      *
-     * Explicitly-passed handlers win over these, matching how the
-     * handlers option replaces the default map.
+     * Explicitly-passed handlers win over these, matching how the handlers
+     * option replaces the default map. Reserved session route names still use
+     * the configured envelope authentication before an override is called.
      */
     private function register_staged_handlers(Site_Export_Staged_Endpoints $endpoints): void {
-        $routes = [
-            'staged_push' => static function (array $config) use ($endpoints): void {
+        $session_routes = [
+            'staged_session_create' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->session_create($config, $_SERVER));
+            },
+            'staged_session_push' => static function (array $config) use ($endpoints): void {
                 $input = @fopen('php://input', 'rb');
                 try {
                     self::emit_json_response(
-                        $endpoints->push_stream($config, $_SERVER, $input === false ? null : $input)
+                        $endpoints->session_push_stream($config, $_SERVER, $input === false ? null : $input)
                     );
                 } finally {
                     if (is_resource($input)) {
@@ -325,18 +495,22 @@ final class Site_Export_HTTP_Server {
                     }
                 }
             },
-            'staged_finalize' => static function (array $config) use ($endpoints): void {
-                self::emit_json_response($endpoints->finalize($config, $_SERVER));
+            'staged_session_advance' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->session_advance($config, $_SERVER));
             },
-            'staged_status' => static function (array $config) use ($endpoints): void {
-                self::emit_json_response($endpoints->status($config));
+            'staged_session_status' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->session_status($config, $_SERVER));
             },
-            'staged_discard' => static function (array $config) use ($endpoints): void {
-                self::emit_json_response($endpoints->discard($config, $_SERVER));
+            'staged_session_discard' => static function (array $config) use ($endpoints): void {
+                self::emit_json_response($endpoints->session_discard($config, $_SERVER));
             },
         ];
+        if (array_keys($session_routes) !== self::STAGED_SESSION_ENDPOINTS) {
+            throw new LogicException('The staged session route registry does not match its authentication allowlist.');
+        }
 
-        foreach ($routes as $endpoint => $handler) {
+        foreach ($session_routes as $endpoint => $handler) {
+            $this->staged_envelope_endpoints[$endpoint] = true;
             if (!isset($this->handlers[$endpoint])) {
                 $this->handlers[$endpoint] = $handler;
             }
@@ -345,12 +519,54 @@ final class Site_Export_HTTP_Server {
     }
 
     /**
+     * Authenticate a staged query route before reading or parsing any other
+     * request input. Envelope HMAC covers the exact method and raw
+     * REQUEST_URI and never reads the request body.
+     *
+     * @param array<string,mixed> $get
+     * @param array<string,mixed> $server
+     */
+    private function pre_authenticate_staged_query(array $get, array $server): bool {
+        $endpoint = $get['endpoint'] ?? null;
+        if (
+            $this->staged_endpoints === null
+            || !is_string($endpoint)
+            || !isset($this->staged_envelope_endpoints[$endpoint])
+        ) {
+            return true;
+        }
+        $error = $this->staged_endpoints->pre_authenticate_envelope($server, $endpoint);
+        if ($error === null) {
+            return true;
+        }
+        self::emit_json_response($error);
+        return false;
+    }
+
+    private function reject_staged_endpoint_outside_query(string $endpoint): void {
+        self::emit_json_response([
+            'http_code' => 400,
+            'body' => [
+                'status' => 'rejected',
+                'reason' => 'endpoint_not_in_query',
+                'detail' => 'Reserved staged endpoint ' . $endpoint . ' must be named in the signed request query.',
+            ],
+        ]);
+    }
+
+    /**
      * @param array{http_code:int,body:array} $response
      */
     private static function emit_json_response(array $response): void {
+        $body = json_encode($response['body']);
+        if ($body === false) {
+            $response['http_code'] = 500;
+            $body = '{"status":"rejected","reason":"response_encoding_failed","detail":"The server could not encode its response as JSON.","committed_bytes":0}';
+        }
         http_response_code($response['http_code']);
         header('Content-Type: application/json');
-        echo json_encode($response['body']);
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Checked json_encode output or a fixed JSON fallback literal.
+        echo $body;
     }
 
     private function is_json_content_type(array $server): bool {

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -1,72 +1,62 @@
 <?php
 
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Endpoint errors are returned as API JSON, never rendered as HTML.
+
 use function WordPress\Reprint\Exporter\parse_size;
 
 if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
     require_once __DIR__ . '/class-staged-push-stream-protocol.php';
 }
+if (!class_exists('Site_Export_Staged_Apply', false)) {
+    require_once __DIR__ . '/class-staged-apply.php';
+}
 
 /**
- * HTTP endpoints for the staged artifact store.
+ * Authenticated HTTP surface for target-owned staged apply sessions.
  *
- * This is the target side of a push stream: the sender opens one request,
- * frames many bounded chunks for many files, and this endpoint commits each
- * frame into Site_Export_Staged_Artifacts instead of touching the live site.
+ * A push request carries typed operations, not an apply manifest. Each frame
+ * is validated and materialized in the private session before its server-owned
+ * journal record becomes durable. `advance` closes uploads and commits a fixed
+ * batch directly from that journal; there is no seal, preparation, or
+ * validation pass between upload and commit.
  *
- * Four routes share the existing endpoint dispatcher:
- *
- * - staged_push     (POST, data plane): framed file chunks in one streamed
- *   request body.
- * - staged_finalize (POST, control plane): confirm the assembled size.
- * - staged_status   (GET, control plane): resume hint for a sender.
- * - staged_discard  (POST, control plane): drop an artifact; retry
- *   until the response says discarded.
- *
- * Control-plane routes have small bodies and ride the embedding layer's
- * existing HMAC verification, like every other endpoint. staged_push uses
- * envelope HMAC instead: authenticate method + request target before reading
- * bytes, then let TLS protect the body. That keeps one push stream as one
- * request even when it carries many frames for many files.
- *
- * Chunk retries are the normal case, not an error: a sender that timed
- * out learns nothing about what landed, retries from its last cursor or
- * asks staged_status for the store's committed offset, and may later
- * resend with shifted boundaries. push_stream therefore compares the store's
- * committed offset with each frame first, skips the committed prefix of a
- * straddling mid-file frame, restarts an artifact when the sender begins it
- * again at offset 0 (the sender only does that when its source changed or
- * it cannot vouch for the staged prefix), and reports offset_gap with the
- * cursor only when a frame starts beyond the frontier.
- *
- * Rejections the chunk sizer must learn from are typed for it: a frame
- * over the frame cap is HTTP 413 with max_frame_bytes in the payload,
- * exactly what record_too_large() consumes. The cap defaults to post_max_size
- * (falling back to the sizer's own 1 GiB hard cap when PHP reports none),
- * because a proxy or PHP itself would refuse larger bodies before this code
- * runs anyway.
- *
- * All options are server-owned. Client config never chooses the staging
- * directory, the secret, or the caps — a request parameter named like
- * an option is ignored. Methods return ['http_code' => int, 'body' =>
- * array] and never echo, so tests drive them directly; the dispatcher
- * wiring in Site_Export_HTTP_Server emits the JSON.
+ * All session parameters live in the signed request target. The streaming
+ * route authenticates its method and target before reading the body and relies
+ * on TLS for body integrity, so it can carry many files in one request without
+ * buffering or hashing the entity body. A request-generation fence rejects a
+ * lost-response replay before PHP reads its body. Status then reports only the
+ * target-confirmed operation count and active file cursor.
  */
 final class Site_Export_Staged_Endpoints {
 
-    /** The chunk sizer never sends more than this, so accept up to it. */
+    /** The sender's hard ceiling for one file-frame payload. */
     private const DEFAULT_MAX_FRAME_BYTES = 1073741824;
 
-    /** One append() step per this many request-body bytes. */
+    /** One durable file-write step per this many request-body bytes. */
     private const DEFAULT_APPEND_BUFFER_BYTES = 262144;
 
-    /** Request-body read size while discarding already-committed bytes. */
-    private const READ_BUFFER_BYTES = 65536;
+    /** Matches the direct session's largest bounded file-write step. */
+    private const MAX_APPEND_BUFFER_BYTES = 4194304;
 
-    /** Detail returned when a control-plane call names the reserved namespace. */
-    private const RESERVED_NAMESPACE_MESSAGE = 'This artifact id is in reprint\'s reserved ".reprint/" namespace; only the deletion manifest may be written there.';
+    /** Bound zero-payload work as well as file chunks in one PHP request. */
+    private const DEFAULT_MAX_FRAMES_PER_REQUEST = 1024;
 
-    /** @var Site_Export_Staged_Artifacts */
-    private $store;
+    /** Endpoint-owned failure when live apply recovery is unavailable. */
+    private const ERROR_APPLY_NOT_CONFIGURED = 2001;
+
+    private const APPLY_NOT_CONFIGURED_MESSAGE = 'Server configuration has not enabled a safe staged-apply recovery entry point.';
+
+    /** @var string */
+    private $staging_dir;
+
+    /** @var string|null */
+    private $apply_target_root;
+
+    /** @var string[] */
+    private $apply_protected_paths;
+
+    /** @var bool */
+    private $apply_sessions_enabled;
 
     /** @var string|null */
     private $secret;
@@ -74,486 +64,549 @@ final class Site_Export_Staged_Endpoints {
     /** @var int */
     private $max_frame_bytes;
 
+    /** @var int|null Actual PHP entity-body limit, when the host reports one. */
+    private $post_max_bytes;
+
     /** @var int */
     private $append_buffer_bytes;
+
+    /** @var int */
+    private $max_frames_per_request;
 
     /** @var int */
     private $timestamp_tolerance;
 
     /**
      * @param array $options Server-owned configuration:
-     *   - staging_dir (string, required): passed to the artifact store.
-     *     Must live outside the web-served tree.
-     *   - secret (?string): shared secret for push authentication.
-     *     Null leaves pushes answering 503 until one is configured.
-     *   - max_frame_bytes (int): single frame payload cap; defaults to
-     *     post_max_size, or 1 GiB when PHP reports no limit.
-     *   - append_buffer_bytes (int): request-to-store step size.
+     *   - staging_dir (string, required): private session storage.
+     *   - secret (?string): shared secret for request authentication.
+     *   - max_frame_bytes (int): maximum file payload in one frame.
+     *   - append_buffer_bytes (int): one target write step.
+     *   - max_frames_per_request (int): bounds metadata-only work.
      *   - timestamp_tolerance (int): HMAC freshness window in seconds.
+     *   - apply_target_root (?string): server-owned live target.
+     *   - apply_protected_paths (string[]): paths sessions never mutate.
+     *   - apply_sessions_enabled (bool): whether a boot-independent recovery
+     *     entry point can finish a live apply.
      */
     public function __construct(array $options) {
         $staging_dir = $options['staging_dir'] ?? null;
         if (!is_string($staging_dir) || $staging_dir === '') {
             throw new InvalidArgumentException('Staged endpoints require a staging_dir option.');
         }
-        $this->store = new Site_Export_Staged_Artifacts($staging_dir);
+        $this->staging_dir = $staging_dir;
+
+        $apply_target_root = $options['apply_target_root'] ?? null;
+        if ($apply_target_root !== null && ( !is_string($apply_target_root) || $apply_target_root === '' )) {
+            throw new InvalidArgumentException('Staged apply target root must be a non-empty string when configured.');
+        }
+        $this->apply_target_root = $apply_target_root;
+
+        $protected_paths = $options['apply_protected_paths'] ?? [];
+        if (!is_array($protected_paths)) {
+            throw new InvalidArgumentException('Staged apply protected paths must be an array of target-relative paths.');
+        }
+        $this->apply_protected_paths = $protected_paths;
+
+        $apply_sessions_enabled = $options['apply_sessions_enabled'] ?? true;
+        if (!is_bool($apply_sessions_enabled)) {
+            throw new InvalidArgumentException('Staged apply_sessions_enabled must be a boolean.');
+        }
+        $this->apply_sessions_enabled = $apply_sessions_enabled;
 
         $secret = $options['secret'] ?? null;
-        $this->secret = is_string($secret) && $secret !== '' ? $secret : null;
-
-        $max_frame_bytes_option = $options['max_frame_bytes'] ?? null;
-        if (!is_numeric($max_frame_bytes_option) || (int) $max_frame_bytes_option <= 0) {
-            $post_max_size = ini_get('post_max_size');
-            $max_frame_bytes_option = is_string($post_max_size) && $post_max_size !== ''
-                ? parse_size($post_max_size)
-                : 0;
-            if ($max_frame_bytes_option <= 0) {
-                $max_frame_bytes_option = self::DEFAULT_MAX_FRAME_BYTES;
-            }
+        if ($secret !== null && ( !is_string($secret) || $secret === '' )) {
+            throw new InvalidArgumentException('Staged secret must be a non-empty string or null when configured.');
         }
-        $this->max_frame_bytes = (int) $max_frame_bytes_option;
+        $this->secret = $secret;
 
-        $append_buffer_bytes_option = $options['append_buffer_bytes'] ?? null;
-        $this->append_buffer_bytes = is_numeric($append_buffer_bytes_option) && (int) $append_buffer_bytes_option > 0
-            ? (int) $append_buffer_bytes_option
-            : self::DEFAULT_APPEND_BUFFER_BYTES;
+        $post_max_size = ini_get('post_max_size');
+        $post_max_bytes = is_string($post_max_size) && $post_max_size !== ''
+            ? parse_size($post_max_size)
+            : 0;
+        $this->post_max_bytes = $post_max_bytes > 0 ? $post_max_bytes : null;
 
-        $timestamp_tolerance_option = $options['timestamp_tolerance'] ?? null;
-        $this->timestamp_tolerance = is_numeric($timestamp_tolerance_option) && (int) $timestamp_tolerance_option > 0
-            ? (int) $timestamp_tolerance_option
-            : 300;
+        $max_frame_bytes = $options['max_frame_bytes'] ?? null;
+        if ($max_frame_bytes === null) {
+            $max_frame_bytes = $this->post_max_bytes ?? self::DEFAULT_MAX_FRAME_BYTES;
+        } elseif (!is_numeric($max_frame_bytes) || (int) $max_frame_bytes <= 0) {
+            throw new InvalidArgumentException('Staged max_frame_bytes must be a positive integer when configured.');
+        }
+        $this->max_frame_bytes = (int) $max_frame_bytes;
+
+        $append_buffer_bytes = $options['append_buffer_bytes'] ?? self::DEFAULT_APPEND_BUFFER_BYTES;
+        if (
+            !is_numeric($append_buffer_bytes)
+            || (int) $append_buffer_bytes <= 0
+            || (int) $append_buffer_bytes > self::MAX_APPEND_BUFFER_BYTES
+        ) {
+            throw new InvalidArgumentException(
+                'Staged append_buffer_bytes must be between 1 and ' . self::MAX_APPEND_BUFFER_BYTES . ' when configured.'
+            );
+        }
+        $this->append_buffer_bytes = (int) $append_buffer_bytes;
+
+        $max_frames_per_request = $options['max_frames_per_request'] ?? self::DEFAULT_MAX_FRAMES_PER_REQUEST;
+        if (
+            !is_numeric($max_frames_per_request)
+            || (int) $max_frames_per_request <= 0
+            || (int) $max_frames_per_request > Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST
+        ) {
+            throw new InvalidArgumentException(
+                'Staged max_frames_per_request must be between 1 and '
+                . Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST . ' when configured.'
+            );
+        }
+        $this->max_frames_per_request = (int) $max_frames_per_request;
+
+        $timestamp_tolerance = $options['timestamp_tolerance'] ?? 300;
+        if (!is_numeric($timestamp_tolerance) || (int) $timestamp_tolerance <= 0) {
+            throw new InvalidArgumentException('Staged timestamp_tolerance must be a positive integer when configured.');
+        }
+        $this->timestamp_tolerance = (int) $timestamp_tolerance;
     }
 
-    /**
-     * Stage a framed stream of chunks for many artifacts in one request.
-     *
-     * Each frame is one JSON line followed by exactly "bytes" raw bytes:
-     *
-     * {"type":"chunk","artifact_id":"<base64 of path>","offset":0,"bytes":123,"total_bytes":456,"final":false}\n
-     *
-     * A frame commits before the next frame is read. If the request dies after
-     * a commit, the next request may replay from the last sender cursor or from
-     * the beginning: verified artifacts replayed at their verified size are
-     * skipped, and an offset-0 frame for anything else that holds bytes
-     * restarts the artifact from zero — the sender only starts a file over
-     * when its source changed or it cannot vouch for the staged prefix, and
-     * appending one version behind another would corrupt the artifact.
-     *
-     * Behavior steps:
-     * 1. Read one JSON header line and validate the frame before reading its
-     *    payload bytes.
-     * 2. Reject frames larger than this endpoint accepts, before consuming the
-     *    oversized payload. Every rejection cursor reports the store's
-     *    committed count, never the offset the sender claimed.
-     * 3. If the artifact is verified and the frame declares its verified size,
-     *    consume the frame payload only to keep the stream aligned with the
-     *    next JSON header.
-     * 4. If the frame starts at byte 0 and the artifact holds anything else,
-     *    discard the staged bytes and stage this frame fresh.
-     * 5. If the artifact is partially committed and the frame starts mid-file,
-     *    discard any replayed prefix bytes the store already has and append
-     *    only the missing suffix, in bounded pieces so one frame cannot force
-     *    the endpoint to hold the full chunk in memory.
-     * 6. Finalize only when the frame marks the artifact final, then report the
-     *    latest cursor for the sender to resume from after failures.
-     *
-     * @param array $config Request parameters.
-     * @param array $headers Request headers/server vars ($_SERVER shape).
-     * @param resource|null $input Request body stream (php://input).
-     * @return array{http_code:int,body:array}
-     */
-    public function push_stream(array $config, array $headers, $input): array {
+    /** @return array{http_code:int,body:array} */
+    public function session_create(array $config, array $headers): array {
         $method_error = $this->require_post($headers);
         if ($method_error !== null) {
             return $method_error;
         }
-        if ($this->secret === null) {
-            return $this->rejected(503, 'not_configured', 'shared_secret');
-        }
-        if (!is_resource($input)) {
-            return $this->rejected(500, 'io_error', 'open_request_body');
-        }
-
-        $request_target = $headers['REQUEST_URI'] ?? null;
-        if (!is_string($request_target) || $request_target === '') {
-            return $this->rejected(400, 'missing_request_target');
-        }
-        $auth_error = (new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance))
-            ->verify_envelope($headers, (string) ( $headers['REQUEST_METHOD'] ?? 'POST' ), $request_target);
+        $auth_error = $this->require_envelope_auth($headers, 'staged_session_create');
         if ($auth_error !== null) {
-            return $this->rejected(403, 'auth_failed', $auth_error);
+            return $auth_error;
         }
 
-        $files_verified = 0;
-        $cursor = null;
-        while (!feof($input)) {
-            $line = fgets($input);
-            if ($line === false) {
+        return $this->session_action(function () use ($config, $headers): array {
+            $parameters = $this->request_target_parameters($headers);
+            $create_token = $parameters['create_token'] ?? null;
+            if (!is_string($create_token) || !preg_match('/^[a-f0-9]{32}$/D', $create_token)) {
+                throw new InvalidArgumentException('Staged apply session creation requires a 32-character lowercase hexadecimal create_token in the signed request target.');
+            }
+            if (array_key_exists('create_token', $config) && $config['create_token'] !== $create_token) {
+                throw new InvalidArgumentException('Staged apply create_token must match the signed request target.');
+            }
+            if (!$this->apply_sessions_enabled || $this->apply_target_root === null) {
+                return $this->rejected(503, 'apply_not_configured', self::APPLY_NOT_CONFIGURED_MESSAGE);
+            }
+
+            // A client persists this token before sending create. The server
+            // derives the id, so replay after a lost response opens the same
+            // workspace without accepting a caller-chosen session id.
+            $server_session_id = substr(hash_hmac('sha256', 'reprint-staged-apply-create-v2:' . $create_token, (string) $this->secret), 0, 32);
+            $retired_session_seconds = $this->timestamp_tolerance > intdiv(PHP_INT_MAX - 1, 2)
+                ? PHP_INT_MAX
+                : $this->timestamp_tolerance * 2 + 1;
+            $session = Site_Export_Staged_Apply::create(
+                $this->staging_dir,
+                $this->apply_target_root,
+                $this->apply_protected_paths,
+                $server_session_id,
+                $retired_session_seconds
+            );
+            $state = $session->get_status();
+            $body = $this->session_state_body($state);
+            $body['status'] = 'created';
+            $body['max_frame_bytes'] = $this->max_frame_bytes;
+            $body['max_frames_per_request'] = $this->max_frames_per_request;
+            // This is the decoded entity-body budget PHP reports. A proxy's
+            // hidden limit is learned later from actual 413 responses.
+            $body['post_max_bytes'] = $this->post_max_bytes;
+            return ['http_code' => 201, 'body' => $body];
+        });
+    }
+
+    /**
+     * Authenticate before the HTTP server parses or buffers other input.
+     *
+     * @return array{http_code:int,body:array}|null
+     */
+    public function pre_authenticate_envelope(array $headers, string $expected_endpoint): ?array {
+        $error = $this->require_envelope_auth($headers, $expected_endpoint);
+        if ($error === null || $error['http_code'] === 503) {
+            return $error;
+        }
+        return $this->rejected(403, 'auth_failed', 'Authentication failed.');
+    }
+
+    /**
+     * Stream typed operations into one isolated target session.
+     *
+     * @param resource|null $input
+     * @return array{http_code:int,body:array}
+     */
+    public function session_push_stream(array $config, array $headers, $input): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        $auth_error = $this->require_envelope_auth($headers, 'staged_session_push');
+        if ($auth_error !== null) {
+            return $auth_error;
+        }
+
+        return $this->session_action(function () use ($config, $headers, $input): array {
+            $expected_request_generation = $this->expected_session_request_generation($headers);
+            $session = $this->open_session($config, $headers);
+            return $session->while_uploading(
+                $expected_request_generation,
+                function (Site_Export_Staged_Apply $locked_session) use ($input): array {
+                    return $this->stream_operation_frames($locked_session, $input);
+                }
+            );
+        });
+    }
+
+    /** Close uploads and commit the next fixed server-owned batch. */
+    public function session_advance(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        $auth_error = $this->require_envelope_auth($headers, 'staged_session_advance');
+        if ($auth_error !== null) {
+            return $auth_error;
+        }
+        return $this->session_action(function () use ($config, $headers): array {
+            $session = $this->open_session($config, $headers);
+            $state = $session->advance($this->expected_session_request_generation($headers));
+            return $this->session_state_response($state);
+        });
+    }
+
+    /** @return array{http_code:int,body:array} */
+    public function session_status(array $config, array $headers): array {
+        $method_error = $this->require_get($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        $auth_error = $this->require_envelope_auth($headers, 'staged_session_status');
+        if ($auth_error !== null) {
+            return $auth_error;
+        }
+        return $this->session_action(function () use ($config, $headers): array {
+            return $this->session_state_response($this->open_session($config, $headers)->get_status());
+        });
+    }
+
+    /** @return array{http_code:int,body:array} */
+    public function session_discard(array $config, array $headers): array {
+        $method_error = $this->require_post($headers);
+        if ($method_error !== null) {
+            return $method_error;
+        }
+        $auth_error = $this->require_envelope_auth($headers, 'staged_session_discard');
+        if ($auth_error !== null) {
+            return $auth_error;
+        }
+        return $this->session_action(function () use ($config, $headers): array {
+            $session = $this->open_session($config, $headers);
+            $discarded = $session->discard($this->expected_session_request_generation($headers));
+            return [
+                'http_code' => 200,
+                'body' => [
+                    'status' => $discarded ? 'discarded' : 'discarding',
+                    'session_id' => $session->get_session_id(),
+                ],
+            ];
+        });
+    }
+
+    /**
+     * Process at most the server-owned frame cap. Each file piece is passed to
+     * the session before the next piece is read, so a truncated request loses
+     * at most one bounded in-memory piece and resumes at the persisted cursor.
+     *
+     * @param resource|null $input
+     * @return array{http_code:int,body:array}
+     */
+    private function stream_operation_frames(Site_Export_Staged_Apply $session, $input): array {
+        if (!is_resource($input)) {
+            return $this->rejected(500, 'io_error', 'Could not open the staged push request body.');
+        }
+
+        $frames_processed = 0;
+        while ($frames_processed < $this->max_frames_per_request && !feof($input)) {
+            try {
+                $line = Site_Export_Staged_Push_Stream_Protocol::read_header_line($input);
+            } catch (InvalidArgumentException $exception) {
+                $session->fail_upload($exception->getMessage());
+                return $this->stream_rejected(400, 'invalid_frame', $exception->getMessage(), $session);
+            } catch (RuntimeException $exception) {
+                // The stream itself failed, rather than carrying a malformed
+                // header. A later request can resume from durable session
+                // state, so this must not turn the session terminal.
+                return $this->stream_rejected(400, 'body_read_failed', $exception->getMessage(), $session);
+            }
+            if ($line === null) {
                 break;
             }
-            $line = rtrim($line, "\r\n");
             try {
-                $frame = Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line);
-            } catch (InvalidArgumentException $e) {
-                return $this->stream_rejected(400, 'invalid_frame', $e->getMessage(), $cursor, $files_verified);
-            }
-            $artifact_id = $frame['artifact_id'];
-            $offset = $frame['offset'];
-            $bytes = $frame['bytes'];
-            $total_bytes = $frame['total_bytes'];
-            $final = $frame['final'];
-
-            // Refuse frames that name reprint's reserved namespace before the
-            // store is touched, so a pushed file can never overwrite the
-            // deletion manifest (or hide as another .reprint/ artifact apply
-            // would then trust). The one deletion-manifest id is allowed
-            // through and stages like any other artifact.
-            if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
-                return $this->stream_rejected(
-                    400,
-                    'reserved_artifact_id',
-                    'The artifact id "' . $artifact_id . '" is in reprint\'s reserved ".reprint/" namespace; only the deletion manifest may be written there.',
-                    ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => 0],
-                    $files_verified
-                );
+                $frame = Site_Export_Staged_Push_Stream_Protocol::decode_operation_header($line);
+            } catch (InvalidArgumentException $exception) {
+                $session->fail_upload($exception->getMessage());
+                return $this->stream_rejected(400, 'invalid_frame', $exception->getMessage(), $session);
             }
 
-            // Response cursors re-encode the id so responses stay valid JSON
-            // for arbitrary-byte paths, and they report only what the store
-            // has confirmed — never the offset the sender claims. A rejection
-            // echoing a claimed offset would send the retry to a position the
-            // store never reached.
-            $status = $this->store->status($artifact_id);
-            $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => (int) $status['committed_bytes']];
-
-            if ($bytes > $this->max_frame_bytes) {
-                $response = $this->stream_rejected(413, 'frame_too_large', null, $cursor, $files_verified);
-                $response['body']['max_frame_bytes'] = $this->max_frame_bytes;
-                return $response;
-            }
-
-            /**
-             * Already-verified replay case.
-             *
-             * The sender may replay a request body from the beginning after a
-             * previous request committed and finalized this artifact. When the
-             * declared size still matches, the store must not append or
-             * finalize again, but the frame payload is still present in the
-             * request body: read and discard those bytes so the next loop
-             * iteration starts at the following JSON header.
-             */
-            if ($status['verified'] && $status['committed_bytes'] === $total_bytes) {
-                if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $bytes, self::READ_BUFFER_BYTES)) {
-                    return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+            ++$frames_processed;
+            if ($frame['type'] === 'directory') {
+                $result = $session->accept_directory($frame['operation_index'], $frame['path']);
+                $rejection = $this->accept_result_rejection($result, $session);
+                if ($rejection !== null) {
+                    return $rejection;
                 }
-                if ($final) {
-                    $files_verified++;
+                continue;
+            }
+            if ($frame['type'] === 'symlink') {
+                $result = $session->accept_symlink($frame['operation_index'], $frame['path'], $frame['target']);
+                $rejection = $this->accept_result_rejection($result, $session);
+                if ($rejection !== null) {
+                    return $rejection;
+                }
+                continue;
+            }
+            if ($frame['type'] === 'delete') {
+                $result = $session->accept_delete($frame['operation_index'], $frame['path']);
+                $rejection = $this->accept_result_rejection($result, $session);
+                if ($rejection !== null) {
+                    return $rejection;
                 }
                 continue;
             }
 
-            /**
-             * Restart case.
-             *
-             * An offset-0 frame for an artifact that already holds bytes means
-             * the sender is pushing the file over: its source changed since
-             * those bytes were staged, or it is replaying after a failure and
-             * cannot vouch for the staged prefix. Drop the staged bytes and
-             * stage this frame fresh — appending a new version behind an old
-             * prefix would build a file no version of the source ever was.
-             */
-            if ($offset === 0 && ($status['verified'] || (int) $status['committed_bytes'] > 0)) {
-                if (!$this->store->discard($artifact_id)) {
-                    return $this->stream_rejected(423, 'busy', null, $cursor, $files_verified);
-                }
-                $status = $this->store->status($artifact_id);
-                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => 0];
-            } elseif ($status['verified']) {
-                // A mid-file frame into a verified artifact of another size:
-                // the source changed but the sender did not restart. Refuse
-                // rather than mix versions; the sender restarts from zero.
-                return $this->stream_rejected(409, 'size_mismatch', null, $cursor, $files_verified);
+            if ($frame['bytes'] > $this->max_frame_bytes) {
+                $response = $this->stream_rejected(413, 'frame_too_large', 'The file frame payload exceeds this target\'s limit.', $session);
+                $response['body']['max_frame_bytes'] = $this->max_frame_bytes;
+                return $response;
             }
 
-            if ($bytes > 0) {
-                $remaining_frame_bytes = $bytes;
-                $append_offset = $offset;
-
-                $committed_bytes = (int) $status['committed_bytes'];
-
-                /**
-                 * Partially-committed replay case.
-                 *
-                 * The sender can retry a frame whose prefix was accepted before
-                 * the earlier request failed. Consume the bytes already stored,
-                 * advance the append offset to the first missing byte, and keep
-                 * the cursor at the remote committed position so the sender can
-                 * resume from that boundary if this request fails too.
-                 */
-                if ($committed_bytes > $offset) {
-                    $already_committed_bytes = min($bytes, $committed_bytes - $offset);
-                    if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $already_committed_bytes, self::READ_BUFFER_BYTES)) {
-                        return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
-                    }
-                    $remaining_frame_bytes -= $already_committed_bytes;
-                    $append_offset += $already_committed_bytes;
-                    $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => $committed_bytes];
+            $remaining = $frame['bytes'];
+            $piece_offset = $frame['offset'];
+            $restart = $frame['restart'];
+            if ($remaining === 0) {
+                $result = $session->append_file_chunk(
+                    $frame['operation_index'],
+                    $frame['path'],
+                    $frame['revision'],
+                    $piece_offset,
+                    '',
+                    $frame['total_bytes'],
+                    $restart
+                );
+                $rejection = $this->accept_result_rejection($result, $session);
+                if ($rejection !== null) {
+                    return $rejection;
                 }
-
-                while ($remaining_frame_bytes > 0) {
-                    $payload_piece_bytes = min($this->append_buffer_bytes, $remaining_frame_bytes);
-                    $payload_piece = Site_Export_Staged_Push_Stream_Protocol::read_exactly($input, $payload_piece_bytes);
-                    if ($payload_piece === null) {
-                        return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
-                    }
-                    $remaining_frame_bytes -= $payload_piece_bytes;
-
-                    while ($payload_piece !== '') {
-                        /**
-                         * Append/reconcile case.
-                         *
-                         * A bounded payload piece normally appends once. If the
-                         * store reports that part of this piece was already
-                         * committed, trim that prefix and retry only the suffix;
-                         * this keeps a resumed request moving forward without
-                         * asking the sender to open another request for the same
-                         * frame.
-                         */
-                        $append_result = $this->store->append($artifact_id, $append_offset, $payload_piece);
-                        if ($append_result['status'] === 'accepted' || $append_result['status'] === 'duplicate') {
-                            $append_offset = max($append_offset + strlen($payload_piece), (int) $append_result['committed_bytes']);
-                            $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => (int) $append_result['committed_bytes']];
-                            break;
-                        }
-
-                        $committed_bytes = (int) $append_result['committed_bytes'];
-                        if (
-                            $append_result['reason'] === 'offset_gap'
-                            && $committed_bytes > $append_offset
-                            && $committed_bytes < $append_offset + strlen($payload_piece)
-                        ) {
-                            $payload_piece = substr($payload_piece, $committed_bytes - $append_offset);
-                            $append_offset = $committed_bytes;
-                            continue;
-                        }
-
-                        $response = $this->from_store_result($append_result);
-                        $response['body']['cursor'] = [
-                            'artifact_id' => base64_encode($artifact_id),
-                            'committed_bytes' => $committed_bytes,
-                        ];
-                        $response['body']['files_verified'] = $files_verified;
-                        return $response;
-                    }
-                }
+                continue;
             }
 
-            /**
-             * Final frame case.
-             *
-             * Payload bytes are durable before this branch runs. Only frames
-             * marked final ask the store to compare committed bytes with
-             * total_bytes and mark the artifact verified.
-             */
-            if ($final) {
-                $finalize_result = $this->store->finalize($artifact_id, $total_bytes);
-                unset($finalize_result['path']);
-                if ($finalize_result['status'] !== 'verified') {
-                    $response = $this->from_store_result($finalize_result);
-                    $response['body']['cursor'] = $cursor;
-                    $response['body']['files_verified'] = $files_verified;
-                    return $response;
+            while ($remaining > 0) {
+                $piece_bytes = min($remaining, $this->append_buffer_bytes);
+                $payload = Site_Export_Staged_Push_Stream_Protocol::read_exactly($input, $piece_bytes);
+                if ($payload === null) {
+                    return $this->stream_rejected(
+                        400,
+                        'body_read_failed',
+                        'The request body ended before the declared file-frame payload was complete.',
+                        $session
+                    );
                 }
-                $files_verified++;
-                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => (int) $finalize_result['committed_bytes']];
+                $result = $session->append_file_chunk(
+                    $frame['operation_index'],
+                    $frame['path'],
+                    $frame['revision'],
+                    $piece_offset,
+                    $payload,
+                    $frame['total_bytes'],
+                    $restart
+                );
+                $rejection = $this->accept_result_rejection($result, $session);
+                if ($rejection !== null) {
+                    return $rejection;
+                }
+                $piece_offset += strlen($payload);
+                $remaining -= strlen($payload);
+                $restart = false;
             }
         }
 
-        return [
-            'http_code' => 200,
-            'body' => [
-                'status' => 'complete',
-                'reason' => null,
-                'detail' => null,
-                'cursor' => $cursor,
-                'files_verified' => $files_verified,
-            ],
-        ];
+        $body = $this->session_state_body($session->get_status());
+        $body['status'] = 'complete';
+        $body['frames_processed'] = $frames_processed;
+        return ['http_code' => 200, 'body' => $body];
     }
 
-    /**
-     * Confirm an assembled artifact against its plan-declared size.
-     *
-     * @return array{http_code:int,body:array}
-     */
-    public function finalize(array $config, array $headers): array {
-        $method_error = $this->require_post($headers);
-        if ($method_error !== null) {
-            return $method_error;
-        }
-
-        $artifact_id = $this->decode_artifact_id_param($config);
-        if ($artifact_id === null) {
-            return $this->rejected(400, 'invalid_artifact_id');
-        }
-        if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
-            return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
-        }
-        $total_bytes = $config['total_bytes'] ?? null;
-        if (!is_numeric($total_bytes) || (int) $total_bytes < 0) {
-            return $this->rejected(400, 'invalid_total');
-        }
-
-        $result = $this->store->finalize($artifact_id, (int) $total_bytes);
-        // The staged path is server-local detail; apply resolves by id.
-        unset($result['path']);
-        return $this->from_store_result($result);
-    }
-
-    /**
-     * Resume hint for a sender: committed offset and verified flag.
-     *
-     * @return array{http_code:int,body:array}
-     */
-    public function status(array $config): array {
-        $artifact_id = $this->decode_artifact_id_param($config);
-        if ($artifact_id === null) {
-            return $this->rejected(400, 'invalid_artifact_id');
-        }
-        if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
-            return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
-        }
-
-        return [
-            'http_code' => 200,
-            'body' => $this->store->status($artifact_id),
-        ];
-    }
-
-    /**
-     * Drop an artifact's staged bytes and records.
-     *
-     * @return array{http_code:int,body:array}
-     */
-    public function discard(array $config, array $headers): array {
-        $method_error = $this->require_post($headers);
-        if ($method_error !== null) {
-            return $method_error;
-        }
-
-        $artifact_id = $this->decode_artifact_id_param($config);
-        if ($artifact_id === null) {
-            return $this->rejected(400, 'invalid_artifact_id');
-        }
-        if (Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)) {
-            return $this->rejected(400, 'reserved_artifact_id', self::RESERVED_NAMESPACE_MESSAGE);
-        }
-
-        if (!$this->store->discard($artifact_id)) {
-            // Held by a concurrent writer or a failed cleanup step; both
-            // are the store's retry-until-true contract.
-            return [
-                'http_code' => 423,
-                'body' => ['discarded' => false],
-            ];
-        }
-        return [
-            'http_code' => 200,
-            'body' => ['discarded' => true],
-        ];
-    }
-
-    /**
-     * Read a control-plane artifact id parameter: base64 in the request —
-     * file paths are arbitrary bytes, the same convention the push stream
-     * frames use — raw path out. Null when missing or not decodable.
-     */
-    private function decode_artifact_id_param(array $config): ?string {
-        $artifact_id = $config['artifact_id'] ?? null;
-        if (!is_string($artifact_id) || $artifact_id === '') {
+    /** @return array{http_code:int,body:array}|null */
+    private function accept_result_rejection(array $result, Site_Export_Staged_Apply $session): ?array {
+        if ($result['status'] !== 'rejected') {
             return null;
         }
-        $artifact_id = base64_decode($artifact_id, true);
-        return $artifact_id === false || $artifact_id === '' ? null : $artifact_id;
+        $reason = (string) $result['reason'];
+        $http_code = $reason === 'operation_gap' || $reason === 'offset_gap'
+            ? 409
+            : 400;
+        return $this->stream_rejected($http_code, $reason, null, $session);
+    }
+
+    private function open_session(array $config, array $headers): Site_Export_Staged_Apply {
+        if (!$this->apply_sessions_enabled || $this->apply_target_root === null) {
+            throw new RuntimeException(self::APPLY_NOT_CONFIGURED_MESSAGE, self::ERROR_APPLY_NOT_CONFIGURED);
+        }
+        $parameters = $this->request_target_parameters($headers);
+        $session_id = $parameters['session_id'] ?? null;
+        if (!is_string($session_id) || $session_id === '') {
+            throw new InvalidArgumentException('Staged apply session requests require a session_id in the signed request target.');
+        }
+        if (array_key_exists('session_id', $config) && $config['session_id'] !== $session_id) {
+            throw new InvalidArgumentException('Staged apply session_id must match the signed request target.');
+        }
+        return Site_Export_Staged_Apply::open(
+            $this->staging_dir,
+            $this->apply_target_root,
+            $session_id,
+            $this->apply_protected_paths
+        );
+    }
+
+    private function expected_session_request_generation(array $headers): int {
+        $parameters = $this->request_target_parameters($headers);
+        $value = $parameters['expected_request_generation'] ?? null;
+        if (!is_string($value) || !preg_match('/^(?:0|[1-9][0-9]*)$/D', $value)) {
+            throw new InvalidArgumentException('Staged apply session requests require a non-negative expected_request_generation in the signed request target.');
+        }
+        $maximum = (string) PHP_INT_MAX;
+        if (strlen($value) > strlen($maximum) || ( strlen($value) === strlen($maximum) && strcmp($value, $maximum) > 0 )) {
+            throw new InvalidArgumentException('The staged apply expected_request_generation exceeds this server\'s integer range: ' . $value . '.');
+        }
+        return (int) $value;
+    }
+
+    /** @return array{http_code:int,body:array} */
+    private function session_state_response(array $state): array {
+        return ['http_code' => 200, 'body' => $this->session_state_body($state)];
+    }
+
+    /** @return array<string,mixed> */
+    private function session_state_body(array $state): array {
+        return [
+            'status' => 'ok',
+            'session_id' => $state['session_id'],
+            'phase' => $state['phase'],
+            'request_generation' => $state['request_generation'],
+            'operation_count' => $state['operation_count'],
+            'current_file' => $state['current_file'] ?? null,
+            'commit_offset' => $state['commit_offset'] ?? 0,
+            'committed_operations' => $state['commit_count'] ?? 0,
+            'failure' => $state['failure'] ?? null,
+        ];
     }
 
     /**
-     * @return array{http_code:int,body:array}|null Null when the method is POST.
+     * @param callable():array{http_code:int,body:array} $callback
+     * @return array{http_code:int,body:array}
      */
+    private function session_action(callable $callback): array {
+        try {
+            return $callback();
+        } catch (InvalidArgumentException $exception) {
+            return $this->rejected(400, 'invalid_session_request', $exception->getMessage());
+        } catch (RuntimeException $exception) {
+            switch ($exception->getCode()) {
+                case self::ERROR_APPLY_NOT_CONFIGURED:
+                    return $this->rejected(503, 'apply_not_configured', $exception->getMessage());
+                case Site_Export_Staged_Apply::ERROR_RETRYABLE_IO:
+                    return $this->rejected(500, 'retryable_io_error', $exception->getMessage());
+                case Site_Export_Staged_Apply::ERROR_BUSY:
+                    return $this->rejected(423, 'busy', $exception->getMessage());
+                case Site_Export_Staged_Apply::ERROR_DISCARD_PENDING:
+                    return $this->rejected(423, 'discard_pending', $exception->getMessage());
+                case Site_Export_Staged_Apply::ERROR_STALE_GENERATION:
+                    return $this->rejected(409, 'stale_session_state', $exception->getMessage());
+                case Site_Export_Staged_Apply::ERROR_SESSION_NOT_FOUND:
+                    return $this->rejected(404, 'session_not_found', $exception->getMessage());
+                default:
+                    return $this->rejected(409, 'session_rejected', $exception->getMessage());
+            }
+        }
+    }
+
+    /** @return array{http_code:int,body:array}|null */
     private function require_post(array $headers): ?array {
-        $method = strtoupper( (string) ( $headers['REQUEST_METHOD'] ?? '' ));
-        if ($method === 'POST') {
+        if (strtoupper( (string) ( $headers['REQUEST_METHOD'] ?? '' )) === 'POST') {
             return null;
         }
         return $this->rejected(405, 'method_not_allowed');
     }
 
-    /**
-     * Map a store result onto an HTTP code, passing its typed body through.
-     *
-     * @return array{http_code:int,body:array}
-     */
-    private function from_store_result(array $result): array {
-        switch ($result['status']) {
-            case 'accepted':
-            case 'duplicate':
-            case 'verified':
-                $code = 200;
-                break;
-            case 'busy':
-                $code = 423;
-                break;
-            default:
-                switch ((string) $result['reason']) {
-                    case 'io_error':
-                        $code = 500;
-                        break;
-                    case 'offset_gap':
-                    case 'already_verified':
-                    case 'size_mismatch':
-                    case 'missing':
-                        $code = 409;
-                        break;
-                    default:
-                        $code = 400;
-                }
+    /** @return array{http_code:int,body:array}|null */
+    private function require_get(array $headers): ?array {
+        if (strtoupper( (string) ( $headers['REQUEST_METHOD'] ?? '' )) === 'GET') {
+            return null;
         }
-
-        return [
-            'http_code' => $code,
-            'body' => $result,
-        ];
+        return $this->rejected(405, 'method_not_allowed');
     }
 
-    /**
-     * @return array{http_code:int,body:array}
-     */
-    private function stream_rejected(int $http_code, string $reason, ?string $detail, ?array $cursor, int $files_verified): array {
+    /** @return array{http_code:int,body:array}|null */
+    private function require_envelope_auth(array $headers, string $expected_endpoint): ?array {
+        if ($this->secret === null) {
+            return $this->rejected(503, 'not_configured', 'Staged session authentication is unavailable because no shared secret is configured.');
+        }
+        $request_target = $headers['REQUEST_URI'] ?? null;
+        if (!is_string($request_target) || $request_target === '') {
+            return $this->rejected(400, 'missing_request_target');
+        }
+        $error = ( new Site_Export_HMAC_Server($this->secret, $this->timestamp_tolerance) )->verify_envelope(
+            $headers,
+            (string) ( $headers['REQUEST_METHOD'] ?? '' ),
+            $request_target
+        );
+        if ($error !== null) {
+            return $this->rejected(403, 'auth_failed', $error);
+        }
+        try {
+            $parameters = $this->request_target_parameters($headers);
+        } catch (InvalidArgumentException $exception) {
+            return $this->rejected(400, 'invalid_request_target', $exception->getMessage());
+        }
+        if (( $parameters['endpoint'] ?? null ) !== $expected_endpoint) {
+            return $this->rejected(400, 'invalid_request_target', 'The signed request target must name endpoint=' . $expected_endpoint . '.');
+        }
+        return null;
+    }
+
+    /** @return array<string,mixed> */
+    private function request_target_parameters(array $headers): array {
+        $request_target = $headers['REQUEST_URI'] ?? null;
+        if (!is_string($request_target) || $request_target === '') {
+            throw new InvalidArgumentException('The request target is missing.');
+        }
+        $query = parse_url($request_target, PHP_URL_QUERY);
+        if ($query === false) {
+            throw new InvalidArgumentException('The request target is malformed.');
+        }
+        $parameters = [];
+        parse_str(is_string($query) ? $query : '', $parameters);
+        return $parameters;
+    }
+
+    /** @return array{http_code:int,body:array} */
+    private function stream_rejected(int $http_code, string $reason, ?string $detail, Site_Export_Staged_Apply $session): array {
+        $body = $this->session_state_body($session->get_status());
+        $body['status'] = 'rejected';
+        $body['reason'] = $reason;
+        $body['detail'] = $detail;
+        return ['http_code' => $http_code, 'body' => $body];
+    }
+
+    /** @return array{http_code:int,body:array} */
+    private function rejected(int $http_code, string $reason, ?string $detail = null): array {
         return [
             'http_code' => $http_code,
             'body' => [
                 'status' => 'rejected',
                 'reason' => $reason,
                 'detail' => $detail,
-                'cursor' => $cursor,
-                'files_verified' => $files_verified,
             ],
         ];
     }
-
-    /**
-     * @return array{http_code:int,body:array}
-     */
-    private function rejected(int $http_code, string $reason, ?string $detail = null, int $committed_bytes = 0): array {
-        return [
-            'http_code' => $http_code,
-            'body' => [
-                'status' => 'rejected',
-                'reason' => $reason,
-                'detail' => $detail,
-                'committed_bytes' => $committed_bytes,
-            ],
-        ];
-    }
-
 }

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -1,12 +1,14 @@
 <?php
 
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation errors are API/CLI messages, never HTML output.
+
 /**
- * Shared wire format helpers for staged push streams.
+ * Shared wire format helpers for staged push operation streams.
  *
- * A staged push stream is a sequence of JSON header lines followed by exactly
- * the number of raw payload bytes declared by each header. Both the importer
- * and the exporter use this class so frame shape, validation, and bounded
- * stream reads stay in one place.
+ * Each frame is one bounded JSON header line. File frames alone carry raw
+ * payload bytes immediately after the line; the header's bytes field says
+ * exactly how many. Paths and symlink targets travel as base64 because file
+ * system names are bytes while JSON strings must be UTF-8.
  */
 final class Site_Export_Staged_Push_Stream_Protocol {
 
@@ -18,130 +20,190 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     /** Holds two maximum base64 fields plus bounded JSON metadata. */
     public const MAX_HEADER_BYTES = 32768;
 
-    /**
-     * Top-level path segment reprint reserves for its own staged bookkeeping.
-     * A sender's file artifacts may never land here — see
-     * is_reserved_sender_artifact_id() — so the apply step can trust that
-     * everything under it is reprint's own, not pushed site content.
-     */
-    public const RESERVED_NAMESPACE_SEGMENT = '.reprint';
+    /** Bounds metadata-only work even when request bodies are tiny. */
+    public const MAX_FRAMES_PER_REQUEST = 1024;
+
+    public const OPERATION_DIRECTORY = 'directory';
+
+    public const OPERATION_FILE = 'file';
+
+    public const OPERATION_SYMLINK = 'symlink';
+
+    public const OPERATION_DELETE = 'delete';
 
     /**
-     * The one artifact id inside the reserved namespace a sender is allowed
-     * to write: the list of paths deleted locally since the last push, staged
-     * like any other artifact so apply can unlink them in its window. Content
-     * is the local-paths-to-delete.jsonl the push journal produces.
-     */
-    public const DELETION_MANIFEST_ARTIFACT_ID = '.reprint/deletions.jsonl';
-
-    /**
-     * Whether a sender-named artifact id intrudes on reprint's reserved
-     * namespace. True for the bare reserved segment and anything beneath it,
-     * except the one deletion-manifest id a sender may legitimately write.
+     * Read one LF-terminated header without ever buffering an unbounded line.
      *
-     * The check is on the first path segment, not a raw string prefix, so
-     * a real site file like ".reprintfoo" or "wp-content/.reprint/x" is not
-     * caught — only the top-level ".reprint" namespace is.
-     */
-    public static function is_reserved_sender_artifact_id(string $artifact_id): bool {
-        if ($artifact_id === self::DELETION_MANIFEST_ARTIFACT_ID) {
-            return false;
-        }
-        return explode('/', $artifact_id, 2)[0] === self::RESERVED_NAMESPACE_SEGMENT;
-    }
-
-    /**
-     * Read the next frame header line from a stream.
+     * A clean EOF before another header returns null; EOF in a header is a
+     * truncated frame, not a shorter valid line.
      *
      * @param resource $input
      */
-    public static function read_header_line($input): ?string {
-        $line = fgets($input);
-        if ($line === false) {
-            return null;
+    public static function read_header_line(
+        $input,
+        int $max_header_bytes = self::MAX_HEADER_BYTES
+    ): ?string {
+        if (!is_resource($input)) {
+            throw new InvalidArgumentException('Expected the staged push stream input to be a resource.');
         }
-        return rtrim($line, "\r\n");
+        if ($max_header_bytes <= 0) {
+            throw new InvalidArgumentException(
+                'Expected the staged push stream header limit to be positive; received ' . $max_header_bytes . '.'
+            );
+        }
+
+        $line = @fgets($input, $max_header_bytes + 2);
+        if ($line === false) {
+            if (feof($input)) {
+                return null;
+            }
+            throw new RuntimeException('Could not read the next staged push stream frame header.');
+        }
+
+        if (substr($line, -1) !== "\n") {
+            if (strlen($line) > $max_header_bytes) {
+                throw new InvalidArgumentException(
+                    'Staged push stream frame header exceeds ' . $max_header_bytes . ' bytes.'
+                );
+            }
+            throw new InvalidArgumentException('Staged push stream frame header ended before its LF terminator.');
+        }
+
+        $line = substr($line, 0, -1);
+        if (substr($line, -1) === "\r") {
+            $line = substr($line, 0, -1);
+        }
+        if (strlen($line) > $max_header_bytes) {
+            throw new InvalidArgumentException(
+                'Staged push stream frame header exceeds ' . $max_header_bytes . ' bytes.'
+            );
+        }
+        return $line;
     }
 
     /**
-     * Decode and validate one chunk frame header.
+     * Encode one sender operation as its LF-terminated wire header.
      *
-     * The artifact_id in the wire frame is base64: file paths are arbitrary
-     * bytes and JSON strings must be UTF-8, so ids travel encoded — the same
-     * convention the pull cursors and the local journal use for paths. The
-     * returned artifact_id is the decoded raw path.
-     *
-     * @return array{artifact_id:string,offset:int,bytes:int,total_bytes:int,final:bool}
+     * The file payload is not concatenated here. The streaming client holds
+     * it separately and hands both strings to curl using copy-on-write.
      */
-    public static function decode_chunk_header(string $line): array {
-        $frame = json_decode($line, true);
-        if (!is_array($frame)) {
+    public static function encode_operation_header(array $operation): string {
+        $type = self::require_operation_type($operation);
+        $operation_index = self::require_non_negative_integer_field($operation, 'operation_index');
+        $path = self::require_raw_path_field($operation, 'path', false);
+
+        $frame = [
+            'type' => $type,
+            'operation_index' => $operation_index,
+            'path' => base64_encode($path),
+        ];
+
+        if ($type === self::OPERATION_SYMLINK) {
+            self::require_exact_fields($operation, ['type', 'operation_index', 'path', 'target']);
+            $frame['target'] = base64_encode(self::require_raw_path_field($operation, 'target', true));
+        } elseif ($type === self::OPERATION_FILE) {
+            self::require_exact_fields(
+                $operation,
+                ['type', 'operation_index', 'path', 'revision', 'offset', 'total_bytes', 'restart', 'payload']
+            );
+            if (!is_string($operation['payload'] ?? null)) {
+                throw new InvalidArgumentException(
+                    'Expected staged push operation field "payload" to be a string; received ' .
+                    self::describe_value($operation['payload'] ?? null) . '.'
+                );
+            }
+            $frame['revision'] = self::require_non_negative_integer_field($operation, 'revision');
+            $frame['offset'] = self::require_non_negative_integer_field($operation, 'offset');
+            $frame['bytes'] = strlen($operation['payload']);
+            $frame['total_bytes'] = self::require_non_negative_integer_field($operation, 'total_bytes');
+            $frame['restart'] = self::require_boolean_field($operation, 'restart');
+        } else {
+            self::require_exact_fields($operation, ['type', 'operation_index', 'path']);
+        }
+
+        $header = json_encode($frame, JSON_UNESCAPED_SLASHES);
+        if ($header === false) {
+            throw new RuntimeException(
+                'Could not encode the staged push operation header for base64 path "' . base64_encode($path) . '".'
+            );
+        }
+
+        // Apply the same range and restart checks on both sides of the wire.
+        self::decode_operation_header($header);
+        if (strlen($header) > self::MAX_HEADER_BYTES) {
+            throw new InvalidArgumentException(
+                'Staged push stream frame header exceeds ' . self::MAX_HEADER_BYTES . ' bytes.'
+            );
+        }
+        return $header . "\n";
+    }
+
+    /**
+     * Decode and validate one typed operation header.
+     *
+     * @return array<string,mixed> Raw-byte path and target values are decoded.
+     */
+    public static function decode_operation_header(string $line): array {
+        $decoded = json_decode($line);
+        if (!is_object($decoded)) {
             throw new InvalidArgumentException('Expected staged push stream frame header to be a JSON object.');
         }
+        $frame = (array) $decoded;
 
-        if (!array_key_exists('type', $frame)) {
-            throw new InvalidArgumentException('Missing staged push stream frame field "type".');
-        }
-        if ($frame['type'] !== 'chunk') {
-            throw new InvalidArgumentException(
-                'Expected staged push stream frame field "type" to be "chunk"; received ' .
-                self::describe_value($frame['type']) .
-                '.'
-            );
-        }
+        $type = self::require_operation_type($frame);
+        $operation_index = self::require_non_negative_integer_field($frame, 'operation_index');
+        $path = self::require_base64_field($frame, 'path', false);
 
-        if (!array_key_exists('artifact_id', $frame)) {
-            throw new InvalidArgumentException('Missing staged push stream frame field "artifact_id".');
-        }
-        if (!is_string($frame['artifact_id']) || $frame['artifact_id'] === '') {
-            throw new InvalidArgumentException(
-                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received ' .
-                self::describe_value($frame['artifact_id']) .
-                '.'
-            );
-        }
-        $artifact_id = base64_decode($frame['artifact_id'], true);
-        if ($artifact_id === false || $artifact_id === '') {
-            throw new InvalidArgumentException(
-                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received ' .
-                self::describe_value($frame['artifact_id']) .
-                '.'
-            );
+        $operation = [
+            'type' => $type,
+            'operation_index' => $operation_index,
+            'path' => $path,
+        ];
+
+        if ($type === self::OPERATION_SYMLINK) {
+            self::require_exact_fields($frame, ['type', 'operation_index', 'path', 'target']);
+            $operation['target'] = self::require_base64_field($frame, 'target', true);
+            return $operation;
         }
 
-        $offset = self::require_non_negative_integer_field($frame, 'offset');
-        $bytes = self::require_non_negative_integer_field($frame, 'bytes');
-        $total_bytes = self::require_non_negative_integer_field($frame, 'total_bytes');
-
-        if (!array_key_exists('final', $frame)) {
-            throw new InvalidArgumentException('Missing staged push stream frame field "final".');
-        }
-        if (!is_bool($frame['final'])) {
-            throw new InvalidArgumentException(
-                'Expected staged push stream frame field "final" to be a boolean; received ' .
-                self::describe_value($frame['final']) .
-                '.'
-            );
+        if ($type !== self::OPERATION_FILE) {
+            self::require_exact_fields($frame, ['type', 'operation_index', 'path']);
+            return $operation;
         }
 
-        if ($offset + $bytes > $total_bytes) {
+        self::require_exact_fields(
+            $frame,
+            ['type', 'operation_index', 'path', 'revision', 'offset', 'bytes', 'total_bytes', 'restart']
+        );
+        $operation['revision'] = self::require_non_negative_integer_field($frame, 'revision');
+        $operation['offset'] = self::require_non_negative_integer_field($frame, 'offset');
+        $operation['bytes'] = self::require_non_negative_integer_field($frame, 'bytes');
+        $operation['total_bytes'] = self::require_non_negative_integer_field($frame, 'total_bytes');
+        $operation['restart'] = self::require_boolean_field($frame, 'restart');
+
+        if ($operation['offset'] > $operation['total_bytes'] ||
+            $operation['bytes'] > $operation['total_bytes'] - $operation['offset']) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Staged push stream frame declares offset %d and %d payload bytes, which exceeds total_bytes %d.',
-                    $offset,
-                    $bytes,
-                    $total_bytes
+                    'Staged push file frame declares offset %d and %d payload bytes, which exceeds total_bytes %d.',
+                    $operation['offset'],
+                    $operation['bytes'],
+                    $operation['total_bytes']
                 )
             );
         }
+        if ($operation['bytes'] === 0 && $operation['offset'] !== $operation['total_bytes']) {
+            throw new InvalidArgumentException(
+                'Staged push file frames with zero payload bytes must be positioned at total_bytes.'
+            );
+        }
+        if ($operation['restart'] && $operation['offset'] !== 0) {
+            throw new InvalidArgumentException(
+                'Staged push file frame field "restart" may be true only when offset is 0.'
+            );
+        }
 
-        return [
-            'artifact_id' => $artifact_id,
-            'offset' => $offset,
-            'bytes' => $bytes,
-            'total_bytes' => $total_bytes,
-            'final' => $frame['final'],
-        ];
+        return $operation;
     }
 
     /**
@@ -149,29 +211,33 @@ final class Site_Export_Staged_Push_Stream_Protocol {
      */
     public static function read_exactly($input, int $bytes): ?string {
         $data = '';
-        while (strlen($data) < $bytes) {
-            $piece = fread($input, $bytes - strlen($data));
+        $remaining = $bytes;
+        while ($remaining > 0) {
+            $piece = fread($input, $remaining);
             if ($piece === false || $piece === '') {
                 return null;
             }
             $data .= $piece;
+            $remaining -= strlen($piece);
         }
         return $data;
     }
 
-    /**
-     * @param resource $input
-     */
-    public static function discard_exactly($input, int $bytes, int $buffer_bytes): bool {
-        $remaining = $bytes;
-        while ($remaining > 0) {
-            $piece = fread($input, min($buffer_bytes, $remaining));
-            if ($piece === false || $piece === '') {
-                return false;
-            }
-            $remaining -= strlen($piece);
+    private static function require_operation_type(array $frame): string {
+        if (!array_key_exists('type', $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "type".');
         }
-        return true;
+        if (!is_string($frame['type']) || !in_array(
+            $frame['type'],
+            [self::OPERATION_DIRECTORY, self::OPERATION_FILE, self::OPERATION_SYMLINK, self::OPERATION_DELETE],
+            true
+        )) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "type" to be "directory", "file", "symlink", or "delete"; received ' .
+                self::describe_value($frame['type']) . '.'
+            );
+        }
+        return $frame['type'];
     }
 
     private static function require_non_negative_integer_field(array $frame, string $field): int {
@@ -181,11 +247,82 @@ final class Site_Export_Staged_Push_Stream_Protocol {
         if (!is_int($frame[$field]) || $frame[$field] < 0) {
             throw new InvalidArgumentException(
                 'Expected staged push stream frame field "' . $field . '" to be a non-negative integer; received ' .
-                self::describe_value($frame[$field]) .
-                '.'
+                self::describe_value($frame[$field]) . '.'
             );
         }
         return $frame[$field];
+    }
+
+    private static function require_boolean_field(array $frame, string $field): bool {
+        if (!array_key_exists($field, $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "' . $field . '".');
+        }
+        if (!is_bool($frame[$field])) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "' . $field . '" to be a boolean; received ' .
+                self::describe_value($frame[$field]) . '.'
+            );
+        }
+        return $frame[$field];
+    }
+
+    private static function require_raw_path_field(array $operation, string $field, bool $allow_empty): string {
+        if (!array_key_exists($field, $operation)) {
+            throw new InvalidArgumentException('Missing staged push operation field "' . $field . '".');
+        }
+        if (!is_string($operation[$field]) || ( !$allow_empty && $operation[$field] === '' )) {
+            throw new InvalidArgumentException(
+                'Expected staged push operation field "' . $field . '" to be ' .
+                ( $allow_empty ? 'a byte string' : 'a non-empty byte string' ) . '; received ' .
+                self::describe_value($operation[$field]) . '.'
+            );
+        }
+        if (strlen($operation[$field]) > self::MAX_PATH_BYTES) {
+            throw new InvalidArgumentException(
+                'Staged push operation field "' . $field . '" exceeds ' . self::MAX_PATH_BYTES
+                . ' raw bytes; observed ' . strlen($operation[$field]) . '.'
+            );
+        }
+        return $operation[$field];
+    }
+
+    private static function require_base64_field(array $frame, string $field, bool $allow_empty): string {
+        if (!array_key_exists($field, $frame)) {
+            throw new InvalidArgumentException('Missing staged push stream frame field "' . $field . '".');
+        }
+        if (!is_string($frame[$field]) || ( !$allow_empty && $frame[$field] === '' )) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "' . $field . '" to be base64 of ' .
+                ( $allow_empty ? 'a byte string' : 'a non-empty path' ) . '; received ' .
+                self::describe_value($frame[$field]) . '.'
+            );
+        }
+        $decoded = base64_decode($frame[$field], true);
+        if ($decoded === false || ( !$allow_empty && $decoded === '' )) {
+            throw new InvalidArgumentException(
+                'Expected staged push stream frame field "' . $field . '" to be base64 of ' .
+                ( $allow_empty ? 'a byte string' : 'a non-empty path' ) . '; received ' .
+                self::describe_value($frame[$field]) . '.'
+            );
+        }
+        if (strlen($decoded) > self::MAX_PATH_BYTES) {
+            throw new InvalidArgumentException(
+                'Staged push stream frame field "' . $field . '" exceeds ' . self::MAX_PATH_BYTES
+                . ' decoded bytes; observed ' . strlen($decoded) . '.'
+            );
+        }
+        return $decoded;
+    }
+
+    private static function require_exact_fields(array $frame, array $expected_fields): void {
+        foreach ($frame as $field => $_value) {
+            if (!in_array($field, $expected_fields, true)) {
+                throw new InvalidArgumentException(
+                    'Unexpected staged push stream frame field "' . $field . '" for operation type "' .
+                    ( is_string($frame['type'] ?? null) ? $frame['type'] : 'unknown' ) . '".'
+                );
+            }
+        }
     }
 
     private static function describe_value($value): string {

--- a/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
@@ -178,10 +178,8 @@ class PushRequestSizer
      * structured request_too_large response.
      *
      * The failed size caps the session ceiling so growth cannot retry it.
-     * When the server reported its actual limit — the staged_push endpoint's
-     * 413 carries max_frame_bytes, which it derives from its request-size
-     * limits — the ceiling drops below that limit directly instead of
-     * probing downward.
+     * When the server reports its actual request-body limit, the ceiling drops
+     * below that limit directly instead of probing downward.
      *
      * @param int|null $reported_max_bytes Server-reported request limit, if any.
      * @return array{action:string,request_body_bytes:int} Decision summary.

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -1,53 +1,43 @@
 <?php
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Client errors are CLI messages, never HTML output.
 /**
  * Sender for the staged push stream endpoint.
  *
  * A push stream is one authenticated HTTP request whose body is a sequence of
- * framed file chunks. The target commits each frame into
- * Site_Export_Staged_Artifacts as it is read, so a broken connection can be
- * retried from the last cursor the sender has, or from the beginning: the
- * target skips replayed files it already verified and restarts partially
- * staged ones from zero, so a source file that changed between requests can
- * never end up half old version, half new. Callers persist the source token
- * (size and ctime — the signals the push journal's own diff keys on)
- * alongside each cursor and restart a file at offset 0 when the file on disk
- * no longer matches it; a same-size edit within the same timestamp second
- * escapes the token, and the diff layer's change detection is the deeper
- * net. The reference loop in StagedPushStreamClientTest::pushOnce() shows
- * both halves.
+ * typed directory, file, symlink, and delete frames. Only file frames carry a
+ * payload. The target stages each operation directly and reports its durable
+ * operation count and partial-file cursor, so a later request resumes from
+ * target-confirmed state instead of uploading a manifest or preparing a
+ * second copy.
  *
  * The client is a pass-through wire. The caller reads a chunk of a file into
  * memory — at most next_chunk_body_bytes(), which is why a chunk is the one
- * thing that may be buffered — and send_chunk() sends it over the network
+ * thing that may be buffered — and send_operation() sends it over the network
  * before returning:
  *
- *     // Open the request only once the first chunk exists — an empty
- *     // source should not cost a network exchange (the reference loop in
- *     // StagedPushStreamClientTest::pushOnce() shows the lazy shape).
+ *     $client->set_session_request_generation($request_generation);
  *     $client->start_push_request();
- *     while (...) {
- *         if ($client->should_finish_request()) {
- *             $result = $client->finish_request();   // persist $result['cursor']
- *             $client->start_push_request();
- *         }
- *         $payload = fread($source_handle, $client->next_chunk_body_bytes());
- *         $client->send_chunk([
- *             'artifact_id' => $artifact_id,
- *             'offset'      => $offset,
- *             'total_bytes' => $total_bytes,
- *             'final'       => $offset + strlen($payload) >= $total_bytes,
- *             'payload'     => $payload,
- *         ]);
- *     }
+ *     $payload = fread($source_handle, $client->next_chunk_body_bytes());
+ *     $client->send_operation([
+ *         'type'            => 'file',
+ *         'operation_index' => $operation_index,
+ *         'path'            => $path,
+ *         'revision'        => $revision,
+ *         'offset'          => $offset,
+ *         'total_bytes'     => $total_bytes,
+ *         'restart'         => false,
+ *         'payload'         => $payload,
+ *     ]);
  *     $result = $client->finish_request();
+ *     persist_target_cursor($result);
  *
  * The transfer runs through libcurl, driven with the curl_multi API so the
- * request stays open between chunks: send_chunk() hands the frame to curl's
+ * request stays open between frames: send_operation() hands the frame to curl's
  * read callback and pumps the transfer until libcurl has consumed every
- * byte. libcurl writes to the socket as it consumes, so when send_chunk()
+ * byte. libcurl writes to the socket as it consumes, so when send_operation()
  * returns true the frame has left for the network — what trails behind is
  * libcurl's upload buffer (64 KiB) and the kernel's socket send buffer,
- * never a request body. Between chunks the read callback returns
+ * never a request body. Between frames the read callback returns
  * CURL_READFUNC_PAUSE, which PHP's curl extension only supports since
  * PHP 8.1 — on 7.4/8.0 that return is misread as end-of-body and the upload
  * silently truncates, so the constructor refuses to run there. The full
@@ -67,16 +57,36 @@
  * measured. That budget is learned per host by PushRequestSizer and charges
  * frame header lines alongside payloads; the transfer framing around them
  * is libcurl's business (chunked on HTTP/1.1, DATA frames on HTTP/2) and
- * rides in the sizer's safety margin. next_chunk_body_bytes() folds both
- * sizes into the one number a caller's fread needs.
+ * rides in the sizer's safety margin. Every header is charged to the request
+ * budget, including metadata-only operations; next_chunk_body_bytes() folds
+ * the payload limits into the one number a caller's fread needs.
  */
 class StagedPushStreamClient
 {
+    private const MAX_CHUNK_BYTES = 4 * 1024 * 1024;
+
+    private const MAX_RESPONSE_BYTES = 65536;
+
     private string $base_url;
 
     private Site_Export_HMAC_Client $hmac_client;
 
     private PushRequestSizer $request_sizer;
+
+    /**
+     * Frames belong to this server-owned staged-apply session. It stays in
+     * the signed request target so one session cannot receive another
+     * session's bytes.
+     */
+    private string $session_id;
+
+    /**
+     * The server-confirmed generation the next session stream must present in
+     * its signed request target. It is cleared as the request starts, so a
+     * caller persists the response value before setting it for every next
+     * request; a lost response cannot replay a stale stream over newer state.
+     */
+    private ?int $session_request_generation = null;
 
     /** Seconds to establish the connection and get the request head out. */
     private int $connect_timeout;
@@ -107,6 +117,13 @@ class StagedPushStreamClient
 
     /** @var int In-memory unit of one caller fread, in bytes. */
     private int $chunk_bytes;
+
+    /**
+     * The smallest payload cap a target has reported for one frame. This is
+     * independent of the request-body budget: many capped frames may share
+     * one request.
+     */
+    private ?int $max_frame_bytes = null;
 
     /** @var resource|object|null curl easy handle for the open request */
     private $curl_handle = null;
@@ -157,11 +174,15 @@ class StagedPushStreamClient
 
     private ?string $transfer_error = null;
 
+    private string $response_body = "";
+
+    private bool $response_too_large = false;
+
     private float $request_started_at = 0.0;
 
     private int $body_bytes_sent = 0;
 
-    private int $chunks_sent = 0;
+    private int $frames_sent = 0;
 
     private ?string $last_error = null;
 
@@ -179,6 +200,9 @@ class StagedPushStreamClient
      *   - hmac_client (Site_Export_HMAC_Client, required): signs every
      *     request; the staged endpoints reject unsigned requests before
      *     reading the body, so there is no unauthenticated push.
+     *   - session_id (string, required): a 32-character lowercase hexadecimal
+     *     staged apply session id. Each request goes to staged_session_push
+     *     and requires set_session_request_generation() before it can start.
      *   - request_sizer (?PushRequestSizer): request-body-size decisions;
      *     defaults to a fresh sizer. Pass one restored from persisted state
      *     to keep learned limits.
@@ -248,12 +272,30 @@ class StagedPushStreamClient
         $this->hmac_client = $hmac_client;
         $this->request_sizer = $options["request_sizer"] ?? new PushRequestSizer();
 
+        $session_id = $options["session_id"] ?? null;
+        if (!is_string($session_id) || preg_match('/^[a-f0-9]{32}$/D', $session_id) !== 1) {
+            throw new InvalidArgumentException(
+                "Expected option \"session_id\" to be 32 lowercase hexadecimal characters; received " . json_encode($session_id) . "."
+            );
+        }
+        $this->session_id = $session_id;
+
         // Absent options get defaults; present-but-invalid options throw —
         // silently substituting a default would hide the caller's mistake
         // until it surfaces as puzzling runtime behavior.
         $chunk_bytes = $options["chunk_bytes"] ?? null;
-        if ($chunk_bytes !== null && (!is_numeric($chunk_bytes) || (int) $chunk_bytes <= 0)) {
-            throw new InvalidArgumentException("Expected option \"chunk_bytes\" to be a positive integer; received " . json_encode($chunk_bytes) . ".");
+        if (
+            $chunk_bytes !== null
+            && (
+                !is_numeric($chunk_bytes)
+                || (int) $chunk_bytes <= 0
+                || (int) $chunk_bytes > self::MAX_CHUNK_BYTES
+            )
+        ) {
+            throw new InvalidArgumentException(
+                "Expected option \"chunk_bytes\" to be between 1 and " . self::MAX_CHUNK_BYTES
+                . " bytes; received " . json_encode($chunk_bytes) . "."
+            );
         }
         $this->chunk_bytes = $chunk_bytes !== null ? (int) $chunk_bytes : 4 * 1024 * 1024;
         $connect_timeout = $options["connect_timeout"] ?? null;
@@ -281,9 +323,9 @@ class StagedPushStreamClient
     }
 
     /**
-     * Open a staged_push request: connect and send the signed request head,
-     * returning once libcurl asks for body bytes. The request body starts
-     * empty; send_chunk() fills it.
+     * Open a staged_session_push request: connect and send the signed request
+     * head, returning once libcurl asks for body bytes. The request body starts
+     * empty; send_operation() fills it.
      *
      * @return bool False when the connection could not be opened;
      *              get_last_error() says why.
@@ -292,6 +334,11 @@ class StagedPushStreamClient
     {
         if ($this->curl_handle !== null) {
             throw new RuntimeException("A push request is already open; call finish_request() before starting another.");
+        }
+        if ($this->session_request_generation === null) {
+            throw new RuntimeException(
+                "A staged session push requires set_session_request_generation() before start_push_request()."
+            );
         }
 
         $this->outbound_frame_header = "";
@@ -302,16 +349,27 @@ class StagedPushStreamClient
         $this->curl_requested_body = false;
         $this->transfer_finished = false;
         $this->transfer_error = null;
+        $this->response_body = "";
+        $this->response_too_large = false;
         $this->body_bytes_sent = 0;
-        $this->chunks_sent = 0;
+        $this->frames_sent = 0;
         $this->last_error = null;
 
         // Signing covers the method and the URL (path + query), so it can
         // happen before the body exists — the body itself is not signed;
         // the X-Auth-Content-Hash header says so explicitly.
+        $request_parameters = [
+            "endpoint" => "staged_session_push",
+            "session_id" => $this->session_id,
+            "expected_request_generation" => $this->session_request_generation,
+        ];
+        // A stream consumes its generation when its signed request target is
+        // made. Requiring the caller to set the next one explicitly makes
+        // persistence part of every request rotation.
+        $this->session_request_generation = null;
         $request_url = $this->base_url
             . (strpos($this->base_url, "?") === false ? "?" : "&")
-            . http_build_query(["endpoint" => "staged_push"]);
+            . http_build_query($request_parameters);
         $request_headers = $this->hmac_client->get_envelope_auth_headers("POST", $request_url);
         $request_headers["Content-Type"] = Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE;
 
@@ -348,12 +406,11 @@ class StagedPushStreamClient
             CURLOPT_UPLOAD => true,
             CURLOPT_CUSTOMREQUEST => "POST",
             CURLOPT_HTTPHEADER => $header_lines,
-            CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_CONNECTTIMEOUT => $this->connect_timeout,
             // Deliberately no CURLOPT_TIMEOUT: a total-transfer cap kills
             // healthy-but-slow bulk uploads. Each phase has its own bound —
-            // connect_timeout, the stall watch in send_chunk(), and
+            // connect_timeout, the stall watch in send_operation(), and
             // response_timeout in finish_request().
             //
             // libcurl drives the upload by asking: whenever the socket can
@@ -365,7 +422,7 @@ class StagedPushStreamClient
             //   - "": the body is complete, libcurl ends the request;
             //   - CURL_READFUNC_PAUSE: nothing to send right now, but the
             //     body is not over — libcurl parks the upload until
-            //     send_chunk() supplies the next frame and unpauses. This
+            //     send_operation() supplies the next frame and unpauses. This
             //     constant is why push needs PHP 8.1+ (class docblock).
             CURLOPT_READFUNCTION => function ($curl_handle, $stream, int $length) {
                 $this->curl_requested_body = true;
@@ -390,12 +447,22 @@ class StagedPushStreamClient
                 }
                 return CURL_READFUNC_PAUSE;
             },
+            CURLOPT_WRITEFUNCTION => function ($curl_handle, string $bytes): int {
+                if (strlen($this->response_body) + strlen($bytes) > self::MAX_RESPONSE_BYTES) {
+                    $this->response_too_large = true;
+                    $this->transfer_error = "The staged session push response exceeded "
+                        . self::MAX_RESPONSE_BYTES . " bytes.";
+                    return 0;
+                }
+                $this->response_body .= $bytes;
+                return strlen($bytes);
+            },
         ]);
 
         // One transfer at a time in one long-lived curl_multi handle. Multi
         // is not for concurrency here: unlike curl_exec(), which blocks
         // until the whole exchange is over, curl_multi_exec() performs one
-        // small slice of work and returns. That is what lets send_chunk()
+        // small slice of work and returns. That is what lets send_operation()
         // feed a frame, pump until libcurl consumed it, and hand control
         // back to the caller while the request stays open. The handle
         // itself lives as long as the client so requests reuse connections
@@ -428,93 +495,40 @@ class StagedPushStreamClient
     }
 
     /**
-     * Send one framed chunk — header line, then the payload — over the
-     * network.
+     * Send one typed operation frame over the network.
      *
-     * This performs the actual network transmission: the frame is handed to
-     * libcurl's read callback and the transfer is pumped until libcurl has
-     * consumed every byte and written it toward the socket. When this
-     * returns true the frame is on the network, not queued in this process;
-     * libcurl's 64 KiB upload buffer and the kernel's socket send buffer
-     * trail behind — buffers, never a request body.
+     * This performs the actual transmission: the frame is handed to libcurl's
+     * read callback and the transfer is pumped until libcurl has consumed
+     * every byte and written it toward the socket. File payloads stay in a
+     * separate copy-on-write field; metadata operations carry no payload.
+     * Invalid descriptors throw before any bytes are sent. Remote conditions
+     * do not throw: false means finish_request() must classify the early end.
      *
-     * The payload's length is the frame's byte count; there is no separate
-     * declaration to reconcile. The artifact_id may be arbitrary bytes —
-     * file names are not guaranteed UTF-8 — and travels base64-encoded
-     * inside the JSON frame header. Invalid descriptors throw with the exact
-     * violated condition. Remote conditions do not throw: false means the
-     * transfer ended early — dead connection or the target already
-     * responded — and finish_request() reports which.
-     *
-     * @param array{artifact_id:string,offset:int,total_bytes:int,final:bool,payload:string} $chunk
+     * @param array<string,mixed> $operation Raw-byte path and target fields.
      */
-    public function send_chunk(array $chunk): bool
+    public function send_operation(array $operation): bool
     {
-        // This mirrors the target's own frame validation, so a bad
-        // descriptor fails here — naming the exact field — instead of after
-        // uploading it. The last two checks are protocol invariants no type
-        // system covers: a zero-byte non-final frame means the source file
-        // shrank under the caller, and a final frame must land exactly on
-        // total_bytes or the target will 409 after staging the bytes.
-        $artifact_id = $chunk["artifact_id"] ?? null;
-        if (!is_string($artifact_id) || $artifact_id === "") {
-            throw new InvalidArgumentException("Expected chunk field \"artifact_id\" to be a non-empty string.");
-        }
-        $offset = $chunk["offset"] ?? null;
-        if (!is_int($offset) || $offset < 0) {
-            throw new InvalidArgumentException("Expected chunk field \"offset\" to be a non-negative integer for \"" . $artifact_id . "\".");
-        }
-        $total_bytes = $chunk["total_bytes"] ?? null;
-        if (!is_int($total_bytes) || $total_bytes < 0) {
-            throw new InvalidArgumentException("Expected chunk field \"total_bytes\" to be a non-negative integer for \"" . $artifact_id . "\".");
-        }
-        $final = $chunk["final"] ?? null;
-        if (!is_bool($final)) {
-            throw new InvalidArgumentException("Expected chunk field \"final\" to be a boolean for \"" . $artifact_id . "\".");
-        }
-        $payload = $chunk["payload"] ?? null;
-        if (!is_string($payload)) {
-            throw new InvalidArgumentException("Expected chunk field \"payload\" to be a string for \"" . $artifact_id . "\".");
-        }
-        if ($offset + strlen($payload) > $total_bytes) {
-            throw new InvalidArgumentException(
-                "Chunk for \"" . $artifact_id . "\" spans bytes " . $offset . "-" . ($offset + strlen($payload)) . ", which exceeds total_bytes " . $total_bytes . "."
-            );
-        }
-        if ($payload === "" && !$final && $total_bytes > 0) {
-            throw new InvalidArgumentException(
-                "Refusing a zero-byte non-final chunk for \"" . $artifact_id . "\" — the source file is shorter than its declared total_bytes " . $total_bytes . "."
-            );
-        }
-        if ($final && $offset + strlen($payload) !== $total_bytes) {
-            throw new InvalidArgumentException(
-                "Chunk for \"" . $artifact_id . "\" is marked final at byte " . ($offset + strlen($payload)) . " but total_bytes is " . $total_bytes . "."
-            );
-        }
+        $frame_header = Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($operation);
+        $payload = $operation['type'] === Site_Export_Staged_Push_Stream_Protocol::OPERATION_FILE
+            ? $operation['payload']
+            : '';
 
         if ($this->curl_handle === null) {
-            throw new RuntimeException("No push request is open; call start_push_request() before send_chunk().");
+            throw new RuntimeException("No push request is open; call start_push_request() before send_operation().");
         }
         if ($this->transfer_finished) {
             return false;
         }
-
-        $frame_header = json_encode([
-            "type" => "chunk",
-            // File paths are arbitrary bytes and JSON strings must be UTF-8,
-            // so the id travels base64-encoded — the same convention the
-            // journal and the pull cursors use. json_encode would return
-            // false on a raw non-UTF-8 name.
-            "artifact_id" => base64_encode($artifact_id),
-            "offset" => $offset,
-            "bytes" => strlen($payload),
-            "total_bytes" => $total_bytes,
-            "final" => $final,
-        ], JSON_UNESCAPED_SLASHES);
-        if ($frame_header === false) {
-            throw new RuntimeException("Could not encode the staged push stream frame header for \"" . $artifact_id . "\".");
+        if (
+            $operation['type'] === Site_Export_Staged_Push_Stream_Protocol::OPERATION_FILE
+            && strlen($payload) > $this->next_chunk_body_bytes()
+        ) {
+            throw new InvalidArgumentException(
+                "File operation " . $operation['operation_index'] . " carries " . strlen($payload)
+                . " payload bytes, exceeding the next bounded chunk allowance of "
+                . $this->next_chunk_body_bytes() . "."
+            );
         }
-        $frame_header .= "\n";
 
         // Copy-on-write assignments: neither line copies the payload bytes.
         // Unpausing tells libcurl to start calling the read callback again.
@@ -533,7 +547,9 @@ class StagedPushStreamClient
                 $consumed_at_last_progress = $this->outbound_consumed_bytes;
                 $last_progress_at = microtime(true);
             } elseif (microtime(true) - $last_progress_at > $this->stall_timeout) {
-                $this->transfer_error = "The push stream stalled: no bytes moved for " . $this->stall_timeout . "s while sending a chunk of \"" . $artifact_id . "\".";
+                $this->transfer_error = "The push stream stalled: no bytes moved for " . $this->stall_timeout
+                    . "s while sending operation " . $operation['operation_index']
+                    . " for base64 path \"" . base64_encode($operation['path']) . "\".";
                 $this->transfer_finished = true;
                 break;
             }
@@ -549,17 +565,18 @@ class StagedPushStreamClient
         }
 
         $this->body_bytes_sent += strlen($frame_header) + strlen($payload);
-        $this->chunks_sent++;
+        $this->frames_sent++;
         return true;
     }
 
     /**
      * How many bytes the caller's next fread should ask for.
      *
-     * The fixed chunk size — the in-memory unit — bounded by what remains of
-     * the host-learned request body budget. That budget is denominated in
-     * entity-body bytes, the dimension request-size limits measure: frame
-     * header lines and payloads. Returns 0 when the request is full;
+     * The fixed chunk size — the in-memory unit — bounded by the smallest
+     * target-reported frame payload cap and what remains of the host-learned
+     * request body budget. That budget is denominated in entity-body bytes,
+     * the dimension request-size limits measure: frame header lines and
+     * payloads. Returns 0 when the request is full;
      * should_finish_request() is already true then. Near the end of a file
      * fread simply returns fewer bytes and the smaller frame is correct, so
      * callers need no min() of their own. The budget is soft: the header
@@ -572,7 +589,7 @@ class StagedPushStreamClient
             throw new RuntimeException("No push request is open; call start_push_request() before next_chunk_body_bytes().");
         }
         $remaining_body_budget = max(0, $this->request_sizer->request_body_bytes() - $this->body_bytes_sent);
-        return min($this->chunk_bytes, $remaining_body_budget);
+        return min($this->chunk_bytes, $this->max_frame_bytes ?? PHP_INT_MAX, $remaining_body_budget);
     }
 
     /**
@@ -586,6 +603,7 @@ class StagedPushStreamClient
             throw new RuntimeException("No push request is open; call start_push_request() before should_finish_request().");
         }
         return $this->transfer_finished
+            || $this->frames_sent >= Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST
             || $this->next_chunk_body_bytes() === 0
             || (microtime(true) - $this->request_started_at) > $this->max_request_seconds;
     }
@@ -599,13 +617,14 @@ class StagedPushStreamClient
      * transfer broke mid-stream, a parseable response still wins over the
      * transport error — a target that rejected mid-stream (413 from a proxy,
      * auth failure) breaks the upload but its response carries the reason
-     * and a resume cursor.
+     * and the target-confirmed operation/file cursor.
      *
-     * The returned cursor is the server-confirmed one from the response, or
-     * null when no response arrived — resume from the last persisted cursor
-     * or ask staged_status.
+     * The returned operation_count and current_file are server-confirmed, or
+     * null when no usable response arrived. Responses also carry the confirmed
+     * request_generation for the next signed stream request; persist all
+     * three before passing the generation to set_session_request_generation().
      *
-     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
+     * @return array{status:string,reason:?string,detail:?string,operation_count:?int,current_file:?array,frames_sent:int,body_bytes_sent:int,request_generation:?int,max_frame_bytes:?int}
      */
     public function finish_request(): array
     {
@@ -628,7 +647,7 @@ class StagedPushStreamClient
 
         $http_code = (int) curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
         $redirect_url = (string) curl_getinfo($this->curl_handle, CURLINFO_REDIRECT_URL);
-        $response_body = (string) curl_multi_getcontent($this->curl_handle);
+        $response_body = $this->response_body;
         // The easy handle is done; the multi handle stays for the next
         // request so its connection cache can hand the connection back.
         curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
@@ -648,8 +667,30 @@ class StagedPushStreamClient
             );
         }
 
+        if ($this->response_too_large && $http_code !== 413) {
+            return $this->result(
+                "failed",
+                "response_too_large",
+                "The staged session push response exceeded " . self::MAX_RESPONSE_BYTES . " bytes."
+            );
+        }
+
         $decoded = json_decode($response_body, true);
         if (!is_array($decoded)) {
+            if ($http_code === 413) {
+                // Proxies often reject an oversized entity before PHP runs,
+                // returning HTML or an empty body instead of the endpoint's
+                // typed frame response. HTTP 413 is still permanent request
+                // budget evidence; only a structured frame_too_large narrows
+                // the separate payload cap below.
+                $decision = $this->request_sizer->record_too_large();
+                return $this->result(
+                    $decision["action"] === "give_up" ? "failed" : "retry",
+                    $decision["action"] === "give_up" ? "request_size_exhausted" : "request_too_large",
+                    $this->transfer_error
+                        ?? "HTTP 413 rejected the push request body before the target returned JSON."
+                );
+            }
             $decision = $this->request_sizer->record_request_failure();
             return $this->result(
                 $decision["action"] === "give_up" ? "failed" : "retry",
@@ -659,54 +700,243 @@ class StagedPushStreamClient
             );
         }
 
-        $response_cursor = is_array($decoded["cursor"] ?? null) ? $decoded["cursor"] : null;
-        if ($response_cursor !== null) {
-            // The wire carries the id base64-encoded (see send_chunk); hand
-            // callers the raw path back. A cursor that does not decode is as
-            // useless as none — callers fall back to their persisted cursor.
-            $decoded_artifact_id = base64_decode((string) ($response_cursor["artifact_id"] ?? ""), true);
-            $response_cursor = $decoded_artifact_id !== false && $decoded_artifact_id !== ""
-                ? ["artifact_id" => $decoded_artifact_id, "committed_bytes" => (int) ($response_cursor["committed_bytes"] ?? 0)]
-                : null;
+        $has_confirmed_session_state = ( $decoded["status"] ?? null ) === "complete"
+            || array_key_exists("request_generation", $decoded)
+            || array_key_exists("operation_count", $decoded)
+            || array_key_exists("current_file", $decoded);
+        if ($has_confirmed_session_state && ( $decoded["session_id"] ?? null ) !== $this->session_id) {
+            return $this->result(
+                "failed",
+                "invalid_session_response",
+                "The staged session push response did not name the requested session " . $this->session_id . "."
+            );
         }
 
-        if ($http_code === 413 || ($decoded["reason"] ?? null) === "frame_too_large") {
-            $reported_limit_bytes = $decoded["max_frame_bytes"] ?? null;
-            $decision = $this->request_sizer->record_too_large(
-                is_numeric($reported_limit_bytes) ? (int) $reported_limit_bytes : null
+        $request_generation = null;
+        if (array_key_exists("request_generation", $decoded)) {
+            $response_generation = $decoded["request_generation"];
+            if (!is_int($response_generation) || $response_generation < 0) {
+                return $this->result(
+                    "failed",
+                    "invalid_session_response",
+                    "The staged session push response reported an invalid request_generation " . json_encode($response_generation) . "."
+                );
+            }
+            $request_generation = $response_generation;
+        }
+
+        $operation_count = null;
+        if (array_key_exists("operation_count", $decoded)) {
+            if (!is_int($decoded["operation_count"]) || $decoded["operation_count"] < 0) {
+                return $this->result(
+                    "failed",
+                    "invalid_session_response",
+                    "The staged session push response reported an invalid operation_count "
+                        . json_encode($decoded["operation_count"]) . ".",
+                    null,
+                    null,
+                    $request_generation
+                );
+            }
+            $operation_count = $decoded["operation_count"];
+        }
+
+        $current_file = null;
+        if (array_key_exists("current_file", $decoded) && $decoded["current_file"] !== null) {
+            if (!is_array($decoded["current_file"])) {
+                return $this->result(
+                    "failed",
+                    "invalid_session_response",
+                    "The staged session push response reported current_file as "
+                        . json_encode($decoded["current_file"]) . " instead of an object or null.",
+                    $operation_count,
+                    null,
+                    $request_generation
+                );
+            }
+            $wire_current_file = $decoded["current_file"];
+            foreach (["operation_index", "revision", "committed_bytes", "total_bytes"] as $field) {
+                if (!is_int($wire_current_file[$field] ?? null) || $wire_current_file[$field] < 0) {
+                    return $this->result(
+                        "failed",
+                        "invalid_session_response",
+                        "The staged session push response reported current_file." . $field . " as "
+                            . json_encode($wire_current_file[$field] ?? null)
+                            . " instead of a non-negative integer.",
+                        $operation_count,
+                        null,
+                        $request_generation
+                    );
+                }
+            }
+            $current_path = is_string($wire_current_file["path_b64"] ?? null)
+                ? base64_decode($wire_current_file["path_b64"], true)
+                : false;
+            if ($current_path === false || $current_path === "") {
+                return $this->result(
+                    "failed",
+                    "invalid_session_response",
+                    "The staged session push response reported current_file.path_b64 as "
+                        . json_encode($wire_current_file["path_b64"] ?? null)
+                        . " instead of base64 for a non-empty path.",
+                    $operation_count,
+                    null,
+                    $request_generation
+                );
+            }
+            if ($wire_current_file["committed_bytes"] > $wire_current_file["total_bytes"]) {
+                return $this->result(
+                    "failed",
+                    "invalid_session_response",
+                    "The staged session push response reported current_file.committed_bytes "
+                        . $wire_current_file["committed_bytes"] . " beyond total_bytes "
+                        . $wire_current_file["total_bytes"] . ".",
+                    $operation_count,
+                    null,
+                    $request_generation
+                );
+            }
+            $current_file = [
+                "operation_index" => $wire_current_file["operation_index"],
+                "path" => $current_path,
+                "revision" => $wire_current_file["revision"],
+                "committed_bytes" => $wire_current_file["committed_bytes"],
+                "total_bytes" => $wire_current_file["total_bytes"],
+            ];
+        }
+
+        if ( ( $decoded["reason"] ?? null ) === "frame_too_large" ) {
+            $reported_max_frame_bytes = $decoded["max_frame_bytes"] ?? null;
+            if (!is_int($reported_max_frame_bytes) || $reported_max_frame_bytes <= 0) {
+                return $this->result(
+                    "failed",
+                    "invalid_frame_limit",
+                    "The staged push response reported frame_too_large without a positive integer max_frame_bytes.",
+                    $operation_count,
+                    $current_file,
+                    $request_generation
+                );
+            }
+            $this->max_frame_bytes = $this->max_frame_bytes === null
+                ? $reported_max_frame_bytes
+                : min($this->max_frame_bytes, $reported_max_frame_bytes);
+            return $this->result(
+                "retry",
+                "frame_too_large",
+                null,
+                $operation_count,
+                $current_file,
+                $request_generation
             );
+        }
+
+        if ($http_code === 413) {
+            $decision = $this->request_sizer->record_too_large();
             return $this->result(
                 $decision["action"] === "give_up" ? "failed" : "retry",
-                $decision["action"] === "give_up" ? "request_size_exhausted" : "frame_too_large",
+                $decision["action"] === "give_up" ? "request_size_exhausted" : "request_too_large",
                 null,
-                $response_cursor
+                $operation_count,
+                $current_file,
+                $request_generation
+            );
+        }
+
+        if (($decoded["status"] ?? null) === "complete" && ($http_code < 200 || $http_code >= 300)) {
+            return $this->result(
+                "failed",
+                "invalid_session_response",
+                "The staged session push response reported complete with HTTP " . $http_code . ".",
+                $operation_count,
+                $current_file,
+                $request_generation
             );
         }
 
         if (($decoded["status"] ?? null) !== "complete") {
             $reason = is_string($decoded["reason"] ?? null) ? $decoded["reason"] : "unexpected_response";
-            // The protocol designs these two as recoverable, not fatal:
-            // busy is the store's retry-until-free lock contract, and
-            // offset_gap arrives with the store's own cursor to resume
-            // from. Neither says anything about request size, so the
-            // sizer records nothing.
-            $retryable = $reason === "busy" || $reason === "offset_gap";
+            // The protocol designs these as recoverable, not fatal. busy is
+            // the store's retry-until-free lock contract; offset_gap arrives
+            // with the store's own cursor; and both I/O reasons report a
+            // server-side persistence failure that a later request may outlive.
+            // None says anything about request size, so the sizer records
+            // nothing.
+            $retryable = $reason === "busy"
+                || $reason === "operation_gap"
+                || $reason === "offset_gap"
+                || $reason === "body_read_failed"
+                || $reason === "io_error"
+                || $reason === "retryable_io_error"
+                // A session stream may have reached the remote and consumed
+                // its generation before this client lost the response. The
+                // driver fetches session status before its next request, so
+                // stale_session_state is recoverable after the driver refreshes
+                // its session state before its next request.
+                || $reason === "stale_session_state";
             return $this->result(
                 $retryable ? "retry" : "failed",
                 $reason,
                 is_string($decoded["detail"] ?? null) ? $decoded["detail"] : ("HTTP " . $http_code),
-                $response_cursor,
-                (int) ($decoded["files_verified"] ?? 0)
+                $operation_count,
+                $current_file,
+                $request_generation
+            );
+        }
+
+        if ($request_generation === null) {
+            return $this->result(
+                "failed",
+                "invalid_session_response",
+                "The staged session push response omitted its server-confirmed request_generation.",
+                $operation_count,
+                $current_file
+            );
+        }
+        if ($operation_count === null) {
+            return $this->result(
+                "failed",
+                "invalid_session_response",
+                "The staged session push response omitted its server-confirmed operation_count.",
+                null,
+                $current_file,
+                $request_generation
             );
         }
 
         // A success only teaches the sizer something when the request
         // carried bytes: "the host accepted an empty body" is no evidence
         // that the current size is safe to grow from.
-        if ($this->chunks_sent > 0) {
+        if ($this->frames_sent > 0) {
             $this->request_sizer->record_success();
         }
-        return $this->result("complete", null, null, $response_cursor, (int) ($decoded["files_verified"] ?? 0));
+        return $this->result(
+            "complete",
+            null,
+            null,
+            $operation_count,
+            $current_file,
+            $request_generation
+        );
+    }
+
+    /**
+     * Set the server-confirmed generation required by the next session push
+     * request. The target increments its generation before it reads a stream,
+     * so callers must persist a response generation before selecting it here.
+     */
+    public function set_session_request_generation(int $expected_request_generation): void
+    {
+        if ($expected_request_generation < 0) {
+            throw new InvalidArgumentException(
+                "Expected a non-negative staged session request generation; received " . $expected_request_generation . "."
+            );
+        }
+        if ($this->curl_handle !== null) {
+            throw new RuntimeException(
+                "Cannot change the staged session request generation while a push request is open; call finish_request() first."
+            );
+        }
+        $this->session_request_generation = $expected_request_generation;
     }
 
     /**
@@ -715,6 +945,31 @@ class StagedPushStreamClient
     public function get_last_error(): ?string
     {
         return $this->last_error;
+    }
+
+    /**
+     * Abandon an open request without sending more body bytes.
+     *
+     * A caller that cannot continue reading its source must not leave the
+     * remote session lock held behind a paused curl read callback. Closing the
+     * easy handle makes the peer observe the broken body; the next driver run
+     * fetches session status before choosing another generation.
+     */
+    public function abort_push_request(): void
+    {
+        if ($this->curl_handle === null) {
+            return;
+        }
+        if ($this->multi_handle !== null) {
+            curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
+        }
+        curl_close($this->curl_handle);
+        $this->curl_handle = null;
+        $this->outbound_frame_header = "";
+        $this->outbound_payload = "";
+        $this->outbound_payload_offset = 0;
+        $this->body_complete = false;
+        $this->transfer_finished = true;
     }
 
     /**
@@ -736,7 +991,7 @@ class StagedPushStreamClient
         while (($message = curl_multi_info_read($this->multi_handle)) !== false) {
             if ($message["msg"] === CURLMSG_DONE) {
                 $this->transfer_finished = true;
-                if ($message["result"] !== CURLE_OK) {
+                if ($message["result"] !== CURLE_OK && $this->transfer_error === null) {
                     $this->transfer_error = curl_error($this->curl_handle) ?: curl_strerror((int) $message["result"]);
                 }
             }
@@ -747,17 +1002,26 @@ class StagedPushStreamClient
         }
     }
 
-    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int} */
-    private function result(string $status, ?string $reason, ?string $detail, ?array $cursor = null, int $files_verified = 0): array
+    /** @return array{status:string,reason:?string,detail:?string,operation_count:?int,current_file:?array,frames_sent:int,body_bytes_sent:int,request_generation:?int,max_frame_bytes:?int} */
+    private function result(
+        string $status,
+        ?string $reason,
+        ?string $detail,
+        ?int $operation_count = null,
+        ?array $current_file = null,
+        ?int $request_generation = null
+    ): array
     {
         return [
             "status" => $status,
             "reason" => $reason,
             "detail" => $detail,
-            "cursor" => $cursor,
-            "files_verified" => $files_verified,
-            "chunks_sent" => $this->chunks_sent,
+            "operation_count" => $operation_count,
+            "current_file" => $current_file,
+            "frames_sent" => $this->frames_sent,
             "body_bytes_sent" => $this->body_bytes_sent,
+            "request_generation" => $request_generation,
+            "max_frame_bytes" => $this->max_frame_bytes,
         ];
     }
 }

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -38,7 +38,9 @@ if ($myRouter->matches('/export')) {
     // otherwise falls back to the site option):
     _site_export_handle_api_request();
 
-    // Or supply your own authentication:
+    // Or supply your own authentication/policy. The staged_session_* routes
+    // still enforce their shared-secret envelope HMAC
+    // after this callback runs:
     _site_export_handle_api_request([
         'authenticate' => function () {
             if (!my_auth_check()) {
@@ -48,6 +50,12 @@ if ($myRouter->matches('/export')) {
     ]);
 }
 ```
+
+The custom callback runs first for every endpoint and replaces the default
+whole-body HMAC check on ordinary routes. The built-in `staged_session_*`
+routes additionally require envelope HMAC with the configured
+Reprint shared secret; the callback does not replace that streaming-safe
+protocol authentication.
 
 `lib.php` defines these constants (using WordPress's `plugin_dir_path`):
 

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -29,11 +29,27 @@ if (!defined('SITE_EXPORT_SECRET_OPTION')) {
  */
 define('SITE_EXPORT_TIMESTAMP_TOLERANCE', 300);
 
-/** Sends a JSON error response and terminates. */
-function _site_export_error(int $code, string $message): void {
+/**
+ * Sends a JSON error response and terminates.
+ *
+ * @return never
+ */
+function _site_export_error(int $code, string $message, ?string $reason = null): void {
+    // The API entry point clears pre-existing output buffers before starting
+    // its request buffer. Drop everything buffered since then before emitting
+    // the one JSON response callers can safely parse.
+    while (ob_get_level()) {
+        ob_end_clean();
+    }
     http_response_code($code);
     header('Content-Type: application/json');
-    echo json_encode(['error' => $message, 'code' => $code]);
+    $response = ['error' => $message, 'code' => $code];
+    if ($reason !== null) {
+        $response['status'] = 'rejected';
+        $response['reason'] = $reason;
+        $response['detail'] = $message;
+    }
+    echo json_encode($response);
     exit;
 }
 
@@ -180,25 +196,176 @@ function _site_export_default_authenticate(): void {
 }
 
 /**
- * Server-side options for the staged artifact endpoints.
+ * Server-side options for direct staged-apply session endpoints.
  *
- * The staging directory must live outside the web-served tree, and WordPress
- * has no guaranteed writable directory there, so the default sits under the
- * system temp dir, keyed by ABSPATH so co-hosted sites do not share staging
- * state. A host that cleans its temp dir only costs a transfer its progress —
- * artifacts re-upload from offset 0. Define SITE_EXPORT_STAGING_DIR to pick a
- * durable location instead.
+ * Push sessions need an administrator-owned staging directory, preferably
+ * outside the web-served tree. WordPress has no guaranteed private writable
+ * directory, so sessions are unavailable until SITE_EXPORT_STAGING_DIR
+ * explicitly supplies one. Pull routes remain available without it. The
+ * WordPress route also keeps live apply disabled until the standalone recovery
+ * endpoint can advance a session without booting WordPress.
  */
-function _site_export_staged_options(): array {
-    $staging_dir = defined('SITE_EXPORT_STAGING_DIR')
-        ? SITE_EXPORT_STAGING_DIR
-        : rtrim(sys_get_temp_dir(), '/') . '/reprint-staging-' . md5(ABSPATH);
+function _site_export_staged_options(): ?array {
+    if (!defined('SITE_EXPORT_STAGING_DIR')) {
+        return null;
+    }
+    if (
+        _site_export_staging_directory_error() !== null
+        || _site_export_apply_target_error() !== null
+    ) {
+        return null;
+    }
+    $staging_dir = rtrim(SITE_EXPORT_STAGING_DIR, '/');
+
+    $apply_target_root = defined('SITE_EXPORT_APPLY_ROOT')
+        ? SITE_EXPORT_APPLY_ROOT
+        : ABSPATH;
+    $apply_target_root = rtrim($apply_target_root, '/');
+    $apply_target_root = $apply_target_root === '' ? '/' : $apply_target_root;
+    $protected_paths = [];
+
+    // __DIR__ resolves a plugin-directory symlink to its target. Keep the
+    // configured path lexical as well, so an apply cannot remove the symlink
+    // WordPress uses to load this plugin.
+    $plugin_directory_candidates = [rtrim(SITE_EXPORT_PLUGIN_DIR, '/')];
+    $real_plugin_dir = realpath(__DIR__);
+    $real_target_root = realpath($apply_target_root);
+
+    // WordPress records plugin symlink mappings before it includes a plugin.
+    // plugin_basename() turns the resolved __FILE__ back into that install
+    // path; only accept a candidate under one of WordPress's two known plugin
+    // roots when it resolves to this plugin's real directory.
+    if (is_string($real_plugin_dir) && function_exists('plugin_basename')) {
+        $plugin_relative_file = plugin_basename(__FILE__);
+        $plugin_relative_directory = dirname($plugin_relative_file);
+        $plugin_relative_segments = explode('/', $plugin_relative_directory);
+        if (
+            $plugin_relative_directory !== '.'
+            && $plugin_relative_directory !== ''
+            && $plugin_relative_directory[0] !== '/'
+            && strpos($plugin_relative_directory, '\\') === false
+            && !in_array('.', $plugin_relative_segments, true)
+            && !in_array('..', $plugin_relative_segments, true)
+        ) {
+            $plugin_roots = [
+                defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR : null,
+                defined('WPMU_PLUGIN_DIR') ? WPMU_PLUGIN_DIR : null,
+            ];
+            foreach ($plugin_roots as $plugin_root) {
+                if (!is_string($plugin_root) || $plugin_root === '') {
+                    continue;
+                }
+                $lexical_plugin_directory = rtrim($plugin_root, '/') . '/' . $plugin_relative_directory;
+                if (
+                    ( is_dir($lexical_plugin_directory) || is_link($lexical_plugin_directory) )
+                    && realpath($lexical_plugin_directory) === $real_plugin_dir
+                ) {
+                    $plugin_directory_candidates[] = $lexical_plugin_directory;
+                }
+            }
+        }
+    }
+
+    $lexical_target_root = rtrim($apply_target_root, '/');
+    $lexical_target_prefix = $lexical_target_root === '' || $lexical_target_root === '/'
+        ? '/'
+        : $lexical_target_root . '/';
+    foreach ($plugin_directory_candidates as $plugin_directory) {
+        if (
+            $plugin_directory === ''
+            || strpos($plugin_directory, $lexical_target_prefix) !== 0
+            || ( !is_dir($plugin_directory) && !is_link($plugin_directory) )
+        ) {
+            continue;
+        }
+        $protected_path = substr($plugin_directory, strlen($lexical_target_prefix));
+        $protected_path_segments = explode('/', $protected_path);
+        if (
+            $protected_path !== ''
+            && !in_array('', $protected_path_segments, true)
+            && !in_array('.', $protected_path_segments, true)
+            && !in_array('..', $protected_path_segments, true)
+            && strpos($protected_path, '\\') === false
+        ) {
+            $protected_paths[] = $protected_path;
+        }
+    }
+
+    // Keep protecting a normal in-tree installation even when WordPress did
+    // not register a symlink mapping and SITE_EXPORT_PLUGIN_DIR is resolved.
+    if (is_string($real_plugin_dir) && is_string($real_target_root)) {
+        $target_prefix = rtrim($real_target_root, '/') . '/';
+        if (strpos($real_plugin_dir, $target_prefix) === 0) {
+            $protected_paths[] = substr($real_plugin_dir, strlen($target_prefix));
+        }
+    }
+    $protected_paths = array_values(array_unique($protected_paths));
 
     return [
         'staging_dir' => $staging_dir,
         'secret' => _site_export_get_shared_secret(),
         'timestamp_tolerance' => SITE_EXPORT_TIMESTAMP_TOLERANCE,
+        'apply_target_root' => $apply_target_root,
+        'apply_protected_paths' => $protected_paths,
+        // A commit can leave WordPress's maintenance marker behind or install
+        // PHP that prevents the next WordPress boot. Do not expose live apply
+        // through this boot-dependent route until the standalone recovery
+        // endpoint can advance the same session without loading WordPress.
+        'apply_sessions_enabled' => false,
     ];
+}
+
+/** Returns a pointed error for a present but unsafe staging directory. */
+function _site_export_staging_directory_error(): ?string {
+    if (!defined('SITE_EXPORT_STAGING_DIR')) {
+        return null;
+    }
+    if (!class_exists('Site_Export_HTTP_Server')) {
+        _site_export_load_exporter_runtime();
+    }
+    if (!class_exists('Site_Export_HTTP_Server')) {
+        return 'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.';
+    }
+    try {
+        Site_Export_HTTP_Server::normalize_storage_path(
+            SITE_EXPORT_STAGING_DIR,
+            'SITE_EXPORT_STAGING_DIR'
+        );
+    } catch (InvalidArgumentException $exception) {
+        return $exception->getMessage();
+    }
+    return null;
+}
+
+/** Returns a pointed error for an unsafe staged-apply target. */
+function _site_export_apply_target_error(): ?string {
+    $apply_target_root = defined('SITE_EXPORT_APPLY_ROOT')
+        ? SITE_EXPORT_APPLY_ROOT
+        : ABSPATH;
+    if (!is_string($apply_target_root)) {
+        return 'SITE_EXPORT_APPLY_ROOT must be a string; observed ' . gettype($apply_target_root) . '.';
+    }
+    if ($apply_target_root === '' || $apply_target_root[0] !== '/' || strpos($apply_target_root, "\0") !== false) {
+        return 'SITE_EXPORT_APPLY_ROOT must be an absolute non-empty path without NUL bytes; observed base64 '
+            . base64_encode($apply_target_root) . '.';
+    }
+    foreach (explode('/', $apply_target_root) as $segment) {
+        if ($segment === '.' || $segment === '..') {
+            return 'SITE_EXPORT_APPLY_ROOT must not contain dot segments; observed base64 '
+                . base64_encode($apply_target_root) . '.';
+        }
+    }
+    $apply_target_root = rtrim($apply_target_root, '/');
+    $apply_target_root = $apply_target_root === '' ? '/' : $apply_target_root;
+    if (!is_dir($apply_target_root)) {
+        return 'SITE_EXPORT_APPLY_ROOT must name an existing directory; observed base64 '
+            . base64_encode($apply_target_root) . '.';
+    }
+    if (!is_string(realpath($apply_target_root))) {
+        return 'SITE_EXPORT_APPLY_ROOT could not be resolved to a canonical directory; observed base64 '
+            . base64_encode($apply_target_root) . '.';
+    }
+    return null;
 }
 
 /**
@@ -209,8 +376,10 @@ function _site_export_staged_options(): array {
  * are all available.
  *
  * @param array $options Optional overrides:
- *   - 'authenticate' (callable): Called to authenticate the request.
- *        Defaults to _site_export_default_authenticate().
+ *   - 'authenticate' (callable): Runs first for every endpoint and replaces
+ *        default whole-body HMAC on ordinary routes. The staged_session_*
+ *        routes additionally require their shared-secret
+ *        envelope HMAC.
  */
 function _site_export_handle_api_request(array $options = []): void {
     // Revert WordPress error display settings (wp_debug_mode may
@@ -226,10 +395,17 @@ function _site_export_handle_api_request(array $options = []): void {
     // Emit CORS headers and short-circuit OPTIONS preflight before
     // authentication runs — browsers send preflight OPTIONS without
     // credentials, so we must not require auth before CORS passes.
-    // The class is loaded by the Composer autoloader on demand, but
-    // load it eagerly in case the autoloader hasn't been required yet.
+    // Load Composer exactly once. clearstatcache() below can make the same
+    // symlinked plugin path resolve under another spelling; requiring its
+    // generated autoloader again would redeclare Composer's initializer.
     if (!class_exists('Site_Export_HTTP_Server')) {
         _site_export_load_exporter_runtime();
+    }
+    if (!class_exists('Site_Export_HTTP_Server')) {
+        _site_export_error(
+            500,
+            'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
+        );
     }
     Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('*');
 
@@ -252,10 +428,7 @@ function _site_export_handle_api_request(array $options = []): void {
             'type' => $errno,
         ];
         error_log('Reprint Exporter API error: ' . json_encode($error));
-        http_response_code(500);
-        @header('Content-Type: application/json');
-        echo json_encode($error);
-        exit(1);
+        _site_export_error(500, 'The Reprint Exporter encountered an internal error.');
     });
 
     set_exception_handler(function ($e) {
@@ -265,52 +438,111 @@ function _site_export_handle_api_request(array $options = []): void {
             'line' => $e->getLine(),
         ];
         error_log('Reprint Exporter API exception: ' . json_encode($error));
-        http_response_code(500);
-        @header('Content-Type: application/json');
-        echo json_encode($error);
-        exit(1);
+        _site_export_error(500, 'The Reprint Exporter encountered an internal error.');
     });
 
     // -- Authenticate --
-    // staged_upload authenticates inside its handler: the default handler
-    // here buffers the whole request body to hash it, which a chunk upload
-    // cannot afford. The upload route verifies the signed headers first and
-    // hashes the body as it streams. A custom authenticate callable still
-    // runs for every endpoint — its embedder owns that tradeoff.
+    // Chunk uploads cannot afford the default handler's whole-body hash, and
+    // every session route needs envelope HMAC to bind its session id and
+    // generation in the exact request target. The retired staged_push route
+    // also takes this path so an older sender's large body can be rejected
+    // without buffering it. Verify the envelope before reading server
+    // configuration; the HTTP route verifies current session routes again for
+    // direct HTTP-server users. TLS protects streamed bytes. A custom
+    // authenticate callable still runs first for every endpoint as an
+    // additional host-owned policy; it never replaces the staged envelope.
     // filter_input, not WP sanitizers: lib.php also runs without WordPress
     // bootstrapped (hosts that route the API from their own index.php).
     $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
     $authenticate = $options['authenticate'] ?? null;
+    $is_staged_session_endpoint = Site_Export_HTTP_Server::is_staged_session_endpoint($endpoint);
+    $is_retired_staged_push_endpoint = $endpoint === 'staged_push';
     if ($authenticate !== null) {
+        // Embedders use this hook for policy as well as authentication, so it
+        // must run for every endpoint before any built-in rejection exits.
         $authenticate();
-    } elseif ($endpoint !== 'staged_upload') {
+    }
+
+    if ($is_staged_session_endpoint || $is_retired_staged_push_endpoint) {
+        $secret = _site_export_get_shared_secret();
+        if ($secret === null) {
+            _site_export_error(
+                503,
+                'Staged session authentication is unavailable because no shared secret is configured.',
+                'not_configured'
+            );
+        }
+        // HMAC must verify the exact request target and method, not sanitized
+        // values that could differ from the bytes the client signed.
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Sanitizing would change the signed bytes.
+        $request_target = $_SERVER['REQUEST_URI'] ?? null;
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- HMAC must verify the exact HTTP method.
+        $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
+        if (!is_string($request_target) || $request_target === '') {
+            _site_export_error(403, 'Authentication failed.', 'auth_failed');
+        }
+        $auth_error = ( new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE) )->verify_envelope(
+            $_SERVER,
+            $request_method,
+            $request_target
+        );
+        if ($auth_error !== null) {
+            _site_export_error(403, 'Authentication failed.', 'auth_failed');
+        }
+    } elseif ($authenticate === null) {
         _site_export_default_authenticate();
     }
 
-    // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server
-    // is resolvable. The class itself will require export.php on demand
-    // via serve() below.
-    if (_site_export_load_exporter_runtime() === null) {
+    if ($is_retired_staged_push_endpoint) {
         _site_export_error(
-            500,
-            'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
+            410,
+            'The staged_push endpoint was removed. Use staged_session_create and staged_session_push.',
+            'endpoint_retired'
         );
     }
 
     // -- Dispatch --
     try {
-        Site_Export_HTTP_Server::serve([
-            'default_directory' => ABSPATH,
-            'staged' => _site_export_staged_options(),
-        ]);
-    } catch (Exception $e) {
-        if (!headers_sent()) {
-            http_response_code(400);
-            header('Content-Type: application/json');
+        $staging_configuration_error = _site_export_staging_directory_error();
+        $apply_target_configuration_error = defined('SITE_EXPORT_STAGING_DIR')
+            && $staging_configuration_error === null
+            ? _site_export_apply_target_error()
+            : null;
+        $staged_options = _site_export_staged_options();
+        if (
+            $staged_options === null
+            && ( $is_staged_session_endpoint || $staging_configuration_error !== null )
+        ) {
+            if ($staging_configuration_error !== null) {
+                _site_export_error(503, $staging_configuration_error, 'apply_storage_invalid');
+            }
+            if ($apply_target_configuration_error !== null) {
+                _site_export_error(503, $apply_target_configuration_error, 'apply_target_invalid');
+            }
+            if ($is_staged_session_endpoint) {
+                _site_export_error(
+                    503,
+                    'Push requires SITE_EXPORT_STAGING_DIR to name an explicitly managed private staging directory.',
+                    'apply_storage_not_configured'
+                );
+            }
         }
-        echo json_encode([
-            'error' => $e->getMessage(),
-            'trace' => $e->getTraceAsString(),
-        ]);
+        $server_options = ['default_directory' => ABSPATH];
+        if ($staged_options !== null) {
+            $server_options['staged'] = $staged_options;
+        } elseif (defined('SITE_EXPORT_STAGING_DIR') && $staging_configuration_error === null) {
+            // A bad apply target must not make pull indexes expose otherwise
+            // valid server-owned staging data.
+            $server_options['storage_path'] = rtrim(SITE_EXPORT_STAGING_DIR, '/');
+        }
+        Site_Export_HTTP_Server::serve($server_options);
+    } catch (InvalidArgumentException $e) {
+        // Dispatcher validation messages are the API's actionable response to
+        // authenticated caller input. Return the message, but never its trace.
+        _site_export_error(400, $e->getMessage());
+    } catch (Exception $e) {
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Details stay in the server log, never the response.
+        error_log('Reprint Exporter API request exception: ' . $e);
+        _site_export_error(500, 'The Reprint Exporter encountered an internal error.');
     }
 }

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-final class ExportHttpServerTest extends TestCase
-{
+final class ExportHttpServerTest extends TestCase {
     public function testParsesJsonBodyAndCastsKnownTypes(): void
     {
         $server = new Site_Export_HTTP_Server();
@@ -26,6 +25,19 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame(7, $config['max_execution_time']);
         $this->assertSame(0.7, $config['memory_threshold']);
         $this->assertTrue($config['create_table_query']);
+    }
+
+    public function testParseHttpConfigRejectsAnEndpointBodyOverride(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must match in the request target and body');
+
+        $server->parse_http_config(
+            ['endpoint' => 'staged_session_push'],
+            ['endpoint' => 'file_index']
+        );
     }
 
     public function testNormalizeConfigAppliesDefaultDirectoryAndDecodesCursorHeader(): void
@@ -57,6 +69,105 @@ final class ExportHttpServerTest extends TestCase
 
         $this->assertSame('/srv/site', $config['directory']);
         $this->assertSame('/srv/site/wp-content', $config['list_dir']);
+    }
+
+    public function testNormalizeConfigRejectsAClientChosenStoragePath(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+
+        $config = $server->normalize_config([
+            'endpoint' => 'file_index',
+            'storage_path' => '/srv/site/client-hidden-path',
+        ]);
+
+        $this->assertArrayNotHasKey('storage_path', $config);
+    }
+
+    public function testNormalizeConfigUsesTheServerStagingDirectoryAsStoragePath(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'staged' => [
+                'staging_dir' => '/srv/site/.reprint-staging',
+                'secret' => 'test-secret',
+            ],
+        ]);
+
+        $config = $server->normalize_config([
+            'endpoint' => 'file_index',
+            'storage_path' => '/srv/site/client-hidden-path',
+        ]);
+
+        $this->assertSame('/srv/site/.reprint-staging', $config['storage_path']);
+    }
+
+    public function testConstructorRejectsConflictingServerStoragePaths(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('storage_path must match staged.staging_dir');
+
+        new Site_Export_HTTP_Server([
+            'storage_path' => '/srv/site/other-storage',
+            'staged' => [
+                'staging_dir' => '/srv/site/.reprint-staging',
+                'secret' => 'test-secret',
+            ],
+        ]);
+    }
+
+    public function testConstructorRejectsRootAndDotSegmentStoragePaths(): void
+    {
+        foreach (['/', '/srv/site/../private'] as $storage_path) {
+            try {
+                new Site_Export_HTTP_Server(['storage_path' => $storage_path]);
+                self::fail('Expected unsafe storage_path to be rejected: ' . $storage_path);
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('HTTP server storage_path', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testConstructorRejectsASymlinkStoragePath(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $target = sys_get_temp_dir() . '/http-server-storage-target-' . $suffix;
+        $link = sys_get_temp_dir() . '/http-server-storage-link-' . $suffix;
+        mkdir($target, 0700);
+        if (!symlink($target, $link)) {
+            rmdir($target);
+            self::fail('Could not create the storage_path symlink fixture.');
+        }
+
+        try {
+            new Site_Export_HTTP_Server(['storage_path' => $link]);
+            self::fail('Expected a symlink storage_path to be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('must not be a symlink', $exception->getMessage());
+            $this->assertStringContainsString(base64_encode($link), $exception->getMessage());
+            $this->assertNotFalse(json_encode(['detail' => $exception->getMessage()]));
+        } finally {
+            unlink($link);
+            rmdir($target);
+        }
+    }
+
+    public function testConstructorRejectsStoragePathsBlockedByARegularFile(): void
+    {
+        $storage_file = tempnam(sys_get_temp_dir(), 'http-server-storage-file-');
+        $this->assertIsString($storage_file);
+
+        try {
+            foreach ([$storage_file, $storage_file . '/child'] as $storage_path) {
+                try {
+                    new Site_Export_HTTP_Server(['storage_path' => $storage_path]);
+                    self::fail('Expected a storage_path blocked by a regular file to be rejected.');
+                } catch (InvalidArgumentException $exception) {
+                    $this->assertStringContainsString('must not be blocked by a non-directory path', $exception->getMessage());
+                    $this->assertStringContainsString(base64_encode($storage_file), $exception->getMessage());
+                }
+            }
+        } finally {
+            unlink($storage_file);
+        }
     }
 
     public function testNormalizeConfigRejectsInvalidCursor(): void
@@ -144,5 +255,192 @@ final class ExportHttpServerTest extends TestCase
         ]);
 
         $this->assertSame([['endpoint' => 'preflight']], $calls);
+    }
+
+    public function testHandleRequestNeverBuffersSessionOrRetiredPushBodies(): void
+    {
+        $session_endpoints = [
+            'staged_session_create',
+            'staged_session_push',
+            'staged_session_advance',
+            'staged_session_status',
+            'staged_session_discard',
+        ];
+        $this->assertSame($session_endpoints, Site_Export_HTTP_Server::STAGED_SESSION_ENDPOINTS);
+
+        $body_reads = 0;
+        $handlers = [];
+        $unbuffered_endpoints = array_merge($session_endpoints, ['staged_push']);
+        foreach ($unbuffered_endpoints as $endpoint) {
+            $handlers[$endpoint] = static function (): void {};
+        }
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => $handlers,
+            'budget_factory' => static function (): array {
+                return [];
+            },
+            'body_reader' => static function () use (&$body_reads): string {
+                ++$body_reads;
+                return str_repeat('untrusted', 1024);
+            },
+        ]);
+
+        foreach ($unbuffered_endpoints as $endpoint) {
+            $server->handle_request([
+                'get' => ['endpoint' => $endpoint],
+                'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json'],
+            ]);
+        }
+
+        $this->assertSame(0, $body_reads);
+    }
+
+    public function testHandleRequestAuthenticatesAStagedQueryBeforeParsingConflictingInput(): void
+    {
+        $body_reads = 0;
+        $server = new Site_Export_HTTP_Server([
+            'staged' => [
+                'staging_dir' => sys_get_temp_dir() . '/export-http-pre-auth-' . bin2hex(random_bytes(8)),
+                'secret' => 'export-http-pre-auth-secret',
+            ],
+            'body_reader' => static function () use (&$body_reads): string {
+                ++$body_reads;
+                return 'endpoint=file_index';
+            },
+        ]);
+        $request_server = [
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/?endpoint=staged_session_create',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        ];
+        $previous_response_code = http_response_code();
+        $buffer_level = ob_get_level();
+        ob_start();
+        try {
+            $server->handle_request([
+                'get' => ['endpoint' => 'staged_session_create'],
+                'post' => ['endpoint' => 'file_index'],
+                'server' => $request_server,
+            ]);
+            $output = ob_get_clean();
+            $response_code = http_response_code();
+        } finally {
+            while (ob_get_level() > $buffer_level) {
+                ob_end_clean();
+            }
+            http_response_code($previous_response_code === false ? 200 : $previous_response_code);
+        }
+
+        $this->assertSame(0, $body_reads);
+        $this->assertSame(403, $response_code);
+        $this->assertSame(
+            [
+                'status' => 'rejected',
+                'reason' => 'auth_failed',
+                'detail' => 'Authentication failed.',
+            ],
+            json_decode( (string) $output, true)
+        );
+    }
+
+    public function testReservedHandlerOverrideCannotBeSelectedFromFormOrJsonBody(): void
+    {
+        $storage_dir = sys_get_temp_dir() . '/export-http-reserved-body-' . bin2hex(random_bytes(8));
+        $calls = 0;
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'staged_session_create' => static function () use (&$calls): void {
+                    ++$calls;
+                },
+            ],
+            'staged' => [
+                'staging_dir' => $storage_dir,
+                'secret' => 'reserved-body-secret',
+            ],
+        ]);
+
+        $requests = [
+            [
+                'get' => [],
+                'post' => ['endpoint' => 'staged_session_create'],
+                'server' => ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/', 'CONTENT_TYPE' => 'application/x-www-form-urlencoded'],
+                'body' => '',
+            ],
+            [
+                'get' => [],
+                'post' => [],
+                'server' => ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/', 'CONTENT_TYPE' => 'application/json'],
+                'body' => '{"endpoint":"staged_session_create"}',
+            ],
+        ];
+        $previous_response_code = http_response_code();
+        try {
+            foreach ($requests as $request) {
+                ob_start();
+                $server->handle_request($request);
+                $response = json_decode( (string) ob_get_clean(), true);
+                self::assertSame(400, http_response_code());
+                self::assertSame('endpoint_not_in_query', $response['reason']);
+            }
+        } finally {
+            http_response_code($previous_response_code === false ? 200 : $previous_response_code);
+            @unlink($storage_dir . '/.htaccess');
+            @unlink($storage_dir . '/index.php');
+            @rmdir($storage_dir);
+        }
+
+        self::assertSame(0, $calls);
+    }
+
+    public function testHandleRequestEmitsJsonFallbackWhenAResponseContainsInvalidUtf8(): void
+    {
+        $storage_dir = sys_get_temp_dir() . '/export-http-invalid-json-' . bin2hex(random_bytes(8));
+        $missing_target = sys_get_temp_dir() . "/export-http-missing-\xff-" . bin2hex(random_bytes(8));
+        $secret = 'export-http-invalid-json-secret';
+        $create_token = str_repeat('a', 32);
+        $request_target = '/?endpoint=staged_session_create&create_token=' . $create_token;
+        $request_server = ( new Site_Export_HMAC_Client($secret) )->get_envelope_auth_headers('POST', $request_target) + [
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => $request_target,
+        ];
+        $server = new Site_Export_HTTP_Server([
+            'staged' => [
+                'staging_dir' => $storage_dir,
+                'secret' => $secret,
+                'apply_target_root' => $missing_target,
+            ],
+        ]);
+        $previous_server = $_SERVER;
+        $previous_response_code = http_response_code();
+        $_SERVER = $request_server;
+        $buffer_level = ob_get_level();
+        ob_start();
+        try {
+            $server->handle_request([
+                'get' => ['endpoint' => 'staged_session_create', 'create_token' => $create_token],
+                'server' => $request_server,
+                'body' => '',
+            ]);
+            $output = ob_get_clean();
+            $response_code = http_response_code();
+        } finally {
+            while (ob_get_level() > $buffer_level) {
+                ob_end_clean();
+            }
+            $_SERVER = $previous_server;
+            http_response_code($previous_response_code === false ? 200 : $previous_response_code);
+            @rmdir($storage_dir);
+        }
+
+        $this->assertSame(500, $response_code);
+        $this->assertSame(
+            [
+                'status' => 'rejected',
+                'reason' => 'response_encoding_failed',
+                'detail' => 'The server could not encode its response as JSON.',
+                'committed_bytes' => 0,
+            ],
+            json_decode( (string) $output, true)
+        );
     }
 }

--- a/tests/ExporterPushPhpCompatibilityTest.php
+++ b/tests/ExporterPushPhpCompatibilityTest.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * The target may run PHP 7.2 even when the sending CLI runs a newer PHP.
  * Repo-wide compatibility lint currently reports unrelated vendor-patched
- * code, so keep an enforced scan over the direct-staging files in this layer.
+ * code, so keep an enforced scan over every direct-push exporter file loaded
+ * by the HTTP server or WordPress wrapper.
  */
 final class ExporterPushPhpCompatibilityTest extends TestCase {
 
@@ -18,6 +19,9 @@ final class ExporterPushPhpCompatibilityTest extends TestCase {
         $relative_paths = [
             '../packages/reprint-exporter/src/class-staged-push-stream-protocol.php',
             '../packages/reprint-exporter/src/class-staged-apply.php',
+            '../packages/reprint-exporter/src/class-staged-endpoints.php',
+            '../packages/reprint-exporter/src/class-http-server.php',
+            '../reprint-exporter-wp/lib.php',
         ];
         $paths = [];
         foreach ($relative_paths as $relative_path) {

--- a/tests/Import/StagedApplyHttpLifecycleTest.php
+++ b/tests/Import/StagedApplyHttpLifecycleTest.php
@@ -1,0 +1,226 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test diagnostics are never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- The test namespace matches the existing ImportTests suite.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Push_Stream_Protocol;
+
+final class StagedApplyHttpLifecycleTest extends TestCase {
+    private const SECRET = 'staged-apply-http-lifecycle-secret';
+
+    private string $server_root;
+    private string $target_root;
+    private string $staging_dir;
+    private string $router_path;
+    private string $base_url;
+
+    /** @var resource|null */
+    private $server_process = null;
+
+    protected function setUp(): void
+    {
+        $this->server_root = sys_get_temp_dir() . '/staged-apply-http-' . bin2hex(random_bytes(8));
+        $this->target_root = $this->server_root . '/target';
+        $this->staging_dir = $this->server_root . '/staging';
+        $this->router_path = $this->server_root . '/router.php';
+        mkdir($this->target_root, 0700, true);
+        $this->write_router();
+        $this->start_server();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            proc_close($this->server_process);
+            $this->server_process = null;
+        }
+        $this->remove_tree($this->server_root);
+    }
+
+    public function testEnabledGenericServerAppliesASessionOverRealHttp(): void
+    {
+        $create_token = bin2hex(random_bytes(16));
+        $created = $this->request_json(
+            'staged_session_create&create_token=' . $create_token,
+            ''
+        );
+        $this->assertSame(201, $created['http_code']);
+        $this->assertSame('created', $created['body']['status']);
+        $session_id = $created['body']['session_id'];
+        $request_generation = $created['body']['request_generation'];
+
+        file_put_contents($this->target_root . '/old.txt', 'old');
+        $content = str_repeat('streamed-session-content-', 200);
+        $frames = [
+            ['type' => 'directory', 'operation_index' => 0, 'path' => 'content'],
+            [
+                'type' => 'file',
+                'operation_index' => 1,
+                'path' => 'content/generic-http-session.txt',
+                'revision' => 1,
+                'offset' => 0,
+                'total_bytes' => strlen($content),
+                'restart' => false,
+                'payload' => $content,
+            ],
+            ['type' => 'delete', 'operation_index' => 2, 'path' => 'old.txt'],
+        ];
+        $stream_body = '';
+        foreach ($frames as $frame) {
+            $stream_body .= Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($frame);
+            if ($frame['type'] === 'file') {
+                $stream_body .= $frame['payload'];
+            }
+        }
+
+        $pushed = $this->request_json(
+            'staged_session_push&session_id=' . $session_id . '&expected_request_generation=' . $request_generation,
+            $stream_body,
+            Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE
+        );
+        $this->assertSame(200, $pushed['http_code']);
+        $this->assertSame('complete', $pushed['body']['status']);
+        $this->assertSame(3, $pushed['body']['operation_count']);
+        $request_generation = $pushed['body']['request_generation'];
+
+        $phase = 'uploading';
+        $observed_phases = [];
+        for ($attempt = 0; $attempt < 100 && $phase !== 'complete'; $attempt++) {
+            $advanced = $this->request_json(
+                'staged_session_advance&session_id=' . $session_id . '&expected_request_generation=' . $request_generation,
+                ''
+            );
+            $this->assertSame(200, $advanced['http_code']);
+            $phase = $advanced['body']['phase'];
+            $observed_phases[] = $phase;
+            $request_generation = $advanced['body']['request_generation'];
+        }
+
+        $this->assertSame('complete', $phase);
+        $this->assertNotContains('sealing', $observed_phases);
+        $this->assertNotContains('preparing', $observed_phases);
+        $this->assertNotContains('verifying', $observed_phases);
+        $this->assertSame($content, file_get_contents($this->target_root . '/content/generic-http-session.txt'));
+        $this->assertFileDoesNotExist($this->target_root . '/old.txt');
+        $this->assertFileDoesNotExist($this->target_root . '/.maintenance');
+    }
+
+    /** @return array{http_code:int,body:array<string,mixed>} */
+    private function request_json(string $query, string $body, string $content_type = 'application/json'): array
+    {
+        $url = $this->base_url . '?endpoint=' . $query;
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $headers['Content-Type'] = $content_type;
+        $response = $this->http_response($url, $body, $headers);
+        $decoded = json_decode($response['body'], true);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('Generic staged server returned invalid JSON: ' . $response['body']);
+        }
+        return ['http_code' => $response['status'], 'body' => $decoded];
+    }
+
+    /** @return array{status:int,body:string} */
+    private function http_response(string $url, string $body, array $headers): array
+    {
+        $handle = curl_init($url);
+        $header_lines = [];
+        foreach ($headers as $name => $value) {
+            $header_lines[] = $name . ': ' . $value;
+        }
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $response = curl_exec($handle);
+        $status = curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+        $error = curl_error($handle);
+        curl_close($handle);
+        if (!is_string($response)) {
+            throw new \RuntimeException('Generic staged server request failed: ' . $error);
+        }
+        return ['status' => $status, 'body' => $response];
+    }
+
+    private function write_router(): void
+    {
+        $autoload_path = realpath(__DIR__ . '/../../vendor/autoload.php');
+        if (!is_string($autoload_path)) {
+            self::fail('Could not locate Composer autoload.php for the generic staged server.');
+        }
+        $autoload_path = addslashes($autoload_path);
+        $target_root = addslashes($this->target_root);
+        $staging_dir = addslashes($this->staging_dir);
+        file_put_contents($this->router_path, <<<PHP_ROUTER
+<?php
+if (parse_url(\$_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__ping') {
+    echo 'ok';
+    return true;
+}
+require '{$autoload_path}';
+Site_Export_HTTP_Server::serve([
+    'default_directory' => '{$target_root}',
+    'staged' => [
+        'staging_dir' => '{$staging_dir}',
+        'secret' => 'staged-apply-http-lifecycle-secret',
+        'apply_target_root' => '{$target_root}',
+        'apply_sessions_enabled' => true,
+    ],
+]);
+return true;
+PHP_ROUTER
+        );
+    }
+
+    private function start_server(): void
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $error_message);
+        if ($socket === false) {
+            self::fail('Could not reserve generic staged server port: ' . $error_message);
+        }
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        $port = (int) substr(strrchr( (string) $address, ':'), 1);
+        $this->base_url = 'http://127.0.0.1:' . $port . '/';
+        $this->server_process = proc_open(
+            [PHP_BINARY, '-n', '-S', '127.0.0.1:' . $port, '-t', $this->server_root, $this->router_path],
+            [0 => ['pipe', 'r'], 1 => ['file', $this->server_root . '/server.log', 'a'], 2 => ['file', $this->server_root . '/server.log', 'a']],
+            $pipes,
+            $this->server_root
+        );
+        if (!is_resource($this->server_process)) {
+            self::fail('Could not start generic staged endpoint test server.');
+        }
+        fclose($pipes[0]);
+        for ($attempt = 0; $attempt < 50; $attempt++) {
+            if (@file_get_contents($this->base_url . '__ping') === 'ok') {
+                return;
+            }
+            usleep(100000);
+        }
+        self::fail('Generic staged endpoint test server did not start.');
+    }
+
+    private function remove_tree(string $path): void
+    {
+        if (is_link($path) || !is_dir($path)) {
+            if (( file_exists($path) || is_link($path) ) && !@unlink($path)) {
+                throw new \RuntimeException('Could not remove generic staged test path: ' . $path);
+            }
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $this->remove_tree($path . '/' . $entry);
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/StagedPluginPushEndpointTest.php
+++ b/tests/Import/StagedPluginPushEndpointTest.php
@@ -1,0 +1,556 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test diagnostics are never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- The test namespace matches the existing ImportTests suite.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+/**
+ * The plugin entry point, not a direct endpoint object: this catches a
+ * body-authentication regression that would buffer or reject an envelope
+ * authenticated staged_session_push request before the streaming handler
+ * receives it.
+ */
+final class StagedPluginPushEndpointTest extends TestCase {
+    private const SECRET = 'staged-plugin-push-test-secret';
+
+    private string $server_root;
+    private string $target_root;
+    private string $plugin_install_dir;
+    private string $staging_dir;
+    private string $secret_path;
+    private string $router_path;
+    private string $base_url;
+
+    /** @var resource|null */
+    private $server_process = null;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(8));
+        $this->server_root = sys_get_temp_dir() . '/staged-plugin-push-server-' . $suffix;
+        $this->target_root = $this->server_root . '/target';
+        $this->plugin_install_dir = $this->target_root . '/wp-content/plugins/site-export';
+        $this->staging_dir = $this->server_root . '/staging';
+        $this->secret_path = $this->server_root . '/secret.php';
+        $this->router_path = $this->server_root . '/router.php';
+        mkdir($this->target_root, 0700, true);
+        mkdir(dirname($this->plugin_install_dir), 0700, true);
+        $plugin_source = realpath(__DIR__ . '/../../reprint-exporter-wp');
+        if ($plugin_source === false || !symlink($plugin_source, $this->plugin_install_dir)) {
+            self::fail('Could not create the lexical in-target plugin symlink.');
+        }
+        file_put_contents($this->secret_path, "<?php\nreturn '" . self::SECRET . "';\n");
+        $this->write_router();
+        $this->start_server();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            proc_close($this->server_process);
+            $this->server_process = null;
+        }
+        $this->remove_tree($this->server_root);
+    }
+
+    public function testPluginAuthenticatesAStagedRequestBeforeParsingItsFormBody(): void
+    {
+        $url = $this->base_url . '&endpoint=staged_session_push';
+        $response = $this->http_response(
+            $url,
+            'endpoint=file_index',
+            ['Content-Type' => 'application/x-www-form-urlencoded']
+        );
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(403, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame(['rejected', 'auth_failed'], [$body['status'], $body['reason']]);
+        $this->assertSame('Authentication failed.', $body['detail']);
+        $this->assertArrayNotHasKey('trace', $body);
+        $this->assertArrayNotHasKey('file', $body);
+        $this->assertStringNotContainsString($this->server_root, $response['body']);
+        $this->assertStringNotContainsString($this->staging_dir, $response['body']);
+    }
+
+    public function testPluginAcceptsEnvelopeAuthenticationForCurrentSessionPushWithoutHashingItsBody(): void
+    {
+        $url = $this->base_url . '&without_staging=1&endpoint=staged_session_push';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $headers['Content-Type'] = 'application/octet-stream';
+        $response = $this->http_response($url, str_repeat('current-stream-body', 4096), $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(503, $response['status'], $response['body']);
+        $this->assertIsArray($body);
+        $this->assertSame('apply_storage_not_configured', $body['reason']);
+    }
+
+    public function testPluginRejectsARetiredLargePushWithoutBufferingItsBody(): void
+    {
+        $url = $this->base_url . '&low_memory=1&endpoint=staged_push';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $headers['Content-Type'] = 'application/octet-stream';
+        $headers['Expect'] = '';
+        $response = $this->http_response($url, str_repeat('x', 12 * 1024 * 1024), $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(410, $response['status'], $response['body']);
+        $this->assertIsArray($body);
+        $this->assertSame('endpoint_retired', $body['reason']);
+        $this->assertSame(
+            'The staged_push endpoint was removed. Use staged_session_create and staged_session_push.',
+            $body['detail']
+        );
+    }
+
+    public function testPluginDoesNotReturnATraceForAnAuthenticatedMalformedRequest(): void
+    {
+        $url = $this->base_url . '&endpoint=staged_session_create&create_token=' . str_repeat('b', 32);
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        $response = $this->http_response($url, 'endpoint=file_index', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(400, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame('endpoint parameter must match in the request target and body.', $body['error']);
+        $this->assertArrayNotHasKey('trace', $body);
+        $this->assertArrayNotHasKey('file', $body);
+        $this->assertStringNotContainsString($this->server_root, $response['body']);
+        $this->assertStringNotContainsString($this->staging_dir, $response['body']);
+    }
+
+    public function testPluginReturnsPointedOrdinaryEndpointValidationWithoutATrace(): void
+    {
+        $requests = [
+            [$this->base_url, 'endpoint parameter is required.'],
+            [$this->base_url . '&endpoint=not_a_real_endpoint', "Invalid endpoint: 'not_a_real_endpoint'."],
+        ];
+
+        foreach ($requests as [$url, $expected_error]) {
+            $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_auth_headers('');
+            $response = $this->http_response($url, '', $headers);
+            $body = json_decode($response['body'], true);
+
+            $this->assertSame(400, $response['status']);
+            $this->assertIsArray($body);
+            $this->assertStringContainsString($expected_error, $body['error']);
+            $this->assertStringContainsString('file_index', $body['error']);
+            $this->assertStringContainsString('sql_chunk', $body['error']);
+            $this->assertArrayNotHasKey('trace', $body);
+            $this->assertArrayNotHasKey('file', $body);
+            $this->assertStringNotContainsString($this->server_root, $response['body']);
+            $this->assertStringNotContainsString($this->staging_dir, $response['body']);
+        }
+    }
+
+    public function testPluginRunsCustomAuthenticationBeforeRejectingAStagedEnvelope(): void
+    {
+        $url = $this->base_url . '&custom_auth=record&without_staging=1&endpoint=staged_session_create&create_token=' . str_repeat('c', 32);
+        $response = $this->http_response($url, '', []);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(403, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame(['rejected', 'auth_failed'], [$body['status'], $body['reason']]);
+        $this->assertSame('Authentication failed.', $body['detail']);
+        $this->assertSame('called', file_get_contents($this->server_root . '/custom-auth-called'));
+        $this->assertStringNotContainsString('custom-auth-output', $response['body']);
+    }
+
+    public function testPluginClearsBufferedOutputBeforeReportingAnInternalError(): void
+    {
+        $url = $this->base_url . '&custom_auth=throw&endpoint=file_index';
+        $response = $this->http_response($url, '', []);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(500, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame(
+            ['The Reprint Exporter encountered an internal error.', 500],
+            [$body['error'], $body['code']]
+        );
+        $this->assertStringNotContainsString('custom-auth-output', $response['body']);
+        $this->assertStringNotContainsString('custom authenticator failed', $response['body']);
+    }
+
+    public function testPluginDoesNotExposeADispatchFailure(): void
+    {
+        $url = $this->base_url . '&dispatch_error=runtime&endpoint=file_index';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_auth_headers('');
+        $response = $this->http_response($url, '', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(500, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame(
+            ['The Reprint Exporter encountered an internal error.', 500],
+            [$body['error'], $body['code']]
+        );
+        $this->assertArrayNotHasKey('trace', $body);
+        $this->assertArrayNotHasKey('file', $body);
+        $this->assertStringNotContainsString('dispatch failed', strtolower($response['body']));
+        $this->assertStringNotContainsString($this->server_root, $response['body']);
+    }
+
+    public function testPluginRejectsSessionCreationWithoutExplicitStorage(): void
+    {
+        $url = $this->base_url . '&without_staging=1&endpoint=staged_session_create&create_token=' . str_repeat('d', 32);
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $response = $this->http_response($url, '', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(503, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame('rejected', $body['status']);
+        $this->assertSame('apply_storage_not_configured', $body['reason']);
+        $this->assertSame(
+            'Push requires SITE_EXPORT_STAGING_DIR to name an explicitly managed private staging directory.',
+            $body['detail']
+        );
+    }
+
+    public function testPluginAuthenticatesSessionRequestsBeforeReportingMissingStorage(): void
+    {
+        $url = $this->base_url . '&without_staging=1&endpoint=staged_session_create&create_token=' . str_repeat('e', 32);
+        $header_sets = [
+            [],
+            ( new Site_Export_HMAC_Client('wrong-secret') )->get_envelope_auth_headers('POST', $url),
+        ];
+
+        foreach ($header_sets as $headers) {
+            $response = $this->http_response($url, '', $headers);
+            $body = json_decode($response['body'], true);
+
+            $this->assertSame(403, $response['status']);
+            $this->assertIsArray($body);
+            $this->assertSame('rejected', $body['status']);
+            $this->assertSame('auth_failed', $body['reason']);
+            $this->assertSame('Authentication failed.', $body['detail']);
+        }
+    }
+
+    public function testPluginAuthenticatesSessionRequestsBeforeReportingInvalidStorage(): void
+    {
+        $url = $this->base_url . '&invalid_staging=root&endpoint=staged_session_create&create_token=' . str_repeat('f', 32);
+        $response = $this->http_response($url, '', []);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(403, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame('auth_failed', $body['reason']);
+        $this->assertSame('Authentication failed.', $body['detail']);
+
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $response = $this->http_response($url, '', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(503, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame('rejected', $body['status']);
+        $this->assertSame('apply_storage_invalid', $body['reason']);
+        $this->assertSame('SITE_EXPORT_STAGING_DIR must not be the filesystem root; observed /.', $body['detail']);
+    }
+
+    public function testPluginReportsAnExistingStagingFileAsTerminalConfiguration(): void
+    {
+        $url = $this->base_url . '&invalid_staging=file&endpoint=staged_session_create&create_token=' . str_repeat('2', 32);
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $response = $this->http_response($url, '', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(503, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame('rejected', $body['status']);
+        $this->assertSame('apply_storage_invalid', $body['reason']);
+        $this->assertStringContainsString('must not be blocked by a non-directory path', $body['detail']);
+        $this->assertStringNotContainsString('retryable_io_error', $response['body']);
+    }
+
+    public function testPluginAuthenticatesSessionRequestsBeforeReportingInvalidApplyTarget(): void
+    {
+        $url = $this->base_url . '&invalid_apply_root=array&endpoint=staged_session_create&create_token=' . str_repeat('1', 32);
+        $header_sets = [
+            [],
+            ( new Site_Export_HMAC_Client('wrong-secret') )->get_envelope_auth_headers('POST', $url),
+        ];
+
+        foreach ($header_sets as $headers) {
+            $response = $this->http_response($url, '', $headers);
+            $body = json_decode($response['body'], true);
+
+            $this->assertSame(403, $response['status']);
+            $this->assertIsArray($body);
+            $this->assertSame('auth_failed', $body['reason']);
+            $this->assertSame('Authentication failed.', $body['detail']);
+        }
+
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $response = $this->http_response($url, '', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(503, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame('rejected', $body['status']);
+        $this->assertSame('apply_target_invalid', $body['reason']);
+        $this->assertSame('SITE_EXPORT_APPLY_ROOT must be a string; observed array.', $body['detail']);
+    }
+
+    public function testPluginKeepsItsServerOwnedStagingDirectoryOutOfFileIndexes(): void
+    {
+        $inside_staging_dir = $this->target_root . '/.reprint-staging';
+        $visible_path = $this->target_root . '/visible.txt';
+        mkdir($inside_staging_dir, 0700, true);
+        file_put_contents($inside_staging_dir . '/session-state.json', 'private');
+        file_put_contents($visible_path, 'visible');
+
+        $url = $this->base_url
+            . '&staging_inside_target=1&endpoint=file_index&list_dir=' . rawurlencode($this->target_root)
+            . '&storage_path=' . rawurlencode($visible_path)
+            . '&invalid_apply_root=array';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_auth_headers('');
+        $response = $this->http_response($url, '', $headers);
+
+        $this->assertSame(200, $response['status'], $response['body']);
+        $paths = $this->decode_file_index_paths($response['body']);
+        $visible_path = (string) realpath($visible_path);
+        $inside_staging_dir = (string) realpath($inside_staging_dir);
+        $this->assertContains(
+            $visible_path,
+            $paths,
+            'A client storage_path must not hide an arbitrary target file: ' . json_encode($paths)
+        );
+        $this->assertNotContains($inside_staging_dir, $paths);
+        $this->assertNotContains($inside_staging_dir . '/session-state.json', $paths);
+    }
+
+    public function testPluginKeepsOrdinaryPullAvailableWithoutStagingConfiguration(): void
+    {
+        $visible_path = $this->target_root . '/visible-without-staging.txt';
+        file_put_contents($visible_path, 'visible');
+        $url = $this->base_url
+            . '&without_staging=1&endpoint=file_index&list_dir=' . rawurlencode($this->target_root);
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_auth_headers('');
+        $response = $this->http_response($url, '', $headers);
+
+        $this->assertSame(200, $response['status'], $response['body']);
+        $visible_path = (string) realpath($visible_path);
+        $this->assertContains($visible_path, $this->decode_file_index_paths($response['body']));
+    }
+
+    public function testPluginOptionsProtectItsLexicalSymlinkInstallPath(): void
+    {
+        $url = str_replace('/?reprint-api=1', '/__staged-options', $this->base_url);
+        $response = $this->http_response($url, '', []);
+        $options = json_decode($response['body'], true);
+
+        $this->assertSame(200, $response['status'], $response['body']);
+        $this->assertIsArray($options);
+        $this->assertFalse($options['apply_sessions_enabled']);
+        $this->assertContains('wp-content/plugins/site-export', $options['apply_protected_paths']);
+    }
+
+    public function testPluginKeepsLiveApplyDisabledUntilNoBootRecoveryExists(): void
+    {
+        $url = $this->base_url . '&endpoint=staged_session_create&create_token=' . str_repeat('a', 32);
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $response = $this->http_response($url, '', $headers);
+        $body = json_decode($response['body'], true);
+
+        $this->assertSame(503, $response['status']);
+        $this->assertIsArray($body);
+        $this->assertSame(['rejected', 'apply_not_configured'], [$body['status'], $body['reason']]);
+        $this->assertSame('Server configuration has not enabled a safe staged-apply recovery entry point.', $body['detail']);
+        $this->assertDirectoryDoesNotExist($this->staging_dir . '/apply-sessions');
+        $this->assertTrue(is_link($this->plugin_install_dir));
+    }
+
+    private function write_router(): void
+    {
+        $plugin_lib = addslashes($this->plugin_install_dir . '/lib.php');
+        $plugin_root = addslashes(dirname($this->plugin_install_dir));
+        $target_root = addslashes($this->target_root . '/');
+        $staging_dir = addslashes($this->staging_dir);
+        $invalid_staging_file = addslashes($this->server_root . '/staging-file');
+        $secret_path = addslashes($this->secret_path);
+        $custom_auth_marker = addslashes($this->server_root . '/custom-auth-called');
+        $dispatch_error_detail = addslashes('Dispatch failed at ' . $this->server_root . '/private-runtime.php.');
+        file_put_contents($this->router_path, <<<PHP_ROUTER
+<?php
+if (parse_url(\$_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__ping') {
+    echo 'ok';
+    return true;
+}
+if ((\$_GET['dispatch_error'] ?? null) === 'runtime') {
+    final class Site_Export_HTTP_Server {
+        public static function handle_cors_headers_and_terminate_on_options(\$origin = '*'): void {}
+        public static function is_staged_session_endpoint(string \$endpoint): bool { return false; }
+        public static function serve(array \$options = []): void {
+            throw new RuntimeException('{$dispatch_error_detail}');
+        }
+    }
+}
+if ((\$_GET['low_memory'] ?? null) === '1') {
+    if (ini_set('memory_limit', '8M') === false) {
+        throw new RuntimeException('Could not lower the endpoint test memory limit.');
+    }
+}
+define('ABSPATH', '{$target_root}');
+if ((\$_GET['without_staging'] ?? null) !== '1') {
+    \$configured_staging_dir = '{$staging_dir}';
+    if ((\$_GET['invalid_staging'] ?? null) === 'root') {
+        \$configured_staging_dir = '/';
+    } elseif ((\$_GET['invalid_staging'] ?? null) === 'file') {
+        \$configured_staging_dir = '{$invalid_staging_file}';
+        file_put_contents(\$configured_staging_dir, 'not a directory');
+    } elseif ((\$_GET['staging_inside_target'] ?? null) === '1') {
+        \$configured_staging_dir = '{$target_root}.reprint-staging';
+    }
+    define('SITE_EXPORT_STAGING_DIR', \$configured_staging_dir);
+}
+\$configured_apply_root = '{$target_root}';
+if ((\$_GET['invalid_apply_root'] ?? null) === 'array') {
+    \$configured_apply_root = [];
+}
+define('SITE_EXPORT_APPLY_ROOT', \$configured_apply_root);
+define('WP_PLUGIN_DIR', '{$plugin_root}');
+define('SITE_EXPORT_SECRET_FILE', '{$secret_path}');
+function plugin_dir_path(\$file) { return dirname(\$file) . '/'; }
+function plugin_basename(\$file) { return 'site-export/lib.php'; }
+require '{$plugin_lib}';
+if (parse_url(\$_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__staged-options') {
+    \$options = _site_export_staged_options();
+    unset(\$options['secret']);
+    header('Content-Type: application/json');
+    echo json_encode(\$options);
+    return true;
+}
+\$options = [];
+if ((\$_GET['custom_auth'] ?? null) === 'record') {
+    \$options['authenticate'] = static function () {
+        file_put_contents('{$custom_auth_marker}', 'called');
+    };
+} elseif ((\$_GET['custom_auth'] ?? null) === 'throw') {
+    \$options['authenticate'] = static function () {
+        echo 'custom-auth-output';
+        throw new RuntimeException('custom authenticator failed');
+    };
+}
+_site_export_handle_api_request(\$options);
+return true;
+PHP_ROUTER
+        );
+    }
+
+    private function start_server(): void
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $error_message);
+        if ($socket === false) {
+            self::fail('Could not reserve plugin test port: ' . $error_message);
+        }
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        $port = (int) substr(strrchr( (string) $address, ':'), 1);
+        $this->base_url = 'http://127.0.0.1:' . $port . '/?reprint-api=1';
+        $this->server_process = proc_open(
+            [PHP_BINARY, '-n', '-d', 'post_max_size=32M', '-S', '127.0.0.1:' . $port, '-t', $this->server_root, $this->router_path],
+            [0 => ['pipe', 'r'], 1 => ['file', $this->server_root . '/server.log', 'a'], 2 => ['file', $this->server_root . '/server.log', 'a']],
+            $pipes,
+            $this->server_root
+        );
+        if (!is_resource($this->server_process)) {
+            self::fail('Could not start plugin endpoint test server.');
+        }
+        fclose($pipes[0]);
+        for ($attempt = 0; $attempt < 50; $attempt++) {
+            if (@file_get_contents('http://127.0.0.1:' . $port . '/__ping') === 'ok') {
+                return;
+            }
+            usleep(100000);
+        }
+        self::fail('Plugin endpoint test server did not start.');
+    }
+
+    /** @return array{status:int,body:string} */
+    private function http_response(string $url, string $body, array $headers): array
+    {
+        $handle = curl_init($url);
+        $header_lines = [];
+        foreach ($headers as $name => $value) {
+            $header_lines[] = $name . ': ' . $value;
+        }
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $response = curl_exec($handle);
+        $status = curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+        $error = curl_error($handle);
+        curl_close($handle);
+        if (!is_string($response)) {
+            throw new \RuntimeException('Plugin endpoint request failed: ' . $error);
+        }
+        return ['status' => $status, 'body' => $response];
+    }
+
+    /** @return string[] */
+    private function decode_file_index_paths(string $response): array
+    {
+        $decoded = @gzdecode($response);
+        $multipart = is_string($decoded) ? $decoded : $response;
+        if (preg_match('/^--(boundary-[A-Za-z0-9]+)/m', $multipart, $matches) !== 1) {
+            throw new \RuntimeException('Plugin file_index response has no multipart boundary.');
+        }
+
+        $paths = [];
+        foreach (explode('--' . $matches[1], $multipart) as $part) {
+            if (strpos($part, 'X-Chunk-Type: index_batch') === false) {
+                continue;
+            }
+            $header_end = strpos($part, "\r\n\r\n");
+            if ($header_end === false) {
+                continue;
+            }
+            $batch = json_decode(rtrim(substr($part, $header_end + 4), "\r\n"), true);
+            if (!is_array($batch)) {
+                throw new \RuntimeException('Plugin file_index returned an invalid index batch.');
+            }
+            foreach ($batch as $item) {
+                $path = is_array($item) && is_string($item['path'] ?? null)
+                    ? base64_decode($item['path'], true)
+                    : false;
+                if (is_string($path)) {
+                    $paths[] = $path;
+                }
+            }
+        }
+        return $paths;
+    }
+
+    private function remove_tree(string $path): void
+    {
+        if (is_link($path) || !is_dir($path)) {
+            if (( file_exists($path) || is_link($path) ) && !@unlink($path)) {
+                throw new \RuntimeException('Could not remove test path: ' . $path);
+            }
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $this->remove_tree($path . '/' . $entry);
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -4,23 +4,24 @@ namespace ImportTests;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Site_Export_HMAC_Client;
-use Site_Export_Staged_Artifacts;
-use StagedPushStreamClient;
 use PushRequestSizer;
+use RuntimeException;
+use Site_Export_HMAC_Client;
+use Site_Export_Staged_Push_Stream_Protocol;
+use StagedPushStreamClient;
 
 require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
 
 /**
- * Drives the push stream client against a local PHP server that dispatches
- * the real staged endpoint routes. The pushAll()/pushOnce() helpers are the
- * reference caller loop: stream the local-paths journal line by line, read
- * each file in budget-sized pieces, rotate requests when the client says so,
- * and retry from the server-confirmed cursor.
+ * Exercises the streaming client against a small real HTTP peer. The peer
+ * records the request body but deliberately knows nothing about target
+ * staging, so these tests lock down the wire and client cursor behavior
+ * without creating a second fake implementation of the apply session.
  */
 class StagedPushStreamClientTest extends TestCase
 {
     private const SECRET = 'staged-push-stream-client-test-secret';
+    private const SESSION_ID = '0123456789abcdef0123456789abcdef';
 
     private static string $server_root;
     private static string $router_path;
@@ -31,22 +32,18 @@ class StagedPushStreamClientTest extends TestCase
     /** @var resource|null */
     private static $server_process = null;
 
-    private string $staging_dir;
-    private string $source_dir;
-
     public static function setUpBeforeClass(): void
     {
-        $suffix = bin2hex(random_bytes(8));
-        self::$server_root = sys_get_temp_dir() . '/staged-push-stream-site-' . $suffix;
+        self::$server_root = sys_get_temp_dir() . '/direct-push-wire-' . bin2hex(random_bytes(8));
         self::$router_path = self::$server_root . '/router.php';
-        self::$config_path = self::$server_root . '/endpoint-config.json';
+        self::$config_path = self::$server_root . '/config.json';
         self::$request_log_path = self::$server_root . '/requests.jsonl';
         mkdir(self::$server_root, 0700, true);
         self::writeRouter();
 
-        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
         if ($socket === false) {
-            self::fail('Could not reserve a local test port: ' . $errstr);
+            self::fail('Could not reserve a local test port: ' . $error_message);
         }
         $address = stream_socket_get_name($socket, false);
         fclose($socket);
@@ -55,27 +52,27 @@ class StagedPushStreamClientTest extends TestCase
 
         self::$server_process = proc_open(
             [PHP_BINARY, '-n', '-S', '127.0.0.1:' . $port, '-t', self::$server_root, self::$router_path],
-            [0 => ['pipe', 'r'], 1 => ['file', self::$server_root . '/server.log', 'a'], 2 => ['file', self::$server_root . '/server.log', 'a']],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['file', self::$server_root . '/server.log', 'a'],
+                2 => ['file', self::$server_root . '/server.log', 'a'],
+            ],
             $pipes,
             self::$server_root
         );
         if (!is_resource(self::$server_process)) {
-            self::fail('Could not start the local staged endpoint server.');
+            self::fail('Could not start the local staged push wire server.');
         }
         fclose($pipes[0]);
 
-        $ready = false;
         for ($attempt = 0; $attempt < 50; $attempt++) {
             if (@file_get_contents('http://127.0.0.1:' . $port . '/__ping') === 'ok') {
-                $ready = true;
-                break;
+                return;
             }
             usleep(100000);
         }
-        if (!$ready) {
-            self::tearDownAfterClass();
-            self::fail('The local staged endpoint server did not start.');
-        }
+        self::tearDownAfterClass();
+        self::fail('The local staged push wire server did not start.');
     }
 
     public static function tearDownAfterClass(): void
@@ -92,936 +89,569 @@ class StagedPushStreamClientTest extends TestCase
 
     protected function setUp(): void
     {
-        $suffix = bin2hex(random_bytes(8));
-        $this->staging_dir = sys_get_temp_dir() . '/staged-push-stream-' . $suffix;
-        $this->source_dir = sys_get_temp_dir() . '/staged-push-source-' . $suffix;
-        mkdir($this->source_dir, 0700, true);
         @unlink(self::$request_log_path);
-        $this->configureEndpoint();
-    }
-
-    protected function tearDown(): void
-    {
-        self::removeDirectory($this->staging_dir);
-        self::removeDirectory($this->source_dir);
-    }
-
-    public function testStreamsManyFilesThroughOneRequest(): void
-    {
-        $this->writeSource('wp-content/uploads/first.bin', str_repeat('a', 10));
-        $this->writeSource('wp-content/uploads/second.bin', str_repeat('bc', 7));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush([
-            'wp-content/uploads/first.bin',
-            'wp-content/uploads/second.bin',
+        $this->configureResponse([
+            'status' => 'complete',
+            'operation_count' => 0,
+            'current_file' => null,
         ]);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(2, $result['files_verified']);
-        $this->assertSame(str_repeat('a', 10), file_get_contents($this->staging_dir . '/files/wp-content/uploads/first.bin'));
-        $this->assertSame(str_repeat('bc', 7), file_get_contents($this->staging_dir . '/files/wp-content/uploads/second.bin'));
-        $this->assertSame(['staged_push'], $this->endpointsSeen(), 'all file chunks travel through one request');
     }
 
-    public function testCursorCanResumeMidFileInTheNextPushStream(): void
+    public function testStreamsTypedOperationsAndFileChunksThroughOneRequest(): void
     {
-        $this->writeSource('first.bin', str_repeat('a', 12));
-        $this->writeSource('second.bin', str_repeat('b', 12));
-        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('second.bin', 0, str_repeat('b', 4));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush([
-            'first.bin',
-            'second.bin',
+        $this->configureResponse([
+            'status' => 'complete',
+            'operation_count' => 4,
+            'current_file' => null,
         ]);
-
-        $result = $this->pushAll($client, $local_paths_to_push, ['artifact_id' => 'second.bin', 'committed_bytes' => 4]);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/first.bin', 'cursor skips files before the resumed artifact');
-        $this->assertSame(str_repeat('b', 12), file_get_contents($this->staging_dir . '/files/second.bin'));
-        $this->assertSame(['staged_push'], $this->endpointsSeen());
-    }
-
-    public function testCallerCanPauseAfterOneChunkAndResumeFromTheCursor(): void
-    {
-        $this->writeSource('chunked.bin', str_repeat('x', 12));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['chunked.bin']);
-
+        $client = $this->makeClient(['chunk_bytes' => 4]);
+        $client->set_session_request_generation(6);
         $this->assertTrue($client->start_push_request());
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'chunked.bin',
-            'offset' => 0,
-            'total_bytes' => 12,
-            'final' => false,
-            'payload' => str_repeat('x', 4),
-        ]));
-        $first_result = $client->finish_request();
 
-        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(1, $first_result['chunks_sent']);
-        $this->assertSame(['artifact_id' => 'chunked.bin', 'committed_bytes' => 4], $first_result['cursor']);
-        $this->assertSame(str_repeat('x', 4), file_get_contents($this->staging_dir . '/files/chunked.bin'));
+        $operations = [
+            ['type' => 'directory', 'operation_index' => 0, 'path' => 'uploads'],
+            [
+                'type' => 'file',
+                'operation_index' => 1,
+                'path' => "uploads/image-\xff.bin",
+                'revision' => 0,
+                'offset' => 0,
+                'total_bytes' => 6,
+                'restart' => false,
+                'payload' => 'abcd',
+            ],
+            [
+                'type' => 'file',
+                'operation_index' => 1,
+                'path' => "uploads/image-\xff.bin",
+                'revision' => 0,
+                'offset' => 4,
+                'total_bytes' => 6,
+                'restart' => false,
+                'payload' => 'ef',
+            ],
+            ['type' => 'symlink', 'operation_index' => 2, 'path' => 'latest', 'target' => 'uploads'],
+            ['type' => 'delete', 'operation_index' => 3, 'path' => 'old-cache'],
+        ];
+        foreach ($operations as $operation) {
+            $this->assertTrue($client->send_operation($operation));
+        }
 
-        $result = $this->pushAll($client, $local_paths_to_push, $first_result['cursor']);
+        $result = $client->finish_request();
 
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(str_repeat('x', 12), file_get_contents($this->staging_dir . '/files/chunked.bin'));
-        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(4, $result['operation_count']);
+        $this->assertNull($result['current_file']);
+        $this->assertSame(7, $result['request_generation']);
+        $this->assertSame(5, $result['frames_sent']);
+
+        $request = $this->requestLogEntries()[0];
+        $this->assertSame('staged_session_push', $request['endpoint']);
+        $this->assertSame(self::SESSION_ID, $request['session_id']);
+        $this->assertSame('6', $request['expected_request_generation']);
+        $this->assertSame(Site_Export_Staged_Push_Stream_Protocol::CONTENT_TYPE, $request['content_type']);
+        $body = base64_decode($request['body_b64'], true);
+        $this->assertIsString($body);
+        $this->assertSame(strlen($body), $result['body_bytes_sent'], 'header lines and payloads are both charged');
+
+        $frames = $this->decodeFrames($body);
+        $this->assertSame(['directory', 'file', 'file', 'symlink', 'delete'], array_column($frames, 'type'));
+        $this->assertSame(['', 'abcd', 'ef', '', ''], array_column($frames, 'payload'));
+        $this->assertSame("uploads/image-\xff.bin", $frames[1]['path']);
+        $this->assertSame(1, $frames[2]['operation_index'], 'file chunks keep one operation index');
     }
 
-    public function testBodyBudgetCountsFrameHeadersWhenRotatingRequests(): void
+    public function testResponseReturnsOnlyTargetConfirmedOperationAndFileCursors(): void
     {
-        $this->writeSource('budget.bin', str_repeat('y', 10));
-        $first_frame_header = json_encode([
-            'type' => 'chunk',
-            'artifact_id' => base64_encode('budget.bin'),
-            'offset' => 0,
-            'bytes' => 4,
-            'total_bytes' => 10,
-            'final' => false,
-        ], JSON_UNESCAPED_SLASHES) . "\n";
-        // Budget for one full frame plus 3 spare bytes, so the value of
-        // next_chunk_body_bytes() after the first chunk reveals whether the
-        // frame header was charged against the budget alongside the payload.
-        // The budget is denominated in entity-body bytes; the transfer
-        // framing around them is libcurl's business.
-        $request_body_budget = strlen($first_frame_header) + 4 + 3;
-        $client = $this->makeClient([
-            'request_sizer' => new PushRequestSizer([
-                'floor_bytes' => 4,
-                'start_bytes' => $request_body_budget,
-                'max_bytes' => $request_body_budget,
-            ]),
+        $current_path = "uploads/partial-\xfe.bin";
+        $this->configureResponse([
+            'status' => 'complete',
+            'operation_count' => 3,
+            'current_file' => [
+                'operation_index' => 3,
+                'path_b64' => base64_encode($current_path),
+                'revision' => 8,
+                'committed_bytes' => 12,
+                'total_bytes' => 20,
+            ],
         ]);
-        $local_paths_to_push = $this->writeLocalPathsToPush(['budget.bin']);
-
+        $client = $this->makeClient();
+        $client->set_session_request_generation(2);
         $this->assertTrue($client->start_push_request());
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'budget.bin',
-            'offset' => 0,
-            'total_bytes' => 10,
-            'final' => false,
-            'payload' => 'yyyy',
+        $this->assertTrue($client->send_operation([
+            'type' => 'file',
+            'operation_index' => 3,
+            'path' => $current_path,
+            'revision' => 8,
+            'offset' => 8,
+            'total_bytes' => 20,
+            'restart' => false,
+            'payload' => '1234',
         ]));
 
-        $this->assertSame(3, $client->next_chunk_body_bytes(), 'the frame header was charged against the budget, not only the payload');
-        $this->assertFalse($client->should_finish_request());
+        $result = $client->finish_request();
 
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'budget.bin',
-            'offset' => 4,
-            'total_bytes' => 10,
-            'final' => false,
-            'payload' => 'yyy',
-        ]));
-        $this->assertSame(0, $client->next_chunk_body_bytes(), 'the second frame header spends the rest of the budget');
-        $this->assertTrue($client->should_finish_request());
-
-        $rotation_result = $client->finish_request();
-        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(['artifact_id' => 'budget.bin', 'committed_bytes' => 7], $rotation_result['cursor']);
-
-        $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(str_repeat('y', 10), file_get_contents($this->staging_dir . '/files/budget.bin'));
-        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
+        $this->assertSame(3, $result['operation_count']);
+        $this->assertSame([
+            'operation_index' => 3,
+            'path' => $current_path,
+            'revision' => 8,
+            'committed_bytes' => 12,
+            'total_bytes' => 20,
+        ], $result['current_file']);
+        $this->assertSame(3, $result['request_generation']);
     }
 
-    public function testTimeBudgetRotatesRequests(): void
+    public function testRecoverableStreamFailuresPreserveConfirmedState(): void
     {
-        $this->writeSource('timed.bin', str_repeat('t', 8));
-        $client = $this->makeClient(['max_request_seconds' => 0.05]);
-        $local_paths_to_push = $this->writeLocalPathsToPush(['timed.bin']);
+        foreach (['operation_gap', 'offset_gap', 'body_read_failed'] as $reason) {
+            @unlink(self::$request_log_path);
+            $this->configureResponse([
+                'http_code' => $reason === 'body_read_failed' ? 400 : 409,
+                'status' => 'rejected',
+                'reason' => $reason,
+                'detail' => 'sender is ahead',
+                'operation_count' => 5,
+                'current_file' => null,
+            ]);
+            $client = $this->makeClient();
+            $client->set_session_request_generation(0);
+            $this->assertTrue($client->start_push_request());
+            $this->assertTrue($client->send_operation([
+                'type' => 'delete',
+                'operation_index' => 8,
+                'path' => 'ahead',
+            ]));
 
-        $this->assertTrue($client->start_push_request());
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'timed.bin',
-            'offset' => 0,
-            'total_bytes' => 8,
-            'final' => false,
-            'payload' => 'tttt',
-        ]));
-        usleep(80000);
-        $this->assertTrue($client->should_finish_request(), 'an open request older than max_request_seconds asks to be finished');
-
-        $rotation_result = $client->finish_request();
-        $this->assertSame('complete', $rotation_result['status'], (string) json_encode($rotation_result, JSON_INVALID_UTF8_SUBSTITUTE));
-
-        $result = $this->pushAll($client, $local_paths_to_push, $rotation_result['cursor']);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(str_repeat('t', 8), file_get_contents($this->staging_dir . '/files/timed.bin'));
-        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen());
+            $result = $client->finish_request();
+            $this->assertSame(['retry', $reason, 5], [
+                $result['status'],
+                $result['reason'],
+                $result['operation_count'],
+            ]);
+        }
     }
 
-    public function testRetryFromTheBeginningSkipsVerifiedFilesAndRestartsPartialOnes(): void
+    public function testFrameTooLargeCapsLaterFilePayloadsButFileSizeRejectionDoesNot(): void
     {
-        // first.bin is verified and gets skipped on replay; second.bin holds
-        // 4 unvouched-for bytes, so the replay restarts it from zero.
-        $this->writeSource('first.bin', str_repeat('a', 8));
-        $this->writeSource('second.bin', str_repeat('b', 8));
-        $store = new Site_Export_Staged_Artifacts($this->staging_dir);
-        $store->append('first.bin', 0, str_repeat('a', 8));
-        $store->finalize('first.bin', 8);
-        $store->append('second.bin', 0, str_repeat('b', 4));
+        $request_sizer = new PushRequestSizer([
+            'floor_bytes' => 1,
+            'start_bytes' => 64,
+            'max_bytes' => 64,
+        ]);
+        $this->configureResponse([
+            'http_code' => 413,
+            'status' => 'rejected',
+            'reason' => 'frame_too_large',
+            'max_frame_bytes' => 2,
+            'operation_count' => 0,
+            'current_file' => null,
+        ]);
         $client = $this->makeClient([
             'chunk_bytes' => 8,
+            'request_sizer' => $request_sizer,
         ]);
-        $local_paths_to_push = $this->writeLocalPathsToPush([
-            'first.bin',
-            'second.bin',
+        $client->set_session_request_generation(0);
+        $this->assertTrue($client->start_push_request());
+        $this->assertTrue($client->send_operation([
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => 'large.bin',
+            'revision' => 0,
+            'offset' => 0,
+            'total_bytes' => 4,
+            'restart' => false,
+            'payload' => '1234',
+        ]));
+        $result = $client->finish_request();
+        $this->assertSame(['retry', 'frame_too_large', 2], [
+            $result['status'],
+            $result['reason'],
+            $result['max_frame_bytes'],
         ]);
 
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(str_repeat('a', 8), file_get_contents($this->staging_dir . '/files/first.bin'));
-        $this->assertSame(str_repeat('b', 8), file_get_contents($this->staging_dir . '/files/second.bin'));
-        $this->assertSame(['staged_push'], $this->endpointsSeen());
+        $this->configureResponse([
+            'http_code' => 409,
+            'status' => 'rejected',
+            'reason' => 'size_exceeded',
+            'operation_count' => 0,
+            'current_file' => null,
+        ]);
+        $client->set_session_request_generation((int) $result['request_generation']);
+        $this->assertTrue($client->start_push_request());
+        $this->assertSame(2, $client->next_chunk_body_bytes());
+        $this->assertTrue($client->send_operation([
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => 'large.bin',
+            'revision' => 0,
+            'offset' => 0,
+            'total_bytes' => 2,
+            'restart' => false,
+            'payload' => '12',
+        ]));
+        $result = $client->finish_request();
+        $this->assertSame(['failed', 'size_exceeded'], [$result['status'], $result['reason']]);
+        $this->assertSame(64, $request_sizer->request_body_bytes(), 'a file range error is not request-size evidence');
     }
 
-    public function testFrameTooLargeShrinksTheBodyBudgetAndRetries(): void
+    public function testRawHttp413PermanentlyLowersTheRequestBodyBudget(): void
     {
-        $this->writeSource('large.bin', str_repeat('x', 20));
-        $this->configureEndpoint(['max_frame_bytes' => 6]);
-        $sizer = new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 12, 'max_bytes' => 12]);
-        $client = $this->makeClient(['request_sizer' => $sizer, 'chunk_bytes' => 12]);
-        $local_paths_to_push = $this->writeLocalPathsToPush(['large.bin']);
-
-        $push_started_at = microtime(true);
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertGreaterThan(0.25, microtime(true) - $push_started_at, 'the retry after the 413 backed off before re-hitting the host');
-        $this->assertSame(str_repeat('x', 20), file_get_contents($this->staging_dir . '/files/large.bin'));
-        // The 413 caps the body budget at the reported 6 * 0.9 = 5 bytes, so
-        // after the rejected first request the remaining 20 bytes travel as
-        // four one-frame requests, chunks sized down to the capacity.
-        $this->assertSame(array_fill(0, 5, 'staged_push'), $this->endpointsSeen());
-        $this->assertLessThanOrEqual(5, $sizer->request_body_bytes());
-    }
-
-    public function testWrongSecretFailsBeforeReadingTheBody(): void
-    {
-        $this->writeSource('secret.bin', 'secret');
-        $client = $this->makeClient([
-            'hmac_client' => new Site_Export_HMAC_Client('wrong-secret'),
+        $request_sizer = new PushRequestSizer([
+            'floor_bytes' => 128,
+            'start_bytes' => 1024,
+            'max_bytes' => 1024,
         ]);
-        $local_paths_to_push = $this->writeLocalPathsToPush(['secret.bin']);
+        $this->configureResponse(['raw_413' => true]);
+        $client = $this->makeClient(['request_sizer' => $request_sizer]);
+        $client->set_session_request_generation(0);
+        $this->assertTrue($client->start_push_request());
+        $this->assertTrue($client->send_operation([
+            'type' => 'delete',
+            'operation_index' => 0,
+            'path' => 'old',
+        ]));
 
-        $result = $this->pushAll($client, $local_paths_to_push);
+        $result = $client->finish_request();
 
-        $this->assertSame(['failed', 'auth_failed'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/secret.bin');
-        $this->assertSame(['staged_push'], $this->endpointsSeen());
+        $this->assertSame(['retry', 'request_too_large'], [$result['status'], $result['reason']]);
+        $this->assertSame(512, $request_sizer->request_body_bytes());
     }
 
-    public function testAFileInTheReservedNamespaceIsRejectedOverTheWire(): void
+    public function testMetadataOnlyStreamsRotateAtTheSharedFrameCap(): void
     {
-        // A local site that happens to hold a .reprint/ file: the push must
-        // be refused end to end, not silently written into reprint's own
-        // namespace where apply would later trust it.
-        $this->writeSource('.reprint/evil.bin', 'x');
+        $this->configureResponse([
+            'status' => 'complete',
+            'operation_count' => Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST,
+            'current_file' => null,
+        ]);
         $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['.reprint/evil.bin']);
+        $client->set_session_request_generation(0);
+        $this->assertTrue($client->start_push_request());
 
-        $result = $this->pushAll($client, $local_paths_to_push);
+        for ($index = 0; $index < Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST; $index++) {
+            $this->assertTrue($client->send_operation([
+                'type' => 'delete',
+                'operation_index' => $index,
+                'path' => 'path-' . $index,
+            ]));
+        }
 
-        $this->assertSame(['failed', 'reserved_artifact_id'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/.reprint/evil.bin');
+        $this->assertTrue($client->should_finish_request());
+        $result = $client->finish_request();
+        $this->assertSame(Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST, $result['frames_sent']);
+        $this->assertLessThan(1024 * 1024, $result['body_bytes_sent']);
     }
 
-    public function testSendChunkWritesBytesToTheNetworkBeforeTheRequestIsFinalized(): void
+    /**
+     * @dataProvider invalidResponseProvider
+     */
+    public function testMalformedConfirmedStateIsTerminal(array $response, string $expected_detail): void
     {
-        // A raw TCP listener instead of the shared endpoint server, so the
-        // test can observe exactly when request bytes reach the network.
-        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
-        $this->assertNotFalse($listener, (string) $errstr);
-        $listener_address = stream_socket_get_name($listener, false);
+        $this->configureResponse($response);
+        $client = $this->makeClient();
+        $client->set_session_request_generation(0);
+        $this->assertTrue($client->start_push_request());
 
-        $client = new StagedPushStreamClient([
+        $result = $client->finish_request();
+
+        $this->assertSame(['failed', 'invalid_session_response'], [$result['status'], $result['reason']]);
+        $this->assertStringContainsString($expected_detail, (string) $result['detail']);
+    }
+
+    public static function invalidResponseProvider(): array
+    {
+        return [
+            'missing operation count' => [[
+                'status' => 'complete',
+                'current_file' => null,
+            ], 'omitted its server-confirmed operation_count'],
+            'string operation count' => [[
+                'status' => 'complete',
+                'operation_count' => '0',
+                'current_file' => null,
+            ], 'invalid operation_count "0"'],
+            'non-base64 current path' => [[
+                'status' => 'complete',
+                'operation_count' => 0,
+                'current_file' => [
+                    'operation_index' => 0,
+                    'path_b64' => '!!!',
+                    'revision' => 0,
+                    'committed_bytes' => 0,
+                    'total_bytes' => 1,
+                ],
+            ], 'current_file.path_b64'],
+            'cursor beyond file' => [[
+                'status' => 'complete',
+                'operation_count' => 0,
+                'current_file' => [
+                    'operation_index' => 0,
+                    'path_b64' => base64_encode('file'),
+                    'revision' => 0,
+                    'committed_bytes' => 2,
+                    'total_bytes' => 1,
+                ],
+            ], 'committed_bytes 2 beyond total_bytes 1'],
+            'different session' => [[
+                'status' => 'complete',
+                'session_id' => str_repeat('b', 32),
+                'operation_count' => 0,
+                'current_file' => null,
+            ], 'did not name the requested session'],
+            'complete on server error' => [[
+                'http_code' => 500,
+                'status' => 'complete',
+                'operation_count' => 0,
+                'current_file' => null,
+            ], 'reported complete with HTTP 500'],
+        ];
+    }
+
+    public function testGenerationMustBeSetForEveryRequest(): void
+    {
+        $client = $this->makeClient();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('requires set_session_request_generation');
+
+        $client->start_push_request();
+    }
+
+    public function testGenerationCannotChangeWhileARequestIsOpen(): void
+    {
+        $client = $this->makeClient();
+        $client->set_session_request_generation(0);
+        $this->assertTrue($client->start_push_request());
+
+        try {
+            $client->set_session_request_generation(1);
+            $this->fail('Expected changing an open request generation to throw.');
+        } catch (RuntimeException $error) {
+            $this->assertStringContainsString('while a push request is open', $error->getMessage());
+        } finally {
+            $client->abort_push_request();
+        }
+    }
+
+    public function testSendOperationPerformsNetworkIoBeforeReturning(): void
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
+        $this->assertNotFalse($listener, (string) $error_message);
+        $listener_address = stream_socket_get_name($listener, false);
+        $client = $this->makeClient([
             'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
-            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'chunk_bytes' => 4,
-            'allow_http' => true,
         ]);
 
         $pending_connections = [$listener];
         $write_sockets = null;
         $except_sockets = null;
-        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 0), 'constructing a client must not open a connection');
+        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 0));
 
+        $client->set_session_request_generation(9);
         $this->assertTrue($client->start_push_request());
         $connection = stream_socket_accept($listener, 5);
         $this->assertNotFalse($connection);
         $received = $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_push HTTP/1.1', $received, 'the request head is on the wire right after start_push_request()');
+        $this->assertStringContainsString('expected_request_generation=9 HTTP/1.1', $received);
 
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'streamed.bin',
-            'offset' => 0,
-            'total_bytes' => 8,
-            'final' => false,
-            'payload' => 'ssss',
-        ]));
-        $received .= $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('"artifact_id":"c3RyZWFtZWQuYmlu","offset":0,"bytes":4', $received);
-        $this->assertStringContainsString('ssss', $received, 'the first frame payload is on the wire before the request is finalized');
-        $this->assertStringNotContainsString("0\r\n\r\n", $received, 'the request body is still open');
-
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'streamed.bin',
-            'offset' => 4,
-            'total_bytes' => 8,
-            'final' => true,
-            'payload' => 'ssss',
-        ]));
-        $received .= $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('"artifact_id":"c3RyZWFtZWQuYmlu","offset":4,"bytes":4', $received);
-        $this->assertSame(2, substr_count($received, 'ssss'), 'the second frame payload followed without finalizing');
-
-        // Drop the connection without responding: the failure must surface as
-        // a retryable request-level result, not an exception.
-        fclose($connection);
-        fclose($listener);
-        $result = $client->finish_request();
-
-        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(2, $result['chunks_sent']);
-        $this->assertGreaterThan(8, $result['body_bytes_sent'], 'body accounting includes the frame headers');
-    }
-
-    public function testStalledConnectionFailsAfterStallTimeoutWhileSlowProgressDoesNot(): void
-    {
-        // A listener that accepts the connection and then never reads: the
-        // kernel and libcurl buffers absorb a few hundred KiB, after which
-        // zero bytes move. The stall watch must fail the request; a total
-        // timeout would instead have killed any slow-but-healthy transfer.
-        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
-        $this->assertNotFalse($listener, (string) $errstr);
-        $listener_address = stream_socket_get_name($listener, false);
-
-        $client = new StagedPushStreamClient([
-            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
-            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'chunk_bytes' => 8 * 1024 * 1024,
-            'stall_timeout' => 1,
-            'allow_http' => true,
-        ]);
-
-        $this->assertTrue($client->start_push_request());
-        $connection = stream_socket_accept($listener, 5);
-        $this->assertNotFalse($connection);
-        // Do not read from $connection: the pipe backs up and stalls.
-
-        $stalled_send_started_at = microtime(true);
-        $sent = $client->send_chunk([
-            'artifact_id' => 'stalled.bin',
-            'offset' => 0,
-            'total_bytes' => 8 * 1024 * 1024,
-            'final' => true,
-            'payload' => str_repeat('s', 8 * 1024 * 1024),
-        ]);
-
-        $this->assertFalse($sent, 'a stalled connection must fail the chunk');
-        $this->assertGreaterThan(1.0, microtime(true) - $stalled_send_started_at, 'the stall watch waited out its window first');
-
-        $result = $client->finish_request();
-        fclose($connection);
-        fclose($listener);
-
-        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertStringContainsString('no bytes moved for 1s', (string) $result['detail']);
-    }
-
-    public function testInvalidChunksThrowSpecificErrors(): void
-    {
-        $client = $this->makeClient();
-        $invalid_chunks = [
-            [
-                ['artifact_id' => 'a.bin', 'offset' => 8, 'total_bytes' => 10, 'final' => false, 'payload' => 'zzzz'],
-                'Chunk for "a.bin" spans bytes 8-12, which exceeds total_bytes 10.',
-            ],
-            [
-                ['artifact_id' => 'a.bin', 'offset' => 4, 'total_bytes' => 10, 'final' => false, 'payload' => ''],
-                'Refusing a zero-byte non-final chunk for "a.bin" — the source file is shorter than its declared total_bytes 10.',
-            ],
-            [
-                ['artifact_id' => 'a.bin', 'offset' => 4, 'total_bytes' => 10, 'final' => true, 'payload' => 'zz'],
-                'Chunk for "a.bin" is marked final at byte 6 but total_bytes is 10.',
-            ],
-        ];
-
-        foreach ($invalid_chunks as [$chunk, $expected_message]) {
-            try {
-                $client->send_chunk($chunk);
-                $this->fail('Expected an InvalidArgumentException for: ' . (string) json_encode($chunk));
-            } catch (InvalidArgumentException $exception) {
-                $this->assertSame($expected_message, $exception->getMessage());
-            }
-        }
-    }
-
-    public function testGivingUpOnRequestSizeReportsRequestSizeExhausted(): void
-    {
-        $this->writeSource('giveup.bin', str_repeat('g', 8));
-        // The target caps frames at 3 bytes; the sizer cannot shrink the
-        // 4-byte body budget below its own floor, so the push must give up —
-        // and the reason names the request-size dimension, not the chunk.
-        $this->configureEndpoint(['max_frame_bytes' => 3]);
-        $client = $this->makeClient([
-            'request_sizer' => new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 4]),
-        ]);
-        $local_paths_to_push = $this->writeLocalPathsToPush(['giveup.bin']);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame(['failed', 'request_size_exhausted'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-    }
-
-    public function testEmptyRequestsDoNotGrowTheBodyBudget(): void
-    {
-        $sizer = new PushRequestSizer([
-            'floor_bytes' => 4,
-            'start_bytes' => 8,
-            'max_bytes' => 32,
-            'growth_holdoff_successes' => 0,
-        ]);
-        $client = $this->makeClient(['request_sizer' => $sizer]);
-
-        // Requests that carried nothing teach the sizer nothing.
-        $this->assertTrue($client->start_push_request());
-        $this->assertSame('complete', $client->finish_request()['status']);
-        $this->assertTrue($client->start_push_request());
-        $this->assertSame('complete', $client->finish_request()['status']);
-        $this->assertSame(8, $sizer->request_body_bytes(), 'accepting an empty body is no evidence the size is safe to grow');
-
-        // A request that carried bytes grows the budget as before.
-        $this->writeSource('grow.bin', 'gggg');
-        $this->assertTrue($client->start_push_request());
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'grow.bin',
+        $this->assertTrue($client->send_operation([
+            'type' => 'file',
+            'operation_index' => 2,
+            'path' => 'streamed.bin',
+            'revision' => 3,
             'offset' => 0,
             'total_bytes' => 4,
-            'final' => true,
-            'payload' => 'gggg',
+            'restart' => true,
+            'payload' => 'data',
         ]));
-        $this->assertSame('complete', $client->finish_request()['status']);
-        $this->assertSame(16, $sizer->request_body_bytes());
+        $received .= $this->readAvailableBytes($connection);
+        $this->assertStringContainsString('"type":"file","operation_index":2', $received);
+        $this->assertStringContainsString('"revision":3,"offset":0,"bytes":4', $received);
+        $this->assertStringContainsString('data', $received, 'the payload reached the socket before finish_request');
+        $this->assertStringNotContainsString("0\r\n\r\n", $received, 'the request body remains open');
+
+        fclose($connection);
+        fclose($listener);
+        $result = $client->finish_request();
+        $this->assertSame(['retry', 'request_failed'], [$result['status'], $result['reason']]);
+        $this->assertSame(1, $result['frames_sent']);
+        $this->assertGreaterThan(4, $result['body_bytes_sent']);
     }
 
-    public function testInvalidOptionsThrowSpecificErrors(): void
+    public function testValidOperationRequiresAnOpenRequest(): void
     {
-        $invalid_options = [
-            [['chunk_bytes' => 0], 'Expected option "chunk_bytes" to be a positive integer; received 0.'],
-            [['stall_timeout' => 'soon'], 'Expected option "stall_timeout" to be a positive integer; received "soon".'],
-            [['max_request_seconds' => -1], 'Expected option "max_request_seconds" to be a positive number; received -1.'],
-        ];
+        $client = $this->makeClient();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No push request is open');
 
-        foreach ($invalid_options as [$options, $expected_message]) {
-            try {
-                $this->makeClient($options);
-                $this->fail('Expected an InvalidArgumentException for: ' . (string) json_encode($options));
-            } catch (InvalidArgumentException $exception) {
-                $this->assertSame($expected_message, $exception->getMessage());
-            }
-        }
+        $client->send_operation([
+            'type' => 'directory',
+            'operation_index' => 0,
+            'path' => 'uploads',
+        ]);
     }
 
-    public function testPlainHttpBaseUrlIsRefusedUnlessAllowed(): void
+    public function testInvalidOperationIsRejectedBeforeOpeningANetworkRequest(): void
     {
-        // Constructing does not open a connection, so these assert the
-        // scheme gate alone.
+        $client = $this->makeClient();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('zero payload bytes must be positioned at total_bytes');
+
+        $client->send_operation([
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => 'short.bin',
+            'revision' => 0,
+            'offset' => 0,
+            'total_bytes' => 1,
+            'restart' => false,
+            'payload' => '',
+        ]);
+    }
+
+    public function testPlainHttpRequiresAnExplicitOptOut(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Refusing to push over plain HTTP');
+
+        $this->makeClient(['allow_http' => false]);
+    }
+
+    public function testPresentOverlargeChunkIsNotSilentlyAccepted(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('between 1 and 4194304 bytes');
+
+        $this->makeClient(['chunk_bytes' => 4194305]);
+    }
+
+    public function testFilePayloadCannotExceedTheOpenRequestsBoundedChunkAllowance(): void
+    {
+        $client = $this->makeClient(['chunk_bytes' => 4]);
+        $client->set_session_request_generation(0);
+        $this->assertTrue($client->start_push_request());
         try {
-            new StagedPushStreamClient([
-                'base_url' => 'http://example.com/?reprint-api=1',
-                'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            ]);
-            $this->fail('Expected an http:// base_url to be refused without allow_http.');
-        } catch (InvalidArgumentException $exception) {
-            $this->assertStringContainsString('Refusing to push over plain HTTP', $exception->getMessage());
-            $this->assertStringContainsString('--force-http', $exception->getMessage());
-        }
-
-        // allow_http opts in; construction succeeds.
-        $this->assertInstanceOf(StagedPushStreamClient::class, new StagedPushStreamClient([
-            'base_url' => 'http://example.com/?reprint-api=1',
-            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'allow_http' => true,
-        ]));
-
-        // https needs no opt-in.
-        $this->assertInstanceOf(StagedPushStreamClient::class, new StagedPushStreamClient([
-            'base_url' => 'https://example.com/?reprint-api=1',
-            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-        ]));
-    }
-
-    public function testNonHttpSchemesAndBadAllowHttpAreRejected(): void
-    {
-        $rejections = [
-            [
-                ['base_url' => 'ftp://example.com/', 'hmac_client' => new Site_Export_HMAC_Client(self::SECRET)],
-                'Expected option "base_url" to be an http:// or https:// URL; received "ftp:\/\/example.com\/".',
-            ],
-            [
-                ['base_url' => 'https://example.com/', 'hmac_client' => new Site_Export_HMAC_Client(self::SECRET), 'allow_http' => 'yes'],
-                'Expected option "allow_http" to be a boolean; received "yes".',
-            ],
-        ];
-
-        foreach ($rejections as [$options, $expected_message]) {
-            try {
-                new StagedPushStreamClient($options);
-                $this->fail('Expected an InvalidArgumentException for: ' . (string) $options['base_url']);
-            } catch (InvalidArgumentException $exception) {
-                $this->assertSame($expected_message, $exception->getMessage());
-            }
-        }
-    }
-
-    public function testEveryRequestMethodThrowsWithoutAnOpenRequest(): void
-    {
-        $client = $this->makeClient();
-        $method_calls = [
-            'next_chunk_body_bytes' => static fn (StagedPushStreamClient $client) => $client->next_chunk_body_bytes(),
-            'should_finish_request' => static fn (StagedPushStreamClient $client) => $client->should_finish_request(),
-            'finish_request' => static fn (StagedPushStreamClient $client) => $client->finish_request(),
-            'send_chunk' => static fn (StagedPushStreamClient $client) => $client->send_chunk([
-                'artifact_id' => 'a.bin',
+            $client->send_operation([
+                'type' => 'file',
+                'operation_index' => 0,
+                'path' => 'file',
+                'revision' => 0,
                 'offset' => 0,
-                'total_bytes' => 4,
-                'final' => true,
-                'payload' => 'aaaa',
-            ]),
-        ];
-
-        foreach ($method_calls as $method_name => $method_call) {
-            try {
-                $method_call($client);
-                $this->fail('Expected a RuntimeException from ' . $method_name . '() without an open request');
-            } catch (\RuntimeException $exception) {
-                $this->assertSame(
-                    'No push request is open; call start_push_request() before ' . $method_name . '().',
-                    $exception->getMessage()
-                );
-            }
+                'total_bytes' => 5,
+                'restart' => false,
+                'payload' => 'abcde',
+            ]);
+            $this->fail('Expected oversized direct payload rejection.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('exceeding the next bounded chunk allowance of 4', $exception->getMessage());
+        } finally {
+            $client->abort_push_request();
         }
     }
 
-    public function testResumeCursorForADeletedFileReplaysFromTheTop(): void
+    public function testOversizedRemoteResponseIsBoundedAndTerminal(): void
     {
-        $this->writeSource('kept-one.bin', str_repeat('k', 6));
-        $this->writeSource('kept-two.bin', str_repeat('K', 6));
+        $this->configureResponse(['oversized_response_bytes' => 65537]);
         $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['kept-one.bin', 'kept-two.bin']);
-
-        // The cursor points at a file that was deleted locally after the
-        // last push, so a rebuilt journal no longer lists it. The push must
-        // replay from the top, not skim past everything and report success.
-        $result = $this->pushAll($client, $local_paths_to_push, ['artifact_id' => 'deleted-since.bin', 'committed_bytes' => 4]);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(2, $result['files_verified']);
-        $this->assertSame(str_repeat('k', 6), file_get_contents($this->staging_dir . '/files/kept-one.bin'));
-        $this->assertSame(str_repeat('K', 6), file_get_contents($this->staging_dir . '/files/kept-two.bin'));
-    }
-
-    public function testEmptyJournalPushesNothingWithoutANetworkRequest(): void
-    {
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush([]);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(0, $result['chunks_sent']);
-        $this->assertSame([], $this->endpointsSeen(), 'an empty journal must not cost a network exchange');
-    }
-
-    public function testRedirectResponseNamesTheTargetInsteadOfRetrying(): void
-    {
-        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
-        $this->assertNotFalse($listener, (string) $errstr);
-        $listener_address = stream_socket_get_name($listener, false);
-
-        $client = new StagedPushStreamClient([
-            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
-            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'chunk_bytes' => 4,
-            'allow_http' => true,
-        ]);
-
+        $client->set_session_request_generation(0);
         $this->assertTrue($client->start_push_request());
-        $connection = stream_socket_accept($listener, 5);
-        $this->assertNotFalse($connection);
-        // The usual misconfiguration: an http:// base_url on a site that
-        // forces https. Answer like such a site would.
-        fwrite(
-            $connection,
-            "HTTP/1.1 301 Moved Permanently\r\n"
-            . "Location: https://example.com/?reprint-api=1&endpoint=staged_push\r\n"
-            . "Content-Length: 0\r\nConnection: close\r\n\r\n"
-        );
-        fclose($connection);
-        fclose($listener);
 
         $result = $client->finish_request();
 
-        $this->assertSame(['failed', 'redirected'], [$result['status'], $result['reason']], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertStringContainsString('https://example.com/?reprint-api=1&endpoint=staged_push', (string) $result['detail']);
-        $this->assertStringContainsString('Use that address as the push base_url', (string) $result['detail']);
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('response_too_large', $result['reason']);
+        $this->assertStringContainsString('exceeded 65536 bytes', $result['detail']);
     }
 
-    public function testResumeAfterTheSourceGrewRestartsTheFile(): void
+    public function testEmptyRequestDoesNotTeachTheRequestSizerToGrow(): void
     {
-        $old_content = str_repeat('o', 12);
-        $source_path = $this->writeSource('drift-grow.bin', $old_content);
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['drift-grow.bin']);
-        $resume_cursor = $this->pushFirstBytes($client, 'drift-grow.bin', $old_content, 4, $source_path);
-
-        // The file changes before the next session: longer and different —
-        // the size alone betrays it.
-        $new_content = str_repeat('n', 16);
-        file_put_contents($source_path, $new_content);
-        clearstatcache();
-
-        $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-grow.bin'), 'no byte of the old version may survive under the new one');
-    }
-
-    public function testResumeAfterASameSizeEditRestartsTheFile(): void
-    {
-        $old_content = str_repeat('o', 12);
-        $source_path = $this->writeSource('drift-edit.bin', $old_content);
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['drift-edit.bin']);
-        $resume_cursor = $this->pushFirstBytes($client, 'drift-edit.bin', $old_content, 4, $source_path);
-
-        // Same byte count, different bytes — only the ctime betrays the
-        // edit, so the rewrite must land in a later timestamp second (ctime
-        // cannot be set the way touch() sets mtime).
-        usleep(1100000);
-        $new_content = str_repeat('n', 12);
-        file_put_contents($source_path, $new_content);
-        clearstatcache();
-
-        $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-edit.bin'), 'no byte of the old version may survive under the new one');
-    }
-
-    public function testResumeCursorBeyondAShrunkenFileRestartsTheFile(): void
-    {
-        $old_content = str_repeat('o', 12);
-        $source_path = $this->writeSource('drift-shrink.bin', $old_content);
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['drift-shrink.bin']);
-        $resume_cursor = $this->pushFirstBytes($client, 'drift-shrink.bin', $old_content, 8, $source_path);
-
-        // The file shrank below the committed offset. Skipping it as "done"
-        // would leave the target holding 8 stale bytes and this push lying.
-        $new_content = str_repeat('n', 6);
-        file_put_contents($source_path, $new_content);
-        clearstatcache();
-
-        $result = $this->pushAll($client, $local_paths_to_push, $resume_cursor);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(1, $result['files_verified']);
-        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/drift-shrink.bin'));
-    }
-
-    public function testFullReplayAfterAPartialCommitRewritesChangedBytes(): void
-    {
-        // 4 bytes of an earlier version are staged; the retry has no cursor
-        // (a transport failure lost it) and replays from the top with the
-        // file's current content. The staged prefix must not survive.
-        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('replayed.bin', 0, 'OOOO');
-        $new_content = 'NNNN' . str_repeat('n', 8);
-        $this->writeSource('replayed.bin', $new_content);
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['replayed.bin']);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame($new_content, file_get_contents($this->staging_dir . '/files/replayed.bin'));
-    }
-
-    /**
-     * Session one: push the first $bytes_to_push bytes of $content, then
-     * stop, returning the resume cursor the reference loop would persist —
-     * the server cursor plus the source token (size and ctime) it saves
-     * alongside.
-     *
-     * @return array{artifact_id:string,committed_bytes:int,total_bytes:int,source_ctime:int}
-     */
-    private function pushFirstBytes(StagedPushStreamClient $client, string $artifact_id, string $content, int $bytes_to_push, string $source_path): array
-    {
-        $this->assertTrue($client->start_push_request());
-        for ($offset = 0; $offset < $bytes_to_push; $offset += 4) {
-            $this->assertTrue($client->send_chunk([
-                'artifact_id' => $artifact_id,
-                'offset' => $offset,
-                'total_bytes' => strlen($content),
-                'final' => false,
-                'payload' => substr($content, $offset, 4),
-            ]));
-        }
-        $first_result = $client->finish_request();
-        $this->assertSame('complete', $first_result['status'], (string) json_encode($first_result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame($bytes_to_push, $first_result['cursor']['committed_bytes']);
-
-        clearstatcache();
-        return $first_result['cursor'] + [
-            'total_bytes' => strlen($content),
-            'source_ctime' => (int) stat($source_path)['ctime'],
-        ];
-    }
-
-    public function testAStoreLockCollisionIsRetryableNotFatal(): void
-    {
-        $this->writeSource('locked.bin', str_repeat('l', 4));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['locked.bin']);
-
-        // Create the store scaffolding, then hold its lock the way a
-        // concurrent writer would. The store's answer is its documented
-        // retry-until-free contract, not a push-ending failure.
-        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('scaffold.bin', 0, 'x');
-        $lock_holder = fopen($this->staging_dir . '/lock', 'r+b');
-        $this->assertNotFalse($lock_holder);
-        $this->assertTrue(flock($lock_holder, LOCK_EX));
-
-        $held_result = $this->pushOnce($client, $local_paths_to_push, null);
-        $this->assertSame(['retry', 'busy'], [$held_result['status'], $held_result['reason']], (string) json_encode($held_result, JSON_INVALID_UTF8_SUBSTITUTE));
-
-        flock($lock_holder, LOCK_UN);
-        fclose($lock_holder);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(str_repeat('l', 4), file_get_contents($this->staging_dir . '/files/locked.bin'));
-    }
-
-    public function testAStaleCursorBeyondTheStoreFrontierRetriesFromTheStoreCursor(): void
-    {
-        $content = str_repeat('g', 8);
-        $source_path = $this->writeSource('gapped.bin', $content);
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['gapped.bin']);
-        clearstatcache();
-        $source_stat = stat($source_path);
-        $this->assertNotFalse($source_stat);
-
-        // The cursor claims 4 committed bytes and its source token matches
-        // the file, but the staging directory was wiped: the store holds
-        // nothing. The server answers offset_gap with its own cursor — the
-        // push must resume from that cursor, not die.
-        $stale_cursor = [
-            'artifact_id' => 'gapped.bin',
-            'committed_bytes' => 4,
-            'total_bytes' => 8,
-            'source_ctime' => (int) $source_stat['ctime'],
-        ];
-
-        $result = $this->pushAll($client, $local_paths_to_push, $stale_cursor);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame($content, file_get_contents($this->staging_dir . '/files/gapped.bin'));
-        $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen(), 'one gap rejection, one clean resume from the store cursor');
-    }
-
-    public function testExhaustedRetriesReportATerminalFailure(): void
-    {
-        $this->writeSource('never.bin', str_repeat('n', 4));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush(['never.bin']);
-
-        // Hold the store lock for the whole push so every attempt gets a
-        // busy -> retry. After the retry budget is spent, the caller must
-        // hear a terminal 'failed', not a 'retry' it can no longer act on.
-        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('scaffold.bin', 0, 'x');
-        $lock_holder = fopen($this->staging_dir . '/lock', 'r+b');
-        $this->assertNotFalse($lock_holder);
-        $this->assertTrue(flock($lock_holder, LOCK_EX));
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        flock($lock_holder, LOCK_UN);
-        fclose($lock_holder);
-
-        $this->assertSame('failed', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame('busy', $result['reason'], 'the terminal failure keeps the reason that kept failing');
-    }
-
-    public function testFilesVerifiedSumsAcrossRequestRotations(): void
-    {
-        // Same-length names so each file's frame is the same size, 4 bytes
-        // each. A request-body budget of 4 is spent by one frame, so each
-        // file finalizes in its own request — three rotations, three
-        // verified files. finish_request() only ever reports the last
-        // request's count, so the loop must sum them.
-        foreach (['a1.bin', 'a2.bin', 'a3.bin'] as $name) {
-            $this->writeSource($name, str_repeat('z', 4));
-        }
-        $client = $this->makeClient([
-            'chunk_bytes' => 4,
-            'request_sizer' => new PushRequestSizer(['floor_bytes' => 4, 'start_bytes' => 4, 'max_bytes' => 4]),
+        $request_sizer = new PushRequestSizer([
+            'floor_bytes' => 64,
+            'start_bytes' => 128,
+            'max_bytes' => 1024,
         ]);
-        $local_paths_to_push = $this->writeLocalPathsToPush(['a1.bin', 'a2.bin', 'a3.bin']);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(3, $result['files_verified'], 'every rotation\'s verified count is summed, not just the last request\'s');
-        $this->assertSame(['staged_push', 'staged_push', 'staged_push'], $this->endpointsSeen());
-    }
-
-    public function testBackToBackRequestsReuseTheConnection(): void
-    {
-        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
-        $this->assertNotFalse($listener, (string) $errstr);
-        $listener_address = stream_socket_get_name($listener, false);
-
-        $client = new StagedPushStreamClient([
-            'base_url' => 'http://' . $listener_address . '/?reprint-api=1',
-            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'chunk_bytes' => 4,
-            'allow_http' => true,
-        ]);
-        $keep_alive_response = static function (): string {
-            $response_body = json_encode(['status' => 'complete', 'cursor' => null, 'files_verified' => 1]);
-            return "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response_body) . "\r\n\r\n" . $response_body;
-        };
-
+        $client = $this->makeClient(['request_sizer' => $request_sizer]);
+        $client->set_session_request_generation(0);
         $this->assertTrue($client->start_push_request());
-        $connection = stream_socket_accept($listener, 5);
-        $this->assertNotFalse($connection);
-        $this->readAvailableBytes($connection);
-        $this->assertTrue($client->send_chunk([
-            'artifact_id' => 'reuse.bin',
-            'offset' => 0,
-            'total_bytes' => 4,
-            'final' => true,
-            'payload' => 'rrrr',
-        ]));
-        $this->readAvailableBytes($connection);
-        fwrite($connection, $keep_alive_response());
-        $this->assertSame('complete', $client->finish_request()['status']);
 
-        // The second request must ride the connection libcurl cached on the
-        // client's long-lived multi handle, not open a new one.
-        $this->assertTrue($client->start_push_request());
-        $pending_connections = [$listener];
-        $write_sockets = null;
-        $except_sockets = null;
-        $this->assertSame(0, stream_select($pending_connections, $write_sockets, $except_sockets, 0, 200000), 'the second request must not open a new connection');
-        $second_request_head = $this->readAvailableBytes($connection);
-        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_push HTTP/1.1', $second_request_head, 'the second request head travels on the reused connection');
+        $result = $client->finish_request();
 
-        fwrite($connection, $keep_alive_response());
-        $this->assertSame('complete', $client->finish_request()['status']);
-        fclose($connection);
-        fclose($listener);
-    }
-
-    public function testEmojiFileNameRoundTrips(): void
-    {
-        $emoji_artifact_id = "wp-content/uploads/\u{1F4F7} photo.bin";
-        $this->writeSource($emoji_artifact_id, str_repeat('e', 10));
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush([$emoji_artifact_id]);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(1, $result['files_verified']);
-        $this->assertSame(str_repeat('e', 10), file_get_contents($this->staging_dir . '/files/' . $emoji_artifact_id));
-    }
-
-    public function testNonUtf8FileNameRoundTrips(): void
-    {
-        // Latin-1 "café" plus a stray 0xFF: bytes json_encode cannot carry
-        // raw, which is why artifact ids travel base64 on the wire.
-        $non_utf8_artifact_id = "caf\xE9-\xFF.bin";
-        if (@file_put_contents($this->source_dir . '/' . $non_utf8_artifact_id, str_repeat('n', 6)) === false) {
-            $this->markTestSkipped('This filesystem rejects non-UTF-8 file names (APFS does; ext4 allows them).');
-        }
-        $client = $this->makeClient();
-        $local_paths_to_push = $this->writeLocalPathsToPush([$non_utf8_artifact_id]);
-
-        $result = $this->pushAll($client, $local_paths_to_push);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE));
-        $this->assertSame(1, $result['files_verified']);
-        $this->assertSame(str_repeat('n', 6), file_get_contents($this->staging_dir . '/files/' . $non_utf8_artifact_id));
+        $this->assertSame('complete', $result['status']);
+        $this->assertSame(0, $result['frames_sent']);
+        $this->assertSame(128, $request_sizer->request_body_bytes());
     }
 
     private static function writeRouter(): void
     {
-        $import_path = addslashes(realpath(__DIR__ . '/../../packages/reprint-importer/src/import.php'));
         $config_path = addslashes(self::$config_path);
         $request_log_path = addslashes(self::$request_log_path);
-
-        file_put_contents(self::$router_path, <<<PHP_ROUTER
+        $router = <<<'PHP_ROUTER'
 <?php
-// PHP 8.1 emits the required CLI script's shebang; keep test HTTP responses clean.
-ob_start();
-require_once '{$import_path}';
-ob_end_clean();
-
-if (parse_url(\$_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__ping') {
+if (parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__ping') {
     echo 'ok';
     return true;
 }
 
-\$config = json_decode((string) file_get_contents('{$config_path}'), true);
-if (!is_array(\$config)) {
+$config = json_decode((string) @file_get_contents('__CONFIG_PATH__'), true);
+if (!is_array($config)) {
     http_response_code(500);
-    header('Content-Type: application/json');
-    echo json_encode(['error' => 'missing endpoint config']);
+    echo 'missing config';
     return true;
 }
 
+$body = (string) file_get_contents('php://input');
 file_put_contents(
-    '{$request_log_path}',
+    '__REQUEST_LOG_PATH__',
     json_encode([
-        'endpoint' => (string) ( \$_GET['endpoint'] ?? '' ),
-        'method' => \$_SERVER['REQUEST_METHOD'] ?? '',
-        'content_length' => \$_SERVER['CONTENT_LENGTH'] ?? null,
+        'endpoint' => (string) ( $_GET['endpoint'] ?? '' ),
+        'session_id' => isset($_GET['session_id']) ? (string) $_GET['session_id'] : null,
+        'expected_request_generation' => isset($_GET['expected_request_generation'])
+            ? (string) $_GET['expected_request_generation']
+            : null,
+        'content_type' => (string) ( $_SERVER['CONTENT_TYPE'] ?? '' ),
+        'body_b64' => base64_encode($body),
     ]) . "\n",
-    FILE_APPEND
+    FILE_APPEND | LOCK_EX
 );
 
-\$server = new Site_Export_HTTP_Server([
-    'staged' => [
-        'staging_dir' => (string) \$config['staging_dir'],
-        'secret' => (string) \$config['secret'],
-        'max_frame_bytes' => (int) ( \$config['max_frame_bytes'] ?? 1073741824 ),
-    ],
-]);
-\$server->handle_request();
+if (($config['raw_413'] ?? false) === true) {
+    http_response_code(413);
+    header('Content-Type: text/html');
+    echo '<html>too large</html>';
+    return true;
+}
+
+if (isset($config['oversized_response_bytes'])) {
+    http_response_code(200);
+    header('Content-Type: text/plain');
+    echo str_repeat('x', (int) $config['oversized_response_bytes']);
+    return true;
+}
+
+$response = $config;
+unset($response['http_code'], $response['raw_413']);
+$response['session_id'] = array_key_exists('session_id', $response)
+    ? $response['session_id']
+    : (string) ( $_GET['session_id'] ?? '' );
+$response['request_generation'] = array_key_exists('request_generation', $response)
+    ? $response['request_generation']
+    : (int) ( $_GET['expected_request_generation'] ?? 0 ) + 1;
+http_response_code((int) ( $config['http_code'] ?? 200 ));
+header('Content-Type: application/json');
+echo json_encode($response);
 return true;
-PHP_ROUTER);
+PHP_ROUTER
+        ;
+        file_put_contents(self::$router_path, str_replace(
+            ['__CONFIG_PATH__', '__REQUEST_LOG_PATH__'],
+            [$config_path, $request_log_path],
+            $router
+        ));
     }
 
-    private function configureEndpoint(array $overrides = []): void
+    private function configureResponse(array $response): void
     {
-        file_put_contents(self::$config_path, json_encode(array_merge([
-            'staging_dir' => $this->staging_dir,
-            'secret' => self::SECRET,
-            'max_frame_bytes' => 1073741824,
-        ], $overrides)));
+        file_put_contents(self::$config_path, json_encode($response));
     }
 
     private function makeClient(array $overrides = []): StagedPushStreamClient
@@ -1029,232 +659,48 @@ PHP_ROUTER);
         return new StagedPushStreamClient(array_merge([
             'base_url' => self::$base_url,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
-            'chunk_bytes' => 4,
-            // The local test endpoint runs over plain HTTP — exactly the
-            // case allow_http exists for.
+            'session_id' => self::SESSION_ID,
+            'chunk_bytes' => 8,
             'allow_http' => true,
         ], $overrides));
     }
 
+    /** @return array<int,array<string,mixed>> */
+    private function decodeFrames(string $body): array
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, $body);
+        rewind($stream);
+        $frames = [];
+        while (($line = Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream)) !== null) {
+            $frame = Site_Export_Staged_Push_Stream_Protocol::decode_operation_header($line);
+            $payload = Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, (int) ($frame['bytes'] ?? 0));
+            $this->assertNotNull($payload);
+            $frame['payload'] = $payload;
+            $frames[] = $frame;
+        }
+        fclose($stream);
+        return $frames;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    private function requestLogEntries(): array
+    {
+        $entries = [];
+        foreach (file(self::$request_log_path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $entry = json_decode($line, true);
+            if (is_array($entry)) {
+                $entries[] = $entry;
+            }
+        }
+        return $entries;
+    }
+
     /**
-     * Push everything, retrying failed requests from the server-confirmed
-     * cursor the way the push command will.
+     * Read bytes that have already arrived, with a short settle for data still
+     * moving from libcurl's upload buffer into the kernel socket buffer.
      *
-     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
-     */
-    private function pushAll(StagedPushStreamClient $client, string $local_paths_to_push, ?array $cursor = null): array
-    {
-        $result = null;
-        for ($attempt = 0; $attempt < 5; $attempt++) {
-            if ($attempt > 0) {
-                // Back off before retrying — the command must too; a
-                // struggling host should not be re-hit at full speed.
-                usleep(min(5000000, 250000 * (2 ** ($attempt - 1))));
-            }
-            $result = $this->pushOnce($client, $local_paths_to_push, $cursor);
-            if ($result['status'] !== 'retry') {
-                return $result;
-            }
-            $cursor = $result['cursor'];
-        }
-        // Retries exhausted — the loop only lands here when the last attempt
-        // was still 'retry'. "Retry" is an instruction the caller can no
-        // longer follow, so report a terminal 'failed' while keeping the
-        // reason and cursor for diagnosis.
-        $result['status'] = 'failed';
-        return $result;
-    }
-
-    /**
-     * One pass over the journal from $cursor: the caller loop the client is
-     * designed for. Streams journal lines, reads each file in pieces sized by
-     * next_chunk_body_bytes(), rotates requests when the client says to, and
-     * persists a source token (size and ctime) with every cursor so a resume
-     * restarts any file that changed since its bytes were staged. files_verified
-     * is per-request, so this pass sums it across rotations.
-     *
-     * @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int}
-     */
-    private function pushOnce(StagedPushStreamClient $client, string $local_paths_to_push, ?array $cursor): array
-    {
-        $journal_handle = fopen($local_paths_to_push, 'r');
-        $this->assertNotFalse($journal_handle);
-
-        // A journal rebuilt since the cursor was saved may no longer contain
-        // the cursor's file (deleted locally). Skimming for a line that never
-        // comes would push nothing and report success, so check first —
-        // replaying from the top is safe, the target absorbs committed frames.
-        $skipping_to_cursor = is_array($cursor) && isset($cursor['artifact_id']);
-        if ($skipping_to_cursor) {
-            $cursor_artifact_in_journal = false;
-            while (($journal_line = fgets($journal_handle)) !== false) {
-                $journal_line = trim($journal_line);
-                if ($journal_line === '') {
-                    continue;
-                }
-                $decoded_line = json_decode($journal_line, true, 512, JSON_THROW_ON_ERROR);
-                if (base64_decode((string) ($decoded_line['path'] ?? ''), true) === $cursor['artifact_id']) {
-                    $cursor_artifact_in_journal = true;
-                    break;
-                }
-            }
-            rewind($journal_handle);
-            $skipping_to_cursor = $cursor_artifact_in_journal;
-        }
-
-        $request_open = false;
-        // finish_request() reports only the request it ends; a push that
-        // rotates requests between files must sum the verified counts itself.
-        $files_verified_total = 0;
-        while (($journal_line = fgets($journal_handle)) !== false) {
-            $journal_line = trim($journal_line);
-            if ($journal_line === '') {
-                continue;
-            }
-            $decoded_line = json_decode($journal_line, true, 512, JSON_THROW_ON_ERROR);
-            $artifact_id = (string) base64_decode((string) $decoded_line['path'], true);
-
-            if ($skipping_to_cursor && $artifact_id !== $cursor['artifact_id']) {
-                continue;
-            }
-            $resuming_this_file = $skipping_to_cursor;
-            $offset = $resuming_this_file ? (int) $cursor['committed_bytes'] : 0;
-            $skipping_to_cursor = false;
-
-            $source_handle = fopen($this->source_dir . '/' . $artifact_id, 'rb');
-            $this->assertNotFalse($source_handle);
-            $source_stat = fstat($source_handle);
-            $total_bytes = (int) $source_stat['size'];
-            $source_ctime = (int) $source_stat['ctime'];
-
-            // The cursor's source token remembers the file the staged bytes
-            // came from. Any change — size or ctime, the same signals the
-            // journal's diff keys on — means those bytes are another version:
-            // restart the file at zero so the target re-stages it instead of
-            // appending one version behind another. A same-size edit within
-            // the same timestamp second escapes this token; the diff layer's
-            // own change detection is the deeper net.
-            if (
-                $resuming_this_file
-                && (
-                    (isset($cursor['total_bytes']) && (int) $cursor['total_bytes'] !== $total_bytes)
-                    || (isset($cursor['source_ctime']) && (int) $cursor['source_ctime'] !== $source_ctime)
-                )
-            ) {
-                $offset = 0;
-            }
-
-            if ($total_bytes > 0 && $offset >= $total_bytes) {
-                fclose($source_handle);
-                continue;
-            }
-            if ($offset > 0) {
-                fseek($source_handle, $offset);
-            }
-
-            while (true) {
-                // Open the request only once there is a chunk to push, so an
-                // empty journal never costs a network exchange.
-                if (!$request_open) {
-                    if (false === $client->start_push_request()) {
-                        fclose($source_handle);
-                        fclose($journal_handle);
-                        return $this->startFailureResult($client, $cursor);
-                    }
-                    $request_open = true;
-                } elseif ($client->should_finish_request()) {
-                    $result = $client->finish_request();
-                    if ($result['status'] !== 'complete') {
-                        fclose($source_handle);
-                        fclose($journal_handle);
-                        $result['files_verified'] += $files_verified_total;
-                        return $this->withSourceToken($result, $artifact_id, $total_bytes, $source_ctime);
-                    }
-                    $files_verified_total += $result['files_verified'];
-                    if (false === $client->start_push_request()) {
-                        fclose($source_handle);
-                        fclose($journal_handle);
-                        return $this->startFailureResult($client, $result['cursor']);
-                    }
-                }
-
-                $payload = $total_bytes === 0
-                    ? ''
-                    : (string) fread($source_handle, $client->next_chunk_body_bytes());
-                $final = $offset + strlen($payload) >= $total_bytes;
-
-                if (!$client->send_chunk([
-                    'artifact_id' => $artifact_id,
-                    'offset' => $offset,
-                    'total_bytes' => $total_bytes,
-                    'final' => $final,
-                    'payload' => $payload,
-                ])) {
-                    fclose($source_handle);
-                    fclose($journal_handle);
-                    $send_failure_result = $client->finish_request();
-                    $send_failure_result['files_verified'] += $files_verified_total;
-                    return $this->withSourceToken($send_failure_result, $artifact_id, $total_bytes, $source_ctime);
-                }
-
-                $offset += strlen($payload);
-                if ($final) {
-                    break;
-                }
-            }
-            fclose($source_handle);
-        }
-        fclose($journal_handle);
-
-        if (!$request_open) {
-            // Nothing needed pushing; report completion without having
-            // touched the network.
-            return [
-                'status' => 'complete',
-                'reason' => null,
-                'detail' => null,
-                'cursor' => $cursor,
-                'files_verified' => 0,
-                'chunks_sent' => 0,
-                'body_bytes_sent' => 0,
-            ];
-        }
-        $final_result = $client->finish_request();
-        $final_result['files_verified'] += $files_verified_total;
-        return $this->withSourceToken($final_result, $artifact_id, $total_bytes, $source_ctime);
-    }
-
-    /**
-     * Attach the source token the reference loop persists alongside a server
-     * cursor: the size and ctime of the file whose bytes the cursor counts.
-     * A later resume compares them against the file on disk and restarts the
-     * file when they differ.
-     */
-    private function withSourceToken(array $result, string $artifact_id, int $total_bytes, int $source_ctime): array
-    {
-        if (is_array($result['cursor'] ?? null) && ($result['cursor']['artifact_id'] ?? null) === $artifact_id) {
-            $result['cursor'] += ['total_bytes' => $total_bytes, 'source_ctime' => $source_ctime];
-        }
-        return $result;
-    }
-
-    /** @return array{status:string,reason:?string,detail:?string,cursor:?array,files_verified:int,chunks_sent:int,body_bytes_sent:int} */
-    private function startFailureResult(StagedPushStreamClient $client, ?array $cursor): array
-    {
-        return [
-            'status' => 'retry',
-            'reason' => 'request_failed',
-            'detail' => $client->get_last_error(),
-            'cursor' => $cursor,
-            'files_verified' => 0,
-            'chunks_sent' => 0,
-            'body_bytes_sent' => 0,
-        ];
-    }
-
-    /**
-     * Read whatever bytes have already arrived on the connection, allowing a
-     * brief settle so kernel-buffered writes from the client become visible.
+     * @param resource $connection
      */
     private function readAvailableBytes($connection): string
     {
@@ -1277,52 +723,13 @@ PHP_ROUTER);
         return $received;
     }
 
-    private function writeSource(string $name, string $body): string
-    {
-        $path = $this->source_dir . '/' . $name;
-        $directory = dirname($path);
-        if (!is_dir($directory)) {
-            mkdir($directory, 0700, true);
-        }
-        file_put_contents($path, $body);
-        return $path;
-    }
-
-    /** @param string[] $artifact_ids */
-    private function writeLocalPathsToPush(array $artifact_ids): string
-    {
-        $path = $this->source_dir . '/local-paths-to-push.jsonl';
-        $body = '';
-        foreach ($artifact_ids as $artifact_id) {
-            $body .= json_encode(['path' => base64_encode($artifact_id)], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-        }
-        file_put_contents($path, $body);
-        return $path;
-    }
-
-    /** @return string[] */
-    private function endpointsSeen(): array
-    {
-        if (!file_exists(self::$request_log_path)) {
-            return [];
-        }
-        $endpoints = [];
-        foreach (file(self::$request_log_path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
-            $decoded = json_decode($line, true);
-            if (is_array($decoded)) {
-                $endpoints[] = (string) ($decoded['endpoint'] ?? '');
-            }
-        }
-        return $endpoints;
-    }
-
     private static function removeDirectory(string $directory): void
     {
         if (!is_dir($directory)) {
             return;
         }
-        foreach (glob($directory . '/*') ?: [] as $directory_entry) {
-            is_dir($directory_entry) ? self::removeDirectory($directory_entry) : @unlink($directory_entry);
+        foreach (glob($directory . '/*') ?: [] as $entry) {
+            is_dir($entry) ? self::removeDirectory($entry) : @unlink($entry);
         }
         @rmdir($directory);
     }

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -5,609 +5,445 @@ use PHPUnit\Framework\TestCase;
 final class StagedEndpointsTest extends TestCase {
 
     private const SECRET = 'staged-endpoints-test-secret';
-    private const PUSH_TARGET = '/?endpoint=staged_push';
 
     private string $staging_dir;
 
-    protected function setUp(): void
-    {
+    private string $target_dir;
+
+    protected function setUp(): void {
         $this->staging_dir = sys_get_temp_dir() . '/staged-endpoints-test-' . bin2hex(random_bytes(8));
+        $this->target_dir = sys_get_temp_dir() . '/staged-endpoints-target-' . bin2hex(random_bytes(8));
+        mkdir($this->target_dir, 0700, true);
     }
 
-    protected function tearDown(): void
-    {
-        $this->removeDir($this->staging_dir);
+    protected function tearDown(): void {
+        $this->remove_tree($this->staging_dir);
+        $this->remove_tree($this->target_dir);
     }
 
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
+    public function test_create_is_idempotent_after_a_lost_response(): void {
+        $endpoints = $this->make_endpoints();
+        $create_token = str_repeat('a', 32);
+
+        $first = $endpoints->session_create(
+            ['create_token' => $create_token],
+            $this->session_headers('staged_session_create', null, null, 'POST', ['create_token' => $create_token])
+        );
+        $second = $endpoints->session_create(
+            ['create_token' => $create_token],
+            $this->session_headers('staged_session_create', null, null, 'POST', ['create_token' => $create_token])
+        );
+
+        $this->assertSame(201, $first['http_code']);
+        $this->assertSame('created', $first['body']['status']);
+        $this->assertSame($first['body']['session_id'], $second['body']['session_id']);
+        $this->assertSame('uploading', $first['body']['phase']);
+        $this->assertSame(0, $first['body']['operation_count']);
+        $this->assertNull($first['body']['current_file']);
+        $this->assertArrayNotHasKey('prepare_chunk_bytes', $first['body']);
+    }
+
+    public function test_typed_operations_stage_and_apply_without_a_manifest_step(): void {
+        file_put_contents($this->target_dir . '/old.txt', 'remove me');
+        $endpoints = $this->make_endpoints();
+        $session = $this->new_session();
+
+        $response = $this->push($endpoints, $session, 0, [
+            ['type' => 'directory', 'operation_index' => 0, 'path' => 'content'],
+            [
+                'type' => 'file',
+                'operation_index' => 1,
+                'path' => 'content/file.txt',
+                'revision' => 1,
+                'offset' => 0,
+                'total_bytes' => 5,
+                'restart' => false,
+                'payload' => 'hello',
+            ],
+            ['type' => 'symlink', 'operation_index' => 2, 'path' => 'content/link', 'target' => 'file.txt'],
+            ['type' => 'delete', 'operation_index' => 3, 'path' => 'old.txt'],
+        ]);
+
+        $this->assertSame(200, $response['http_code']);
+        $this->assertSame('complete', $response['body']['status']);
+        $this->assertSame(4, $response['body']['operation_count']);
+        $this->assertNull($response['body']['current_file']);
+        $this->assertSame('uploading', $response['body']['phase']);
+
+        $final = $this->advance_until_complete($endpoints, $session, $response['body']['request_generation']);
+        $this->assertSame('complete', $final['phase']);
+        $this->assertSame('hello', file_get_contents($this->target_dir . '/content/file.txt'));
+        $this->assertSame('file.txt', readlink($this->target_dir . '/content/link'));
+        $this->assertFileDoesNotExist($this->target_dir . '/old.txt');
+    }
+
+    public function test_file_upload_resumes_from_target_confirmed_bytes(): void {
+        $endpoints = $this->make_endpoints();
+        $session = $this->new_session();
+
+        $first = $this->push($endpoints, $session, 0, [[
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => 'partial.bin',
+            'revision' => 7,
+            'offset' => 0,
+            'total_bytes' => 4,
+            'restart' => false,
+            'payload' => 'ab',
+        ]]);
+
+        $this->assertSame(0, $first['body']['operation_count']);
+        $this->assertSame(2, $first['body']['current_file']['committed_bytes']);
+        $this->assertSame(7, $first['body']['current_file']['revision']);
+
+        $second = $this->push($endpoints, $session, $first['body']['request_generation'], [[
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => 'partial.bin',
+            'revision' => 7,
+            'offset' => 2,
+            'total_bytes' => 4,
+            'restart' => false,
+            'payload' => 'cd',
+        ]]);
+
+        $this->assertSame(1, $second['body']['operation_count']);
+        $this->assertNull($second['body']['current_file']);
+        $final = $this->advance_until_complete($endpoints, $session, $second['body']['request_generation']);
+        $this->assertSame('complete', $final['phase']);
+        $this->assertSame('abcd', file_get_contents($this->target_dir . '/partial.bin'));
+    }
+
+    public function test_replaying_the_same_restart_revision_does_not_truncate_its_prefix(): void {
+        $endpoints = $this->make_endpoints();
+        $session = $this->new_session();
+        $first = $this->push($endpoints, $session, 0, [[
+            'type' => 'file', 'operation_index' => 0, 'path' => 'changing.bin',
+            'revision' => 1, 'offset' => 0, 'total_bytes' => 4, 'restart' => false, 'payload' => 'ab',
+        ]]);
+        $restarted = $this->push($endpoints, $session, $first['body']['request_generation'], [[
+            'type' => 'file', 'operation_index' => 0, 'path' => 'changing.bin',
+            'revision' => 2, 'offset' => 0, 'total_bytes' => 4, 'restart' => true, 'payload' => 'XY',
+        ]]);
+
+        // Simulate retrying the request whose response was lost. Its signed
+        // generation is stale, so the body is rejected before it can restart
+        // the file a second time.
+        $stale = $this->push($endpoints, $session, $first['body']['request_generation'], [[
+            'type' => 'file', 'operation_index' => 0, 'path' => 'changing.bin',
+            'revision' => 2, 'offset' => 0, 'total_bytes' => 4, 'restart' => true, 'payload' => 'XY',
+        ]]);
+        $this->assertSame(409, $stale['http_code']);
+        $this->assertSame('stale_session_state', $stale['body']['reason']);
+
+        $status = $endpoints->session_status(
+            ['session_id' => $session->get_session_id()],
+            $this->session_headers('staged_session_status', $session->get_session_id(), null, 'GET')
+        );
+        $this->assertSame(2, $status['body']['current_file']['revision']);
+        $this->assertSame(2, $status['body']['current_file']['committed_bytes']);
+
+        $finished = $this->push($endpoints, $session, $restarted['body']['request_generation'], [
+            [
+                'type' => 'file', 'operation_index' => 0, 'path' => 'changing.bin',
+                'revision' => 2, 'offset' => 0, 'total_bytes' => 4, 'restart' => true, 'payload' => 'XY',
+            ],
+            [
+                'type' => 'file', 'operation_index' => 0, 'path' => 'changing.bin',
+                'revision' => 2, 'offset' => 2, 'total_bytes' => 4, 'restart' => false, 'payload' => 'ZW',
+            ],
+        ]);
+        $this->assertSame(1, $finished['body']['operation_count']);
+        $this->advance_until_complete($endpoints, $session, $finished['body']['request_generation']);
+        $this->assertSame('XYZW', file_get_contents($this->target_dir . '/changing.bin'));
+    }
+
+    public function test_invalid_frame_fails_the_session_instead_of_skipping_an_operation(): void {
+        $endpoints = $this->make_endpoints();
+        $session = $this->new_session();
+        $stream = $this->body_stream("not-json\n");
+        try {
+            $response = $endpoints->session_push_stream(
+                ['session_id' => $session->get_session_id()],
+                $this->session_headers('staged_session_push', $session->get_session_id(), 0),
+                $stream
+            );
+        } finally {
+            fclose($stream);
         }
-        foreach (glob($dir . '/*') ?: [] as $entry) {
-            is_dir($entry) ? $this->removeDir($entry) : @unlink($entry);
-        }
-        @rmdir($dir);
+
+        $this->assertSame(400, $response['http_code']);
+        $this->assertSame('invalid_frame', $response['body']['reason']);
+        $this->assertSame('failed', $response['body']['phase']);
+
+        $retry = $this->push($endpoints, $session, $response['body']['request_generation'], [
+            ['type' => 'delete', 'operation_index' => 0, 'path' => 'ignored.txt'],
+        ]);
+        $this->assertSame(409, $retry['http_code']);
+        $this->assertSame('session_rejected', $retry['body']['reason']);
     }
 
-    private function makeEndpoints(array $overrides = []): Site_Export_Staged_Endpoints
-    {
-        return new Site_Export_Staged_Endpoints(array_merge([
-            'staging_dir' => $this->staging_dir,
-            'secret' => self::SECRET,
-        ], $overrides));
+    public function test_payload_cap_rejection_keeps_the_session_resumable(): void {
+        $endpoints = $this->make_endpoints(['max_frame_bytes' => 2]);
+        $session = $this->new_session();
+        $oversized = $this->push($endpoints, $session, 0, [[
+            'type' => 'file', 'operation_index' => 0, 'path' => 'small.bin',
+            'revision' => 1, 'offset' => 0, 'total_bytes' => 3, 'restart' => false, 'payload' => 'abc',
+        ]]);
+
+        $this->assertSame(413, $oversized['http_code']);
+        $this->assertSame(2, $oversized['body']['max_frame_bytes']);
+        $this->assertSame(0, $oversized['body']['operation_count']);
+        $this->assertSame('uploading', $oversized['body']['phase']);
+
+        $accepted = $this->push($endpoints, $session, $oversized['body']['request_generation'], [
+            [
+                'type' => 'file', 'operation_index' => 0, 'path' => 'small.bin',
+                'revision' => 1, 'offset' => 0, 'total_bytes' => 3, 'restart' => false, 'payload' => 'ab',
+            ],
+            [
+                'type' => 'file', 'operation_index' => 0, 'path' => 'small.bin',
+                'revision' => 1, 'offset' => 2, 'total_bytes' => 3, 'restart' => false, 'payload' => 'c',
+            ],
+        ]);
+        $this->assertSame(1, $accepted['body']['operation_count']);
+    }
+
+    public function test_truncated_payload_keeps_the_confirmed_partial_cursor_resumable(): void {
+        $endpoints = $this->make_endpoints(['append_buffer_bytes' => 2]);
+        $session = $this->new_session();
+        $operation = [
+            'type' => 'file', 'operation_index' => 0, 'path' => 'truncated.bin',
+            'revision' => 1, 'offset' => 0, 'total_bytes' => 4, 'restart' => false, 'payload' => 'abcd',
+        ];
+        $body = Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($operation) . 'ab';
+        $stream = $this->body_stream($body);
+        try {
+            $response = $endpoints->session_push_stream(
+                ['session_id' => $session->get_session_id()],
+                $this->session_headers('staged_session_push', $session->get_session_id(), 0),
+                $stream
+            );
+        } finally {
+            fclose($stream);
+        }
+
+        $this->assertSame(400, $response['http_code']);
+        $this->assertSame('body_read_failed', $response['body']['reason']);
+        $this->assertSame('uploading', $response['body']['phase']);
+        $this->assertSame(2, $response['body']['current_file']['committed_bytes']);
+
+        $finished = $this->push($endpoints, $session, $response['body']['request_generation'], [[
+            'type' => 'file', 'operation_index' => 0, 'path' => 'truncated.bin',
+            'revision' => 1, 'offset' => 2, 'total_bytes' => 4, 'restart' => false, 'payload' => 'cd',
+        ]]);
+        $this->assertSame(1, $finished['body']['operation_count']);
+    }
+
+    public function test_metadata_only_requests_stop_at_the_server_frame_cap(): void {
+        $endpoints = $this->make_endpoints(['max_frames_per_request' => 2]);
+        $session = $this->new_session();
+        $first = $this->push($endpoints, $session, 0, [
+            ['type' => 'delete', 'operation_index' => 0, 'path' => 'a'],
+            ['type' => 'delete', 'operation_index' => 1, 'path' => 'b'],
+            ['type' => 'delete', 'operation_index' => 2, 'path' => 'c'],
+        ]);
+
+        $this->assertSame(2, $first['body']['frames_processed']);
+        $this->assertSame(2, $first['body']['operation_count']);
+        $second = $this->push($endpoints, $session, $first['body']['request_generation'], [
+            ['type' => 'delete', 'operation_index' => 2, 'path' => 'c'],
+        ]);
+        $this->assertSame(3, $second['body']['operation_count']);
+    }
+
+    public function test_staged_symlink_ancestor_cannot_escape_the_private_tree(): void {
+        $outside = sys_get_temp_dir() . '/staged-endpoints-outside-' . bin2hex(random_bytes(8));
+        mkdir($outside, 0700, true);
+        try {
+            $endpoints = $this->make_endpoints();
+            $session = $this->new_session();
+            $response = $this->push($endpoints, $session, 0, [
+                ['type' => 'symlink', 'operation_index' => 0, 'path' => 'escape', 'target' => $outside],
+                [
+                    'type' => 'file', 'operation_index' => 1, 'path' => 'escape/written.txt',
+                    'revision' => 1, 'offset' => 0, 'total_bytes' => 1, 'restart' => false, 'payload' => 'x',
+                ],
+            ]);
+
+            $this->assertSame(409, $response['http_code']);
+            $this->assertSame('failed', $session->get_status()['phase']);
+            $this->assertFileDoesNotExist($outside . '/written.txt');
+        } finally {
+            $this->remove_tree($outside);
+        }
+    }
+
+    public function test_real_site_paths_under_dot_reprint_are_not_reserved(): void {
+        $endpoints = $this->make_endpoints();
+        $session = $this->new_session();
+        $response = $this->push($endpoints, $session, 0, [[
+            'type' => 'file', 'operation_index' => 0, 'path' => '.reprint/site-file',
+            'revision' => 1, 'offset' => 0, 'total_bytes' => 1, 'restart' => false, 'payload' => 'x',
+        ]]);
+
+        $this->assertSame(1, $response['body']['operation_count']);
+        $this->advance_until_complete($endpoints, $session, $response['body']['request_generation']);
+        $this->assertSame('x', file_get_contents($this->target_dir . '/.reprint/site-file'));
+    }
+
+    public function test_wrong_secret_is_rejected_before_the_body_is_opened(): void {
+        $endpoints = $this->make_endpoints();
+        $session = $this->new_session();
+        $headers = $this->session_headers('staged_session_push', $session->get_session_id(), 0);
+        $target = $headers['REQUEST_URI'];
+        $wrong = ( new Site_Export_HMAC_Client('wrong-secret') )->get_envelope_auth_headers('POST', $target) + [
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => $target,
+        ];
+
+        $response = $endpoints->session_push_stream(
+            ['session_id' => $session->get_session_id()],
+            $wrong,
+            null
+        );
+
+        $this->assertSame(403, $response['http_code']);
+        $this->assertSame('auth_failed', $response['body']['reason']);
+        $this->assertSame(0, $session->get_status()['request_generation']);
+    }
+
+    public function test_present_invalid_endpoint_limits_are_not_silently_defaulted(): void {
+        foreach (
+            [
+                ['secret' => ''],
+                ['secret' => false],
+                ['max_frame_bytes' => 0],
+                ['append_buffer_bytes' => 'no'],
+                ['append_buffer_bytes' => 4194305],
+                ['max_frames_per_request' => -1],
+                ['max_frames_per_request' => Site_Export_Staged_Push_Stream_Protocol::MAX_FRAMES_PER_REQUEST + 1],
+                ['timestamp_tolerance' => 0],
+            ] as $invalid
+        ) {
+            try {
+                $this->make_endpoints($invalid);
+                $this->fail('Expected invalid endpoint option to throw: ' . json_encode($invalid));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('must be', $exception->getMessage());
+            }
+        }
+    }
+
+    private function make_endpoints(array $overrides = []): Site_Export_Staged_Endpoints {
+        return new Site_Export_Staged_Endpoints(array_merge(
+            [
+                'staging_dir' => $this->staging_dir,
+                'secret' => self::SECRET,
+                'apply_target_root' => $this->target_dir,
+            ],
+            $overrides
+        ));
+    }
+
+    private function new_session(): Site_Export_Staged_Apply {
+        return Site_Export_Staged_Apply::create($this->staging_dir, $this->target_dir);
+    }
+
+    /** @param array<int,array<string,mixed>> $operations */
+    private function push(
+        Site_Export_Staged_Endpoints $endpoints,
+        Site_Export_Staged_Apply $session,
+        int $generation,
+        array $operations
+    ): array {
+        $body = '';
+        foreach ($operations as $operation) {
+            $body .= Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($operation);
+            if ($operation['type'] === 'file') {
+                $body .= $operation['payload'];
+            }
+        }
+        $stream = $this->body_stream($body);
+        try {
+            return $endpoints->session_push_stream(
+                ['session_id' => $session->get_session_id()],
+                $this->session_headers('staged_session_push', $session->get_session_id(), $generation),
+                $stream
+            );
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    /** @return array<string,mixed> */
+    private function advance_until_complete(
+        Site_Export_Staged_Endpoints $endpoints,
+        Site_Export_Staged_Apply $session,
+        int $generation
+    ): array {
+        for ($attempt = 0; $attempt < 100; ++$attempt) {
+            $response = $endpoints->session_advance(
+                ['session_id' => $session->get_session_id()],
+                $this->session_headers('staged_session_advance', $session->get_session_id(), $generation)
+            );
+            $this->assertSame(200, $response['http_code'], json_encode($response['body']));
+            $generation = $response['body']['request_generation'];
+            if ($response['body']['phase'] === 'complete') {
+                return $response['body'];
+            }
+        }
+        $this->fail('The staged apply session did not complete within 100 bounded advances.');
+    }
+
+    private function session_headers(
+        string $endpoint,
+        ?string $session_id = null,
+        ?int $expected_generation = null,
+        string $method = 'POST',
+        array $extra_parameters = []
+    ): array {
+        $target = '/?endpoint=' . rawurlencode($endpoint);
+        if ($session_id !== null) {
+            $target .= '&session_id=' . rawurlencode($session_id);
+        }
+        if ($expected_generation !== null) {
+            $target .= '&expected_request_generation=' . $expected_generation;
+        }
+        foreach ($extra_parameters as $name => $value) {
+            $target .= '&' . rawurlencode((string) $name) . '=' . rawurlencode((string) $value);
+        }
+        return ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers($method, $target) + [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $target,
+        ];
     }
 
     /** @return resource */
-    private function bodyStream(string $body)
-    {
+    private function body_stream(string $body) {
         $stream = fopen('php://temp', 'w+b');
-        fwrite($stream, $body);
-        rewind($stream);
+        if ($stream === false || fwrite($stream, $body) !== strlen($body) || fseek($stream, 0) !== 0) {
+            throw new RuntimeException('Could not create the staged endpoint test body.');
+        }
         return $stream;
     }
 
-    private function pushHeaders(string $secret = self::SECRET, array $overrides = []): array
-    {
-        $headers = (new Site_Export_HMAC_Client($secret))->get_envelope_auth_headers('POST', self::PUSH_TARGET);
-        return array_merge([
-            'REQUEST_METHOD' => 'POST',
-            'REQUEST_URI' => self::PUSH_TARGET,
-        ], $headers, $overrides);
-    }
-
-    /** @param array<int,array{artifact_id:string,offset:int,bytes:string,total_bytes:int,final:bool}> $frames */
-    private function pushBody(array $frames): string
-    {
-        $body = '';
-        foreach ($frames as $frame) {
-            $header = json_encode([
-                'type' => 'chunk',
-                'artifact_id' => base64_encode($frame['artifact_id']),
-                'offset' => $frame['offset'],
-                'bytes' => strlen($frame['bytes']),
-                'total_bytes' => $frame['total_bytes'],
-                'final' => $frame['final'],
-            ], JSON_UNESCAPED_SLASHES);
-            if ($header === false) {
-                throw new RuntimeException('Could not encode staged push stream frame header.');
-            }
-            $body .= $header . "\n" . $frame['bytes'];
+    private function remove_tree(string $path): void {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
         }
-        return $body;
-    }
-
-    /** @param array<int,array{artifact_id:string,offset:int,bytes:string,total_bytes:int,final:bool}> $frames */
-    private function push(
-        Site_Export_Staged_Endpoints $endpoints,
-        array $frames,
-        array $headers = [],
-        array $config = []
-    ): array {
-        $stream = $this->bodyStream($this->pushBody($frames));
-        try {
-            return $endpoints->push_stream($config, $headers ?: $this->pushHeaders(), $stream);
-        } finally {
-            fclose($stream);
+        if (!is_dir($path)) {
+            return;
         }
-    }
-
-    // ---------------------------------------------------------------
-    // Push data plane
-    // ---------------------------------------------------------------
-
-    public function testPushStreamStagesManyChunksAndFinalizes(): void
-    {
-        // A small append buffer forces many store steps per frame.
-        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
-        $body = 'the quick brown fox jumps over the lazy dog';
-        $split = 20;
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'a/b/dump.sql', 'offset' => 0, 'bytes' => substr($body, 0, $split), 'total_bytes' => strlen($body), 'final' => false],
-            ['artifact_id' => 'a/b/dump.sql', 'offset' => $split, 'bytes' => substr($body, $split), 'total_bytes' => strlen($body), 'final' => true],
-        ]);
-
-        $this->assertSame(200, $result['http_code']);
-        $this->assertSame('complete', $result['body']['status']);
-        $this->assertSame(['artifact_id' => base64_encode('a/b/dump.sql'), 'committed_bytes' => strlen($body)], $result['body']['cursor']);
-        $this->assertSame(1, $result['body']['files_verified']);
-        $this->assertSame($body, file_get_contents($this->staging_dir . '/files/a/b/dump.sql'));
-    }
-
-    public function testPushStreamRetryAbsorbsDuplicateBytes(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $frame = ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcdefghij', 'total_bytes' => 10, 'final' => true];
-        $this->push($endpoints, [$frame]);
-
-        // The sender timed out without the response and retries from the same cursor.
-        $retry = $this->push($endpoints, [$frame]);
-
-        $this->assertSame(200, $retry['http_code']);
-        $this->assertSame('complete', $retry['body']['status']);
-        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 10], $retry['body']['cursor']);
-        $this->assertSame(1, $retry['body']['files_verified']);
-        $this->assertSame('abcdefghij', file_get_contents($this->staging_dir . '/files/artifact-1'));
-    }
-
-    public function testPushStreamStraddlingFrameAppendsOnlyTheTail(): void
-    {
-        $endpoints = $this->makeEndpoints(['append_buffer_bytes' => 4]);
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcdefghij', 'total_bytes' => 15, 'final' => false],
-        ]);
-
-        // After a resync the sender resends from offset 0 with a larger
-        // frame; only the bytes past the committed frontier may land.
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcdefghijKLMNO', 'total_bytes' => 15, 'final' => true],
-        ]);
-
-        $this->assertSame(200, $result['http_code']);
-        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 15], $result['body']['cursor']);
-        $this->assertSame('abcdefghijKLMNO', file_get_contents($this->staging_dir . '/files/artifact-1'));
-    }
-
-    public function testPushStreamFrameBeyondTheFrontierIsAnOffsetGapWithResumeHint(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcde', 'total_bytes' => 20, 'final' => false],
-        ]);
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 50, 'bytes' => 'later-bytes', 'total_bytes' => 100, 'final' => false],
-        ]);
-
-        $this->assertSame(409, $result['http_code']);
-        $this->assertSame('offset_gap', $result['body']['reason']);
-        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 5], $result['body']['cursor']);
-    }
-
-    public function testPushStreamRejectsWrongSecretBeforeTheStore(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'secret.bin', 'offset' => 0, 'bytes' => 'secret', 'total_bytes' => 6, 'final' => true],
-        ], $this->pushHeaders('wrong-secret'));
-
-        $this->assertSame(403, $result['http_code']);
-        $this->assertSame('auth_failed', $result['body']['reason']);
-        $this->assertDirectoryDoesNotExist($this->staging_dir);
-    }
-
-    public function testPushStreamWithoutAConfiguredSecretIsUnavailable(): void
-    {
-        $endpoints = $this->makeEndpoints(['secret' => null]);
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 7, 'final' => true],
-        ]);
-
-        $this->assertSame(503, $result['http_code']);
-        $this->assertSame('not_configured', $result['body']['reason']);
-    }
-
-    public function testPushStreamBodyOverTheCapIs413WithMaxFrameBytes(): void
-    {
-        $endpoints = $this->makeEndpoints(['max_frame_bytes' => 64]);
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => str_repeat('x', 100), 'total_bytes' => 100, 'final' => true],
-        ]);
-
-        $this->assertSame(413, $result['http_code']);
-        $this->assertSame('frame_too_large', $result['body']['reason']);
-        $this->assertSame(64, $result['body']['max_frame_bytes']);
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/artifact-1');
-    }
-
-    public function testPushStreamWhileTheStoreIsHeldReportsBusy(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'first', 'total_bytes' => 11, 'final' => false],
-        ]);
-
-        $holder = fopen($this->staging_dir . '/lock', 'r+b');
-        flock($holder, LOCK_EX);
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 5, 'bytes' => 'second', 'total_bytes' => 11, 'final' => true],
-        ]);
-        flock($holder, LOCK_UN);
-        fclose($holder);
-
-        $this->assertSame(423, $result['http_code']);
-        $this->assertSame('busy', $result['body']['status']);
-        $this->assertSame(['artifact_id' => base64_encode('artifact-1'), 'committed_bytes' => 5], $result['body']['cursor']);
-    }
-
-    public function testMalformedPushFrameIsRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $stream = $this->bodyStream(json_encode(['type' => 'chunk', 'artifact_id' => base64_encode('a'), 'offset' => 5, 'bytes' => 1, 'total_bytes' => 3, 'final' => false]) . "\nX");
-        try {
-            $result = $endpoints->push_stream([], $this->pushHeaders(), $stream);
-        } finally {
-            fclose($stream);
-        }
-
-        $this->assertSame(400, $result['http_code']);
-        $this->assertSame('invalid_frame', $result['body']['reason']);
-        $this->assertStringContainsString('offset 5 and 1 payload bytes, which exceeds total_bytes 3', $result['body']['detail']);
-    }
-
-    public function testPushStreamRejectsAReservedNamespaceFrameBeforeTheStore(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => '.reprint/evil.txt', 'offset' => 0, 'bytes' => 'x', 'total_bytes' => 1, 'final' => true],
-        ]);
-
-        $this->assertSame(400, $result['http_code']);
-        $this->assertSame('reserved_artifact_id', $result['body']['reason']);
-        $this->assertStringContainsString('.reprint/', $result['body']['detail']);
-        // The store never saw it: nothing was written under files/.reprint/.
-        $this->assertFileDoesNotExist($this->staging_dir . '/files/.reprint/evil.txt');
-        $this->assertSame(['artifact_id' => base64_encode('.reprint/evil.txt'), 'committed_bytes' => 0], $result['body']['cursor']);
-    }
-
-    public function testPushStreamAcceptsTheDeletionManifestId(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $manifest = json_encode(['path' => base64_encode('wp-content/gone.txt')]) . "\n";
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => '.reprint/deletions.jsonl', 'offset' => 0, 'bytes' => $manifest, 'total_bytes' => strlen($manifest), 'final' => true],
-        ]);
-
-        // The one reserved id a sender may write stages like any artifact.
-        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
-        $this->assertSame('complete', $result['body']['status']);
-        $this->assertSame(1, $result['body']['files_verified']);
-        $this->assertSame($manifest, file_get_contents($this->staging_dir . '/files/.reprint/deletions.jsonl'));
-    }
-
-    public function testControlPlaneRoutesRefuseTheReservedNamespace(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $reserved = base64_encode('.reprint/evil.txt');
-
-        $finalize = $endpoints->finalize(['artifact_id' => $reserved, 'total_bytes' => 1], ['REQUEST_METHOD' => 'POST']);
-        $status = $endpoints->status(['artifact_id' => $reserved]);
-        $discard = $endpoints->discard(['artifact_id' => $reserved], ['REQUEST_METHOD' => 'POST']);
-
-        foreach (['finalize' => $finalize, 'status' => $status, 'discard' => $discard] as $route => $result) {
-            $this->assertSame(400, $result['http_code'], $route);
-            $this->assertSame('reserved_artifact_id', $result['body']['reason'], $route);
-        }
-
-        // The manifest id passes the gate on the control plane too.
-        $manifest_status = $endpoints->status(['artifact_id' => base64_encode('.reprint/deletions.jsonl')]);
-        $this->assertSame(200, $manifest_status['http_code']);
-    }
-
-    // ---------------------------------------------------------------
-    // Control plane: finalize, status, discard
-    // ---------------------------------------------------------------
-
-    public function testFinalizeWithWrongTotalIsRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 10, 'final' => false],
-        ]);
-
-        $result = $this->finalize($endpoints, 'artifact-1', 99);
-
-        $this->assertSame(409, $result['http_code']);
-        $this->assertSame('size_mismatch', $result['body']['reason']);
-    }
-
-    private function finalize(Site_Export_Staged_Endpoints $endpoints, string $artifact_id, int $total): array
-    {
-        return $endpoints->finalize(
-            ['artifact_id' => base64_encode($artifact_id), 'total_bytes' => $total],
-            ['REQUEST_METHOD' => 'POST']
-        );
-    }
-
-    public function testFinalizeOfUnknownArtifactReportsMissing(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $result = $this->finalize($endpoints, 'never-uploaded', 5);
-
-        $this->assertSame(409, $result['http_code']);
-        $this->assertSame('missing', $result['body']['reason']);
-    }
-
-    public function testFinalizeIsIdempotentAndZeroByteArtifactsVerify(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 7, 'final' => true],
-        ]);
-
-        $this->assertSame(200, $this->finalize($endpoints, 'artifact-1', 7)['http_code']);
-        $this->assertSame('verified', $this->finalize($endpoints, 'empty.txt', 0)['body']['status']);
-    }
-
-    public function testStatusReportsResumeState(): void
-    {
-        $endpoints = $this->makeEndpoints();
-
-        $unknown = $endpoints->status(['artifact_id' => base64_encode('artifact-1')]);
-        $this->assertSame(200, $unknown['http_code']);
-        $this->assertSame(
-            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
-            $unknown['body']
-        );
-
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'abcde', 'total_bytes' => 10, 'final' => false],
-        ]);
-        $known = $endpoints->status(['artifact_id' => base64_encode('artifact-1')]);
-        $this->assertSame(
-            ['exists' => true, 'committed_bytes' => 5, 'verified' => false],
-            $known['body']
-        );
-    }
-
-    public function testDiscardReportsHeldStoreAsRetriable(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => 'payload', 'total_bytes' => 7, 'final' => true],
-        ]);
-
-        $holder = fopen($this->staging_dir . '/lock', 'r+b');
-        flock($holder, LOCK_EX);
-        $busy = $endpoints->discard(
-            ['artifact_id' => base64_encode('artifact-1')],
-            ['REQUEST_METHOD' => 'POST']
-        );
-        flock($holder, LOCK_UN);
-        fclose($holder);
-
-        $this->assertSame(423, $busy['http_code']);
-        $this->assertSame(['discarded' => false], $busy['body']);
-
-        $done = $endpoints->discard(
-            ['artifact_id' => base64_encode('artifact-1')],
-            ['REQUEST_METHOD' => 'POST']
-        );
-        $this->assertSame(200, $done['http_code']);
-        $this->assertSame(['discarded' => true], $done['body']);
-    }
-
-    // ---------------------------------------------------------------
-    // Request validation and server-owned options
-    // ---------------------------------------------------------------
-
-    public function testOversizedFrameCursorReportsOnlyStoreCommittedBytes(): void
-    {
-        $endpoints = $this->makeEndpoints(['max_frame_bytes' => 6]);
-
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'claimed.bin', 'offset' => 4, 'bytes' => str_repeat('x', 10), 'total_bytes' => 20, 'final' => false],
-        ]);
-
-        $this->assertSame(413, $result['http_code']);
-        $this->assertSame(
-            ['artifact_id' => base64_encode('claimed.bin'), 'committed_bytes' => 0],
-            $result['body']['cursor'],
-            'a rejection cursor must report what the store confirmed, not what the sender claimed'
-        );
-    }
-
-    public function testOffsetZeroFrameRestartsAnUnverifiedArtifact(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        (new Site_Export_Staged_Artifacts($this->staging_dir))->append('restarted.bin', 0, 'AAAA');
-
-        // A frame starting at byte 0 means the sender is pushing the file
-        // over — it cannot vouch for the staged prefix. The old bytes must
-        // not survive underneath the new ones.
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'restarted.bin', 'offset' => 0, 'bytes' => 'BBBBBBBB', 'total_bytes' => 8, 'final' => true],
-        ]);
-
-        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
-        $this->assertSame(1, $result['body']['files_verified']);
-        $this->assertSame('BBBBBBBB', file_get_contents($this->staging_dir . '/files/restarted.bin'));
-    }
-
-    public function testOffsetZeroFrameWithANewTotalRestartsAVerifiedArtifact(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $store = new Site_Export_Staged_Artifacts($this->staging_dir);
-        $store->append('reverified.bin', 0, str_repeat('A', 8));
-        $store->finalize('reverified.bin', 8);
-
-        // The source changed after verification; the sender restarts the
-        // file with its new size. Refusing forever would deadlock the push.
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'reverified.bin', 'offset' => 0, 'bytes' => 'CCCCCC', 'total_bytes' => 6, 'final' => true],
-        ]);
-
-        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
-        $this->assertSame(1, $result['body']['files_verified']);
-        $this->assertSame('CCCCCC', file_get_contents($this->staging_dir . '/files/reverified.bin'));
-    }
-
-    public function testMutatingRoutesRequirePost(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $get = ['REQUEST_METHOD' => 'GET'];
-        $stream = $this->bodyStream('');
-
-        $push = $endpoints->push_stream([], $get, $stream);
-        fclose($stream);
-        $finalize = $endpoints->finalize(['artifact_id' => 'a', 'total_bytes' => 1], $get);
-        $discard = $endpoints->discard(['artifact_id' => 'a'], $get);
-
-        foreach ([$push, $finalize, $discard] as $result) {
-            $this->assertSame(405, $result['http_code']);
-            $this->assertSame('method_not_allowed', $result['body']['reason']);
-        }
-    }
-
-    public function testMalformedParametersAreRejected(): void
-    {
-        $endpoints = $this->makeEndpoints();
-        $post = ['REQUEST_METHOD' => 'POST'];
-
-        $bad_total = $endpoints->finalize(['artifact_id' => base64_encode('a'), 'total_bytes' => 'many'], $post);
-        $this->assertSame('invalid_total', $bad_total['body']['reason']);
-
-        $bad_status_id = $endpoints->status(['artifact_id' => '']);
-        $this->assertSame(400, $bad_status_id['http_code']);
-
-        // Control-plane ids travel base64, like push stream frames.
-        $undecodable_status_id = $endpoints->status(['artifact_id' => '!!!not-base64!!!']);
-        $this->assertSame(400, $undecodable_status_id['http_code']);
-        $this->assertSame('invalid_artifact_id', $undecodable_status_id['body']['reason']);
-    }
-
-    public function testClientParametersCannotChooseServerOptions(): void
-    {
-        $endpoints = $this->makeEndpoints(['max_frame_bytes' => 1024]);
-        $evil_dir = $this->staging_dir . '-evil';
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'artifact-1', 'offset' => 0, 'bytes' => str_repeat('x', 100), 'total_bytes' => 100, 'final' => true],
-        ], [], [
-            // Options are server-owned; parameters with the same names
-            // must be ignored.
-            'staging_dir' => $evil_dir,
-            'max_frame_bytes' => 10,
-            'secret' => 'attacker-chosen',
-        ]);
-
-        $this->assertSame(200, $result['http_code']);
-        $this->assertFileExists($this->staging_dir . '/files/artifact-1');
-        $this->assertDirectoryDoesNotExist($evil_dir);
-    }
-
-    // ---------------------------------------------------------------
-    // Dispatcher wiring
-    // ---------------------------------------------------------------
-
-    public function testHttpServerRoutesStagedEndpoints(): void
-    {
-        $server = new Site_Export_HTTP_Server([
-            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
-        ]);
-
-        ob_start();
-        $server->handle_request([
-            'get' => ['endpoint' => 'staged_status', 'artifact_id' => base64_encode('artifact-1')],
-            'server' => ['REQUEST_METHOD' => 'GET'],
-            'body' => '',
-        ]);
-        $output = ob_get_clean();
-
-        $this->assertSame(
-            ['exists' => false, 'committed_bytes' => 0, 'verified' => false],
-            json_decode( (string) $output, true)
-        );
-    }
-
-    public function testStagedRoutesAreAbsentWithoutTheStagedOption(): void
-    {
-        $server = new Site_Export_HTTP_Server();
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid endpoint: 'staged_status'");
-
-        $server->dispatch(['endpoint' => 'staged_status']);
-    }
-
-    public function testExplicitHandlersWinOverStagedRegistration(): void
-    {
-        $called = false;
-        $server = new Site_Export_HTTP_Server([
-            'handlers' => [
-                'staged_status' => function (array $config) use (&$called): void {
-                    $called = true;
-                },
-            ],
-            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
-        ]);
-
-        $server->dispatch(['endpoint' => 'staged_status']);
-
-        $this->assertTrue($called);
-    }
-
-    public function testHandleRequestOnlyReadsTheBodyForJsonContent(): void
-    {
-        $reads = 0;
-        $options = [
-            'handlers' => ['preflight' => static function (array $config): void {}],
-            'body_reader' => function () use (&$reads): string {
-                ++$reads;
-                return '';
-            },
-        ];
-        $server = new Site_Export_HTTP_Server($options);
-
-        $server->handle_request([
-            'get' => ['endpoint' => 'preflight'],
-            'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/octet-stream'],
-        ]);
-        $this->assertSame(0, $reads, 'a raw body must not be buffered for config parsing');
-
-        $server->handle_request([
-            'get' => ['endpoint' => 'preflight'],
-            'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json; charset=utf-8'],
-        ]);
-        $this->assertSame(1, $reads, 'a JSON body still feeds config parsing');
-    }
-
-    public function testHandleRequestDoesNotBufferStagedPushBodies(): void
-    {
-        $reads = 0;
-        $server = new Site_Export_HTTP_Server([
-            'staged' => ['staging_dir' => $this->staging_dir, 'secret' => self::SECRET],
-            'body_reader' => function () use (&$reads): string {
-                ++$reads;
-                return 'this would buffer the raw push body';
-            },
-        ]);
-
-        $previous_request_method = $_SERVER['REQUEST_METHOD'] ?? null;
-        $previous_request_uri = $_SERVER['REQUEST_URI'] ?? null;
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-        $_SERVER['REQUEST_URI'] = self::PUSH_TARGET;
-        $buffer_level = ob_get_level();
-        ob_start();
-        try {
-            $server->handle_request([
-                'get' => ['endpoint' => 'staged_push'],
-                'server' => ['REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => 'application/json'],
-            ]);
-            $output = ob_get_clean();
-        } finally {
-            while (ob_get_level() > $buffer_level) {
-                ob_end_clean();
-            }
-            if ($previous_request_method === null) {
-                unset($_SERVER['REQUEST_METHOD']);
-            } else {
-                $_SERVER['REQUEST_METHOD'] = $previous_request_method;
-            }
-            if ($previous_request_uri === null) {
-                unset($_SERVER['REQUEST_URI']);
-            } else {
-                $_SERVER['REQUEST_URI'] = $previous_request_uri;
+        $entries = scandir($path);
+        if (is_array($entries)) {
+            foreach ($entries as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->remove_tree($path . '/' . $entry);
+                }
             }
         }
-
-        $this->assertSame(0, $reads, 'staged_push body bytes must only be read by the staged handler');
-        $this->assertSame('auth_failed', json_decode( (string) $output, true)['reason']);
+        @rmdir($path);
     }
 }

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -4,118 +4,268 @@ use PHPUnit\Framework\TestCase;
 
 final class StagedPushStreamProtocolTest extends TestCase
 {
-    public function testChunkHeadersDecodeFromJsonLines(): void
-    {
-        $line = json_encode([
-            'type' => 'chunk',
-            'artifact_id' => base64_encode('wp-content/uploads/photo.jpg'),
-            'offset' => 10,
-            'bytes' => 5,
-            'total_bytes' => 20,
-            'final' => false,
-        ], JSON_UNESCAPED_SLASHES);
-
-        // The wire carries the id base64-encoded; decoding hands back the
-        // raw path.
-        $this->assertSame([
-            'artifact_id' => 'wp-content/uploads/photo.jpg',
-            'offset' => 10,
-            'bytes' => 5,
-            'total_bytes' => 20,
-            'final' => false,
-        ], Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line));
-    }
-
     /**
-     * @dataProvider reservedArtifactIdProvider
+     * @dataProvider metadataOperationProvider
      */
-    public function testReservedNamespaceGuardsEveryReprintIdButTheManifest(string $artifact_id, bool $forbidden): void
+    public function testMetadataOperationHeadersRoundTripRawBytes(array $operation): void
     {
+        $header = Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($operation);
+
+        $this->assertStringEndsWith("\n", $header);
         $this->assertSame(
-            $forbidden,
-            Site_Export_Staged_Push_Stream_Protocol::is_reserved_sender_artifact_id($artifact_id)
+            $operation,
+            Site_Export_Staged_Push_Stream_Protocol::decode_operation_header(rtrim($header, "\n"))
         );
     }
 
-    public static function reservedArtifactIdProvider(): array
+    public static function metadataOperationProvider(): array
     {
         return [
-            'the deletion manifest is the one allowed reserved id' => ['.reprint/deletions.jsonl', false],
-            'a sibling in the namespace is forbidden' => ['.reprint/evil.jsonl', true],
-            'a nested path in the namespace is forbidden' => ['.reprint/sub/dir/file', true],
-            'the bare namespace segment is forbidden' => ['.reprint', true],
-            'a real file that merely starts with the segment is allowed' => ['.reprintfoo', false],
-            'a nested .reprint below a real dir is allowed' => ['wp-content/.reprint/x', false],
-            'an ordinary site file is allowed' => ['wp-content/uploads/photo.jpg', false],
+            'directory' => [[
+                'type' => 'directory',
+                'operation_index' => 0,
+                'path' => 'wp-content/uploads',
+            ]],
+            'delete' => [[
+                'type' => 'delete',
+                'operation_index' => 1,
+                'path' => "cache/invalid-utf8-\xff",
+            ]],
+            'symlink with arbitrary-byte target' => [[
+                'type' => 'symlink',
+                'operation_index' => 2,
+                'path' => 'current',
+                'target' => "releases/build-\xfe",
+            ]],
+            'symlink with empty target for filesystem validation' => [[
+                'type' => 'symlink',
+                'operation_index' => 3,
+                'path' => 'empty-target',
+                'target' => '',
+            ]],
         ];
     }
 
-    public function testChunkHeaderValidationRejectsRangesOutsideTheDeclaredFile(): void
+    public function testMaximumPathAndSymlinkTargetFitOneBoundedHeader(): void
+    {
+        $operation = [
+            'type' => 'symlink',
+            'operation_index' => 0,
+            'path' => str_repeat('p', Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES),
+            'target' => str_repeat('t', Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES),
+        ];
+
+        $header = Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($operation);
+
+        $this->assertLessThanOrEqual(Site_Export_Staged_Push_Stream_Protocol::MAX_HEADER_BYTES + 1, strlen($header));
+        $this->assertSame(
+            $operation,
+            Site_Export_Staged_Push_Stream_Protocol::decode_operation_header(rtrim($header, "\n"))
+        );
+    }
+
+    public function testPathBeyondSharedRawByteLimitIsRejectedBeforeEncoding(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('offset 8 and 4 payload bytes, which exceeds total_bytes 10');
+        $this->expectExceptionMessage('exceeds 8192 raw bytes');
 
-        Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(json_encode([
-            'type' => 'chunk',
-            'artifact_id' => base64_encode('file.txt'),
-            'offset' => 8,
-            'bytes' => 4,
-            'total_bytes' => 10,
-            'final' => true,
-        ], JSON_UNESCAPED_SLASHES));
+        Site_Export_Staged_Push_Stream_Protocol::encode_operation_header([
+            'type' => 'delete',
+            'operation_index' => 0,
+            'path' => str_repeat('p', Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES + 1),
+        ]);
+    }
+
+    public function testFileHeaderDerivesPayloadBytesWithoutBufferingThemIntoJson(): void
+    {
+        $operation = [
+            'type' => 'file',
+            'operation_index' => 4,
+            'path' => 'wp-content/uploads/photo.jpg',
+            'revision' => 7,
+            'offset' => 10,
+            'total_bytes' => 15,
+            'restart' => false,
+            'payload' => "a\0bcd",
+        ];
+
+        $header = Site_Export_Staged_Push_Stream_Protocol::encode_operation_header($operation);
+        $this->assertStringNotContainsString($operation['payload'], $header);
+        $this->assertSame([
+            'type' => 'file',
+            'operation_index' => 4,
+            'path' => 'wp-content/uploads/photo.jpg',
+            'revision' => 7,
+            'offset' => 10,
+            'bytes' => 5,
+            'total_bytes' => 15,
+            'restart' => false,
+        ], Site_Export_Staged_Push_Stream_Protocol::decode_operation_header(rtrim($header, "\n")));
+    }
+
+    public function testZeroByteFileFrameIsAllowedOnlyAtEndOfFile(): void
+    {
+        $header = Site_Export_Staged_Push_Stream_Protocol::encode_operation_header([
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => 'empty.txt',
+            'revision' => 0,
+            'offset' => 0,
+            'total_bytes' => 0,
+            'restart' => true,
+            'payload' => '',
+        ]);
+
+        $this->assertSame(0, Site_Export_Staged_Push_Stream_Protocol::decode_operation_header(
+            rtrim($header, "\n")
+        )['bytes']);
     }
 
     /**
-     * @dataProvider invalidChunkHeaderProvider
+     * @dataProvider invalidHeaderProvider
      */
-    public function testChunkHeaderValidationNamesTheExactInvalidField(array $header, string $expected_message): void
+    public function testOperationHeaderValidationNamesTheViolatedCondition(array $header, string $expected_message): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expected_message);
 
-        Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header(json_encode($header, JSON_UNESCAPED_SLASHES));
+        Site_Export_Staged_Push_Stream_Protocol::decode_operation_header(
+            json_encode($header, JSON_UNESCAPED_SLASHES)
+        );
     }
 
-    public static function invalidChunkHeaderProvider(): array
+    public static function invalidHeaderProvider(): array
     {
+        $file = [
+            'type' => 'file',
+            'operation_index' => 0,
+            'path' => base64_encode('file.txt'),
+            'revision' => 1,
+            'offset' => 0,
+            'bytes' => 1,
+            'total_bytes' => 1,
+            'restart' => false,
+        ];
+
         return [
-            'missing type' => [
-                ['artifact_id' => base64_encode('file.txt'), 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
-                'Missing staged push stream frame field "type".',
+            'old generic chunk type' => [
+                array_merge($file, ['type' => 'chunk']),
+                'field "type" to be "directory", "file", "symlink", or "delete"',
             ],
-            'empty artifact id' => [
-                ['type' => 'chunk', 'artifact_id' => '', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
-                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received string "".',
+            'missing operation index' => [
+                ['type' => 'directory', 'path' => base64_encode('dir')],
+                'Missing staged push stream frame field "operation_index".',
             ],
-            'artifact id that is not base64' => [
-                ['type' => 'chunk', 'artifact_id' => '!!!not-base64!!!', 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
-                'Expected staged push stream frame field "artifact_id" to be base64 of a non-empty path; received string "!!!not-base64!!!".',
+            'numeric-string operation index' => [
+                ['type' => 'directory', 'operation_index' => '0', 'path' => base64_encode('dir')],
+                'field "operation_index" to be a non-negative integer; received string "0"',
             ],
-            'negative offset' => [
-                ['type' => 'chunk', 'artifact_id' => base64_encode('file.txt'), 'offset' => -1, 'bytes' => 1, 'total_bytes' => 1, 'final' => false],
-                'Expected staged push stream frame field "offset" to be a non-negative integer; received integer -1.',
+            'invalid path base64' => [
+                ['type' => 'delete', 'operation_index' => 0, 'path' => '!!!'],
+                'field "path" to be base64 of a non-empty path',
             ],
-            'string byte count' => [
-                ['type' => 'chunk', 'artifact_id' => base64_encode('file.txt'), 'offset' => 0, 'bytes' => '1', 'total_bytes' => 1, 'final' => false],
-                'Expected staged push stream frame field "bytes" to be a non-negative integer; received string "1".',
+            'missing symlink target' => [
+                ['type' => 'symlink', 'operation_index' => 0, 'path' => base64_encode('link')],
+                'Missing staged push stream frame field "target".',
             ],
-            'missing final flag' => [
-                ['type' => 'chunk', 'artifact_id' => base64_encode('file.txt'), 'offset' => 0, 'bytes' => 1, 'total_bytes' => 1],
-                'Missing staged push stream frame field "final".',
+            'directory file field' => [
+                ['type' => 'directory', 'operation_index' => 0, 'path' => base64_encode('dir'), 'bytes' => 0],
+                'Unexpected staged push stream frame field "bytes" for operation type "directory".',
+            ],
+            'file range beyond declared size' => [
+                array_merge($file, ['offset' => 1, 'bytes' => 1]),
+                'declares offset 1 and 1 payload bytes, which exceeds total_bytes 1',
+            ],
+            'zero payload before eof' => [
+                array_merge($file, ['bytes' => 0, 'total_bytes' => 1]),
+                'zero payload bytes must be positioned at total_bytes',
+            ],
+            'restart away from offset zero' => [
+                array_merge($file, ['offset' => 1, 'bytes' => 0, 'restart' => true]),
+                'field "restart" may be true only when offset is 0',
+            ],
+            'string revision' => [
+                array_merge($file, ['revision' => '1']),
+                'field "revision" to be a non-negative integer; received string "1"',
             ],
         ];
     }
 
-    public function testReadAndDiscardUseTheSameBoundedStreamHelpers(): void
+    public function testJsonArrayIsNotAcceptedAsAnOperationObject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected staged push stream frame header to be a JSON object.');
+
+        Site_Export_Staged_Push_Stream_Protocol::decode_operation_header('[]');
+    }
+
+    public function testSenderRejectsFieldsThatDoNotBelongToTheOperationType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unexpected staged push stream frame field "payload" for operation type "delete".');
+
+        Site_Export_Staged_Push_Stream_Protocol::encode_operation_header([
+            'type' => 'delete',
+            'operation_index' => 0,
+            'path' => 'old.txt',
+            'payload' => '',
+        ]);
+    }
+
+    public function testHeaderReaderHandlesLfCrLfAndCleanEof(): void
     {
         $stream = fopen('php://temp', 'w+b');
-        fwrite($stream, "abc\ndefghijk");
+        fwrite($stream, "one\nsecond\r\n");
         rewind($stream);
 
-        $this->assertSame("abc\n", fgets($stream));
-        $this->assertSame('def', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 3));
-        $this->assertTrue(Site_Export_Staged_Push_Stream_Protocol::discard_exactly($stream, 3, 2));
-        $this->assertSame('jk', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 2));
+        $this->assertSame('one', Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream));
+        $this->assertSame('second', Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream));
+        $this->assertNull(Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream));
+
+        fclose($stream);
+    }
+
+    public function testHeaderReaderRejectsAnUnterminatedHeader(): void
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, 'truncated');
+        rewind($stream);
+
+        try {
+            Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream);
+            $this->fail('Expected the unterminated header to be rejected.');
+        } catch (InvalidArgumentException $error) {
+            $this->assertStringContainsString('ended before its LF terminator', $error->getMessage());
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testHeaderReaderRejectsBeforeBufferingPastItsLimit(): void
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, "12345\nremaining");
+        rewind($stream);
+
+        try {
+            Site_Export_Staged_Push_Stream_Protocol::read_header_line($stream, 4);
+            $this->fail('Expected the oversized header to be rejected.');
+        } catch (InvalidArgumentException $error) {
+            $this->assertSame('Staged push stream frame header exceeds 4 bytes.', $error->getMessage());
+            $this->assertSame("\n", fread($stream, 1));
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testReadExactlyUsesTheRequestedBoundedPayloadLength(): void
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite($stream, 'abcde');
+        rewind($stream);
+
+        $this->assertSame('abc', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 3));
+        $this->assertSame('de', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 2));
 
         fclose($stream);
     }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -34,6 +34,7 @@
             <file>StagedArtifactsTest.php</file>
             <file>StagedApplyTest.php</file>
             <file>StagedEndpointsTest.php</file>
+            <file>StagedPushStreamProtocolTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>


### PR DESCRIPTION
## What it does

Exposes the direct staged-apply lifecycle from #338 as authenticated `create`, `push`, `status`, `advance`, and `discard` operations. Typed frames carry byte-exact paths as base64; one request may stream many bounded file chunks and metadata operations. Header size, file payload size, response size, request bytes, elapsed request time, and metadata frame count are independently bounded.

Session routes authenticate the signed query before reading the body. A form or JSON field cannot select a reserved handler. The retired session-less `staged_push` target returns an authenticated terminal response before its body is buffered. The WordPress wrapper requires server-owned private staging and keeps live apply disabled until a boot-independent recovery entry point exists. It also loads Composer exactly once before CORS so a symlinked `wp-content` path cannot redeclare Composer's generated initializer after stat caches are cleared.

This PR adds the wire client and real HTTP coverage. It does not add sender orchestration or CLI wiring; #336 adds the bounded driver. The old artifact store is left unreachable until #337 deletes it.

## Rationale

The target, not the sender, owns the accepted operation count, partial-file cursor, request generation, and commit phase. Lost responses therefore recover through `status` instead of replaying an uncertain mutation.

Separating exposure from the target engine keeps HTTP authentication, request limits, error classification, and WordPress boot constraints in one review layer.

## Testing instructions

```bash
cd tests
../vendor/bin/phpunit \
  ExporterPushPhpCompatibilityTest.php \
  ExportHttpServerTest.php \
  StagedApplyTest.php \
  StagedArtifactsTest.php \
  StagedEndpointsTest.php \
  StagedPushStreamProtocolTest.php \
  Import/StagedPushStreamClientTest.php \
  Import/StagedApplyHttpLifecycleTest.php \
  Import/StagedPluginPushEndpointTest.php \
  Import/PushClientPhpCompatibilityTest.php
```

The focused run passes 197 tests and 2,025 assertions, with one filesystem-dependent raw-byte filename test skipped. Exporter/plugin code passes PHPCompatibility 7.2; the importer upload code passes PHPCompatibility 7.4. Targeted PHPStan is clean.
