### PR TITLE
[Push] Seed single-root push baselines from full-root pulls

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -25,6 +25,7 @@ baseline:
   local-delete-stream.bin
   session.json
   last-sync-local-files.jsonl
+  last-sync-local-files.identity.json
 ~~~
 
 The source scan reads directory entries one at a time into an unsorted JSONL
@@ -60,6 +61,42 @@ next push rather than being silently called deployed.
 The token is deliberately small rather than a content hash. A same-size edit
 within the filesystem ctime resolution can escape both it and the snapshot
 diff, which uses the same size and ctime signals.
+
+### Baseline initialization from pull
+
+Without pull seeding, only a successful push can establish or replace the
+sender baseline. Reprint additionally supports the full-root pull → edit → push
+workflow: a completed, unfiltered filesystem pull may publish the resulting
+local filesystem snapshot as that same sender baseline for the same target,
+managed directory, local root, and state directory. The snapshot is generated
+from the finished local tree, so remote ctimes are never reused as local change
+evidence. The small adjacent identity file binds the JSONL snapshot to the
+managed directory and canonical local root; it is not another baseline. There
+is still one baseline format and one target-specific source of truth.
+
+The shared pull/push URL must contain exactly one scalar absolute `directory`
+query parameter. This gives the sender the managed-directory identity without
+another preflight or a target index. Publication also requires `--filter=none`,
+no `--only` or `--remap`, and normal overwrite behavior rather than
+`--on-fs-root-nonempty=preserve-local`. Repeated, bracketed, relative, or
+dot-segment directory forms do not publish a baseline. They are not rejected as
+pull inputs: a multi-root `directory[]` pull still traverses every root, but the
+current single-root push model cannot represent it as one baseline identity.
+
+Before a new pull first mutates the applicable local tree, it invalidates the
+old baseline. It publishes a replacement through adjacent temporary files and
+atomic renames only after the complete unfiltered filesystem phase and local
+snapshot both succeed. The identity is removed before either final rename, so
+an interrupted publication is unavailable rather than paired with stale
+identity. An interrupted pull, a filtered pull, or a failed snapshot
+publication therefore leaves the full-root baseline unavailable; a later push
+cannot interpret partially pulled files as user edits.
+
+A push without a compatible baseline keeps create-only semantics. It neither
+downloads a remote index nor compares ctimes from different machines. Against
+an existing full target it fails safely and directs the operator to complete an
+unfiltered pull with the same explicit managed-directory URL and state
+directory; there is no public initialization flag or second baseline.
 
 ## Endpoint vocabulary and authentication
 
@@ -357,11 +394,13 @@ reprint push-status <target-url> \
   --state-dir=DIR --secret=TOKEN [--allow-http] [--verbose]
 ~~~
 
-push resumes an existing compatible local session by default. --dry-run builds
-and reports the local plan without creating a target session or publishing a
-baseline, and rejects when an active push already exists. --abort removes local
-state only after target discard confirms; once direct live mutation began it
-refuses and tells the operator to rerun normal push.
+Invoking push without --dry-run authorizes applying the delta computed by that
+invocation. --dry-run builds and reports the current local plan without creating
+a target session or publishing a baseline; a later push rescans rather than
+reusing that plan. An empty delta completes locally without opening a target
+session. Push resumes an existing compatible local session by default. --abort
+removes local state only after target discard confirms; once direct live mutation
+began it refuses and tells the operator to rerun normal push.
 push-status does not require a source root, does not scan a tree, and never
 creates a session.
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1353,7 +1353,7 @@ class ImportClient
                 'base_url' => $this->remote_url,
                 // push-status never scans this directory. Give the shared
                 // state reader a real harmless root so status also works
-                // before --state-dir has been created by a first push.
+                // before any push has created --state-dir.
                 'source_root' => $command === 'push' ? $options['source_root'] : getcwd(),
                 'state_dir' => $this->state_dir,
                 'secret' => $secret,
@@ -2627,6 +2627,12 @@ class ImportClient
                 );
             }
 
+            // Once a new pull may change the local tree, the previous
+            // full-root snapshot can no longer prove which edits belong to
+            // the user. A partial, filtered, or ambiguously rooted pull leaves
+            // the target's one baseline invalid.
+            PushJournal::invalidate_local_files_baseline($this->state_dir, $this->remote_url);
+
             $this->import_state()->active_resumable_command->command_name = "files-pull";
             $this->import_state()->active_resumable_command->completion_state = "in_progress";
             $this->import_state()->active_resumable_command->current_stage = "index";
@@ -2685,6 +2691,8 @@ class ImportClient
             return;
         }
 
+        $this->publish_pull_push_baseline();
+
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->save_state($this->state);
 
@@ -2710,6 +2718,74 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+    }
+
+    /**
+     * Publishes an actual-local-tree snapshot after an eligible full pull.
+     *
+     * Remote index ctimes belong to another machine and cannot seed push
+     * change detection. The shared push scanner records local ctimes after all
+     * writes finish, then PushJournal publishes the existing baseline format
+     * before files-pull is marked complete.
+     */
+    private function publish_pull_push_baseline(): void
+    {
+        if (
+            $this->filter !== "none" ||
+            $this->pull_only_files_with_path_prefixes !== [] ||
+            $this->remap_rules !== [] ||
+            $this->fs_root_nonempty_behavior === 'preserve-local'
+        ) {
+            return;
+        }
+        $push_baseline = $this->pull_push_baseline_identity();
+        if ($push_baseline === null) {
+            return;
+        }
+
+        $snapshot = $this->state_dir . '/.pull-push-baseline-' . bin2hex(random_bytes(8)) . '.jsonl';
+        try {
+            MultipartPush::write_local_snapshot(
+                $push_baseline['local_root'],
+                $snapshot,
+                $this->state_dir
+            );
+            $push_baseline['journal']->capture_local_files_baseline($snapshot);
+        } finally {
+            @unlink($snapshot);
+            @unlink($snapshot . '.tmp');
+        }
+    }
+
+    /**
+     * Resolves the exact local root represented by the URL's managed directory.
+     *
+     * A pull can seed a push only when its URL carries one scalar absolute
+     * `directory` value. That same URL and state directory then select the
+     * journal used by push; no remote index or machine-local ctime crosses the
+     * boundary.
+     *
+     * @return array{journal:PushJournal,local_root:string}|null
+     */
+    private function pull_push_baseline_identity(): ?array
+    {
+        $managed_directory = PushJournal::managed_directory_from_url($this->remote_url);
+        if ($managed_directory === null) {
+            return null;
+        }
+        $filesystem_root = $this->get_filesystem_root_path();
+        $local_root = $managed_directory === '/'
+            ? $filesystem_root
+            : $filesystem_root . $managed_directory;
+        $canonical_local_root = realpath($local_root);
+        if (is_string($canonical_local_root)) {
+            $local_root = $canonical_local_root;
+        }
+        $local_root = $local_root === '/' ? '/' : rtrim($local_root, '/');
+        return [
+            'journal' => new PushJournal($this->state_dir, $this->remote_url, $local_root),
+            'local_root' => $local_root,
+        ];
     }
 
     /**
@@ -12530,7 +12606,9 @@ if (
                 "push baseline, then streams changed files, symlinks, empty directories,\n" .
                 "and deletes to one private target session. After upload completes, the target\n" .
                 "deletes planned roots and installs staged values directly. Re-run after an\n" .
-                "interruption; it resumes from target-confirmed staging state.\n",
+                "interruption; it resumes from target-confirmed staging state. Running push\n" .
+                "authorizes applying the delta computed by that invocation. --dry-run reports\n" .
+                "the current plan without contacting the target; a later push rescans the source tree.\n",
             "extra" =>
                 "Examples:\n" .
                 "  reprint push https://example.com --source-root=./wordpress \\\n" .

--- a/packages/reprint-importer/src/lib/push/class-multipart-push.php
+++ b/packages/reprint-importer/src/lib/push/class-multipart-push.php
@@ -5,12 +5,13 @@
 /**
  * Drives a local source tree through the resumable staged-push protocol.
  *
- * This is the sender's high-level lifecycle. A first run scans the source
- * without following symlinks, externally sorts a JSONL snapshot, and compares
- * it with the last completed baseline. Changed and deleted paths remain as
- * disk-backed streaming plans. The driver then creates one target workspace,
- * uploads many bounded parts per HTTP request, and repeats bounded commit calls
- * until the target has deleted and directly installed every planned value.
+ * This is the sender's high-level lifecycle. A new push with no active session
+ * scans the source without following symlinks, externally sorts a JSONL
+ * snapshot, and compares it with the compatible local baseline. Changed and
+ * deleted paths remain as disk-backed streaming plans. The driver then creates
+ * one target workspace, uploads many bounded parts per HTTP request, and
+ * repeats bounded commit calls until the target has deleted and directly
+ * installed every planned value.
  *
  * Example:
  *
@@ -192,7 +193,7 @@ class MultipartPush
         $this->allow_http = $allow_http;
         $this->verbose = (bool) ($options['verbose'] ?? false);
         $this->status_only = $status_only;
-        $this->journal = new PushJournal($this->state_dir, $this->base_url);
+        $this->journal = new PushJournal($this->state_dir, $this->base_url, $this->source_root);
         $this->site_dir = dirname($this->journal->local_files_baseline_path);
         $this->session_path = $this->site_dir . '/session.json';
         $this->snapshot_path = $this->site_dir . '/current-local-files.jsonl';
@@ -203,10 +204,13 @@ class MultipartPush
      *
      * Dry runs build the same disk-backed snapshot and plans without creating
      * a target session, which makes their changed/deleted counts representative
-     * without mutating the target. A normal first run persists its create token
-     * before contacting the target, then checkpoints every target-confirmed
-     * cursor and learned request-size decision. Re-running after an exception
-     * continues the active phase rather than rescanning underneath it.
+     * without mutating the target. A later non-dry-run invocation rescans; that
+     * invocation authorizes applying the delta it computes. An empty delta
+     * refreshes the local baseline without contacting the target. A normal run
+     * with work persists its create token before contacting the target, then
+     * checkpoints every target-confirmed cursor and learned request-size
+     * decision. Re-running after an exception continues the active phase rather
+     * than rescanning underneath it.
      *
      * After target commit completes, the starting snapshot atomically becomes
      * the next local baseline. The sender then discards the successful target
@@ -237,6 +241,13 @@ class MultipartPush
             $summary = $this->prepare_new_push();
             if ($dry_run) {
                 return array_merge(['status' => 'dry_run'], $summary);
+            }
+            if ($summary['changed'] === 0 && $summary['deleted'] === 0) {
+                // An empty delta has nothing to stage or commit. Refresh the
+                // snapshot-backed baseline locally instead of opening a target
+                // session whose empty commit would briefly enter maintenance.
+                $this->journal->capture_local_files_baseline($this->snapshot_path);
+                return array_merge(['status' => 'complete'], $summary);
             }
             $state = [
                 'version' => 1,
@@ -422,28 +433,61 @@ class MultipartPush
         if (!is_dir($this->site_dir) && !@mkdir($this->site_dir, 0700, true) && !is_dir($this->site_dir)) {
             throw new RuntimeException('Could not create push state directory ' . $this->site_dir . '.');
         }
-        $temporary = $this->snapshot_path . '.tmp';
+        self::write_local_snapshot($this->source_root, $this->snapshot_path, $this->site_dir);
+        return $this->journal->diff_local_files($this->snapshot_path);
+    }
+
+    /**
+     * Writes the same sorted local snapshot used to plan a push.
+     *
+     * A completed full-root pull uses this after all local writes finish, so
+     * its baseline records local ctimes and the private structural markers a
+     * later push diff needs. The temporary scan remains bounded by the external
+     * sort's memory limit and is removed on success or failure.
+     *
+     * @param string $source_root Canonical local directory to scan.
+     * @param string $snapshot_path Final sorted JSONL snapshot path.
+     * @param string $working_dir Existing directory for external-sort chunks.
+     */
+    public static function write_local_snapshot(string $source_root, string $snapshot_path, string $working_dir): void
+    {
+        $requested_source_root = $source_root;
+        $source_root = realpath($requested_source_root);
+        if ($source_root === false || !is_dir($source_root) || is_link($requested_source_root)) {
+            throw new RuntimeException(
+                'Could not snapshot local root ' . $requested_source_root
+                . ': it must resolve to a real directory and cannot be a symlink.'
+            );
+        }
+        if (!is_dir($working_dir)) {
+            throw new RuntimeException('Could not write a local snapshot without an existing working directory: ' . $working_dir . '.');
+        }
+        $source_root = $source_root === '/' ? '/' : rtrim($source_root, '/');
+        $temporary = $snapshot_path . '.tmp';
         $handle = @fopen($temporary, 'wb');
         if ($handle === false) {
             throw new RuntimeException('Could not write local push snapshot ' . $temporary . '.');
         }
         try {
-            $this->scan_directory($this->source_root, '', $handle, null);
-        } finally {
-            fclose($handle);
-        }
-        (new ExternalMergeSort(function (string $line): ?string {
-            $entry = json_decode($line, true);
-            if (!is_array($entry) || !isset($entry['path']) || !is_string($entry['path'])) {
-                return null;
+            self::scan_directory($source_root, '', $handle, null);
+            if (!fclose($handle)) {
+                throw new RuntimeException('Could not finish local push snapshot ' . $temporary . '.');
             }
-            $path = base64_decode($entry['path'], true);
-            return $path === false ? null : $path;
-        }, self::SNAPSHOT_SORT_MEMORY_BYTES, true, $this->site_dir))->sort($temporary, $this->snapshot_path);
-        if (is_file($temporary)) {
+            $handle = null;
+            ( new ExternalMergeSort(function (string $line): ?string {
+                $entry = json_decode($line, true);
+                if (!is_array($entry) || !isset($entry['path']) || !is_string($entry['path'])) {
+                    return null;
+                }
+                $path = base64_decode($entry['path'], true);
+                return $path === false ? null : $path;
+            }, self::SNAPSHOT_SORT_MEMORY_BYTES, true, $working_dir) )->sort($temporary, $snapshot_path);
+        } finally {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
             @unlink($temporary);
         }
-        return $this->journal->diff_local_files($this->snapshot_path);
     }
 
     /**
@@ -455,7 +499,7 @@ class MultipartPush
      * @param resource $handle Writable unsorted snapshot stream.
      * @param int|null $directory_ctime Parent-supplied lstat ctime for this directory.
      */
-    private function scan_directory(string $directory, string $relative_path, $handle, ?int $directory_ctime): void
+    private static function scan_directory(string $directory, string $relative_path, $handle, ?int $directory_ctime): void
     {
         $directory_handle = @opendir($directory);
         if ($directory_handle === false) {
@@ -478,38 +522,38 @@ class MultipartPush
                         // children create them. Keep an existence-only baseline marker so
                         // deleting a whole non-empty directory also removes the now-empty
                         // directory on the target.
-                        $this->write_snapshot_entry($handle, $relative_path, 'tree-directory', 0, $directory_ctime ?? 0);
+                        self::write_snapshot_entry($handle, $relative_path, 'tree-directory', 0, $directory_ctime ?? 0);
                     }
                 }
                 $path = $relative_path === '' ? $entry : $relative_path . '/' . $entry;
-                $this->validate_relative_path($path);
+                self::validate_relative_path($path);
                 $absolute_path = $directory . '/' . $entry;
                 clearstatcache(true, $absolute_path);
                 $stat = @lstat($absolute_path);
                 if (!is_array($stat) || !isset($stat['mode'], $stat['ctime'], $stat['size'])) {
-                    throw new RuntimeException('Could not stat source path ' . $this->display_path($path) . '.');
+                    throw new RuntimeException('Could not stat source path ' . self::display_path($path) . '.');
                 }
                 $mode = (int) $stat['mode'];
                 $type_bits = $mode & 0170000;
                 if ($type_bits === 0040000) {
-                    $this->scan_directory($absolute_path, $path, $handle, (int) $stat['ctime']);
+                    self::scan_directory($absolute_path, $path, $handle, (int) $stat['ctime']);
                 } elseif ($type_bits === 0100000) {
-                    $this->write_snapshot_entry($handle, $path, 'file', (int) $stat['size'], (int) $stat['ctime']);
+                    self::write_snapshot_entry($handle, $path, 'file', (int) $stat['size'], (int) $stat['ctime']);
                 } elseif ($type_bits === 0120000) {
                     $target = @readlink($absolute_path);
                     if (!is_string($target)) {
-                        throw new RuntimeException('Could not read source symlink ' . $this->display_path($path) . '.');
+                        throw new RuntimeException('Could not read source symlink ' . self::display_path($path) . '.');
                     }
-                    $this->write_snapshot_entry($handle, $path, 'symlink', (int) $stat['size'], (int) $stat['ctime'], $target);
+                    self::write_snapshot_entry($handle, $path, 'symlink', (int) $stat['size'], (int) $stat['ctime'], $target);
                 } else {
-                    throw new RuntimeException('Source path ' . $this->display_path($path) . ' has an unsupported filesystem type.');
+                    throw new RuntimeException('Source path ' . self::display_path($path) . ' has an unsupported filesystem type.');
                 }
             }
         } finally {
             closedir($directory_handle);
         }
         if ($relative_path !== '' && !$has_children) {
-            $this->write_snapshot_entry($handle, $relative_path, 'directory', 0, $directory_ctime ?? 0);
+            self::write_snapshot_entry($handle, $relative_path, 'directory', 0, $directory_ctime ?? 0);
         }
     }
 
@@ -528,7 +572,7 @@ class MultipartPush
      * @param int $ctime lstat change timestamp in seconds.
      * @param string|null $target Literal symlink target, when applicable.
      */
-    private function write_snapshot_entry($handle, string $path, string $type, int $size, int $ctime, ?string $target = null): void
+    private static function write_snapshot_entry($handle, string $path, string $type, int $size, int $ctime, ?string $target = null): void
     {
         $entry = [
             'path' => base64_encode($path),
@@ -541,7 +585,7 @@ class MultipartPush
         }
         $line = json_encode($entry, JSON_UNESCAPED_SLASHES);
         if ($line === false || fwrite($handle, $line . "\n") !== strlen($line) + 1) {
-            throw new RuntimeException('Could not write local push snapshot entry for ' . $this->display_path($path) . '.');
+            throw new RuntimeException('Could not write local push snapshot entry for ' . self::display_path($path) . '.');
         }
     }
 
@@ -1101,7 +1145,7 @@ class MultipartPush
                 continue;
             }
             if (($confirmation['path_b64'] ?? null) !== base64_encode($descriptor['path']) || ($confirmation['state'] ?? null) !== 'complete') {
-                throw new RuntimeException('Target did not confirm completed ' . $descriptor['type'] . ' ' . $this->display_path($descriptor['path']) . '.');
+                throw new RuntimeException('Target did not confirm completed ' . $descriptor['type'] . ' ' . self::display_path($descriptor['path']) . '.');
             }
             $state['plan_offset'] = $descriptor['next_plan_offset'];
         }
@@ -1125,9 +1169,21 @@ class MultipartPush
             $target_response = is_array($result['response'] ?? null)
                 ? json_encode($result['response'], JSON_UNESCAPED_SLASHES)
                 : false;
+            $detail = is_string($result['detail'] ?? null) ? $result['detail'] : '';
+            $baseline_guidance = '';
+            if (
+                ( $result['reason'] ?? null ) === 'invalid_session_request' &&
+                strpos($detail, 'Protected target-relative path cannot be changed:') === 0 &&
+                !$this->journal->has_compatible_local_files_baseline()
+            ) {
+                $baseline_guidance = ' This push has no compatible full-root baseline. Abort this private push, '
+                    . 'complete an unfiltered files-pull from the same target using one explicit absolute directory '
+                    . 'query parameter and the same --state-dir, then push the pulled local site root with that URL.';
+            }
             throw new RuntimeException(
-                'Multipart upload failed: ' . ( $result['reason'] ?? 'unknown' ) . '. ' . ( $result['detail'] ?? '' )
+                'Multipart upload failed: ' . ( $result['reason'] ?? 'unknown' ) . '. ' . $detail
                 . ( $target_response === false ? '' : ' Target response: ' . $target_response )
+                . $baseline_guidance
             );
         }
         // A retry has no sender-confirmed outcome. Ask the target for only
@@ -1328,7 +1384,7 @@ class MultipartPush
             }
             $type = $entry['type'] ?? null;
             if (!is_string($type) || !in_array($type, ['file', 'directory', 'symlink'], true)) {
-                throw new RuntimeException('Local changed-path list contains no supported logical type for ' . $this->display_path($path) . '.');
+                throw new RuntimeException('Local changed-path list contains no supported logical type for ' . self::display_path($path) . '.');
             }
             return [
                 'path' => $path,
@@ -1520,7 +1576,7 @@ class MultipartPush
      */
     private function source_path(string $relative_path): string
     {
-        $this->validate_relative_path($relative_path);
+        self::validate_relative_path($relative_path);
         return ($this->source_root === '/' ? '' : $this->source_root) . '/' . $relative_path;
     }
 
@@ -1532,14 +1588,14 @@ class MultipartPush
      *
      * @param string $path Target-relative source path.
      */
-    private function validate_relative_path(string $path): void
+    private static function validate_relative_path(string $path): void
     {
         if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
-            throw new RuntimeException('Source path cannot be sent safely: ' . $this->display_path($path) . '.');
+            throw new RuntimeException('Source path cannot be sent safely: ' . self::display_path($path) . '.');
         }
         foreach (explode('/', $path) as $segment) {
             if ($segment === '' || $segment === '.' || $segment === '..') {
-                throw new RuntimeException('Source path cannot be sent safely: ' . $this->display_path($path) . '.');
+                throw new RuntimeException('Source path cannot be sent safely: ' . self::display_path($path) . '.');
             }
         }
         if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
@@ -1553,7 +1609,7 @@ class MultipartPush
      * @param string $path Raw filesystem path bytes.
      * @return string Base64 representation.
      */
-    private function display_path(string $path): string
+    private static function display_path(string $path): string
     {
         return base64_encode($path);
     }

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -2,7 +2,7 @@
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal errors are CLI values, never HTML output.
 /**
- * Per-remote-site memory of the last completed push: the local baseline.
+ * Per-remote-site source snapshot used to plan a push: the local baseline.
  *
  * ctime is machine-local, so push never compares a local timestamp against
  * a remote one. Each machine is compared against its own past instead
@@ -10,22 +10,21 @@
  * on the local machine, one directory per remote site:
  *
  *     <state-dir>/push/<site>/last-sync-local-files.jsonl
+ *     <state-dir>/push/<site>/last-sync-local-files.identity.json
  *
  * The baseline is a copy of a file index in the same format as
  * .import-index.jsonl: one JSON object per line with a base64-encoded path
  * plus ctime, size, type, and any symlink target, sorted by
  * decoded path. Non-empty directories use a private `tree-directory` marker:
  * it is never uploaded, but lets a later diff remove a vanished directory
- * after its last child goes. The push driver captures it at the end of a
- * successful push. A capture writes a temporary file and renames it into
- * place, so a killed process never leaves a truncated baseline for the next
- * push to trust — until the rename lands, the previous baseline stays in
- * effect.
+ * after its last child goes. The adjacent identity binds that snapshot to
+ * the managed remote directory and canonical local root which produced it.
+ * A completed push or eligible full-root pull captures both.
  *
- * diff_local_files() answers "what changed on this machine since the last
- * push to this site". It streams the current index and the local baseline
- * together — both are sorted by path, so one pass suffices — and writes
- * two outputs into the site directory:
+ * diff_local_files() answers "what changed on this machine since this
+ * compatible baseline was captured". It streams the current index and the
+ * local baseline together — both are sorted by path, so one pass suffices —
+ * and writes two outputs into the site directory:
  *
  *     local-paths-to-push.jsonl  paths new since the baseline, or whose
  *                                ctime, size, or type differs
@@ -44,7 +43,8 @@
  * positive changes immediately before upload; their fields are the normalized
  * logical change, not source truth after the plan was written.
  *
- * With no baseline yet — the first push to a site — every uploadable current
+ * With no compatible baseline — because none has been captured yet, or the
+ * push uses another managed directory or local root — every uploadable current
  * entry counts as changed and no deletion can be detected.
  *
  * Producing the current index is the caller's job; this class only
@@ -61,7 +61,7 @@
  *
  * Example:
  *
- *     $journal = new PushJournal('/srv/reprint-state', $target_url);
+ *     $journal = new PushJournal('/srv/reprint-state', $target_url, '/srv/local-site');
  *     $summary = $journal->diff_local_files($current_snapshot);
  *     // Stream the positive plan and raw delete stream, then wait for commit.
  *     // After target commit succeeds:
@@ -87,6 +87,20 @@ class PushJournal
     public string $local_files_baseline_path;
 
     /**
+     * Identity which makes the adjacent baseline eligible for this source.
+     *
+     * @var string
+     */
+    public string $local_files_identity_path;
+
+    /**
+     * Managed remote directory and local root expected by this journal.
+     *
+     * @var array{managed_directory_b64:string|null,local_root_b64:string}
+     */
+    private array $local_files_identity;
+
+    /**
      * JSONL current-snapshot entries which the active push must materialize.
      *
      * @var string
@@ -108,11 +122,22 @@ class PushJournal
      *
      * @param string $state_dir Local root shared by push state for all targets.
      * @param string $site_url Remote site URL used to isolate this baseline.
+     * @param string $local_root Canonical local root represented by the baseline.
      */
-    public function __construct(string $state_dir, string $site_url)
+    public function __construct(string $state_dir, string $site_url, string $local_root)
     {
+        if ($local_root === '' || $local_root[0] !== '/') {
+            throw new InvalidArgumentException("Push journal local_root must be an absolute path: {$local_root}");
+        }
+        $local_root = $local_root === '/' ? '/' : rtrim($local_root, '/');
+        $managed_directory = self::managed_directory_from_url($site_url);
         $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
         $this->local_files_baseline_path = $this->site_dir . "/last-sync-local-files.jsonl";
+        $this->local_files_identity_path = $this->site_dir . "/last-sync-local-files.identity.json";
+        $this->local_files_identity = [
+            'managed_directory_b64' => $managed_directory === null ? null : base64_encode($managed_directory),
+            'local_root_b64' => base64_encode($local_root),
+        ];
         $this->local_paths_to_push = $this->site_dir . "/local-paths-to-push.jsonl";
         $this->local_delete_stream_path = $this->site_dir . "/local-delete-stream.bin";
     }
@@ -159,19 +184,129 @@ class PushJournal
     }
 
     /**
+     * Returns the one explicit absolute directory selected by a target URL.
+     *
+     * Pull baseline publication needs an exact managed-directory identity.
+     * A missing parameter, a repeated/array parameter, or a relative value is
+     * ambiguous and therefore cannot seed a full-root push baseline.
+     *
+     * @param string $site_url Exporter URL supplied to both pull and push.
+     * @return string|null Normalized absolute directory, or null when ambiguous.
+     */
+    public static function managed_directory_from_url(string $site_url): ?string
+    {
+        $query = parse_url($site_url, PHP_URL_QUERY);
+        if (!is_string($query) || $query === '') {
+            return null;
+        }
+        $directories = [];
+        foreach (explode('&', $query) as $parameter) {
+            [$encoded_name, $encoded_value] = array_pad(explode('=', $parameter, 2), 2, '');
+            $name = urldecode($encoded_name);
+            if (
+                strpos($name, 'directory[') === 0 ||
+                strpos($name, 'directory]') === 0
+            ) {
+                return null;
+            }
+            if ($name === 'directory') {
+                $directories[] = urldecode($encoded_value);
+            }
+        }
+        if (count($directories) !== 1) {
+            return null;
+        }
+        $directory = $directories[0];
+        if ($directory === '' || $directory[0] !== '/' || strpos($directory, "\0") !== false) {
+            return null;
+        }
+        foreach (explode('/', $directory) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                return null;
+            }
+        }
+        $directory = rtrim($directory, '/');
+        return $directory === '' ? '/' : $directory;
+    }
+
+    /**
      * Stores a copy of the local file index as the new local baseline.
      *
      * The push driver calls this at the end of a successful push; from then
-     * on "changed locally" means "different from this index". The copy is
-     * atomic (temp file + rename) and the source file is left untouched.
+     * on "changed locally" means "different from this index". Both files are
+     * prepared before the old identity is invalidated. The baseline and then
+     * its identity are renamed into place, so any interrupted publication is
+     * unavailable rather than trusted with the wrong identity. The source file
+     * is left untouched.
      *
-     * @param string $index_file Sorted JSONL snapshot whose target commit completed.
+     * @param string $index_file Sorted JSONL snapshot whose push or pull filesystem phase completed.
      *
      * @throws RuntimeException If the snapshot is missing or cannot be published.
      */
     public function capture_local_files_baseline(string $index_file): void
     {
-        $this->replace_file($this->local_files_baseline_path, $index_file);
+        if (!is_file($index_file)) {
+            throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$index_file}");
+        }
+        $this->ensure_site_dir();
+        $baseline_tmp = $this->local_files_baseline_path . ".tmp";
+        $identity_tmp = $this->local_files_identity_path . ".tmp";
+        if (!copy($index_file, $baseline_tmp)) {
+            throw new RuntimeException("Failed to copy the index into a baseline temp file: {$baseline_tmp}");
+        }
+        $identity = json_encode($this->local_files_identity, JSON_UNESCAPED_SLASHES);
+        if ($identity === false || file_put_contents($identity_tmp, $identity . "\n") !== strlen($identity) + 1) {
+            @unlink($baseline_tmp);
+            @unlink($identity_tmp);
+            throw new RuntimeException("Failed to write the local baseline identity: {$identity_tmp}");
+        }
+        if (is_file($this->local_files_identity_path) && !unlink($this->local_files_identity_path)) {
+            @unlink($baseline_tmp);
+            @unlink($identity_tmp);
+            throw new RuntimeException("Failed to invalidate the prior local baseline identity: {$this->local_files_identity_path}");
+        }
+        if (!rename($baseline_tmp, $this->local_files_baseline_path)) {
+            @unlink($baseline_tmp);
+            @unlink($identity_tmp);
+            throw new RuntimeException("Failed to move the baseline into place: {$this->local_files_baseline_path}");
+        }
+        if (!rename($identity_tmp, $this->local_files_identity_path)) {
+            @unlink($identity_tmp);
+            throw new RuntimeException("Failed to move the local baseline identity into place: {$this->local_files_identity_path}");
+        }
+    }
+
+    /** Returns whether the existing baseline belongs to this exact source. */
+    public function has_compatible_local_files_baseline(): bool
+    {
+        if (!is_file($this->local_files_baseline_path) || !is_file($this->local_files_identity_path)) {
+            return false;
+        }
+        // phpcs:ignore WordPress.WhiteSpace.CastStructureSpacing.NoSpaceBeforeOpenParenthesis -- Match this class's established cast style.
+        $identity = json_decode((string) file_get_contents($this->local_files_identity_path), true);
+        return is_array($identity) && $identity === $this->local_files_identity;
+    }
+
+    /**
+     * Makes the current baseline unavailable before a pull can mutate files.
+     *
+     * The baseline goes first. If removing the identity subsequently fails,
+     * no snapshot remains for that identity to make trustworthy.
+     *
+     * @param string $state_dir Local root shared by push state for all targets.
+     * @param string $site_url Remote site URL whose one baseline is invalidated.
+     */
+    public static function invalidate_local_files_baseline(string $state_dir, string $site_url): void
+    {
+        $site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
+        $baseline_path = $site_dir . "/last-sync-local-files.jsonl";
+        $identity_path = $site_dir . "/last-sync-local-files.identity.json";
+        if (is_file($baseline_path) && !unlink($baseline_path)) {
+            throw new RuntimeException("Failed to invalidate the local baseline: {$baseline_path}");
+        }
+        if (is_file($identity_path) && !unlink($identity_path)) {
+            throw new RuntimeException("Failed to remove the invalid local baseline identity: {$identity_path}");
+        }
     }
 
     /**
@@ -208,7 +343,7 @@ class PushJournal
             throw new RuntimeException("Failed to open the current index: {$current_index_file}");
         }
         $baseline_handle = null;
-        if (is_file($this->local_files_baseline_path)) {
+        if ($this->has_compatible_local_files_baseline()) {
             $baseline_handle = fopen($this->local_files_baseline_path, "r");
             if (!$baseline_handle) {
                 fclose($current_handle);
@@ -432,30 +567,6 @@ class PushJournal
         }
         $entry = $decoded_entry;
         $path = $decoded_path;
-    }
-
-    /**
-     * Copies an index file over a baseline through an adjacent temporary file.
-     *
-     * The final rename means readers see either the prior completed baseline or
-     * the new complete snapshot, never a partially copied index.
-     *
-     * @param string $target Final baseline path.
-     * @param string $source_index_file Completed snapshot to copy.
-     */
-    private function replace_file(string $target, string $source_index_file): void
-    {
-        if (!is_file($source_index_file)) {
-            throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$source_index_file}");
-        }
-        $this->ensure_site_dir();
-        $tmp = $target . ".tmp";
-        if (!copy($source_index_file, $tmp)) {
-            throw new RuntimeException("Failed to copy the index into a baseline temp file: {$tmp}");
-        }
-        if (!rename($tmp, $target)) {
-            throw new RuntimeException("Failed to move the baseline into place: {$target}");
-        }
     }
 
     /**

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -45,6 +45,8 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--dry-run', $output);
         $this->assertStringContainsString('--abort', $output);
         $this->assertStringContainsString('--allow-http', $output);
+        $this->assertStringContainsString('authorizes applying the delta', $output);
+        $this->assertStringContainsString('a later push rescans the source tree', $output);
         $this->assertStringNotContainsString('push-commit', $output);
     }
 }

--- a/tests/Import/MultipartPushTest.php
+++ b/tests/Import/MultipartPushTest.php
@@ -44,6 +44,8 @@ final class MultipartPushTest extends TestCase {
     private ?string $reject_upload_marker = null;
     private ?string $drop_discard_response_marker = null;
     private bool $make_checkpoint_unremovable_after_discard = false;
+    /** @var string[] */
+    private array $apply_protected_paths = [];
 
     public static function setUpBeforeClass(): void {
         if (!function_exists('curl_init')) {
@@ -115,6 +117,54 @@ final class MultipartPushTest extends TestCase {
         }
     }
 
+    public function testSharedSnapshotWriterKeepsStructuralMarkersOutOfTheUploadPlan(): void {
+        $this->write_source('wp-content/plugins/demo/plugin.php', '<?php');
+        mkdir($this->source . '/empty', 0700, true);
+        $snapshot = $this->state . '/pulled-local-files.jsonl';
+        mkdir($this->state, 0700, true);
+
+        \MultipartPush::write_local_snapshot($this->source, $snapshot, $this->state);
+
+        $entries = array_map(static function (string $line): array {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $entry['path'] = base64_decode($entry['path'], true);
+            return $entry;
+        }, file($snapshot, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
+        $types = [];
+        foreach ($entries as $entry) {
+            $types[$entry['path']] = $entry['type'];
+        }
+        $this->assertSame('tree-directory', $types['wp-content'] ?? null);
+        $this->assertSame('tree-directory', $types['wp-content/plugins'] ?? null);
+        $this->assertSame('file', $types['wp-content/plugins/demo/plugin.php'] ?? null);
+        $this->assertSame('directory', $types['empty'] ?? null);
+
+        $journal = new \PushJournal($this->state, self::$base_url, $this->source);
+        $journal->diff_local_files($snapshot);
+        $plannedTypes = array_map(static function (string $line): ?string {
+            $entry = json_decode($line, true);
+            return is_array($entry) ? ( $entry['type'] ?? null ) : null;
+        }, file($journal->local_paths_to_push, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
+        $this->assertNotContains('tree-directory', $plannedTypes);
+    }
+
+    public function testNakedFullRootPushExplainsHowToSeedTheBaselineAfterProtectedRejection(): void {
+        $this->apply_protected_paths = ['wp-content/plugins/site-export'];
+        $this->configure_server();
+        $this->write_source('wp-content/plugins/site-export/index.php', 'sender copy');
+        mkdir($this->target . '/wp-content/plugins/site-export', 0700, true);
+        file_put_contents($this->target . '/wp-content/plugins/site-export/index.php', 'live exporter');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertNotSame(0, $result['exit_code']);
+        $this->assertStringContainsString('no compatible full-root baseline', $result['stderr']);
+        $this->assertStringContainsString('unfiltered files-pull', $result['stderr']);
+        $this->assertStringContainsString('same --state-dir', $result['stderr']);
+        $this->assertSame('live exporter', file_get_contents($this->target . '/wp-content/plugins/site-export/index.php'));
+        $this->assertFileDoesNotExist($this->target . '/.maintenance');
+    }
+
     public function testCliPushDeliversInitialAndDeltaTreesThroughTheRealRouter(): void {
         $this->write_source('large.bin', str_repeat('payload-', 80));
         $this->write_source('delete-on-delta.txt', 'delete me');
@@ -171,6 +221,23 @@ final class MultipartPushTest extends TestCase {
         $status = $this->run_cli('push-status');
         $this->assertSame(0, $status['exit_code'], $status['stderr']);
         $this->assertSame('no_active_push', $status['json']['status'] ?? null);
+    }
+
+    public function testZeroDeltaPushCompletesWithoutContactingTarget(): void {
+        $this->write_source('unchanged.txt', 'same bytes');
+        $first = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertSame(0, $first['exit_code'], $first['stderr']);
+        $requests_before = file_get_contents($this->request_log);
+        $this->assertIsString($requests_before);
+
+        $second = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $second['exit_code'], $second['stderr']);
+        $this->assertSame('complete', $second['json']['status'] ?? null);
+        $this->assertSame(0, $second['json']['changed'] ?? null);
+        $this->assertSame(0, $second['json']['deleted'] ?? null);
+        $this->assertSame($requests_before, file_get_contents($this->request_log));
+        $this->assertFileDoesNotExist($this->target . '/.maintenance');
     }
 
     public function testPushMakesTheTargetTreeExactlyMatchAStandaloneSourceSnapshot(): void {
@@ -709,6 +776,28 @@ final class MultipartPushTest extends TestCase {
         $this->assertSame([], glob($this->state . '/push/*/last-sync-local-files.jsonl') ?: []);
     }
 
+    public function testPushAfterDryRunRescansAndAppliesTheCurrentDelta(): void {
+        $this->write_source('rescanned.txt', 'baseline');
+        $initial = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertSame(0, $initial['exit_code'], $initial['stderr']);
+
+        $this->write_source('rescanned.txt', 'dry-run contents');
+        $dry_run = $this->run_cli('push', ['--source-root=' . $this->source, '--dry-run']);
+        $this->assertSame(0, $dry_run['exit_code'], $dry_run['stderr']);
+        $this->assertSame('dry_run', $dry_run['json']['status'] ?? null);
+        $this->assertSame('baseline', file_get_contents($this->target . '/rescanned.txt'));
+
+        $this->write_source('rescanned.txt', 'confirmed contents');
+        $this->write_source('added-after-dry-run.txt', 'newly confirmed');
+        $pushed = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $pushed['exit_code'], $pushed['stderr']);
+        $this->assertSame('complete', $pushed['json']['status'] ?? null);
+        $this->assertSame(2, $pushed['json']['changed'] ?? null);
+        $this->assertSame('confirmed contents', file_get_contents($this->target . '/rescanned.txt'));
+        $this->assertSame('newly confirmed', file_get_contents($this->target . '/added-after-dry-run.txt'));
+    }
+
     public function testDryRunRejectsAnActivePushWithoutAdvancingIt(): void {
         $this->reject_upload_marker = $this->case_root . '/rejected-upload';
         $this->configure_server();
@@ -1070,6 +1159,7 @@ final class MultipartPushTest extends TestCase {
             'reject_upload_marker' => $this->reject_upload_marker,
             'drop_discard_response_marker' => $this->drop_discard_response_marker,
             'make_checkpoint_unremovable_after_discard' => $this->make_checkpoint_unremovable_after_discard,
+            'apply_protected_paths' => $this->apply_protected_paths,
             'local_state_dir' => $this->state,
         ]));
     }

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -95,11 +95,178 @@ final class PushJournalTest extends TestCase
         $this->makeJournal()->capture_local_files_baseline($this->tempDir . '/no-such-index.jsonl');
     }
 
+    public function testCapturedBaselineIsUsableOnlyForItsManagedDirectoryAndLocalRoot(): void
+    {
+        $stateDir = $this->tempDir . '/state';
+        $localRoot = $this->tempDir . '/local-site';
+        $target = 'https://example.com/export?directory=%2Fsrv%2Fsite';
+        $index = $this->writeIndex(['index.php' => [100, 5, 'file']]);
+        $journal = new PushJournal($stateDir, $target, $localRoot);
+
+        $journal->capture_local_files_baseline($index);
+
+        $this->assertTrue($journal->has_compatible_local_files_baseline());
+        $this->assertSame(
+            ['changed' => 0, 'deleted' => 0],
+            $journal->diff_local_files($index)
+        );
+        $otherManagedDirectory = new PushJournal(
+            $stateDir,
+            'https://example.com/export?directory=%2Fsrv%2Fother',
+            $localRoot
+        );
+        $otherLocalRoot = new PushJournal(
+            $stateDir,
+            $target,
+            $this->tempDir . '/other-local-site'
+        );
+        $this->assertFalse($otherManagedDirectory->has_compatible_local_files_baseline());
+        $this->assertFalse($otherLocalRoot->has_compatible_local_files_baseline());
+    }
+
+    public function testTargetAndStateDirectoryKeepBaselinesIndependent(): void
+    {
+        $index = $this->writeIndex(['index.php' => [100, 5, 'file']]);
+        $localRoot = $this->tempDir . '/local-site';
+        $target = 'https://example.com/export?directory=%2Fsrv%2Fsite';
+        $journal = new PushJournal($this->tempDir . '/state-a', $target, $localRoot);
+        $journal->capture_local_files_baseline($index);
+
+        $otherTarget = new PushJournal(
+            $this->tempDir . '/state-a',
+            'https://other.example/export?directory=%2Fsrv%2Fsite',
+            $localRoot
+        );
+        $otherStateDirectory = new PushJournal($this->tempDir . '/state-b', $target, $localRoot);
+        $this->assertFalse($otherTarget->has_compatible_local_files_baseline());
+        $this->assertFalse($otherStateDirectory->has_compatible_local_files_baseline());
+    }
+
+    public function testIncompatibleIdentityUsesCreateOnlyDiff(): void
+    {
+        $stateDir = $this->tempDir . '/state';
+        $localRoot = $this->tempDir . '/local-site';
+        $index = $this->writeIndex(['index.php' => [100, 5, 'file']]);
+        $baselineJournal = new PushJournal(
+            $stateDir,
+            'https://example.com/export?directory=%2Fsrv%2Fsite',
+            $localRoot
+        );
+        $baselineJournal->capture_local_files_baseline($index);
+
+        $journal = new PushJournal(
+            $stateDir,
+            'https://example.com/export?directory=%2Fsrv%2Fother',
+            $localRoot
+        );
+
+        $this->assertSame(['changed' => 1, 'deleted' => 0], $journal->diff_local_files($index));
+        $this->assertSame(['index.php'], $this->listPaths($journal->local_paths_to_push));
+    }
+
+    public function testBaselineWithoutItsIdentityIsNeverTrusted(): void
+    {
+        $journal = $this->makeJournal();
+        $index = $this->writeIndex(['index.php' => [100, 5, 'file']]);
+        mkdir(dirname($journal->local_files_baseline_path), 0755, true);
+        copy($index, $journal->local_files_baseline_path);
+
+        $this->assertFalse($journal->has_compatible_local_files_baseline());
+        $this->assertSame(['changed' => 1, 'deleted' => 0], $journal->diff_local_files($index));
+        $this->assertSame(['index.php'], $this->listPaths($journal->local_paths_to_push));
+    }
+
+    public function testInvalidationRemovesBothBaselineAndIdentity(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'index.php' => [100, 5, 'file'],
+        ]));
+        $this->assertTrue($journal->has_compatible_local_files_baseline());
+
+        PushJournal::invalidate_local_files_baseline(
+            $this->tempDir . '/state',
+            'https://example.com/'
+        );
+
+        $this->assertFalse($journal->has_compatible_local_files_baseline());
+        $this->assertFileDoesNotExist($journal->local_files_baseline_path);
+        $this->assertFileDoesNotExist($journal->local_files_identity_path);
+    }
+
+    public function testFailedCaptureAfterInvalidationCannotRestoreStaleTrust(): void
+    {
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'index.php' => [100, 5, 'file'],
+        ]));
+        PushJournal::invalidate_local_files_baseline(
+            $this->tempDir . '/state',
+            'https://example.com/?directory=%2Fsrv%2Fsite'
+        );
+
+        try {
+            $journal->capture_local_files_baseline($this->tempDir . '/missing-snapshot.jsonl');
+            $this->fail('Expected the missing snapshot capture to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('index file is missing', $exception->getMessage());
+        }
+
+        $this->assertFalse($journal->has_compatible_local_files_baseline());
+    }
+
+    public function testManagedDirectoryRequiresOneAbsoluteScalarUrlParameter(): void
+    {
+        $this->assertSame(
+            '/srv/site',
+            PushJournal::managed_directory_from_url(
+                'https://example.com/export?reprint-api=1&directory=%2Fsrv%2Fsite%2F'
+            )
+        );
+        $this->assertSame(
+            '/',
+            PushJournal::managed_directory_from_url('https://example.com/export?directory=%2F')
+        );
+        $this->assertSame(
+            '/srv//site',
+            PushJournal::managed_directory_from_url('https://example.com/export?directory=%2Fsrv%2F%2Fsite%2F%2F')
+        );
+    }
+
+    public function testManagedDirectoryRejectsEveryUnrepresentableQueryShape(): void
+    {
+        $ineligible_urls = [
+            'missing' => 'https://example.com/export',
+            'empty' => 'https://example.com/export?directory=',
+            'relative' => 'https://example.com/export?directory=relative',
+            'NUL' => 'https://example.com/export?directory=%2Fsrv%00site',
+            'dot segment' => 'https://example.com/export?directory=%2Fsrv%2F.%2Fsite',
+            'dot-dot segment' => 'https://example.com/export?directory=%2Fsrv%2F..%2Fsite',
+            'repeated scalar' => 'https://example.com/export?directory=%2Fsrv%2Fsite&directory=%2Fsrv%2Fother',
+            'literal array' => 'https://example.com/export?directory[]=%2Fsrv%2Fsite',
+            'encoded array' => 'https://example.com/export?directory%5B%5D=%2Fsrv%2Fsite',
+            'indexed array' => 'https://example.com/export?directory%5B0%5D=%2Fsrv%2Fsite',
+            'keyed array' => 'https://example.com/export?directory%5Bsite%5D=%2Fsrv%2Fsite',
+            'nested array' => 'https://example.com/export?directory%5Bsite%5D%5Broot%5D=%2Fsrv%2Fsite',
+            'unclosed bracket' => 'https://example.com/export?directory%5Bsite=%2Fsrv%2Fsite',
+            'unopened bracket' => 'https://example.com/export?directory%5D=%2Fsrv%2Fsite',
+            'mixed scalar and array' => 'https://example.com/export?directory=%2Fsrv%2Fsite&directory%5B%5D=%2Fsrv%2Fother',
+            'encoded name and array' => 'https://example.com/export?%64irectory%5B%5D=%2Fsrv%2Fsite',
+        ];
+
+        foreach ($ineligible_urls as $description => $url) {
+            $this->assertNull(
+                PushJournal::managed_directory_from_url($url),
+                $description
+            );
+        }
+    }
+
     // ------------------------------------------------------------------
     //  Local diff
     // ------------------------------------------------------------------
 
-    public function testFirstPushTreatsEveryEntryAsChanged(): void
+    public function testNoCompatibleBaselineTreatsEveryEntryAsChanged(): void
     {
         $journal = $this->makeJournal();
         $counts = $journal->diff_local_files($this->writeIndex([
@@ -221,7 +388,7 @@ final class PushJournalTest extends TestCase
         foreach ($types as $previousType) {
             foreach ($types as $currentType) {
                 $caseRoot = $this->tempDir . '/' . $previousType . '-to-' . $currentType;
-                $journal = new PushJournal($caseRoot, 'https://example.com/');
+                $journal = new PushJournal($caseRoot, 'https://example.com/', $caseRoot . '/local-site');
                 $baseline = $this->writeLogicalIndex($caseRoot . '-baseline.jsonl', $previousType, 1);
                 $current = $this->writeLogicalIndex($caseRoot . '-current.jsonl', $currentType, 2);
                 $journal->capture_local_files_baseline($baseline);
@@ -294,7 +461,7 @@ final class PushJournalTest extends TestCase
         $journal = $this->makeJournal();
         $index = $this->writeIndex(['a.txt' => [100, 5, 'file']]);
 
-        // First run, no baseline: a.txt lands in local_paths_to_push.
+        // With no compatible baseline, a.txt lands in local_paths_to_push.
         $journal->diff_local_files($index);
         $this->assertSame(['a.txt'], $this->listPaths($journal->local_paths_to_push));
 
@@ -440,7 +607,7 @@ file_put_contents($baseline, json_encode([
     'size' => 0,
     'type' => 'tree-directory',
 ]) . "\n");
-$journal = new PushJournal($root . '/state', 'https://example.com/');
+$journal = new PushJournal($root . '/state', 'https://example.com/', $root . '/local-site');
 $journal->capture_local_files_baseline($baseline);
 $summary = $journal->diff_local_files($current);
 if ($summary !== ['changed' => 500000, 'deleted' => 1]) {
@@ -469,7 +636,11 @@ PHP;
 
     private function makeJournal(): PushJournal
     {
-        return new PushJournal($this->tempDir . '/state', 'https://example.com/');
+        return new PushJournal(
+            $this->tempDir . '/state',
+            'https://example.com/?directory=%2Fsrv%2Fsite',
+            $this->tempDir . '/local-site'
+        );
     }
 
     /**

--- a/tests/Import/StagingExclusionPullTest.php
+++ b/tests/Import/StagingExclusionPullTest.php
@@ -115,7 +115,47 @@ final class StagingExclusionPullTest extends TestCase {
         $this->assertFileDoesNotExist($local_private_path);
         $this->assertNotContains(self::$internal_staging_root, $this->indexedPaths());
         $this->assertNotContains(self::$internal_staging_root . '/private.txt', $this->indexedPaths());
+        $journal_dir = self::$state_dir . '/push/' . \PushJournal::site_key(
+            self::$base_url . '/?directory=' . rawurlencode(self::$remote_site)
+        );
+        $baseline_path = $journal_dir . '/last-sync-local-files.jsonl';
+        $this->assertFileExists($baseline_path);
+        $this->assertFileExists($journal_dir . '/last-sync-local-files.identity.json');
+        $baseline_paths = $this->encodedPathsFromJsonLines($baseline_path);
+        $this->assertNotContains('.reprint-staging', $baseline_paths);
+        $this->assertNotContains('.reprint-staging/private.txt', $baseline_paths);
         $this->assertImporterRequestsContainNoPrivateConfiguration();
+    }
+
+    public function testMultiRootPullTraversesEveryRootWithoutPublishingPushBaseline(): void {
+        $first_root = self::$case_root . '/multi-root-first';
+        $second_root = self::$case_root . '/multi-root-second';
+        mkdir($first_root, 0700, true);
+        mkdir($second_root, 0700, true);
+        file_put_contents($first_root . '/first.txt', 'first root');
+        file_put_contents($second_root . '/second.txt', 'second root');
+        $first_root = (string) realpath($first_root);
+        $second_root = (string) realpath($second_root);
+        $state_dir = self::$case_root . '/multi-root-state';
+        $filesystem_root = self::$case_root . '/multi-root-files';
+        $url = self::$base_url . '/?directory%5B%5D=' . rawurlencode($first_root) .
+            '&directory%5B%5D=' . rawurlencode($second_root);
+        $client = new \ImportClient($url, $state_dir, $filesystem_root);
+        $this->writePreflightState($client, $state_dir, [$first_root, $second_root]);
+
+        $client->run([
+            'command' => 'files-pull',
+            'follow_symlinks' => false,
+        ]);
+
+        $this->assertSame('first root', file_get_contents($filesystem_root . $first_root . '/first.txt'));
+        $this->assertSame('second root', file_get_contents($filesystem_root . $second_root . '/second.txt'));
+        $indexed_paths = $this->encodedPathsFromJsonLines($state_dir . '/.import-index.jsonl');
+        $this->assertContains($first_root . '/first.txt', $indexed_paths);
+        $this->assertContains($second_root . '/second.txt', $indexed_paths);
+        $journal_dir = $state_dir . '/push/' . \PushJournal::site_key($url);
+        $this->assertFileDoesNotExist($journal_dir . '/last-sync-local-files.jsonl');
+        $this->assertFileDoesNotExist($journal_dir . '/last-sync-local-files.identity.json');
     }
 
     private function client(): \ImportClient {
@@ -128,16 +168,22 @@ final class StagingExclusionPullTest extends TestCase {
 
     private function seedPreflightState(): void {
         $client = $this->client();
+        $this->writePreflightState($client, self::$state_dir, [self::$remote_site]);
+    }
+
+    /** @param list<string> $roots */
+    private function writePreflightState(\ImportClient $client, string $state_dir, array $roots): void {
         $state = $client->default_state();
         $state['preflight'] = [
             'http_code' => 200,
             'data' => [
                 'ok' => true,
-                'wp_detect' => [
-                    'roots' => [['path' => self::$remote_site]],
-                ],
+                'wp_detect' => ['roots' => array_map(
+                    static fn(string $path): array => ['path' => $path],
+                    $roots
+                )],
                 'runtime' => [
-                    'document_root' => self::$remote_site,
+                    'document_root' => $roots[0],
                     'ini_get_all' => [],
                 ],
                 'database' => [
@@ -150,7 +196,7 @@ final class StagingExclusionPullTest extends TestCase {
         $state['remote_protocol_min_version'] = 1;
         $state['follow_symlinks'] = false;
         file_put_contents(
-            self::$state_dir . '/.import-state.json',
+            $state_dir . '/.import-state.json',
             json_encode($state, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
         );
     }

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -338,7 +338,7 @@ export function runPush(siteName, sourceDir, stateDir, options = {}) {
     const args = [
         IMPORTER_PATH,
         'push',
-        getSiteUrl(siteName),
+        options.url || getSiteUrl(siteName),
         `--state-dir=${stateDir}`,
         `--source-root=${sourceDir}`,
         `--secret=${getSiteSecret(siteName)}`,

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -145,6 +145,9 @@
     },
     "push-live-conflict": {
       "port": 8127
+    },
+    "push-pull-roundtrip": {
+      "port": 8128
     }
   }
 }

--- a/tests/e2e/tests/import-53-push-direct-apply.test.js
+++ b/tests/e2e/tests/import-53-push-direct-apply.test.js
@@ -10,7 +10,7 @@ import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync,
-    rmSync, symlinkSync, writeFileSync,
+    realpathSync, rmSync, symlinkSync, writeFileSync,
 } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join, relative } from 'node:path';
@@ -434,6 +434,10 @@ describe.sequential('Import: cross-device push refusal', { timeout: 180000 }, ()
             indexRecord('mounted-parent', 'tree-directory', 0),
             indexRecord('mounted-parent/sentinel', 'file', 4),
         ].join('\n') + '\n');
+        writeFileSync(join(pushStateRoot, 'last-sync-local-files.identity.json'), JSON.stringify({
+            managed_directory_b64: null,
+            local_root_b64: Buffer.from(realpathSync(source)).toString('base64'),
+        }) + '\n');
         result = runPush(mountedSite, source, state);
         assert.notEqual(result.exitCode, 0);
         rejection = targetErrorFromPusher(result.stderr);

--- a/tests/e2e/tests/import-54-pull-seeded-push.test.js
+++ b/tests/e2e/tests/import-54-pull-seeded-push.test.js
@@ -1,0 +1,367 @@
+/**
+ * Test 54: a normal WordPress-root pull seeds the existing push baseline.
+ *
+ * The exporter is installed in wp-content/plugins and its durable staging
+ * directory is inside ABSPATH. All traffic uses the public CLI and the real
+ * nginx/FPM endpoint; no exporter files are mounted outside the site root.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync,
+    writeFileSync,
+} from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    cleanupTempDir, createTempDir, fsRootDir, getSiteDir, getSiteSecret,
+    getSiteUrl, runImporter, runPush,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const IMPORTER_PATH = join(import.meta.dirname, '..', '..', '..', 'importer', 'import.php');
+const PHP_BINARY = process.env.PHP_BINARY || 'php';
+const PHP_VERSION_ID = Number(execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION_ID;'], { encoding: 'utf8' }));
+const describeSupportedPush = PHP_VERSION_ID >= 80100 ? describe.sequential : describe.skip;
+
+describeSupportedPush('Import: pull-seeded full-root push', { timeout: 300000 }, () => {
+    const site = 'push-pull-roundtrip';
+    const targetRoot = getSiteDir(site);
+    const stagingDir = join(targetRoot, '.reprint-staging');
+    const fixturePath = 'roundtrip-fixture';
+    const targetFixture = join(targetRoot, fixturePath);
+    const exporterPath = 'wp-content/plugins/site-export/index.php';
+    let caseRoot;
+    let stateDir;
+    let localRoot;
+    let url;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            afterConfig: async (siteDir) => configureStaging(siteDir, stagingDir),
+        });
+        configureStaging(targetRoot, stagingDir);
+        execFileSync('sudo', ['rm', '-rf', targetFixture, stagingDir]);
+        execFileSync('sudo', ['mkdir', '-p', stagingDir]);
+        execFileSync('sudo', ['chown', '-R', 'nginx:nginx', stagingDir]);
+        writeTarget('edit.txt', 'original edit value');
+        writeTarget('delete.txt', 'delete this leaf');
+        writeTarget('delete-tree/a/b.txt', 'delete this subtree');
+        writeTarget('type-swap', 'file before type transition');
+        execFileSync('sudo', ['chown', '-R', 'nginx:nginx', targetFixture]);
+        caseRoot = createTempDir('e2e-pull-seeded-push');
+        stateDir = join(caseRoot, 'state');
+        url = `${getSiteUrl(site)}&directory=${encodeURIComponent(targetRoot)}`;
+    });
+
+    afterAll(() => {
+        cleanupTempDir(caseRoot);
+        execFileSync('sudo', ['rm', '-rf', targetFixture, stagingDir]);
+    });
+
+    it('publishes a local-ctime baseline only after the full pull completes', () => {
+        const result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site),
+            wallTimeout: 300000,
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        localRoot = join(fsRootDir(stateDir), targetRoot);
+        assert.ok(existsSync(join(localRoot, 'index.php')), 'The pull omitted the WordPress root.');
+
+        const journal = journalRoot(stateDir);
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.jsonl')));
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.identity.json')));
+        const identity = JSON.parse(readFileSync(join(journal, 'last-sync-local-files.identity.json'), 'utf8'));
+        assert.equal(Buffer.from(identity.managed_directory_b64, 'base64').toString(), targetRoot);
+        assert.equal(Buffer.from(identity.local_root_b64, 'base64').toString(), localRoot);
+    });
+
+    it('keeps structural markers private and staging absent from the pulled baseline', () => {
+        const baseline = snapshotEntries(join(journalRoot(stateDir), 'last-sync-local-files.jsonl'));
+        const byPath = new Map(baseline.map((entry) => [entry.path, entry]));
+        assert.equal(byPath.get('wp-content')?.type, 'tree-directory');
+        assert.equal(byPath.get('wp-content/plugins')?.type, 'tree-directory');
+        assert.equal(byPath.get(exporterPath)?.type, 'file');
+        assert.ok(!baseline.some((entry) => entry.path === '.reprint-staging'
+            || entry.path.startsWith('.reprint-staging/')));
+        assert.ok(!existsSync(join(localRoot, '.reprint-staging')));
+    });
+
+    it('immediate push is a no-op and never plans exporter or structural entries', () => {
+        const result = runPush(site, localRoot, stateDir, { url });
+        const summary = assertSuccessfulPush(result);
+        assert.equal(summary.changed, 0);
+        assert.equal(summary.deleted, 0);
+
+        const journal = journalRoot(stateDir);
+        const plan = snapshotEntries(join(journal, 'local-paths-to-push.jsonl'));
+        assert.deepEqual(plan, []);
+        assert.ok(!plan.some((entry) => entry.type === 'tree-directory'));
+        assert.ok(!plan.some((entry) => entry.path === exporterPath));
+        assert.ok(!plan.some((entry) => entry.path === '.reprint-staging'
+            || entry.path.startsWith('.reprint-staging/')));
+        assert.ok(!existsSync(join(stagingDir, 'apply-sessions')), 'zero-delta push created a target session');
+    });
+
+    it('editing one ordinary leaf sends only that leaf', () => {
+        writeFileSync(join(localRoot, fixturePath, 'edit.txt'), 'edited local value with a new size');
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 1);
+        assert.equal(summary.deleted, 0);
+        assert.deepEqual(plannedPaths(stateDir), [`${fixturePath}/edit.txt`]);
+        assert.equal(readFileSync(join(targetFixture, 'edit.txt'), 'utf8'), 'edited local value with a new size');
+    });
+
+    it('adding one leaf plans it as the only positive change', () => {
+        writeFileSync(join(localRoot, fixturePath, 'added.txt'), 'added locally');
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 1);
+        assert.equal(summary.deleted, 0);
+        assert.deepEqual(plannedPaths(stateDir), [`${fixturePath}/added.txt`]);
+        assert.equal(readFileSync(join(targetFixture, 'added.txt'), 'utf8'), 'added locally');
+    });
+
+    it('deleting one leaf produces exactly one deletion', () => {
+        rmSync(join(localRoot, fixturePath, 'delete.txt'));
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 0);
+        assert.equal(summary.deleted, 1);
+        assert.deepEqual(deletedPaths(stateDir), [`${fixturePath}/delete.txt`]);
+        assert.ok(!existsSync(join(targetFixture, 'delete.txt')));
+    });
+
+    it('deleting a nonempty subtree collapses descendants into one root deletion', () => {
+        rmSync(join(localRoot, fixturePath, 'delete-tree'), { recursive: true });
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 0);
+        assert.equal(summary.deleted, 1);
+        assert.deepEqual(deletedPaths(stateDir), [`${fixturePath}/delete-tree`]);
+        assert.ok(!existsSync(join(targetFixture, 'delete-tree')));
+    });
+
+    it('a file-to-structural-directory transition sends its leaf and correct clear', () => {
+        rmSync(join(localRoot, fixturePath, 'type-swap'));
+        mkdirSync(join(localRoot, fixturePath, 'type-swap'), { recursive: true });
+        writeFileSync(join(localRoot, fixturePath, 'type-swap/child.txt'), 'new child');
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 1);
+        assert.equal(summary.deleted, 1);
+        assert.deepEqual(plannedPaths(stateDir), [`${fixturePath}/type-swap/child.txt`]);
+        assert.deepEqual(deletedPaths(stateDir), [`${fixturePath}/type-swap`]);
+        assert.ok(lstatSync(join(targetFixture, 'type-swap')).isDirectory());
+        assert.equal(readFileSync(join(targetFixture, 'type-swap/child.txt'), 'utf8'), 'new child');
+    });
+
+    it('sequential pushes advance the same baseline', () => {
+        writeFileSync(join(localRoot, fixturePath, 'edit.txt'), 'third edit is longer again');
+        rmSync(join(localRoot, fixturePath, 'added.txt'));
+        let summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 1);
+        assert.equal(summary.deleted, 1);
+
+        summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 0);
+        assert.equal(summary.deleted, 0);
+    });
+
+    it('editing the installed exporter is still rejected before live mutation', () => {
+        const localExporter = join(localRoot, exporterPath);
+        const targetExporter = join(targetRoot, exporterPath);
+        const localBefore = readFileSync(localExporter);
+        const targetBefore = readFileSync(targetExporter);
+        writeFileSync(localExporter, Buffer.concat([localBefore, Buffer.from('\n// local protected edit\n')]));
+
+        const rejected = runPush(site, localRoot, stateDir, { url });
+        assert.notEqual(rejected.exitCode, 0);
+        assert.match(rejected.stderr, /Protected target-relative path cannot be changed/);
+        assert.doesNotMatch(rejected.stderr, /no compatible full-root baseline/);
+        assert.deepEqual(readFileSync(targetExporter), targetBefore);
+        assert.ok(!existsSync(join(targetRoot, '.maintenance')));
+
+        writeFileSync(localExporter, localBefore);
+        const aborted = runPush(site, localRoot, stateDir, { url, extraArgs: ['--abort'] });
+        assert.equal(aborted.exitCode, 0, aborted.stderr);
+    });
+
+    it('a push without a compatible baseline fails safely with pull guidance', () => {
+        const stateWithoutBaseline = join(caseRoot, 'state-without-baseline');
+        const targetSentinel = readFileSync(join(targetFixture, 'edit.txt'));
+        const rejected = runPush(site, localRoot, stateWithoutBaseline, { url, timeout: 300000 });
+        assert.notEqual(rejected.exitCode, 0);
+        assert.match(rejected.stderr, /no compatible full-root baseline/);
+        assert.match(rejected.stderr, /unfiltered files-pull/);
+        assert.match(rejected.stderr, /same --state-dir/);
+        assert.deepEqual(readFileSync(join(targetFixture, 'edit.txt')), targetSentinel);
+        assert.ok(!existsSync(join(targetRoot, '.maintenance')));
+        const aborted = runPush(site, localRoot, stateWithoutBaseline, { url, extraArgs: ['--abort'] });
+        assert.equal(aborted.exitCode, 0, aborted.stderr);
+    });
+
+    it('a filtered pull invalidates and cannot republish the full-root baseline', () => {
+        let result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site), extraArgs: ['--abort'],
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site), extraArgs: ['--filter=essential-files'], wallTimeout: 300000,
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        const journal = journalRoot(stateDir);
+        assert.ok(!existsSync(join(journal, 'last-sync-local-files.jsonl')));
+        assert.ok(!existsSync(join(journal, 'last-sync-local-files.identity.json')));
+
+        const dryRun = runPush(site, localRoot, stateDir, { url, extraArgs: ['--dry-run'] });
+        const summary = assertSuccessfulPush(dryRun, 'dry_run');
+        assert.ok(summary.changed > 0);
+        assert.ok(plannedPaths(stateDir).some((path) => path === exporterPath));
+    });
+
+    it('a later complete unfiltered pull publishes a replacement baseline', () => {
+        let result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site), extraArgs: ['--abort'],
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site), extraArgs: ['--filter=none'], wallTimeout: 300000,
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        const journal = journalRoot(stateDir);
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.jsonl')));
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.identity.json')));
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 0);
+        assert.equal(summary.deleted, 0);
+    });
+
+    it('an interrupted fresh pull removes stale synchronization evidence first', async () => {
+        writeRandomTarget('interrupted.bin', 64);
+        let result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site), extraArgs: ['--abort'],
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        const journal = journalRoot(stateDir);
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.jsonl')));
+
+        const running = startFilesPull(url, stateDir);
+        await waitFor(
+            () => !existsSync(join(journal, 'last-sync-local-files.jsonl')),
+            60000,
+            'The fresh pull never invalidated the prior push baseline.',
+        );
+        running.child.kill('SIGKILL');
+        const interrupted = await running.completed;
+        assert.notEqual(interrupted.exitCode, 0);
+        assert.ok(!existsSync(join(journal, 'last-sync-local-files.jsonl')));
+        assert.ok(!existsSync(join(journal, 'last-sync-local-files.identity.json')));
+    });
+
+    it('pull restart republishes only after eventual completion', () => {
+        const result = runImporter(url, stateDir, 'files-pull', {
+            secret: getSiteSecret(site), wallTimeout: 300000,
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+        assert.equal(lstatSync(join(localRoot, fixturePath, 'interrupted.bin')).size, 64 * 1024 * 1024);
+        const journal = journalRoot(stateDir);
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.jsonl')));
+        assert.ok(existsSync(join(journal, 'last-sync-local-files.identity.json')));
+        const summary = assertSuccessfulPush(runPush(site, localRoot, stateDir, { url }));
+        assert.equal(summary.changed, 0);
+        assert.equal(summary.deleted, 0);
+    });
+
+    function writeTarget(relativePath, contents) {
+        const path = join(targetFixture, relativePath);
+        execFileSync('sudo', ['mkdir', '-p', join(path, '..')]);
+        execFileSync('sudo', ['tee', path], { input: contents, stdio: ['pipe', 'ignore', 'inherit'] });
+        execFileSync('sudo', ['chown', 'nginx:nginx', path]);
+    }
+
+    function writeRandomTarget(relativePath, mebibytes) {
+        const path = join(targetFixture, relativePath);
+        execFileSync('sudo', ['mkdir', '-p', join(path, '..')]);
+        execFileSync('sudo', [
+            'dd', 'if=/dev/urandom', `of=${path}`, 'bs=1M', `count=${mebibytes}`, 'status=none',
+        ]);
+        execFileSync('sudo', ['chown', 'nginx:nginx', path]);
+    }
+});
+
+function configureStaging(siteDir, stagingDir) {
+    const configPath = join(siteDir, 'wp-config.php');
+    let config = readFileSync(configPath, 'utf8');
+    const definition = `define('SITE_EXPORT_STAGING_DIR', '${stagingDir}');`;
+    if (/define\('SITE_EXPORT_STAGING_DIR'/.test(config)) {
+        config = config.replace(/define\('SITE_EXPORT_STAGING_DIR'[^\n]+/, definition);
+    } else {
+        config = config.replace("if ( ! defined( 'ABSPATH' ) )", definition + "\nif ( ! defined( 'ABSPATH' ) )");
+    }
+    execFileSync('sudo', ['tee', configPath], { input: config, stdio: ['pipe', 'ignore', 'inherit'] });
+    execFileSync('sudo', ['chown', 'nginx:nginx', configPath]);
+    execFileSync('sudo', ['mkdir', '-p', stagingDir]);
+    execFileSync('sudo', ['chown', '-R', 'nginx:nginx', stagingDir]);
+}
+
+function journalRoot(stateDir) {
+    const pushRoot = join(stateDir, 'push');
+    const directories = readdirSync(pushRoot);
+    assert.equal(directories.length, 1, `Expected one target journal, got ${directories.join(', ')}`);
+    return join(pushRoot, directories[0]);
+}
+
+function snapshotEntries(path) {
+    if (!existsSync(path)) return [];
+    return readFileSync(path, 'utf8').trim().split('\n').filter(Boolean).map((line) => {
+        const entry = JSON.parse(line);
+        return {
+            ...entry,
+            path: Buffer.from(entry.path, 'base64').toString(),
+        };
+    });
+}
+
+function plannedPaths(stateDir) {
+    return snapshotEntries(join(journalRoot(stateDir), 'local-paths-to-push.jsonl'))
+        .map((entry) => entry.path);
+}
+
+function deletedPaths(stateDir) {
+    const stream = readFileSync(join(journalRoot(stateDir), 'local-delete-stream.bin'));
+    if (stream.length === 0) return [];
+    assert.equal(stream.at(-1), 0, 'The local delete stream must end at a NUL record boundary.');
+    return stream.subarray(0, -1).toString().split('\0');
+}
+
+function assertSuccessfulPush(result, expectedStatus = 'complete') {
+    assert.equal(result.exitCode, 0, `push failed\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    const lines = result.stdout.trim().split('\n').filter(Boolean);
+    const summary = JSON.parse(lines.at(-1));
+    assert.equal(summary.status, expectedStatus);
+    return summary;
+}
+
+function startFilesPull(url, stateDir) {
+    const child = spawn(PHP_BINARY, [
+        IMPORTER_PATH, 'files-pull', url,
+        `--state-dir=${stateDir}`, `--fs-root=${fsRootDir(stateDir)}`,
+        `--secret=${getSiteSecret('push-pull-roundtrip')}`,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data) => { stdout += data; });
+    child.stderr.on('data', (data) => { stderr += data; });
+    const completed = new Promise((resolve) => {
+        child.on('close', (exitCode, signal) => resolve({ exitCode, signal, stdout, stderr }));
+    });
+    return { child, completed };
+}
+
+async function waitFor(predicate, timeout, message) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        if (predicate()) return;
+        await sleep(5);
+    }
+    assert.fail(message);
+}


### PR DESCRIPTION
An eligible full-root pull now seeds the sender baseline from the finished local tree. An immediate push computes an empty delta and completes locally, without opening a target session or briefly entering maintenance. Later pushes plan only local edits. Remote ctimes never become local change evidence.

Every invocation without `--dry-run` authorizes the delta that invocation computes. `--dry-run` only reports the current plan; it neither publishes a baseline nor pins work for a later push. A later real push rescans the source tree. An interrupted push with an active compatible session still resumes from target-confirmed state.

Baseline publication requires exactly one unbracketed scalar absolute `directory` query value, `--filter=none`, no `--only` or `--remap`, and normal overwrite behavior. Repeated, bracketed, mixed, relative, NUL, and dot-segment forms remain valid pull inputs where the exporter accepts them, but they cannot publish one single-root push identity. A real endpoint test pulls two roots completely and confirms that no baseline appears. The adjacent identity binds a published snapshot to its managed directory and canonical local root.

A new pull invalidates the old baseline before changing files. Interrupted and filtered pulls leave it unavailable. Structural directory markers stay private, server staging is absent from both the pulled tree and baseline, and a push without a compatible baseline that reaches protected exporter content explains how to seed one.

Tests run:
- `cd tests && ../vendor/bin/phpunit Import` — 440 tests, 1,592 assertions, 6 skips
- `cd tests && ../vendor/bin/phpunit Import/MultipartPushTest.php Import/PushJournalTest.php Import/StagingExclusionPullTest.php Import/CliHelpTest.php` — 65 tests, 778 assertions, 2 environment skips
- Docker pull-seeded-push E2E on the complete stack — 15 tests
- `composer analyze -- --memory-limit=1G`
- PHPCompatibility at PHP 7.4+ and PHP 7.4 parsing on the changed importer production files
- PHPCS per-file error and warning counts did not increase
- `node --check tests/e2e/tests/import-54-pull-seeded-push.test.js`
- `git diff --check`

The red monolithic E2E checks on this stack layer are confined to the pre-existing `import-53` push suite: unsupported-importer cases still run, cross-device storage has no tmpfs, and process-race probes lack the permissions and synchronization they need. The dependent #346 supplies that job split and setup; its integrated head is 27/27 green. This PR's `import-54` pull-seeded-push suite passes all 15 tests on this head.
