### PR TITLE
[Push] Reject upload resumes after staged byte loss

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -104,12 +104,17 @@ half-written record), one small verified marker per finished artifact under
 drives the loop — one `append()` per buffer, individually committed, so the
 transfer can stop after any step and resume from `committed_bytes` in a new
 request. `finalize()` checks the assembled size against the size declared in
-the plan; nothing re-reads or hashes artifacts.
+the plan; nothing re-reads or hashes artifacts. A missing, shortened, or
+non-regular file behind the cursor is lost progress, not a valid resume point:
+status reports a zero frontier, a mid-file push retries from zero, and an
+offset-zero push replaces the damaged state.
 
 Driver rule: **a discard that did not return true must be retried until it
-does** — before re-uploading an artifact and before starting a fresh push
-over leftovers. A half-finished discard leaves states that only another
-discard cleans up.
+does** so all stale bytes are eventually removed. Discard invalidates cursor
+and verification records before unlinking the artifact, so an interrupted
+discard may leave untrusted bytes behind but never metadata authorizing bytes
+that were already removed. A fresh offset-zero upload safely replaces such an
+orphan.
 
 ## Where reprint stores its own data on the remote
 
@@ -197,10 +202,6 @@ Stated here so nobody rediscovers them as surprises:
   before pushing over them.
 - **Shell and cron can write during the maintenance window.** Maintenance
   blocks web requests; it cannot block SSH or system cron.
-- **A sender that abandons a failed discard and re-uploads anyway** can end
-  up with a zero-filled prefix that passes the size check. The discard
-  retry rule exists precisely to make this unreachable.
-
 ## Delivery plan
 
 Files first, database second, each PR small and stacked in this order:

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -105,9 +105,10 @@ drives the loop — one `append()` per buffer, individually committed, so the
 transfer can stop after any step and resume from `committed_bytes` in a new
 request. `finalize()` checks the assembled size against the size declared in
 the plan; nothing re-reads or hashes artifacts. A missing, shortened, or
-non-regular file behind the cursor is lost progress, not a valid resume point:
-status reports a zero frontier, a mid-file push retries from zero, and an
-offset-zero push replaces the damaged state.
+non-regular file behind the cursor is damaged staging, not a valid resume
+point: status reports a zero frontier, a mid-file frame ends the request with
+`staging_file_damaged` before its payload is read, and a later offset-zero push
+replaces the damaged state.
 
 Driver rule: **a discard that did not return true must be retried until it
 does** so all stale bytes are eventually removed. Discard invalidates cursor

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -39,8 +39,8 @@
  * does not read the artifact back, so finalize() costs the same for a 1 KB
  * file and a 50 GB dump. Corruption that preserves length is not detected,
  * the same trust pull's writer places in its local disk. A missing, shortened,
- * or non-regular file behind a committed cursor is rejected as lost progress
- * instead of being extended with zero bytes. The wire belongs to TLS,
+ * or non-regular file behind a committed cursor is rejected as damaged
+ * staging instead of being extended with zero bytes. The wire belongs to TLS,
  * and whether a caller may talk to the endpoint at all is checked by
  * Site_Export_HMAC_Server before any of this code runs.
  *
@@ -745,7 +745,7 @@ final class Site_Export_Staged_Artifacts {
     private function damaged_cursor_result(string $damage): array {
         return [
             'status' => 'rejected',
-            'reason' => 'offset_gap',
+            'reason' => 'staging_file_damaged',
             'detail' => $damage,
             'committed_bytes' => 0,
         ];

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -209,12 +209,12 @@ final class Site_Export_Staged_Artifacts {
             // append to any other artifact starts it from scratch.
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
-            $staging_file_damage = $this->staging_file_damage($file_path, $committed);
-            if ($staging_file_damage !== null) {
+            $staging_file_diagnostic = $this->diagnose_staging_file($file_path, $committed);
+            if ($staging_file_diagnostic !== null) {
                 return [
                     'status' => 'rejected',
                     'reason' => 'staging_file_damaged',
-                    'detail' => $staging_file_damage,
+                    'detail' => $staging_file_diagnostic,
                     'committed_bytes' => 0,
                 ];
             }
@@ -249,12 +249,12 @@ final class Site_Export_Staged_Artifacts {
             // bytes until the cursor decides what tail to discard.
             $file = @fopen($file_path, $committed > 0 ? 'r+b' : 'c+b');
             if ($file === false) {
-                $staging_file_damage = $this->staging_file_damage($file_path, $committed);
-                if ($staging_file_damage !== null) {
+                $staging_file_diagnostic = $this->diagnose_staging_file($file_path, $committed);
+                if ($staging_file_diagnostic !== null) {
                     return [
                         'status' => 'rejected',
                         'reason' => 'staging_file_damaged',
-                        'detail' => $staging_file_damage,
+                        'detail' => $staging_file_diagnostic,
                         'committed_bytes' => 0,
                     ];
                 }
@@ -267,12 +267,12 @@ final class Site_Export_Staged_Artifacts {
             }
 
             try {
-                $opened_staging_file_damage = $this->opened_staging_file_damage($file, $committed);
-                if ($opened_staging_file_damage !== null) {
+                $staging_file_diagnostic = $this->diagnose_staging_file($file, $committed);
+                if ($staging_file_diagnostic !== null) {
                     return [
                         'status' => 'rejected',
                         'reason' => 'staging_file_damaged',
-                        'detail' => $opened_staging_file_damage,
+                        'detail' => $staging_file_diagnostic,
                         'committed_bytes' => 0,
                     ];
                 }
@@ -431,12 +431,12 @@ final class Site_Export_Staged_Artifacts {
 
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
-            $staging_file_damage = $this->staging_file_damage($file_path, $committed);
-            if ($staging_file_damage !== null) {
+            $staging_file_diagnostic = $this->diagnose_staging_file($file_path, $committed);
+            if ($staging_file_diagnostic !== null) {
                 return [
                     'status' => 'rejected',
                     'reason' => 'staging_file_damaged',
-                    'detail' => $staging_file_damage,
+                    'detail' => $staging_file_diagnostic,
                     'committed_bytes' => 0,
                     'path' => null,
                 ];
@@ -477,12 +477,12 @@ final class Site_Export_Staged_Artifacts {
 
             $file = @fopen($file_path, $committed > 0 ? 'r+b' : 'c+b');
             if ($file === false) {
-                $staging_file_damage = $this->staging_file_damage($file_path, $committed);
-                if ($staging_file_damage !== null) {
+                $staging_file_diagnostic = $this->diagnose_staging_file($file_path, $committed);
+                if ($staging_file_diagnostic !== null) {
                     return [
                         'status' => 'rejected',
                         'reason' => 'staging_file_damaged',
-                        'detail' => $staging_file_damage,
+                        'detail' => $staging_file_diagnostic,
                         'committed_bytes' => 0,
                         'path' => null,
                     ];
@@ -495,13 +495,13 @@ final class Site_Export_Staged_Artifacts {
                     'path' => null,
                 ];
             }
-            $opened_staging_file_damage = $this->opened_staging_file_damage($file, $committed);
-            if ($opened_staging_file_damage !== null) {
+            $staging_file_diagnostic = $this->diagnose_staging_file($file, $committed);
+            if ($staging_file_diagnostic !== null) {
                 fclose($file);
                 return [
                     'status' => 'rejected',
                     'reason' => 'staging_file_damaged',
-                    'detail' => $opened_staging_file_damage,
+                    'detail' => $staging_file_diagnostic,
                     'committed_bytes' => 0,
                     'path' => null,
                 ];
@@ -580,14 +580,14 @@ final class Site_Export_Staged_Artifacts {
 
         $state = $this->read_state();
         $committed_bytes = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
-        $staging_file_damage = $this->staging_file_damage($file_path, $committed_bytes);
+        $staging_file_diagnostic = $this->diagnose_staging_file($file_path, $committed_bytes);
         $status = [
             'exists' => file_exists($file_path),
-            'committed_bytes' => $staging_file_damage === null ? $committed_bytes : 0,
+            'committed_bytes' => $staging_file_diagnostic === null ? $committed_bytes : 0,
             'verified' => false,
         ];
-        if ($staging_file_damage !== null) {
-            $status['damage'] = $staging_file_damage;
+        if ($staging_file_diagnostic !== null) {
+            $status['damage'] = $staging_file_diagnostic;
             $status['recorded_committed_bytes'] = $committed_bytes;
         }
         return $status;
@@ -718,43 +718,29 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Return why a nonzero cursor no longer has trustworthy backing bytes.
+     * Diagnose whether a nonzero cursor still has trustworthy backing bytes.
      * A longer file is valid: it is an uncommitted tail left by an interrupted
      * append and the next writer truncates it back to the cursor.
-     */
-    private function staging_file_damage(string $file_path, int $committed_bytes): ?string {
-        if ($committed_bytes === 0) {
-            return null;
-        }
-
-        $file_stat = @lstat($file_path);
-        if (!is_array($file_stat)) {
-            return 'staging_file_missing_at_cursor';
-        }
-        if (
-            !isset($file_stat['mode'])
-            || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 )
-        ) {
-            return 'staging_file_not_regular';
-        }
-        if (!isset($file_stat['size']) || (int) $file_stat['size'] < $committed_bytes) {
-            return 'staging_file_shorter_than_cursor';
-        }
-        return null;
-    }
-
-    /**
-     * Recheck the opened file before ftruncate() can extend it. The path check
-     * and open are separate filesystem operations, so cleanup may race them.
      *
-     * @param resource $file
+     * A path is inspected with lstat() so links are never followed. An open
+     * handle is rechecked with fstat() before ftruncate() can extend it: the
+     * path check and open are separate operations, so cleanup may race them.
+     *
+     * @param string|resource $staging_file_path_or_handle
      */
-    private function opened_staging_file_damage($file, int $committed_bytes): ?string {
+    private function diagnose_staging_file($staging_file_path_or_handle, int $committed_bytes): ?string {
         if ($committed_bytes === 0) {
             return null;
         }
 
-        $file_stat = @fstat($file);
+        if (is_string($staging_file_path_or_handle)) {
+            $file_stat = @lstat($staging_file_path_or_handle);
+            if (!is_array($file_stat)) {
+                return 'staging_file_missing_at_cursor';
+            }
+        } else {
+            $file_stat = @fstat($staging_file_path_or_handle);
+        }
         if (
             !is_array($file_stat)
             || !isset($file_stat['mode'])

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -211,7 +211,12 @@ final class Site_Export_Staged_Artifacts {
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
             $staging_file_damage = $this->staging_file_damage($file_path, $committed);
             if ($staging_file_damage !== null) {
-                return $this->damaged_cursor_result($staging_file_damage);
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'staging_file_damaged',
+                    'detail' => $staging_file_damage,
+                    'committed_bytes' => 0,
+                ];
             }
 
             if ($offset + strlen($bytes) <= $committed) {
@@ -246,7 +251,12 @@ final class Site_Export_Staged_Artifacts {
             if ($file === false) {
                 $staging_file_damage = $this->staging_file_damage($file_path, $committed);
                 if ($staging_file_damage !== null) {
-                    return $this->damaged_cursor_result($staging_file_damage);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'staging_file_damaged',
+                        'detail' => $staging_file_damage,
+                        'committed_bytes' => 0,
+                    ];
                 }
                 return [
                     'status' => 'rejected',
@@ -259,7 +269,12 @@ final class Site_Export_Staged_Artifacts {
             try {
                 $opened_staging_file_damage = $this->opened_staging_file_damage($file, $committed);
                 if ($opened_staging_file_damage !== null) {
-                    return $this->damaged_cursor_result($opened_staging_file_damage);
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'staging_file_damaged',
+                        'detail' => $opened_staging_file_damage,
+                        'committed_bytes' => 0,
+                    ];
                 }
 
                 // Discard any uncommitted tail from an interrupted earlier
@@ -418,9 +433,13 @@ final class Site_Export_Staged_Artifacts {
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
             $staging_file_damage = $this->staging_file_damage($file_path, $committed);
             if ($staging_file_damage !== null) {
-                $result = $this->damaged_cursor_result($staging_file_damage);
-                $result['path'] = null;
-                return $result;
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'staging_file_damaged',
+                    'detail' => $staging_file_damage,
+                    'committed_bytes' => 0,
+                    'path' => null,
+                ];
             }
 
             if (!file_exists($file_path)) {
@@ -460,9 +479,13 @@ final class Site_Export_Staged_Artifacts {
             if ($file === false) {
                 $staging_file_damage = $this->staging_file_damage($file_path, $committed);
                 if ($staging_file_damage !== null) {
-                    $result = $this->damaged_cursor_result($staging_file_damage);
-                    $result['path'] = null;
-                    return $result;
+                    return [
+                        'status' => 'rejected',
+                        'reason' => 'staging_file_damaged',
+                        'detail' => $staging_file_damage,
+                        'committed_bytes' => 0,
+                        'path' => null,
+                    ];
                 }
                 return [
                     'status' => 'rejected',
@@ -475,9 +498,13 @@ final class Site_Export_Staged_Artifacts {
             $opened_staging_file_damage = $this->opened_staging_file_damage($file, $committed);
             if ($opened_staging_file_damage !== null) {
                 fclose($file);
-                $result = $this->damaged_cursor_result($opened_staging_file_damage);
-                $result['path'] = null;
-                return $result;
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'staging_file_damaged',
+                    'detail' => $opened_staging_file_damage,
+                    'committed_bytes' => 0,
+                    'path' => null,
+                ];
             }
 
             // Drop any uncommitted tail so the artifact holds committed bytes only.
@@ -739,16 +766,6 @@ final class Site_Export_Staged_Artifacts {
             return 'staging_file_shorter_than_cursor';
         }
         return null;
-    }
-
-    /** @return array{status:string,reason:string,detail:string,committed_bytes:int} */
-    private function damaged_cursor_result(string $damage): array {
-        return [
-            'status' => 'rejected',
-            'reason' => 'staging_file_damaged',
-            'detail' => $damage,
-            'committed_bytes' => 0,
-        ];
     }
 
     /**

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -38,9 +38,9 @@
  * time. That catches truncation, missing bytes, and resume-offset bugs; it
  * does not read the artifact back, so finalize() costs the same for a 1 KB
  * file and a 50 GB dump. Corruption that preserves length — including a
- * staging file that shrank between requests and was zero-filled back to the
- * committed size by the next append's ftruncate — is not detected, the same
- * trust pull's writer places in its local disk. The wire belongs to TLS,
+ * same-size local edit between requests — is not detected, the same trust
+ * pull's writer places in its local disk. A file shorter than its committed
+ * cursor is rejected rather than being zero-filled. The wire belongs to TLS,
  * and whether a caller may talk to the endpoint at all is checked by
  * Site_Export_HMAC_Server before any of this code runs.
  *
@@ -209,6 +209,34 @@ final class Site_Export_Staged_Artifacts {
             // append to any other artifact starts it from scratch.
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false)) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'create_staging_dir',
+                    'committed_bytes' => $committed,
+                ];
+            }
+            $file_stat = @lstat($file_path);
+            $file_is_regular = is_array($file_stat)
+                && isset($file_stat['mode'])
+                && ( ( (int) $file_stat['mode'] & 0170000 ) === 0100000 );
+            if (is_array($file_stat) && !$file_is_regular) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'open_artifact_file',
+                    'committed_bytes' => 0,
+                ];
+            }
+            if ($committed > 0 && ( !$file_is_regular || !isset($file_stat['size']) || (int) $file_stat['size'] < $committed )) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'staging_file_shorter_than_cursor',
+                    'committed_bytes' => 0,
+                ];
+            }
 
             if ($offset + strlen($bytes) <= $committed) {
                 return [
@@ -227,7 +255,7 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            if (!$this->ensure_parent_dir($file_path)) {
+            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, true)) {
                 return [
                     'status' => 'rejected',
                     'reason' => 'io_error',
@@ -369,6 +397,28 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
+            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false)) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'create_staging_dir',
+                    'committed_bytes' => 0,
+                    'path' => null,
+                ];
+            }
+            $file_stat = @lstat($file_path);
+            if (
+                is_array($file_stat)
+                && ( !isset($file_stat['mode']) || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 ) )
+            ) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'open_artifact_file',
+                    'committed_bytes' => 0,
+                    'path' => null,
+                ];
+            }
             $verified_size = $this->read_verified_size($artifact_id);
             if ($verified_size !== null) {
                 // The record can outlive the file — a discard killed between
@@ -404,6 +454,19 @@ final class Site_Export_Staged_Artifacts {
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
 
+            if (
+                is_array($file_stat)
+                && isset($file_stat['size'])
+                && (int) $file_stat['size'] < $committed
+            ) {
+                return [
+                    'status' => 'rejected',
+                    'reason' => 'io_error',
+                    'detail' => 'staging_file_shorter_than_cursor',
+                    'committed_bytes' => 0,
+                    'path' => null,
+                ];
+            }
             if (!file_exists($file_path)) {
                 // A zero-byte artifact legitimately has no appends; the fopen
                 // below creates its empty file.
@@ -416,7 +479,7 @@ final class Site_Export_Staged_Artifacts {
                         'path' => null,
                     ];
                 }
-                if (!$this->ensure_parent_dir($file_path)) {
+                if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, true)) {
                     return [
                         'status' => 'rejected',
                         'reason' => 'io_error',
@@ -494,7 +557,11 @@ final class Site_Export_Staged_Artifacts {
      * This is advisory and intentionally lock-free; writers still enforce the
      * committed offset under the lock before accepting bytes.
      *
-     * @return array{exists:bool,committed_bytes:int,verified:bool}
+     * When a cursor's staged file is missing, short, or not regular,
+     * committed_bytes stays zero and the response adds damage plus the
+     * recorded cursor so the caller can distinguish damage from no progress.
+     *
+     * @return array{exists:bool,committed_bytes:int,verified:bool,damage?:string,recorded_committed_bytes?:int}
      */
     public function status(string $artifact_id): array {
         $file_path = $this->artifact_path($artifact_id);
@@ -505,22 +572,42 @@ final class Site_Export_Staged_Artifacts {
                 'verified' => false,
             ];
         }
+        $file_parent_is_safe = $this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false);
 
         $verified_size = $this->read_verified_size($artifact_id);
         if ($verified_size !== null) {
             return [
-                'exists' => file_exists($file_path),
+                'exists' => $file_parent_is_safe && file_exists($file_path),
                 'committed_bytes' => $verified_size,
                 'verified' => true,
             ];
         }
 
         $state = $this->read_state();
-        return [
-            'exists' => file_exists($file_path),
-            'committed_bytes' => $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0,
+        $file_stat = $file_parent_is_safe ? @lstat($file_path) : false;
+        $committed_bytes = 0;
+        $damage = null;
+        if ($state['artifact_id'] === $artifact_id) {
+            if (!$file_parent_is_safe || ( is_array($file_stat) && ( !isset($file_stat['mode']) || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 ) ) )) {
+                $damage = 'staging_file_not_regular';
+            } elseif (!is_array($file_stat)) {
+                $damage = 'staging_file_missing_at_cursor';
+            } elseif (!isset($file_stat['size']) || (int) $file_stat['size'] < $state['committed_bytes']) {
+                $damage = 'staging_file_shorter_than_cursor';
+            } else {
+                $committed_bytes = $state['committed_bytes'];
+            }
+        }
+        $status = [
+            'exists' => $file_parent_is_safe && file_exists($file_path),
+            'committed_bytes' => $committed_bytes,
             'verified' => false,
         ];
+        if ($damage !== null) {
+            $status['damage'] = $damage;
+            $status['recorded_committed_bytes'] = $state['committed_bytes'];
+        }
+        return $status;
     }
 
     /**
@@ -561,7 +648,10 @@ final class Site_Export_Staged_Artifacts {
                 return false;
             }
 
-            if (file_exists($file_path) && !@unlink($file_path)) {
+            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false)) {
+                return false;
+            }
+            if (( file_exists($file_path) || is_link($file_path) ) && !@unlink($file_path)) {
                 return false;
             }
             $state = $this->read_state();
@@ -620,23 +710,55 @@ final class Site_Export_Staged_Artifacts {
      * files, and the index exclusion of storage_path still applies.
      */
     private function ensure_web_guards(string $dir): void {
-        $htaccess = $dir . '/.htaccess';
-        if (!file_exists($htaccess)) {
-            @file_put_contents(
-                $htaccess,
-                "# Reprint staging area - never web-served.\n" .
-                "<IfModule mod_authz_core.c>\n" .
-                "    Require all denied\n" .
-                "</IfModule>\n" .
-                "<IfModule !mod_authz_core.c>\n" .
-                "    Deny from all\n" .
-                "</IfModule>\n"
-            );
+        $this->ensure_web_guard(
+            $dir . '/.htaccess',
+            "# Reprint staging area - never web-served.\n" .
+            "<IfModule mod_authz_core.c>\n" .
+            "    Require all denied\n" .
+            "</IfModule>\n" .
+            "<IfModule !mod_authz_core.c>\n" .
+            "    Deny from all\n" .
+            "</IfModule>\n"
+        );
+        $this->ensure_web_guard($dir . '/index.php', "<?php\n");
+    }
+
+    /**
+     * Leave a regular guard alone, or replace any other leaf without ever
+     * opening a planted symlink. Exclusive creation also makes a race that
+     * installs a new leaf between lstat() and fopen() fail closed.
+     */
+    private function ensure_web_guard(string $path, string $contents): void {
+        $guard_stat = @lstat($path);
+        if (
+            is_array($guard_stat)
+            && isset($guard_stat['mode'])
+            && ( ( (int) $guard_stat['mode'] & 0170000 ) === 0100000 )
+        ) {
+            return;
+        }
+        if (is_array($guard_stat) && !@unlink($path)) {
+            return;
         }
 
-        $index = $dir . '/index.php';
-        if (!file_exists($index)) {
-            @file_put_contents($index, "<?php\n");
+        $guard = @fopen($path, 'xb');
+        if ($guard === false) {
+            return;
+        }
+
+        $contents_length = strlen($contents);
+        $written_bytes = 0;
+        while ($written_bytes < $contents_length) {
+            $written = @fwrite($guard, substr($contents, $written_bytes));
+            if (!is_int($written) || $written === 0) {
+                break;
+            }
+            $written_bytes += $written;
+        }
+        $write_succeeded = $written_bytes === $contents_length && @fflush($guard);
+        @fclose($guard);
+        if (!$write_succeeded) {
+            @unlink($path);
         }
     }
 
@@ -644,6 +766,40 @@ final class Site_Export_Staged_Artifacts {
         $dir = dirname($path);
         // A concurrent creator winning the mkdir race is success, not failure.
         return is_dir($dir) || @mkdir($dir, 0700, true) || is_dir($dir);
+    }
+
+    /**
+     * Check every parent below an artifact root without following symlinks.
+     * A missing parent either gets created one component at a time and
+     * rechecked, or proves that a read/removal cannot reach an artifact.
+     */
+    private function artifact_parent_directories_are_safe(string $root_dir, string $artifact_id, bool $create_missing): bool {
+        $parent_segments = explode('/', $artifact_id);
+        array_pop($parent_segments);
+        $directory = $root_dir;
+        $segment_index = 0;
+
+        while (true) {
+            $directory_stat = @lstat($directory);
+            if ($directory_stat === false && $create_missing) {
+                @mkdir($directory, 0700);
+                $directory_stat = @lstat($directory);
+            }
+            if ($directory_stat === false) {
+                return !$create_missing;
+            }
+            if (
+                !isset($directory_stat['mode'])
+                || ( ( (int) $directory_stat['mode'] & 0170000 ) !== 0040000 )
+            ) {
+                return false;
+            }
+            if ($segment_index === count($parent_segments)) {
+                return true;
+            }
+            $directory .= '/' . $parent_segments[$segment_index];
+            ++$segment_index;
+        }
     }
 
     /**
@@ -684,29 +840,15 @@ final class Site_Export_Staged_Artifacts {
     }
 
     private function write_state(?string $artifact_id, int $committed_bytes): bool {
-        // Write-then-rename keeps the cursor atomic: readers see the old
-        // record or the new one, never a torn file. The temp file sits next
-        // to the target so rename stays on the same filesystem.
-        $tmp_path = $this->state_path . '.tmp';
         // The id is stored base64: file names are arbitrary bytes, JSON
         // strings must be UTF-8, and json_encode() returning false would
-        // otherwise slip through the strlen() comparison below as an empty
+        // otherwise slip through the atomic writer as an empty
         // record — committed_bytes would silently reset to 0 on every read.
         $json = json_encode([
             'artifact_id' => $artifact_id !== null ? base64_encode($artifact_id) : null,
             'committed_bytes' => $committed_bytes,
         ]);
-        // A short write (disk full) returns a byte count, not false — never
-        // rename a torn record over the good one.
-        if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
-            @unlink($tmp_path);
-            return false;
-        }
-        if (!@rename($tmp_path, $this->state_path)) {
-            @unlink($tmp_path);
-            return false;
-        }
-        return true;
+        return $this->write_atomically($this->state_path, $this->state_path . '.tmp', $json);
     }
 
     /**
@@ -725,7 +867,19 @@ final class Site_Export_Staged_Artifacts {
      * worst case is re-finalizing an artifact, never trusting a torn record.
      */
     private function read_verified_size(string $artifact_id): ?int {
-        $raw = @file_get_contents($this->verified_marker_path($artifact_id));
+        if (!$this->artifact_parent_directories_are_safe($this->verified_dir, $artifact_id, false)) {
+            return null;
+        }
+        $marker_path = $this->verified_marker_path($artifact_id);
+        $marker_stat = @lstat($marker_path);
+        if (
+            !is_array($marker_stat)
+            || !isset($marker_stat['mode'])
+            || ( ( (int) $marker_stat['mode'] & 0170000 ) !== 0100000 )
+        ) {
+            return null;
+        }
+        $raw = @file_get_contents($marker_path);
         if ($raw === false) {
             return null;
         }
@@ -738,25 +892,42 @@ final class Site_Export_Staged_Artifacts {
 
     private function write_verified_marker(string $artifact_id, int $size): bool {
         $marker_path = $this->verified_marker_path($artifact_id);
-        if (!$this->ensure_parent_dir($marker_path)) {
+        if (!$this->artifact_parent_directories_are_safe($this->verified_dir, $artifact_id, true)) {
             return false;
         }
         $json = json_encode(['size' => $size]);
-        // Same discipline as the cursor: a short write (disk full) must
-        // never become a marker, so write whole to the temp file and rename.
-        if (@file_put_contents($this->verified_tmp_path, $json) !== strlen($json)) {
-            @unlink($this->verified_tmp_path);
-            return false;
-        }
-        if (!@rename($this->verified_tmp_path, $marker_path)) {
-            @unlink($this->verified_tmp_path);
-            return false;
-        }
-        return true;
+        return $this->write_atomically($marker_path, $this->verified_tmp_path, $json);
     }
 
     private function remove_verified_marker(string $artifact_id): bool {
+        if (!$this->artifact_parent_directories_are_safe($this->verified_dir, $artifact_id, false)) {
+            return false;
+        }
         $marker_path = $this->verified_marker_path($artifact_id);
-        return !file_exists($marker_path) || @unlink($marker_path);
+        return !( file_exists($marker_path) || is_link($marker_path) ) || @unlink($marker_path);
+    }
+
+    /**
+     * Atomically replace a small record without ever opening a planted temp
+     * symlink or hardlink. Readers see the old record or the new one, never a
+     * torn file; the temp path shares the target's filesystem for rename().
+     */
+    private function write_atomically(string $target_path, string $temporary_path, string $contents): bool {
+        @unlink($temporary_path);
+        $temporary_file = @fopen($temporary_path, 'xb');
+        if ($temporary_file === false) {
+            return false;
+        }
+
+        // A short write (disk full) returns a byte count, not false — never
+        // rename a torn record over the good one.
+        $written = @fwrite($temporary_file, $contents);
+        $write_succeeded = $written === strlen($contents) && @fflush($temporary_file);
+        @fclose($temporary_file);
+        if (!$write_succeeded || !@rename($temporary_path, $target_path)) {
+            @unlink($temporary_path);
+            return false;
+        }
+        return true;
     }
 }

--- a/packages/reprint-exporter/src/class-staged-artifacts.php
+++ b/packages/reprint-exporter/src/class-staged-artifacts.php
@@ -37,10 +37,10 @@
  * finalize() compares the assembled size against the total declared at plan
  * time. That catches truncation, missing bytes, and resume-offset bugs; it
  * does not read the artifact back, so finalize() costs the same for a 1 KB
- * file and a 50 GB dump. Corruption that preserves length — including a
- * same-size local edit between requests — is not detected, the same trust
- * pull's writer places in its local disk. A file shorter than its committed
- * cursor is rejected rather than being zero-filled. The wire belongs to TLS,
+ * file and a 50 GB dump. Corruption that preserves length is not detected,
+ * the same trust pull's writer places in its local disk. A missing, shortened,
+ * or non-regular file behind a committed cursor is rejected as lost progress
+ * instead of being extended with zero bytes. The wire belongs to TLS,
  * and whether a caller may talk to the endpoint at all is checked by
  * Site_Export_HMAC_Server before any of this code runs.
  *
@@ -209,33 +209,9 @@ final class Site_Export_Staged_Artifacts {
             // append to any other artifact starts it from scratch.
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
-            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false)) {
-                return [
-                    'status' => 'rejected',
-                    'reason' => 'io_error',
-                    'detail' => 'create_staging_dir',
-                    'committed_bytes' => $committed,
-                ];
-            }
-            $file_stat = @lstat($file_path);
-            $file_is_regular = is_array($file_stat)
-                && isset($file_stat['mode'])
-                && ( ( (int) $file_stat['mode'] & 0170000 ) === 0100000 );
-            if (is_array($file_stat) && !$file_is_regular) {
-                return [
-                    'status' => 'rejected',
-                    'reason' => 'io_error',
-                    'detail' => 'open_artifact_file',
-                    'committed_bytes' => 0,
-                ];
-            }
-            if ($committed > 0 && ( !$file_is_regular || !isset($file_stat['size']) || (int) $file_stat['size'] < $committed )) {
-                return [
-                    'status' => 'rejected',
-                    'reason' => 'io_error',
-                    'detail' => 'staging_file_shorter_than_cursor',
-                    'committed_bytes' => 0,
-                ];
+            $staging_file_damage = $this->staging_file_damage($file_path, $committed);
+            if ($staging_file_damage !== null) {
+                return $this->damaged_cursor_result($staging_file_damage);
             }
 
             if ($offset + strlen($bytes) <= $committed) {
@@ -255,7 +231,7 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, true)) {
+            if (!$this->ensure_parent_dir($file_path)) {
                 return [
                     'status' => 'rejected',
                     'reason' => 'io_error',
@@ -266,8 +242,12 @@ final class Site_Export_Staged_Artifacts {
 
             // Open without truncating: a resumed transfer must keep committed
             // bytes until the cursor decides what tail to discard.
-            $file = @fopen($file_path, 'c+b');
+            $file = @fopen($file_path, $committed > 0 ? 'r+b' : 'c+b');
             if ($file === false) {
+                $staging_file_damage = $this->staging_file_damage($file_path, $committed);
+                if ($staging_file_damage !== null) {
+                    return $this->damaged_cursor_result($staging_file_damage);
+                }
                 return [
                     'status' => 'rejected',
                     'reason' => 'io_error',
@@ -277,6 +257,11 @@ final class Site_Export_Staged_Artifacts {
             }
 
             try {
+                $opened_staging_file_damage = $this->opened_staging_file_damage($file, $committed);
+                if ($opened_staging_file_damage !== null) {
+                    return $this->damaged_cursor_result($opened_staging_file_damage);
+                }
+
                 // Discard any uncommitted tail from an interrupted earlier
                 // step, then append at the only offset the cursor says is
                 // committed.
@@ -397,28 +382,6 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false)) {
-                return [
-                    'status' => 'rejected',
-                    'reason' => 'io_error',
-                    'detail' => 'create_staging_dir',
-                    'committed_bytes' => 0,
-                    'path' => null,
-                ];
-            }
-            $file_stat = @lstat($file_path);
-            if (
-                is_array($file_stat)
-                && ( !isset($file_stat['mode']) || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 ) )
-            ) {
-                return [
-                    'status' => 'rejected',
-                    'reason' => 'io_error',
-                    'detail' => 'open_artifact_file',
-                    'committed_bytes' => 0,
-                    'path' => null,
-                ];
-            }
             $verified_size = $this->read_verified_size($artifact_id);
             if ($verified_size !== null) {
                 // The record can outlive the file — a discard killed between
@@ -453,20 +416,13 @@ final class Site_Export_Staged_Artifacts {
 
             $state = $this->read_state();
             $committed = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
-
-            if (
-                is_array($file_stat)
-                && isset($file_stat['size'])
-                && (int) $file_stat['size'] < $committed
-            ) {
-                return [
-                    'status' => 'rejected',
-                    'reason' => 'io_error',
-                    'detail' => 'staging_file_shorter_than_cursor',
-                    'committed_bytes' => 0,
-                    'path' => null,
-                ];
+            $staging_file_damage = $this->staging_file_damage($file_path, $committed);
+            if ($staging_file_damage !== null) {
+                $result = $this->damaged_cursor_result($staging_file_damage);
+                $result['path'] = null;
+                return $result;
             }
+
             if (!file_exists($file_path)) {
                 // A zero-byte artifact legitimately has no appends; the fopen
                 // below creates its empty file.
@@ -479,7 +435,7 @@ final class Site_Export_Staged_Artifacts {
                         'path' => null,
                     ];
                 }
-                if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, true)) {
+                if (!$this->ensure_parent_dir($file_path)) {
                     return [
                         'status' => 'rejected',
                         'reason' => 'io_error',
@@ -500,8 +456,14 @@ final class Site_Export_Staged_Artifacts {
                 ];
             }
 
-            $file = @fopen($file_path, 'c+b');
+            $file = @fopen($file_path, $committed > 0 ? 'r+b' : 'c+b');
             if ($file === false) {
+                $staging_file_damage = $this->staging_file_damage($file_path, $committed);
+                if ($staging_file_damage !== null) {
+                    $result = $this->damaged_cursor_result($staging_file_damage);
+                    $result['path'] = null;
+                    return $result;
+                }
                 return [
                     'status' => 'rejected',
                     'reason' => 'io_error',
@@ -510,6 +472,14 @@ final class Site_Export_Staged_Artifacts {
                     'path' => null,
                 ];
             }
+            $opened_staging_file_damage = $this->opened_staging_file_damage($file, $committed);
+            if ($opened_staging_file_damage !== null) {
+                fclose($file);
+                $result = $this->damaged_cursor_result($opened_staging_file_damage);
+                $result['path'] = null;
+                return $result;
+            }
+
             // Drop any uncommitted tail so the artifact holds committed bytes only.
             $truncated = ftruncate($file, $committed);
             fclose($file);
@@ -557,9 +527,8 @@ final class Site_Export_Staged_Artifacts {
      * This is advisory and intentionally lock-free; writers still enforce the
      * committed offset under the lock before accepting bytes.
      *
-     * When a cursor's staged file is missing, short, or not regular,
-     * committed_bytes stays zero and the response adds damage plus the
-     * recorded cursor so the caller can distinguish damage from no progress.
+     * When the recorded cursor has lost its backing file, committed_bytes is
+     * zero and the response describes the damage and the untrusted old cursor.
      *
      * @return array{exists:bool,committed_bytes:int,verified:bool,damage?:string,recorded_committed_bytes?:int}
      */
@@ -572,40 +541,27 @@ final class Site_Export_Staged_Artifacts {
                 'verified' => false,
             ];
         }
-        $file_parent_is_safe = $this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false);
 
         $verified_size = $this->read_verified_size($artifact_id);
         if ($verified_size !== null) {
             return [
-                'exists' => $file_parent_is_safe && file_exists($file_path),
+                'exists' => file_exists($file_path),
                 'committed_bytes' => $verified_size,
                 'verified' => true,
             ];
         }
 
         $state = $this->read_state();
-        $file_stat = $file_parent_is_safe ? @lstat($file_path) : false;
-        $committed_bytes = 0;
-        $damage = null;
-        if ($state['artifact_id'] === $artifact_id) {
-            if (!$file_parent_is_safe || ( is_array($file_stat) && ( !isset($file_stat['mode']) || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 ) ) )) {
-                $damage = 'staging_file_not_regular';
-            } elseif (!is_array($file_stat)) {
-                $damage = 'staging_file_missing_at_cursor';
-            } elseif (!isset($file_stat['size']) || (int) $file_stat['size'] < $state['committed_bytes']) {
-                $damage = 'staging_file_shorter_than_cursor';
-            } else {
-                $committed_bytes = $state['committed_bytes'];
-            }
-        }
+        $committed_bytes = $state['artifact_id'] === $artifact_id ? $state['committed_bytes'] : 0;
+        $staging_file_damage = $this->staging_file_damage($file_path, $committed_bytes);
         $status = [
-            'exists' => $file_parent_is_safe && file_exists($file_path),
-            'committed_bytes' => $committed_bytes,
+            'exists' => file_exists($file_path),
+            'committed_bytes' => $staging_file_damage === null ? $committed_bytes : 0,
             'verified' => false,
         ];
-        if ($damage !== null) {
-            $status['damage'] = $damage;
-            $status['recorded_committed_bytes'] = $state['committed_bytes'];
+        if ($staging_file_damage !== null) {
+            $status['damage'] = $staging_file_damage;
+            $status['recorded_committed_bytes'] = $committed_bytes;
         }
         return $status;
     }
@@ -614,9 +570,10 @@ final class Site_Export_Staged_Artifacts {
      * Remove all staged data and records for an artifact. Safe to call for
      * unknown ids.
      *
-     * Retry until true: a discard killed between its steps — or stopped by
-     * a failing one — leaves a partial state that only another discard
-     * fully cleans up. Every partial state is retriable.
+     * Cursor and verification records are removed before the artifact. A kill
+     * or failed unlink can therefore leave untrusted bytes behind, but never a
+     * durable cursor or marker that authorizes bytes already removed. Retry
+     * until true to finish removing any such orphan.
      *
      * @return bool False when a concurrent writer holds the store (an
      *              unguarded unlink would let that writer's commit resurrect
@@ -648,17 +605,14 @@ final class Site_Export_Staged_Artifacts {
                 return false;
             }
 
-            if (!$this->artifact_parent_directories_are_safe($this->files_dir, $artifact_id, false)) {
-                return false;
-            }
-            if (( file_exists($file_path) || is_link($file_path) ) && !@unlink($file_path)) {
-                return false;
-            }
             $state = $this->read_state();
             if ($state['artifact_id'] === $artifact_id && !$this->write_state(null, 0)) {
                 return false;
             }
-            return $this->remove_verified_marker($artifact_id);
+            if (!$this->remove_verified_marker($artifact_id)) {
+                return false;
+            }
+            return !( file_exists($file_path) || is_link($file_path) ) || @unlink($file_path);
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -710,55 +664,23 @@ final class Site_Export_Staged_Artifacts {
      * files, and the index exclusion of storage_path still applies.
      */
     private function ensure_web_guards(string $dir): void {
-        $this->ensure_web_guard(
-            $dir . '/.htaccess',
-            "# Reprint staging area - never web-served.\n" .
-            "<IfModule mod_authz_core.c>\n" .
-            "    Require all denied\n" .
-            "</IfModule>\n" .
-            "<IfModule !mod_authz_core.c>\n" .
-            "    Deny from all\n" .
-            "</IfModule>\n"
-        );
-        $this->ensure_web_guard($dir . '/index.php', "<?php\n");
-    }
-
-    /**
-     * Leave a regular guard alone, or replace any other leaf without ever
-     * opening a planted symlink. Exclusive creation also makes a race that
-     * installs a new leaf between lstat() and fopen() fail closed.
-     */
-    private function ensure_web_guard(string $path, string $contents): void {
-        $guard_stat = @lstat($path);
-        if (
-            is_array($guard_stat)
-            && isset($guard_stat['mode'])
-            && ( ( (int) $guard_stat['mode'] & 0170000 ) === 0100000 )
-        ) {
-            return;
-        }
-        if (is_array($guard_stat) && !@unlink($path)) {
-            return;
+        $htaccess = $dir . '/.htaccess';
+        if (!file_exists($htaccess)) {
+            @file_put_contents(
+                $htaccess,
+                "# Reprint staging area - never web-served.\n" .
+                "<IfModule mod_authz_core.c>\n" .
+                "    Require all denied\n" .
+                "</IfModule>\n" .
+                "<IfModule !mod_authz_core.c>\n" .
+                "    Deny from all\n" .
+                "</IfModule>\n"
+            );
         }
 
-        $guard = @fopen($path, 'xb');
-        if ($guard === false) {
-            return;
-        }
-
-        $contents_length = strlen($contents);
-        $written_bytes = 0;
-        while ($written_bytes < $contents_length) {
-            $written = @fwrite($guard, substr($contents, $written_bytes));
-            if (!is_int($written) || $written === 0) {
-                break;
-            }
-            $written_bytes += $written;
-        }
-        $write_succeeded = $written_bytes === $contents_length && @fflush($guard);
-        @fclose($guard);
-        if (!$write_succeeded) {
-            @unlink($path);
+        $index = $dir . '/index.php';
+        if (!file_exists($index)) {
+            @file_put_contents($index, "<?php\n");
         }
     }
 
@@ -769,37 +691,64 @@ final class Site_Export_Staged_Artifacts {
     }
 
     /**
-     * Check every parent below an artifact root without following symlinks.
-     * A missing parent either gets created one component at a time and
-     * rechecked, or proves that a read/removal cannot reach an artifact.
+     * Return why a nonzero cursor no longer has trustworthy backing bytes.
+     * A longer file is valid: it is an uncommitted tail left by an interrupted
+     * append and the next writer truncates it back to the cursor.
      */
-    private function artifact_parent_directories_are_safe(string $root_dir, string $artifact_id, bool $create_missing): bool {
-        $parent_segments = explode('/', $artifact_id);
-        array_pop($parent_segments);
-        $directory = $root_dir;
-        $segment_index = 0;
-
-        while (true) {
-            $directory_stat = @lstat($directory);
-            if ($directory_stat === false && $create_missing) {
-                @mkdir($directory, 0700);
-                $directory_stat = @lstat($directory);
-            }
-            if ($directory_stat === false) {
-                return !$create_missing;
-            }
-            if (
-                !isset($directory_stat['mode'])
-                || ( ( (int) $directory_stat['mode'] & 0170000 ) !== 0040000 )
-            ) {
-                return false;
-            }
-            if ($segment_index === count($parent_segments)) {
-                return true;
-            }
-            $directory .= '/' . $parent_segments[$segment_index];
-            ++$segment_index;
+    private function staging_file_damage(string $file_path, int $committed_bytes): ?string {
+        if ($committed_bytes === 0) {
+            return null;
         }
+
+        $file_stat = @lstat($file_path);
+        if (!is_array($file_stat)) {
+            return 'staging_file_missing_at_cursor';
+        }
+        if (
+            !isset($file_stat['mode'])
+            || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 )
+        ) {
+            return 'staging_file_not_regular';
+        }
+        if (!isset($file_stat['size']) || (int) $file_stat['size'] < $committed_bytes) {
+            return 'staging_file_shorter_than_cursor';
+        }
+        return null;
+    }
+
+    /**
+     * Recheck the opened file before ftruncate() can extend it. The path check
+     * and open are separate filesystem operations, so cleanup may race them.
+     *
+     * @param resource $file
+     */
+    private function opened_staging_file_damage($file, int $committed_bytes): ?string {
+        if ($committed_bytes === 0) {
+            return null;
+        }
+
+        $file_stat = @fstat($file);
+        if (
+            !is_array($file_stat)
+            || !isset($file_stat['mode'])
+            || ( ( (int) $file_stat['mode'] & 0170000 ) !== 0100000 )
+        ) {
+            return 'staging_file_not_regular';
+        }
+        if (!isset($file_stat['size']) || (int) $file_stat['size'] < $committed_bytes) {
+            return 'staging_file_shorter_than_cursor';
+        }
+        return null;
+    }
+
+    /** @return array{status:string,reason:string,detail:string,committed_bytes:int} */
+    private function damaged_cursor_result(string $damage): array {
+        return [
+            'status' => 'rejected',
+            'reason' => 'offset_gap',
+            'detail' => $damage,
+            'committed_bytes' => 0,
+        ];
     }
 
     /**
@@ -840,15 +789,29 @@ final class Site_Export_Staged_Artifacts {
     }
 
     private function write_state(?string $artifact_id, int $committed_bytes): bool {
+        // Write-then-rename keeps the cursor atomic: readers see the old
+        // record or the new one, never a torn file. The temp file sits next
+        // to the target so rename stays on the same filesystem.
+        $tmp_path = $this->state_path . '.tmp';
         // The id is stored base64: file names are arbitrary bytes, JSON
         // strings must be UTF-8, and json_encode() returning false would
-        // otherwise slip through the atomic writer as an empty
+        // otherwise slip through the strlen() comparison below as an empty
         // record — committed_bytes would silently reset to 0 on every read.
         $json = json_encode([
             'artifact_id' => $artifact_id !== null ? base64_encode($artifact_id) : null,
             'committed_bytes' => $committed_bytes,
         ]);
-        return $this->write_atomically($this->state_path, $this->state_path . '.tmp', $json);
+        // A short write (disk full) returns a byte count, not false — never
+        // rename a torn record over the good one.
+        if (@file_put_contents($tmp_path, $json) !== strlen($json)) {
+            @unlink($tmp_path);
+            return false;
+        }
+        if (!@rename($tmp_path, $this->state_path)) {
+            @unlink($tmp_path);
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -867,19 +830,7 @@ final class Site_Export_Staged_Artifacts {
      * worst case is re-finalizing an artifact, never trusting a torn record.
      */
     private function read_verified_size(string $artifact_id): ?int {
-        if (!$this->artifact_parent_directories_are_safe($this->verified_dir, $artifact_id, false)) {
-            return null;
-        }
-        $marker_path = $this->verified_marker_path($artifact_id);
-        $marker_stat = @lstat($marker_path);
-        if (
-            !is_array($marker_stat)
-            || !isset($marker_stat['mode'])
-            || ( ( (int) $marker_stat['mode'] & 0170000 ) !== 0100000 )
-        ) {
-            return null;
-        }
-        $raw = @file_get_contents($marker_path);
+        $raw = @file_get_contents($this->verified_marker_path($artifact_id));
         if ($raw === false) {
             return null;
         }
@@ -892,42 +843,25 @@ final class Site_Export_Staged_Artifacts {
 
     private function write_verified_marker(string $artifact_id, int $size): bool {
         $marker_path = $this->verified_marker_path($artifact_id);
-        if (!$this->artifact_parent_directories_are_safe($this->verified_dir, $artifact_id, true)) {
+        if (!$this->ensure_parent_dir($marker_path)) {
             return false;
         }
         $json = json_encode(['size' => $size]);
-        return $this->write_atomically($marker_path, $this->verified_tmp_path, $json);
-    }
-
-    private function remove_verified_marker(string $artifact_id): bool {
-        if (!$this->artifact_parent_directories_are_safe($this->verified_dir, $artifact_id, false)) {
+        // Same discipline as the cursor: a short write (disk full) must
+        // never become a marker, so write whole to the temp file and rename.
+        if (@file_put_contents($this->verified_tmp_path, $json) !== strlen($json)) {
+            @unlink($this->verified_tmp_path);
             return false;
         }
-        $marker_path = $this->verified_marker_path($artifact_id);
-        return !( file_exists($marker_path) || is_link($marker_path) ) || @unlink($marker_path);
-    }
-
-    /**
-     * Atomically replace a small record without ever opening a planted temp
-     * symlink or hardlink. Readers see the old record or the new one, never a
-     * torn file; the temp path shares the target's filesystem for rename().
-     */
-    private function write_atomically(string $target_path, string $temporary_path, string $contents): bool {
-        @unlink($temporary_path);
-        $temporary_file = @fopen($temporary_path, 'xb');
-        if ($temporary_file === false) {
-            return false;
-        }
-
-        // A short write (disk full) returns a byte count, not false — never
-        // rename a torn record over the good one.
-        $written = @fwrite($temporary_file, $contents);
-        $write_succeeded = $written === strlen($contents) && @fflush($temporary_file);
-        @fclose($temporary_file);
-        if (!$write_succeeded || !@rename($temporary_path, $target_path)) {
-            @unlink($temporary_path);
+        if (!@rename($this->verified_tmp_path, $marker_path)) {
+            @unlink($this->verified_tmp_path);
             return false;
         }
         return true;
+    }
+
+    private function remove_verified_marker(string $artifact_id): bool {
+        $marker_path = $this->verified_marker_path($artifact_id);
+        return !file_exists($marker_path) || @unlink($marker_path);
     }
 }

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -34,10 +34,9 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * resend with shifted boundaries. push_stream therefore compares the store's
  * committed offset with each frame first, skips the committed prefix of a
  * straddling mid-file frame, restarts an artifact when the sender begins it
- * again at offset 0 and the store has existing or damaged state (the sender
- * only does that when its source changed or it cannot vouch for the staged
- * prefix), and reports offset_gap with the cursor only when a frame starts
- * beyond the frontier.
+ * again at offset 0 (the sender only does that when its source changed or
+ * it cannot vouch for the staged prefix), and reports offset_gap with cursor
+ * zero when the staged bytes behind a durable cursor were lost.
  *
  * Rejections the chunk sizer must learn from are typed for it: a frame
  * over the frame cap is HTTP 413 with max_frame_bytes in the payload,
@@ -135,10 +134,12 @@ final class Site_Export_Staged_Endpoints {
      * A frame commits before the next frame is read. If the request dies after
      * a commit, the next request may replay from the last sender cursor or from
      * the beginning: verified artifacts replayed at their verified size are
-     * skipped, and an offset-0 frame for anything else with staged or damaged
-     * state restarts the artifact from zero — the sender only starts a file
-     * over when its source changed or it cannot vouch for the staged prefix,
-     * and appending one version behind another would corrupt the artifact.
+     * skipped, and an offset-0 frame for anything else that holds bytes
+     * restarts the artifact from zero. A damaged cursor is discarded; a
+     * mid-file frame then receives offset_gap at zero so its retry restarts.
+     * The sender only starts a file over when its source changed or it cannot
+     * vouch for the staged prefix, and appending one version behind another
+     * would corrupt the artifact.
      *
      * Behavior steps:
      * 1. Read one JSON header line and validate the frame before reading its
@@ -149,13 +150,15 @@ final class Site_Export_Staged_Endpoints {
      * 3. If the artifact is verified and the frame declares its verified size,
      *    consume the frame payload only to keep the stream aligned with the
      *    next JSON header.
-     * 4. If the frame starts at byte 0 and the artifact has staged or damaged
-     *    state, discard that state and stage this frame fresh.
-     * 5. If the artifact is partially committed and the frame starts mid-file,
+     * 4. A damaged cursor makes a mid-file frame retry from zero; an
+     *    offset-zero frame discards the damaged state and stages fresh.
+     * 5. If the frame starts at byte 0 and the artifact holds anything else,
+     *    discard the staged bytes and stage this frame fresh.
+     * 6. If the artifact is partially committed and the frame starts mid-file,
      *    discard any replayed prefix bytes the store already has and append
      *    only the missing suffix, in bounded pieces so one frame cannot force
      *    the endpoint to hold the full chunk in memory.
-     * 6. Finalize only when the frame marks the artifact final, then report the
+     * 7. Finalize only when the frame marks the artifact final, then report the
      *    latest cursor for the sender to resume from after failures.
      *
      * @param array $config Request parameters.
@@ -233,6 +236,18 @@ final class Site_Export_Staged_Endpoints {
                 return $response;
             }
 
+            if (isset($status['damage'])) {
+                $damage = (string) $status['damage'];
+                if ($offset !== 0) {
+                    return $this->stream_rejected(409, 'offset_gap', $damage, $cursor, $files_verified);
+                }
+                if (!$this->store->discard($artifact_id)) {
+                    return $this->stream_rejected(423, 'busy', $damage, $cursor, $files_verified);
+                }
+                $status = $this->store->status($artifact_id);
+                $cursor = ['artifact_id' => base64_encode($artifact_id), 'committed_bytes' => 0];
+            }
+
             /**
              * Already-verified replay case.
              *
@@ -256,18 +271,14 @@ final class Site_Export_Staged_Endpoints {
             /**
              * Restart case.
              *
-             * An offset-0 frame for an artifact with staged or damaged state
-             * means the sender is pushing the file over: its source changed
-             * since those bytes were staged, or it is replaying after a
-             * failure and cannot vouch for the staged prefix. Drop the old
-             * state and stage this frame fresh — appending a new version
-             * behind an old prefix would build a file no version of the source
-             * ever was.
+             * An offset-0 frame for an artifact that already holds bytes means
+             * the sender is pushing the file over: its source changed since
+             * those bytes were staged, or it is replaying after a failure and
+             * cannot vouch for the staged prefix. Drop the staged bytes and
+             * stage this frame fresh — appending a new version behind an old
+             * prefix would build a file no version of the source ever was.
              */
-            if (
-                $offset === 0
-                && ( $status['verified'] || (int) $status['committed_bytes'] > 0 || isset($status['damage']) )
-            ) {
+            if ($offset === 0 && ($status['verified'] || (int) $status['committed_bytes'] > 0)) {
                 if (!$this->store->discard($artifact_id)) {
                     return $this->stream_rejected(423, 'busy', null, $cursor, $files_verified);
                 }

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -34,9 +34,10 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * resend with shifted boundaries. push_stream therefore compares the store's
  * committed offset with each frame first, skips the committed prefix of a
  * straddling mid-file frame, restarts an artifact when the sender begins it
- * again at offset 0 (the sender only does that when its source changed or
- * it cannot vouch for the staged prefix), and reports offset_gap with the
- * cursor only when a frame starts beyond the frontier.
+ * again at offset 0 and the store has existing or damaged state (the sender
+ * only does that when its source changed or it cannot vouch for the staged
+ * prefix), and reports offset_gap with the cursor only when a frame starts
+ * beyond the frontier.
  *
  * Rejections the chunk sizer must learn from are typed for it: a frame
  * over the frame cap is HTTP 413 with max_frame_bytes in the payload,
@@ -134,10 +135,10 @@ final class Site_Export_Staged_Endpoints {
      * A frame commits before the next frame is read. If the request dies after
      * a commit, the next request may replay from the last sender cursor or from
      * the beginning: verified artifacts replayed at their verified size are
-     * skipped, and an offset-0 frame for anything else that holds bytes
-     * restarts the artifact from zero — the sender only starts a file over
-     * when its source changed or it cannot vouch for the staged prefix, and
-     * appending one version behind another would corrupt the artifact.
+     * skipped, and an offset-0 frame for anything else with staged or damaged
+     * state restarts the artifact from zero — the sender only starts a file
+     * over when its source changed or it cannot vouch for the staged prefix,
+     * and appending one version behind another would corrupt the artifact.
      *
      * Behavior steps:
      * 1. Read one JSON header line and validate the frame before reading its
@@ -148,8 +149,8 @@ final class Site_Export_Staged_Endpoints {
      * 3. If the artifact is verified and the frame declares its verified size,
      *    consume the frame payload only to keep the stream aligned with the
      *    next JSON header.
-     * 4. If the frame starts at byte 0 and the artifact holds anything else,
-     *    discard the staged bytes and stage this frame fresh.
+     * 4. If the frame starts at byte 0 and the artifact has staged or damaged
+     *    state, discard that state and stage this frame fresh.
      * 5. If the artifact is partially committed and the frame starts mid-file,
      *    discard any replayed prefix bytes the store already has and append
      *    only the missing suffix, in bounded pieces so one frame cannot force
@@ -255,14 +256,18 @@ final class Site_Export_Staged_Endpoints {
             /**
              * Restart case.
              *
-             * An offset-0 frame for an artifact that already holds bytes means
-             * the sender is pushing the file over: its source changed since
-             * those bytes were staged, or it is replaying after a failure and
-             * cannot vouch for the staged prefix. Drop the staged bytes and
-             * stage this frame fresh — appending a new version behind an old
-             * prefix would build a file no version of the source ever was.
+             * An offset-0 frame for an artifact with staged or damaged state
+             * means the sender is pushing the file over: its source changed
+             * since those bytes were staged, or it is replaying after a
+             * failure and cannot vouch for the staged prefix. Drop the old
+             * state and stage this frame fresh — appending a new version
+             * behind an old prefix would build a file no version of the source
+             * ever was.
              */
-            if ($offset === 0 && ($status['verified'] || (int) $status['committed_bytes'] > 0)) {
+            if (
+                $offset === 0
+                && ( $status['verified'] || (int) $status['committed_bytes'] > 0 || isset($status['damage']) )
+            ) {
                 if (!$this->store->discard($artifact_id)) {
                     return $this->stream_rejected(423, 'busy', null, $cursor, $files_verified);
                 }

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -33,10 +33,10 @@ if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
  * asks staged_status for the store's committed offset, and may later
  * resend with shifted boundaries. push_stream therefore compares the store's
  * committed offset with each frame first, skips the committed prefix of a
- * straddling mid-file frame, restarts an artifact when the sender begins it
- * again at offset 0 (the sender only does that when its source changed or
- * it cannot vouch for the staged prefix), and reports offset_gap with cursor
- * zero when the staged bytes behind a durable cursor were lost.
+ * straddling mid-file frame, and restarts an artifact when the sender begins
+ * it again at offset 0 (the sender only does that when its source changed or
+ * it cannot vouch for the staged prefix). If a cursor's staged bytes were
+ * lost, a mid-file frame fails the request without consuming its payload.
  *
  * Rejections the chunk sizer must learn from are typed for it: a frame
  * over the frame cap is HTTP 413 with max_frame_bytes in the payload,
@@ -135,11 +135,12 @@ final class Site_Export_Staged_Endpoints {
      * a commit, the next request may replay from the last sender cursor or from
      * the beginning: verified artifacts replayed at their verified size are
      * skipped, and an offset-0 frame for anything else that holds bytes
-     * restarts the artifact from zero. A damaged cursor is discarded; a
-     * mid-file frame then receives offset_gap at zero so its retry restarts.
-     * The sender only starts a file over when its source changed or it cannot
-     * vouch for the staged prefix, and appending one version behind another
-     * would corrupt the artifact.
+     * restarts the artifact from zero. A mid-file frame behind a damaged
+     * cursor fails without consuming its payload or later frames. An
+     * offset-zero frame discards the damage and stages fresh. The sender only
+     * starts a file over when its source changed or it cannot vouch for the
+     * staged prefix, and appending one version behind another would corrupt
+     * the artifact.
      *
      * Behavior steps:
      * 1. Read one JSON header line and validate the frame before reading its
@@ -150,8 +151,9 @@ final class Site_Export_Staged_Endpoints {
      * 3. If the artifact is verified and the frame declares its verified size,
      *    consume the frame payload only to keep the stream aligned with the
      *    next JSON header.
-     * 4. A damaged cursor makes a mid-file frame retry from zero; an
-     *    offset-zero frame discards the damaged state and stages fresh.
+     * 4. A damaged cursor rejects a mid-file frame without consuming its
+     *    payload or later frames; an offset-zero frame discards the damaged
+     *    state and stages fresh.
      * 5. If the frame starts at byte 0 and the artifact holds anything else,
      *    discard the staged bytes and stage this frame fresh.
      * 6. If the artifact is partially committed and the frame starts mid-file,
@@ -239,7 +241,7 @@ final class Site_Export_Staged_Endpoints {
             if (isset($status['damage'])) {
                 $damage = (string) $status['damage'];
                 if ($offset !== 0) {
-                    return $this->stream_rejected(409, 'offset_gap', $damage, $cursor, $files_verified);
+                    return $this->stream_rejected(409, 'staging_file_damaged', $damage, $cursor, $files_verified);
                 }
                 if (!$this->store->discard($artifact_id)) {
                     return $this->stream_rejected(423, 'busy', $damage, $cursor, $files_verified);
@@ -528,6 +530,7 @@ final class Site_Export_Staged_Endpoints {
                     case 'already_verified':
                     case 'size_mismatch':
                     case 'missing':
+                    case 'staging_file_damaged':
                         $code = 409;
                         break;
                     default:

--- a/tests/Import/StagedPushStreamClientTest.php
+++ b/tests/Import/StagedPushStreamClientTest.php
@@ -841,6 +841,32 @@ class StagedPushStreamClientTest extends TestCase
         $this->assertSame(['staged_push', 'staged_push'], $this->endpointsSeen(), 'one gap rejection, one clean resume from the store cursor');
     }
 
+    public function testDamagedStagingStopsThePush(): void
+    {
+        $content = str_repeat('d', 8);
+        $source_path = $this->writeSource('damaged.bin', $content);
+        ( new Site_Export_Staged_Artifacts($this->staging_dir) )->append('damaged.bin', 0, 'AAAA');
+        file_put_contents($this->staging_dir . '/files/damaged.bin', 'A');
+        clearstatcache();
+        $source_stat = stat($source_path);
+        $this->assertNotFalse($source_stat);
+
+        $result = $this->pushAll($this->makeClient(), $this->writeLocalPathsToPush(['damaged.bin']), [
+            'artifact_id' => 'damaged.bin',
+            'committed_bytes' => 4,
+            'total_bytes' => 8,
+            'source_ctime' => (int) $source_stat['ctime'],
+        ]);
+
+        $this->assertSame(
+            ['failed', 'staging_file_damaged', 'staging_file_shorter_than_cursor'],
+            [$result['status'], $result['reason'], $result['detail']],
+            (string) json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE)
+        );
+        $this->assertSame('A', file_get_contents($this->staging_dir . '/files/damaged.bin'));
+        $this->assertSame(['staged_push'], $this->endpointsSeen());
+    }
+
     public function testExhaustedRetriesReportATerminalFailure(): void
     {
         $this->writeSource('never.bin', str_repeat('n', 4));

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -233,20 +233,51 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
     }
 
-    public function testShrunkenStagingFileIsZeroFilledBackToTheCursor(): void
+    public function testShrunkenStagingFileIsRejectedWithoutChangingIt(): void
     {
         $store = $this->makeStore();
         $store->append('artifact-1', 0, 'first');
 
         // The staging file drifts between requests: something shrinks it
-        // below the committed size. The cursor, not the file, is the
-        // authority — the next append zero-fills back to the committed size.
+        // below the committed size. Resuming at the cursor must not silently
+        // fill the missing committed bytes with zeroes.
         file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
 
-        $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
-        $verified = $store->finalize('artifact-1', 11);
-        $this->assertSame('verified', $verified['status']);
-        $this->assertSame("fi\0\0\0second", file_get_contents($verified['path']));
+        $result = $store->append('artifact-1', 5, 'second');
+
+        $this->assertSame(
+            ['rejected', 'io_error', 'staging_file_shorter_than_cursor', 0],
+            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
+        );
+        $this->assertSame(
+            'staging_file_shorter_than_cursor',
+            $store->finalize('artifact-1', 5)['detail']
+        );
+        $this->assertSame('fi', file_get_contents($this->staging_dir . '/files/artifact-1'));
+        $this->assertSame(
+            [
+                'exists' => true,
+                'committed_bytes' => 0,
+                'verified' => false,
+                'damage' => 'staging_file_shorter_than_cursor',
+                'recorded_committed_bytes' => 5,
+            ],
+            $store->status('artifact-1')
+        );
+
+        unlink($this->staging_dir . '/files/artifact-1');
+        $missing = $store->status('artifact-1');
+        $this->assertSame(
+            [false, 0, 'staging_file_missing_at_cursor', 5],
+            [$missing['exists'], $missing['committed_bytes'], $missing['damage'], $missing['recorded_committed_bytes']]
+        );
+
+        mkdir($this->staging_dir . '/files/artifact-1');
+        $not_regular = $store->status('artifact-1');
+        $this->assertSame(
+            [true, 0, 'staging_file_not_regular', 5],
+            [$not_regular['exists'], $not_regular['committed_bytes'], $not_regular['damage'], $not_regular['recorded_committed_bytes']]
+        );
     }
 
     // ---------------------------------------------------------------
@@ -287,6 +318,66 @@ final class StagedArtifactsTest extends TestCase
         $verified = $store->finalize('artifact-1', 11);
         $this->assertSame('verified', $verified['status']);
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
+    }
+
+    public function testRecordTempLinksCannotOverwriteOutsideFiles(): void
+    {
+        $store = $this->makeStore();
+        $temporary_path = $this->staging_dir . '/state.json.tmp';
+        $outside_symlink_target = $this->staging_dir . '-outside-symlink';
+        $outside_hardlink_target = $this->staging_dir . '-outside-hardlink';
+        $outside_verified_target = $this->staging_dir . '-outside-verified-temp';
+        mkdir($this->staging_dir, 0700, true);
+        file_put_contents($outside_symlink_target, 'symlink sentinel');
+        symlink($outside_symlink_target, $temporary_path);
+
+        try {
+            $this->assertSame('accepted', $store->append('artifact-1', 0, 'first')['status']);
+            $this->assertSame('symlink sentinel', file_get_contents($outside_symlink_target));
+
+            file_put_contents($outside_hardlink_target, 'hardlink sentinel');
+            link($outside_hardlink_target, $temporary_path);
+            $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
+            $this->assertSame('hardlink sentinel', file_get_contents($outside_hardlink_target));
+
+            file_put_contents($outside_verified_target, 'verified sentinel');
+            symlink($outside_verified_target, $this->staging_dir . '/verified.tmp');
+            $this->assertSame('verified', $store->finalize('artifact-1', 11)['status']);
+            $this->assertSame('verified sentinel', file_get_contents($outside_verified_target));
+        } finally {
+            @unlink($outside_symlink_target);
+            @unlink($outside_hardlink_target);
+            @unlink($outside_verified_target);
+        }
+    }
+
+    public function testVerifiedParentSymlinkCannotReachOutsideMarkers(): void
+    {
+        $store = $this->makeStore();
+        $store->append('a/artifact', 0, 'x');
+        $outside_directory = $this->staging_dir . '-outside-verified';
+        $outside_marker = $outside_directory . '/artifact';
+        $verified_parent = $this->staging_dir . '/verified/a';
+        mkdir($outside_directory, 0700, true);
+        mkdir(dirname($verified_parent), 0700, true);
+        file_put_contents($outside_marker, json_encode(['size' => 1]));
+        symlink($outside_directory, $verified_parent);
+
+        try {
+            $this->assertFalse($store->status('a/artifact')['verified']);
+
+            file_put_contents($outside_marker, 'outside sentinel');
+            $finalized = $store->finalize('a/artifact', 1);
+            $this->assertSame('persist_verified_record', $finalized['detail']);
+            $this->assertSame('outside sentinel', file_get_contents($outside_marker));
+
+            $this->assertFalse($store->discard('a/artifact'));
+            $this->assertSame('outside sentinel', file_get_contents($outside_marker));
+        } finally {
+            @unlink($verified_parent);
+            @unlink($outside_marker);
+            @rmdir($outside_directory);
+        }
     }
 
     public function testTornVerifiedRecordIsIgnoredAndRefinalizeRecovers(): void
@@ -355,6 +446,7 @@ final class StagedArtifactsTest extends TestCase
         $store->append('artifact-1', 0, 'first');
         unlink($this->staging_dir . '/files/artifact-1');
 
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
         $this->assertTrue($store->discard('artifact-1'));
         $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
         $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
@@ -387,6 +479,25 @@ final class StagedArtifactsTest extends TestCase
             ['rejected', 'io_error', 'create_staging_dir'],
             [$blocked_by_file['status'], $blocked_by_file['reason'], $blocked_by_file['detail']]
         );
+    }
+
+    public function testDanglingArtifactSymlinksAreRejectedAndDiscarded(): void
+    {
+        $store = $this->makeStore();
+        $store->append('seed', 0, 'x');
+        $outside = $this->staging_dir . '-outside';
+        $files = $this->staging_dir . '/files';
+        symlink($outside . '-append', $files . '/dangling-append');
+        symlink($outside . '-finalize', $files . '/dangling-finalize');
+
+        $append = $store->append('dangling-append', 0, 'bad');
+        $finalize = $store->finalize('dangling-finalize', 0);
+        $this->assertSame('open_artifact_file', $append['detail']);
+        $this->assertSame('open_artifact_file', $finalize['detail']);
+        $this->assertTrue($store->discard('dangling-append'));
+        $this->assertFalse(is_link($files . '/dangling-append'));
+        $this->assertFileDoesNotExist($outside . '-append');
+        $this->assertFileDoesNotExist($outside . '-finalize');
     }
 
     public function testUnwritableStagingDirectoryIsATypedError(): void
@@ -472,6 +583,34 @@ final class StagedArtifactsTest extends TestCase
         // stages site files with the same names.
         $this->assertSame('accepted', $store->append('.htaccess', 0, 'site rules')['status']);
         $this->assertSame('site rules', file_get_contents($this->staging_dir . '/files/.htaccess'));
+    }
+
+    public function testWebGuardsNeverFollowPlantedSymlinks(): void
+    {
+        $outside_dir = $this->staging_dir . '-outside-web-guards';
+        $outside_htaccess = $outside_dir . '/created-through-htaccess';
+        $outside_index = $outside_dir . '/index-sentinel.php';
+        mkdir($this->staging_dir, 0700, true);
+        mkdir($outside_dir, 0700, true);
+        file_put_contents($outside_index, 'outside index sentinel');
+        symlink($outside_htaccess, $this->staging_dir . '/.htaccess');
+        symlink($outside_index, $this->staging_dir . '/index.php');
+
+        try {
+            $store = $this->makeStore();
+
+            $this->assertSame('accepted', $store->append('artifact-1', 0, 'bytes')['status']);
+            $this->assertFileDoesNotExist($outside_htaccess);
+            $this->assertSame('outside index sentinel', file_get_contents($outside_index));
+            $this->assertFalse(is_link($this->staging_dir . '/.htaccess'));
+            $this->assertTrue(is_file($this->staging_dir . '/.htaccess'));
+            $this->assertFalse(is_link($this->staging_dir . '/index.php'));
+            $this->assertTrue(is_file($this->staging_dir . '/index.php'));
+        } finally {
+            @unlink($outside_htaccess);
+            @unlink($outside_index);
+            @rmdir($outside_dir);
+        }
     }
 
     public function testSiteFilenamesThatLookLikeStagingRecordsStageVerbatim(): void
@@ -685,7 +824,7 @@ final class StagedArtifactsTest extends TestCase
         // the artifact unlink itself only needs write on files/.
         chmod($this->staging_dir, 0500);
         $this->assertFalse($store->discard('artifact-1'));
-        $this->assertSame(7, $store->status('artifact-1')['committed_bytes']);
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
 
         chmod($this->staging_dir, 0700);
         $this->assertTrue($store->discard('artifact-1'));

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -233,27 +233,26 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
     }
 
-    public function testShrunkenStagingFileIsRejectedWithoutChangingIt(): void
+    public function testDamagedStagingFileForcesRestartFromZero(): void
     {
         $store = $this->makeStore();
         $store->append('artifact-1', 0, 'first');
 
         // The staging file drifts between requests: something shrinks it
-        // below the committed size. Resuming at the cursor must not silently
-        // fill the missing committed bytes with zeroes.
+        // below the committed size. Never fill the missing committed bytes
+        // with zeroes; report lost progress so the sender restarts from zero.
         file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
 
-        $result = $store->append('artifact-1', 5, 'second');
-
+        $resumed = $store->append('artifact-1', 5, 'second');
         $this->assertSame(
-            ['rejected', 'io_error', 'staging_file_shorter_than_cursor', 0],
-            [$result['status'], $result['reason'], $result['detail'], $result['committed_bytes']]
+            ['rejected', 'offset_gap', 'staging_file_shorter_than_cursor', 0],
+            [$resumed['status'], $resumed['reason'], $resumed['detail'], $resumed['committed_bytes']]
         );
+        $finalized = $store->finalize('artifact-1', 5);
         $this->assertSame(
-            'staging_file_shorter_than_cursor',
-            $store->finalize('artifact-1', 5)['detail']
+            ['offset_gap', 'staging_file_shorter_than_cursor', 0],
+            [$finalized['reason'], $finalized['detail'], $finalized['committed_bytes']]
         );
-        $this->assertSame('fi', file_get_contents($this->staging_dir . '/files/artifact-1'));
         $this->assertSame(
             [
                 'exists' => true,
@@ -264,20 +263,28 @@ final class StagedArtifactsTest extends TestCase
             ],
             $store->status('artifact-1')
         );
+        $this->assertSame('fi', file_get_contents($this->staging_dir . '/files/artifact-1'));
 
         unlink($this->staging_dir . '/files/artifact-1');
-        $missing = $store->status('artifact-1');
         $this->assertSame(
-            [false, 0, 'staging_file_missing_at_cursor', 5],
-            [$missing['exists'], $missing['committed_bytes'], $missing['damage'], $missing['recorded_committed_bytes']]
+            [
+                'exists' => false,
+                'committed_bytes' => 0,
+                'verified' => false,
+                'damage' => 'staging_file_missing_at_cursor',
+                'recorded_committed_bytes' => 5,
+            ],
+            $store->status('artifact-1')
         );
-
         mkdir($this->staging_dir . '/files/artifact-1');
-        $not_regular = $store->status('artifact-1');
-        $this->assertSame(
-            [true, 0, 'staging_file_not_regular', 5],
-            [$not_regular['exists'], $not_regular['committed_bytes'], $not_regular['damage'], $not_regular['recorded_committed_bytes']]
-        );
+        $this->assertSame('staging_file_not_regular', $store->status('artifact-1')['damage']);
+        rmdir($this->staging_dir . '/files/artifact-1');
+
+        $this->assertTrue($store->discard('artifact-1'));
+        $this->assertSame('accepted', $store->append('artifact-1', 0, 'firstsecond')['status']);
+        $verified = $store->finalize('artifact-1', 11);
+        $this->assertSame('verified', $verified['status']);
+        $this->assertSame('firstsecond', file_get_contents($verified['path']));
     }
 
     // ---------------------------------------------------------------
@@ -318,66 +325,6 @@ final class StagedArtifactsTest extends TestCase
         $verified = $store->finalize('artifact-1', 11);
         $this->assertSame('verified', $verified['status']);
         $this->assertSame('firstsecond', file_get_contents($verified['path']));
-    }
-
-    public function testRecordTempLinksCannotOverwriteOutsideFiles(): void
-    {
-        $store = $this->makeStore();
-        $temporary_path = $this->staging_dir . '/state.json.tmp';
-        $outside_symlink_target = $this->staging_dir . '-outside-symlink';
-        $outside_hardlink_target = $this->staging_dir . '-outside-hardlink';
-        $outside_verified_target = $this->staging_dir . '-outside-verified-temp';
-        mkdir($this->staging_dir, 0700, true);
-        file_put_contents($outside_symlink_target, 'symlink sentinel');
-        symlink($outside_symlink_target, $temporary_path);
-
-        try {
-            $this->assertSame('accepted', $store->append('artifact-1', 0, 'first')['status']);
-            $this->assertSame('symlink sentinel', file_get_contents($outside_symlink_target));
-
-            file_put_contents($outside_hardlink_target, 'hardlink sentinel');
-            link($outside_hardlink_target, $temporary_path);
-            $this->assertSame('accepted', $store->append('artifact-1', 5, 'second')['status']);
-            $this->assertSame('hardlink sentinel', file_get_contents($outside_hardlink_target));
-
-            file_put_contents($outside_verified_target, 'verified sentinel');
-            symlink($outside_verified_target, $this->staging_dir . '/verified.tmp');
-            $this->assertSame('verified', $store->finalize('artifact-1', 11)['status']);
-            $this->assertSame('verified sentinel', file_get_contents($outside_verified_target));
-        } finally {
-            @unlink($outside_symlink_target);
-            @unlink($outside_hardlink_target);
-            @unlink($outside_verified_target);
-        }
-    }
-
-    public function testVerifiedParentSymlinkCannotReachOutsideMarkers(): void
-    {
-        $store = $this->makeStore();
-        $store->append('a/artifact', 0, 'x');
-        $outside_directory = $this->staging_dir . '-outside-verified';
-        $outside_marker = $outside_directory . '/artifact';
-        $verified_parent = $this->staging_dir . '/verified/a';
-        mkdir($outside_directory, 0700, true);
-        mkdir(dirname($verified_parent), 0700, true);
-        file_put_contents($outside_marker, json_encode(['size' => 1]));
-        symlink($outside_directory, $verified_parent);
-
-        try {
-            $this->assertFalse($store->status('a/artifact')['verified']);
-
-            file_put_contents($outside_marker, 'outside sentinel');
-            $finalized = $store->finalize('a/artifact', 1);
-            $this->assertSame('persist_verified_record', $finalized['detail']);
-            $this->assertSame('outside sentinel', file_get_contents($outside_marker));
-
-            $this->assertFalse($store->discard('a/artifact'));
-            $this->assertSame('outside sentinel', file_get_contents($outside_marker));
-        } finally {
-            @unlink($verified_parent);
-            @unlink($outside_marker);
-            @rmdir($outside_directory);
-        }
     }
 
     public function testTornVerifiedRecordIsIgnoredAndRefinalizeRecovers(): void
@@ -439,25 +386,29 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('verified', $store->finalize('artifact-1', 7)['status']);
     }
 
-    public function testDiscardKilledMidwayIsRetriable(): void
+    public function testDiscardKilledMidwayLeavesOnlyUntrustedBytes(): void
     {
-        // Window 1: the artifact file was unlinked, the cursor survived.
+        // Window 1: the cursor was cleared, then the process died before the
+        // artifact unlink. With no trusted cursor, offset zero replaces it.
         $store = $this->makeStore();
         $store->append('artifact-1', 0, 'first');
-        unlink($this->staging_dir . '/files/artifact-1');
+        file_put_contents(
+            $this->staging_dir . '/state.json',
+            json_encode(['artifact_id' => null, 'committed_bytes' => 0])
+        );
 
-        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
-        $this->assertTrue($store->discard('artifact-1'));
         $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
         $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
+        $this->assertSame('fresh', file_get_contents($this->staging_dir . '/files/artifact-1'));
 
-        // Window 2: the cursor was cleared, the verified record survived.
+        // Window 2: the verification marker was removed before the artifact.
+        // The surviving bytes are untrusted and may likewise be overwritten.
         $store->finalize('artifact-1', 5);
-        unlink($this->staging_dir . '/files/artifact-1');
+        unlink($this->staging_dir . '/verified/artifact-1');
 
-        $this->assertTrue($store->discard('artifact-1'));
         $this->assertFalse($store->status('artifact-1')['verified']);
         $this->assertSame('accepted', $store->append('artifact-1', 0, 'again')['status']);
+        $this->assertSame('again', file_get_contents($this->staging_dir . '/files/artifact-1'));
     }
 
     public function testArtifactPathBlockedByAnotherEntryIsATypedError(): void
@@ -479,25 +430,6 @@ final class StagedArtifactsTest extends TestCase
             ['rejected', 'io_error', 'create_staging_dir'],
             [$blocked_by_file['status'], $blocked_by_file['reason'], $blocked_by_file['detail']]
         );
-    }
-
-    public function testDanglingArtifactSymlinksAreRejectedAndDiscarded(): void
-    {
-        $store = $this->makeStore();
-        $store->append('seed', 0, 'x');
-        $outside = $this->staging_dir . '-outside';
-        $files = $this->staging_dir . '/files';
-        symlink($outside . '-append', $files . '/dangling-append');
-        symlink($outside . '-finalize', $files . '/dangling-finalize');
-
-        $append = $store->append('dangling-append', 0, 'bad');
-        $finalize = $store->finalize('dangling-finalize', 0);
-        $this->assertSame('open_artifact_file', $append['detail']);
-        $this->assertSame('open_artifact_file', $finalize['detail']);
-        $this->assertTrue($store->discard('dangling-append'));
-        $this->assertFalse(is_link($files . '/dangling-append'));
-        $this->assertFileDoesNotExist($outside . '-append');
-        $this->assertFileDoesNotExist($outside . '-finalize');
     }
 
     public function testUnwritableStagingDirectoryIsATypedError(): void
@@ -583,34 +515,6 @@ final class StagedArtifactsTest extends TestCase
         // stages site files with the same names.
         $this->assertSame('accepted', $store->append('.htaccess', 0, 'site rules')['status']);
         $this->assertSame('site rules', file_get_contents($this->staging_dir . '/files/.htaccess'));
-    }
-
-    public function testWebGuardsNeverFollowPlantedSymlinks(): void
-    {
-        $outside_dir = $this->staging_dir . '-outside-web-guards';
-        $outside_htaccess = $outside_dir . '/created-through-htaccess';
-        $outside_index = $outside_dir . '/index-sentinel.php';
-        mkdir($this->staging_dir, 0700, true);
-        mkdir($outside_dir, 0700, true);
-        file_put_contents($outside_index, 'outside index sentinel');
-        symlink($outside_htaccess, $this->staging_dir . '/.htaccess');
-        symlink($outside_index, $this->staging_dir . '/index.php');
-
-        try {
-            $store = $this->makeStore();
-
-            $this->assertSame('accepted', $store->append('artifact-1', 0, 'bytes')['status']);
-            $this->assertFileDoesNotExist($outside_htaccess);
-            $this->assertSame('outside index sentinel', file_get_contents($outside_index));
-            $this->assertFalse(is_link($this->staging_dir . '/.htaccess'));
-            $this->assertTrue(is_file($this->staging_dir . '/.htaccess'));
-            $this->assertFalse(is_link($this->staging_dir . '/index.php'));
-            $this->assertTrue(is_file($this->staging_dir . '/index.php'));
-        } finally {
-            @unlink($outside_htaccess);
-            @unlink($outside_index);
-            @rmdir($outside_dir);
-        }
     }
 
     public function testSiteFilenamesThatLookLikeStagingRecordsStageVerbatim(): void
@@ -804,6 +708,7 @@ final class StagedArtifactsTest extends TestCase
         chmod($this->staging_dir . '/files', 0500);
         $this->assertFalse($store->discard('artifact-1'));
         $this->assertFileExists($this->staging_dir . '/files/artifact-1');
+        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
 
         // Retry until true: the next attempt finishes the cleanup.
         chmod($this->staging_dir . '/files', 0700);
@@ -824,7 +729,7 @@ final class StagedArtifactsTest extends TestCase
         // the artifact unlink itself only needs write on files/.
         chmod($this->staging_dir, 0500);
         $this->assertFalse($store->discard('artifact-1'));
-        $this->assertSame(0, $store->status('artifact-1')['committed_bytes']);
+        $this->assertSame(7, $store->status('artifact-1')['committed_bytes']);
 
         chmod($this->staging_dir, 0700);
         $this->assertTrue($store->discard('artifact-1'));

--- a/tests/StagedArtifactsTest.php
+++ b/tests/StagedArtifactsTest.php
@@ -233,24 +233,24 @@ final class StagedArtifactsTest extends TestCase
         $this->assertSame('accepted', $store->append('artifact-1', 0, 'fresh')['status']);
     }
 
-    public function testDamagedStagingFileForcesRestartFromZero(): void
+    public function testDamagedStagingFileIsRejected(): void
     {
         $store = $this->makeStore();
         $store->append('artifact-1', 0, 'first');
 
         // The staging file drifts between requests: something shrinks it
         // below the committed size. Never fill the missing committed bytes
-        // with zeroes; report lost progress so the sender restarts from zero.
+        // with zeroes or treat this as an ordinary, recoverable offset gap.
         file_put_contents($this->staging_dir . '/files/artifact-1', 'fi');
 
         $resumed = $store->append('artifact-1', 5, 'second');
         $this->assertSame(
-            ['rejected', 'offset_gap', 'staging_file_shorter_than_cursor', 0],
+            ['rejected', 'staging_file_damaged', 'staging_file_shorter_than_cursor', 0],
             [$resumed['status'], $resumed['reason'], $resumed['detail'], $resumed['committed_bytes']]
         );
         $finalized = $store->finalize('artifact-1', 5);
         $this->assertSame(
-            ['offset_gap', 'staging_file_shorter_than_cursor', 0],
+            ['staging_file_damaged', 'staging_file_shorter_than_cursor', 0],
             [$finalized['reason'], $finalized['detail'], $finalized['committed_bytes']]
         );
         $this->assertSame(

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -421,7 +421,7 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame('BBBBBBBB', file_get_contents($this->staging_dir . '/files/restarted.bin'));
     }
 
-    public function testDamagedCursorRetriesFromZero(): void
+    public function testDamagedCursorStopsBeforeReadingTheFramePayload(): void
     {
         $endpoints = $this->makeEndpoints();
         ( new Site_Export_Staged_Artifacts($this->staging_dir) )->append('damaged.bin', 0, 'AAAA');
@@ -437,19 +437,40 @@ final class StagedEndpointsTest extends TestCase {
             ]
         );
 
-        // The sender still has its old mid-file cursor. Return the
-        // store-confirmed zero frontier; its offset-zero retry replaces damage.
-        $resume = $this->push($endpoints, [
+        // PHP may receive the whole request before this code runs. Once the
+        // damaged cursor is found, leave its payload and every later frame
+        // unread instead of doing more work from a request that must fail.
+        $body = $this->pushBody([
             ['artifact_id' => 'damaged.bin', 'offset' => 4, 'bytes' => 'BBBB', 'total_bytes' => 8, 'final' => true],
+            ['artifact_id' => 'later.bin', 'offset' => 0, 'bytes' => 'later', 'total_bytes' => 5, 'final' => true],
         ]);
-        $this->assertSame(409, $resume['http_code']);
-        $this->assertSame('offset_gap', $resume['body']['reason']);
-        $this->assertSame('staging_file_shorter_than_cursor', $resume['body']['detail']);
-        $this->assertSame(
-            ['artifact_id' => base64_encode('damaged.bin'), 'committed_bytes' => 0],
-            $resume['body']['cursor']
-        );
+        $first_header_bytes = strpos($body, "\n") + 1;
+        $stream = $this->bodyStream($body);
+        try {
+            $result = $endpoints->push_stream([], $this->pushHeaders(), $stream);
+
+            $this->assertSame(409, $result['http_code']);
+            $this->assertSame('staging_file_damaged', $result['body']['reason']);
+            $this->assertSame('staging_file_shorter_than_cursor', $result['body']['detail']);
+            $this->assertSame(
+                ['artifact_id' => base64_encode('damaged.bin'), 'committed_bytes' => 0],
+                $result['body']['cursor']
+            );
+            $this->assertSame($first_header_bytes, ftell($stream));
+            $this->assertSame(substr($body, $first_header_bytes), stream_get_contents($stream));
+        } finally {
+            fclose($stream);
+        }
+
         $this->assertSame('A', file_get_contents($this->staging_dir . '/files/damaged.bin'));
+        $this->assertFileDoesNotExist($this->staging_dir . '/files/later.bin');
+    }
+
+    public function testOffsetZeroFrameReplacesADamagedArtifact(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        ( new Site_Export_Staged_Artifacts($this->staging_dir) )->append('damaged.bin', 0, 'AAAA');
+        file_put_contents($this->staging_dir . '/files/damaged.bin', 'A');
 
         $restarted = $this->push($endpoints, [
             ['artifact_id' => 'damaged.bin', 'offset' => 0, 'bytes' => 'BBBBBBBB', 'total_bytes' => 8, 'final' => true],

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -421,6 +421,25 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame('BBBBBBBB', file_get_contents($this->staging_dir . '/files/restarted.bin'));
     }
 
+    public function testOffsetZeroFrameRestartsAnArtifactWithADamagedCursor(): void
+    {
+        $endpoints = $this->makeEndpoints();
+        ( new Site_Export_Staged_Artifacts($this->staging_dir) )->append('damaged.bin', 0, 'AAAA');
+        file_put_contents($this->staging_dir . '/files/damaged.bin', 'A');
+
+        $damaged_status = $endpoints->status(['artifact_id' => base64_encode('damaged.bin')]);
+        $this->assertSame(0, $damaged_status['body']['committed_bytes']);
+        $this->assertSame('staging_file_shorter_than_cursor', $damaged_status['body']['damage']);
+        $this->assertSame(4, $damaged_status['body']['recorded_committed_bytes']);
+
+        $result = $this->push($endpoints, [
+            ['artifact_id' => 'damaged.bin', 'offset' => 0, 'bytes' => 'BBBB', 'total_bytes' => 4, 'final' => true],
+        ]);
+
+        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
+        $this->assertSame('BBBB', file_get_contents($this->staging_dir . '/files/damaged.bin'));
+    }
+
     public function testOffsetZeroFrameWithANewTotalRestartsAVerifiedArtifact(): void
     {
         $endpoints = $this->makeEndpoints();

--- a/tests/StagedEndpointsTest.php
+++ b/tests/StagedEndpointsTest.php
@@ -421,23 +421,41 @@ final class StagedEndpointsTest extends TestCase {
         $this->assertSame('BBBBBBBB', file_get_contents($this->staging_dir . '/files/restarted.bin'));
     }
 
-    public function testOffsetZeroFrameRestartsAnArtifactWithADamagedCursor(): void
+    public function testDamagedCursorRetriesFromZero(): void
     {
         $endpoints = $this->makeEndpoints();
         ( new Site_Export_Staged_Artifacts($this->staging_dir) )->append('damaged.bin', 0, 'AAAA');
         file_put_contents($this->staging_dir . '/files/damaged.bin', 'A');
 
         $damaged_status = $endpoints->status(['artifact_id' => base64_encode('damaged.bin')]);
-        $this->assertSame(0, $damaged_status['body']['committed_bytes']);
-        $this->assertSame('staging_file_shorter_than_cursor', $damaged_status['body']['damage']);
-        $this->assertSame(4, $damaged_status['body']['recorded_committed_bytes']);
+        $this->assertSame(
+            [0, 'staging_file_shorter_than_cursor', 4],
+            [
+                $damaged_status['body']['committed_bytes'],
+                $damaged_status['body']['damage'],
+                $damaged_status['body']['recorded_committed_bytes'],
+            ]
+        );
 
-        $result = $this->push($endpoints, [
-            ['artifact_id' => 'damaged.bin', 'offset' => 0, 'bytes' => 'BBBB', 'total_bytes' => 4, 'final' => true],
+        // The sender still has its old mid-file cursor. Return the
+        // store-confirmed zero frontier; its offset-zero retry replaces damage.
+        $resume = $this->push($endpoints, [
+            ['artifact_id' => 'damaged.bin', 'offset' => 4, 'bytes' => 'BBBB', 'total_bytes' => 8, 'final' => true],
         ]);
+        $this->assertSame(409, $resume['http_code']);
+        $this->assertSame('offset_gap', $resume['body']['reason']);
+        $this->assertSame('staging_file_shorter_than_cursor', $resume['body']['detail']);
+        $this->assertSame(
+            ['artifact_id' => base64_encode('damaged.bin'), 'committed_bytes' => 0],
+            $resume['body']['cursor']
+        );
+        $this->assertSame('A', file_get_contents($this->staging_dir . '/files/damaged.bin'));
 
-        $this->assertSame(200, $result['http_code'], (string) json_encode($result['body']));
-        $this->assertSame('BBBB', file_get_contents($this->staging_dir . '/files/damaged.bin'));
+        $restarted = $this->push($endpoints, [
+            ['artifact_id' => 'damaged.bin', 'offset' => 0, 'bytes' => 'BBBBBBBB', 'total_bytes' => 8, 'final' => true],
+        ]);
+        $this->assertSame(200, $restarted['http_code'], (string) json_encode($restarted['body']));
+        $this->assertSame('BBBBBBBB', file_get_contents($this->staging_dir . '/files/damaged.bin'));
     }
 
     public function testOffsetZeroFrameWithANewTotalRestartsAVerifiedArtifact(): void


### PR DESCRIPTION
Resumed pushes now stop if `state.json` says we've saved more bytes than we actually did.

Before this PR, lost bytes could become NULs in a corrupt file that still passed the final size check. The old writer extended the empty file to offset 5. The filesystem filled the gap with NULs. Later chunks restored the expected length, so `finalize()` accepted the file.

With this PR, any uploaded file chunk that can't be cleanly appended to the partial staged file halts processing the request. No skipping, no recovery attempt, just full stop. PHP likely has more uploaded file data buffered, but we don't care. Correctness is more important than performance and in the initial Push version, we'll be very strict. In a future iteration we may set that one broken file aside and communicate to the source site "hey, resend that path please", but for now we'll err on the side of simplicity.