### PR TITLE
[Push] Reject incomplete pull framing and keep staging private

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -273,8 +273,14 @@ direct installation requires same-filesystem rename.
 
 The session storage path is automatically protected if it lies under the
 target, as are .maintenance and the installed Reprint plugin. A push cannot
-stage, delete, or replace those paths. Target and workspace inspection uses
-lstat() and refuses symlinked parents rather than following them.
+stage, delete, or replace those paths. The server's `staging_dir` setting is
+target-private and is never supplied by a pulling client. File indexes exclude
+that root, its descendants, and aliases which resolve into it. If an older
+saved fetch list still names an excluded path, the server rejects the whole
+list and directs the operator to run `files-pull --abort` before rerunning the
+full pull; the fresh index and ordinary diff then remove the old local entries.
+Target and workspace inspection uses lstat() and refuses symlinked parents
+rather than following them.
 
 ## Commit, maintenance, and recovery
 

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -2,6 +2,10 @@
 
 use function WordPress\Reprint\Exporter\parse_size;
 
+if (!class_exists('Site_Export_Multipart_Processor', false)) {
+    require_once __DIR__ . '/class-multipart-processor.php';
+}
+
 /**
  * Parses and dispatches HTTP requests for the Site Export API.
  *
@@ -79,6 +83,9 @@ final class Site_Export_HTTP_Server {
     /** @var string|null Directory inserted when an ordinary request omits one. */
     private $default_directory;
 
+    /** @var string|null Server-owned directory used for staged push storage. */
+    private $staging_dir;
+
     /**
      * Configured staged target endpoints, or null when push is unavailable.
      *
@@ -116,9 +123,13 @@ final class Site_Export_HTTP_Server {
         };
         $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
         $this->default_directory = $options['default_directory'] ?? null;
+        $this->staging_dir = null;
         $this->staged_endpoints = null;
 
         if (isset($options['staged']) && is_array($options['staged'])) {
+            if (isset($options['staged']['staging_dir']) && is_string($options['staged']['staging_dir'])) {
+                $this->staging_dir = $options['staged']['staging_dir'];
+            }
             $this->staged_endpoints = new Site_Export_Staged_Endpoints($options['staged']);
             $this->register_staged_handlers($this->staged_endpoints);
         }
@@ -380,6 +391,14 @@ final class Site_Export_HTTP_Server {
      * @throws InvalidArgumentException If the endpoint or cursor is malformed.
      */
     public function normalize_config(array $config, array $server = []): array {
+        unset($config['storage_path'], $config['staging_dir'], $config['excluded_staging_root']);
+        if (
+            $this->staging_dir !== null &&
+            in_array($config['endpoint'] ?? null, ['file_index', 'file_fetch'], true)
+        ) {
+            $config['excluded_staging_root'] = $this->staging_dir;
+        }
+
         if (
             $this->default_directory !== null &&
             !isset($config['directory'])
@@ -406,6 +425,42 @@ final class Site_Export_HTTP_Server {
     }
 
     /**
+     * Encodes one opaque response cursor without exceeding a multipart header line.
+     *
+     * Importers return this value unchanged. Short JSON cursors retain their
+     * historical base64 representation; longer cursors use gzip before base64
+     * so ordinary in-flight SQL rows still fit the strict multipart grammar.
+     * decode_cursor() accepts both representations.
+     *
+     * @param string $cursor_json Endpoint-specific cursor JSON.
+     * @return string Base64 transport value for X-Cursor.
+     *
+     * @throws RuntimeException If even the compressed cursor cannot fit.
+     */
+    public static function encode_cursor(string $cursor_json): string {
+        $maximum_value_bytes = Site_Export_Multipart_Processor::MAX_HEADER_LINE_BYTES - strlen('X-Cursor: ');
+        $cursor_b64 = base64_encode($cursor_json);
+        if (strlen($cursor_b64) <= $maximum_value_bytes) {
+            return $cursor_b64;
+        }
+
+        $compressed_cursor = gzencode($cursor_json);
+        if ($compressed_cursor === false) {
+            throw new RuntimeException('Failed to compress the response cursor for its multipart header.');
+        }
+        $cursor_b64 = base64_encode($compressed_cursor);
+        if (strlen($cursor_b64) > $maximum_value_bytes) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Byte counts are CLI/API diagnostics, never HTML output.
+            throw new RuntimeException(
+                'The encoded response cursor requires ' . strlen($cursor_b64) . ' bytes, but X-Cursor permits at most '
+                . $maximum_value_bytes . ' bytes.'
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+        return $cursor_b64;
+    }
+
+    /**
      * Decodes one transport cursor while verifying that it contains JSON.
      *
      * The JSON text, rather than its decoded PHP value, is returned because
@@ -423,6 +478,14 @@ final class Site_Export_HTTP_Server {
             throw new InvalidArgumentException(
                 'Cursor must be base64-encoded. Received invalid base64: ' . substr($cursor_b64, 0, 50)
             );
+        }
+
+        if (strncmp($cursor_json, "\x1f\x8b", 2) === 0) {
+            $decoded_cursor = @gzdecode($cursor_json);
+            if ($decoded_cursor === false) {
+                throw new InvalidArgumentException('Cursor contains an invalid gzip stream.');
+            }
+            $cursor_json = $decoded_cursor;
         }
 
         $cursor_data = json_decode($cursor_json, true);

--- a/packages/reprint-exporter/src/class-multipart-processor.php
+++ b/packages/reprint-exporter/src/class-multipart-processor.php
@@ -73,7 +73,7 @@ final class Site_Export_Multipart_Processor {
      * The count excludes CRLF. An unterminated line is rejected as soon as it
      * can no longer fit within this bound.
      */
-    private const MAX_HEADER_LINE_BYTES = 8192;
+    public const MAX_HEADER_LINE_BYTES = 8192;
 
     /**
      * Maximum aggregate bytes accepted for one part's headers, including CRLF.

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -928,7 +928,7 @@ function endpoint_sql_chunk(
                 "Content-Length: " . strlen($sql) . "\r\n" .
                 "X-Chunk-Type: sql\r\n" .
                 "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
-                "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                 "\r\n"
             );
             $gz->write($sql);
@@ -1088,7 +1088,7 @@ function endpoint_db_index(
                 "Content-Length: " . strlen($payload) . "\r\n" .
                 "X-Chunk-Type: table_stats\r\n" .
                 "X-Tables: " . count($tables) . "\r\n" .
-                "X-Cursor: " . base64_encode($cursor_json) . "\r\n" .
+                "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor_json) . "\r\n" .
                 "\r\n" .
                 $payload . "\r\n"
             );
@@ -2229,7 +2229,7 @@ function stream_file_producer(
             "Content-Type: application/json\r\n" .
             "Content-Length: " . strlen($initial_progress_json) . "\r\n" .
             "X-Chunk-Type: progress\r\n" .
-            "X-Cursor: " . base64_encode($initial_cursor) . "\r\n" .
+            "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($initial_cursor) . "\r\n" .
             "\r\n" .
             $initial_progress_json . "\r\n"
         );
@@ -2282,7 +2282,7 @@ function stream_file_producer(
                         "Content-Type: application/json\r\n" .
                         "Content-Length: " . strlen($progress_json) . "\r\n" .
                         "X-Chunk-Type: progress\r\n" .
-                        "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                        "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                         "\r\n" .
                         $progress_json . "\r\n"
                     );
@@ -2304,7 +2304,7 @@ function stream_file_producer(
                     "Content-Type: application/octet-stream\r\n" .
                     "Content-Length: 0\r\n" .
                     "X-Chunk-Type: directory\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                    "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                     "X-Directory-Path: " . base64_encode($chunk["path"]) . "\r\n";
                 if (isset($chunk["ctime"])) {
                     $part .= "X-Directory-Ctime: " . $chunk["ctime"] . "\r\n";
@@ -2317,7 +2317,7 @@ function stream_file_producer(
                     "Content-Type: application/octet-stream\r\n" .
                     "Content-Length: 0\r\n" .
                     "X-Chunk-Type: symlink\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                    "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                     "X-Symlink-Path: " . base64_encode($chunk["path"]) . "\r\n" .
                     "X-Symlink-Target: " . base64_encode($chunk["target"]) . "\r\n" .
                     "X-Symlink-Ctime: " . $chunk["ctime"] . "\r\n" .
@@ -2330,7 +2330,7 @@ function stream_file_producer(
                     "Content-Type: application/octet-stream\r\n" .
                     "Content-Length: 0\r\n" .
                     "X-Chunk-Type: index\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                    "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                     "X-Index-Path: " . base64_encode($chunk["path"]) . "\r\n" .
                     "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
                     "X-File-Size: " . $chunk["size"] . "\r\n" .
@@ -2343,7 +2343,7 @@ function stream_file_producer(
                     "Content-Type: application/octet-stream\r\n" .
                     "Content-Length: 0\r\n" .
                     "X-Chunk-Type: missing\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                    "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                     "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
                     "\r\n\r\n"
                 );
@@ -2366,7 +2366,7 @@ function stream_file_producer(
                     "Content-Type: application/json\r\n" .
                     "Content-Length: " . strlen($json) . "\r\n" .
                     "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                    "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                     "\r\n" .
                     $json . "\r\n"
                 );
@@ -2393,7 +2393,7 @@ function stream_file_producer(
                     "Content-Type: application/octet-stream\r\n" .
                     "Content-Length: " . strlen($data) . "\r\n" .
                     "X-Chunk-Type: file\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                    "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($cursor) . "\r\n" .
                     "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
                     "X-File-Size: " . $chunk["size"] . "\r\n" .
                     "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
@@ -2439,7 +2439,7 @@ function stream_file_producer(
                 "Content-Type: application/json\r\n" .
                 "Content-Length: " . strlen($json) . "\r\n" .
                 "X-Chunk-Type: error\r\n" .
-                "X-Cursor: " . base64_encode($last_cursor) . "\r\n" .
+                "X-Cursor: " . Site_Export_HTTP_Server::encode_cursor($last_cursor) . "\r\n" .
                 "\r\n" .
                 $json . "\r\n"
             );
@@ -2745,28 +2745,14 @@ function endpoint_file_index(
     // scratch files unless the client explicitly opts in. See
     // path_is_default_skipped() for the full deny-list and rationale.
     $include_caches = !empty($config["include_caches"]);
-    // Reprint's own storage (the push staging area and apply bookkeeping)
-    // must never appear in an index: it can sit inside the document root on
-    // hosts that allow writing nowhere else, and indexing it would sync or
-    // delete reprint's own records mid-transfer. storage_path is the
-    // server's own setting, so it is known here for every request — a
-    // pulling peer's request does not need to mention it.
-    $storage_path = isset($config["storage_path"]) && is_string($config["storage_path"])
-        ? rtrim($config["storage_path"], "/")
-        : "";
-    if ($storage_path !== "") {
-        // The traversal canonicalizes every path with realpath() (see the
-        // wp.com note further down), so the setting must be compared in the
-        // same form. path_is_within_root() compares plain strings, and a
-        // trailing slash on the setting would make it miss — hence the
-        // rtrim above. When the directory does not exist yet there is
-        // nothing to exclude and the trimmed value stays as a harmless
-        // fallback.
-        $storage_real = realpath($storage_path);
-        if ($storage_real !== false) {
-            $storage_path = $storage_real;
-        }
-    }
+    // Reprint's private staging tree can sit inside a listed site root. The
+    // HTTP server injects this server-owned value after discarding request
+    // values, so a pulling peer cannot choose which directory is hidden.
+    $excluded_staging_roots = reprint_build_staging_exclusion_roots(
+        isset($config["excluded_staging_root"]) && is_string($config["excluded_staging_root"])
+            ? $config["excluded_staging_root"]
+            : ""
+    );
 
     // Find the starting point – either by parsing the cursor, or by
     // sourcing it from the filesystem.
@@ -2806,6 +2792,17 @@ function endpoint_file_index(
                     throw new InvalidArgumentException("Index cursor frame has invalid after encoding");
                 }
             }
+            // A cursor may predate a staging configuration change. Drop the
+            // stale frame before it can become response metadata or be read.
+            if (
+                reprint_path_is_within_excluded_staging_roots(
+                    $dir,
+                    $excluded_staging_roots,
+                    $directories
+                )
+            ) {
+                continue;
+            }
             $stack[] = [
                 "dir" => $dir,
                 "after" => $after,
@@ -2843,7 +2840,16 @@ function endpoint_file_index(
             );
         }
 
-        $ordered = [$list_dir_real];
+        $ordered = [];
+        if (
+            !reprint_path_is_within_excluded_staging_roots(
+                $list_dir_real,
+                $excluded_staging_roots,
+                $directories
+            )
+        ) {
+            $ordered[] = $list_dir_real;
+        }
         $extra_roots = [];
         foreach ($directories as $root) {
             if ($root === $list_dir_real) {
@@ -2863,6 +2869,15 @@ function endpoint_file_index(
                 // prevents re-entering child roots (i.e. when traversing
                 // /srv/htdocs we won't descend back into __wp__/).
                 if (in_array($root, $ordered, true)) {
+                    continue;
+                }
+                if (
+                    reprint_path_is_within_excluded_staging_roots(
+                        $root,
+                        $excluded_staging_roots,
+                        $directories
+                    )
+                ) {
                     continue;
                 }
                 $ordered[] = $root;
@@ -2951,6 +2966,17 @@ function endpoint_file_index(
             $current_dir = $frame["dir"];
             $current_after = $frame["after"] ?? null;
 
+            if (
+                reprint_path_is_within_excluded_staging_roots(
+                    $current_dir,
+                    $excluded_staging_roots,
+                    $directories
+                )
+            ) {
+                array_pop($stack);
+                continue;
+            }
+
             clearstatcache(true, $current_dir);
             $current_real = realpath($current_dir);
             if ($current_real === false || !is_dir($current_real)) {
@@ -2965,7 +2991,7 @@ function endpoint_file_index(
                     ["stack" => encode_index_stack($stack)],
                     JSON_UNESCAPED_SLASHES
                 );
-                $cursor_b64 = base64_encode($cursor_json);
+                $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
                 $gz->write(
                     "--{$boundary}\r\n" .
                     "Content-Type: application/json\r\n" .
@@ -3004,7 +3030,7 @@ function endpoint_file_index(
                     ["stack" => encode_index_stack($stack)],
                     JSON_UNESCAPED_SLASHES
                 );
-                $cursor_b64 = base64_encode($cursor_json);
+                $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
                 $gz->write(
                     "--{$boundary}\r\n" .
                     "Content-Type: application/json\r\n" .
@@ -3042,7 +3068,7 @@ function endpoint_file_index(
                     ["stack" => encode_index_stack($stack)],
                     JSON_UNESCAPED_SLASHES
                 );
-                $cursor_b64 = base64_encode($cursor_json);
+                $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
                 $gz->write(
                     "--{$boundary}\r\n" .
                     "Content-Type: application/json\r\n" .
@@ -3096,9 +3122,13 @@ function endpoint_file_index(
                 if (!$include_caches && path_is_default_skipped($path)) {
                     continue;
                 }
-                // The "" guard matters: path_is_within_root() with an empty
-                // root would match every absolute path.
-                if ($storage_path !== "" && path_is_within_root($path, $storage_path)) {
+                if (
+                    reprint_path_is_within_excluded_staging_roots(
+                        $path,
+                        $excluded_staging_roots,
+                        $directories
+                    )
+                ) {
                     continue;
                 }
                 clearstatcache(true, $path);
@@ -3156,7 +3186,7 @@ function endpoint_file_index(
                         ["stack" => encode_index_stack($stack)],
                         JSON_UNESCAPED_SLASHES
                     );
-                    $cursor_b64 = base64_encode($cursor_json);
+                    $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
                     $json = json_encode_or_throw(
                         encode_index_batch($batch_items),
                         JSON_UNESCAPED_SLASHES
@@ -3232,7 +3262,7 @@ function endpoint_file_index(
             ["stack" => encode_index_stack($stack)],
             JSON_UNESCAPED_SLASHES
         );
-        $cursor_b64 = base64_encode($cursor_json);
+        $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
         $json = json_encode_or_throw(
             encode_index_batch($batch_items),
             JSON_UNESCAPED_SLASHES
@@ -3262,7 +3292,7 @@ function endpoint_file_index(
                 ["stack" => encode_index_stack($stack)],
                 JSON_UNESCAPED_SLASHES
             );
-            $cursor_b64 = base64_encode($cursor_json);
+            $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
             $gz->write(
                 "--{$boundary}\r\n" .
                 "Content-Type: application/json\r\n" .
@@ -3280,7 +3310,7 @@ function endpoint_file_index(
             ["stack" => encode_index_stack($stack)],
             JSON_UNESCAPED_SLASHES
         );
-        $cursor_b64 = base64_encode($cursor_json);
+        $cursor_b64 = Site_Export_HTTP_Server::encode_cursor($cursor_json);
 
         $gz->write(
             "--{$boundary}\r\n" .
@@ -3327,6 +3357,11 @@ function endpoint_file_fetch(
     clearstatcache(true);
 
     $directories = resolve_directories($config);
+    $excluded_staging_roots = reprint_build_staging_exclusion_roots(
+        isset($config["excluded_staging_root"]) && is_string($config["excluded_staging_root"])
+            ? $config["excluded_staging_root"]
+            : ""
+    );
 
     $list_path = $config["file_list_path"] ?? null;
     if ($list_path === null && isset($_FILES["file_list"])) {
@@ -3363,6 +3398,28 @@ function endpoint_file_fetch(
         $paths[] = $path;
     }
 
+    $excluded_path = null;
+    foreach ($paths as $path) {
+        if (
+            reprint_path_is_within_excluded_staging_roots(
+                $path,
+                $excluded_staging_roots,
+                $directories
+            ) && $excluded_path === null
+        ) {
+            $excluded_path = $path;
+        }
+    }
+    if ($excluded_path !== null) {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error text is serialized at the HTTP boundary, not emitted as HTML.
+        throw new InvalidArgumentException(
+            "The file list path with base64 value \"" . base64_encode($excluded_path) .
+                "\" is in Reprint's private staging directory. " .
+                "Run files-pull --abort, then rerun the full pull."
+        );
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+    }
+
     $chunk_size = $config["chunk_size"] ?? FileTreeProducer::DEFAULT_CHUNK_SIZE;
     $chunk_size = require_int_range(
         "chunk_size",
@@ -3386,6 +3443,142 @@ function endpoint_file_fetch(
         $config,
         file_fetch_paths_should_gzip($paths)
     );
+}
+
+/**
+ * Returns true when a transfer path names or resolves into the server-owned
+ * staging tree. Relative file-fetch paths are resolved in the same allowed-root
+ * order as FileTreeProducer.
+ */
+function reprint_path_is_within_excluded_staging_roots(
+    string $path,
+    array $excluded_staging_roots,
+    array $allowed_roots
+): bool {
+    if ($path === "" || $excluded_staging_roots === []) {
+        return false;
+    }
+
+    if ($path[0] === "/") {
+        $candidates = [$path];
+    } else {
+        $candidates = [];
+        $fallback_candidates = [];
+        foreach ($allowed_roots as $allowed_root) {
+            if (!is_string($allowed_root) || $allowed_root === "") {
+                continue;
+            }
+            $candidate = rtrim($allowed_root, "/") . "/" . $path;
+            $fallback_candidates[] = $candidate;
+            clearstatcache(true, $candidate);
+            if (file_exists($candidate) || is_link($candidate)) {
+                // FileTreeProducer uses the first allowed root containing the
+                // relative path, so classification must use the same one.
+                $candidates = [$candidate];
+                break;
+            }
+        }
+        if ($candidates === []) {
+            $candidates = $fallback_candidates;
+        }
+    }
+
+    foreach ($candidates as $candidate) {
+        $candidate_paths = [reprint_normalize_staging_exclusion_path($candidate)];
+        $canonical_candidate = reprint_resolve_from_existing_ancestor(
+            $candidate
+        );
+        if (is_string($canonical_candidate)) {
+            $candidate_paths[] = reprint_normalize_staging_exclusion_path(
+                $canonical_candidate
+            );
+        }
+
+        foreach (array_unique($candidate_paths) as $candidate_path) {
+            foreach ($excluded_staging_roots as $excluded_staging_root) {
+                if (
+                    $excluded_staging_root === "/"
+                        ? isset($candidate_path[0]) && $candidate_path[0] === "/"
+                        : path_is_within_root(
+                            $candidate_path,
+                            $excluded_staging_root
+                        )
+                ) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Captures staging-root topology once per endpoint request; candidate aliases
+ * are still resolved separately for every path.
+ *
+ * @return list<string>
+ */
+function reprint_build_staging_exclusion_roots(
+    string $excluded_staging_root
+): array {
+    if ($excluded_staging_root === "") {
+        return [];
+    }
+
+    $excluded_staging_roots = [
+        reprint_normalize_staging_exclusion_path($excluded_staging_root),
+    ];
+    $canonical_excluded_staging_root = reprint_resolve_from_existing_ancestor(
+        $excluded_staging_root
+    );
+    if ($canonical_excluded_staging_root !== null) {
+        $excluded_staging_roots[] = $canonical_excluded_staging_root;
+    }
+
+    return array_values(
+        array_filter(array_unique($excluded_staging_roots))
+    );
+}
+
+function reprint_normalize_staging_exclusion_path(string $path): string
+{
+    $normalized = normalize_dot_segments($path);
+    $normalized = rtrim($normalized, "/");
+    if ($normalized === "" && isset($path[0]) && $path[0] === "/") {
+        return "/";
+    }
+    return $normalized;
+}
+
+/**
+ * realpath() rejects a missing leaf, so resolve its deepest existing ancestor
+ * to retain any symlink transition before appending the stale suffix.
+ */
+function reprint_resolve_from_existing_ancestor(string $path): ?string
+{
+    $current_path = $path;
+    $missing_segments = [];
+    while (true) {
+        clearstatcache(true, $current_path);
+        $canonical_ancestor = @realpath($current_path);
+        if ($canonical_ancestor !== false) {
+            foreach ($missing_segments as $missing_segment) {
+                $canonical_ancestor =
+                    rtrim($canonical_ancestor, "/") . "/" . $missing_segment;
+            }
+            return reprint_normalize_staging_exclusion_path(
+                $canonical_ancestor
+            );
+        }
+
+        $parent_path = dirname($current_path);
+        if ($parent_path === $current_path) {
+            return null;
+        }
+        array_unshift($missing_segments, basename($current_path));
+        $current_path = $parent_path;
+    }
 }
 
 /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5783,11 +5783,15 @@ class ImportClient
 
             // Streamed file bodies can arrive in multiple parser callbacks
             // for one exporter file part. Save only at the part boundary:
-            // mid-body, the cursor already points to the end of the part
-            // while file_bytes_written may still lag; at is_streaming_close
-            // the bytes are on disk and we force a per-part checkpoint.
+            // mid-body, the header cursor points to the end of a part whose
+            // bytes have not all arrived. Confirm that cursor only at
+            // is_streaming_close, when the bytes are on disk, and force a
+            // per-part checkpoint there.
             $is_streaming_body = !empty($chunk["is_streaming_body"]);
             $is_streaming_close = !empty($chunk["is_streaming_close"]);
+            if (!$is_streaming_body && isset($chunk["headers"]["x-cursor"])) {
+                $cursor = $chunk["headers"]["x-cursor"];
+            }
             if (!$is_streaming_body) {
                 $chunks_since_save++;
                 $force_save = $is_streaming_close;
@@ -5806,10 +5810,6 @@ class ImportClient
                     $this->save_state($this->state);
                     $chunks_since_save = 0;
                 }
-            }
-
-            if (isset($chunk["headers"]["x-cursor"])) {
-                $cursor = $chunk["headers"]["x-cursor"];
             }
 
             $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
@@ -5883,18 +5883,30 @@ class ImportClient
             // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
             // with no progress, so we don't retry forever.
             $this->assert_can_retry_consecutive_timeout("file_fetch", $cursor_before, $cursor);
-            // Save state so the next invocation resumes from the
-            // last cursor instead of crashing with exit code 1.
-            $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-            $this->finalize_index_updates();
-            if ($context->file_handle && $context->file_path) {
-                fflush($context->file_handle);
-                $this->import_state()->current_file = $context->file_path;
-                $this->import_state()->current_file_bytes = $context->file_bytes_written;
+            return $this->checkpoint_incomplete_file_fetch($state_key, $cursor, $context);
+        } catch (RuntimeException $e) {
+            // A server crash can close an otherwise valid response before its
+            // completion part arrives. Preserve the confirmed cursor and file
+            // bytes just as the timeout path does. Strict framing failures
+            // after a claimed completion remain terminal.
+            $message = $e->getMessage();
+            $is_retryable_curl = preg_match(
+                '/cURL error \((\d+)\):/',
+                $message,
+                $curl_match,
+            ) && in_array( (int) $curl_match[1], [18, 52, 56], true );
+            $is_retryable =
+                strpos($message, "missing completion chunk") !== false ||
+                $is_retryable_curl;
+            if (!$is_retryable) {
+                throw $e;
             }
-            $this->import_state()->active_resumable_command->completion_state = "partial";
-            $this->save_state($this->state);
-            return false;
+            $this->audit_log(
+                "INCOMPLETE FILE RESPONSE | " . $message . " — will save state for retry",
+                true,
+            );
+            $this->assert_can_retry_consecutive_timeout("file_fetch", $cursor_before, $cursor);
+            return $this->checkpoint_incomplete_file_fetch($state_key, $cursor, $context);
         }
         $this->import_state()->consecutive_timeouts = 0;
         $wall_time = microtime(true) - $request_start;
@@ -5918,6 +5930,43 @@ class ImportClient
         $this->save_state($this->state);
 
         return $complete;
+    }
+
+    /**
+     * Persist the last confirmed file-fetch progress for the next invocation.
+     *
+     * An unconfirmed tail of a tracked file is discarded so the returned
+     * cursor and local byte count continue to describe the same point after a
+     * timeout or truncated response. An unconfirmed first part is overwritten
+     * when the previous cursor is replayed.
+     */
+    private function checkpoint_incomplete_file_fetch(
+        string $state_key,
+        ?string $cursor,
+        StreamingContext $context
+    ): bool {
+        $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
+        $this->finalize_index_updates();
+        $confirmed_file = $this->import_state()->current_file ?? null;
+        $confirmed_bytes = $this->import_state()->current_file_bytes ?? null;
+        if (
+            $context->file_handle &&
+            $context->file_path === $confirmed_file &&
+            is_int($confirmed_bytes)
+        ) {
+            fflush($context->file_handle);
+            if (!ftruncate($context->file_handle, $confirmed_bytes)) {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Local paths and byte counts are CLI diagnostics, never HTML output.
+                throw new RuntimeException(
+                    "Failed to discard an incomplete file response after {$confirmed_bytes} confirmed bytes: {$confirmed_file}",
+                );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            }
+            $context->file_bytes_written = $confirmed_bytes;
+        }
+        $this->import_state()->active_resumable_command->completion_state = "partial";
+        $this->save_state($this->state);
+        return false;
     }
 
     /**
@@ -10628,20 +10677,15 @@ class ImportClient
             false,
         );
 
+        $transport_error = null;
         try {
             try {
                 $this->check_curl_error($ch);
             } catch (RuntimeException $curl_error) {
-                if ($endpoint !== null) {
-                    $this->handle_tuner_error($endpoint, [
-                        "http_code" => 0,
-                        "timeout" => $this->last_curl_timeout,
-                        "curl_errno" => $this->last_curl_errno,
-                    ]);
-                }
-                throw $curl_error;
+                // Preserve the transport result until strict multipart EOF
+                // validation has had a chance to reject a claimed completion.
+                $transport_error = $curl_error;
             }
-
             $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $redirect_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL) ?: null;
             $ttfb = (float) curl_getinfo($ch, CURLINFO_STARTTRANSFER_TIME);
@@ -10655,6 +10699,27 @@ class ImportClient
         }
         $context->response_stats["ttfb"] = $ttfb;
         $context->response_stats["total_time"] = $total_time;
+
+        // A completion part is only trustworthy when its MIME close also
+        // arrived. Validate that claim before classifying a simultaneous cURL
+        // error, otherwise a framing failure could be retried as truncation.
+        if ($context->saw_completion) {
+            if ($multipart_processor === null) {
+                throw new LogicException('A completion part was observed without a multipart processor.');
+            }
+            $multipart_processor->finish_input();
+        }
+
+        if ($transport_error !== null) {
+            if ($endpoint !== null) {
+                $this->handle_tuner_error($endpoint, [
+                    "http_code" => 0,
+                    "timeout" => $this->last_curl_timeout,
+                    "curl_errno" => $this->last_curl_errno,
+                ]);
+            }
+            throw $transport_error;
+        }
 
         if ($http_code !== 200) {
             if ($endpoint !== null) {
@@ -10693,11 +10758,6 @@ class ImportClient
                     ($snippet !== "" ? "Body: {$snippet}" : ""),
             );
         }
-
-        // Every response part may already have been delivered, but the MIME
-        // close is still protocol evidence. Reject a transport which ended
-        // after a plausible completion part but before its closing boundary.
-        $multipart_processor->finish_input();
 
         if (!$context->saw_completion) {
             throw new RuntimeException(

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -44,6 +44,39 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame('{"offset":10}', $config['cursor']);
     }
 
+    public function testLargeCursorRoundTripsThroughTheBoundedMultipartHeader(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+        $cursor_json = json_encode([
+            'current_row' => str_repeat('compressible WordPress option data ', 2000),
+        ]) ?: '';
+
+        $cursor_header = Site_Export_HTTP_Server::encode_cursor($cursor_json);
+        $config = $server->normalize_config([
+            'endpoint' => 'sql_chunk',
+            'cursor' => $cursor_header,
+        ]);
+
+        $this->assertLessThanOrEqual(
+            Site_Export_Multipart_Processor::MAX_HEADER_LINE_BYTES - strlen('X-Cursor: '),
+            strlen($cursor_header)
+        );
+        $this->assertSame($cursor_json, $config['cursor']);
+    }
+
+    public function testCursorWhichCannotFitTheBoundedHeaderIsRejectedBeforeEmission(): void
+    {
+        $bytes = '';
+        for ($index = 0; $index < 400; ++$index) {
+            $bytes .= hash('sha256', (string) $index, true);
+        }
+        $cursor_json = json_encode(['current_row' => base64_encode($bytes)]) ?: '';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('encoded response cursor requires');
+        Site_Export_HTTP_Server::encode_cursor($cursor_json);
+    }
+
     public function testNormalizeConfigAppliesDefaultDirectoryEvenWhenListDirPresent(): void
     {
         $server = new Site_Export_HTTP_Server([
@@ -57,6 +90,90 @@ final class ExportHttpServerTest extends TestCase
 
         $this->assertSame('/srv/site', $config['directory']);
         $this->assertSame('/srv/site/wp-content', $config['list_dir']);
+    }
+
+    public function testQueryCannotOverrideOrLeakPrivateStagingConfiguration(): void
+    {
+        $config = $this->captureFileHandlerConfig([
+            'get' => [
+                'endpoint' => 'file_index',
+                'storage_path' => '/client/storage',
+                'staging_dir' => '/client/staging',
+                'excluded_staging_root' => '/client/excluded',
+            ],
+            'post' => [],
+            'server' => ['REQUEST_METHOD' => 'GET'],
+            'body' => '',
+        ]);
+
+        $this->assertSame('/srv/site/.reprint-staging', $config['excluded_staging_root']);
+        $this->assertArrayNotHasKey('storage_path', $config);
+        $this->assertArrayNotHasKey('staging_dir', $config);
+    }
+
+    public function testFormCannotOverrideOrLeakPrivateStagingConfiguration(): void
+    {
+        $config = $this->captureFileHandlerConfig([
+            'get' => [],
+            'post' => [
+                'endpoint' => 'file_fetch',
+                'storage_path' => '/client/storage',
+                'staging_dir' => '/client/staging',
+                'excluded_staging_root' => '/client/excluded',
+            ],
+            'server' => [
+                'REQUEST_METHOD' => 'POST',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            ],
+            'body' => '',
+        ]);
+
+        $this->assertSame('/srv/site/.reprint-staging', $config['excluded_staging_root']);
+        $this->assertArrayNotHasKey('storage_path', $config);
+        $this->assertArrayNotHasKey('staging_dir', $config);
+    }
+
+    public function testJsonCannotOverrideOrLeakPrivateStagingConfiguration(): void
+    {
+        $config = $this->captureFileHandlerConfig([
+            'get' => [],
+            'post' => [],
+            'server' => [
+                'REQUEST_METHOD' => 'POST',
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            'body' => json_encode([
+                'endpoint' => 'file_index',
+                'storage_path' => '/client/storage',
+                'staging_dir' => '/client/staging',
+                'excluded_staging_root' => '/client/excluded',
+            ]) ?: '',
+        ]);
+
+        $this->assertSame('/srv/site/.reprint-staging', $config['excluded_staging_root']);
+        $this->assertArrayNotHasKey('storage_path', $config);
+        $this->assertArrayNotHasKey('staging_dir', $config);
+    }
+
+    public function testPrivateStagingConfigurationIsNotInjectedIntoOtherHandlers(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'staged' => [
+                'staging_dir' => '/srv/site/.reprint-staging',
+                'secret' => 'test-secret',
+            ],
+        ]);
+
+        $config = $server->normalize_config([
+            'endpoint' => 'sql_chunk',
+            'storage_path' => '/client/storage',
+            'staging_dir' => '/client/staging',
+            'excluded_staging_root' => '/client/excluded',
+        ]);
+
+        $this->assertArrayNotHasKey('storage_path', $config);
+        $this->assertArrayNotHasKey('staging_dir', $config);
+        $this->assertArrayNotHasKey('excluded_staging_root', $config);
     }
 
     public function testNormalizeConfigRejectsInvalidCursor(): void
@@ -144,5 +261,37 @@ final class ExportHttpServerTest extends TestCase
         ]);
 
         $this->assertSame([['endpoint' => 'preflight']], $calls);
+    }
+
+    /**
+     * Dispatches one request to a file handler and returns its configuration.
+     *
+     * @param array<string,mixed> $request Request overrides for handle_request().
+     * @return array<string,mixed>
+     */
+    private function captureFileHandlerConfig(array $request): array
+    {
+        $captured_config = null;
+        $handler = static function (array $config) use (&$captured_config): void {
+            $captured_config = $config;
+        };
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'file_index' => $handler,
+                'file_fetch' => $handler,
+            ],
+            'budget_factory' => static function (): stdClass {
+                return new stdClass();
+            },
+            'staged' => [
+                'staging_dir' => '/srv/site/.reprint-staging',
+                'secret' => 'test-secret',
+            ],
+        ]);
+
+        $server->handle_request($request);
+
+        $this->assertIsArray($captured_config);
+        return $captured_config;
     }
 }

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -154,6 +154,139 @@ final class FileIndexSkipDefaultsTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider excludedStagingPathCases
+     * @param list<string> $allowedRoots
+     */
+    public function testExcludedStagingPathClassifier(
+        string $path,
+        string $excludedStagingRoot,
+        array $allowedRoots,
+        bool $expected
+    ): void {
+        require_once __DIR__ . '/../packages/reprint-exporter/src/export.php';
+
+        $this->assertSame(
+            $expected,
+            reprint_path_is_within_excluded_staging_roots(
+                $path,
+                reprint_build_staging_exclusion_roots($excludedStagingRoot),
+                $allowedRoots
+            )
+        );
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:list<string>,3:bool}>
+     */
+    public static function excludedStagingPathCases(): array
+    {
+        return [
+            'absolute root' => [
+                '/srv/site/.reprint-staging',
+                '/srv/site/.reprint-staging',
+                ['/srv/site'],
+                true,
+            ],
+            'absolute descendant with trailing root separator' => [
+                '/srv/site/.reprint-staging/session/state.json',
+                '/srv/site/.reprint-staging/',
+                ['/srv/site'],
+                true,
+            ],
+            'relative descendant' => [
+                '.reprint-staging/session/state.json',
+                '/srv/site/.reprint-staging',
+                ['/srv/site'],
+                true,
+            ],
+            'relative path through a parent segment' => [
+                '../private-staging/state.json',
+                '/srv/private-staging',
+                ['/srv/site'],
+                true,
+            ],
+            'absolute neighboring prefix' => [
+                '/srv/site/.reprint-staging-backup/state.json',
+                '/srv/site/.reprint-staging',
+                ['/srv/site'],
+                false,
+            ],
+            'relative neighboring prefix' => [
+                '.reprint-staging-backup/state.json',
+                '/srv/site/.reprint-staging',
+                ['/srv/site'],
+                false,
+            ],
+            'dot segment escapes the lexical prefix' => [
+                '/srv/site/.reprint-staging/../keep.txt',
+                '/srv/site/.reprint-staging',
+                ['/srv/site'],
+                false,
+            ],
+            'filesystem root excludes every absolute path' => [
+                '/srv/site/index.php',
+                '/',
+                ['/srv/site'],
+                true,
+            ],
+            'filesystem root excludes relative paths' => [
+                'index.php',
+                '/',
+                ['/srv/site'],
+                true,
+            ],
+        ];
+    }
+
+    public function testExcludedStagingPathClassifierFollowsSymlinkChanges(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-exporter/src/export.php';
+
+        $siteDir = $this->tempDir . '/site';
+        $staging = $siteDir . '/private-staging';
+        $ordinary = $siteDir . '/ordinary';
+        mkdir($staging, 0755, true);
+        mkdir($ordinary, 0755, true);
+        file_put_contents($staging . '/state.json', '{}');
+        file_put_contents($ordinary . '/state.json', '{}');
+        $excludedStagingRoots = reprint_build_staging_exclusion_roots(
+            $staging
+        );
+        $alias = $siteDir . '/current';
+        if (!@symlink($ordinary, $alias)) {
+            $this->markTestSkipped('The filesystem does not permit symlinks.');
+        }
+
+        $this->assertFalse(
+            reprint_path_is_within_excluded_staging_roots(
+                $alias . '/state.json',
+                $excludedStagingRoots,
+                [$siteDir]
+            )
+        );
+
+        unlink($alias);
+        symlink($staging, $alias);
+
+        $this->assertTrue(
+            reprint_path_is_within_excluded_staging_roots(
+                $alias . '/state.json',
+                $excludedStagingRoots,
+                [$siteDir]
+            ),
+            'the realpath cache from the previous symlink target must not be reused'
+        );
+        $this->assertTrue(
+            reprint_path_is_within_excluded_staging_roots(
+                $alias . '/missing/session.json',
+                $excludedStagingRoots,
+                [$siteDir]
+            ),
+            'a missing leaf must retain the canonical staging ancestor'
+        );
+    }
+
     // ------------------------------------------------------------------
     // Integration tests — endpoint_file_index() over the fixture
     // ------------------------------------------------------------------
@@ -239,6 +372,209 @@ final class FileIndexSkipDefaultsTest extends TestCase
         $this->assertNotContains('wp-content/reprint-storage/state.json', $withCaches);
     }
 
+    public function testActiveStorageChangesNeverLeakIntoSubsequentIndexes(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $storage = $siteDir . '/.reprint-staging';
+        mkdir($storage . '/apply-sessions/first/work/files', 0755, true);
+        file_put_contents($storage . '/apply-sessions/first/work/files/old.txt', 'old');
+
+        $first = $this->relativePaths(
+            $this->runFileIndexEntries($siteDir, false, 5000, $storage),
+            $siteDir
+        );
+        file_put_contents($storage . '/apply-sessions/first/work/files/new.txt', 'new');
+        $second = $this->relativePaths(
+            $this->runFileIndexEntries($siteDir, false, 5000, $storage),
+            $siteDir
+        );
+
+        $isStoragePath = static fn(string $path): bool => strpos($path, '.reprint-staging') === 0;
+        $this->assertSame([], array_values(array_filter($first, $isStoragePath)));
+        $this->assertSame([], array_values(array_filter($second, $isStoragePath)));
+    }
+
+    public function testExternalStorageDoesNotHideAnUnrelatedSiteDirectory(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        mkdir($siteDir . '/.reprint-staging', 0755, true);
+        file_put_contents($siteDir . '/.reprint-staging/user-file.txt', 'site content');
+        $externalStorage = $this->tempDir . '/external-staging';
+        mkdir($externalStorage, 0755, true);
+
+        $paths = $this->relativePaths(
+            $this->runFileIndexEntries($siteDir, false, 5000, $externalStorage),
+            $siteDir
+        );
+
+        $this->assertContains('.reprint-staging/user-file.txt', $paths);
+    }
+
+    public function testSymlinkedStorageConfigurationExcludesItsCanonicalSiteTarget(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $storage = $siteDir . '/private-staging';
+        mkdir($storage, 0755, true);
+        file_put_contents($storage . '/state.json', '{}');
+        file_put_contents($siteDir . '/private-staging-neighbor.txt', 'keep');
+        $storageAlias = $this->tempDir . '/staging-alias';
+        if (!@symlink($storage, $storageAlias)) {
+            $this->markTestSkipped('The filesystem does not permit symlinks.');
+        }
+
+        $paths = $this->relativePaths(
+            $this->runFileIndexEntries($siteDir, false, 5000, $storageAlias),
+            $siteDir
+        );
+
+        $this->assertNotContains('private-staging/state.json', $paths);
+        $this->assertContains('private-staging-neighbor.txt', $paths);
+    }
+
+    public function testFileIndexSkipsAnInTreeSymlinkAliasIntoStaging(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $staging = $siteDir . '/private-staging';
+        mkdir($staging, 0755, true);
+        file_put_contents($staging . '/state.json', '{}');
+        $alias = $siteDir . '/public-alias';
+        if (!@symlink($staging, $alias)) {
+            $this->markTestSkipped('The filesystem does not permit symlinks.');
+        }
+
+        $paths = $this->relativePaths(
+            $this->runFileIndexEntries($siteDir, false, 5000, $staging),
+            $siteDir
+        );
+
+        $this->assertNotContains('private-staging/state.json', $paths);
+        $this->assertNotContains('public-alias', $paths);
+        $this->assertContains('index.php', $paths);
+    }
+
+    public function testFileIndexDropsAStaleCursorFrameAfterStagingConfigurationChanges(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $staging = $siteDir . '/private-staging';
+        mkdir($staging, 0755, true);
+        file_put_contents($staging . '/state.json', '{}');
+
+        // This frame represents a cursor issued before private-staging became
+        // the server's configured staging root.
+        $cursor = json_encode([
+            'stack' => [
+                [
+                    'dir' => base64_encode(realpath($siteDir) ?: $siteDir),
+                    'after' => null,
+                ],
+                [
+                    'dir' => base64_encode(realpath($staging) ?: $staging),
+                    'after' => null,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $paths = $this->relativePaths(
+            $this->runFileIndexEntries(
+                $siteDir,
+                false,
+                5000,
+                $staging,
+                $cursor
+            ),
+            $siteDir
+        );
+
+        $this->assertNotContains('private-staging', $paths);
+        $this->assertNotContains('private-staging/state.json', $paths);
+        $this->assertContains('index.php', $paths);
+    }
+
+    public function testFileIndexCompletesWithAnEmptyIndexWhenTheOnlyRootIsStaging(): void
+    {
+        $staging = $this->tempDir . '/private-staging';
+        mkdir($staging, 0755, true);
+        file_put_contents($staging . '/state.json', '{}');
+
+        $entries = $this->runFileIndexEntries(
+            $staging,
+            false,
+            5000,
+            $staging
+        );
+
+        $this->assertSame([], $entries);
+    }
+
+    public function testFileFetchRejectsAMixedListBeforeStreamingAnyFile(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $staging = $siteDir . '/private-staging';
+        mkdir($staging, 0755, true);
+        $allowed = $siteDir . '/allowed.php';
+        $excluded = $staging . '/state.php';
+        file_put_contents($allowed, 'allowed-file-body');
+        file_put_contents($excluded, 'private-staging-body');
+
+        // The invalid cursor would fail in FileTreeProducer's constructor;
+        // staging rejection must happen first, before both it and gzip choice.
+        $result = $this->runFileFetch(
+            $siteDir,
+            [$allowed, $excluded],
+            $staging,
+            'not-json'
+        );
+
+        $this->assertSame(1, $result['exit_code'], $result['stderr']);
+        $this->assertStringContainsString('files-pull --abort', $result['stdout']);
+        $this->assertStringContainsString('rerun the full pull', $result['stdout']);
+        $this->assertStringNotContainsString('--boundary-', $result['stdout']);
+        $this->assertStringNotContainsString('allowed-file-body', $result['stdout']);
+        $this->assertStringNotContainsString('private-staging-body', $result['stdout']);
+    }
+
+    public function testFileFetchRejectsRelativeAndSymlinkedStagingPathsButAllowsNeighbor(): void
+    {
+        $siteDir = $this->buildFixtureSite();
+        $staging = $siteDir . '/private-staging';
+        mkdir($staging, 0755, true);
+        file_put_contents($staging . '/state.php', 'private-staging-body');
+        $neighbor = $siteDir . '/private-staging-neighbor.php';
+        file_put_contents($neighbor, 'neighbor-body');
+        $alias = $siteDir . '/staging-alias';
+        if (!@symlink($staging, $alias)) {
+            $this->markTestSkipped('The filesystem does not permit symlinks.');
+        }
+
+        foreach (
+            [
+                'relative' => 'private-staging/state.php',
+                'absolute alias' => $alias . '/state.php',
+                'absolute alias with missing leaf' => $alias . '/missing/state.php',
+            ] as $label => $path
+        ) {
+            $result = $this->runFileFetch($siteDir, [$path], $staging);
+            $this->assertSame(1, $result['exit_code'], $label . ': ' . $result['stderr']);
+            $this->assertStringContainsString('files-pull --abort', $result['stdout'], $label);
+            $this->assertStringNotContainsString('--boundary-', $result['stdout'], $label);
+        }
+
+        foreach (
+            [
+                'relative neighbor' => 'private-staging-neighbor.php',
+                'absolute neighbor' => $neighbor,
+            ] as $label => $path
+        ) {
+            $result = $this->runFileFetch($siteDir, [$path], $staging);
+            $this->assertSame(0, $result['exit_code'], $label . ': ' . $result['stderr']);
+            $body = @gzdecode($result['stdout']);
+            if ($body === false) {
+                $body = $result['stdout'];
+            }
+            $this->assertStringContainsString('neighbor-body', $body, $label);
+        }
+    }
+
     public function testFileIndexFilterDoesNotBreakResume(): void
     {
         // The skip is applied AFTER the cursor's "after" pointer is updated,
@@ -310,9 +646,21 @@ final class FileIndexSkipDefaultsTest extends TestCase
     /**
      * @return list<array{path: string, type: string}>
      */
-    private function runFileIndexEntries(string $siteDir, bool $includeCaches, int $batchSize = 5000, ?string $storagePath = null): array
+    private function runFileIndexEntries(
+        string $siteDir,
+        bool $includeCaches,
+        int $batchSize = 5000,
+        ?string $excludedStagingRoot = null,
+        ?string $cursor = null
+    ): array
     {
-        $stdout = $this->runFileIndex($siteDir, $includeCaches, $batchSize, $storagePath);
+        $stdout = $this->runFileIndex(
+            $siteDir,
+            $includeCaches,
+            $batchSize,
+            $excludedStagingRoot,
+            $cursor
+        );
 
         // The response is `multipart/mixed; boundary="…"` containing one or
         // more `index_batch` JSON chunks. Parse out each batch and flatten.
@@ -368,7 +716,10 @@ final class FileIndexSkipDefaultsTest extends TestCase
      */
     private function relativePaths(array $entries, string $siteDir): array
     {
-        $prefix = $siteDir . '/';
+        // endpoint_file_index() reports canonical paths. macOS exposes /tmp
+        // and /var through /private symlinks, so compare against the same form.
+        $siteRoot = realpath($siteDir) ?: $siteDir;
+        $prefix = rtrim($siteRoot, '/') . '/';
         $out = [];
         foreach ($entries as $e) {
             $p = $e['path'];
@@ -380,7 +731,13 @@ final class FileIndexSkipDefaultsTest extends TestCase
         return $out;
     }
 
-    private function runFileIndex(string $siteDir, bool $includeCaches, int $batchSize, ?string $storagePath = null): string
+    private function runFileIndex(
+        string $siteDir,
+        bool $includeCaches,
+        int $batchSize,
+        ?string $excludedStagingRoot = null,
+        ?string $cursor = null
+    ): string
     {
         $configPath = $this->tempDir . '/index-config.json';
         $config = [
@@ -389,8 +746,11 @@ final class FileIndexSkipDefaultsTest extends TestCase
             'batch_size' => $batchSize,
             'include_caches' => $includeCaches,
         ];
-        if ($storagePath !== null) {
-            $config['storage_path'] = $storagePath;
+        if ($excludedStagingRoot !== null) {
+            $config['excluded_staging_root'] = $excludedStagingRoot;
+        }
+        if ($cursor !== null) {
+            $config['cursor'] = $cursor;
         }
         file_put_contents($configPath, json_encode($config, JSON_THROW_ON_ERROR));
 
@@ -428,6 +788,77 @@ PHP,
         $this->assertSame(0, $exitCode, "file_index should exit cleanly.\nstderr: {$stderr}");
 
         return $stdout;
+    }
+
+    /**
+     * @param list<string> $paths
+     * @return array{stdout:string,stderr:string,exit_code:int}
+     */
+    private function runFileFetch(
+        string $siteDir,
+        array $paths,
+        string $excludedStagingRoot,
+        ?string $cursor = null
+    ): array {
+        $listPath = $this->tempDir . '/file-fetch-list.json';
+        file_put_contents($listPath, json_encode($paths, JSON_THROW_ON_ERROR));
+
+        $configPath = $this->tempDir . '/file-fetch-config.json';
+        $config = [
+            'directory' => $siteDir,
+            'file_list_path' => $listPath,
+            'excluded_staging_root' => $excludedStagingRoot,
+        ];
+        if ($cursor !== null) {
+            $config['cursor'] = $cursor;
+        }
+        file_put_contents(
+            $configPath,
+            json_encode($config, JSON_THROW_ON_ERROR)
+        );
+
+        $scriptPath = $this->tempDir . '/run-file-fetch.php';
+        file_put_contents(
+            $scriptPath,
+            sprintf(
+                <<<'PHP'
+<?php
+declare(strict_types=1);
+require_once %s;
+$config = json_decode(file_get_contents(%s), true, 512, JSON_THROW_ON_ERROR);
+$budget = new ResourceBudget(microtime(true), 10, 128 * 1024 * 1024, 0.9);
+endpoint_file_fetch($config, $budget);
+PHP,
+                json_encode(
+                    dirname(__DIR__) . '/packages/reprint-exporter/src/export.php',
+                    JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES
+                ),
+                json_encode(
+                    $configPath,
+                    JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES
+                ),
+            ),
+        );
+
+        $command = sprintf('%s %s', escapeshellarg(PHP_BINARY), escapeshellarg($scriptPath));
+        $descriptorSpec = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($command, $descriptorSpec, $pipes);
+        $this->assertIsResource($process);
+
+        $stdout = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        return [
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'exit_code' => $exitCode,
+        ];
     }
 
     private function recursiveDelete(string $dir): void

--- a/tests/Import/PullMultipartCompletionTest.php
+++ b/tests/Import/PullMultipartCompletionTest.php
@@ -1,0 +1,213 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Matches the established PHPUnit namespace.
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test setup failures are CLI diagnostics, never HTML output.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- The small client subclass exposes one protected method to the tests.
+// phpcs:disable Generic.WhiteSpace.ArbitraryParenthesesSpacing -- Match the established compact style in importer PHPUnit tests.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+/** Exercises pull completion semantics through a real local HTTP endpoint. */
+final class PullMultipartCompletionTest extends TestCase {
+
+    private static string $server_root;
+    private static string $base_url;
+
+    /** @var resource|null */
+    private static $server_process;
+
+    private string $case_root;
+    private PullMultipartCompletionClient $client;
+
+    public static function setUpBeforeClass(): void {
+        if (!function_exists('curl_init')) {
+            self::markTestSkipped('Pull streaming requires the curl extension.');
+        }
+        self::$server_root = sys_get_temp_dir() . '/pull-multipart-http-' . bin2hex(random_bytes(8));
+        mkdir(self::$server_root, 0700, true);
+        $router_path = self::$server_root . '/router.php';
+        file_put_contents($router_path, <<<'PHP'
+<?php
+if (parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) === '/__ping') {
+    echo 'ok';
+    return;
+}
+$case = $_GET['case'] ?? '';
+$boundary = 'pull-completion';
+header('Content-Type: multipart/mixed; boundary=' . $boundary);
+$completion = "--{$boundary}\r\nContent-Type: application/octet-stream\r\nContent-Length: 0\r\nX-Chunk-Type: completion\r\nX-Status: complete\r\n\r\n\r\n";
+if ($case === 'truncated-before-completion') {
+    $body = "--{$boundary}\r\nContent-Type: application/octet-stream\r\nContent-Length: 4\r\nX-Chunk-Type: data\r\n\r\ndata\r\n";
+    header('Content-Length: ' . strlen($body));
+    echo $body;
+    return;
+}
+if ($case === 'truncated-file') {
+    $body = "--{$boundary}\r\nContent-Type: application/octet-stream\r\nContent-Length: 8\r\nX-Chunk-Type: file\r\nX-Cursor: next-cursor\r\nX-File-Path: " . base64_encode('/cursor.bin') . "\r\nX-File-Size: 8\r\nX-File-Ctime: 1234567890\r\nX-Chunk-Offset: 0\r\nX-Chunk-Size: 8\r\nX-First-Chunk: 1\r\nX-Last-Chunk: 1\r\n\r\nabcd";
+    header('Content-Length: ' . strlen($body));
+    echo $body;
+    return;
+}
+$body = $completion;
+if ($case === 'closed' || $case === 'closed-curl-error') {
+    $body .= "--{$boundary}--\r\n";
+}
+header('Content-Length: ' . (strlen($body) + (substr($case, -11) === '-curl-error' ? 64 : 0)));
+echo $body;
+PHP
+        );
+
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        if ($socket === false) {
+            throw new \RuntimeException('Could not reserve a local HTTP port: ' . $error . ' (' . $errno . ').');
+        }
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        $port = (int) substr( strrchr( (string) $address, ':' ), 1 );
+        self::$base_url = 'http://127.0.0.1:' . $port;
+        self::$server_process = proc_open(
+            [PHP_BINARY, '-n', '-S', '127.0.0.1:' . $port, '-t', self::$server_root, $router_path],
+            [0 => ['pipe', 'r'], 1 => ['file', self::$server_root . '/server.log', 'a'], 2 => ['file', self::$server_root . '/server.log', 'a']],
+            $pipes,
+            self::$server_root
+        );
+        if (!is_resource(self::$server_process)) {
+            throw new \RuntimeException('Could not start the local pull endpoint server.');
+        }
+        fclose($pipes[0]);
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            try {
+                $ping = @file_get_contents(self::$base_url . '/__ping');
+            } catch ( \Throwable $error ) {
+                // import.php converts PHP warnings into exceptions. A refused
+                // connection is expected while the real server starts.
+                $ping = false;
+            }
+            if ($ping === 'ok') {
+                return;
+            }
+            usleep(100000);
+        }
+        self::tearDownAfterClass();
+        throw new \RuntimeException('The local pull endpoint server did not start.');
+    }
+
+    public static function tearDownAfterClass(): void {
+        if (is_resource(self::$server_process)) {
+            proc_terminate(self::$server_process);
+            proc_close(self::$server_process);
+            self::$server_process = null;
+        }
+        if (isset(self::$server_root)) {
+            self::remove_tree(self::$server_root);
+        }
+    }
+
+    protected function setUp(): void {
+        $this->case_root = self::$server_root . '/case-' . bin2hex(random_bytes(8));
+        $state = $this->case_root . '/state';
+        $files = $this->case_root . '/files';
+        $this->client = new PullMultipartCompletionClient(self::$base_url, $state, $files);
+    }
+
+    protected function tearDown(): void {
+        self::remove_tree($this->case_root);
+    }
+
+    public function testResponseWithoutCompletionRetainsTheRetryableMissingCompletionError(): void {
+        $context = $this->completion_context();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing completion chunk');
+        $this->client->fetch_test_response(self::$base_url . '/?case=truncated-before-completion', $context);
+    }
+
+    public function testCompletionWithoutMimeCloseIsTerminal(): void {
+        $context = $this->completion_context();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('closing boundary');
+        $this->client->fetch_test_response(self::$base_url . '/?case=unclosed', $context);
+    }
+
+    public function testCompletionWithoutMimeCloseTakesPrecedenceOverACurlError(): void {
+        $context = $this->completion_context();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('closing boundary');
+        $this->client->fetch_test_response(self::$base_url . '/?case=unclosed-curl-error', $context);
+    }
+
+    public function testProperlyClosedCompletionSucceeds(): void {
+        $context = $this->completion_context();
+
+        $this->client->fetch_test_response(self::$base_url . '/?case=closed', $context);
+
+        $this->assertTrue($context->saw_completion);
+    }
+
+    public function testProperlyClosedCompletionRetainsTheCurlError(): void {
+        $context = $this->completion_context();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('cURL error (18)');
+        $this->client->fetch_test_response(self::$base_url . '/?case=closed-curl-error', $context);
+    }
+
+    public function testTruncatedFileKeepsTheLastConfirmedCursor(): void {
+        $client = new PullMultipartCompletionClient(
+            self::$base_url . '/?case=truncated-file',
+            $this->case_root . '/cursor-state',
+            $this->case_root . '/cursor-files'
+        );
+        $client->get_import_state()->fetch->cursor = 'confirmed-cursor';
+
+        $complete = $client->download_test_file_response('confirmed-cursor');
+
+        $this->assertFalse($complete);
+        $this->assertSame('confirmed-cursor', $client->get_import_state()->fetch->cursor);
+        $this->assertSame('abcd', file_get_contents($this->case_root . '/cursor-files/cursor.bin'));
+    }
+
+    private function completion_context(): \StreamingContext {
+        $context = new \StreamingContext();
+        $context->on_chunk = static function (array $chunk) use ($context): void {
+            if (($chunk['headers']['x-chunk-type'] ?? '') === 'completion') {
+                $context->saw_completion = true;
+            }
+        };
+        return $context;
+    }
+
+    private static function remove_tree(string $path): void {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (!is_dir($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                self::remove_tree($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}
+
+final class PullMultipartCompletionClient extends \ImportClient {
+
+    public function fetch_test_response(string $url, \StreamingContext $context): void {
+        $this->fetch_streaming($url, null, $context);
+    }
+
+    public function download_test_file_response(?string $cursor): bool {
+        $method = new \ReflectionMethod(\ImportClient::class, 'download_file_fetch');
+        return $method->invoke($this, null, $cursor, 'fetch');
+    }
+}

--- a/tests/Import/StagingExclusionPullTest.php
+++ b/tests/Import/StagingExclusionPullTest.php
@@ -1,0 +1,336 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Matches the established PHPUnit namespace.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+/** Exercises staging exclusion and stale-pull recovery through a real endpoint. */
+final class StagingExclusionPullTest extends TestCase {
+
+    private static string $case_root;
+    private static string $remote_site;
+    private static string $external_staging_root;
+    private static string $internal_staging_root;
+    private static string $state_dir;
+    private static string $filesystem_root;
+    private static string $mode_path;
+    private static string $request_log_path;
+    private static string $base_url;
+
+    /** @var resource|null */
+    private static $server_process;
+
+    public static function setUpBeforeClass(): void {
+        if (!function_exists('curl_init')) {
+            self::markTestSkipped('Pull streaming requires the curl extension.');
+        }
+
+        self::$case_root = sys_get_temp_dir() . '/staging-exclusion-pull-' . bin2hex(random_bytes(8));
+        mkdir(self::$case_root, 0700, true);
+        self::$remote_site = self::$case_root . '/remote-site';
+        self::$external_staging_root = self::$case_root . '/external-staging';
+        self::$internal_staging_root = self::$remote_site . '/.reprint-staging';
+        self::$state_dir = self::$case_root . '/state';
+        self::$filesystem_root = self::$case_root . '/files';
+        self::$mode_path = self::$case_root . '/mode';
+        self::$request_log_path = self::$case_root . '/requests.jsonl';
+
+        mkdir(self::$remote_site, 0700, true);
+        mkdir(self::$external_staging_root, 0700, true);
+        mkdir(self::$internal_staging_root, 0700, true);
+        file_put_contents(self::$remote_site . '/allowed.txt', 'allowed-v1');
+        file_put_contents(self::$internal_staging_root . '/private.txt', 'private-v1');
+        file_put_contents(self::$mode_path, 'external');
+        file_put_contents(self::$request_log_path, '');
+
+        self::$remote_site = (string) realpath(self::$remote_site);
+        self::$external_staging_root = (string) realpath(self::$external_staging_root);
+        self::$internal_staging_root = (string) realpath(self::$internal_staging_root);
+
+        $router_path = self::$case_root . '/router.php';
+        self::writeRouter($router_path);
+        self::startServer($router_path);
+    }
+
+    public static function tearDownAfterClass(): void {
+        if (is_resource(self::$server_process)) {
+            proc_terminate(self::$server_process);
+            proc_close(self::$server_process);
+            self::$server_process = null;
+        }
+        if (isset(self::$case_root)) {
+            self::removeTree(self::$case_root);
+        }
+    }
+
+    public function testStaleListRejectsAtomicallyAndAbortReindexRemovesStaging(): void {
+        $this->seedPreflightState();
+        $this->runFilesPull();
+
+        $local_site = self::$filesystem_root . self::$remote_site;
+        $local_allowed_path = $local_site . '/allowed.txt';
+        $local_private_path = $local_site . '/.reprint-staging/private.txt';
+        $this->assertSame('allowed-v1', file_get_contents($local_allowed_path));
+        $this->assertSame('private-v1', file_get_contents($local_private_path));
+        $this->assertContains(self::$internal_staging_root . '/private.txt', $this->indexedPaths());
+
+        file_put_contents(self::$remote_site . '/allowed.txt', 'allowed-version-two');
+        file_put_contents(self::$internal_staging_root . '/private.txt', 'private-version-two');
+        $this->abortFilesPull();
+
+        // The index still treats the in-tree directory as ordinary, but fetch
+        // now sees it as the server-owned staging root. The complete mixed
+        // batch must be rejected before either changed file is transmitted.
+        file_put_contents(self::$mode_path, 'split');
+        try {
+            $this->runFilesPull();
+            $this->fail('A fetch list made stale by target configuration was accepted.');
+        } catch (\RuntimeException $error) {
+            $this->assertStringContainsString('files-pull --abort', $error->getMessage());
+            $this->assertStringContainsString('rerun the full pull', $error->getMessage());
+            $this->assertStringContainsString(
+                base64_encode(self::$internal_staging_root . '/private.txt'),
+                $error->getMessage()
+            );
+        }
+
+        $this->assertSame('allowed-v1', file_get_contents($local_allowed_path));
+        $this->assertSame('private-v1', file_get_contents($local_private_path));
+        $this->assertFileExists(self::$state_dir . '/.import-download-list.jsonl');
+        $stale_download_paths = $this->encodedPathsFromJsonLines(
+            self::$state_dir . '/.import-download-list.jsonl'
+        );
+        $this->assertContains(self::$remote_site . '/allowed.txt', $stale_download_paths);
+        $this->assertContains(self::$internal_staging_root . '/private.txt', $stale_download_paths);
+
+        $this->abortFilesPull();
+        file_put_contents(self::$mode_path, 'internal');
+        $this->runFilesPull();
+
+        $this->assertSame('allowed-version-two', file_get_contents($local_allowed_path));
+        $this->assertFileDoesNotExist($local_private_path);
+        $this->assertNotContains(self::$internal_staging_root, $this->indexedPaths());
+        $this->assertNotContains(self::$internal_staging_root . '/private.txt', $this->indexedPaths());
+        $this->assertImporterRequestsContainNoPrivateConfiguration();
+    }
+
+    private function client(): \ImportClient {
+        return new \ImportClient(
+            self::$base_url . '/?directory=' . rawurlencode(self::$remote_site),
+            self::$state_dir,
+            self::$filesystem_root
+        );
+    }
+
+    private function seedPreflightState(): void {
+        $client = $this->client();
+        $state = $client->default_state();
+        $state['preflight'] = [
+            'http_code' => 200,
+            'data' => [
+                'ok' => true,
+                'wp_detect' => [
+                    'roots' => [['path' => self::$remote_site]],
+                ],
+                'runtime' => [
+                    'document_root' => self::$remote_site,
+                    'ini_get_all' => [],
+                ],
+                'database' => [
+                    'wp' => ['paths_urls' => ['content_dir' => null]],
+                ],
+                'limits' => ['max_request_bytes' => 4 * 1024 * 1024],
+            ],
+        ];
+        $state['remote_protocol_version'] = 1;
+        $state['remote_protocol_min_version'] = 1;
+        $state['follow_symlinks'] = false;
+        file_put_contents(
+            self::$state_dir . '/.import-state.json',
+            json_encode($state, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function runFilesPull(): void {
+        $this->client()->run([
+            'command' => 'files-pull',
+            'follow_symlinks' => false,
+        ]);
+    }
+
+    private function abortFilesPull(): void {
+        $this->client()->run([
+            'command' => 'files-pull',
+            'follow_symlinks' => false,
+            'abort' => true,
+        ]);
+    }
+
+    /** @return list<string> */
+    private function indexedPaths(): array {
+        return $this->encodedPathsFromJsonLines(
+            self::$state_dir . '/.import-index.jsonl'
+        );
+    }
+
+    /** @return list<string> */
+    private function encodedPathsFromJsonLines(string $path): array {
+        $paths = [];
+        foreach (file($path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $path = base64_decode( (string) ( $entry['path'] ?? '' ), true);
+            if (is_string($path)) {
+                $paths[] = $path;
+            }
+        }
+        return $paths;
+    }
+
+    private function assertImporterRequestsContainNoPrivateConfiguration(): void {
+        $saw_file_index = false;
+        $saw_file_fetch = false;
+        foreach (file(self::$request_log_path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $request = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $endpoint = $request['endpoint'] ?? null;
+            $saw_file_index = $saw_file_index || $endpoint === 'file_index';
+            $saw_file_fetch = $saw_file_fetch || $endpoint === 'file_fetch';
+            $request_keys = array_merge(
+                $request['get_keys'] ?? [],
+                $request['post_keys'] ?? []
+            );
+            foreach (['storage_path', 'staging_dir', 'excluded_staging_root'] as $private_key) {
+                $this->assertNotContains($private_key, $request_keys, $endpoint ?? 'unknown endpoint');
+            }
+            if ($endpoint === 'file_fetch') {
+                $this->assertSame(['file_list'], $request['file_keys'] ?? []);
+            }
+        }
+        $this->assertTrue($saw_file_index, 'The real importer made no file_index request.');
+        $this->assertTrue($saw_file_fetch, 'The real importer made no file_fetch request.');
+    }
+
+    private static function writeRouter(string $router_path): void {
+        $autoload_path = dirname(__DIR__, 2) . '/vendor/autoload.php';
+        $class_path = dirname(__DIR__, 2) . '/packages/reprint-exporter/src/class-http-server.php';
+        $router = sprintf(
+            <<<'PHP'
+<?php
+if (parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) === '/__ping') {
+    echo 'ok';
+    return true;
+}
+
+require_once %s;
+require_once %s;
+$endpoint = (string) ($_GET['endpoint'] ?? $_POST['endpoint'] ?? '');
+file_put_contents(
+    %s,
+    json_encode([
+        'endpoint' => $endpoint,
+        'method' => $_SERVER['REQUEST_METHOD'] ?? '',
+        'get_keys' => array_keys($_GET),
+        'post_keys' => array_keys($_POST),
+        'file_keys' => array_keys($_FILES),
+    ], JSON_UNESCAPED_SLASHES) . "\n",
+    FILE_APPEND | LOCK_EX
+);
+
+$mode = trim((string) file_get_contents(%s));
+$staging_root = %s;
+if ($mode === 'internal' || ($mode === 'split' && $endpoint === 'file_fetch')) {
+    $staging_root = %s;
+}
+
+try {
+    Site_Export_HTTP_Server::serve([
+        'default_directory' => %s,
+        'staged' => [
+            'staging_dir' => $staging_root,
+            'secret' => 'test-secret',
+        ],
+    ]);
+} catch (Throwable $error) {
+    if (!headers_sent()) {
+        http_response_code(400);
+        header('Content-Type: application/json');
+    }
+    echo json_encode(['error' => $error->getMessage()], JSON_UNESCAPED_SLASHES);
+}
+PHP,
+            self::phpStringLiteral($autoload_path),
+            self::phpStringLiteral($class_path),
+            self::phpStringLiteral(self::$request_log_path),
+            self::phpStringLiteral(self::$mode_path),
+            self::phpStringLiteral(self::$external_staging_root),
+            self::phpStringLiteral(self::$internal_staging_root),
+            self::phpStringLiteral(self::$remote_site)
+        );
+        file_put_contents($router_path, $router);
+    }
+
+    private static function phpStringLiteral(string $value): string {
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The generated router needs a valid PHP string literal.
+        return var_export($value, true);
+    }
+
+    private static function startServer(string $router_path): void {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        if ($socket === false) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This exception is not HTML output.
+            throw new \RuntimeException('Could not reserve a local HTTP port: ' . $error . ' (' . $errno . ').');
+        }
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        $port = (int) substr(strrchr( (string) $address, ':'), 1);
+        self::$base_url = 'http://127.0.0.1:' . $port;
+        self::$server_process = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, '-t', self::$case_root, $router_path],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['file', self::$case_root . '/server.log', 'a'],
+                2 => ['file', self::$case_root . '/server.log', 'a'],
+            ],
+            $pipes,
+            self::$case_root
+        );
+        if (!is_resource(self::$server_process)) {
+            throw new \RuntimeException('Could not start the staging exclusion endpoint.');
+        }
+        fclose($pipes[0]);
+
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            try {
+                $ping = @file_get_contents(self::$base_url . '/__ping');
+            } catch (\Throwable $error) {
+                $ping = false;
+            }
+            if ($ping === 'ok') {
+                return;
+            }
+            usleep(100000);
+        }
+
+        self::tearDownAfterClass();
+        throw new \RuntimeException('The staging exclusion endpoint did not start.');
+    }
+
+    private static function removeTree(string $path): void {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (!is_dir($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                self::removeTree($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -4,10 +4,10 @@
  * Specifically guards the contract introduced by the "stream file parts
  * directly to disk" change: now that bytes hit the local file before a
  * multipart part finishes, a request cut mid-body leaves a partially-
- * written file on disk. The importer must resume that exact file —
- * not start over (truncation) and not append duplicates (overlap) —
- * and the server-side cursor must cooperate by skipping the bytes the
- * importer already has.
+ * written file on disk. The importer must resume from its last confirmed
+ * multipart boundary. It may discard an unconfirmed tail, but must never
+ * advance to the header cursor for a body that did not arrive completely or
+ * append duplicated bytes on retry.
  *
  * Setup: a 2 MiB random binary file. With --file-chunk-max=262144, the
  * file is sliced into eight chunks. A test_hook_before_file_chunk hook
@@ -116,13 +116,14 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
 
         const result = runImporter(importUrl(), tempDir, 'files-sync', {
             secret: getSiteSecret(site),
+            autoResume: false,
             extraArgs: [
                 '--file-chunk-start=262144',
                 '--file-chunk-max=262144',
             ],
         });
-        assert.notEqual(result.exitCode, 0,
-            `Expected first run to fail due to mid-file exit\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        assert.equal(result.exitCode, 2,
+            `Expected first run to remain retryable after the truncated response\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
     });
 
     it('partial file is on disk and smaller than source', () => {
@@ -135,13 +136,20 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
             `Expected a partial file (0 < size < ${fileSize}), got ${partialSize}`);
     });
 
-    it('state records current_file and current_file_bytes for resume', () => {
+    it('state records only multipart-confirmed file bytes for resume', () => {
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected import state file to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.ok(state.current_file, 'Expected state.current_file to be set after a mid-file crash');
-        assert.ok(typeof state.current_file_bytes === 'number' && state.current_file_bytes > 0,
-            `Expected state.current_file_bytes > 0, got ${state.current_file_bytes}`);
+        assert.equal(state.active_resumable_command.completion_state, 'partial');
+        if (state.current_file === null) {
+            assert.equal(state.current_file_bytes, null,
+                'An unconfirmed file path must not carry a sender-claimed byte offset');
+        } else {
+            const partialSize = statSync(state.current_file).size;
+            assert.ok(typeof state.current_file_bytes === 'number' && state.current_file_bytes > 0);
+            assert.ok(state.current_file_bytes <= partialSize,
+                `Confirmed ${state.current_file_bytes} bytes beyond the ${partialSize}-byte local file`);
+        }
     });
 
     it('resume completes after removing the hook', () => {

--- a/tests/e2e/tests/import-53-push-direct-apply.test.js
+++ b/tests/e2e/tests/import-53-push-direct-apply.test.js
@@ -17,7 +17,8 @@ import { join, relative } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { randomBytes } from 'node:crypto';
 import {
-    cleanupTempDir, createTempDir, getSiteDir, getSiteSecret, getSiteUrl, runPush,
+    cleanupTempDir, createTempDir, fsRootDir, getSiteDir, getSiteSecret, getSiteUrl,
+    runImporter, runPush,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { HmacClient } from '../lib/hmac-client.js';
@@ -51,6 +52,32 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
     });
 
     afterAll(() => cleanupTempDir(caseRoot));
+
+    it('excludes active server-owned staging storage from a full pull', () => {
+        const pullState = join(caseRoot, 'storage-pull');
+        const stagingSentinel = join(stagingDir, 'apply-sessions/active/work/files/private.txt');
+        execFileSync('sudo', ['mkdir', '-p', join(stagingSentinel, '..')]);
+        execFileSync('sudo', ['sh', '-c', `printf private > ${shellQuote(stagingSentinel)}`]);
+        execFileSync('sudo', ['chown', '-R', 'nginx:nginx', stagingDir]);
+
+        const result = runImporter(
+            `${getSiteUrl(site)}&directory=${targetRoot}`,
+            pullState,
+            'files-pull',
+            { secret: getSiteSecret(site) },
+        );
+
+        assert.equal(result.exitCode, 0, result.stderr);
+        const pulledSite = join(fsRootDir(pullState), targetRoot);
+        assert.ok(existsSync(join(pulledSite, 'index.php')), 'The full pull omitted the WordPress root.');
+        assert.ok(!existsSync(join(pulledSite, '.reprint-staging')),
+            'Server-owned staging storage leaked into the pulled tree.');
+        const indexedPaths = readFileSync(join(pullState, '.import-index.jsonl'), 'utf8')
+            .trim().split('\n').filter(Boolean)
+            .map((line) => Buffer.from(JSON.parse(line).path, 'base64').toString());
+        assert.ok(!indexedPaths.some((path) => path === stagingDir || path.startsWith(`${stagingDir}/`)),
+            'Server-owned staging storage leaked into the completed pull index.');
+    });
 
     it('applies basic and delta trees without target-side planning artifacts', () => {
         writeSource(sourceRoot, 'push-fixture/file.txt', 'first');


### PR DESCRIPTION
Truncated pulls now resume from the last confirmed multipart boundary instead of trusting a header cursor before its body arrives. A response that contains a completion part must also contain the closing MIME boundary. That framing failure stays terminal and takes precedence over a simultaneous cURL 18, 52, or 56 error. Large endpoint cursors stay within the same strict header bound: compressible JSON uses gzip before base64, and a cursor that still cannot fit is rejected before emission.

The HTTP server strips request-provided `storage_path`, `staging_dir`, and `excluded_staging_root`, then injects its configured `staging_dir` only into file index and fetch handlers. Indexes omit the staging root, descendants, and aliases into it. Fetch rejects a stale mixed list in full and tells the operator to abort and rerun, so confirmed cursor progress cannot silently skip private paths. The real pull lifecycle test also proves that aborting and re-indexing removes a staging path saved by an older pull.

Tests run:
- `cd tests && ../vendor/bin/phpunit Import` — 427 tests, 1,502 assertions, 6 skips
- `cd tests && ../vendor/bin/phpunit FileIndexSkipDefaultsTest.php FileFetchCompressionTest.php ExportHttpServerTest.php` — 130 tests, 302 assertions
- Docker SQL-stream crash/resume E2E — 7 tests
- `composer analyze -- --memory-limit=1G`
- PHPCompatibility on the changed exporter files at PHP 7.2+ and importer file at PHP 7.4+
- Real PHP 7.2 parse checks on the changed exporter source and both mirrors
- PHPCS per-file error and warning counts did not increase
- `node --check` on both changed E2E files
- `git diff --check`
