### PR TITLE
[Push] Stream staged apply changes into resumable sessions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-f26d/exporter-php-72-support",
+            "version": "dev-review/pr339-simplify",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "20a5cb0a822b98cafe39173c563a28ab9267786c"
+                "reference": "592957e10635ad3300ec6b7b33c7c2a304f94fea"
             },
             "require": {
                 "php": ">=7.2",
@@ -385,7 +385,9 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-staged-artifacts.php",
+                    "src/class-staged-apply-session.php",
                     "src/class-staged-push-stream-protocol.php",
+                    "src/class-staged-push-stream-parser.php",
                     "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -23,7 +23,9 @@
             "src/class-hmac-server.php",
             "src/class-http-server.php",
             "src/class-staged-artifacts.php",
+            "src/class-staged-apply-session.php",
             "src/class-staged-push-stream-protocol.php",
+            "src/class-staged-push-stream-parser.php",
             "src/class-staged-endpoints.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -1,0 +1,939 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Runtime errors are returned as API JSON, never rendered as HTML.
+
+if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
+    require_once __DIR__ . '/class-staged-push-stream-protocol.php';
+}
+if (!class_exists('Site_Export_Staged_Push_Stream_Parser', false)) {
+    require_once __DIR__ . '/class-staged-push-stream-parser.php';
+}
+
+/**
+ * Owns one resumable staged-apply upload session.
+ *
+ * Directory and symlink changes are stored below the private staged tree.
+ * The receiver writes every accepted change, including a delete, to
+ * journal.jsonl. A complete journal line is accepted; an incomplete final
+ * line is dropped before the next upload. The final complete directory or
+ * symlink record is materialized again before reading new changes, so a
+ * stopped request can resume without rebuilding the whole staged tree. The
+ * live target tree is never mutated during upload.
+ * The caller accepts the upload, calls next_change() until it returns false,
+ * then finishes the upload.
+ */
+final class Site_Export_Staged_Apply_Session {
+
+    public const ERROR_BUSY = 1001;
+
+    public const ERROR_SESSION_NOT_FOUND = 1002;
+
+    public const ERROR_RETRYABLE_IO = 1003;
+
+    public const ERROR_INVALID_CHANGE = 1004;
+
+    private const MAX_METADATA_BYTES = 1048576;
+
+    private const MAX_PATH_BYTES = Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES;
+
+    private const MAX_JOURNAL_LINE_BYTES = Site_Export_Staged_Push_Stream_Protocol::MAX_HEADER_BYTES + 1;
+
+    /**
+     * Canonical live tree that this session may change during its later commit.
+     *
+     * @var string
+     */
+    private $target_root;
+
+    /**
+     * Server-owned opaque identifier used to name this session.
+     *
+     * @var string
+     */
+    private $session_id;
+
+    /**
+     * Private directory holding this session's metadata, journal, and staged tree.
+     *
+     * @var string
+     */
+    private $session_directory;
+
+    /**
+     * Immutable metadata binding this session to its target tree.
+     *
+     * @var string
+     */
+    private $session_metadata_path;
+
+    /**
+     * Fixed regular file used to exclude concurrent uploads for this session.
+     *
+     * @var string
+     */
+    private $lock_path;
+
+    /**
+     * JSONL journal of accepted directory, symlink, and delete changes.
+     *
+     * @var string
+     */
+    private $journal_path;
+
+    /**
+     * Private materialized tree for the directories and symlinks in the journal.
+     *
+     * @var string
+     */
+    private $staged_directory;
+
+    /** @var resource|null Exclusive lock held while one upload is open. */
+    private $upload_lock_handle = null;
+
+    /** @var string|null Last accepted raw-byte path while an upload is open. */
+    private $upload_last_path = null;
+
+    /** @var Site_Export_Staged_Push_Stream_Parser|null Parser for the open request body. */
+    private $upload_stream_parser = null;
+
+    /** @var array<string,mixed>|null Change accepted by the last next_change() call. */
+    private $current_change = null;
+
+    /**
+     * Records the canonical paths used by one session handle.
+     *
+     * The constructor does not inspect or create the workspace. Call create()
+     * for a new session or open() for an existing session.
+     *
+     * @param string $staging_directory Existing staging root shared by apply sessions.
+     * @param string $target_root Canonical root the later commit phase will change.
+     * @param string $session_id  Random lowercase hexadecimal session identifier.
+     */
+    private function __construct(string $staging_directory, string $target_root, string $session_id) {
+        $this->target_root = $target_root;
+        $this->session_id = $session_id;
+        $this->session_directory = $staging_directory . '/apply-sessions/' . $session_id;
+        $this->session_metadata_path = $this->session_directory . '/session.json';
+        $this->lock_path = $this->session_directory . '/lock';
+        $this->journal_path = $this->session_directory . '/work/journal.jsonl';
+        $this->staged_directory = $this->session_directory . '/work/files';
+    }
+
+    /**
+     * Creates a private upload session with a random server-owned id.
+     *
+     * The existing staging directory must be outside the target. The caller
+     * is responsible for keeping it outside the web-served tree, as required
+     * by the existing staged artifact store.
+     *
+     * @param string $staging_directory Existing absolute staging directory that owns all apply sessions.
+     * @param string $target_root Existing absolute directory to bind to the session.
+     * @return self The newly initialized session.
+     */
+    public static function create(string $staging_directory, string $target_root): self {
+        $target_root = self::require_absolute_directory($target_root, 'apply target');
+        $staging_directory = self::require_staging_directory($staging_directory, $target_root);
+
+        $sessions_directory = $staging_directory . '/apply-sessions';
+        if (!@mkdir($sessions_directory, 0700) && !file_exists($sessions_directory) && !is_link($sessions_directory)) {
+            throw new RuntimeException('Could not create the staged apply sessions directory: ' . $sessions_directory, self::ERROR_RETRYABLE_IO);
+        }
+        self::require_real_directory($sessions_directory, 'staged apply sessions directory');
+
+        $session_id = bin2hex(random_bytes(16));
+        $session_directory = $sessions_directory . '/' . $session_id;
+        if (!@mkdir($session_directory, 0700)) {
+            throw new RuntimeException('Could not create staged apply session directory: ' . $session_directory, self::ERROR_RETRYABLE_IO);
+        }
+        $session = new self($staging_directory, $target_root, $session_id);
+        // A failed initialization removes only paths below this new,
+        // random session directory before returning the error.
+        try {
+            if (!@mkdir($session->staged_directory, 0700, true) && !is_dir($session->staged_directory)) {
+                throw new RuntimeException('Could not create staged apply workspace directory: ' . $session->staged_directory, self::ERROR_RETRYABLE_IO);
+            }
+            if (@file_put_contents($session->lock_path, '') === false) {
+                throw new RuntimeException('Could not create the staged apply session lock: ' . $session->lock_path, self::ERROR_RETRYABLE_IO);
+            }
+            $journal_handle = @fopen($session->journal_path, 'x+b');
+            if ($journal_handle === false) {
+                throw new RuntimeException('Could not create journal.jsonl: ' . $session->journal_path, self::ERROR_RETRYABLE_IO);
+            }
+            fclose($journal_handle);
+            $session->write_session_metadata([
+                'version' => 1,
+                'session_id' => $session_id,
+                'target_root_b64' => base64_encode($target_root),
+            ]);
+        } catch (Throwable $exception) {
+            foreach ([$session->session_metadata_path, $session->lock_path, $session->journal_path] as $path) {
+                if ($session->path_present($path)) {
+                    @unlink($path);
+                }
+            }
+            @rmdir($session->staged_directory);
+            @rmdir(dirname($session->staged_directory));
+            @rmdir($session->session_directory);
+            throw $exception;
+        }
+        return $session;
+    }
+
+    /**
+     * Opens an active session.
+     *
+     * The supplied target must match the target stored in the session.
+     *
+     * @param string $staging_directory Existing absolute staging directory used at creation.
+     * @param string $target_root Absolute target path originally bound to the session.
+     * @param string $session_id  Lowercase hexadecimal id returned by get_session_id().
+     * @return self The active session.
+     */
+    public static function open(string $staging_directory, string $target_root, string $session_id): self {
+        $target_root = self::require_absolute_directory($target_root, 'apply target');
+        $staging_directory = self::require_staging_directory($staging_directory, $target_root);
+        self::require_real_directory($staging_directory . '/apply-sessions', 'staged apply sessions directory');
+        if (!preg_match('/^[a-f0-9]{32}$/D', $session_id)) {
+            throw new InvalidArgumentException('The staged apply session id must be a 32-character lowercase hexadecimal value.');
+        }
+        $session = new self($staging_directory, $target_root, $session_id);
+        $session_metadata = @lstat($session->session_directory);
+        if (!is_array($session_metadata) || !self::is_real_directory($session_metadata)) {
+            if (is_array($session_metadata)) {
+                throw new RuntimeException('The staged apply session path is not a real directory: ' . $session->session_directory);
+            }
+            throw new RuntimeException('The staged apply session does not exist: ' . $session_id, self::ERROR_SESSION_NOT_FOUND);
+        }
+        $session->assert_workspace_structure();
+        $session->read_session_metadata();
+        return $session;
+    }
+
+    /**
+     * Returns the opaque id used to address this session.
+     *
+     * @return string Lowercase hexadecimal session id.
+     */
+    public function get_session_id(): string {
+        return $this->session_id;
+    }
+
+    /**
+     * Returns progress from the final complete journal line.
+     *
+     * @return array{journal_bytes:int,last_path_b64:?string}
+     */
+    public function get_status(): array {
+        if (!$this->session_directory_exists()) {
+            throw new RuntimeException('The staged apply session does not exist: ' . $this->session_id, self::ERROR_SESSION_NOT_FOUND);
+        }
+        $this->assert_workspace_structure();
+        $lock_handle = @fopen($this->lock_path, 'r+b');
+        if ($lock_handle === false) {
+            throw new RuntimeException('Could not open staged apply session lock: ' . $this->lock_path, self::ERROR_RETRYABLE_IO);
+        }
+        if (!flock($lock_handle, LOCK_SH | LOCK_NB)) {
+            fclose($lock_handle);
+            throw new RuntimeException('Staged apply session ' . $this->session_id . ' is busy. Retry the status request.', self::ERROR_BUSY);
+        }
+        try {
+            $this->read_session_metadata();
+            $journal_status = $this->read_journal_tail(false);
+            return [
+                'journal_bytes' => $journal_status['journal_bytes'],
+                'last_path_b64' => $journal_status['last_path_b64'],
+            ];
+        } finally {
+            flock($lock_handle, LOCK_UN);
+            fclose($lock_handle);
+        }
+    }
+
+    /**
+     * Accepts one upload request that streams changes into this session.
+     *
+     * This takes the session lock, drops an incomplete journal tail, and
+     * materializes the final complete change again before reading this request.
+     * The caller must call finish_upload() in a finally block.
+     * Each next_change() call reads and stages one change before returning.
+     *
+     * @param resource $input Framed request body stream.
+     */
+    public function accept_upload($input): void {
+        if ($this->upload_lock_handle !== null) {
+            throw new LogicException('A staged apply upload is already open; call finish_upload() before starting another.');
+        }
+        $stream_parser = new Site_Export_Staged_Push_Stream_Parser($input);
+        if (!$this->session_directory_exists()) {
+            throw new RuntimeException('The staged apply session does not exist: ' . $this->session_id, self::ERROR_SESSION_NOT_FOUND);
+        }
+        $this->assert_workspace_structure();
+        $lock_handle = @fopen($this->lock_path, 'r+b');
+        if ($lock_handle === false) {
+            throw new RuntimeException('Could not open staged apply session lock: ' . $this->lock_path, self::ERROR_RETRYABLE_IO);
+        }
+        if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
+            fclose($lock_handle);
+            throw new RuntimeException('Staged apply session ' . $this->session_id . ' is busy. Retry the upload.', self::ERROR_BUSY);
+        }
+        try {
+            $this->read_session_metadata();
+            $journal_status = $this->read_journal_tail(true);
+            $last_change = $journal_status['last_change'];
+            if (is_array($last_change)) {
+                $this->materialize_change($last_change);
+            }
+            $this->upload_lock_handle = $lock_handle;
+            $this->upload_last_path = is_array($last_change) ? $last_change['path'] : null;
+            $this->upload_stream_parser = $stream_parser;
+            $this->current_change = null;
+        } catch (Throwable $exception) {
+            flock($lock_handle, LOCK_UN);
+            fclose($lock_handle);
+            throw $exception;
+        }
+    }
+
+    /** Ends an upload request and releases the session lock. */
+    public function finish_upload(): void {
+        if ($this->upload_lock_handle === null) {
+            throw new LogicException('No staged apply upload is open; call accept_upload() before finish_upload().');
+        }
+        $lock_handle = $this->upload_lock_handle;
+        $this->upload_lock_handle = null;
+        $this->upload_last_path = null;
+        $this->upload_stream_parser = null;
+        $this->current_change = null;
+        flock($lock_handle, LOCK_UN);
+        fclose($lock_handle);
+    }
+
+    /**
+     * Reads and stages the next change in the open upload request.
+     *
+     * Returns false at the clean end of the request body. Invalid headers or
+     * changes stop this request and throw before later request-body frames are
+     * read.
+     */
+    public function next_change(): bool {
+        if ($this->upload_lock_handle === null) {
+            throw new LogicException('Accept an upload before reading changes.');
+        }
+        if ($this->upload_stream_parser === null) {
+            throw new LogicException('This staged apply upload stopped after a rejected change; call finish_upload() before starting another.');
+        }
+        $this->current_change = null;
+        try {
+            if (!$this->upload_stream_parser->next_frame()) {
+                return false;
+            }
+            $change = Site_Export_Staged_Push_Stream_Protocol::decode_apply_change_frame(
+                $this->upload_stream_parser->get_current_frame()
+            );
+            if ($change['type'] === 'directory') {
+                $this->stage_directory_change($change['path']);
+            } elseif ($change['type'] === 'symlink') {
+                $this->stage_symlink_change($change['path'], $change['target']);
+            } else {
+                $this->stage_delete_change($change['path']);
+            }
+            $this->current_change = $change;
+            return true;
+        } catch (Throwable $exception) {
+            // Stop this request after a failed change. The next request can
+            // retry from the final complete journal line.
+            $this->upload_stream_parser = null;
+            throw $exception;
+        }
+    }
+
+    /** Returns the change staged by the last successful next_change() call. */
+    public function get_current_change(): ?array {
+        return $this->current_change;
+    }
+
+    /**
+     * Stages one directory change and records it in the journal.
+     *
+     * @param string $path Raw-byte target-relative directory path.
+     */
+    private function stage_directory_change(string $path): void {
+        $this->require_next_path($path);
+        $this->require_directory_can_be_materialized($path);
+        $this->append_change_to_journal(['type' => 'directory', 'path_b64' => base64_encode($path)], $path);
+        $this->materialize_directory_change($path);
+    }
+
+    /** Materializes a validated directory below the private staged tree. */
+    private function materialize_directory_change(string $path): void {
+        $this->require_directory_can_be_materialized($path);
+        $this->ensure_staged_parents($path);
+        $staged_path = $this->staged_path($path);
+        if ($this->path_present($staged_path)) {
+            return;
+        } elseif (!@mkdir($staged_path, 0700)) {
+            throw new RuntimeException('Could not create staged directory ' . $this->describe_path($path) . '.', self::ERROR_RETRYABLE_IO);
+        }
+    }
+
+    /**
+     * Stages one symlink without following its target.
+     *
+     * The target is stored as bounded raw bytes, but may not be empty or
+     * contain NUL.
+     *
+     * @param string $path   Raw-byte target-relative symlink path.
+     * @param string $target Raw-byte symlink target stored without resolution.
+     */
+    private function stage_symlink_change(string $path, string $target): void {
+        $this->require_next_path($path);
+        $this->require_symlink_target($path, $target);
+        $this->require_symlink_can_be_materialized($path, $target);
+        $this->append_change_to_journal(
+            ['type' => 'symlink', 'path_b64' => base64_encode($path), 'target_b64' => base64_encode($target)],
+            $path
+        );
+        $this->materialize_symlink_change($path, $target);
+    }
+
+    /** Materializes a validated symlink below the private staged tree. */
+    private function materialize_symlink_change(string $path, string $target): void {
+        $this->require_symlink_can_be_materialized($path, $target);
+        $this->ensure_staged_parents($path);
+        $staged_path = $this->staged_path($path);
+        if ($this->path_present($staged_path)) {
+            return;
+        } elseif (!@symlink($target, $staged_path)) {
+            throw new RuntimeException('Could not create staged symlink ' . $this->describe_path($path) . '.', self::ERROR_RETRYABLE_IO);
+        }
+    }
+
+    /** Materializes the directory or symlink represented by one journal record. */
+    private function materialize_change(array $change): void {
+        if ($change['type'] === 'directory') {
+            $this->materialize_directory_change($change['path']);
+            return;
+        }
+        if ($change['type'] === 'symlink') {
+            $this->materialize_symlink_change($change['path'], $change['target']);
+            return;
+        }
+        if ($change['type'] !== 'delete') {
+            throw new LogicException('The staged change journal has an unknown change type.');
+        }
+    }
+
+    /** Requires a bounded, non-empty raw-byte symlink target. */
+    private function require_symlink_target(string $path, string $target): void {
+        if ($target === '') {
+            throw new RuntimeException(
+                'The target for staged symlink ' . $this->describe_path($path) . ' must not be empty.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+        if (strpos($target, "\0") !== false) {
+            throw new RuntimeException(
+                'The target for staged symlink ' . $this->describe_path($path) . ' must not contain NUL bytes.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+        $target_bytes = strlen($target);
+        if ($target_bytes > self::MAX_PATH_BYTES) {
+            throw new RuntimeException(
+                'The target for staged symlink ' . $this->describe_path($path) . ' is ' . $target_bytes
+                . ' bytes; the maximum is ' . self::MAX_PATH_BYTES . ' bytes.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+    }
+
+    /**
+     * Records one delete in journal.jsonl.
+     *
+     * Deletes have no staging-tree representation: absence means unchanged,
+     * and a tombstone would wrongly block replacing a file with a directory.
+     *
+     * @param string $path Raw-byte target-relative path to remove during commit.
+     */
+    private function stage_delete_change(string $path): void {
+        $this->require_next_path($path);
+        $this->append_change_to_journal(['type' => 'delete', 'path_b64' => base64_encode($path)], $path);
+    }
+
+    /**
+     * Verifies that every fixed workspace component has its expected file type.
+     *
+     * No check here follows a workspace link.
+     */
+    private function assert_workspace_structure(): void {
+        foreach (
+            [
+                dirname($this->session_directory) => 'staged apply sessions directory',
+                $this->session_directory => 'staged apply session directory',
+                dirname($this->staged_directory) => 'staged apply work directory',
+                $this->staged_directory => 'staged apply staged tree',
+            ] as $path => $description
+        ) {
+            self::require_real_directory($path, $description);
+        }
+        foreach (
+            [
+                $this->session_metadata_path => 'staged apply session metadata',
+                $this->lock_path => 'staged apply lock',
+                $this->journal_path => 'staged change journal',
+            ] as $path => $description
+        ) {
+            $file_metadata = @lstat($path);
+            if (
+                !is_array($file_metadata)
+                || !isset($file_metadata['mode'])
+                || !is_int($file_metadata['mode'])
+                || ( $file_metadata['mode'] & 0170000 ) !== 0100000
+            ) {
+                throw new RuntimeException('The ' . $description . ' must be a real regular file, not a symlink or another file type: ' . $path);
+            }
+        }
+    }
+
+    /** Requires each new path to sort after the last accepted path. */
+    private function require_next_path(string $path): void {
+        $this->require_path_after($path, $this->upload_last_path);
+    }
+
+    /** Requires a valid path to sort after a supplied raw-byte path. */
+    private function require_path_after(string $path, ?string $last_path): void {
+        $path_bytes = strlen($path);
+        if ($path_bytes > self::MAX_PATH_BYTES) {
+            throw new RuntimeException(
+                'Refusing staged apply path of ' . $path_bytes . ' bytes; the maximum is ' . self::MAX_PATH_BYTES . ' bytes.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+        try {
+            $this->require_target_relative_path($path);
+        } catch (RuntimeException $exception) {
+            throw new RuntimeException($exception->getMessage(), self::ERROR_INVALID_CHANGE);
+        }
+        if ($last_path !== null && strcmp($last_path, $path) >= 0) {
+            throw new RuntimeException(
+                'Each staged apply path must sort after the last accepted path using raw byte order; received '
+                . $this->describe_path($path) . ' after ' . $this->describe_path($last_path) . '.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+    }
+
+    /**
+     * Appends one accepted change as one journal line.
+     *
+     * @param array<string,mixed> $record JSON-safe journal record; callers base64-encode raw path bytes.
+     * @param string              $path   Raw path saved as the last accepted path.
+     */
+    private function append_change_to_journal(array $record, string $path): void {
+        $encoded_record = json_encode($record, JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded_record)) {
+            throw new RuntimeException('Could not encode a staged change journal record.');
+        }
+        $line = $encoded_record . "\n";
+        if (strlen($line) > self::MAX_JOURNAL_LINE_BYTES) {
+            throw new RuntimeException('A staged change journal record exceeds its bounded size.');
+        }
+        $journal_handle = @fopen($this->journal_path, 'r+b');
+        if ($journal_handle === false) {
+            throw new RuntimeException('Could not open journal.jsonl: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            if (fseek($journal_handle, 0, SEEK_END) !== 0 || !self::write_all($journal_handle, $line) || !fflush($journal_handle)) {
+                throw new RuntimeException('Could not append a staged change for ' . $this->describe_path($path) . '.', self::ERROR_RETRYABLE_IO);
+            }
+        } finally {
+            fclose($journal_handle);
+        }
+        $this->upload_last_path = $path;
+    }
+
+    /**
+     * Writes the immutable metadata for a new session.
+     *
+     * @param array<string,mixed> $metadata
+     */
+    private function write_session_metadata(array $metadata): void {
+        $encoded_metadata = json_encode($metadata, JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded_metadata)) {
+            throw new RuntimeException('Could not encode staged apply session metadata.');
+        }
+        if (strlen($encoded_metadata) > self::MAX_METADATA_BYTES) {
+            throw new RuntimeException('The staged apply session metadata exceeds its bounded size: ' . $this->session_metadata_path);
+        }
+        $metadata_handle = @fopen($this->session_metadata_path, 'x+b');
+        if ($metadata_handle === false) {
+            throw new RuntimeException('Could not write staged apply session metadata: ' . $this->session_metadata_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            if (!self::write_all($metadata_handle, $encoded_metadata) || !fflush($metadata_handle)) {
+                throw new RuntimeException('Could not flush staged apply session metadata: ' . $this->session_metadata_path, self::ERROR_RETRYABLE_IO);
+            }
+        } finally {
+            fclose($metadata_handle);
+        }
+    }
+
+    /**
+     * Reads immutable metadata that binds this session to its target tree.
+     *
+     * Upload does not mutate the target; its identity is checked later during
+     * the commit phase.
+     *
+     * @return array<string,mixed>
+     */
+    private function read_session_metadata(): array {
+        $contents = @file_get_contents($this->session_metadata_path, false, null, 0, self::MAX_METADATA_BYTES + 1);
+        if ($contents === false) {
+            throw new RuntimeException('Could not read staged apply session metadata: ' . $this->session_metadata_path, self::ERROR_RETRYABLE_IO);
+        }
+        if (strlen($contents) > self::MAX_METADATA_BYTES) {
+            throw new RuntimeException('The staged apply session metadata exceeds its bounded size: ' . $this->session_metadata_path);
+        }
+        $decoded_metadata = json_decode($contents);
+        if (!is_object($decoded_metadata)) {
+            throw new RuntimeException('The staged apply session metadata must be a JSON object: ' . $this->session_metadata_path);
+        }
+        $metadata = get_object_vars($decoded_metadata);
+        if (( $metadata['version'] ?? null ) !== 1) {
+            throw new RuntimeException('The staged apply session metadata version must be 1: ' . $this->session_metadata_path);
+        }
+        if (( $metadata['session_id'] ?? null ) !== $this->session_id) {
+            throw new RuntimeException('The staged apply session metadata id does not match its directory: ' . $this->session_metadata_path);
+        }
+        $encoded_target_root = $metadata['target_root_b64'] ?? null;
+        if (!is_string($encoded_target_root)) {
+            throw new RuntimeException('The staged apply session metadata must contain a base64-encoded target root.');
+        }
+        $stored_target_root = base64_decode($encoded_target_root, true);
+        if (!is_string($stored_target_root)) {
+            throw new RuntimeException('The staged apply session metadata target root is not valid base64.');
+        }
+        if ($stored_target_root !== $this->target_root) {
+            throw new RuntimeException('The staged apply session belongs to another target directory.');
+        }
+        return $metadata;
+    }
+
+    /**
+     * Returns the usable journal prefix and its final complete change.
+     *
+     * Only the final line is read. With an exclusive upload lock, an
+     * incomplete final line is discarded before another change is accepted.
+     *
+     * @param bool $discard_incomplete_tail Whether this caller holds the exclusive upload lock.
+     * @return array{journal_bytes:int,last_path_b64:?string,last_change:?array<string,mixed>}
+     */
+    private function read_journal_tail(bool $discard_incomplete_tail): array {
+        $journal_handle = @fopen($this->journal_path, $discard_incomplete_tail ? 'r+b' : 'rb');
+        if ($journal_handle === false) {
+            throw new RuntimeException('Could not read journal.jsonl: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            $journal_metadata = fstat($journal_handle);
+            $observed_journal_bytes = is_array($journal_metadata) && isset($journal_metadata['size'])
+                ? (int) $journal_metadata['size']
+                : -1;
+            if ($observed_journal_bytes < 0) {
+                throw new RuntimeException('Could not determine the size of journal.jsonl: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+            }
+            if ($observed_journal_bytes === 0) {
+                return [
+                    'journal_bytes' => 0,
+                    'last_path_b64' => null,
+                    'last_change' => null,
+                ];
+            }
+
+            $tail_bytes = min($observed_journal_bytes, self::MAX_JOURNAL_LINE_BYTES + 1);
+            $tail_start = $observed_journal_bytes - $tail_bytes;
+            if (fseek($journal_handle, $tail_start, SEEK_SET) !== 0) {
+                throw new RuntimeException('Could not seek to the end of journal.jsonl: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+            }
+            $tail = stream_get_contents($journal_handle, $tail_bytes);
+            if (!is_string($tail) || strlen($tail) !== $tail_bytes) {
+                throw new RuntimeException('Could not read the end of journal.jsonl: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+            }
+
+            $last_newline = strrpos($tail, "\n");
+            $last_change = null;
+            if ($last_newline === false) {
+                if ($observed_journal_bytes > self::MAX_JOURNAL_LINE_BYTES) {
+                    throw new RuntimeException('The final staged change journal line exceeds its bounded size.');
+                }
+                $complete_journal_bytes = 0;
+            } else {
+                $complete_journal_bytes = $observed_journal_bytes - ( $tail_bytes - $last_newline - 1 );
+                $previous_newline = strrpos(substr($tail, 0, $last_newline), "\n");
+                if ($previous_newline === false) {
+                    if ($tail_start !== 0) {
+                        throw new RuntimeException('The final staged change journal line exceeds its bounded size.');
+                    }
+                    $line = substr($tail, 0, $last_newline);
+                } else {
+                    $line = substr($tail, $previous_newline + 1, $last_newline - $previous_newline - 1);
+                }
+                $last_change = $this->decode_journal_change($line);
+            }
+
+            if ($discard_incomplete_tail && $complete_journal_bytes !== $observed_journal_bytes) {
+                if (!ftruncate($journal_handle, $complete_journal_bytes) || !fflush($journal_handle)) {
+                    throw new RuntimeException('Could not remove the incomplete staged change journal tail.', self::ERROR_RETRYABLE_IO);
+                }
+            }
+            return [
+                'journal_bytes' => $complete_journal_bytes,
+                'last_path_b64' => $last_change === null ? null : base64_encode($last_change['path']),
+                'last_change' => $last_change,
+            ];
+        } finally {
+            fclose($journal_handle);
+        }
+    }
+
+    /** Decodes and validates one complete journal line. */
+    private function decode_journal_change(string $line): array {
+        $record = json_decode($line, true);
+        if (!is_array($record)) {
+            throw new RuntimeException('The staged change journal contains an invalid JSON record.');
+        }
+        if (!array_key_exists('bytes', $record)) {
+            $record['bytes'] = 0;
+        }
+        try {
+            $change = Site_Export_Staged_Push_Stream_Protocol::decode_apply_change_frame($record);
+            $this->require_path_after($change['path'], null);
+            if ($change['type'] === 'symlink') {
+                $this->require_symlink_target($change['path'], $change['target']);
+            }
+        } catch (InvalidArgumentException $exception) {
+            throw new RuntimeException('The staged change journal contains an invalid change: ' . $exception->getMessage());
+        } catch (RuntimeException $exception) {
+            throw new RuntimeException('The staged change journal contains an invalid change: ' . $exception->getMessage());
+        }
+        return $change;
+    }
+
+    /** Checks whether the active session directory still exists without cached stat data. */
+    private function session_directory_exists(): bool {
+        clearstatcache(true, $this->session_directory);
+        return is_dir($this->session_directory);
+    }
+
+    /**
+     * Creates missing staging parents as real 0700 directories without following links.
+     */
+    private function ensure_staged_parents(string $path): void {
+        $segments = explode('/', $path);
+        array_pop($segments);
+        $current_directory = $this->staged_directory;
+        foreach ($segments as $segment) {
+            $current_directory .= '/' . $segment;
+            $directory_metadata = @lstat($current_directory);
+            if (is_array($directory_metadata) && self::is_real_directory($directory_metadata)) {
+                continue;
+            }
+            if (!is_array($directory_metadata) && !$this->path_present($current_directory)) {
+                if (!@mkdir($current_directory, 0700)) {
+                    throw new RuntimeException(
+                        'Could not create staged apply parent directory ' . $this->describe_path($current_directory) . '.',
+                        self::ERROR_RETRYABLE_IO
+                    );
+                }
+                continue;
+            }
+            throw new RuntimeException(
+                'Cannot stage ' . $this->describe_path($path) . ' below a non-directory staged ancestor.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+    }
+
+    /** Requires a directory change not to conflict with the staged tree. */
+    private function require_directory_can_be_materialized(string $path): void {
+        $this->require_staged_parents_are_directories($path);
+        $staged_path = $this->staged_path($path);
+        if ($this->path_present($staged_path) && ( !is_dir($staged_path) || is_link($staged_path) )) {
+            throw new RuntimeException(
+                'Cannot stage directory ' . $this->describe_path($path) . ' because that staged path is not a real directory.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+    }
+
+    /** Requires a symlink change not to conflict with the staged tree. */
+    private function require_symlink_can_be_materialized(string $path, string $target): void {
+        $this->require_staged_parents_are_directories($path);
+        $staged_path = $this->staged_path($path);
+        if (!$this->path_present($staged_path)) {
+            return;
+        }
+        if (!is_link($staged_path)) {
+            throw new RuntimeException(
+                'Cannot stage symlink ' . $this->describe_path($path) . ' because that staged path is not a symlink.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+        if (readlink($staged_path) !== $target) {
+            throw new RuntimeException(
+                'Cannot stage symlink ' . $this->describe_path($path) . ' because that staged symlink has another target.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+    }
+
+    /** Requires existing staging parents to be real directories. */
+    private function require_staged_parents_are_directories(string $path): void {
+        $segments = explode('/', $path);
+        array_pop($segments);
+        $current_directory = $this->staged_directory;
+        foreach ($segments as $segment) {
+            $current_directory .= '/' . $segment;
+            $directory_metadata = @lstat($current_directory);
+            if (is_array($directory_metadata) && self::is_real_directory($directory_metadata)) {
+                continue;
+            }
+            if (!is_array($directory_metadata) && !$this->path_present($current_directory)) {
+                continue;
+            }
+            throw new RuntimeException(
+                'Cannot stage ' . $this->describe_path($path) . ' below a non-directory staged ancestor.',
+                self::ERROR_INVALID_CHANGE
+            );
+        }
+    }
+
+    /** Validates target-relative path syntax without assuming UTF-8. */
+    private function require_target_relative_path(string $path): void {
+        if ($path === '') {
+            throw new RuntimeException('The staged apply path must not be empty.');
+        }
+        if ($path[0] === '/') {
+            throw new RuntimeException('The staged apply path must be relative: ' . $this->describe_path($path));
+        }
+        if (strpos($path, "\0") !== false) {
+            throw new RuntimeException('The staged apply path must not contain NUL bytes: ' . $this->describe_path($path));
+        }
+        if (strpos($path, '\\') !== false) {
+            throw new RuntimeException('The staged apply path must not contain backslashes: ' . $this->describe_path($path));
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '') {
+                throw new RuntimeException('The staged apply path must not contain empty segments: ' . $this->describe_path($path));
+            }
+            if ($segment === '.' || $segment === '..') {
+                throw new RuntimeException('The staged apply path must not contain "' . $segment . '" segments: ' . $this->describe_path($path));
+            }
+        }
+    }
+
+    /** Appends a validated target-relative path to the staged-tree root. */
+    private function staged_path(string $path): string {
+        return $this->staged_directory . '/' . $path;
+    }
+
+    /** Checks path presence without treating a dangling symlink as absent. */
+    private function path_present(string $path): bool {
+        return file_exists($path) || is_link($path);
+    }
+
+    /** Formats arbitrary path bytes safely for diagnostics. */
+    private function describe_path(string $path): string {
+        return 'base64:' . base64_encode($path);
+    }
+
+    /**
+     * Writes an entire bounded string, retrying ordinary short writes.
+     *
+     * @param resource $handle
+     */
+    private static function write_all($handle, string $bytes): bool {
+        $written_bytes = 0;
+        $total_bytes = strlen($bytes);
+        while ($written_bytes < $total_bytes) {
+            $written = fwrite($handle, substr($bytes, $written_bytes));
+            if (!is_int($written) || $written <= 0) {
+                return false;
+            }
+            $written_bytes += $written;
+        }
+        return true;
+    }
+
+    /** Requires a directory whose leaf is not a symlink. */
+    private static function require_real_directory(string $path, string $description): void {
+        $directory_metadata = @lstat($path);
+        if (!is_array($directory_metadata) || !self::is_real_directory($directory_metadata)) {
+            throw new RuntimeException('The ' . $description . ' must be a real directory, not a symlink or another file type: ' . $path);
+        }
+    }
+
+    /**
+     * Checks an lstat record for a real directory mode.
+     *
+     * @param array<string,mixed> $directory_metadata
+     */
+    private static function is_real_directory(array $directory_metadata): bool {
+        return isset($directory_metadata['mode'])
+            && is_int($directory_metadata['mode'])
+            && ( $directory_metadata['mode'] & 0170000 ) === 0040000;
+    }
+
+    /** Opens a staging root that is separate from the apply target. */
+    private static function require_staging_directory(string $path, string $target_root): string {
+        $resolved_staging_directory = self::require_absolute_directory($path, 'staging directory');
+        $staging_leaf = rtrim($path, '/');
+        $staging_leaf = $staging_leaf === '' ? '/' : $staging_leaf;
+        if ($staging_leaf === '/') {
+            throw new InvalidArgumentException('The staging directory must not be the filesystem root.');
+        }
+        if (is_link($staging_leaf)) {
+            throw new InvalidArgumentException('The staging directory must not be a symlink: ' . $path);
+        }
+        $target_prefix = rtrim($target_root, '/') . '/';
+        $staging_prefix = rtrim($resolved_staging_directory, '/') . '/';
+        if (
+            $resolved_staging_directory === $target_root
+            || strpos($resolved_staging_directory, $target_prefix) === 0
+            || strpos($target_root, $staging_prefix) === 0
+        ) {
+            throw new InvalidArgumentException('The staging directory and apply target must be separate directory trees.');
+        }
+        return $resolved_staging_directory;
+    }
+
+    /**
+     * Validates and canonicalizes an existing absolute directory.
+     */
+    private static function require_absolute_directory(string $path, string $name): string {
+        clearstatcache(true);
+        if ($path === '') {
+            throw new InvalidArgumentException('The ' . $name . ' path must not be empty.');
+        }
+        if ($path[0] !== '/') {
+            throw new InvalidArgumentException('The ' . $name . ' must be an absolute path: ' . $path);
+        }
+        if (strpos($path, "\0") !== false) {
+            throw new InvalidArgumentException('The ' . $name . ' path must not contain NUL bytes.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException('The ' . $name . ' must not contain dot segments: ' . $path);
+            }
+        }
+        $path = rtrim($path, '/');
+        $path = $path === '' ? '/' : $path;
+        if (!is_dir($path)) {
+            throw new RuntimeException('The ' . $name . ' is not an existing directory: ' . $path);
+        }
+        $resolved_path = realpath($path);
+        if (!is_string($resolved_path)) {
+            throw new RuntimeException('Could not resolve the ' . $name . ': ' . $path, self::ERROR_RETRYABLE_IO);
+        }
+        return $resolved_path;
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -5,6 +5,9 @@ use function WordPress\Reprint\Exporter\parse_size;
 if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
     require_once __DIR__ . '/class-staged-push-stream-protocol.php';
 }
+if (!class_exists('Site_Export_Staged_Push_Stream_Parser', false)) {
+    require_once __DIR__ . '/class-staged-push-stream-parser.php';
+}
 
 /**
  * HTTP endpoints for the staged artifact store.
@@ -190,18 +193,21 @@ final class Site_Export_Staged_Endpoints {
             return $this->rejected(403, 'auth_failed', $auth_error);
         }
 
+        $stream_parser = new Site_Export_Staged_Push_Stream_Parser($input);
         $files_verified = 0;
         $cursor = null;
-        while (!feof($input)) {
-            $line = fgets($input);
-            if ($line === false) {
-                break;
-            }
-            $line = rtrim($line, "\r\n");
+        while (true) {
             try {
-                $frame = Site_Export_Staged_Push_Stream_Protocol::decode_chunk_header($line);
-            } catch (InvalidArgumentException $e) {
-                return $this->stream_rejected(400, 'invalid_frame', $e->getMessage(), $cursor, $files_verified);
+                if (!$stream_parser->next_frame()) {
+                    break;
+                }
+                $frame = Site_Export_Staged_Push_Stream_Protocol::decode_chunk_frame(
+                    $stream_parser->get_current_frame()
+                );
+            } catch (InvalidArgumentException $exception) {
+                return $this->stream_rejected(400, 'invalid_frame', $exception->getMessage(), $cursor, $files_verified);
+            } catch (RuntimeException $exception) {
+                return $this->stream_rejected(400, 'body_read_failed', $exception->getMessage(), $cursor, $files_verified);
             }
             $artifact_id = $frame['artifact_id'];
             $offset = $frame['offset'];
@@ -261,8 +267,10 @@ final class Site_Export_Staged_Endpoints {
              * iteration starts at the following JSON header.
              */
             if ($status['verified'] && $status['committed_bytes'] === $total_bytes) {
-                if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $bytes, self::READ_BUFFER_BYTES)) {
-                    return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+                try {
+                    $stream_parser->discard_payload_bytes($bytes, self::READ_BUFFER_BYTES);
+                } catch (RuntimeException $exception) {
+                    return $this->stream_rejected(400, 'body_read_failed', $exception->getMessage(), $cursor, $files_verified);
                 }
                 if ($final) {
                     $files_verified++;
@@ -310,8 +318,10 @@ final class Site_Export_Staged_Endpoints {
                  */
                 if ($committed_bytes > $offset) {
                     $already_committed_bytes = min($bytes, $committed_bytes - $offset);
-                    if (!Site_Export_Staged_Push_Stream_Protocol::discard_exactly($input, $already_committed_bytes, self::READ_BUFFER_BYTES)) {
-                        return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+                    try {
+                        $stream_parser->discard_payload_bytes($already_committed_bytes, self::READ_BUFFER_BYTES);
+                    } catch (RuntimeException $exception) {
+                        return $this->stream_rejected(400, 'body_read_failed', $exception->getMessage(), $cursor, $files_verified);
                     }
                     $remaining_frame_bytes -= $already_committed_bytes;
                     $append_offset += $already_committed_bytes;
@@ -320,11 +330,12 @@ final class Site_Export_Staged_Endpoints {
 
                 while ($remaining_frame_bytes > 0) {
                     $payload_piece_bytes = min($this->append_buffer_bytes, $remaining_frame_bytes);
-                    $payload_piece = Site_Export_Staged_Push_Stream_Protocol::read_exactly($input, $payload_piece_bytes);
-                    if ($payload_piece === null) {
-                        return $this->stream_rejected(400, 'body_read_failed', null, $cursor, $files_verified);
+                    try {
+                        $payload_piece = $stream_parser->read_payload_piece($payload_piece_bytes);
+                    } catch (RuntimeException $exception) {
+                        return $this->stream_rejected(400, 'body_read_failed', $exception->getMessage(), $cursor, $files_verified);
                     }
-                    $remaining_frame_bytes -= $payload_piece_bytes;
+                    $remaining_frame_bytes -= strlen($payload_piece);
 
                     while ($payload_piece !== '') {
                         /**

--- a/packages/reprint-exporter/src/class-staged-push-stream-parser.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-parser.php
@@ -1,0 +1,136 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Parser errors are returned as API JSON, never rendered as HTML.
+
+if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
+    require_once __DIR__ . '/class-staged-push-stream-protocol.php';
+}
+
+/**
+ * Reads one framed staged-push request body without buffering its payloads.
+ *
+ * Call next_frame() to expose a decoded JSON header, then consume its payload
+ * in bounded pieces before advancing again. The parser never reads a later
+ * frame while bytes from the current frame remain unread.
+ */
+final class Site_Export_Staged_Push_Stream_Parser {
+
+    /** @var resource */
+    private $input;
+
+    /** @var array<string,mixed>|null */
+    private $current_frame = null;
+
+    /** @var int */
+    private $remaining_payload_bytes = 0;
+
+    /** @param resource $input Request body stream. */
+    public function __construct($input) {
+        if (!is_resource($input)) {
+            throw new InvalidArgumentException('The staged push stream input must be a readable stream resource.');
+        }
+        $this->input = $input;
+    }
+
+    /**
+     * Advances to the next frame header.
+     *
+     * Returns false only at a clean end of the request body. The caller must
+     * consume the current payload before calling this again.
+     */
+    public function next_frame(): bool {
+        if ($this->remaining_payload_bytes !== 0) {
+            throw new LogicException(
+                'Read or discard the current staged push stream frame payload before reading another frame.'
+            );
+        }
+
+        // The extra two bytes allow a maximum-sized JSON header to end in
+        // CRLF without treating the carriage return as part of the header.
+        $line = fgets($this->input, Site_Export_Staged_Push_Stream_Protocol::MAX_HEADER_BYTES + 3);
+        if ($line === false) {
+            if (feof($this->input)) {
+                $this->current_frame = null;
+                return false;
+            }
+            throw new RuntimeException('Could not read the next staged push stream frame header.');
+        }
+        if (substr($line, -1) !== "\n") {
+            throw new InvalidArgumentException(
+                'A staged push stream frame header exceeds '
+                . Site_Export_Staged_Push_Stream_Protocol::MAX_HEADER_BYTES
+                . ' bytes or is missing its line feed.'
+            );
+        }
+        $line = substr($line, 0, -1);
+        if (substr($line, -1) === "\r") {
+            $line = substr($line, 0, -1);
+        }
+        if (strlen($line) > Site_Export_Staged_Push_Stream_Protocol::MAX_HEADER_BYTES) {
+            throw new InvalidArgumentException(
+                'A staged push stream frame header exceeds '
+                . Site_Export_Staged_Push_Stream_Protocol::MAX_HEADER_BYTES . ' bytes.'
+            );
+        }
+
+        $frame = Site_Export_Staged_Push_Stream_Protocol::decode_frame_header($line);
+        $this->current_frame = $frame;
+        $this->remaining_payload_bytes = Site_Export_Staged_Push_Stream_Protocol::frame_payload_bytes($frame);
+        return true;
+    }
+
+    /** Returns the decoded header from the successful next_frame() call. */
+    public function get_current_frame(): array {
+        if ($this->current_frame === null) {
+            throw new LogicException('No staged push stream frame is current; call next_frame() first.');
+        }
+        return $this->current_frame;
+    }
+
+    /**
+     * Reads no more than the requested number of bytes from the current payload.
+     *
+     * Returns an empty string once that payload is complete. A shorter nonempty
+     * string is valid: stream reads are allowed to return early.
+     */
+    public function read_payload_piece(int $maximum_payload_bytes): string {
+        if ($this->current_frame === null) {
+            throw new LogicException('No staged push stream frame is current; call next_frame() first.');
+        }
+        if ($maximum_payload_bytes <= 0) {
+            throw new InvalidArgumentException('The maximum staged push stream payload piece must be greater than zero.');
+        }
+        if ($this->remaining_payload_bytes === 0) {
+            return '';
+        }
+
+        $payload_piece = fread($this->input, min($maximum_payload_bytes, $this->remaining_payload_bytes));
+        if ($payload_piece === false || $payload_piece === '') {
+            throw new RuntimeException('The staged push stream frame payload ended before its declared byte count.');
+        }
+        $this->remaining_payload_bytes -= strlen($payload_piece);
+        return $payload_piece;
+    }
+
+    /** Discards a bounded prefix of the current payload. */
+    public function discard_payload_bytes(int $payload_bytes, int $buffer_bytes): void {
+        if ($this->current_frame === null) {
+            throw new LogicException('No staged push stream frame is current; call next_frame() first.');
+        }
+        if ($payload_bytes < 0 || $payload_bytes > $this->remaining_payload_bytes) {
+            throw new InvalidArgumentException(
+                'Cannot discard ' . $payload_bytes . ' staged push stream payload bytes; '
+                . $this->remaining_payload_bytes . ' bytes remain in the frame.'
+            );
+        }
+        if ($buffer_bytes <= 0) {
+            throw new InvalidArgumentException('The staged push stream discard buffer must be greater than zero.');
+        }
+
+        $remaining_bytes = $payload_bytes;
+        while ($remaining_bytes > 0) {
+            $payload_piece = $this->read_payload_piece(min($buffer_bytes, $remaining_bytes));
+            $remaining_bytes -= strlen($payload_piece);
+        }
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -1,16 +1,24 @@
 <?php
 
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol errors are returned as API JSON, never rendered as HTML.
+
 /**
  * Shared wire format helpers for staged push streams.
  *
  * A staged push stream is a sequence of JSON header lines followed by exactly
  * the number of raw payload bytes declared by each header. Both the importer
- * and the exporter use this class so frame shape, validation, and bounded
- * stream reads stay in one place.
+ * and the exporter use this class so frame shape and validation stay in one
+ * place. Site_Export_Staged_Push_Stream_Parser reads those frames.
  */
 final class Site_Export_Staged_Push_Stream_Protocol {
 
     public const CONTENT_TYPE = 'application/x-reprint-staged-push-stream';
+
+    /** Maximum raw bytes accepted for one path or symlink target. */
+    public const MAX_PATH_BYTES = 8192;
+
+    /** Maximum JSON header bytes in one framed request-body record. */
+    public const MAX_HEADER_BYTES = 32768;
 
     /**
      * Top-level path segment reprint reserves for its own staged bookkeeping.
@@ -44,17 +52,18 @@ final class Site_Export_Staged_Push_Stream_Protocol {
         return explode('/', $artifact_id, 2)[0] === self::RESERVED_NAMESPACE_SEGMENT;
     }
 
-    /**
-     * Read the next frame header line from a stream.
-     *
-     * @param resource $input
-     */
-    public static function read_header_line($input): ?string {
-        $line = fgets($input);
-        if ($line === false) {
-            return null;
+    /** Decodes the JSON object shared by every staged push frame header. */
+    public static function decode_frame_header(string $line): array {
+        $frame = json_decode($line, true);
+        if (!is_array($frame)) {
+            throw new InvalidArgumentException('Expected staged push stream frame header to be a JSON object.');
         }
-        return rtrim($line, "\r\n");
+        return $frame;
+    }
+
+    /** Returns the raw payload byte count declared by a decoded frame header. */
+    public static function frame_payload_bytes(array $frame): int {
+        return self::require_non_negative_integer_field($frame, 'bytes');
     }
 
     /**
@@ -68,10 +77,15 @@ final class Site_Export_Staged_Push_Stream_Protocol {
      * @return array{artifact_id:string,offset:int,bytes:int,total_bytes:int,final:bool}
      */
     public static function decode_chunk_header(string $line): array {
-        $frame = json_decode($line, true);
-        if (!is_array($frame)) {
-            throw new InvalidArgumentException('Expected staged push stream frame header to be a JSON object.');
-        }
+        return self::decode_chunk_frame(self::decode_frame_header($line));
+    }
+
+    /**
+     * Decodes a chunk header already read by Site_Export_Staged_Push_Stream_Parser.
+     *
+     * @return array{artifact_id:string,offset:int,bytes:int,total_bytes:int,final:bool}
+     */
+    public static function decode_chunk_frame(array $frame): array {
 
         if (!array_key_exists('type', $frame)) {
             throw new InvalidArgumentException('Missing staged push stream frame field "type".');
@@ -104,7 +118,7 @@ final class Site_Export_Staged_Push_Stream_Protocol {
         }
 
         $offset = self::require_non_negative_integer_field($frame, 'offset');
-        $bytes = self::require_non_negative_integer_field($frame, 'bytes');
+        $bytes = self::frame_payload_bytes($frame);
         $total_bytes = self::require_non_negative_integer_field($frame, 'total_bytes');
 
         if (!array_key_exists('final', $frame)) {
@@ -139,33 +153,109 @@ final class Site_Export_Staged_Push_Stream_Protocol {
     }
 
     /**
-     * @param resource $input
+     * Encodes one file chunk header for the importer to send.
+     *
+     * The artifact id is base64 because file names are arbitrary bytes while
+     * JSON strings must be UTF-8.
+     *
+     * @param string $artifact_id Raw-byte path.
      */
-    public static function read_exactly($input, int $bytes): ?string {
-        $data = '';
-        while (strlen($data) < $bytes) {
-            $piece = fread($input, $bytes - strlen($data));
-            if ($piece === false || $piece === '') {
-                return null;
-            }
-            $data .= $piece;
-        }
-        return $data;
+    public static function encode_chunk_header(string $artifact_id, int $offset, int $payload_bytes, int $total_bytes, bool $is_final): string {
+        return self::encode_header([
+            'type' => 'chunk',
+            'artifact_id' => base64_encode($artifact_id),
+            'offset' => $offset,
+            'bytes' => $payload_bytes,
+            'total_bytes' => $total_bytes,
+            'final' => $is_final,
+        ]);
     }
 
     /**
-     * @param resource $input
+     * Encodes one payload-free directory, symlink, or delete change header.
+     *
+     * @param array<string,mixed> $change type, path, and target for a symlink.
      */
-    public static function discard_exactly($input, int $bytes, int $buffer_bytes): bool {
-        $remaining = $bytes;
-        while ($remaining > 0) {
-            $piece = fread($input, min($buffer_bytes, $remaining));
-            if ($piece === false || $piece === '') {
-                return false;
-            }
-            $remaining -= strlen($piece);
+    public static function encode_apply_change_header(array $change): string {
+        $type = $change['type'] ?? null;
+        $path = $change['path'] ?? null;
+        if (!in_array($type, ['directory', 'symlink', 'delete'], true)) {
+            throw new InvalidArgumentException('Expected staged apply change field "type" to be "directory", "symlink", or "delete".');
         }
-        return true;
+        if (!is_string($path)) {
+            throw new InvalidArgumentException('Expected staged apply change field "path" to be a string.');
+        }
+        $frame = [
+            'type' => $type,
+            'path_b64' => base64_encode($path),
+            'bytes' => 0,
+        ];
+        if ($type === 'symlink') {
+            $target = $change['target'] ?? null;
+            if (!is_string($target)) {
+                throw new InvalidArgumentException('Expected staged apply symlink change field "target" to be a string.');
+            }
+            $frame['target_b64'] = base64_encode($target);
+        }
+        return self::encode_header($frame);
+    }
+
+    /**
+     * Decodes one payload-free directory, symlink, or delete change frame.
+     *
+     * @return array{type:string,path:string,target?:string}
+     */
+    public static function decode_apply_change_frame(array $frame): array {
+        if (!array_key_exists('type', $frame)) {
+            throw new InvalidArgumentException('Missing staged apply change frame field "type".');
+        }
+        if (!in_array($frame['type'], ['directory', 'symlink', 'delete'], true)) {
+            throw new InvalidArgumentException(
+                'Expected staged apply change frame field "type" to be "directory", "symlink", or "delete"; received '
+                . self::describe_value($frame['type']) . '.'
+            );
+        }
+        if (self::frame_payload_bytes($frame) !== 0) {
+            throw new InvalidArgumentException('A staged apply change frame must not declare payload bytes.');
+        }
+
+        $path = self::decode_non_empty_base64_path($frame, 'path_b64', 'staged apply change');
+        if ($frame['type'] !== 'symlink') {
+            return ['type' => $frame['type'], 'path' => $path];
+        }
+        if (!array_key_exists('target_b64', $frame) || !is_string($frame['target_b64'])) {
+            throw new InvalidArgumentException('Expected staged apply symlink change frame field "target_b64" to be base64 text.');
+        }
+        $target = base64_decode($frame['target_b64'], true);
+        if ($target === false) {
+            throw new InvalidArgumentException('Expected staged apply symlink change frame field "target_b64" to be valid base64 text.');
+        }
+        return ['type' => 'symlink', 'path' => $path, 'target' => $target];
+    }
+
+    /** @param array<string,mixed> $frame */
+    private static function encode_header(array $frame): string {
+        $encoded_frame = json_encode($frame, JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded_frame)) {
+            throw new RuntimeException('Could not encode a staged push stream frame header.');
+        }
+        return $encoded_frame . "\n";
+    }
+
+    /** @param array<string,mixed> $frame */
+    private static function decode_non_empty_base64_path(array $frame, string $field, string $frame_description): string {
+        if (!array_key_exists($field, $frame) || !is_string($frame[$field]) || $frame[$field] === '') {
+            throw new InvalidArgumentException(
+                'Expected ' . $frame_description . ' frame field "' . $field . '" to be base64 of a non-empty path.'
+            );
+        }
+        $path = base64_decode($frame[$field], true);
+        if ($path === false || $path === '') {
+            throw new InvalidArgumentException(
+                'Expected ' . $frame_description . ' frame field "' . $field . '" to be base64 of a non-empty path.'
+            );
+        }
+        return $path;
     }
 
     private static function require_non_negative_integer_field(array $frame, string $field): int {

--- a/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-staged-push-stream-client.php
@@ -499,22 +499,13 @@ class StagedPushStreamClient
             return false;
         }
 
-        $frame_header = json_encode([
-            "type" => "chunk",
-            // File paths are arbitrary bytes and JSON strings must be UTF-8,
-            // so the id travels base64-encoded — the same convention the
-            // journal and the pull cursors use. json_encode would return
-            // false on a raw non-UTF-8 name.
-            "artifact_id" => base64_encode($artifact_id),
-            "offset" => $offset,
-            "bytes" => strlen($payload),
-            "total_bytes" => $total_bytes,
-            "final" => $final,
-        ], JSON_UNESCAPED_SLASHES);
-        if ($frame_header === false) {
-            throw new RuntimeException("Could not encode the staged push stream frame header for \"" . $artifact_id . "\".");
-        }
-        $frame_header .= "\n";
+        $frame_header = Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
+            $artifact_id,
+            $offset,
+            strlen($payload),
+            $total_bytes,
+            $final
+        );
 
         // Copy-on-write assignments: neither line copies the payload bytes.
         // Unpausing tells libcurl to start calling the read callback again.

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,14 +358,14 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-push/staged-upload-endpoints-next",
+            "version": "dev-review/pr339-simplify",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "75a17c2864d635cf0dc6f9db022a40319a3999b5"
+                "reference": "592957e10635ad3300ec6b7b33c7c2a304f94fea"
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=7.2",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0"
             },
@@ -385,6 +385,9 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-staged-artifacts.php",
+                    "src/class-staged-apply-session.php",
+                    "src/class-staged-push-stream-protocol.php",
+                    "src/class-staged-push-stream-parser.php",
                     "src/class-staged-endpoints.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -175,14 +175,13 @@ class StagedPushStreamClientTest extends TestCase
     public function testBodyBudgetCountsFrameHeadersWhenRotatingRequests(): void
     {
         $this->writeSource('budget.bin', str_repeat('y', 10));
-        $first_frame_header = json_encode([
-            'type' => 'chunk',
-            'artifact_id' => base64_encode('budget.bin'),
-            'offset' => 0,
-            'bytes' => 4,
-            'total_bytes' => 10,
-            'final' => false,
-        ], JSON_UNESCAPED_SLASHES) . "\n";
+        $first_frame_header = \Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header(
+            'budget.bin',
+            0,
+            4,
+            10,
+            false
+        );
         // Budget for one full frame plus 3 spare bytes, so the value of
         // next_chunk_body_bytes() after the first chunk reveals whether the
         // frame header was charged against the budget alongside the payload.

--- a/tests/StagedApplySessionTest.php
+++ b/tests/StagedApplySessionTest.php
@@ -1,0 +1,646 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply-session.php';
+
+final class StagedApplySessionTest extends TestCase {
+
+    private string $temporary_directory;
+
+    private string $staging_directory;
+
+    private string $target_directory;
+
+    /** Creates isolated staging and target roots for one test. */
+    protected function setUp(): void {
+        $this->temporary_directory = sys_get_temp_dir() . '/reprint-direct-apply-' . bin2hex(random_bytes(8));
+        $this->staging_directory = $this->temporary_directory . '/staging';
+        $this->target_directory = $this->temporary_directory . '/target';
+        mkdir($this->temporary_directory, 0700, true);
+        mkdir($this->target_directory, 0700, true);
+        mkdir($this->staging_directory, 0700, true);
+    }
+
+    /** Removes the isolated filesystem tree after each test. */
+    protected function tearDown(): void {
+        $this->removeTree($this->temporary_directory);
+    }
+
+    /** Verifies session creation installs the private fixed workspace. */
+    public function testCreateBuildsPrivateWorkspace(): void {
+        $session = $this->createSession();
+        $session_directory = $this->sessionDirectory($session);
+
+        self::assertDirectoryExists($session_directory . '/work/files');
+        self::assertSame('', file_get_contents($session_directory . '/work/journal.jsonl'));
+        self::assertFileExists($session_directory . '/session.json');
+        self::assertFileDoesNotExist($session_directory . '/state.json');
+        self::assertFileDoesNotExist($this->staging_directory . '/.htaccess');
+        self::assertFileDoesNotExist($this->staging_directory . '/index.php');
+
+        self::assertSame(
+            ['journal_bytes' => 0, 'last_path_b64' => null],
+            $session->get_status()
+        );
+    }
+
+    /** Verifies every typed change stages and journals without live mutation. */
+    public function testTypedChangesStageAndJournalWithoutMutatingTheTarget(): void {
+        file_put_contents($this->target_directory . '/b-delete', 'old');
+        $session = $this->createSession();
+        $input = $this->requestBody([
+            ['type' => 'directory', 'path' => 'a-directory'],
+            ['type' => 'delete', 'path' => 'b-delete'],
+            ['type' => 'directory', 'path' => 'c-directory'],
+            ['type' => 'symlink', 'path' => 'd-link', 'target' => 'c-directory'],
+        ]);
+
+        $session->accept_upload($input);
+        try {
+            $changes = [];
+            while ($session->next_change()) {
+                $changes[] = $session->get_current_change();
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+
+        self::assertSame(
+            [
+                ['type' => 'directory', 'path' => 'a-directory'],
+                ['type' => 'delete', 'path' => 'b-delete'],
+                ['type' => 'directory', 'path' => 'c-directory'],
+                ['type' => 'symlink', 'path' => 'd-link', 'target' => 'c-directory'],
+            ],
+            $changes
+        );
+
+        $session_directory = $this->sessionDirectory($session);
+        $staged_directory = $session_directory . '/work/files';
+        self::assertDirectoryExists($staged_directory . '/a-directory');
+        self::assertDirectoryExists($staged_directory . '/c-directory');
+        self::assertTrue(is_link($staged_directory . '/d-link'));
+        self::assertSame('c-directory', readlink($staged_directory . '/d-link'));
+
+        $journal_entries = array_map(
+            static function (string $line): array {
+                return json_decode($line, true);
+            },
+            file($session_directory . '/work/journal.jsonl', FILE_IGNORE_NEW_LINES)
+        );
+        self::assertSame(
+            [
+                ['type' => 'directory', 'path_b64' => base64_encode('a-directory')],
+                ['type' => 'delete', 'path_b64' => base64_encode('b-delete')],
+                ['type' => 'directory', 'path_b64' => base64_encode('c-directory')],
+                [
+                    'type' => 'symlink',
+                    'path_b64' => base64_encode('d-link'),
+                    'target_b64' => base64_encode('c-directory'),
+                ],
+            ],
+            $journal_entries
+        );
+
+        $status = $session->get_status();
+        self::assertSame(base64_encode('d-link'), $status['last_path_b64']);
+        self::assertSame(filesize($session_directory . '/work/journal.jsonl'), $status['journal_bytes']);
+        self::assertSame('old', file_get_contents($this->target_directory . '/b-delete'));
+        self::assertFileDoesNotExist($this->target_directory . '/a-directory');
+        self::assertFileDoesNotExist($this->target_directory . '/c-directory');
+        self::assertFileDoesNotExist($this->target_directory . '/d-link');
+    }
+
+    /** Changes belong to an upload request, not to an unlocked session. */
+    public function testChangesRequireAnOpenUpload(): void {
+        $session = $this->createSession();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Accept an upload before reading changes.');
+        $session->next_change();
+    }
+
+    /** A rejected frame leaves its payload and later frames unread. */
+    public function testRejectedChangeFrameDoesNotReadItsPayloadOrLaterFrames(): void {
+        $session = $this->createSession();
+        $next_header = Site_Export_Staged_Push_Stream_Protocol::encode_apply_change_header([
+            'type' => 'directory',
+            'path' => 'later',
+        ]);
+        $input = fopen('php://temp', 'w+b');
+        self::assertIsResource($input);
+        fwrite($input, json_encode([
+            'type' => 'directory',
+            'path_b64' => base64_encode('first'),
+            'bytes' => 1,
+        ], JSON_UNESCAPED_SLASHES) . "\n" . 'x' . $next_header);
+        rewind($input);
+
+        $session->accept_upload($input);
+        try {
+            try {
+                $session->next_change();
+                self::fail('Expected payload-bearing metadata frame rejection.');
+            } catch (InvalidArgumentException $exception) {
+                self::assertSame('A staged apply change frame must not declare payload bytes.', $exception->getMessage());
+            }
+            try {
+                $session->next_change();
+                self::fail('Expected the rejected request body to stay stopped.');
+            } catch (LogicException $exception) {
+                self::assertSame(
+                    'This staged apply upload stopped after a rejected change; call finish_upload() before starting another.',
+                    $exception->getMessage()
+                );
+            }
+            self::assertSame('x' . $next_header, stream_get_contents($input));
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+        self::assertNull($session->get_status()['last_path_b64']);
+    }
+
+    /** The last saved path tells a retry where to continue. */
+    public function testLastPathTellsARetryWhereToContinue(): void {
+        $session = $this->createSession();
+        $first_input = $this->requestBody([['type' => 'directory', 'path' => 'a']]);
+        $session->accept_upload($first_input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($first_input);
+        }
+        self::assertSame(base64_encode('a'), $session->get_status()['last_path_b64']);
+
+        $reopened = Site_Export_Staged_Apply_Session::open(
+            $this->staging_directory,
+            $this->target_directory,
+            $session->get_session_id()
+        );
+        $duplicate_input = $this->requestBody([['type' => 'directory', 'path' => 'a']]);
+        $reopened->accept_upload($duplicate_input);
+        try {
+            try {
+                $reopened->next_change();
+                self::fail('Expected a retry at the saved path to be rejected.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_CHANGE, $exception->getCode());
+                self::assertStringContainsString('must sort after the last accepted path', $exception->getMessage());
+            }
+        } finally {
+            $reopened->finish_upload();
+            fclose($duplicate_input);
+        }
+        $next_input = $this->requestBody([['type' => 'directory', 'path' => 'b']]);
+        $reopened->accept_upload($next_input);
+        try {
+            self::assertTrue($reopened->next_change());
+            self::assertFalse($reopened->next_change());
+        } finally {
+            $reopened->finish_upload();
+            fclose($next_input);
+        }
+        self::assertSame(base64_encode('b'), $reopened->get_status()['last_path_b64']);
+    }
+
+    /** An invalid change leaves earlier accepted changes retryable. */
+    public function testUnsafeChangeLeavesTheSessionRetryable(): void {
+        $session = $this->createSession();
+        $later_header = Site_Export_Staged_Push_Stream_Protocol::encode_apply_change_header([
+            'type' => 'directory',
+            'path' => 'later',
+        ]);
+        $invalid_input = $this->requestBody([
+            ['type' => 'directory', 'path' => '../escape'],
+            ['type' => 'directory', 'path' => 'later'],
+        ]);
+        $session->accept_upload($invalid_input);
+        try {
+            try {
+                $session->next_change();
+                self::fail('Expected unsafe path rejection.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_CHANGE, $exception->getCode());
+            }
+            try {
+                $session->next_change();
+                self::fail('Expected the rejected request body to stay stopped.');
+            } catch (LogicException $exception) {
+                self::assertStringContainsString('stopped after a rejected change', $exception->getMessage());
+            }
+            self::assertSame($later_header, stream_get_contents($invalid_input));
+        } finally {
+            $session->finish_upload();
+            fclose($invalid_input);
+        }
+        $safe_input = $this->requestBody([['type' => 'directory', 'path' => 'safe']]);
+        $session->accept_upload($safe_input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($safe_input);
+        }
+        self::assertSame(base64_encode('safe'), $session->get_status()['last_path_b64']);
+    }
+
+    /** An out-of-order path leaves earlier accepted changes retryable. */
+    public function testOutOfOrderPathLeavesTheSessionRetryable(): void {
+        $out_of_order = $this->createSession();
+        $out_of_order_input = $this->requestBody([
+            ['type' => 'directory', 'path' => 'z-last'],
+            ['type' => 'directory', 'path' => 'a-first'],
+        ]);
+        $out_of_order->accept_upload($out_of_order_input);
+        try {
+            self::assertTrue($out_of_order->next_change());
+            try {
+                $out_of_order->next_change();
+                self::fail('Expected out-of-order path rejection.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_CHANGE, $exception->getCode());
+                self::assertStringContainsString('must sort after the last accepted path', $exception->getMessage());
+            }
+        } finally {
+            $out_of_order->finish_upload();
+            fclose($out_of_order_input);
+        }
+        $next_input = $this->requestBody([['type' => 'directory', 'path' => 'zz-next']]);
+        $out_of_order->accept_upload($next_input);
+        try {
+            self::assertTrue($out_of_order->next_change());
+            self::assertFalse($out_of_order->next_change());
+        } finally {
+            $out_of_order->finish_upload();
+            fclose($next_input);
+        }
+        self::assertSame(base64_encode('zz-next'), $out_of_order->get_status()['last_path_b64']);
+    }
+
+    /** Verifies path limits fail without reflecting unbounded input. */
+    public function testOverlongPathsAreRejectedWithBoundedDiagnostics(): void {
+        $overlong_path = str_repeat('a', Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES + 1);
+        $expected_size_detail = ( Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES + 1 )
+            . ' bytes; the maximum is ' . Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES . ' bytes';
+        $session = $this->createSession();
+        $input = $this->requestBody([['type' => 'directory', 'path' => $overlong_path]]);
+        $session->accept_upload($input);
+        try {
+            try {
+                $session->next_change();
+                self::fail('Expected the overlong change path to be rejected.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_CHANGE, $exception->getCode());
+                self::assertStringContainsString($expected_size_detail, $exception->getMessage());
+                self::assertLessThan(200, strlen($exception->getMessage()));
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+        self::assertNull($session->get_status()['last_path_b64']);
+    }
+
+    /** Verifies reopening never follows a substituted work directory. */
+    public function testOpenRejectsASymlinkedPrivateWorkDirectory(): void {
+        $session = $this->createSession();
+        $session_directory = $this->sessionDirectory($session);
+        rename($session_directory . '/work', $session_directory . '/work-real');
+        symlink($this->temporary_directory, $session_directory . '/work');
+
+        try {
+            Site_Export_Staged_Apply_Session::open(
+                $this->staging_directory,
+                $this->target_directory,
+                $session->get_session_id()
+            );
+            self::fail('Expected private work-directory symlink rejection.');
+        } catch (RuntimeException $exception) {
+            self::assertStringContainsString('work directory must be a real directory', $exception->getMessage());
+        }
+    }
+
+    /** Staging may neither contain nor live inside the apply target. */
+    public function testStagingAndTargetMustBeSeparateDirectoryTrees(): void {
+        $inside_target = $this->target_directory . '/staging';
+        mkdir($inside_target);
+        foreach ([$inside_target, $this->target_directory, $this->temporary_directory] as $staging_directory) {
+            try {
+                Site_Export_Staged_Apply_Session::create($staging_directory, $this->target_directory);
+                self::fail('Expected overlapping staging and target trees to be rejected.');
+            } catch (InvalidArgumentException $exception) {
+                self::assertStringContainsString('must be separate directory trees', $exception->getMessage());
+            }
+        }
+        self::assertDirectoryDoesNotExist($inside_target . '/apply-sessions');
+    }
+
+    /** The caller owns the staging root; session creation does not create it. */
+    public function testStagingDirectoryMustAlreadyExist(): void {
+        $missing_staging_directory = $this->temporary_directory . '/missing-staging';
+
+        try {
+            Site_Export_Staged_Apply_Session::create($missing_staging_directory, $this->target_directory);
+            self::fail('Expected a missing staging directory to be rejected.');
+        } catch (RuntimeException $exception) {
+            self::assertStringContainsString('is not an existing directory', $exception->getMessage());
+        }
+        self::assertDirectoryDoesNotExist($missing_staging_directory);
+    }
+
+    /** A new upload repeats the final complete journal change after a process cut. */
+    public function testFinalJournalChangeIsMaterializedAgainAfterAProcessCut(): void {
+        $session = $this->createSession();
+        $session_directory = $this->sessionDirectory($session);
+        $input = $this->requestBody([
+            ['type' => 'directory', 'path' => 'a-earlier'],
+            ['type' => 'directory', 'path' => 'b-final'],
+        ]);
+        $session->accept_upload($input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+
+        // b-final is the state left when the process stops after its journal
+        // line is flushed but before the directory is created. a-earlier
+        // proves that recovery does not replay the whole journal.
+        rmdir($session_directory . '/work/files/a-earlier');
+        rmdir($session_directory . '/work/files/b-final');
+
+        $reopened = Site_Export_Staged_Apply_Session::open(
+            $this->staging_directory,
+            $this->target_directory,
+            $session->get_session_id()
+        );
+        $empty_input = $this->requestBody([]);
+        $reopened->accept_upload($empty_input);
+        try {
+            self::assertFalse($reopened->next_change());
+        } finally {
+            $reopened->finish_upload();
+            fclose($empty_input);
+        }
+
+        self::assertDirectoryDoesNotExist($session_directory . '/work/files/a-earlier');
+        self::assertDirectoryExists($session_directory . '/work/files/b-final');
+        self::assertSame(base64_encode('b-final'), $reopened->get_status()['last_path_b64']);
+        self::assertCount(2, file($session_directory . '/work/journal.jsonl', FILE_IGNORE_NEW_LINES));
+    }
+
+    /** Verifies symlinks cannot acquire staged descendants. */
+    public function testSymlinkAncestorsRejectDescendantMaterialization(): void {
+        $outside = $this->temporary_directory . '/outside';
+        mkdir($outside);
+
+        $session = $this->createSession();
+        $input = $this->requestBody([
+            ['type' => 'symlink', 'path' => 'node', 'target' => $outside],
+            ['type' => 'directory', 'path' => 'node/child'],
+        ]);
+        $session->accept_upload($input);
+        try {
+            self::assertTrue($session->next_change());
+            try {
+                $session->next_change();
+                self::fail('Expected descendant rejection below a staged symlink.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_CHANGE, $exception->getCode());
+                self::assertStringContainsString('non-directory staged ancestor', $exception->getMessage());
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+        self::assertSame(base64_encode('node'), $session->get_status()['last_path_b64']);
+        self::assertFileDoesNotExist($outside . '/child');
+
+        $next_input = $this->requestBody([['type' => 'directory', 'path' => 'z-next']]);
+        $session->accept_upload($next_input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($next_input);
+        }
+        self::assertSame(base64_encode('z-next'), $session->get_status()['last_path_b64']);
+    }
+
+    /** An incomplete journal tail is removed before the next change. */
+    public function testIncompleteJournalTailIsRemovedBeforeTheNextChange(): void {
+        $session = $this->createSession();
+        $first_input = $this->requestBody([['type' => 'directory', 'path' => 'a']]);
+        $session->accept_upload($first_input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($first_input);
+        }
+        $journal = $this->sessionDirectory($session) . '/work/journal.jsonl';
+        file_put_contents($journal, '{uncommitted', FILE_APPEND);
+
+        $next_input = $this->requestBody([['type' => 'directory', 'path' => 'b']]);
+        $session->accept_upload($next_input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($next_input);
+        }
+
+        self::assertCount(2, file($journal, FILE_IGNORE_NEW_LINES));
+        self::assertSame(base64_encode('b'), $session->get_status()['last_path_b64']);
+    }
+
+    /** Status ignores an incomplete journal tail without changing the journal. */
+    public function testStatusReportsOnlyTheCompleteJournalPrefix(): void {
+        $session = $this->createSession();
+        $input = $this->requestBody([['type' => 'directory', 'path' => 'directory']]);
+        $session->accept_upload($input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+        $journal = $this->sessionDirectory($session) . '/work/journal.jsonl';
+        $complete_journal_bytes = filesize($journal);
+        self::assertIsInt($complete_journal_bytes);
+        self::assertNotFalse(file_put_contents($journal, '{unfinished', FILE_APPEND));
+
+        self::assertSame(
+            [
+                'journal_bytes' => $complete_journal_bytes,
+                'last_path_b64' => base64_encode('directory'),
+            ],
+            $session->get_status()
+        );
+        self::assertSame($complete_journal_bytes + strlen('{unfinished'), filesize($journal));
+    }
+
+    /** One upload holds the session until its caller finishes it. */
+    public function testOpenUploadRejectsAnotherUploadUntilFinished(): void {
+        $session = $this->createSession();
+        $input = $this->requestBody([]);
+        $session->accept_upload($input);
+        $reopened = Site_Export_Staged_Apply_Session::open(
+            $this->staging_directory,
+            $this->target_directory,
+            $session->get_session_id()
+        );
+        $contending_input = $this->requestBody([]);
+        try {
+            try {
+                $reopened->get_status();
+                self::fail('Expected an open upload to block its status request.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_BUSY, $exception->getCode());
+            }
+            try {
+                $reopened->accept_upload($contending_input);
+                self::fail('Expected an open upload to hold the session lock.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_BUSY, $exception->getCode());
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+            fclose($contending_input);
+        }
+        $next_input = $this->requestBody([['type' => 'directory', 'path' => 'directory']]);
+        $reopened->accept_upload($next_input);
+        try {
+            self::assertTrue($reopened->next_change());
+            self::assertFalse($reopened->next_change());
+        } finally {
+            $reopened->finish_upload();
+            fclose($next_input);
+        }
+        self::assertSame(base64_encode('directory'), $reopened->get_status()['last_path_b64']);
+    }
+
+    /** Verifies arbitrary path bytes remain base64-safe in the journal. */
+    public function testRawNonUtf8PathRoundTripsThroughJournal(): void {
+        $path = "raw-\xff";
+        $probe = $this->target_directory . '/' . $path;
+        if (@file_put_contents($probe, 'probe') === false) {
+            self::markTestSkipped('This filesystem API does not accept a non-UTF-8 file name.');
+        }
+        unlink($probe);
+        $session = $this->createSession();
+        $input = $this->requestBody([['type' => 'directory', 'path' => $path]]);
+        $session->accept_upload($input);
+        try {
+            self::assertTrue($session->next_change());
+            self::assertFalse($session->next_change());
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+
+        self::assertSame(base64_encode($path), $session->get_status()['last_path_b64']);
+        self::assertDirectoryExists($this->sessionDirectory($session) . '/work/files/' . $path);
+        self::assertFileDoesNotExist($this->target_directory . '/' . $path);
+    }
+
+    /** Verifies filesystem errors encode arbitrary path bytes for JSON responses. */
+    public function testRawNonUtf8PathIsEncodedInFilesystemFailure(): void {
+        $path = str_repeat('a', 255) . "\xff/file";
+        $session = $this->createSession();
+
+        $input = $this->requestBody([['type' => 'directory', 'path' => $path]]);
+        $session->accept_upload($input);
+        try {
+            try {
+                $session->next_change();
+                self::fail('Expected the overlong filesystem segment to fail materialization.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_RETRYABLE_IO, $exception->getCode());
+                self::assertStringContainsString('base64:', $exception->getMessage());
+                self::assertStringNotContainsString("\xff", $exception->getMessage());
+                self::assertNotFalse(json_encode(['error' => $exception->getMessage()]));
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+    }
+
+    /**
+     * Builds one framed request body from raw change values.
+     *
+     * @param array<int,array<string,mixed>> $changes
+     * @return resource
+     */
+    private function requestBody(array $changes) {
+        $input = fopen('php://temp', 'w+b');
+        if ($input === false) {
+            throw new RuntimeException('Could not create staged apply request-body test stream.');
+        }
+        foreach ($changes as $change) {
+            if (fwrite($input, Site_Export_Staged_Push_Stream_Protocol::encode_apply_change_header($change)) === false) {
+                throw new RuntimeException('Could not write staged apply request-body test stream.');
+            }
+        }
+        rewind($input);
+        return $input;
+    }
+
+    /** Creates a session in this test's isolated roots. */
+    private function createSession(): Site_Export_Staged_Apply_Session {
+        return Site_Export_Staged_Apply_Session::create(
+            $this->staging_directory,
+            $this->target_directory
+        );
+    }
+
+    /** Returns the filesystem directory owned by a test session. */
+    private function sessionDirectory(Site_Export_Staged_Apply_Session $session): string {
+        return $this->staging_directory . '/apply-sessions/' . $session->get_session_id();
+    }
+
+    /** Removes an isolated test tree without following symlinks. */
+    private function removeTree(string $path): void {
+        if (is_link($path) || !is_dir($path)) {
+            if (file_exists($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $directory = opendir($path);
+        if ($directory === false) {
+            return;
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+        } finally {
+            closedir($directory);
+        }
+        rmdir($path);
+    }
+}

--- a/tests/StagedPushStreamProtocolTest.php
+++ b/tests/StagedPushStreamProtocolTest.php
@@ -106,17 +106,111 @@ final class StagedPushStreamProtocolTest extends TestCase
         ];
     }
 
-    public function testReadAndDiscardUseTheSameBoundedStreamHelpers(): void
+    public function testParserReadsAndDiscardsBoundedPayloads(): void
     {
         $stream = fopen('php://temp', 'w+b');
-        fwrite($stream, "abc\ndefghijk");
+        $first_header = rtrim(
+            Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header('first.txt', 0, 5, 5, true),
+            "\n"
+        ) . "\r\n";
+        fwrite(
+            $stream,
+            $first_header
+            . 'abcde'
+            . Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header('second.txt', 0, 2, 2, true)
+            . 'fg'
+        );
         rewind($stream);
 
-        $this->assertSame("abc\n", fgets($stream));
-        $this->assertSame('def', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 3));
-        $this->assertTrue(Site_Export_Staged_Push_Stream_Protocol::discard_exactly($stream, 3, 2));
-        $this->assertSame('jk', Site_Export_Staged_Push_Stream_Protocol::read_exactly($stream, 2));
+        try {
+            $parser = new Site_Export_Staged_Push_Stream_Parser($stream);
 
-        fclose($stream);
+            $this->assertTrue($parser->next_frame());
+            $this->assertSame(
+                ['artifact_id' => 'first.txt', 'offset' => 0, 'bytes' => 5, 'total_bytes' => 5, 'final' => true],
+                Site_Export_Staged_Push_Stream_Protocol::decode_chunk_frame($parser->get_current_frame())
+            );
+            $this->assertSame('ab', $parser->read_payload_piece(2));
+            $this->assertSame('cde', $parser->read_payload_piece(8));
+
+            $this->assertTrue($parser->next_frame());
+            $this->assertSame(
+                ['artifact_id' => 'second.txt', 'offset' => 0, 'bytes' => 2, 'total_bytes' => 2, 'final' => true],
+                Site_Export_Staged_Push_Stream_Protocol::decode_chunk_frame($parser->get_current_frame())
+            );
+            $parser->discard_payload_bytes(2, 1);
+            $this->assertFalse($parser->next_frame());
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testParserDoesNotAdvanceBeforeTheCurrentPayloadIsConsumed(): void
+    {
+        $next_header = Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header('second.txt', 0, 0, 0, true);
+        $stream = fopen('php://temp', 'w+b');
+        fwrite(
+            $stream,
+            Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header('first.txt', 0, 1, 1, true)
+            . 'x'
+            . $next_header
+        );
+        rewind($stream);
+
+        try {
+            $parser = new Site_Export_Staged_Push_Stream_Parser($stream);
+            $this->assertTrue($parser->next_frame());
+
+            try {
+                $parser->next_frame();
+                $this->fail('Expected parser to require the current payload first.');
+            } catch (LogicException $exception) {
+                $this->assertSame(
+                    'Read or discard the current staged push stream frame payload before reading another frame.',
+                    $exception->getMessage()
+                );
+            }
+
+            $this->assertSame('x' . $next_header, stream_get_contents($stream));
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testParserRejectsATruncatedPayload(): void
+    {
+        $stream = fopen('php://temp', 'w+b');
+        fwrite(
+            $stream,
+            Site_Export_Staged_Push_Stream_Protocol::encode_chunk_header('short.txt', 0, 2, 2, true) . 'x'
+        );
+        rewind($stream);
+
+        try {
+            $parser = new Site_Export_Staged_Push_Stream_Parser($stream);
+            $this->assertTrue($parser->next_frame());
+            $this->assertSame('x', $parser->read_payload_piece(2));
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('payload ended before its declared byte count');
+            $parser->read_payload_piece(2);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testApplyChangeHeadersRoundTrip(): void
+    {
+        $changes = [
+            ['type' => 'directory', 'path' => 'directory'],
+            ['type' => 'symlink', 'path' => 'link', 'target' => "raw-\xff"],
+            ['type' => 'delete', 'path' => 'deleted'],
+        ];
+
+        foreach ($changes as $change) {
+            $header = Site_Export_Staged_Push_Stream_Protocol::encode_apply_change_header($change);
+            $frame = Site_Export_Staged_Push_Stream_Protocol::decode_frame_header(rtrim($header, "\n"));
+            $this->assertSame($change, Site_Export_Staged_Push_Stream_Protocol::decode_apply_change_frame($frame));
+        }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,10 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-push-stream-protocol.php';
 }
 
+if (!class_exists('Site_Export_Staged_Push_Stream_Parser', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-push-stream-parser.php';
+}
+
 if (!class_exists('Site_Export_Staged_Endpoints', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-endpoints.php';
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -31,6 +31,8 @@
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
             <file>StagedArtifactsTest.php</file>
+            <file>StagedApplySessionTest.php</file>
+            <file>StagedPushStreamProtocolTest.php</file>
             <file>StagedEndpointsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">


### PR DESCRIPTION
Staged-apply sessions now consume one framed directory, symlink, or delete change at a time, so an interrupted upload can resume at its last saved path without touching the live tree.

Before this, callers had to parse the request body and call separate `accept_*` methods. The HTTP layer would have had to duplicate the framing and decide when to stop reading after a bad frame.

```php
$session->accept_upload($input);
try {
    while ($session->next_change()) {
    }
} finally {
    $session->finish_upload();
}
```

`next_change()` stages and journals one frame. A bad frame stops this request before its payload or later frames are read. The same bounded frame parser now drives artifact uploads, and the importer uses the shared frame encoder.
