### PR TITLE
Never delete the --only roots themselves in the files-pull delete drains

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8745,7 +8745,11 @@ class ImportClient
      * Whether $path is selected by the active --only file path prefixes. With no
      * --only flag, every file path is selected (returns true) — this keeps
      * the diff's delete drains at their default behavior. When --only is set,
-     * true only when $path falls under one of those file path prefixes.
+     * true only when $path falls under one of those file path prefixes IF it is
+     * NOT the directory itself (when the path remainder is an empty string): an
+     * --only remote index lists what is inside each selected directory, never
+     * the directory itself, so to the diff the selected directories always
+     * appear deleted-on-remote even though they exist.
      */
     private function is_file_path_selected_by_pull_only_files(string $path): bool
     {
@@ -8754,7 +8758,11 @@ class ImportClient
         }
 
         foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
-            if (self::path_remainder_under($path, $prefix) !== null) {
+            $remainder = self::path_remainder_under($path, $prefix);
+            if ($remainder === "") {
+                return false;
+            }
+            if ($remainder !== null) {
                 return true;
             }
         }

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -154,4 +154,36 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $this->assertFileDoesNotExist($orphan);
         $this->assertNotContains('/wp-content/old/orphan.txt', $this->readLocalIndexPaths());
     }
+
+    public function testOnlyRootItselfSurvivesTheDeleteDrains(): void
+    {
+        // A remote index built with --only lists each selected directory's
+        // *contents* but never the directory itself, so the --only roots
+        // always look deleted-on-remote to the diff. The drains must not
+        // delete them: that would recursively remove the very directories
+        // the user asked to pull, while the matched children keep the
+        // download list empty — silent data loss.
+        $this->writeIndex('.import-index.jsonl',
+            $this->indexLine('/wp-content/themes', 1000, 0, 'dir')
+            . $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
+            . $this->indexLine('/wp-content/themes/old/orphan.css', 1000, 10)
+        );
+        $this->writeIndex('.import-remote-index.jsonl',
+            $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
+        );
+
+        $kept = $this->seedLocalFile('/wp-content/themes/keep/style.css');
+        $orphan = $this->seedLocalFile('/wp-content/themes/old/orphan.css');
+
+        [$client, $r] = $this->prepareClient(['/wp-content/themes']);
+        $r->getMethod('diff_indexes_and_build_fetch_list')->invoke($client);
+
+        // The selected root, its matched contents, and its index entry survive…
+        $this->assertDirectoryExists($this->fs_root . '/wp-content/themes');
+        $this->assertFileExists($kept);
+        $this->assertContains('/wp-content/themes', $this->readLocalIndexPaths());
+        // …while a genuine orphan inside it is still drained.
+        $this->assertFileDoesNotExist($orphan);
+        $this->assertNotContains('/wp-content/themes/old/orphan.css', $this->readLocalIndexPaths());
+    }
 }


### PR DESCRIPTION
## What it does

Stops an incremental `files-pull --only=<dirs>` from deleting the selected directories locally.

## Rationale

An `--only` remote index lists what is *inside* each selected directory, never the directory itself — while the local index from an earlier broader pull does contain those directories as entries. The diff therefore classifies every `--only` root as deleted-on-remote and the delete drains remove it recursively. 

## Implementation

`is_file_path_selected_by_pull_only_files()` now requires a path to fall *strictly under* a prefix — a path that is exactly one of the `--only` prefixes is never deletable. Orphans inside selected directories are still drained; unscoped pulls are unaffected.

## Testing instructions

- `cd tests && ../vendor/bin/phpunit --filter OnlyFilesPathPrefixDiffTest` — the new `testOnlyRootItselfSurvivesTheDeleteDrains` fails on trunk with the live signature (the selected directory vanishes) and passes with the fix.
- Live repro: full pull of a WP Cloud site, then `pull-files <api> --filter=essential-files --only=:wp-plugins:`. Before: the audit log shows `Deleted: …/wp-content/plugins` and the plugins directory is gone. After: zero deletions, the directory refreshes.