### PR TITLE
Support PHP 7.2 in Reprint exporter

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,9 +117,11 @@ jobs:
           SECRET="test-secret-basic"
           BASE="http://127.0.0.1:8081/?reprint-api"
           DIR="/srv/e2e-sites/basic"
+          STATE_DIR="/tmp/e2e-smoke-state"
+          FS_ROOT="/tmp/e2e-smoke-fs"
 
           echo "=== Importer preflight ==="
-          preflight_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1)" || {
+          preflight_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" || {
             status=$?
             echo "$preflight_output" | head -50
             echo "EXIT: $status"
@@ -128,7 +130,7 @@ jobs:
           echo "$preflight_output" | head -50
 
           echo "=== Importer files-pull ==="
-          files_pull_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1)" || {
+          files_pull_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" || {
             status=$?
             echo "$files_pull_output" | head -50
             echo "EXIT: $status"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,14 +29,30 @@ jobs:
           path: reprint.phar
 
   e2e:
-    name: E2E (PHP ${{ matrix.php }})
+    name: E2E (exporter PHP ${{ matrix.exporter_php }}, importer PHP ${{ matrix.importer_php }})
     needs: build-phar
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        include:
+          - exporter_php: '7.2'
+            importer_php: '8.2'
+          - exporter_php: '7.4'
+            importer_php: '7.4'
+          - exporter_php: '8.0'
+            importer_php: '8.0'
+          - exporter_php: '8.1'
+            importer_php: '8.1'
+          - exporter_php: '8.2'
+            importer_php: '8.2'
+          - exporter_php: '8.3'
+            importer_php: '8.3'
+          - exporter_php: '8.4'
+            importer_php: '8.4'
+          - exporter_php: '8.5'
+            importer_php: '8.5'
 
     steps:
       - uses: actions/checkout@v5
@@ -51,17 +67,25 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup importer PHP
+        if: matrix.importer_php != matrix.exporter_php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.importer_php }}
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
+          coverage: none
+
       # PHP comes from the runner's pre-cached toolcache via this
       # action; we don't try to apt-install ondrej/php ourselves
       # because every Launchpad endpoint flakes regularly.
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.exporter_php }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
       - name: Setup infrastructure
-        run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.php }}"
+        run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.exporter_php }}"
 
       - name: Setup test sites
         run: tests/e2e/setup.sh
@@ -73,6 +97,7 @@ jobs:
       - name: Provision basic site and smoke-test API
         env:
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          IMPORTER_PHP: php${{ matrix.importer_php }}
         working-directory: tests/e2e
         run: |
           # Download WP-CLI (normally done by Vitest globalSetup, but we need it here)
@@ -94,12 +119,25 @@ jobs:
           DIR="/srv/e2e-sites/basic"
 
           echo "=== Importer preflight ==="
-          timeout 30 php "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          preflight_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1)" || {
+            status=$?
+            echo "$preflight_output" | head -50
+            echo "EXIT: $status"
+            exit "$status"
+          }
+          echo "$preflight_output" | head -50
 
           echo "=== Importer files-pull ==="
-          timeout 30 php "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          files_pull_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1)" || {
+            status=$?
+            echo "$files_pull_output" | head -50
+            echo "EXIT: $status"
+            exit "$status"
+          }
+          echo "$files_pull_output" | head -50
 
       - name: Run E2E tests
+        if: matrix.exporter_php != '7.2'
         env:
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
         working-directory: tests/e2e
@@ -117,7 +155,7 @@ jobs:
           echo "--- Nginx config test ---"
           sudo nginx -t 2>&1 || true
           echo "--- PHP-FPM journal ---"
-          sudo journalctl -u "php${{ matrix.php }}-fpm" --no-pager -n 30 2>/dev/null || true
+          sudo journalctl -u "php${{ matrix.exporter_php }}-fpm" --no-pager -n 30 2>/dev/null || true
           echo "--- Nginx journal ---"
           sudo journalctl -u nginx --no-pager -n 30 2>/dev/null || true
           echo "--- MariaDB journal ---"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -38,7 +38,8 @@ jobs:
 
       - run: composer install --no-interaction --prefer-dist
 
-      # Exporter runs on shared hosting down to PHP 7.2; importer requires 7.4.
+      # Checks exporter compat at PHP 7.2 (shared hosting) and importer at 7.4,
+      # via two PHPCompatibility runs (see lint:php:compat in composer.json).
       - run: composer lint:php:compat
 
   syntax-72:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,3 +22,43 @@ jobs:
       - run: composer install --no-interaction --prefer-dist
 
       - run: composer analyze
+
+  compat:
+    name: PHP Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+
+      - run: composer install --no-interaction --prefer-dist
+
+      # Exporter runs on shared hosting down to PHP 7.2; importer requires 7.4.
+      - run: composer lint:php:compat
+
+  syntax-72:
+    # PHPCompatibility 9.3.5 misses arrow functions and numeric separators, so
+    # a real PHP 7.2 parser is the authoritative check that the exporter (which
+    # runs on old shared hosting) contains no 7.3/7.4-only syntax.
+    name: PHP 7.2 syntax (exporter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.2"
+          coverage: none
+
+      - name: Lint exporter sources for PHP 7.2 parse errors
+        run: |
+          find packages/reprint-exporter/src reprint-exporter-wp \
+            -name '*.php' -not -path 'reprint-exporter-wp/wordpress/*' \
+            -print0 | xargs -0 -n1 php -l

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
         "analyze": "phpstan analyze --memory-limit=1G",
         "lint:php": "phpcs --standard=phpcs.xml.dist",
         "lint:php:fix": "phpcbf --standard=phpcs.xml.dist",
-        "lint:php:compat": "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-exporter/src packages/reprint-importer/src reprint-exporter-wp --ignore=reprint-exporter-wp/wordpress",
+        "lint:php:compat": [
+            "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps packages/reprint-exporter/src reprint-exporter-wp --ignore=reprint-exporter-wp/wordpress",
+            "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-importer/src"
+        ],
         "compat": "@lint:php:compat"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
@@ -64,25 +64,25 @@
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "6eaab346858777b197a5e530157b7388cf3e9cc7"
+                "reference": "63e2035a5d9ef069d13b0285150e1cbc72fab407"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/6eaab346858777b197a5e530157b7388cf3e9cc7",
-                "reference": "6eaab346858777b197a5e530157b7388cf3e9cc7",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/63e2035a5d9ef069d13b0285150e1cbc72fab407",
+                "reference": "63e2035a5d9ef069d13b0285150e1cbc72fab407",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.8",
-                "wp-php-toolkit/filesystem": "^0.8",
-                "wp-php-toolkit/html": "^0.8",
-                "wp-php-toolkit/http-client": "^0.8",
-                "wp-php-toolkit/xml": "^0.8"
+                "wp-php-toolkit/bytestream": "^0.8.1",
+                "wp-php-toolkit/filesystem": "^0.8.1",
+                "wp-php-toolkit/html": "^0.8.1",
+                "wp-php-toolkit/http-client": "^0.8.1",
+                "wp-php-toolkit/xml": "^0.8.1"
             },
             "type": "library",
             "autoload": {
@@ -123,11 +123,11 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-19T19:53:55+00:00"
+            "time": "2026-05-27T22:01:51+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
@@ -182,21 +182,21 @@
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "5887e3a81cbed593180f9761cb1c855a5c0be80c"
+                "reference": "a86e7a3916c48ac9d29bb13bdb15c1cf122800c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/5887e3a81cbed593180f9761cb1c855a5c0be80c",
-                "reference": "5887e3a81cbed593180f9761cb1c855a5c0be80c",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/a86e7a3916c48ac9d29bb13bdb15c1cf122800c1",
+                "reference": "a86e7a3916c48ac9d29bb13bdb15c1cf122800c1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.8"
+                "wp-php-toolkit/bytestream": "^0.8.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -238,11 +238,11 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:36+00:00"
+            "time": "2026-05-27T22:01:51+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
@@ -299,23 +299,23 @@
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "7d3b83e4af8a5740f3f290bf1c641767e716b1cc"
+                "reference": "4574ed51c15882190b46aee5564910bf4429f3c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/7d3b83e4af8a5740f3f290bf1c641767e716b1cc",
-                "reference": "7d3b83e4af8a5740f3f290bf1c641767e716b1cc",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/4574ed51c15882190b46aee5564910bf4429f3c0",
+                "reference": "4574ed51c15882190b46aee5564910bf4429f3c0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.8",
-                "wp-php-toolkit/data-liberation": "^0.8",
-                "wp-php-toolkit/filesystem": "^0.8"
+                "wp-php-toolkit/bytestream": "^0.8.1",
+                "wp-php-toolkit/data-liberation": "^0.8.1",
+                "wp-php-toolkit/filesystem": "^0.8.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -354,15 +354,15 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:36+00:00"
+            "time": "2026-05-27T22:01:51+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-upload-endpoints-next",
+            "version": "dev-f26d/exporter-php-72-support",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
+                "reference": "20a5cb0a822b98cafe39173c563a28ab9267786c"
             },
             "require": {
                 "php": ">=7.2",
@@ -406,7 +406,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "dev-a87e2773f3b6375f2d6c44ec6f9eb16a3a4561f4",
+            "version": "dev-f26d/exporter-php-72-support",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-importer",
@@ -435,21 +435,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "02ebcc706b1639751380a6501a7ec05431329865"
+                "reference": "a6b49175d5bab2e76816dd7bf514b81f51cc1109"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/02ebcc706b1639751380a6501a7ec05431329865",
-                "reference": "02ebcc706b1639751380a6501a7ec05431329865",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/a6b49175d5bab2e76816dd7bf514b81f51cc1109",
+                "reference": "a6b49175d5bab2e76816dd7bf514b81f51cc1109",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.8"
+                "wp-php-toolkit/encoding": "^0.8.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -488,22 +488,22 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:36+00:00"
+            "time": "2026-05-27T22:01:51+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -586,7 +586,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -650,20 +650,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -702,9 +701,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1437,24 +1436,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.63",
+            "version": "10.5.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
-                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -1518,31 +1517,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:48:37+00:00"
+            "time": "2026-07-06T14:50:35+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -365,7 +365,7 @@
                 "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=7.2",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
             },
@@ -385,6 +385,7 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-staged-artifacts.php",
+                    "src/class-staged-push-stream-protocol.php",
                     "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.2",
         "wp-php-toolkit/data-liberation": "^0.8.0",
         "wp-php-toolkit/html": "^0.8.0"
     },

--- a/packages/reprint-exporter/src/class-file-tree-producer.php
+++ b/packages/reprint-exporter/src/class-file-tree-producer.php
@@ -7,25 +7,35 @@
  */
 class FileTreeProducer
 {
-    public const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
+    const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
 
     const PHASE_STREAMING = "streaming";
     const PHASE_FINISHED = "finished";
 
-    private array $directories;
-    private int $chunk_size;
-    private bool $index_only;
-    private ?string $filesystem_root;
+    /** @var array */
+    private $directories;
+    /** @var int */
+    private $chunk_size;
+    /** @var bool */
+    private $index_only;
+    /** @var string|null */
+    private $filesystem_root;
 
-    private string $phase;
-    private ?array $current_chunk = null;
+    /** @var string */
+    private $phase;
+    /** @var array|null */
+    private $current_chunk = null;
 
     /** Explicit list of paths to stream, sorted on first use. */
-    private array $paths;
-    private bool $paths_sorted = false;
-    private bool $paths_positioned = false;
+    /** @var array */
+    private $paths;
+    /** @var bool */
+    private $paths_sorted = false;
+    /** @var bool */
+    private $paths_positioned = false;
     /** Ephemeral index into $paths; NOT stored in cursor. */
-    private int $paths_position = 0;
+    /** @var int */
+    private $paths_position = 0;
 
     /** State for the file currently being streamed in chunks. */
     private $streaming_file_handle = null;
@@ -37,12 +47,16 @@ class FileTreeProducer
             $this->streaming_file_handle = null;
         }
     }
-    private int $streaming_file_offset = 0;
-    private ?array $current_file_meta = null;
+    /** @var int */
+    private $streaming_file_offset = 0;
+    /** @var array|null */
+    private $current_file_meta = null;
 
     /** Tracks the last emitted path for cursor generation. */
-    private ?string $last_emitted_path = null;
-    private ?int $last_emitted_ctime = null;
+    /** @var string|null */
+    private $last_emitted_path = null;
+    /** @var int|null */
+    private $last_emitted_ctime = null;
 
     /**
      * @param string|array $directories Root directories to scan.
@@ -61,7 +75,7 @@ class FileTreeProducer
 
         if (!isset($options["paths"]) || !is_array($options["paths"])) {
             throw new InvalidArgumentException(
-                "The 'paths' option is required and must be an array",
+                "The 'paths' option is required and must be an array"
             );
         }
         $this->paths = $options["paths"];
@@ -111,7 +125,7 @@ class FileTreeProducer
         $cursor = json_decode($cursor_json, true);
         if ($cursor === null && json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidArgumentException(
-                "Invalid cursor format: " . json_last_error_msg(),
+                "Invalid cursor format: " . json_last_error_msg()
             );
         }
 
@@ -170,7 +184,9 @@ class FileTreeProducer
         if (is_string($directories)) {
             return [rtrim($directories, "/")];
         }
-        return array_map(fn($d) => rtrim($d, "/"), $directories);
+        return array_map(function ($d) {
+            return rtrim($d, "/");
+        }, $directories);
     }
 
     /**
@@ -266,7 +282,7 @@ class FileTreeProducer
             if ($this->last_emitted_path !== null) {
                 $this->paths_position = $this->binary_search_next(
                     $this->paths,
-                    $this->last_emitted_path,
+                    $this->last_emitted_path
                 );
             } else {
                 $this->paths_position = 0;
@@ -413,7 +429,7 @@ class FileTreeProducer
             if ($this->streaming_file_offset > 0) {
                 $seek_result = fseek(
                     $this->streaming_file_handle,
-                    $this->streaming_file_offset,
+                    $this->streaming_file_offset
                 );
                 if ($seek_result === -1) {
                     fclose($this->streaming_file_handle);

--- a/packages/reprint-exporter/src/class-mysql-dump-producer.php
+++ b/packages/reprint-exporter/src/class-mysql-dump-producer.php
@@ -316,7 +316,7 @@ class MySQLDumpProducer
                 $this->current_result_set = $this->db->query($query);
             } catch (\PDOException $e) {
                 throw new \RuntimeException(
-                    "Database query `{$query}` failed for table " . $this->quote_identifier($this->current_table) . ": " . $e->getMessage(),
+                    "Database query `{$query}` failed for table " . $this->quote_identifier($this->current_table) . ": " . $e->getMessage()
                 );
             }
             $this->rows_fetched_from_current_query = 0;
@@ -384,7 +384,7 @@ class MySQLDumpProducer
             ",",
             array_map(function ($col) {
                 return $this->quote_identifier($col);
-            }, $this->current_column_names),
+            }, $this->current_column_names)
         );
 
         $header = "INSERT INTO " . $this->quote_identifier($this->current_table) . " ({$column_list}) VALUES\n";
@@ -488,7 +488,7 @@ class MySQLDumpProducer
             $row = $result->fetch(PDO::FETCH_ASSOC);
         } catch (\PDOException $e) {
             throw new \RuntimeException(
-                "Failed to get CREATE TABLE for {$quoted_table}: " . $e->getMessage() . " Query: {$query}",
+                "Failed to get CREATE TABLE for {$quoted_table}: " . $e->getMessage() . " Query: {$query}"
             );
         }
 
@@ -716,7 +716,7 @@ class MySQLDumpProducer
             $current_condition_parts[] = $this->build_comparison(
                 $col,
                 $value,
-                ">",
+                ">"
             );
             $conditions[] =
                 "(" . implode(" AND ", $current_condition_parts) . ")";
@@ -762,7 +762,7 @@ class MySQLDumpProducer
             $stmt->execute([$db_name, $table]);
         } catch (\PDOException $e) {
             throw new \RuntimeException(
-                "Failed to get primary key columns for " . $this->quote_identifier($table) . ": " . $e->getMessage() . " Query: {$query}",
+                "Failed to get primary key columns for " . $this->quote_identifier($table) . ": " . $e->getMessage() . " Query: {$query}"
             );
         }
 
@@ -788,12 +788,12 @@ class MySQLDumpProducer
 
         if ($this->current_table) {
             $this->current_pk_columns = $this->get_primary_key_columns(
-                $this->current_table,
+                $this->current_table
             );
             $this->last_pk_values = null;
             $this->current_offset = 0;
             $this->current_column_types = $this->get_column_types(
-                $this->current_table,
+                $this->current_table
             );
             $this->current_column_names = null;
             $this->current_row = null;
@@ -824,7 +824,7 @@ class MySQLDumpProducer
              FROM INFORMATION_SCHEMA.TABLES
              WHERE TABLE_SCHEMA = ?
                AND TABLE_TYPE = 'BASE TABLE'
-             ORDER BY TABLE_NAME",
+             ORDER BY TABLE_NAME"
         );
         $stmt->execute([$db_name]);
 
@@ -869,7 +869,7 @@ class MySQLDumpProducer
         ]);
         if ($json === false) {
             throw new \RuntimeException(
-                "Failed to encode reentrancy cursor: " . json_last_error_msg(),
+                "Failed to encode reentrancy cursor: " . json_last_error_msg()
             );
         }
         return $json;
@@ -1033,7 +1033,7 @@ class MySQLDumpProducer
 
             if ($this->current_table) {
                 $this->current_column_types = $this->get_column_types(
-                    $this->current_table,
+                    $this->current_table
                 );
                 if (empty($this->current_column_types)) {
                     throw new \RuntimeException(
@@ -1060,12 +1060,12 @@ class MySQLDumpProducer
                  FROM INFORMATION_SCHEMA.COLUMNS
                  WHERE TABLE_SCHEMA = ?
                    AND TABLE_NAME = ?
-                 ORDER BY ORDINAL_POSITION',
+                 ORDER BY ORDINAL_POSITION'
             );
             $stmt->execute([$database_name, $table_name]);
         } catch (\PDOException $e) {
             throw new \RuntimeException(
-                "Failed to get column types for " . $this->quote_identifier($table_name) . ": " . $e->getMessage(),
+                "Failed to get column types for " . $this->quote_identifier($table_name) . ": " . $e->getMessage()
             );
         }
 
@@ -1444,7 +1444,7 @@ class MySQLDumpProducer
         $chunk = $this->fetch_value_substring_from_the_current_oversized_row(
             $column,
             $byte_offset + 1,
-            $chunk_size,
+            $chunk_size
         );
 
         $formatted_chunk = $this->format_value($chunk, $data_type);

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -154,7 +154,7 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
 
     if ($require_headers && !$can_send_headers) {
         throw new RuntimeException(
-            "Cannot begin multipart stream: headers already sent",
+            "Cannot begin multipart stream: headers already sent"
         );
     }
 
@@ -221,7 +221,7 @@ function resolve_db_credentials(): array
         throw new InvalidArgumentException(
             "Database credentials not found. Please provide via environment variables, " .
                 "PHP constants, or ensure wp-config.php exists with valid credentials. " .
-                "Missing: " . implode(", ", $missing),
+                "Missing: " . implode(", ", $missing)
         );
     }
 
@@ -288,7 +288,7 @@ function create_db_connection(array $creds, array $options = [])
         "mysql:host={$creds['db_host']};dbname={$creds['db_name']};charset=utf8mb4",
         $creds["db_user"],
         $creds["db_password"],
-        $merged_options,
+        $merged_options
     );
 }
 
@@ -433,7 +433,7 @@ set_error_handler(function ($errno, $errstr, $errfile, $errline) {
         emit_error_chunk(
             $streaming_context['gz'],
             $streaming_context['boundary'],
-            "PHP Error ({$errno}): {$errstr} in {$errfile}:{$errline}",
+            "PHP Error ({$errno}): {$errstr} in {$errfile}:{$errline}"
         );
         return true;
     }
@@ -460,7 +460,7 @@ set_exception_handler(function ($e) {
         emit_error_chunk(
             $streaming_context['gz'],
             $streaming_context['boundary'],
-            get_class($e) . ": " . $e->getMessage(),
+            get_class($e) . ": " . $e->getMessage()
         );
         return;
     }
@@ -495,7 +495,7 @@ register_shutdown_function(function () {
             emit_error_chunk(
                 $streaming_context['gz'],
                 $streaming_context['boundary'],
-                $message,
+                $message
             );
         } catch (Throwable $ignored) {
             // Stream is too broken to write to — nothing more we can do.
@@ -607,7 +607,8 @@ function prepare_streaming_response(): void
 class GzipOutputStream
 {
     private $deflate_ctx;
-    private bool $enabled = true;
+    /** @var bool */
+    private $enabled = true;
 
     public function __construct(bool $enabled = true)
     {
@@ -616,7 +617,7 @@ class GzipOutputStream
             $this->deflate_ctx = deflate_init(ZLIB_ENCODING_GZIP, ["level" => 6]);
             if ($this->deflate_ctx === false) {
                 throw new \RuntimeException(
-                    "deflate_init() failed — zlib may be misconfigured",
+                    "deflate_init() failed — zlib may be misconfigured"
                 );
             }
             if (!headers_sent()) {
@@ -646,7 +647,7 @@ class GzipOutputStream
         $compressed = deflate_add(
             $this->deflate_ctx,
             $data,
-            ZLIB_NO_FLUSH,
+            ZLIB_NO_FLUSH
         );
         if ($compressed === false) {
             throw new \RuntimeException("deflate_add() failed during gzip write");
@@ -668,7 +669,7 @@ class GzipOutputStream
         $compressed = deflate_add(
             $this->deflate_ctx,
             "",
-            ZLIB_SYNC_FLUSH,
+            ZLIB_SYNC_FLUSH
         );
         if ($compressed === false) {
             throw new \RuntimeException("deflate_add() failed during gzip sync");
@@ -788,7 +789,7 @@ function endpoint_sql_chunk(
         "fragments_per_batch",
         (int) $fragments_per_batch,
         1,
-        10000,
+        10000
     );
 
     $pdo_options = [];
@@ -824,7 +825,7 @@ function endpoint_sql_chunk(
             if ($server_statement_size !== null) {
                 $producer_options["max_statement_size"] = min(
                     $client_statement_size,
-                    $server_statement_size,
+                    $server_statement_size
                 );
             } else {
                 $producer_options["max_statement_size"] = $client_statement_size;
@@ -838,7 +839,7 @@ function endpoint_sql_chunk(
             "db_query_time_limit",
             (int) $config["db_query_time_limit"],
             0,
-            300_000,
+            300000
         );
         $query_time_limit = min($query_time_limit, $execution_budget_ms);
         if ($query_time_limit > 0) {
@@ -857,7 +858,7 @@ function endpoint_sql_chunk(
 
     $reader = new WordPress\DataLiberation\MySQLDumpProducer(
         $mysql,
-        $producer_options,
+        $producer_options
     );
 
     if (ob_get_level()) {
@@ -928,7 +929,7 @@ function endpoint_sql_chunk(
                 "X-Chunk-Type: sql\r\n" .
                 "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
                 "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                "\r\n",
+                "\r\n"
             );
             $gz->write($sql);
             $gz->write("\r\n");
@@ -969,7 +970,7 @@ function endpoint_sql_chunk(
             "X-Time-Elapsed: " . (microtime(true) - $budget->start_time) . "\r\n" .
             "\r\n" .
             "\r\n" .
-            "--{$boundary}--\r\n",
+            "--{$boundary}--\r\n"
         );
         $gz->finish();
     } catch (\Throwable $e) {
@@ -1003,7 +1004,7 @@ function endpoint_db_index(
         "tables_per_batch",
         (int) $tables_per_batch,
         10,
-        10000,
+        10000
     );
 
     $cursor = null;
@@ -1011,7 +1012,7 @@ function endpoint_db_index(
         $cursor = json_decode($config["cursor"], true);
         if ($cursor === null && json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidArgumentException(
-                "Invalid cursor format: " . json_last_error_msg(),
+                "Invalid cursor format: " . json_last_error_msg()
             );
         }
     }
@@ -1089,7 +1090,7 @@ function endpoint_db_index(
                 "X-Tables: " . count($tables) . "\r\n" .
                 "X-Cursor: " . base64_encode($cursor_json) . "\r\n" .
                 "\r\n" .
-                $payload . "\r\n",
+                $payload . "\r\n"
             );
             $gz->sync();
 
@@ -1117,7 +1118,7 @@ function endpoint_db_index(
             "X-Time-Elapsed: " . (microtime(true) - $budget->start_time) . "\r\n" .
             "\r\n" .
             "\r\n" .
-            "--{$boundary}--\r\n",
+            "--{$boundary}--\r\n"
         );
         $gz->finish();
     } catch (\Throwable $e) {
@@ -1143,7 +1144,7 @@ function resolve_directories(array $config): array
     $directories_input = $config["directory"] ?? null;
     if (!$directories_input) {
         throw new InvalidArgumentException(
-            "directory is required for files operation",
+            "directory is required for files operation"
         );
     }
 
@@ -1155,7 +1156,7 @@ function resolve_directories(array $config): array
     foreach ($dir_list as $directory) {
         if (!is_string($directory)) {
             throw new InvalidArgumentException(
-                "directory entries must be non-empty strings",
+                "directory entries must be non-empty strings"
             );
         }
         $directory = trim($directory);
@@ -1239,7 +1240,9 @@ function endpoint_preflight(array $config): array
                     : null,
                 __DIR__,
             ],
-            fn($value) => $value !== null && $value !== "",
+            function ($value) {
+                return $value !== null && $value !== "";
+            }
         );
         $search_roots = normalize_path_list($filtered);
     }
@@ -1275,7 +1278,7 @@ function endpoint_preflight(array $config): array
     $scan_roots = normalize_path_list($scan_roots);
 
     $wp_scan_roots = normalize_path_list(
-        array_merge($scan_roots, $detected_root_paths),
+        array_merge($scan_roots, $detected_root_paths)
     );
 
     // -- Probe each directory --
@@ -1371,9 +1374,11 @@ function endpoint_preflight(array $config): array
 
     $wp_paths = normalize_path_list(
         array_map(
-            fn($entry) => $entry["root"] ?? null,
-            $wp_paths,
-        ),
+            function ($entry) {
+                return $entry["root"] ?? null;
+            },
+            $wp_paths
+        )
     );
     $wp_paths = array_map(function ($root) {
         $root = rtrim($root, "/");
@@ -1565,7 +1570,7 @@ function endpoint_preflight(array $config): array
                             "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " .
                                 "WHERE TABLE_SCHEMA = DATABASE() " .
                                 "AND TABLE_NAME LIKE '%\\_options' ESCAPE '\\\\' " .
-                                "LIMIT 5",
+                                "LIMIT 5"
                         );
                         if ($stmt !== false) {
                             $names = $stmt->fetchAll(PDO::FETCH_COLUMN);
@@ -1581,7 +1586,7 @@ function endpoint_preflight(array $config): array
                                     $table_prefix = substr(
                                         $name,
                                         0,
-                                        -strlen($suffix),
+                                        -strlen($suffix)
                                     );
                                     break;
                                 }
@@ -1749,7 +1754,7 @@ function endpoint_preflight(array $config): array
                             function_exists("get_site_option")
                         ) {
                             $db["wp"]["active_sitewide_plugins"] = get_site_option(
-                                "active_sitewide_plugins",
+                                "active_sitewide_plugins"
                             );
                         }
 
@@ -1897,7 +1902,7 @@ function endpoint_preflight(array $config): array
                                 "@@collation_connection AS connection_collation, " .
                                 "@@max_allowed_packet AS max_allowed_packet, " .
                                 "@@sql_mode AS sql_mode, " .
-                                "@@lower_case_table_names AS lower_case_table_names",
+                                "@@lower_case_table_names AS lower_case_table_names"
                         )
                         ->fetch(PDO::FETCH_ASSOC);
                     if (is_array($vars)) {
@@ -1912,7 +1917,7 @@ function endpoint_preflight(array $config): array
                             : null;
                         $db["sql_mode"] = $vars["sql_mode"] ?? null;
                         $db["lower_case_table_names"] = isset(
-                            $vars["lower_case_table_names"],
+                            $vars["lower_case_table_names"]
                         )
                             ? (int) $vars["lower_case_table_names"]
                             : null;
@@ -1925,7 +1930,7 @@ function endpoint_preflight(array $config): array
                 try {
                     $stmt = $mysql->query(
                         "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " .
-                            "WHERE TABLE_SCHEMA = DATABASE() LIMIT 1",
+                            "WHERE TABLE_SCHEMA = DATABASE() LIMIT 1"
                     );
                     if ($stmt !== false) {
                         $stmt->fetchColumn();
@@ -2019,7 +2024,9 @@ function endpoint_preflight(array $config): array
             }
             usort(
                 $root_entry["plugins"],
-                fn($a, $b) => strcmp($a["name"], $b["name"]),
+                function ($a, $b) {
+                    return strcmp($a["name"], $b["name"]);
+                }
             );
         }
 
@@ -2038,7 +2045,9 @@ function endpoint_preflight(array $config): array
             }
             usort(
                 $root_entry["mu_plugins"],
-                fn($a, $b) => strcmp($a["name"], $b["name"]),
+                function ($a, $b) {
+                    return strcmp($a["name"], $b["name"]);
+                }
             );
         }
 
@@ -2138,7 +2147,7 @@ function endpoint_preflight(array $config): array
             // importer can use their presence as a webhost detection signal.
             "env_names" => array_values(array_unique(array_merge(
                 array_keys($_ENV),
-                array_keys(getenv()),
+                array_keys(getenv())
             ))),
             '$_SERVER_names' => array_keys($_SERVER),
         ],
@@ -2216,7 +2225,7 @@ function stream_file_producer(
             "X-Chunk-Type: progress\r\n" .
             "X-Cursor: " . base64_encode($initial_cursor) . "\r\n" .
             "\r\n" .
-            $initial_progress_json . "\r\n",
+            $initial_progress_json . "\r\n"
         );
         $gz->sync();
         while (true) {
@@ -2248,7 +2257,7 @@ function stream_file_producer(
                     "X-Chunk-Type: metadata\r\n" .
                     "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
                     "\r\n" .
-                    $metadata_json . "\r\n",
+                    $metadata_json . "\r\n"
                 );
                 $gz->sync();
 
@@ -2269,7 +2278,7 @@ function stream_file_producer(
                         "X-Chunk-Type: progress\r\n" .
                         "X-Cursor: " . base64_encode($cursor) . "\r\n" .
                         "\r\n" .
-                        $progress_json . "\r\n",
+                        $progress_json . "\r\n"
                     );
                     $gz->sync();
 
@@ -2306,7 +2315,7 @@ function stream_file_producer(
                     "X-Symlink-Path: " . base64_encode($chunk["path"]) . "\r\n" .
                     "X-Symlink-Target: " . base64_encode($chunk["target"]) . "\r\n" .
                     "X-Symlink-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "\r\n\r\n",
+                    "\r\n\r\n"
                 );
                 $gz->sync();
             } elseif ($chunk_type === "index") {
@@ -2319,7 +2328,7 @@ function stream_file_producer(
                     "X-Index-Path: " . base64_encode($chunk["path"]) . "\r\n" .
                     "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
                     "X-File-Size: " . $chunk["size"] . "\r\n" .
-                    "\r\n\r\n",
+                    "\r\n\r\n"
                 );
                 $gz->sync();
             } elseif ($chunk_type === "missing") {
@@ -2330,7 +2339,7 @@ function stream_file_producer(
                     "X-Chunk-Type: missing\r\n" .
                     "X-Cursor: " . base64_encode($cursor) . "\r\n" .
                     "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "\r\n\r\n",
+                    "\r\n\r\n"
                 );
                 $gz->sync();
             } elseif ($chunk_type === "error") {
@@ -2353,7 +2362,7 @@ function stream_file_producer(
                     "X-Chunk-Type: error\r\n" .
                     "X-Cursor: " . base64_encode($cursor) . "\r\n" .
                     "\r\n" .
-                    $json . "\r\n",
+                    $json . "\r\n"
                 );
                 $gz->sync();
             } else {
@@ -2426,7 +2435,7 @@ function stream_file_producer(
                 "X-Chunk-Type: error\r\n" .
                 "X-Cursor: " . base64_encode($last_cursor) . "\r\n" .
                 "\r\n" .
-                $json . "\r\n",
+                $json . "\r\n"
             );
             $gz->sync();
         }
@@ -2443,7 +2452,7 @@ function stream_file_producer(
 
         error_log(
             "Export completion: status={$status}, phase={$progress["phase"]}, " .
-                "chunks={$chunks_processed}, files={$files_completed}, bytes={$bytes_processed}",
+                "chunks={$chunks_processed}, files={$files_completed}, bytes={$bytes_processed}"
         );
 
         $gz->write(
@@ -2460,7 +2469,7 @@ function stream_file_producer(
             "X-Time-Elapsed: " . (microtime(true) - $budget->start_time) . "\r\n" .
             "\r\n" .
             "\r\n" .
-            "--{$boundary}--\r\n",
+            "--{$boundary}--\r\n"
         );
         $gz->finish();
     } catch (\Throwable $e) {
@@ -2717,7 +2726,7 @@ function endpoint_file_index(
         "batch_size",
         (int) $batch_size,
         100,
-        100000,
+        100000
     );
 
     $list_dir = $config["list_dir"] ?? null;
@@ -2805,7 +2814,7 @@ function endpoint_file_index(
         $list_dir_real = realpath($list_dir);
         if ($list_dir_real === false || !is_dir($list_dir_real)) {
             throw new InvalidArgumentException(
-                "list_dir does not exist or is not accessible: {$list_dir}",
+                "list_dir does not exist or is not accessible: {$list_dir}"
             );
         }
 
@@ -2824,7 +2833,7 @@ function endpoint_file_index(
         // via HMAC, so there is no untrusted-input risk.
         if (!$allowed && !$follow_symlinks) {
             throw new InvalidArgumentException(
-                "list_dir is outside of allowed roots: {$list_dir_real}",
+                "list_dir is outside of allowed roots: {$list_dir_real}"
             );
         }
 
@@ -2920,7 +2929,7 @@ function endpoint_file_index(
             "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
             "X-Index-Dir: " . base64_encode($list_dir_real ?? "") . "\r\n" .
             "\r\n" .
-            $metadata_json . "\r\n",
+            $metadata_json . "\r\n"
         );
         $gz->sync();
         $stop = false;
@@ -2948,7 +2957,7 @@ function endpoint_file_index(
                 $json = json_encode_or_throw($abort_payload);
                 $cursor_json = json_encode_or_throw(
                     ["stack" => encode_index_stack($stack)],
-                    JSON_UNESCAPED_SLASHES,
+                    JSON_UNESCAPED_SLASHES
                 );
                 $cursor_b64 = base64_encode($cursor_json);
                 $gz->write(
@@ -2958,7 +2967,7 @@ function endpoint_file_index(
                     "X-Chunk-Type: error\r\n" .
                     "X-Cursor: " . $cursor_b64 . "\r\n" .
                     "\r\n" .
-                    $json . "\r\n",
+                    $json . "\r\n"
                 );
                 $gz->sync();
                 $abort_payload = null;
@@ -2987,7 +2996,7 @@ function endpoint_file_index(
                 $json = json_encode_or_throw($abort_payload);
                 $cursor_json = json_encode_or_throw(
                     ["stack" => encode_index_stack($stack)],
-                    JSON_UNESCAPED_SLASHES,
+                    JSON_UNESCAPED_SLASHES
                 );
                 $cursor_b64 = base64_encode($cursor_json);
                 $gz->write(
@@ -2997,7 +3006,7 @@ function endpoint_file_index(
                     "X-Chunk-Type: error\r\n" .
                     "X-Cursor: " . $cursor_b64 . "\r\n" .
                     "\r\n" .
-                    $json . "\r\n",
+                    $json . "\r\n"
                 );
                 $gz->sync();
                 $abort_payload = null;
@@ -3025,7 +3034,7 @@ function endpoint_file_index(
                 $json = json_encode_or_throw($abort_payload);
                 $cursor_json = json_encode_or_throw(
                     ["stack" => encode_index_stack($stack)],
-                    JSON_UNESCAPED_SLASHES,
+                    JSON_UNESCAPED_SLASHES
                 );
                 $cursor_b64 = base64_encode($cursor_json);
                 $gz->write(
@@ -3035,7 +3044,7 @@ function endpoint_file_index(
                     "X-Chunk-Type: error\r\n" .
                     "X-Cursor: " . $cursor_b64 . "\r\n" .
                     "\r\n" .
-                    $json . "\r\n",
+                    $json . "\r\n"
                 );
                 $gz->sync();
                 $abort_payload = null;
@@ -3139,12 +3148,12 @@ function endpoint_file_index(
 
                     $cursor_json = json_encode_or_throw(
                         ["stack" => encode_index_stack($stack)],
-                        JSON_UNESCAPED_SLASHES,
+                        JSON_UNESCAPED_SLASHES
                     );
                     $cursor_b64 = base64_encode($cursor_json);
                     $json = json_encode_or_throw(
                         encode_index_batch($batch_items),
-                        JSON_UNESCAPED_SLASHES,
+                        JSON_UNESCAPED_SLASHES
                     );
 
                     $gz->write(
@@ -3154,7 +3163,7 @@ function endpoint_file_index(
                         "X-Chunk-Type: index_batch\r\n" .
                         "X-Cursor: " . $cursor_b64 . "\r\n" .
                         "X-Batch-Size: " . count($batch_items) . "\r\n" .
-                        "\r\n",
+                        "\r\n"
                     );
                     $gz->write($json);
                     $gz->write("\r\n");
@@ -3215,12 +3224,12 @@ function endpoint_file_index(
     if (!empty($batch_items)) {
         $cursor_json = json_encode_or_throw(
             ["stack" => encode_index_stack($stack)],
-            JSON_UNESCAPED_SLASHES,
+            JSON_UNESCAPED_SLASHES
         );
         $cursor_b64 = base64_encode($cursor_json);
         $json = json_encode_or_throw(
             encode_index_batch($batch_items),
-            JSON_UNESCAPED_SLASHES,
+            JSON_UNESCAPED_SLASHES
         );
 
         $gz->write(
@@ -3230,7 +3239,7 @@ function endpoint_file_index(
             "X-Chunk-Type: index_batch\r\n" .
             "X-Cursor: " . $cursor_b64 . "\r\n" .
             "X-Batch-Size: " . count($batch_items) . "\r\n" .
-            "\r\n",
+            "\r\n"
         );
         $gz->write($json);
         $gz->write("\r\n");
@@ -3245,7 +3254,7 @@ function endpoint_file_index(
             $json = json_encode_or_throw($abort_payload);
             $cursor_json = json_encode_or_throw(
                 ["stack" => encode_index_stack($stack)],
-                JSON_UNESCAPED_SLASHES,
+                JSON_UNESCAPED_SLASHES
             );
             $cursor_b64 = base64_encode($cursor_json);
             $gz->write(
@@ -3255,7 +3264,7 @@ function endpoint_file_index(
                 "X-Chunk-Type: error\r\n" .
                 "X-Cursor: " . $cursor_b64 . "\r\n" .
                 "\r\n" .
-                $json . "\r\n",
+                $json . "\r\n"
             );
             $gz->sync();
             $status = "partial";
@@ -3263,7 +3272,7 @@ function endpoint_file_index(
 
         $cursor_json = json_encode_or_throw(
             ["stack" => encode_index_stack($stack)],
-            JSON_UNESCAPED_SLASHES,
+            JSON_UNESCAPED_SLASHES
         );
         $cursor_b64 = base64_encode($cursor_json);
 
@@ -3282,7 +3291,7 @@ function endpoint_file_index(
             "X-Time-Elapsed: " . (microtime(true) - $budget->start_time) . "\r\n" .
             "\r\n" .
             "\r\n" .
-            "--{$boundary}--\r\n",
+            "--{$boundary}--\r\n"
         );
         $gz->finish();
     } catch (\Throwable $e) {
@@ -3318,7 +3327,7 @@ function endpoint_file_fetch(
         $tmp_name = $_FILES["file_list"]["tmp_name"] ?? "";
         if ($tmp_name === "" || !is_uploaded_file($tmp_name)) {
             throw new InvalidArgumentException(
-                "file_list upload missing or invalid",
+                "file_list upload missing or invalid"
             );
         }
         $list_path = $tmp_name;
@@ -3326,7 +3335,7 @@ function endpoint_file_fetch(
 
     if ($list_path === null) {
         throw new InvalidArgumentException(
-            "file_list is required for file_fetch endpoint",
+            "file_list is required for file_fetch endpoint"
         );
     }
 
@@ -3337,7 +3346,7 @@ function endpoint_file_fetch(
     $decoded = json_decode($raw, true);
     if (!is_array($decoded)) {
         throw new InvalidArgumentException(
-            "file_list must be a JSON array of paths",
+            "file_list must be a JSON array of paths"
         );
     }
     $paths = [];
@@ -3353,7 +3362,7 @@ function endpoint_file_fetch(
         "chunk_size",
         (int) $chunk_size,
         16 * 1024,
-        32 * 1024 * 1024,
+        32 * 1024 * 1024
     );
 
     $sync_options = [
@@ -3369,7 +3378,7 @@ function endpoint_file_fetch(
         $producer,
         $budget,
         $config,
-        file_fetch_paths_should_gzip($paths),
+        file_fetch_paths_should_gzip($paths)
     );
 }
 
@@ -3756,7 +3765,7 @@ function require_int_range(
 ): int {
     if ($value < $min || $value > $max) {
         throw new InvalidArgumentException(
-            "{$name} out of range. Expected {$min}-{$max}, got {$value}",
+            "{$name} out of range. Expected {$min}-{$max}, got {$value}"
         );
     }
     return $value;
@@ -3773,7 +3782,7 @@ function require_float_range(
 ): float {
     if ($value < $min || $value > $max) {
         throw new InvalidArgumentException(
-            "{$name} out of range. Expected {$min}-{$max}, got {$value}",
+            "{$name} out of range. Expected {$min}-{$max}, got {$value}"
         );
     }
     return $value;

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -130,7 +130,7 @@ function parse_size(string $value): int
     $value = trim($value);
     if (!preg_match('/^(\d+(?:\.\d+)?)\s*([KMGkmg])?[Bb]?$/', $value, $m)) {
         throw new InvalidArgumentException(
-            "Invalid size value: '{$value}'. Use a number optionally followed by K, M, or G (e.g. 64M).",
+            "Invalid size value: '{$value}'. Use a number optionally followed by K, M, or G (e.g. 64M)."
         );
     }
     $num = (float) $m[1];
@@ -218,7 +218,7 @@ function assert_valid_path(string $path, string $label = "path"): void
     foreach (explode("/", $path) as $segment) {
         if ($segment === "." || $segment === "..") {
             throw new InvalidArgumentException(
-                "{$label} must not contain dot-segments (. or ..): {$path}",
+                "{$label} must not contain dot-segments (. or ..): {$path}"
             );
         }
     }

--- a/packages/reprint-importer/src/lib/target-runtime/functions.php
+++ b/packages/reprint-importer/src/lib/target-runtime/functions.php
@@ -245,6 +245,7 @@ function ensure_sqlite_plugin_database_driver(string $source_dir, string $target
         return;
     }
 
+    // phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.sqliteRemoved -- user-defined helper, not the removed sqlite extension.
     $source_database_dir = sqlite_plugin_database_driver_source($source_dir);
     remove_sqlite_runtime_path_recursive($target_database_dir);
     copy_directory_recursive($source_database_dir, $target_database_dir);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,11 +41,6 @@ parameters:
 			path: packages/reprint-exporter/src/export.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
-			count: 1
-			path: packages/reprint-exporter/src/class-file-tree-producer.php
-
-		-
 			message: "#^Function _doing_it_wrong not found\\.$#"
 			count: 1
 			path: packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php

--- a/tests/e2e/setup.sh
+++ b/tests/e2e/setup.sh
@@ -3,12 +3,15 @@ set -euo pipefail
 
 # Install Composer dependencies (vendor/ is gitignored).
 # Needed for the importer package and the bundled plugin runtime.
+#
+# --ignore-platform-req=php: packages declare php >=7.4, but the exporter is
+# tested on 7.2. No-op on >=7.4.
 PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 if command -v composer &>/dev/null && [ -f "$PROJECT_ROOT/composer.json" ]; then
-    composer install --no-dev --no-interaction --prefer-dist --working-dir="$PROJECT_ROOT"
+    composer install --no-dev --no-interaction --prefer-dist --ignore-platform-req=php --working-dir="$PROJECT_ROOT"
 fi
 if command -v composer &>/dev/null && [ -f "$PROJECT_ROOT/reprint-exporter-wp/composer.json" ]; then
-    composer install --no-dev --no-interaction --prefer-dist --working-dir="$PROJECT_ROOT/reprint-exporter-wp"
+    composer install --no-dev --no-interaction --prefer-dist --ignore-platform-req=php --working-dir="$PROJECT_ROOT/reprint-exporter-wp"
 fi
 
 # JavaScript dependencies are installed by the dedicated workflow step after

--- a/tests/e2e/setup.sh
+++ b/tests/e2e/setup.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 # Install Composer dependencies (vendor/ is gitignored).
 # Needed for the importer package and the bundled plugin runtime.
 #
-# --ignore-platform-req=php: packages declare php >=7.4, but the exporter is
-# tested on 7.2. No-op on >=7.4.
+# `--ignore-platform-req=php` avoids `composer install` errors on PHP 7.2
 PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 if command -v composer &>/dev/null && [ -f "$PROJECT_ROOT/composer.json" ]; then
     composer install --no-dev --no-interaction --prefer-dist --ignore-platform-req=php --working-dir="$PROJECT_ROOT"


### PR DESCRIPTION
### Background

Our initial strategy for shipping the Reprint exporter to Pressable sites is to include it in the stock Jetpack plugin. The Reprint exporter already lives in wpcomsh (which is part of Jetpack), so the tactic is:

1. Duplicate that implementation in the regular Jetpack plugin, gating the Reprint exporter feature to Pressable and WoA sites.
2. After deploying that change, update the Reprint client to use the new Jetpack API URLs to interact with the Reprint exporter.
3. Remove the wpcomsh Reprint exporter implementation from the Jetpack repo.

One obvious concern here is, "Is it really good UX to deploy this through Jetpack?" The answer is that we are doing this to support Studio sync, which already depends on Jetpack for Pressable sites to work, and Jetpack also gives us auth. Long-term, it is very likely there'll be a standalone Reprint exporter plugin, just not to begin with.

### What is this PR?

The standard Jetpack plugin supports PHP 7.2. To be able to include the Reprint exporter there, we need to update the Reprint exporter code to work with PHP 7.2 This PR does just that.

The client is not affected. You can still use newer PHP syntax and features there.

### Testing instructions 

CI should pass