### PR TITLE
[Push] Discard apply sessions in bounded calls

### DIFF
--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -31,6 +31,8 @@ final class Site_Export_Staged_Apply_Session {
 
     private const MAX_PATH_BYTES = Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES;
 
+    private const DISCARD_ENTRY_LIMIT = 256;
+
     /** @var string */
     private $target_root;
 
@@ -158,6 +160,114 @@ final class Site_Export_Staged_Apply_Session {
         $session->require_private_workspace();
         $session->read_state();
         return $session;
+    }
+
+    /**
+     * Removes one session in bounded calls without following staged links.
+     *
+     * The first call locks and renames the active session to a private
+     * tombstone, so no later upload can open it. Each call then removes at
+     * most DISCARD_ENTRY_LIMIT filesystem entries. False means the client
+     * must call again. A missing active session and tombstone means discard
+     * already finished.
+     *
+     * @param string $storage_dir Absolute directory that owns all apply sessions.
+     * @param string $session_id  Lowercase hexadecimal id returned by get_session_id().
+     * @return bool True when no session data remains, false when cleanup is pending.
+     */
+    public static function discard(string $storage_dir, string $session_id): bool {
+        $storage_dir = self::require_absolute_directory($storage_dir, 'staged apply storage directory', false, true);
+        $sessions_dir = $storage_dir . '/apply-sessions';
+        self::require_real_directory_path($sessions_dir, 'staged apply sessions directory', false);
+        if (!preg_match('/^[a-f0-9]{32}$/D', $session_id)) {
+            throw new InvalidArgumentException('The staged apply session id must be a 32-character lowercase hexadecimal value.');
+        }
+
+        $active_session_dir = $sessions_dir . '/' . $session_id;
+        $discarding_session_dir = $sessions_dir . '/.discarding-' . $session_id;
+        $active_session_stat = @lstat($active_session_dir);
+        $discarding_session_stat = @lstat($discarding_session_dir);
+        if (!is_array($active_session_stat) && !is_array($discarding_session_stat)) {
+            return true;
+        }
+        if (is_array($active_session_stat) && !self::stat_is_real_directory($active_session_stat)) {
+            throw new RuntimeException('The staged apply session path is not a real directory: ' . $active_session_dir);
+        }
+        if (is_array($discarding_session_stat) && !self::stat_is_real_directory($discarding_session_stat)) {
+            throw new RuntimeException('The staged apply discard tombstone is not a real directory: ' . $discarding_session_dir);
+        }
+        if (is_array($active_session_stat) && is_array($discarding_session_stat)) {
+            throw new RuntimeException('Both the active staged apply session and its discard tombstone exist: ' . $session_id . '.');
+        }
+
+        $session_dir = is_array($discarding_session_stat) ? $discarding_session_dir : $active_session_dir;
+        $lock_path = $session_dir . '/lock';
+        $lock_stat = @lstat($lock_path);
+        if (!is_array($lock_stat)) {
+            if ($session_dir === $discarding_session_dir && @rmdir($discarding_session_dir)) {
+                return true;
+            }
+            if ($session_dir === $discarding_session_dir) {
+                throw new RuntimeException('The staged apply discard tombstone has no lock and is not an empty removable directory: ' . $discarding_session_dir);
+            }
+            throw new RuntimeException('The staged apply session lock is missing: ' . $lock_path);
+        }
+        if (
+            !isset($lock_stat['mode'])
+            || !is_int($lock_stat['mode'])
+            || ( $lock_stat['mode'] & 0170000 ) !== 0100000
+        ) {
+            throw new RuntimeException('The staged apply discard lock must be a real regular file: ' . $lock_path);
+        }
+        $lock = @fopen($lock_path, 'r+b');
+        if ($lock === false) {
+            throw new RuntimeException('Could not open the staged apply discard lock: ' . $lock_path, self::ERROR_RETRYABLE_IO);
+        }
+
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                throw new RuntimeException('The staged apply session is busy and cannot be discarded: ' . $session_id . '.', self::ERROR_BUSY);
+            }
+
+            // Another discard may have finished after this caller opened the
+            // old lock inode but before it acquired that lock.
+            $active_session_stat = @lstat($active_session_dir);
+            $discarding_session_stat = @lstat($discarding_session_dir);
+            if (!is_array($active_session_stat) && !is_array($discarding_session_stat)) {
+                return true;
+            }
+            if (is_array($active_session_stat) && !self::stat_is_real_directory($active_session_stat)) {
+                throw new RuntimeException('The staged apply session path is not a real directory: ' . $active_session_dir);
+            }
+            if (is_array($discarding_session_stat) && !self::stat_is_real_directory($discarding_session_stat)) {
+                throw new RuntimeException('The staged apply discard tombstone is not a real directory: ' . $discarding_session_dir);
+            }
+            if (is_array($active_session_stat) && is_array($discarding_session_stat)) {
+                throw new RuntimeException('Both the active staged apply session and its discard tombstone exist: ' . $session_id . '.');
+            }
+            if (is_array($active_session_stat)) {
+                if (!@rename($active_session_dir, $discarding_session_dir)) {
+                    throw new RuntimeException('Could not retire staged apply session before discarding it: ' . $session_id . '.', self::ERROR_RETRYABLE_IO);
+                }
+            }
+
+            // Reserve the last two removals for the lock and tombstone root.
+            $remaining_entries = self::DISCARD_ENTRY_LIMIT - 2;
+            if (!self::discard_directory_entries($discarding_session_dir, $remaining_entries, true)) {
+                return false;
+            }
+            $discard_lock_path = $discarding_session_dir . '/lock';
+            if (!@unlink($discard_lock_path)) {
+                throw new RuntimeException('Could not remove the staged apply discard lock: ' . $discard_lock_path, self::ERROR_RETRYABLE_IO);
+            }
+            if (!@rmdir($discarding_session_dir)) {
+                throw new RuntimeException('Could not remove the empty staged apply discard tombstone: ' . $discarding_session_dir, self::ERROR_RETRYABLE_IO);
+            }
+            return true;
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
     }
 
     /**
@@ -929,6 +1039,56 @@ final class Site_Export_Staged_Apply_Session {
         return isset($stat['mode'])
             && is_int($stat['mode'])
             && ( $stat['mode'] & 0170000 ) === 0040000;
+    }
+
+    /**
+     * Removes up to the caller's remaining entry budget below one directory.
+     *
+     * @param int  $remaining_entries Number of unlinks or directory removals left.
+     * @param bool $preserve_lock     Whether to leave this directory's lock entry.
+     * @return bool True when no removable entries remain below this directory.
+     */
+    private static function discard_directory_entries(string $directory_path, int &$remaining_entries, bool $preserve_lock = false): bool {
+        $directory = @opendir($directory_path);
+        if ($directory === false) {
+            throw new RuntimeException('Could not read staged apply discard directory: ' . $directory_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory);
+                if ($entry === false) {
+                    return true;
+                }
+                if ($entry === '.' || $entry === '..' || ( $preserve_lock && $entry === 'lock' )) {
+                    continue;
+                }
+                if ($remaining_entries === 0) {
+                    return false;
+                }
+
+                $entry_path = $directory_path . '/' . $entry;
+                $entry_stat = @lstat($entry_path);
+                if (!is_array($entry_stat)) {
+                    throw new RuntimeException('The staged apply discard entry disappeared during cleanup: ' . $entry_path, self::ERROR_RETRYABLE_IO);
+                }
+                if (self::stat_is_real_directory($entry_stat)) {
+                    if (!self::discard_directory_entries($entry_path, $remaining_entries)) {
+                        return false;
+                    }
+                    if ($remaining_entries === 0) {
+                        return false;
+                    }
+                    if (!@rmdir($entry_path)) {
+                        throw new RuntimeException('Could not remove staged apply discard directory: ' . $entry_path, self::ERROR_RETRYABLE_IO);
+                    }
+                } elseif (!@unlink($entry_path)) {
+                    throw new RuntimeException('Could not remove staged apply discard entry: ' . $entry_path, self::ERROR_RETRYABLE_IO);
+                }
+                --$remaining_entries;
+            }
+        } finally {
+            closedir($directory);
+        }
     }
 
     /** Requires a path's leaf to be a real regular file. */

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -1,0 +1,1082 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Runtime errors are returned as API JSON, never rendered as HTML.
+
+if (!class_exists('Site_Export_Staged_Push_Stream_Protocol', false)) {
+    require_once __DIR__ . '/class-staged-push-stream-protocol.php';
+}
+
+/**
+ * Owns one direct, resumable staged-apply upload session.
+ *
+ * Typed operations are materialized directly below the private staged tree
+ * as they are accepted. The target writes one bounded JSONL record for each
+ * completed operation; there is no uploaded manifest, validation pass, or
+ * prepared copy. This class owns operation completion, ordering, and replay.
+ * The live target tree is never mutated by this upload-only session.
+ */
+final class Site_Export_Staged_Apply_Session {
+
+    public const ERROR_BUSY = 1001;
+
+    public const ERROR_SESSION_NOT_FOUND = 1002;
+
+    public const ERROR_RETRYABLE_IO = 1003;
+
+    public const ERROR_INVALID_OPERATION = 1004;
+
+    private const MAX_METADATA_BYTES = 1048576;
+
+    private const MAX_OPERATION_LINE_BYTES = 32768;
+
+    private const MAX_PATH_BYTES = Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES;
+
+    /** @var string */
+    private $target_root;
+
+    /** @var string[] */
+    private $protected_paths;
+
+    /** @var string */
+    private $session_id;
+
+    /** @var string */
+    private $session_dir;
+
+    /** @var string */
+    private $state_path;
+
+    /** @var string */
+    private $lock_path;
+
+    /** @var string */
+    private $journal_path;
+
+    /** @var string */
+    private $staged_dir;
+
+    /** @var bool */
+    private $upload_lock_held = false;
+
+    /**
+     * Records the canonical paths used by one session handle.
+     *
+     * The constructor does not inspect or create the workspace. Call create()
+     * for a new session or open() for an existing session.
+     *
+     * @param string   $storage_dir     Canonical staging root shared by apply sessions.
+     * @param string   $target_root     Canonical root the later commit phase will change.
+     * @param string   $session_id      Random lowercase hexadecimal session identifier.
+     * @param string[] $protected_paths Target-relative paths this session may not change.
+     */
+    private function __construct(string $storage_dir, string $target_root, string $session_id, array $protected_paths) {
+        $this->target_root = $target_root;
+        $this->protected_paths = $protected_paths;
+        $this->session_id = $session_id;
+        $this->session_dir = $storage_dir . '/apply-sessions/' . $session_id;
+        $this->state_path = $this->session_dir . '/state.json';
+        $this->lock_path = $this->session_dir . '/lock';
+        $this->journal_path = $this->session_dir . '/work/operations.jsonl';
+        $this->staged_dir = $this->session_dir . '/work/files';
+    }
+
+    /**
+     * Creates a private upload session with a random server-owned id.
+     *
+     * The storage directory is created when needed. When it is inside the
+     * target, its relative path is added to the protected set automatically.
+     * Session creation does not mutate the target outside that protected
+     * storage subtree.
+     *
+     * @param string   $storage_dir     Absolute directory that owns all apply sessions.
+     * @param string   $target_root     Existing absolute directory to bind to the session.
+     * @param string[] $protected_paths Target-relative paths this session may not change.
+     * @return self The newly initialized session.
+     */
+    public static function create(
+        string $storage_dir,
+        string $target_root,
+        array $protected_paths = []
+    ): self {
+        $target_root = self::require_absolute_directory($target_root, 'apply target', false);
+        $storage_dir = self::require_staging_directory($storage_dir, $target_root, true);
+        $protected_paths = self::protect_storage_path(
+            $storage_dir,
+            $target_root,
+            $protected_paths
+        );
+
+        $sessions_dir = $storage_dir . '/apply-sessions';
+        self::require_real_directory_path($sessions_dir, 'staged apply sessions directory', true);
+
+        for ($attempt = 0; $attempt < 10; $attempt++) {
+            $session_id = bin2hex(random_bytes(16));
+            if (@mkdir($sessions_dir . '/' . $session_id, 0700)) {
+                return self::initialize_created_session($storage_dir, $target_root, $session_id, $protected_paths);
+            }
+        }
+        throw new RuntimeException('Could not create a unique staged apply session after 10 attempts.', self::ERROR_RETRYABLE_IO);
+    }
+
+    /**
+     * Opens an active session.
+     *
+     * The supplied target and protected paths must match the configuration
+     * stored in the session.
+     *
+     * @param string   $storage_dir     Existing absolute staging root used at creation.
+     * @param string   $target_root     Absolute target path originally bound to the session.
+     * @param string   $session_id      Lowercase hexadecimal id returned by get_session_id().
+     * @param string[] $protected_paths Target-relative paths this session may not change.
+     * @return self The active session.
+     */
+    public static function open(
+        string $storage_dir,
+        string $target_root,
+        string $session_id,
+        array $protected_paths = []
+    ): self {
+        $target_root = self::require_absolute_directory($target_root, 'apply target', false);
+        $storage_dir = self::require_staging_directory($storage_dir, $target_root, false);
+        self::require_real_directory_path($storage_dir . '/apply-sessions', 'staged apply sessions directory', false);
+        if (!preg_match('/^[a-f0-9]{32}$/D', $session_id)) {
+            throw new InvalidArgumentException('The staged apply session id must be a 32-character lowercase hexadecimal value.');
+        }
+        $protected_paths = self::protect_storage_path(
+            $storage_dir,
+            $target_root,
+            $protected_paths
+        );
+        $session = new self($storage_dir, $target_root, $session_id, $protected_paths);
+        $session_stat = @lstat($session->session_dir);
+        if (!is_array($session_stat) || !self::stat_is_real_directory($session_stat)) {
+            if (is_array($session_stat)) {
+                throw new RuntimeException('The staged apply session path is not a real directory: ' . $session->session_dir);
+            }
+            throw new RuntimeException('The staged apply session does not exist: ' . $session_id, self::ERROR_SESSION_NOT_FOUND);
+        }
+        $session->require_private_workspace();
+        $session->read_state();
+        return $session;
+    }
+
+    /**
+     * Returns the opaque id used to address this session.
+     *
+     * @return string Lowercase hexadecimal session id.
+     */
+    public function get_session_id(): string {
+        return $this->session_id;
+    }
+
+    /**
+     * Returns durable upload progress without taking the writer lock.
+     *
+     * The response includes phase, operation_count, journal_bytes,
+     * last_path_b64, and failure.
+     *
+     * @return array<string,mixed> Durable session status.
+     */
+    public function get_status(): array {
+        if (!$this->session_directory_exists()) {
+            throw new RuntimeException('The staged apply session does not exist: ' . $this->session_id, self::ERROR_SESSION_NOT_FOUND);
+        }
+        $this->require_private_workspace();
+        return $this->read_state();
+    }
+
+    /**
+     * Locks one upload request while its callback accepts frames.
+     *
+     * A concurrent request fails with ERROR_BUSY. Once the lock is released,
+     * operation indexes and staged shapes make a replay safe. The caller
+     * remains responsible for its per-request frame and time budgets.
+     *
+     * @param callable $callback Processes frames through the locked handle.
+     * @return mixed The callback's return value.
+     */
+    public function while_uploading(callable $callback) {
+        return $this->with_session_lock(function () use ($callback) {
+            $state = $this->read_state();
+            if ($state['phase'] !== 'uploading') {
+                throw new RuntimeException('The staged apply session is not accepting operations because its phase is ' . $state['phase'] . '.');
+            }
+            if ($this->upload_lock_held) {
+                throw new LogicException('The staged apply upload callback cannot be nested.');
+            }
+            $this->upload_lock_held = true;
+            try {
+                return $callback($this);
+            } finally {
+                $this->upload_lock_held = false;
+            }
+        });
+    }
+
+    /**
+     * Stages one directory operation and records it in the journal.
+     *
+     * Replaying the current operation is idempotent only when it names the
+     * same directory. Earlier indexes return duplicate; later indexes return
+     * operation_gap.
+     *
+     * @param int    $operation_index Zero-based index expected next by the target.
+     * @param string $path            Raw-byte target-relative directory path.
+     * @return array{status:string,reason:?string,operation_count:int}
+     */
+    public function accept_directory(int $operation_index, string $path): array {
+        $this->require_upload_lock();
+        $state = $this->read_state();
+        $gap = $this->operation_gap_result($state, $operation_index);
+        if ($gap !== null) {
+            return $gap;
+        }
+        $this->validate_new_path_or_fail($state, $path, 'directory');
+        $entry = ['type' => 'directory', 'path' => $path];
+        $staged = $this->staged_path($path);
+        if (!$this->ensure_staged_parents($path)) {
+            $this->fail_invalid_operation('Cannot stage directory ' . $this->describe_path($path) . ' below a non-directory staged ancestor.');
+        }
+        if ($this->path_present($staged)) {
+            if (!is_dir($staged) || is_link($staged)) {
+                $this->fail_invalid_operation('Cannot stage directory ' . $this->describe_path($path) . ' because that staged path is already a non-directory.');
+            }
+        } elseif (!@mkdir($staged, 0700)) {
+            throw new RuntimeException('Could not create staged directory ' . $this->describe_path($path) . '.', self::ERROR_RETRYABLE_IO);
+        }
+        return $this->complete_upload_operation($state, $entry);
+    }
+
+    /**
+     * Stages one symlink without following its target.
+     *
+     * The target is stored as bounded raw bytes, but may not be empty or
+     * contain NUL. A replay must match any symlink already materialized at
+     * that path.
+     *
+     * @param int    $operation_index Zero-based index expected next by the target.
+     * @param string $path            Raw-byte target-relative symlink path.
+     * @param string $target          Raw-byte symlink target stored without resolution.
+     * @return array{status:string,reason:?string,operation_count:int}
+     */
+    public function accept_symlink(int $operation_index, string $path, string $target): array {
+        $this->require_upload_lock();
+        $state = $this->read_state();
+        $gap = $this->operation_gap_result($state, $operation_index);
+        if ($gap !== null) {
+            return $gap;
+        }
+        $this->validate_new_path_or_fail($state, $path, 'symlink');
+        if ($target === '' || strpos($target, "\0") !== false || strlen($target) > self::MAX_PATH_BYTES) {
+            $this->fail_invalid_operation('Refusing staged symlink ' . $this->describe_path($path) . ' with an empty, NUL-containing, or overlong target.');
+        }
+        $entry = ['type' => 'symlink', 'path' => $path, 'target' => $target];
+        if (!$this->ensure_staged_parents($path)) {
+            $this->fail_invalid_operation('Cannot stage symlink ' . $this->describe_path($path) . ' below a non-directory staged ancestor.');
+        }
+        $staged = $this->staged_path($path);
+        if ($this->path_present($staged)) {
+            if (!is_link($staged) || readlink($staged) !== $target) {
+                $this->fail_invalid_operation('Cannot stage symlink ' . $this->describe_path($path) . ' because that staged path already has another shape.');
+            }
+        } elseif (!@symlink($target, $staged)) {
+            throw new RuntimeException('Could not create staged symlink ' . $this->describe_path($path) . '.', self::ERROR_RETRYABLE_IO);
+        }
+        return $this->complete_upload_operation($state, $entry);
+    }
+
+    /**
+     * Records one delete in the target-authored journal.
+     *
+     * Deletes have no staging-tree representation: absence means unchanged,
+     * and a tombstone would wrongly block replacing a file with a directory.
+     *
+     * @param int    $operation_index Zero-based index expected next by the target.
+     * @param string $path            Raw-byte target-relative path to remove during commit.
+     * @return array{status:string,reason:?string,operation_count:int}
+     */
+    public function accept_delete(int $operation_index, string $path): array {
+        $this->require_upload_lock();
+        $state = $this->read_state();
+        $gap = $this->operation_gap_result($state, $operation_index);
+        if ($gap !== null) {
+            return $gap;
+        }
+        $this->validate_new_path_or_fail($state, $path, 'delete');
+        $entry = ['type' => 'delete', 'path' => $path];
+        return $this->complete_upload_operation($state, $entry);
+    }
+
+    /**
+     * Marks a malformed or semantically invalid upload as failed.
+     *
+     * No later operation may be accepted. The failure remains available in
+     * status for diagnosis.
+     *
+     * @param string $detail Stable human-readable reason the upload is invalid.
+     */
+    public function fail_upload(string $detail): void {
+        $this->require_upload_lock();
+        if ($detail === '' || strlen($detail) > self::MAX_METADATA_BYTES / 2) {
+            throw new InvalidArgumentException('The staged apply failure detail must be a non-empty bounded string.');
+        }
+        $state = $this->read_state();
+        if ($state['phase'] !== 'uploading') {
+            throw new RuntimeException('Cannot fail staged apply upload while its phase is ' . $state['phase'] . '.');
+        }
+        $state['phase'] = 'failed';
+        $state['failure'] = $detail;
+        $this->write_state($state);
+    }
+
+    /**
+     * Initializes the fixed workspace layout after its random directory wins mkdir().
+     *
+     * If initialization fails, paths created for this random session are
+     * removed on a best-effort basis before the exception is rethrown.
+     *
+     * @param string   $storage_dir     Canonical staging root shared by apply sessions.
+     * @param string   $target_root     Canonical root the later commit phase will change.
+     * @param string   $session_id      Random lowercase hexadecimal session identifier.
+     * @param string[] $protected_paths Target-relative paths this session may not change.
+     * @return self The initialized session.
+     */
+    private static function initialize_created_session(
+        string $storage_dir,
+        string $target_root,
+        string $session_id,
+        array $protected_paths
+    ): self {
+        $session = new self($storage_dir, $target_root, $session_id, $protected_paths);
+        try {
+            if (!@mkdir($session->staged_dir, 0700, true) && !is_dir($session->staged_dir)) {
+                throw new RuntimeException('Could not create staged apply workspace directory: ' . $session->staged_dir, self::ERROR_RETRYABLE_IO);
+            }
+            if (@file_put_contents($session->lock_path, '') === false) {
+                throw new RuntimeException('Could not create the staged apply session lock: ' . $session->lock_path, self::ERROR_RETRYABLE_IO);
+            }
+            $journal = @fopen($session->journal_path, 'x+b');
+            if ($journal === false) {
+                throw new RuntimeException('Could not create the target-authored staged apply journal: ' . $session->journal_path, self::ERROR_RETRYABLE_IO);
+            }
+            try {
+                if (!fflush($journal)) {
+                    throw new RuntimeException('Could not flush the target-authored staged apply journal: ' . $session->journal_path, self::ERROR_RETRYABLE_IO);
+                }
+            } finally {
+                fclose($journal);
+            }
+            $session->write_state([
+                'version' => 1,
+                'session_id' => $session_id,
+                'target_root_b64' => base64_encode($target_root),
+                'protected_paths_b64' => array_map('base64_encode', $protected_paths),
+                'phase' => 'uploading',
+                'operation_count' => 0,
+                'journal_bytes' => 0,
+                'last_path_b64' => null,
+                'failure' => null,
+            ]);
+        } catch (Throwable $exception) {
+            foreach ([$session->state_path . '.tmp', $session->state_path, $session->lock_path, $session->journal_path] as $path) {
+                if ($session->path_present($path)) {
+                    @unlink($path);
+                }
+            }
+            @rmdir($session->staged_dir);
+            @rmdir(dirname($session->staged_dir));
+            @rmdir($session->session_dir);
+            throw $exception;
+        }
+        return $session;
+    }
+
+    /** Ensures an operation is being accepted inside the locked upload callback. */
+    private function require_upload_lock(): void {
+        if (!$this->upload_lock_held) {
+            throw new LogicException('Staged apply operations may be accepted only inside while_uploading().');
+        }
+    }
+
+    /**
+     * Verifies that every fixed workspace component has its expected file type.
+     *
+     * The fixed session state, lock, journal, and work tree must have their
+     * expected leaf types. No check here follows a workspace link.
+     */
+    private function require_private_workspace(): void {
+        foreach (
+            [
+                dirname($this->session_dir) => 'staged apply sessions directory',
+                $this->session_dir => 'staged apply session directory',
+                dirname($this->staged_dir) => 'staged apply work directory',
+                $this->staged_dir => 'staged apply staged tree',
+            ] as $path => $description
+        ) {
+            self::require_real_directory_path($path, $description, false);
+        }
+        foreach (
+            [
+                $this->state_path => 'staged apply state',
+                $this->lock_path => 'staged apply lock',
+                $this->journal_path => 'target-authored staged apply journal',
+            ] as $path => $description
+        ) {
+            self::require_real_regular_file($path, $description);
+        }
+    }
+
+    /**
+     * Classifies an operation index against the next durable journal index.
+     *
+     * @param array<string,mixed> $state
+     * @return array<string,mixed>|null A duplicate/gap response, or null for the next index.
+     */
+    private function operation_gap_result(array $state, int $operation_index): ?array {
+        if ($operation_index < 0) {
+            $this->fail_invalid_operation('The staged apply operation index must be non-negative; observed ' . $operation_index . '.');
+        }
+        if ($state['phase'] !== 'uploading') {
+            throw new RuntimeException('The staged apply session is not accepting operations because its phase is ' . $state['phase'] . '.');
+        }
+        if ($operation_index !== (int) $state['operation_count']) {
+            return $this->upload_result(
+                $operation_index < (int) $state['operation_count'] ? 'duplicate' : 'rejected',
+                $operation_index < (int) $state['operation_count'] ? null : 'operation_gap',
+                $state
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Validates a new path against safety, protection, length, and ordering rules.
+     *
+     * Any violation fails the whole upload because accepting a later
+     * operation would no longer describe one ordered target plan.
+     *
+     * @param array<string,mixed> $state
+     */
+    private function validate_new_path_or_fail(array $state, string $path, string $type): void {
+        $path_bytes = strlen($path);
+        if ($path_bytes > self::MAX_PATH_BYTES) {
+            $this->fail_invalid_operation(
+                'Refusing staged apply path of ' . $path_bytes . ' bytes; the maximum is ' . self::MAX_PATH_BYTES . ' bytes.'
+            );
+        }
+        try {
+            $this->require_writable_target_path($path, $type);
+        } catch (RuntimeException $exception) {
+            $this->fail_invalid_operation($exception->getMessage());
+        }
+        $last_path = $state['last_path_b64'] === null ? null : base64_decode($state['last_path_b64'], true);
+        if (is_string($last_path) && strcmp($last_path, $path) >= 0) {
+            $this->fail_invalid_operation(
+                'Staged apply paths must be strictly increasing by raw bytes; received ' . $this->describe_path($path)
+                . ' after ' . $this->describe_path($last_path) . '.'
+            );
+        }
+    }
+
+    /**
+     * Appends one completed operation and advances state past the flushed line.
+     *
+     * Any journal tail beyond state.json's cursor came from an interrupted
+     * earlier attempt and is truncated before this record is written again.
+     *
+     * @param array<string,mixed> $state
+     * @param array<string,mixed> $entry
+     * @return array<string,mixed>
+     */
+    private function complete_upload_operation(array $state, array $entry): array {
+        $this->truncate_journal_tail( (int) $state['journal_bytes']);
+        $record = [
+            'operation_index' => (int) $state['operation_count'],
+            'entry' => $this->serialize_entry($entry),
+        ];
+        $encoded = json_encode($record, JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded)) {
+            throw new RuntimeException('Could not encode target-authored staged apply journal operation.');
+        }
+        $line = $encoded . "\n";
+        if (strlen($line) > self::MAX_OPERATION_LINE_BYTES) {
+            $this->fail_invalid_operation('The target-authored staged apply operation exceeds its bounded encoded size.');
+        }
+        $journal = @fopen($this->journal_path, 'c+b');
+        if ($journal === false) {
+            throw new RuntimeException('Could not open the target-authored staged apply journal: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            if (fseek($journal, (int) $state['journal_bytes'], SEEK_SET) !== 0 || !self::write_all($journal, $line) || !fflush($journal)) {
+                throw new RuntimeException('Could not append target-authored staged apply operation ' . $state['operation_count'] . '.', self::ERROR_RETRYABLE_IO);
+            }
+        } finally {
+            fclose($journal);
+        }
+
+        ++$state['operation_count'];
+        $state['journal_bytes'] += strlen($line);
+        $state['last_path_b64'] = base64_encode($entry['path']);
+        $this->write_state($state);
+        return $this->upload_result('accepted', null, $state);
+    }
+
+    /**
+     * Builds the bounded response returned for an accepted, duplicate, or rejected frame.
+     *
+     * @param string              $status Accepted, duplicate, or rejected.
+     * @param string|null         $reason Stable rejection reason, or null otherwise.
+     * @param array<string,mixed> $state
+     * @return array{status:string,reason:?string,operation_count:int}
+     */
+    private function upload_result(string $status, ?string $reason, array $state): array {
+        return [
+            'status' => $status,
+            'reason' => $reason,
+            'operation_count' => (int) $state['operation_count'],
+        ];
+    }
+
+    /** Marks the upload failed and throws the stable invalid-operation error. */
+    private function fail_invalid_operation(string $detail): void {
+        $this->fail_upload($detail);
+        throw new RuntimeException($detail, self::ERROR_INVALID_OPERATION);
+    }
+
+    /**
+     * Truncates bytes written beyond the durable journal cursor after a crash.
+     */
+    private function truncate_journal_tail(int $journal_bytes): void {
+        $journal = @fopen($this->journal_path, 'c+b');
+        if ($journal === false) {
+            throw new RuntimeException('Could not open the target-authored staged apply journal: ' . $this->journal_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            $stat = fstat($journal);
+            $observed_bytes = is_array($stat) && isset($stat['size']) ? (int) $stat['size'] : -1;
+            if ($observed_bytes < $journal_bytes) {
+                throw new RuntimeException(
+                    'The target-authored staged apply journal is shorter than its durable cursor; expected at least '
+                    . $journal_bytes . ' bytes, observed ' . $observed_bytes . '.'
+                );
+            }
+            if ($observed_bytes > $journal_bytes && ( !ftruncate($journal, $journal_bytes) || !fflush($journal) )) {
+                throw new RuntimeException('Could not remove the uncommitted staged apply journal tail after byte ' . $journal_bytes . '.', self::ERROR_RETRYABLE_IO);
+            }
+        } finally {
+            fclose($journal);
+        }
+    }
+
+    /**
+     * Encodes arbitrary path and symlink-target bytes for JSON persistence.
+     *
+     * @param array<string,mixed> $entry
+     * @return array<string,mixed>
+     */
+    private function serialize_entry(array $entry): array {
+        $serialized = $entry;
+        $serialized['path_b64'] = base64_encode($entry['path']);
+        unset($serialized['path']);
+        if (array_key_exists('target', $serialized)) {
+            $serialized['target_b64'] = base64_encode($serialized['target']);
+            unset($serialized['target']);
+        }
+        return $serialized;
+    }
+
+    /**
+     * Atomically replaces the session's bounded state record.
+     *
+     * @param array<string,mixed> $state
+     */
+    private function write_state(array $state): void {
+        $this->write_json_file($this->state_path, $state);
+    }
+
+    /**
+     * Reads and validates the complete durable session state.
+     *
+     * This validates stored configuration and progress, but deliberately does
+     * not inspect the live target identity. Upload never mutates the target;
+     * identity validation is deferred to the later commit phase.
+     *
+     * @return array<string,mixed>
+     */
+    private function read_state(): array {
+        $state = $this->read_json_file($this->state_path);
+        if (!is_array($state) || ( $state['version'] ?? null ) !== 1 || ( $state['session_id'] ?? null ) !== $this->session_id) {
+            throw new RuntimeException('The staged apply session state is missing or malformed: ' . $this->state_path);
+        }
+        $encoded_target_root = $state['target_root_b64'] ?? null;
+        $encoded_protected_paths = $state['protected_paths_b64'] ?? null;
+        if (!is_string($encoded_target_root) || !is_array($encoded_protected_paths)) {
+            throw new RuntimeException('The staged apply session configuration is malformed.');
+        }
+        $stored_target_root = base64_decode($encoded_target_root, true);
+        $stored_protected_paths = [];
+        foreach ($encoded_protected_paths as $encoded_path) {
+            $protected_path = is_string($encoded_path) ? base64_decode($encoded_path, true) : false;
+            if ($protected_path === false || $protected_path === '') {
+                throw new RuntimeException('The staged apply session protected paths are malformed.');
+            }
+            $stored_protected_paths[] = $protected_path;
+        }
+        if ($stored_target_root !== $this->target_root || $stored_protected_paths !== $this->protected_paths) {
+            throw new RuntimeException('The staged apply session configuration no longer matches its target or protected paths.');
+        }
+        foreach (['operation_count', 'journal_bytes'] as $field) {
+            if (!isset($state[$field]) || !is_int($state[$field]) || $state[$field] < 0) {
+                throw new RuntimeException('The staged apply session state field ' . $field . ' must be a non-negative integer.');
+            }
+        }
+        $journal_stat = @lstat($this->journal_path);
+        $journal_size = is_array($journal_stat) && isset($journal_stat['size']) ? (int) $journal_stat['size'] : -1;
+        if ($journal_size < $state['journal_bytes']) {
+            throw new RuntimeException(
+                'The target-authored staged apply journal is shorter than its durable cursor; expected at least '
+                . $state['journal_bytes'] . ' bytes, observed ' . $journal_size . '.'
+            );
+        }
+        $phase = $state['phase'] ?? null;
+        if (!in_array($phase, ['uploading', 'failed'], true)) {
+            throw new RuntimeException('The staged apply session phase is invalid: ' . ( is_string($phase) ? $phase : gettype($phase) ) . '.');
+        }
+        $last_path_b64 = $state['last_path_b64'] ?? null;
+        $last_path = is_string($last_path_b64) ? base64_decode($last_path_b64, true) : null;
+        if (
+            ( $last_path_b64 !== null && ( $last_path === false || $last_path === '' ) )
+            || ( ( $state['operation_count'] === 0 ) !== ( $last_path_b64 === null ) )
+        ) {
+            throw new RuntimeException('The staged apply last accepted path state is malformed.');
+        }
+        if (is_string($last_path)) {
+            // Directory is the least restrictive legal shape: an accepted
+            // directory may be an ancestor of a protected descendant.
+            $this->require_writable_target_path($last_path, 'directory');
+        }
+        $failure = $state['failure'] ?? null;
+        if (( $phase === 'failed' && ( !is_string($failure) || $failure === '' ) ) || ( $phase !== 'failed' && $failure !== null )) {
+            throw new RuntimeException('The staged apply failure state is malformed.');
+        }
+        return $state;
+    }
+
+    /**
+     * Reads one bounded JSON object, or null when the path is absent or malformed.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function read_json_file(string $path): ?array {
+        if (!$this->path_present($path)) {
+            return null;
+        }
+        $contents = @file_get_contents($path, false, null, 0, self::MAX_METADATA_BYTES + 1);
+        if ($contents === false) {
+            throw new RuntimeException('Could not read staged apply metadata: ' . $path, self::ERROR_RETRYABLE_IO);
+        }
+        if (strlen($contents) > self::MAX_METADATA_BYTES) {
+            throw new RuntimeException('The staged apply metadata exceeds the bounded size: ' . $path);
+        }
+        $value = json_decode($contents, true);
+        return is_array($value) ? $value : null;
+    }
+
+    /**
+     * Writes a bounded JSON object through an exclusive temporary file and rename.
+     *
+     * Existing temporary paths are unlinked first, so a leftover symlink or
+     * hard link is never opened for writing.
+     *
+     * @param array<string,mixed> $value
+     */
+    private function write_json_file(string $path, array $value, int $max_bytes = self::MAX_METADATA_BYTES): void {
+        $encoded = json_encode($value, JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded)) {
+            throw new RuntimeException('Could not encode staged apply metadata: ' . $path);
+        }
+        if (strlen($encoded) > $max_bytes) {
+            throw new RuntimeException('The staged apply metadata exceeds the bounded size: ' . $path);
+        }
+        $tmp = $path . '.tmp';
+        $tmp_stat = @lstat($tmp);
+        if (is_array($tmp_stat)) {
+            if (self::stat_is_real_directory($tmp_stat)) {
+                throw new RuntimeException('The staged apply metadata temporary path is a directory: ' . $tmp);
+            }
+            if (!@unlink($tmp)) {
+                throw new RuntimeException('Could not clear staged apply metadata temporary path: ' . $tmp, self::ERROR_RETRYABLE_IO);
+            }
+        }
+        // Exclusive creation cannot follow a symlink planted after the
+        // lstat/unlink check. A leftover hard link is unlinked, never opened.
+        $handle = @fopen($tmp, 'x+b');
+        if ($handle === false) {
+            throw new RuntimeException('Could not write staged apply metadata: ' . $tmp, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            if (!self::write_all($handle, $encoded) || !fflush($handle)) {
+                throw new RuntimeException('Could not flush staged apply metadata: ' . $tmp, self::ERROR_RETRYABLE_IO);
+            }
+        } finally {
+            fclose($handle);
+        }
+        if (!@rename($tmp, $path)) {
+            throw new RuntimeException('Could not commit staged apply metadata: ' . $path, self::ERROR_RETRYABLE_IO);
+        }
+    }
+
+    /**
+     * Runs one session transition under its non-blocking, never-replaced lock.
+     *
+     * @return mixed
+     */
+    private function with_session_lock(callable $callback) {
+        if (!$this->session_directory_exists()) {
+            throw new RuntimeException('The staged apply session does not exist: ' . $this->session_id, self::ERROR_SESSION_NOT_FOUND);
+        }
+        $this->require_private_workspace();
+        $lock = @fopen($this->lock_path, 'c+b');
+        if ($lock === false) {
+            throw new RuntimeException('Could not open staged apply session lock: ' . $this->lock_path, self::ERROR_RETRYABLE_IO);
+        }
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                throw new RuntimeException('Staged apply session ' . $this->session_id . ' is busy. Retry with the same session id.', self::ERROR_BUSY);
+            }
+            return $callback();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /** Checks whether the active session directory still exists without cached stat data. */
+    private function session_directory_exists(): bool {
+        clearstatcache(true, $this->session_dir);
+        return is_dir($this->session_dir);
+    }
+
+    /**
+     * Creates missing staging parents as real 0700 directories without following links.
+     *
+     * @return bool False when an existing ancestor is not a real directory.
+     */
+    private function ensure_staged_parents(string $path): bool {
+        $segments = explode('/', $path);
+        array_pop($segments);
+        $current = $this->staged_dir;
+        foreach ($segments as $segment) {
+            $current .= '/' . $segment;
+            $stat = @lstat($current);
+            if (is_array($stat)) {
+                if (self::stat_is_real_directory($stat)) {
+                    continue;
+                }
+                return false;
+            }
+            if ($this->path_present($current)) {
+                return false;
+            }
+            if (!@mkdir($current, 0700)) {
+                throw new RuntimeException(
+                    'Could not create staged apply parent directory ' . $this->describe_path($current) . '.',
+                    self::ERROR_RETRYABLE_IO
+                );
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Validates one target-relative path against syntax and protected paths.
+     *
+     * Directories may be ancestors of a protected path because installing
+     * their permitted siblings still needs structural staging parents. Other
+     * entry types may neither equal nor contain a protected path.
+     */
+    private function require_writable_target_path(string $path, ?string $entry_type = null): void {
+        if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            throw new RuntimeException('Refusing unsafe staged apply path: ' . $this->describe_path($path));
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new RuntimeException('Refusing unsafe staged apply path: ' . $this->describe_path($path));
+            }
+        }
+        foreach ($this->protected_paths as $protected_path) {
+            if ($path === $protected_path || strpos($path, $protected_path . '/') === 0) {
+                throw new RuntimeException('Refusing protected staged apply path: ' . $this->describe_path($path));
+            }
+            if (strpos($protected_path, $path . '/') === 0 && $entry_type !== 'directory') {
+                throw new RuntimeException('Refusing protected staged apply ancestor path: ' . $this->describe_path($path));
+            }
+        }
+    }
+
+    /** Appends a validated target-relative path to the staged-tree root. */
+    private function staged_path(string $path): string {
+        return $this->staged_dir . '/' . $path;
+    }
+
+    /** Checks path presence without treating a dangling symlink as absent. */
+    private function path_present(string $path): bool {
+        return file_exists($path) || is_link($path);
+    }
+
+    /** Formats arbitrary path bytes safely for diagnostics. */
+    private function describe_path(string $path): string {
+        return 'base64:' . base64_encode($path);
+    }
+
+    /**
+     * Writes an entire bounded string, retrying ordinary short writes.
+     *
+     * @param resource $handle
+     */
+    private static function write_all($handle, string $bytes): bool {
+        $written_bytes = 0;
+        $total_bytes = strlen($bytes);
+        while ($written_bytes < $total_bytes) {
+            $written = fwrite($handle, substr($bytes, $written_bytes));
+            if (!is_int($written) || $written <= 0) {
+                return false;
+            }
+            $written_bytes += $written;
+        }
+        return true;
+    }
+
+    /**
+     * Validates, sorts, and deduplicates target-relative protected paths.
+     *
+     * @param string[] $protected_paths
+     * @return string[]
+     */
+    private static function normalize_protected_paths(array $protected_paths): array {
+        $normalized = [];
+        foreach ($protected_paths as $path) {
+            if (!is_string($path) || $path === '') {
+                throw new InvalidArgumentException('Each protected staged apply path must be a non-empty relative string.');
+            }
+            $path_bytes = strlen($path);
+            if ($path_bytes > self::MAX_PATH_BYTES) {
+                throw new InvalidArgumentException(
+                    'Protected staged apply path has ' . $path_bytes . ' bytes; the maximum is ' . self::MAX_PATH_BYTES . ' bytes.'
+                );
+            }
+            if ($path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+                throw new InvalidArgumentException('Protected staged apply path is unsafe: ' . base64_encode($path));
+            }
+            foreach (explode('/', $path) as $segment) {
+                if ($segment === '' || $segment === '.' || $segment === '..') {
+                    throw new InvalidArgumentException('Protected staged apply path is unsafe: ' . base64_encode($path));
+                }
+            }
+            $normalized[] = $path;
+        }
+        sort($normalized, SORT_STRING);
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * Validates the protected set and adds storage when it lives below the target.
+     *
+     * Storage that equals or contains the target is rejected because the
+     * target index cannot safely exclude that topology.
+     *
+     * @param string[] $protected_paths
+     * @return string[]
+     */
+    private static function protect_storage_path(string $storage_dir, string $target_root, array $protected_paths): array {
+        if ($storage_dir === $target_root) {
+            throw new InvalidArgumentException('The staged apply storage directory must not be the same directory as its apply target.');
+        }
+        $storage_prefix = $storage_dir === '/' ? '/' : $storage_dir . '/';
+        if (strpos($target_root, $storage_prefix) === 0) {
+            throw new InvalidArgumentException('The staged apply storage directory must not contain its apply target.');
+        }
+        $target_prefix = $target_root === '/' ? '/' : $target_root . '/';
+        if (strpos($storage_dir, $target_prefix) === 0) {
+            $protected_paths[] = substr($storage_dir, strlen($target_prefix));
+        }
+        return self::normalize_protected_paths($protected_paths);
+    }
+
+    /** Creates or validates a directory using lstat so the leaf cannot be a symlink. */
+    private static function require_real_directory_path(string $path, string $description, bool $create): void {
+        $stat = @lstat($path);
+        if (!is_array($stat) && $create) {
+            if (!@mkdir($path, 0700, true)) {
+                $stat = @lstat($path);
+                if (!is_array($stat)) {
+                    throw new RuntimeException('Could not create the ' . $description . ': ' . $path, self::ERROR_RETRYABLE_IO);
+                }
+            }
+            $stat = @lstat($path);
+        }
+        if (!is_array($stat) || !self::stat_is_real_directory($stat)) {
+            throw new RuntimeException('The ' . $description . ' must be a real directory, not a symlink or another file type: ' . $path);
+        }
+    }
+
+    /**
+     * Checks an lstat record for a real directory mode.
+     *
+     * @param array<string,mixed> $stat
+     */
+    private static function stat_is_real_directory(array $stat): bool {
+        return isset($stat['mode'])
+            && is_int($stat['mode'])
+            && ( $stat['mode'] & 0170000 ) === 0040000;
+    }
+
+    /** Requires a path's leaf to be a real regular file. */
+    private static function require_real_regular_file(string $path, string $description): void {
+        $stat = @lstat($path);
+        if (
+            !is_array($stat)
+            || !isset($stat['mode'])
+            || !is_int($stat['mode'])
+            || ( $stat['mode'] & 0170000 ) !== 0100000
+        ) {
+            throw new RuntimeException('The ' . $description . ' must be a real regular file, not a symlink or another file type: ' . $path);
+        }
+    }
+
+    /**
+     * Creates or opens the staging root and installs its web-access guards.
+     *
+     * A staging path below the target may not reach its leaf through a
+     * target-owned symlink, because later relative protection would inspect
+     * a different tree than filesystem writes use.
+     */
+    private static function require_staging_directory(string $path, string $target_root, bool $create): string {
+        self::require_no_symlinked_staging_components_inside_target($path, $target_root);
+        $resolved = self::require_absolute_directory($path, 'staging directory', $create, true);
+        self::require_no_symlinked_staging_components_inside_target($path, $target_root);
+        self::ensure_storage_web_guards($resolved);
+        return $resolved;
+    }
+
+    /**
+     * Validates, optionally creates, and canonicalizes an absolute directory.
+     */
+    private static function require_absolute_directory(string $path, string $name, bool $create, bool $reject_symlinks = false): string {
+        clearstatcache(true);
+        if ($path === '' || $path[0] !== '/' || strpos($path, "\0") !== false) {
+            throw new InvalidArgumentException('The ' . $name . ' must be an absolute path without NUL bytes: ' . $path);
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException('The ' . $name . ' must not contain dot segments: ' . $path);
+            }
+        }
+        $path = rtrim($path, '/');
+        $path = $path === '' ? '/' : $path;
+        if ($reject_symlinks && ( $path === '/' || is_link($path) )) {
+            throw new InvalidArgumentException('The ' . $name . ' must not be the filesystem root or a symlink: ' . $path);
+        }
+        if ($create && !is_dir($path) && !@mkdir($path, 0700, true) && !is_dir($path)) {
+            throw new RuntimeException('Could not create the ' . $name . ': ' . $path, self::ERROR_RETRYABLE_IO);
+        }
+        if (!is_dir($path)) {
+            throw new RuntimeException('The ' . $name . ' is not an existing directory: ' . $path);
+        }
+        if ($reject_symlinks && is_link($path)) {
+            throw new InvalidArgumentException('The ' . $name . ' must not be a symlink: ' . $path);
+        }
+        $resolved = realpath($path);
+        if (!is_string($resolved)) {
+            throw new RuntimeException('Could not resolve the ' . $name . ': ' . $path, self::ERROR_RETRYABLE_IO);
+        }
+        return $resolved;
+    }
+
+    /** Creates missing web guards and requires existing guards to retain the expected contents. */
+    private static function ensure_storage_web_guards(string $storage_dir): void {
+        self::ensure_storage_web_guard(
+            $storage_dir . '/.htaccess',
+            "# Reprint staging area - never web-served.\n"
+                . "<IfModule mod_authz_core.c>\n"
+                . "    Require all denied\n"
+                . "</IfModule>\n"
+                . "<IfModule !mod_authz_core.c>\n"
+                . "    Deny from all\n"
+                . "</IfModule>\n",
+            'web-server'
+        );
+        self::ensure_storage_web_guard($storage_dir . '/index.php', "<?php\n", 'index');
+    }
+
+    /** Creates one guard exclusively, or verifies an existing real regular guard. */
+    private static function ensure_storage_web_guard(string $path, string $contents, string $description): void {
+        $stat = @lstat($path);
+        if (!is_array($stat)) {
+            $guard = @fopen($path, 'x+b');
+            if ($guard !== false) {
+                try {
+                    if (!self::write_all($guard, $contents) || !fflush($guard)) {
+                        throw new RuntimeException('Could not write the staging ' . $description . ' guard: ' . $path, self::ERROR_RETRYABLE_IO);
+                    }
+                } catch (Throwable $exception) {
+                    fclose($guard);
+                    @unlink($path);
+                    throw $exception;
+                }
+                fclose($guard);
+                return;
+            }
+
+            // A concurrent creator may have won exclusive creation. It must
+            // have installed the same real guard that this call would write.
+            $stat = @lstat($path);
+            if (!is_array($stat)) {
+                throw new RuntimeException('Could not create the staging ' . $description . ' guard: ' . $path, self::ERROR_RETRYABLE_IO);
+            }
+        }
+
+        self::require_real_regular_file($path, 'staging ' . $description . ' guard');
+        $observed_contents = @file_get_contents($path, false, null, 0, strlen($contents) + 1);
+        if ($observed_contents === false) {
+            throw new RuntimeException('Could not read the existing staging ' . $description . ' guard.', self::ERROR_RETRYABLE_IO);
+        }
+        if ($observed_contents !== $contents) {
+            $observed_bytes = isset($stat['size']) && is_int($stat['size']) ? $stat['size'] : -1;
+            throw new RuntimeException(
+                'The staging ' . $description . ' guard contents do not match Reprint\'s required guard; expected '
+                . strlen($contents) . ' bytes, observed ' . $observed_bytes . ' bytes.'
+            );
+        }
+    }
+
+    /**
+     * Rejects a staging path that traverses a symlink owned by the target tree.
+     */
+    private static function require_no_symlinked_staging_components_inside_target(string $path, string $target_root): void {
+        if ($path === '' || $path[0] !== '/' || strpos($path, "\0") !== false) {
+            return;
+        }
+        $current = '';
+        $target_prefix = $target_root === '/' ? '/' : $target_root . '/';
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+            if ($segment === '.' || $segment === '..') {
+                return;
+            }
+            $current .= '/' . $segment;
+            if (!is_link($current)) {
+                continue;
+            }
+            $resolved_parent = realpath(dirname($current));
+            if (is_string($resolved_parent) && ( $resolved_parent === $target_root || strpos($resolved_parent, $target_prefix) === 0 )) {
+                throw new InvalidArgumentException(
+                    'The staging directory must not use a symlinked component inside the apply target; component base64 is '
+                    . base64_encode($current) . '.'
+                );
+            }
+        }
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
+++ b/packages/reprint-exporter/src/class-staged-push-stream-protocol.php
@@ -12,6 +12,9 @@ final class Site_Export_Staged_Push_Stream_Protocol {
 
     public const CONTENT_TYPE = 'application/x-reprint-staged-push-stream';
 
+    /** Maximum raw bytes accepted for one path or symlink target. */
+    public const MAX_PATH_BYTES = 8192;
+
     /**
      * Top-level path segment reprint reserves for its own staged bookkeeping.
      * A sender's file artifacts may never land here — see

--- a/tests/StagedApplyDiscardTest.php
+++ b/tests/StagedApplyDiscardTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply-session.php';
+
+final class StagedApplyDiscardTest extends TestCase {
+
+    private string $temporary_directory;
+
+    private string $storage_directory;
+
+    private string $target_directory;
+
+    /** Creates isolated storage and target roots for one test. */
+    protected function setUp(): void {
+        $this->temporary_directory = sys_get_temp_dir() . '/reprint-direct-discard-' . bin2hex(random_bytes(8));
+        $this->storage_directory = $this->temporary_directory . '/staging';
+        $this->target_directory = $this->temporary_directory . '/target';
+        mkdir($this->temporary_directory, 0700, true);
+        mkdir($this->target_directory, 0700, true);
+    }
+
+    /** Removes the isolated filesystem tree after each test. */
+    protected function tearDown(): void {
+        $this->removeTree($this->temporary_directory);
+    }
+
+    /** Verifies discard removes staged state without following staged links. */
+    public function testDiscardRemovesOnlyTheSession(): void {
+        $session = $this->createSession();
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+            $upload->accept_directory(0, 'nested');
+        });
+        $outside_file = $this->temporary_directory . '/outside.txt';
+        file_put_contents($outside_file, 'keep');
+        symlink($outside_file, $this->sessionDirectory($session) . '/work/files/outside-link');
+
+        self::assertTrue(Site_Export_Staged_Apply_Session::discard(
+            $this->storage_directory,
+            $session->get_session_id()
+        ));
+
+        self::assertDirectoryDoesNotExist($this->sessionDirectory($session));
+        self::assertFileExists($outside_file);
+        self::assertSame('keep', file_get_contents($outside_file));
+        self::assertTrue(Site_Export_Staged_Apply_Session::discard(
+            $this->storage_directory,
+            $session->get_session_id()
+        ));
+    }
+
+    /** Verifies each call removes a bounded number of entries and can resume. */
+    public function testLargeDiscardFinishesAcrossCalls(): void {
+        $session = $this->createSession();
+        $many_files = $this->sessionDirectory($session) . '/work/files/many';
+        mkdir($many_files, 0700, true);
+        for ($index = 0; $index < 300; ++$index) {
+            file_put_contents($many_files . '/' . str_pad( (string) $index, 3, '0', STR_PAD_LEFT), 'x');
+        }
+
+        self::assertFalse(Site_Export_Staged_Apply_Session::discard(
+            $this->storage_directory,
+            $session->get_session_id()
+        ));
+        self::assertDirectoryDoesNotExist($this->sessionDirectory($session));
+        $discarding_directory = $this->discardingDirectory($session);
+        self::assertDirectoryExists($discarding_directory);
+        $remaining_files = glob($discarding_directory . '/work/files/many/*');
+        self::assertIsArray($remaining_files);
+        self::assertNotEmpty($remaining_files);
+        self::assertLessThan(300, count($remaining_files));
+
+        for ($attempt = 0; $attempt < 5; ++$attempt) {
+            if (Site_Export_Staged_Apply_Session::discard($this->storage_directory, $session->get_session_id())) {
+                self::assertDirectoryDoesNotExist($discarding_directory);
+                return;
+            }
+        }
+        self::fail('The bounded staged apply discard did not finish within five calls.');
+    }
+
+    /** Verifies discard refuses to race an active upload. */
+    public function testDiscardReturnsBusyWhileTheSessionLockIsHeld(): void {
+        $session = $this->createSession();
+        $session_lock = fopen($this->sessionDirectory($session) . '/lock', 'r+b');
+        self::assertIsResource($session_lock);
+        self::assertTrue(flock($session_lock, LOCK_EX | LOCK_NB));
+        try {
+            Site_Export_Staged_Apply_Session::discard($this->storage_directory, $session->get_session_id());
+            self::fail('Expected discard to reject a held session lock.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_BUSY, $exception->getCode());
+        } finally {
+            flock($session_lock, LOCK_UN);
+            fclose($session_lock);
+        }
+
+        self::assertDirectoryExists($this->sessionDirectory($session));
+        self::assertDirectoryDoesNotExist($this->discardingDirectory($session));
+    }
+
+    /** Verifies a retry continues after the active directory was renamed. */
+    public function testDiscardResumesFromTheTombstone(): void {
+        $session = $this->createSession();
+        self::assertTrue(rename($this->sessionDirectory($session), $this->discardingDirectory($session)));
+
+        self::assertTrue(Site_Export_Staged_Apply_Session::discard(
+            $this->storage_directory,
+            $session->get_session_id()
+        ));
+        self::assertDirectoryDoesNotExist($this->discardingDirectory($session));
+
+        $session = $this->createSession();
+        $discarding_directory = $this->discardingDirectory($session);
+        self::assertTrue(rename($this->sessionDirectory($session), $discarding_directory));
+        $this->removeTree($discarding_directory . '/state.json');
+        $this->removeTree($discarding_directory . '/work');
+        $this->removeTree($discarding_directory . '/lock');
+
+        // Simulate a cut after the lock was unlinked but before the empty
+        // tombstone itself was removed.
+        self::assertTrue(Site_Export_Staged_Apply_Session::discard(
+            $this->storage_directory,
+            $session->get_session_id()
+        ));
+        self::assertDirectoryDoesNotExist($discarding_directory);
+    }
+
+    /** Creates a session in this test's isolated roots. */
+    private function createSession(): Site_Export_Staged_Apply_Session {
+        return Site_Export_Staged_Apply_Session::create(
+            $this->storage_directory,
+            $this->target_directory
+        );
+    }
+
+    /** Returns the active directory owned by a test session. */
+    private function sessionDirectory(Site_Export_Staged_Apply_Session $session): string {
+        return $this->storage_directory . '/apply-sessions/' . $session->get_session_id();
+    }
+
+    /** Returns the private tombstone used while deleting a session. */
+    private function discardingDirectory(Site_Export_Staged_Apply_Session $session): string {
+        return $this->storage_directory . '/apply-sessions/.discarding-' . $session->get_session_id();
+    }
+
+    /** Removes an isolated test tree without following symlinks. */
+    private function removeTree(string $path): void {
+        if (is_link($path) || !is_dir($path)) {
+            if (file_exists($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $directory = opendir($path);
+        if ($directory === false) {
+            return;
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+        } finally {
+            closedir($directory);
+        }
+        rmdir($path);
+    }
+}

--- a/tests/StagedApplySessionTest.php
+++ b/tests/StagedApplySessionTest.php
@@ -1,0 +1,411 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply-session.php';
+
+final class StagedApplySessionTest extends TestCase {
+
+    private string $temporary_directory;
+
+    private string $storage_directory;
+
+    private string $target_directory;
+
+    /** Creates isolated storage and target roots for one test. */
+    protected function setUp(): void {
+        $this->temporary_directory = sys_get_temp_dir() . '/reprint-direct-apply-' . bin2hex(random_bytes(8));
+        $this->storage_directory = $this->temporary_directory . '/staging';
+        $this->target_directory = $this->temporary_directory . '/target';
+        mkdir($this->temporary_directory, 0700, true);
+        mkdir($this->target_directory, 0700, true);
+    }
+
+    /** Removes the isolated filesystem tree after each test. */
+    protected function tearDown(): void {
+        $this->removeTree($this->temporary_directory);
+    }
+
+    /** Verifies session creation installs the private fixed workspace. */
+    public function testCreateBuildsPrivateWorkspace(): void {
+        $session = $this->createSession();
+        $session_directory = $this->sessionDirectory($session);
+
+        self::assertFileExists($this->storage_directory . '/.htaccess');
+        self::assertStringContainsString('Require all denied', (string) file_get_contents($this->storage_directory . '/.htaccess'));
+        self::assertSame("<?php\n", file_get_contents($this->storage_directory . '/index.php'));
+        self::assertDirectoryExists($session_directory . '/work/files');
+        self::assertSame('', file_get_contents($session_directory . '/work/operations.jsonl'));
+
+        $status = $session->get_status();
+        self::assertSame('uploading', $status['phase']);
+        self::assertSame(0, $status['operation_count']);
+    }
+
+    /** Verifies every typed operation stages and journals without live mutation. */
+    public function testTypedOperationsStageAndJournalWithoutMutatingTheTarget(): void {
+        file_put_contents($this->target_directory . '/b-delete', 'old');
+        $session = $this->createSession();
+
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+            $upload->accept_directory(0, 'a-directory');
+            $upload->accept_delete(1, 'b-delete');
+            $upload->accept_directory(2, 'c-directory');
+            $upload->accept_symlink(3, 'd-link', 'c-directory');
+        });
+
+        $session_directory = $this->sessionDirectory($session);
+        $staged_directory = $session_directory . '/work/files';
+        self::assertDirectoryExists($staged_directory . '/a-directory');
+        self::assertDirectoryExists($staged_directory . '/c-directory');
+        self::assertTrue(is_link($staged_directory . '/d-link'));
+        self::assertSame('c-directory', readlink($staged_directory . '/d-link'));
+
+        $journal_entries = array_map(
+            static function (string $line): array {
+                return json_decode($line, true);
+            },
+            file($session_directory . '/work/operations.jsonl', FILE_IGNORE_NEW_LINES)
+        );
+        self::assertSame(
+            ['directory', 'delete', 'directory', 'symlink'],
+            array_column(array_column($journal_entries, 'entry'), 'type')
+        );
+        self::assertSame(
+            array_map('base64_encode', ['a-directory', 'b-delete', 'c-directory', 'd-link']),
+            array_column(array_column($journal_entries, 'entry'), 'path_b64')
+        );
+
+        $status = $session->get_status();
+        self::assertSame(4, $status['operation_count']);
+        self::assertSame('old', file_get_contents($this->target_directory . '/b-delete'));
+        self::assertFileDoesNotExist($this->target_directory . '/a-directory');
+        self::assertFileDoesNotExist($this->target_directory . '/c-directory');
+        self::assertFileDoesNotExist($this->target_directory . '/d-link');
+    }
+
+    /** Verifies an unsafe path permanently stops the session. */
+    public function testUnsafeOperationPoisonsTheSession(): void {
+        $session = $this->createSession();
+        try {
+            $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+                $upload->accept_directory(0, '../escape');
+            });
+            self::fail('Expected unsafe path rejection.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_OPERATION, $exception->getCode());
+        }
+
+        self::assertSame('failed', $session->get_status()['phase']);
+    }
+
+    /** Verifies protocol failure remains available in status. */
+    public function testMalformedUploadFailsTheSession(): void {
+        $session = $this->createSession();
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+            $upload->fail_upload('The following frame header is malformed.');
+        });
+
+        $status = $session->get_status();
+        self::assertSame('failed', $status['phase']);
+        self::assertSame('The following frame header is malformed.', $status['failure']);
+    }
+
+    /** Verifies protected and noncanonical operation paths are terminal. */
+    public function testProtectedAndOutOfOrderPathsPoisonTheirSessions(): void {
+        $protected = $this->createSession(['protected']);
+        try {
+            $protected->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+                $upload->accept_directory(0, 'protected');
+            });
+            self::fail('Expected protected path rejection.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_OPERATION, $exception->getCode());
+            self::assertStringContainsString('protected staged apply path', $exception->getMessage());
+        }
+        self::assertSame('failed', $protected->get_status()['phase']);
+
+        $out_of_order = $this->createSession();
+        try {
+            $out_of_order->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+                $upload->accept_directory(0, 'z-last');
+                $upload->accept_directory(1, 'a-first');
+            });
+            self::fail('Expected out-of-order path rejection.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_OPERATION, $exception->getCode());
+            self::assertStringContainsString('strictly increasing', $exception->getMessage());
+        }
+        self::assertSame('failed', $out_of_order->get_status()['phase']);
+        self::assertSame(1, $out_of_order->get_status()['operation_count']);
+    }
+
+    /** Verifies path limits fail without reflecting unbounded input. */
+    public function testOverlongPathsAreRejectedWithBoundedDiagnostics(): void {
+        $overlong_path = str_repeat('a', Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES + 1);
+        $expected_size_detail = ( Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES + 1 )
+            . ' bytes; the maximum is ' . Site_Export_Staged_Push_Stream_Protocol::MAX_PATH_BYTES . ' bytes';
+        $session = $this->createSession();
+        try {
+            $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload) use ($overlong_path): void {
+                $upload->accept_directory(0, $overlong_path);
+            });
+            self::fail('Expected the overlong operation path to be rejected.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_OPERATION, $exception->getCode());
+            self::assertStringContainsString($expected_size_detail, $exception->getMessage());
+            self::assertLessThan(200, strlen($exception->getMessage()));
+        }
+        self::assertSame('failed', $session->get_status()['phase']);
+
+        try {
+            $this->createSession([$overlong_path]);
+            self::fail('Expected the overlong protected path to be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            self::assertStringContainsString($expected_size_detail, $exception->getMessage());
+            self::assertLessThan(200, strlen($exception->getMessage()));
+        }
+    }
+
+    /** Verifies reopening never follows a substituted work directory. */
+    public function testOpenRejectsASymlinkedPrivateWorkDirectory(): void {
+        $session = $this->createSession();
+        $session_directory = $this->sessionDirectory($session);
+        rename($session_directory . '/work', $session_directory . '/work-real');
+        symlink($this->temporary_directory, $session_directory . '/work');
+
+        try {
+            Site_Export_Staged_Apply_Session::open(
+                $this->storage_directory,
+                $this->target_directory,
+                $session->get_session_id()
+            );
+            self::fail('Expected private work-directory symlink rejection.');
+        } catch (RuntimeException $exception) {
+            self::assertStringContainsString('work directory must be a real directory', $exception->getMessage());
+        }
+    }
+
+    /** Verifies storage guard creation cannot write through planted links. */
+    public function testStorageWebGuardsNeverFollowPlantedSymlinks(): void {
+        foreach (['.htaccess', 'index.php'] as $guard_name) {
+            $storage_directory = $this->temporary_directory . '/staging-' . str_replace('.', '-', $guard_name);
+            mkdir($storage_directory, 0700);
+            $outside = $this->temporary_directory . '/outside-' . str_replace('.', '-', $guard_name);
+            if ($guard_name === 'index.php') {
+                file_put_contents($outside, 'keep');
+            }
+            symlink($outside, $storage_directory . '/' . $guard_name);
+
+            try {
+                Site_Export_Staged_Apply_Session::create($storage_directory, $this->target_directory);
+                self::fail('Expected the planted ' . $guard_name . ' symlink to be rejected.');
+            } catch (RuntimeException $exception) {
+                self::assertStringContainsString('must be a real regular file', $exception->getMessage(), $guard_name);
+            }
+
+            if ($guard_name === 'index.php') {
+                self::assertSame('keep', file_get_contents($outside));
+            } else {
+                self::assertFileDoesNotExist($outside);
+            }
+        }
+    }
+
+    /** Verifies pre-existing storage guards cannot silently permit web access. */
+    public function testStorageWebGuardsRejectUnexpectedRegularContents(): void {
+        foreach (['.htaccess', 'index.php'] as $guard_name) {
+            $storage_directory = $this->temporary_directory . '/staging-wrong-' . str_replace('.', '-', $guard_name);
+            mkdir($storage_directory, 0700);
+            file_put_contents($storage_directory . '/' . $guard_name, 'unsafe');
+
+            try {
+                Site_Export_Staged_Apply_Session::create($storage_directory, $this->target_directory);
+                self::fail('Expected the unexpected ' . $guard_name . ' contents to be rejected.');
+            } catch (RuntimeException $exception) {
+                self::assertStringContainsString('guard contents do not match', $exception->getMessage(), $guard_name);
+            }
+            self::assertSame('unsafe', file_get_contents($storage_directory . '/' . $guard_name));
+        }
+    }
+
+    /** Verifies a materialized operation can be replayed after a process cut. */
+    public function testMaterializedOperationCanBeReplayedAfterAProcessCut(): void {
+        $session = $this->createSession();
+        $session_directory = $this->sessionDirectory($session);
+        $state_path = $session_directory . '/state.json';
+        mkdir($session_directory . '/work/files/directory');
+        $outside = $this->temporary_directory . '/outside-metadata';
+        file_put_contents($outside, 'keep');
+        symlink($outside, $state_path . '.tmp');
+
+        $result = $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): array {
+            return $upload->accept_directory(0, 'directory');
+        });
+        self::assertSame(1, $result['operation_count']);
+        self::assertSame('keep', file_get_contents($outside));
+        self::assertFileDoesNotExist($state_path . '.tmp');
+        self::assertCount(1, file($session_directory . '/work/operations.jsonl', FILE_IGNORE_NEW_LINES));
+    }
+
+    /** Verifies symlinks cannot acquire staged descendants. */
+    public function testSymlinkAncestorsRejectDescendantMaterialization(): void {
+        $outside = $this->temporary_directory . '/outside';
+        mkdir($outside);
+
+        $session = $this->createSession();
+        try {
+            $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload) use ($outside): void {
+                $upload->accept_symlink(0, 'node', $outside);
+                $upload->accept_directory(1, 'node/child');
+            });
+            self::fail('Expected descendant rejection below a staged symlink.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_INVALID_OPERATION, $exception->getCode());
+            self::assertStringContainsString('non-directory staged ancestor', $exception->getMessage());
+        }
+        self::assertSame('failed', $session->get_status()['phase']);
+        self::assertSame(1, $session->get_status()['operation_count']);
+        self::assertFileDoesNotExist($outside . '/child');
+    }
+
+    /** Verifies crash-left journal bytes are removed before replay. */
+    public function testUncommittedJournalTailIsTruncatedBeforeTheNextOperation(): void {
+        $session = $this->createSession();
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+            $upload->accept_directory(0, 'a');
+        });
+        $journal = $this->sessionDirectory($session) . '/work/operations.jsonl';
+        file_put_contents($journal, '{uncommitted', FILE_APPEND);
+
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+            $upload->accept_directory(1, 'b');
+        });
+
+        self::assertCount(2, file($journal, FILE_IGNORE_NEW_LINES));
+        self::assertSame(2, $session->get_status()['operation_count']);
+    }
+
+    /** Verifies status fails when the durable journal prefix was lost. */
+    public function testShortJournalFailsStatusEarly(): void {
+        $session = $this->createSession();
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload): void {
+            $upload->accept_directory(0, 'directory');
+        });
+        $journal = $this->sessionDirectory($session) . '/work/operations.jsonl';
+        self::assertNotFalse(file_put_contents($journal, ''));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('journal is shorter than its durable cursor');
+        $session->get_status();
+    }
+
+    /** Verifies lock contention cannot enter an upload callback. */
+    public function testHeldSessionFlockRejectsUploadBeforeItsCallbackRuns(): void {
+        $session = $this->createSession();
+        $session_lock = fopen($this->sessionDirectory($session) . '/lock', 'c+b');
+        self::assertIsResource($session_lock);
+        self::assertTrue(flock($session_lock, LOCK_EX | LOCK_NB));
+        $called = false;
+        try {
+            try {
+                $session->while_uploading(function () use (&$called): void {
+                    $called = true;
+                });
+                self::fail('Expected held session-lock contention.');
+            } catch (RuntimeException $exception) {
+                self::assertSame(Site_Export_Staged_Apply_Session::ERROR_BUSY, $exception->getCode());
+            }
+        } finally {
+            flock($session_lock, LOCK_UN);
+            fclose($session_lock);
+        }
+
+        self::assertFalse($called);
+    }
+
+    /** Verifies arbitrary path bytes remain base64-safe across persistence. */
+    public function testRawNonUtf8PathRoundTripsThroughStateAndJournal(): void {
+        $path = "raw-\xff";
+        $probe = $this->target_directory . '/' . $path;
+        if (@file_put_contents($probe, 'probe') === false) {
+            self::markTestSkipped('This filesystem API does not accept a non-UTF-8 file name.');
+        }
+        unlink($probe);
+        $session = $this->createSession();
+        $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload) use ($path): void {
+            $upload->accept_directory(0, $path);
+        });
+
+        self::assertSame(base64_encode($path), $session->get_status()['last_path_b64']);
+        self::assertDirectoryExists($this->sessionDirectory($session) . '/work/files/' . $path);
+        self::assertFileDoesNotExist($this->target_directory . '/' . $path);
+    }
+
+    /** Verifies filesystem errors encode arbitrary path bytes for JSON responses. */
+    public function testRawNonUtf8PathIsEncodedInFilesystemFailure(): void {
+        $path = str_repeat('a', 255) . "\xff/file";
+        $session = $this->createSession();
+
+        try {
+            $session->while_uploading(function (Site_Export_Staged_Apply_Session $upload) use ($path): void {
+                $upload->accept_directory(0, $path);
+            });
+            self::fail('Expected the overlong filesystem segment to fail materialization.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(Site_Export_Staged_Apply_Session::ERROR_RETRYABLE_IO, $exception->getCode());
+            self::assertStringContainsString('base64:', $exception->getMessage());
+            self::assertStringNotContainsString("\xff", $exception->getMessage());
+            self::assertNotFalse(json_encode(['error' => $exception->getMessage()]));
+        }
+    }
+
+    /**
+     * Creates a session in this test's isolated roots.
+     *
+     * @param string[] $protected_paths Target-relative paths the session must reject.
+     * @return Site_Export_Staged_Apply_Session The new test session.
+     */
+    private function createSession(array $protected_paths = []): Site_Export_Staged_Apply_Session {
+        return Site_Export_Staged_Apply_Session::create(
+            $this->storage_directory,
+            $this->target_directory,
+            $protected_paths
+        );
+    }
+
+    /** Returns the filesystem directory owned by a test session. */
+    private function sessionDirectory(Site_Export_Staged_Apply_Session $session): string {
+        return $this->storage_directory . '/apply-sessions/' . $session->get_session_id();
+    }
+
+    /** Removes an isolated test tree without following symlinks. */
+    private function removeTree(string $path): void {
+        if (is_link($path) || !is_dir($path)) {
+            if (file_exists($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $directory = opendir($path);
+        if ($directory === false) {
+            return;
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+        } finally {
+            closedir($directory);
+        }
+        rmdir($path);
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -32,6 +32,7 @@
             <file>SiteExportSecretTest.php</file>
             <file>StagedArtifactsTest.php</file>
             <file>StagedApplySessionTest.php</file>
+            <file>StagedApplyDiscardTest.php</file>
             <file>StagedEndpointsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -31,6 +31,7 @@
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
             <file>StagedArtifactsTest.php</file>
+            <file>StagedApplySessionTest.php</file>
             <file>StagedEndpointsTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">


### PR DESCRIPTION
Staged apply sessions can now be discarded in bounded calls, so cleanup work does not grow with the whole staging tree.

The first call locks the session and renames it to a private tombstone. Uploads can no longer open it. Each call removes at most 256 entries and returns `false` while data remains; the client retries until `true`. Retries simply walk the smaller tombstone again. There is no cleanup journal, and staged symlinks are unlinked rather than followed.
