### PR TITLE
[Push] Retry target contention from confirmed cursors

### DIFF
--- a/.github/workflows/e2e-playground.yml
+++ b/.github/workflows/e2e-playground.yml
@@ -67,6 +67,15 @@ jobs:
       - name: Setup test sites
         run: tests/e2e/setup.sh
 
+      - name: Mount required separate filesystems
+        run: |
+          sudo mkdir -p /srv/reprint-e2e-staging
+          sudo mkdir -p /srv/e2e-sites/push-mounted-parent/mounted-parent
+          sudo mount -t tmpfs -o size=64m tmpfs /srv/reprint-e2e-staging
+          sudo mount -t tmpfs -o size=64m tmpfs /srv/e2e-sites/push-mounted-parent/mounted-parent
+          test "$(stat -c %d /srv/reprint-e2e-staging)" != "$(stat -c %d /srv/e2e-sites)"
+          test "$(stat -c %d /srv/e2e-sites/push-mounted-parent/mounted-parent)" != "$(stat -c %d /srv/e2e-sites/push-mounted-parent)"
+
       - name: Install E2E dependencies
         working-directory: tests/e2e
         run: npm install

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -1,0 +1,162 @@
+name: E2E suite
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: E2E fault domain to run.
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    name: ${{ inputs.suite }} cases
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      DIRECT_PUSH_CORE_PATTERN: 'excludes active|applies basic|seeds independently|applies a |applies an |updates children|replaces and recursively|Import: incompatible live drift'
+      DIRECT_PUSH_NETWORK_PATTERN: 'resumes after externally killing|resumes delete bytes|intentionally replaces compatible drift'
+      DIRECT_PUSH_PRIVILEGED_PATTERN: 'Import: cross-device push refusal'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: importer-phar
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # PHP comes from the runner's pre-cached toolcache via this action. The
+      # Launchpad endpoints used by apt-based installation are too unreliable
+      # for required test jobs.
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
+          coverage: none
+
+      - name: Setup infrastructure
+        run: tests/e2e/ci/setup-infrastructure.sh 8.2
+
+      - name: Setup test sites
+        run: tests/e2e/setup.sh
+
+      - name: Mount required separate filesystems
+        if: inputs.suite == 'privileged-filesystem'
+        run: |
+          sudo mkdir -p /srv/reprint-e2e-staging
+          sudo mkdir -p /srv/e2e-sites/push-mounted-parent/mounted-parent
+          sudo mount -t tmpfs -o size=64m tmpfs /srv/reprint-e2e-staging
+          sudo mount -t tmpfs -o size=64m tmpfs /srv/e2e-sites/push-mounted-parent/mounted-parent
+          test "$(stat -c %d /srv/reprint-e2e-staging)" != "$(stat -c %d /srv/e2e-sites)"
+          test "$(stat -c %d /srv/e2e-sites/push-mounted-parent/mounted-parent)" != "$(stat -c %d /srv/e2e-sites/push-mounted-parent)"
+
+      - name: Install dependencies
+        working-directory: tests/e2e
+        run: npm install
+
+      - name: Run core cases
+        if: inputs.suite == 'core'
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          PHP_BINARY: php8.2
+        working-directory: tests/e2e
+        run: |
+          mapfile -t direct_push_cases < <(
+            npx vitest list tests/import-53-push-direct-apply.test.js \
+              | grep '^tests/import-53-push-direct-apply\.test\.js > '
+          )
+          test "${#direct_push_cases[@]}" -gt 0
+          for case_name in "${direct_push_cases[@]}"; do
+            matching_groups=0
+            if [[ "$case_name" =~ $DIRECT_PUSH_CORE_PATTERN ]]; then
+              matching_groups=$((matching_groups + 1))
+            fi
+            if [[ "$case_name" =~ $DIRECT_PUSH_NETWORK_PATTERN ]]; then
+              matching_groups=$((matching_groups + 1))
+            fi
+            if [[ "$case_name" =~ $DIRECT_PUSH_PRIVILEGED_PATTERN ]]; then
+              matching_groups=$((matching_groups + 1))
+            fi
+            if [ "$matching_groups" -ne 1 ]; then
+              echo "Direct-push case belongs to $matching_groups CI groups: $case_name" >&2
+              exit 1
+            fi
+          done
+          mapfile -t test_files < <(
+            find tests -maxdepth 1 -type f -name 'import-*.test.js' -print \
+              | sort \
+              | grep -Ev 'import-(07-permission-errors|09-resume-sql|10-resume-files|12-gzip-corruption|14-buffered-response|15-volatile-files|17-redirect|19-error-chunks|20-request-cutoff|26-completion-headers|28-concurrent-errors|31-follow-symlinks|36-mysql-mode-crash-recovery|43-sql-stream-crash|47-pull-multi-request|48-pull-crash-resume|50-file-body-resume|53-push-direct-apply|55-push-busy|56-compatibility-smoke)\.test\.js$'
+          )
+          npx vitest run "${test_files[@]}" --reporter=verbose
+          npx vitest run tests/import-53-push-direct-apply.test.js \
+            --testNamePattern="$DIRECT_PUSH_CORE_PATTERN" \
+            --reporter=verbose
+
+      - name: Run network and interruption cases
+        if: inputs.suite == 'network-interruption'
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          PHP_BINARY: php8.2
+        working-directory: tests/e2e
+        run: |
+          npx vitest run \
+            tests/import-09-resume-sql.test.js \
+            tests/import-10-resume-files.test.js \
+            tests/import-12-gzip-corruption.test.js \
+            tests/import-14-buffered-response.test.js \
+            tests/import-15-volatile-files.test.js \
+            tests/import-17-redirect.test.js \
+            tests/import-20-request-cutoff.test.js \
+            tests/import-26-completion-headers.test.js \
+            tests/import-36-mysql-mode-crash-recovery.test.js \
+            tests/import-43-sql-stream-crash.test.js \
+            tests/import-47-pull-multi-request.test.js \
+            tests/import-48-pull-crash-resume.test.js \
+            tests/import-50-file-body-resume.test.js \
+            tests/import-55-push-busy.test.js \
+            --reporter=verbose
+          npx vitest run tests/import-53-push-direct-apply.test.js \
+            --testNamePattern="$DIRECT_PUSH_NETWORK_PATTERN" \
+            --reporter=verbose
+
+      - name: Run privileged filesystem cases
+        if: inputs.suite == 'privileged-filesystem'
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          PHP_BINARY: php8.2
+        working-directory: tests/e2e
+        run: |
+          npx vitest run \
+            tests/import-07-permission-errors.test.js \
+            tests/import-19-error-chunks.test.js \
+            tests/import-28-concurrent-errors.test.js \
+            tests/import-31-follow-symlinks.test.js \
+            --reporter=verbose
+          npx vitest run tests/import-53-push-direct-apply.test.js \
+            --testNamePattern="$DIRECT_PUSH_PRIVILEGED_PATTERN" \
+            --reporter=verbose
+
+      - name: Debug logs
+        if: always()
+        run: |
+          echo "--- Listening ports ---"
+          sudo ss -tlnp 2>/dev/null || true
+          echo "--- PHP-FPM error log ---"
+          sudo cat /tmp/php-e2e-errors.log 2>/dev/null || echo "(empty)"
+          echo "--- Nginx error log ---"
+          sudo tail -100 /var/log/nginx/error.log 2>/dev/null || echo "(empty)"
+          echo "--- Nginx config test ---"
+          sudo nginx -t 2>&1 || true
+          echo "--- PHP-FPM journal ---"
+          sudo journalctl -u php8.2-fpm --no-pager -n 30 2>/dev/null || true
+          echo "--- Nginx journal ---"
+          sudo journalctl -u nginx --no-pager -n 30 2>/dev/null || true
+          echo "--- MariaDB journal ---"
+          sudo journalctl -u mariadb --no-pager -n 30 2>/dev/null || true
+          echo "--- PHP processes ---"
+          ps aux | grep php || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,11 +28,32 @@ jobs:
           name: importer-phar
           path: reprint.phar
 
-  e2e:
-    name: E2E (exporter PHP ${{ matrix.exporter_php }}, importer PHP ${{ matrix.importer_php }})
+  core:
+    name: Core
+    needs: build-phar
+    uses: ./.github/workflows/e2e-suite.yml
+    with:
+      suite: core
+
+  network-interruption:
+    name: Network and interruption
+    needs: build-phar
+    uses: ./.github/workflows/e2e-suite.yml
+    with:
+      suite: network-interruption
+
+  privileged-filesystem:
+    name: Privileged filesystem
+    needs: build-phar
+    uses: ./.github/workflows/e2e-suite.yml
+    with:
+      suite: privileged-filesystem
+
+  compatibility-smoke:
+    name: Compatibility smoke (exporter PHP ${{ matrix.exporter_php }}, importer PHP ${{ matrix.importer_php }})
     needs: build-phar
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -41,8 +62,12 @@ jobs:
             importer_php: '8.2'
           - exporter_php: '7.4'
             importer_php: '7.4'
+          - exporter_php: '7.4'
+            importer_php: '8.2'
           - exporter_php: '8.0'
             importer_php: '8.0'
+          - exporter_php: '8.0'
+            importer_php: '8.2'
           - exporter_php: '8.1'
             importer_php: '8.1'
           - exporter_php: '8.2'
@@ -75,75 +100,34 @@ jobs:
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
-      # PHP comes from the runner's pre-cached toolcache via this
-      # action; we don't try to apt-install ondrej/php ourselves
-      # because every Launchpad endpoint flakes regularly.
-      - uses: shivammathur/setup-php@v2
+      # PHP comes from the runner's pre-cached toolcache via this action. The
+      # Launchpad endpoints used by apt-based installation are too unreliable
+      # for required test jobs.
+      - name: Setup exporter PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.exporter_php }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
       - name: Setup infrastructure
+        if: matrix.importer_php != '7.4' && matrix.importer_php != '8.0'
         run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.exporter_php }}"
 
       - name: Setup test sites
+        if: matrix.importer_php != '7.4' && matrix.importer_php != '8.0'
         run: tests/e2e/setup.sh
 
       - name: Install dependencies
         working-directory: tests/e2e
         run: npm install
 
-      - name: Provision basic site and smoke-test API
+      - name: Run compatibility cases
         env:
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
-          IMPORTER_PHP: php${{ matrix.importer_php }}
+          PHP_BINARY: php${{ matrix.importer_php }}
         working-directory: tests/e2e
-        run: |
-          # Download WP-CLI (normally done by Vitest globalSetup, but we need it here)
-          if [ ! -f /tmp/wp-cli.phar ]; then
-            curl -sfL "https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar" -o /tmp/wp-cli.phar
-            chmod +x /tmp/wp-cli.phar
-          fi
-
-          # Provision the "basic" site
-          node --input-type=module <<'NODESCRIPT'
-          import { ensureSite } from "./lib/site-setup.js";
-          await ensureSite("basic");
-          console.log("Basic site provisioned");
-          NODESCRIPT
-
-          # Quick smoke test: use the importer CLI to hit the export API.
-          SECRET="test-secret-basic"
-          BASE="http://127.0.0.1:8081/?reprint-api"
-          DIR="/srv/e2e-sites/basic"
-          STATE_DIR="/tmp/e2e-smoke-state"
-          FS_ROOT="/tmp/e2e-smoke-fs"
-
-          echo "=== Importer preflight ==="
-          preflight_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" || {
-            status=$?
-            echo "$preflight_output" | head -50
-            echo "EXIT: $status"
-            exit "$status"
-          }
-          echo "$preflight_output" | head -50
-
-          echo "=== Importer files-pull ==="
-          files_pull_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" || {
-            status=$?
-            echo "$files_pull_output" | head -50
-            echo "EXIT: $status"
-            exit "$status"
-          }
-          echo "$files_pull_output" | head -50
-
-      - name: Run E2E tests
-        if: matrix.exporter_php != '7.2'
-        env:
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
-        working-directory: tests/e2e
-        run: npx vitest run
+        run: npx vitest run tests/import-56-compatibility-smoke.test.js --reporter=verbose
 
       - name: Debug logs
         if: always()

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -58,6 +58,15 @@ reports complete, by atomically publishing the snapshot used to make the plan.
 A source change after a snapshot was made therefore remains a delta for the
 next push rather than being silently called deployed.
 
+Upload and control responses pass through the same reason classifier. `busy`
+and `offset_gap` are the only recoverable protocol rejections: the sender waits
+with bounded exponential backoff, reconciles upload cursors from status, and
+tries a continuously rejected operation at most five times. Persistent
+contention exits as a failure while preserving the last confirmed phase for a
+later `push` process.
+Authentication failures, redirects, malformed responses, live-tree conflicts,
+and cross-device rejections remain terminal. There is no retry option.
+
 The token is deliberately small rather than a content hash. A same-size edit
 within the filesystem ctime resolution can escape both it and the snapshot
 diff, which uses the same size and ctime signals.
@@ -126,7 +135,7 @@ workspace.
 Classified target failures use the same descriptive string inside the server
 and in the authenticated JSON `reason`; PHP's integer exception code is not a
 second vocabulary. `apply_not_configured` maps to 503, `busy` to 423,
-`session_not_found` to 404, `commit_required`, `live_tree_changed`,
+`session_not_found` to 404, `commit_required`, `offset_gap`, `live_tree_changed`,
 `cross_device_filesystem`, and `invalid_session_state` to 409, and
 `retryable_io_error` to 500. A runtime failure without one of those deliberate
 classifications remains the generic 409 `session_rejected` response instead
@@ -185,7 +194,8 @@ The target validates paths one at a time and stores the raw NUL-delimited byte
 stream in `work/deletes`. Every part carries the sender's confirmed byte
 offset. An offset before the stored end is an exact replay: matching bytes are
 accepted and a matching suffix may continue the stream, while different bytes
-are rejected. An offset beyond the actual file size is a gap and is rejected.
+are rejected. An offset beyond the actual file size is rejected as
+`offset_gap`; the sender resumes from the `delete_bytes` returned by status.
 Status reports that actual size as `delete_bytes`; it never trusts a claimed
 cursor. A path may span parts when the target's part ceiling is smaller than
 its record, and the sender packs successive bounded parts into each request.
@@ -288,7 +298,8 @@ truth:
 - a missing file accepts offset zero;
 - an offset matching its actual regular-file size appends;
 - offset zero discards a partial or completed staged version and restarts;
-- every other offset is rejected.
+- every other offset is rejected as `offset_gap`, so the sender asks status and
+  resumes from the target's actual staged size.
 
 If a crash leaves a full-sized file in `work/partial` before its promotion
 rename, status reports that actual size and the sender supplies an empty final
@@ -419,4 +430,6 @@ request-size learning, and the local baseline. Raw TCP tests prove that a part
 reaches the network before send_part() returns. Docker end-to-end tests use a
 real WordPress target and HMAC requests, kill the push PHP process during commit,
 exercise symlinks and empty directories, and mount separate filesystems to
-verify cross-device refusal before an unsafe mutation.
+verify cross-device refusal before an unsafe mutation. Separate-process flock
+and discard-tombstone tests hold creation, upload, commit, and cleanup busy long
+enough to prove both automatic recovery and bounded failure plus restart.

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -22,6 +22,7 @@ if (!class_exists('Site_Export_Staged_Apply_Exception', false)) {
 final class Site_Export_Staged_Apply_Session {
 
     public const ERROR_BUSY = 'busy';
+    public const ERROR_OFFSET_GAP = 'offset_gap';
     public const ERROR_SESSION_NOT_FOUND = 'session_not_found';
     public const ERROR_RETRYABLE_IO = 'retryable_io_error';
     public const ERROR_COMMIT_REQUIRED = 'commit_required';
@@ -503,7 +504,10 @@ final class Site_Export_Staged_Apply_Session {
                 $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => $total_bytes];
                 return;
             } else {
-                throw new InvalidArgumentException('Completed staged file ' . base64_encode($path) . ' can only be restarted at offset 0.');
+                throw new Site_Export_Staged_Apply_Exception(
+                    self::ERROR_OFFSET_GAP,
+                    'Completed staged file ' . base64_encode($path) . ' can only be restarted at offset 0.'
+                );
             }
         }
 
@@ -518,7 +522,10 @@ final class Site_Export_Staged_Apply_Session {
             }
             $actual_bytes = 0;
         } elseif ($offset !== $actual_bytes) {
-            throw new InvalidArgumentException('File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but work/partial contains ' . $actual_bytes . ' bytes. Start at offset 0 or resume at the actual size.');
+            throw new Site_Export_Staged_Apply_Exception(
+                self::ERROR_OFFSET_GAP,
+                'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but work/partial contains ' . $actual_bytes . ' bytes. Start at offset 0 or resume at the actual size.'
+            );
         }
 
         $handle = @fopen($partial_path, $actual_bytes === 0 ? 'wb' : 'ab');
@@ -625,7 +632,10 @@ final class Site_Export_Staged_Apply_Session {
         try {
             $stored_bytes = $this->file_size_from_handle($handle, 'staged delete stream');
             if ($offset > $stored_bytes) {
-                throw new InvalidArgumentException('Delete-list part starts at offset ' . $offset . ', but the target has stored ' . $stored_bytes . ' bytes.');
+                throw new Site_Export_Staged_Apply_Exception(
+                    self::ERROR_OFFSET_GAP,
+                    'Delete-list part starts at offset ' . $offset . ', but the target has stored ' . $stored_bytes . ' bytes.'
+                );
             }
             $position = $offset;
             $trailing_path = $this->read_delete_trailing_path($handle, $stored_bytes);

--- a/packages/reprint-exporter/src/class-staged-endpoints.php
+++ b/packages/reprint-exporter/src/class-staged-endpoints.php
@@ -761,6 +761,9 @@ final class Site_Export_Staged_Endpoints {
                 case Site_Export_Staged_Apply_Session::ERROR_COMMIT_REQUIRED:
                     $http_code = 409;
                     break;
+                case Site_Export_Staged_Apply_Session::ERROR_OFFSET_GAP:
+                    $http_code = 409;
+                    break;
                 case Site_Export_Staged_Apply_Session::ERROR_LIVE_TREE_CHANGED:
                     $http_code = 409;
                     break;

--- a/packages/reprint-importer/src/lib/push/class-multipart-push.php
+++ b/packages/reprint-importer/src/lib/push/class-multipart-push.php
@@ -80,6 +80,12 @@ class MultipartPush
      */
     private const MAX_PLAN_LINE_BYTES = 16384;
 
+    /** Maximum consecutive recoverable responses for one operation. */
+    private const MAX_RECOVERABLE_RESPONSE_ATTEMPTS = 5;
+
+    /** Initial delay for exponential recoverable-response backoff. */
+    private const RECOVERABLE_RESPONSE_DELAY_MICROSECONDS = 100000;
+
     /** @var string Exporter API URL, including any required API selector query. */
     private string $base_url;
 
@@ -331,7 +337,13 @@ class MultipartPush
             is_array($state['sizer'] ?? null) ? $state['sizer'] : [],
             is_numeric($state['max_frame_bytes'] ?? null) ? (int) $state['max_frame_bytes'] : null
         );
-        $response = $client->control_request('GET', 'staged_session_status', ['session_id' => $session_id]);
+        $response = $this->control_response(
+            $client,
+            'GET',
+            'staged_session_status',
+            ['session_id' => $session_id],
+            ['ok']
+        );
         $response['local_phase'] = $state['phase'] ?? 'unknown';
         $current = $state['current'] ?? null;
         if (is_array($current) && is_string($current['path_b64'] ?? null)) {
@@ -400,8 +412,13 @@ class MultipartPush
         if (!is_string($create_token) || preg_match('/^[a-f0-9]{32}$/D', $create_token) !== 1) {
             throw new RuntimeException('Push session checkpoint has no valid create token.');
         }
-        $response = $client->control_request('POST', 'staged_session_create', ['create_token' => $create_token]);
-        $this->require_control_status($response, 'created');
+        $response = $this->control_response(
+            $client,
+            'POST',
+            'staged_session_create',
+            ['create_token' => $create_token],
+            ['created']
+        );
         $session_id = $response['session_id'] ?? null;
         if (!is_string($session_id) || preg_match('/^[a-f0-9]{32}$/D', $session_id) !== 1) {
             throw new RuntimeException('Target create response has no valid session_id.');
@@ -609,6 +626,7 @@ class MultipartPush
         if ( (int) $state['delete_offset'] === $local_stream_size) {
             return;
         }
+        $recoverable_attempts = 0;
         $handle = @fopen($this->journal->local_delete_stream_path, 'rb');
         if ($handle === false) {
             throw new RuntimeException('Could not open the local delete stream: ' . $this->journal->local_delete_stream_path . '.');
@@ -670,12 +688,21 @@ class MultipartPush
                     if ( (int) $state['delete_offset'] !== $target_start) {
                         $state['sizer'] = $client->get_request_sizer_state();
                         $this->write_state($state);
+                        if ( (int) $state['delete_offset'] > $target_start) {
+                            $recoverable_attempts = 0;
+                            continue;
+                        }
+                        if ($result['status'] !== 'complete') {
+                            $this->handle_unknown_upload_result($state, $client, $result, null);
+                            $this->wait_for_recoverable_response($result, $recoverable_attempts, 'Delete-list upload');
+                        }
                         continue;
                     }
                     if ($result['status'] === 'complete') {
                         throw new RuntimeException('Multipart request could not fit one delete-list part inside its request-body budget.');
                     }
                     $this->handle_unknown_upload_result($state, $client, $result, null);
+                    $this->wait_for_recoverable_response($result, $recoverable_attempts, 'Delete-list upload');
                     continue;
                 }
                 if ($result['status'] !== 'complete') {
@@ -683,6 +710,11 @@ class MultipartPush
                         $this->reconcile_delete_upload_status($state, $client, $local_stream_size);
                     }
                     $this->handle_unknown_upload_result($state, $client, $result, null);
+                    if ( (int) $state['delete_offset'] > $target_start) {
+                        $recoverable_attempts = 0;
+                        continue;
+                    }
+                    $this->wait_for_recoverable_response($result, $recoverable_attempts, 'Delete-list upload');
                     continue;
                 }
                 $accepted = $result['response']['accepted'] ?? null;
@@ -714,11 +746,13 @@ class MultipartPush
                     $this->reconcile_delete_upload_status($state, $client, $local_stream_size);
                     $state['sizer'] = $client->get_request_sizer_state();
                     $this->write_state($state);
+                    $recoverable_attempts = 0;
                     continue;
                 }
                 $state['delete_offset'] = $sent[$sent_count - 1];
                 $state['sizer'] = $client->get_request_sizer_state();
                 $this->write_state($state);
+                $recoverable_attempts = 0;
             }
         } finally {
             fclose($handle);
@@ -735,6 +769,7 @@ class MultipartPush
                 . ', before the ' . $local_stream_size . '-byte local delete stream reached EOF.'
             );
         }
+        $recoverable_attempts = 0;
         while (true) {
             $target_offset = (int) ( $state['delete_offset'] ?? 0 );
             if (!$client->start_upload_request($this->session_id_from_state($state))) {
@@ -748,7 +783,15 @@ class MultipartPush
             ]);
             $result = $client->finish_request();
             if (!$sent || $result['status'] !== 'complete') {
+                if ($result['status'] !== 'failed') {
+                    $this->reconcile_delete_upload_status($state, $client, $local_stream_size);
+                }
                 $this->handle_unknown_upload_result($state, $client, $result, null);
+                $this->wait_for_recoverable_response($result, $recoverable_attempts, 'Delete-list completion upload');
+                if ( (int) $state['delete_offset'] < $local_stream_size) {
+                    $this->upload_deletes($state, $client);
+                    $recoverable_attempts = 0;
+                }
                 continue;
             }
             $accepted = $result['response']['accepted'] ?? null;
@@ -802,10 +845,13 @@ class MultipartPush
     /** Replaces the local delete cursor with signed target status. */
     private function reconcile_delete_upload_status(array &$state, MultipartPushStreamClient $client, int $local_stream_size): void
     {
-        $response = $client->control_request('GET', 'staged_session_status', [
-            'session_id' => $this->session_id_from_state($state),
-        ]);
-        $this->require_control_status($response, 'ok');
+        $response = $this->control_response(
+            $client,
+            'GET',
+            'staged_session_status',
+            ['session_id' => $this->session_id_from_state($state)],
+            ['ok']
+        );
         $target_offset = $this->require_non_negative_delete_offset(
             $response['delete_bytes'] ?? null,
             'Target status delete_bytes'
@@ -841,6 +887,7 @@ class MultipartPush
      */
     private function upload_changes(array &$state, MultipartPushStreamClient $client): void
     {
+        $recoverable_attempts = 0;
         while ($this->read_plan_entry((int) ($state['plan_offset'] ?? 0)) !== null) {
             $session_id = $this->session_id_from_state($state);
             if (!$client->start_upload_request($session_id)) {
@@ -952,15 +999,32 @@ class MultipartPush
                     throw new RuntimeException('Multipart request could not fit one upload part inside its request-body budget.');
                 }
                 $this->handle_unknown_upload_result($state, $client, $result, null);
+                $this->wait_for_recoverable_response($result, $recoverable_attempts, 'Multipart upload');
                 continue;
             }
             if ($result['status'] !== 'complete') {
+                $plan_offset_before = (int) ( $state['plan_offset'] ?? 0 );
+                $current_before = $state['current'] ?? null;
+                $accepted_bytes_before = is_array($current_before)
+                    ? (int) ( $current_before['accepted_bytes'] ?? 0 )
+                    : 0;
                 $this->handle_unknown_upload_result($state, $client, $result, $sent[0]);
+                $current_after = $state['current'] ?? null;
+                $confirmed_progress = (int) ( $state['plan_offset'] ?? 0 ) > $plan_offset_before || (
+                    is_array($current_after) &&
+                    (int) ( $current_after['accepted_bytes'] ?? 0 ) > $accepted_bytes_before
+                );
+                if ($confirmed_progress) {
+                    $recoverable_attempts = 0;
+                    continue;
+                }
+                $this->wait_for_recoverable_response($result, $recoverable_attempts, 'Multipart upload');
                 continue;
             }
             $this->apply_upload_response($state, $sent, $result['response']);
             $state['sizer'] = $client->get_request_sizer_state();
             $this->write_state($state);
+            $recoverable_attempts = 0;
         }
     }
 
@@ -1209,11 +1273,16 @@ class MultipartPush
     private function recover_first_sent_status(array &$state, MultipartPushStreamClient $client, array $sent): void
     {
         $session_id = $this->session_id_from_state($state);
-        $response = $client->control_request('GET', 'staged_session_status', [
-            'session_id' => $session_id,
-            'path' => base64_encode($sent['path']),
-        ]);
-        $this->require_control_status($response, 'ok');
+        $response = $this->control_response(
+            $client,
+            'GET',
+            'staged_session_status',
+            [
+                'session_id' => $session_id,
+                'path' => base64_encode($sent['path']),
+            ],
+            ['ok']
+        );
         $paths = $response['paths'] ?? null;
         $target = is_array($paths) && isset($paths[0]) && is_array($paths[0]) ? $paths[0] : null;
         if ($target === null || ($target['path_b64'] ?? null) !== base64_encode($sent['path'])) {
@@ -1254,6 +1323,11 @@ class MultipartPush
                     throw new RuntimeException('Target status has no valid partial byte count.');
                 }
                 $state['current']['accepted_bytes'] = (int) $accepted_bytes;
+            } elseif ( ( $target['state'] ?? null ) === 'missing' ) {
+                if ( (int) ( $target['accepted_bytes'] ?? -1 ) !== 0 ) {
+                    throw new RuntimeException('Target status reported a missing file with a nonzero accepted byte count.');
+                }
+                $state['current']['accepted_bytes'] = 0;
             }
             return;
         }
@@ -1309,8 +1383,13 @@ class MultipartPush
     {
         $session_id = $this->session_id_from_state($state);
         do {
-            $response = $client->control_request('POST', 'staged_session_commit', ['session_id' => $session_id]);
-            $this->require_control_status($response, 'ok');
+            $response = $this->control_response(
+                $client,
+                'POST',
+                'staged_session_commit',
+                ['session_id' => $session_id],
+                ['ok']
+            );
             $this->log('Commit phase ' . ($response['phase'] ?? 'unknown') . '.');
         } while (!empty($response['send_next_request']));
     }
@@ -1329,18 +1408,14 @@ class MultipartPush
     private function discard_target_session(array $state, MultipartPushStreamClient $client): void
     {
         do {
-            $response = $client->control_request('POST', 'staged_session_discard', [
-                'session_id' => $this->session_id_from_state($state),
-            ]);
-            if (( $response['reason'] ?? null ) === 'commit_required') {
-                throw new RuntimeException(
-                    'Push commit has begun on the target. Re-run push to finish it; a live mutation cannot be discarded.'
-                );
-            }
+            $response = $this->control_response(
+                $client,
+                'POST',
+                'staged_session_discard',
+                ['session_id' => $this->session_id_from_state($state)],
+                ['discarding', 'discarded']
+            );
             $status = $response['status'] ?? null;
-            if ($status !== 'discarding' && $status !== 'discarded') {
-                $this->require_control_status($response, 'discarded');
-            }
             $send_next_request = $response['send_next_request'] ?? null;
             if (!is_bool($send_next_request) || ( $status === 'discarding' ) !== $send_next_request) {
                 throw new RuntimeException('Target discard response has inconsistent status and send_next_request fields.');
@@ -1551,21 +1626,77 @@ class MultipartPush
     }
 
     /**
-     * Requires the target's machine-readable control status to match expectation.
+     * Sends a control request until it succeeds or its retry budget is spent.
      *
-     * @param array<string,mixed> $response Decoded control response.
-     * @param string $expected_status Success status required by this lifecycle step.
+     * Every target response is classified by MultipartPushStreamClient before
+     * this method sees it. Only `busy` and `offset_gap` consume this bounded
+     * backoff; authentication and protocol failures stop immediately.
+     *
+     * @param MultipartPushStreamClient $client Signed target client.
+     * @param string $method GET or POST.
+     * @param string $endpoint Protocol endpoint query value.
+     * @param array<string,mixed> $parameters Additional signed query parameters.
+     * @param string[] $expected_statuses Successful statuses for this request.
+     * @return array<string,mixed> Decoded successful target response.
      */
-    private function require_control_status(array $response, string $expected_status): void
-    {
-        if (($response['status'] ?? null) !== $expected_status) {
-            $encoded_response = json_encode($response, JSON_UNESCAPED_SLASHES);
-            throw new RuntimeException(
-                'Push control request expected status ' . $expected_status . ', received '
-                . json_encode($response['status'] ?? null) . ': '
-                . ( is_string($encoded_response) ? $encoded_response : (string) ( $response['detail'] ?? $response['reason'] ?? '' ) )
+    private function control_response(
+        MultipartPushStreamClient $client,
+        string $method,
+        string $endpoint,
+        array $parameters,
+        array $expected_statuses
+    ): array {
+        $recoverable_attempts = 0;
+        while (true) {
+            $result = $client->control_request($method, $endpoint, $parameters, $expected_statuses);
+            if ( ( $result['status'] ?? null ) === 'complete' && is_array($result['response'] ?? null) ) {
+                return $result['response'];
+            }
+            if ( ( $result['status'] ?? null ) === 'failed' ) {
+                if ($endpoint === 'staged_session_discard' && ( $result['reason'] ?? null ) === 'commit_required') {
+                    throw new RuntimeException(
+                        'Push commit has begun on the target. Re-run push to finish it; a live mutation cannot be discarded.'
+                    );
+                }
+                $encoded_response = is_array($result['response'] ?? null)
+                    ? json_encode($result['response'], JSON_UNESCAPED_SLASHES)
+                    : false;
+                $reason = is_string($result['reason'] ?? null) ? $result['reason'] : 'unknown';
+                $detail = is_string($result['detail'] ?? null) ? $result['detail'] : '';
+                throw new RuntimeException(
+                    'Push control request ' . $endpoint . ' failed: ' . $reason . '. ' . $detail
+                    . ( $encoded_response === false ? '' : ' Target response: ' . $encoded_response )
+                );
+            }
+            $this->wait_for_recoverable_response(
+                $result,
+                $recoverable_attempts,
+                'Push control request ' . $endpoint
             );
         }
+    }
+
+    /**
+     * Applies one shared bounded exponential backoff to recoverable responses.
+     *
+     * @param array<string,mixed> $result Classified request result.
+     * @param int $attempts Consecutive recoverable responses for this operation.
+     * @param string $operation Human-readable operation name for exhaustion.
+     */
+    private function wait_for_recoverable_response(array $result, int &$attempts, string $operation): void
+    {
+        $reason = $result['reason'] ?? null;
+        if (( $result['status'] ?? null ) !== 'retry' || !in_array($reason, ['busy', 'offset_gap'], true)) {
+            return;
+        }
+        ++$attempts;
+        if ($attempts >= self::MAX_RECOVERABLE_RESPONSE_ATTEMPTS) {
+            throw new RuntimeException(
+                $operation . ' remained ' . $reason . ' after ' . $attempts . ' attempts. '
+                . ( is_string($result['detail'] ?? null) ? $result['detail'] : '' )
+            );
+        }
+        usleep(self::RECOVERABLE_RESPONSE_DELAY_MICROSECONDS * ( 1 << ( $attempts - 1 ) ));
     }
 
     /**

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -47,9 +47,9 @@
  * A curl_multi handle outlives individual requests so libcurl may reuse its
  * connection. The active easy handle exists only from start_upload_request()
  * through finish_request(). Timeouts are per phase rather than total-transfer
- * deadlines: connection establishment, lack of upload progress, and waiting
- * for a response after the closing boundary. A slow upload which continues
- * moving bytes is allowed to continue.
+ * deadlines: connection establishment, lack of upload progress, and lack of
+ * finish/response progress after the closing boundary is queued. A slow
+ * connection which continues moving bytes is allowed to continue.
  *
  * Pausing from a PHP cURL read callback is reliable only on PHP 8.1 and newer;
  * older bindings interpret CURL_READFUNC_PAUSE as end-of-body and silently
@@ -79,7 +79,7 @@ class MultipartPushStreamClient
     /** @var int Seconds allowed with no multipart bytes consumed by libcurl. */
     private int $stall_timeout;
 
-    /** @var int Seconds allowed for the finish/response phase after the close is queued. */
+    /** @var int Seconds allowed without finish/response progress after the close is queued. */
     private int $response_timeout;
 
     /**
@@ -482,8 +482,8 @@ class MultipartPushStreamClient
      *
      * When the transfer is still active, this queues the closing boundary and
      * signals EOF only after cURL consumes it. The finish phase has its own
-     * deadline beginning when that closing boundary is queued, not at request
-     * start. Redirects,
+     * no-progress timer beginning when that closing boundary is queued, not a
+     * total deadline measured from request start. Redirects,
      * structured target rejections, HTTP 413, invalid JSON, and cURL failures are
      * converted into stable `complete`, `retry`, or `failed` results.
      *
@@ -509,13 +509,22 @@ class MultipartPushStreamClient
             $this->outbound_suffix = '';
             $this->body_complete = true;
             curl_pause($this->curl_handle, CURLPAUSE_CONT);
-            $deadline = microtime(true) + $this->response_timeout;
+            $seen_outbound_bytes = $this->outbound_consumed_bytes;
+            $seen_inbound_bytes = (float) curl_getinfo($this->curl_handle, CURLINFO_SIZE_DOWNLOAD)
+                + (int) curl_getinfo($this->curl_handle, CURLINFO_HEADER_SIZE);
+            $last_progress_at = microtime(true);
             while (!$this->transfer_finished) {
-                if (microtime(true) > $deadline) {
-                    $this->transfer_error = 'No response arrived within ' . $this->response_timeout . 's of finishing the multipart upload body.';
+                $this->pump_transfer();
+                $inbound_bytes = (float) curl_getinfo($this->curl_handle, CURLINFO_SIZE_DOWNLOAD)
+                    + (int) curl_getinfo($this->curl_handle, CURLINFO_HEADER_SIZE);
+                if ($seen_outbound_bytes !== $this->outbound_consumed_bytes || $seen_inbound_bytes !== $inbound_bytes) {
+                    $seen_outbound_bytes = $this->outbound_consumed_bytes;
+                    $seen_inbound_bytes = $inbound_bytes;
+                    $last_progress_at = microtime(true);
+                } elseif (microtime(true) - $last_progress_at > $this->response_timeout) {
+                    $this->transfer_error = 'The multipart request finish phase stalled: no upload or response bytes moved for ' . $this->response_timeout . 's.';
                     break;
                 }
-                $this->pump_transfer();
             }
         }
 
@@ -527,8 +536,8 @@ class MultipartPushStreamClient
 
         if (in_array($http_code, [301, 302, 303, 307, 308], true)) {
             return $this->result('failed', 'redirected', $redirect_url === ''
-                ? 'The target redirected the upload. Use its final URL as the push target.'
-                : 'The target redirected to ' . $redirect_url . '. Use that address as the push target.');
+                ? 'The target redirected the upload. Use its final URL as the push base_url.'
+                : 'The target redirected to ' . $redirect_url . '. Use that address as the push base_url.');
         }
         $decoded = json_decode($body, true);
         if ($http_code === 413) {
@@ -542,6 +551,13 @@ class MultipartPushStreamClient
             );
         }
         if (!is_array($decoded)) {
+            if ($body !== '') {
+                return $this->result(
+                    'failed',
+                    'malformed_response',
+                    'Invalid JSON response (HTTP ' . $http_code . '): ' . substr($body, 0, 160)
+                );
+            }
             $decision = $this->request_sizer->record_request_failure();
             return $this->result(
                 $decision['action'] === 'give_up' ? 'failed' : 'retry',
@@ -549,19 +565,15 @@ class MultipartPushStreamClient
                 $this->transfer_error ?? 'Invalid JSON response (HTTP ' . $http_code . '): ' . substr($body, 0, 160)
             );
         }
-        if (($decoded['status'] ?? null) !== 'accepted') {
-            $reason = is_string($decoded['reason'] ?? null) ? $decoded['reason'] : 'unexpected_response';
-            return $this->result(
-                in_array($reason, ['busy'], true) ? 'retry' : 'failed',
-                $reason,
-                is_string($decoded['detail'] ?? null) ? $decoded['detail'] : 'HTTP ' . $http_code,
-                $decoded
-            );
+        $decoded['http_code'] = $http_code;
+        $result = $this->classify_response($decoded, ['accepted']);
+        if ($result['status'] !== 'complete') {
+            return $result;
         }
         if ($this->parts_sent > 0) {
             $this->request_sizer->record_success();
         }
-        return $this->result('complete', null, null, $decoded);
+        return $result;
     }
 
     /**
@@ -573,16 +585,20 @@ class MultipartPushStreamClient
      * @param string $method GET or POST.
      * @param string $endpoint Protocol endpoint query value.
      * @param array<string,mixed> $parameters Additional signed query parameters.
-     * @return array<string,mixed> Decoded target body plus its HTTP status code.
+     * @param string[] $expected_statuses Successful protocol statuses for this endpoint.
+     * @return array<string,mixed> Complete, retryable, or terminal response classification.
      *
      * @throws InvalidArgumentException If the method is unsupported.
      * @throws RuntimeException If transport, redirect, or JSON decoding fails.
      */
-    public function control_request(string $method, string $endpoint, array $parameters = []): array
+    public function control_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
     {
         $method = strtoupper($method);
         if (!in_array($method, ['GET', 'POST'], true)) {
             throw new InvalidArgumentException('Multipart push control method must be GET or POST.');
+        }
+        if ($expected_statuses === [] || count(array_filter($expected_statuses, 'is_string')) !== count($expected_statuses)) {
+            throw new InvalidArgumentException('Multipart push control requests require one or more string success statuses.');
         }
         $url = $this->endpoint_url($endpoint, $parameters);
         $headers = $this->hmac_client->get_envelope_auth_headers($method, $url);
@@ -618,7 +634,7 @@ class MultipartPushStreamClient
         $redirect_url = (string) curl_getinfo($handle, CURLINFO_REDIRECT_URL);
         curl_close($handle);
         if (in_array($http_code, [301, 302, 303, 307, 308], true)) {
-            throw new RuntimeException('The target redirected to ' . ($redirect_url === '' ? 'another address' : $redirect_url) . '. Use that address as the push target.');
+            throw new RuntimeException('The target redirected to ' . ($redirect_url === '' ? 'another address' : $redirect_url) . '. Use that address as the push base_url.');
         }
         if (!is_string($body)) {
             throw new RuntimeException('Push control request failed: ' . ($error === '' ? 'no response' : $error) . '.');
@@ -628,7 +644,7 @@ class MultipartPushStreamClient
             throw new RuntimeException('Push control request returned invalid JSON (HTTP ' . $http_code . '): ' . substr($body, 0, 160));
         }
         $decoded['http_code'] = $http_code;
-        return $decoded;
+        return $this->classify_response($decoded, $expected_statuses);
     }
 
     /**
@@ -861,7 +877,34 @@ class MultipartPushStreamClient
     }
 
     /**
-     * Builds the stable upload result shape consumed by MultipartPush.
+     * Classifies every decoded upload and control response by protocol reason.
+     *
+     * `busy` and `offset_gap` are recoverable because a later request can use
+     * the target-confirmed cursor. Every other rejection is terminal; HTTP
+     * status alone never promotes an unknown reason into a retry.
+     *
+     * @param array<string,mixed> $response Decoded target response with http_code.
+     * @param string[] $expected_statuses Successful statuses for this request.
+     * @return array<string,mixed> Stable complete, retry, or failed result.
+     */
+    private function classify_response(array $response, array $expected_statuses): array
+    {
+        if (in_array($response['status'] ?? null, $expected_statuses, true)) {
+            return $this->result('complete', null, null, $response);
+        }
+        $reason = is_string($response['reason'] ?? null) ? $response['reason'] : 'unexpected_response';
+        return $this->result(
+            in_array($reason, ['busy', 'offset_gap'], true) ? 'retry' : 'failed',
+            $reason,
+            is_string($response['detail'] ?? null)
+                ? $response['detail']
+                : 'HTTP ' . (int) ($response['http_code'] ?? 0),
+            $response
+        );
+    }
+
+    /**
+     * Builds the stable response result shape consumed by MultipartPush.
      *
      * @param string $status `complete`, `retry`, or `failed`.
      * @param string|null $reason Machine-readable target/transport classification.

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -184,6 +184,284 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertLessThan(32 * 1024 * 1024, $client->get_request_sizer_state()['request_body_bytes']);
     }
 
+    public function testMalformedNonemptyUploadResponseIsTerminal(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('e', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->read_available($connection);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'malformed-response.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $response = '<html>not json</html>';
+        fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('malformed_response', $result['reason']);
+        $this->assertStringContainsString('Invalid JSON response', $result['detail']);
+    }
+
+    public function testZeroProgressUploadStallStopsWithoutATotalTransferTimeout(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 16 * 1024 * 1024,
+            'connect_timeout' => 2,
+            'stall_timeout' => 1,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('f', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $started = microtime(true);
+        $sent = $client->send_part([
+            'type' => 'file',
+            'path' => 'stalled.bin',
+            'total_bytes' => 16 * 1024 * 1024,
+            'offset' => 0,
+            'payload' => str_repeat('x', 16 * 1024 * 1024),
+        ]);
+        $elapsed = microtime(true) - $started;
+        $result = $client->finish_request();
+        fclose($connection);
+        fclose($listener);
+
+        $this->assertFalse($sent);
+        $this->assertGreaterThanOrEqual(0.9, $elapsed);
+        $this->assertLessThan(3.0, $elapsed);
+        $this->assertSame('retry', $result['status']);
+        $this->assertSame('request_failed', $result['reason']);
+        $this->assertStringContainsString('no bytes moved for 1s', $result['detail']);
+    }
+
+    public function testResponseWaitTimeoutStartsAfterTheClosingBoundary(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 1,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('1', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'waiting.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $started = microtime(true);
+        $result = $client->finish_request();
+        $elapsed = microtime(true) - $started;
+        fclose($connection);
+        fclose($listener);
+
+        $this->assertGreaterThanOrEqual(0.9, $elapsed);
+        $this->assertLessThan(3.0, $elapsed);
+        $this->assertSame('retry', $result['status']);
+        $this->assertSame('request_failed', $result['reason']);
+        $this->assertStringContainsString('no upload or response bytes moved for 1s', $result['detail']);
+    }
+
+    public function testSlowContinuousResponseProgressMayExceedTheResponseTimeout(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Slow wire coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_blocking($connection, false);
+            $deadline = microtime(true) + 10;
+            $received = '';
+            $closing = null;
+            while (!feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (is_string($piece) && $piece !== '') {
+                    $received .= $piece;
+                    if ($closing === null && preg_match('/boundary=(reprint-[a-f0-9]+)/', $received, $matches) === 1) {
+                        $closing = '--' . $matches[1] . "--\r\n";
+                    }
+                    if ($closing !== null && strpos($received, $closing) !== false) {
+                        break;
+                    }
+                } elseif (microtime(true) > $deadline) {
+                    exit(3);
+                } else {
+                    usleep(1000);
+                }
+            }
+            $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+            fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n");
+            foreach (str_split($response, 8) as $piece) {
+                if (@fwrite($connection, $piece) === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(4);
+                }
+                usleep(350000);
+            }
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 1,
+        ]);
+        $this->assertTrue($client->start_upload_request(str_repeat('3', 32)));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'slow-response.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $started = microtime(true);
+        $result = $client->finish_request();
+        $elapsed = microtime(true) - $started;
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertGreaterThan(1.0, $elapsed);
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+    }
+
+    public function testSlowContinuousUploadProgressMayExceedTheStallTimeout(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Slow wire coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_blocking($connection, false);
+            $deadline = microtime(true) + 15;
+            $received = '';
+            $closing = null;
+            $tail = '';
+            while (!feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    if (microtime(true) > $deadline) {
+                        exit(3);
+                    }
+                    usleep(1000);
+                    continue;
+                }
+                if ($closing === null) {
+                    $received .= $piece;
+                    if (preg_match('/boundary=(reprint-[a-f0-9]+)/', $received, $matches) === 1) {
+                        $closing = '--' . $matches[1] . "--\r\n";
+                        $tail = substr($received, -strlen($closing));
+                        $received = '';
+                    }
+                } else {
+                    $tail .= $piece;
+                }
+                usleep(2000);
+                if ($closing !== null) {
+                    if (strpos($tail, $closing) !== false) {
+                        break;
+                    }
+                    $tail = substr($tail, -strlen($closing));
+                }
+            }
+            $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+            fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 8 * 1024 * 1024,
+            'connect_timeout' => 2,
+            'stall_timeout' => 1,
+            'response_timeout' => 5,
+        ]);
+        $started = microtime(true);
+        $this->assertTrue($client->start_upload_request(str_repeat('2', 32)));
+        $sent = $client->send_part([
+            'type' => 'file',
+            'path' => 'slow-progress.bin',
+            'total_bytes' => 8 * 1024 * 1024,
+            'offset' => 0,
+            'payload' => str_repeat('x', 8 * 1024 * 1024),
+        ]);
+        $result = $client->finish_request();
+        $elapsed = microtime(true) - $started;
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertGreaterThan(1.0, $elapsed);
+        $this->assertTrue($sent, (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+    }
+
     private function read_available($connection): string {
         stream_set_blocking($connection, false);
         $received = '';

--- a/tests/Import/MultipartPushTest.php
+++ b/tests/Import/MultipartPushTest.php
@@ -44,6 +44,11 @@ final class MultipartPushTest extends TestCase {
     private ?string $reject_upload_marker = null;
     private ?string $drop_discard_response_marker = null;
     private bool $make_checkpoint_unremovable_after_discard = false;
+    /** @var array<string,int> */
+    private array $busy_response_limits = [];
+    private string $server_secret = self::SECRET;
+    private ?string $control_fault = null;
+    private int $too_large_upload_responses = 0;
     /** @var string[] */
     private array $apply_protected_paths = [];
 
@@ -163,6 +168,214 @@ final class MultipartPushTest extends TestCase {
         $this->assertStringContainsString('same --state-dir', $result['stderr']);
         $this->assertSame('live exporter', file_get_contents($this->target . '/wp-content/plugins/site-export/index.php'));
         $this->assertFileDoesNotExist($this->target . '/.maintenance');
+    }
+
+    public function testBusySessionCreationRetriesUntilTheTargetBecomesAvailable(): void {
+        $this->busy_response_limits = ['staged_session_create' => 2];
+        $this->configure_server();
+        $this->write_source('created-after-contention.txt', 'created');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('created', file_get_contents($this->target . '/created-after-contention.txt'));
+        $this->assertSame(3, $this->endpoint_count('staged_session_create'));
+    }
+
+    public function testBusyUploadRetriesUntilTheTargetBecomesAvailable(): void {
+        $this->busy_response_limits = ['staged_session_upload' => 2];
+        $this->configure_server();
+        $this->write_source('uploaded-after-contention.txt', 'uploaded');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('uploaded', file_get_contents($this->target . '/uploaded-after-contention.txt'));
+        $this->assertGreaterThanOrEqual(4, $this->endpoint_count('staged_session_upload'));
+    }
+
+    public function testBusyCommitRetriesUntilTheTargetBecomesAvailable(): void {
+        $this->busy_response_limits = ['staged_session_commit' => 2];
+        $this->configure_server();
+        $this->write_source('committed-after-contention.txt', 'committed');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('committed', file_get_contents($this->target . '/committed-after-contention.txt'));
+        $this->assertGreaterThanOrEqual(3, $this->endpoint_count('staged_session_commit'));
+    }
+
+    public function testBusyDiscardRetriesUntilTheTargetBecomesAvailable(): void {
+        $this->busy_response_limits = ['staged_session_discard' => 2];
+        $this->configure_server();
+        $this->write_source('cleaned-after-contention.txt', 'cleaned');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('cleaned', file_get_contents($this->target . '/cleaned-after-contention.txt'));
+        $this->assertSame(3, $this->endpoint_count('staged_session_discard'));
+        $this->assertSame([], glob($this->state . '/push/*/session.json') ?: []);
+    }
+
+    public function testPersistentBusyUploadFailsBoundedlyAndTheNextProcessResumes(): void {
+        $this->busy_response_limits = ['staged_session_upload' => 6];
+        $this->configure_server();
+        $this->write_source('resumed-after-contention.txt', 'resumed');
+
+        $failed = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertNotSame(0, $failed['exit_code']);
+        $this->assertStringContainsString('remained busy after 5 attempts', $failed['stderr']);
+        $this->assertCount(1, glob($this->state . '/push/*/session.json') ?: []);
+        $this->assertFileDoesNotExist($this->target . '/resumed-after-contention.txt');
+
+        $this->busy_response_limits = [];
+        $this->configure_server();
+        $resumed = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $resumed['exit_code'], $resumed['stderr']);
+        $this->assertSame('resumed', file_get_contents($this->target . '/resumed-after-contention.txt'));
+        $this->assertSame([], glob($this->state . '/push/*/session.json') ?: []);
+    }
+
+    public function testAuthenticationFailureIsTerminalWithoutRetrying(): void {
+        $this->server_secret = 'different-target-secret';
+        $this->configure_server();
+        $this->write_source('must-not-authenticate.txt', 'no');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertNotSame(0, $result['exit_code']);
+        $this->assertStringContainsString('authentication', strtolower($result['stderr']));
+        $this->assertSame(1, $this->endpoint_count('staged_session_create'));
+        $this->assertFileDoesNotExist($this->target . '/must-not-authenticate.txt');
+    }
+
+    public function testControlRedirectIsTerminalWithTargetGuidance(): void {
+        $this->control_fault = 'redirect';
+        $this->configure_server();
+        $this->write_source('must-not-redirect.txt', 'no');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertNotSame(0, $result['exit_code']);
+        $this->assertStringContainsString('redirected to', $result['stderr']);
+        $this->assertStringContainsString('Use that address as the push base_url', $result['stderr']);
+        $this->assertSame(1, $this->endpoint_count('staged_session_create'));
+        $this->assertFileDoesNotExist($this->target . '/must-not-redirect.txt');
+    }
+
+    public function testMalformedControlResponseIsTerminalWithoutRetrying(): void {
+        $this->control_fault = 'malformed';
+        $this->configure_server();
+        $this->write_source('must-not-accept-malformed.txt', 'no');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertNotSame(0, $result['exit_code']);
+        $this->assertStringContainsString('invalid JSON', $result['stderr']);
+        $this->assertSame(1, $this->endpoint_count('staged_session_create'));
+        $this->assertFileDoesNotExist($this->target . '/must-not-accept-malformed.txt');
+    }
+
+    public function testHttp413ShrinksTheRequestAndResumesFromTargetStatus(): void {
+        $this->too_large_upload_responses = 1;
+        $this->configure_server();
+        $this->write_source('accepted-after-413.txt', 'right-sized retry');
+
+        $result = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('right-sized retry', file_get_contents($this->target . '/accepted-after-413.txt'));
+        $this->assertGreaterThanOrEqual(3, $this->endpoint_count('staged_session_upload'));
+        $this->assertGreaterThanOrEqual(1, $this->endpoint_count('staged_session_status'));
+    }
+
+    public function testOffsetGapResumesFromTheTargetConfirmedFileCursor(): void {
+        $this->reject_upload_marker = $this->case_root . '/rejected-before-offset-gap';
+        $this->configure_server();
+        $this->write_source('offset-gap.bin', 'target starts with no bytes');
+
+        $interrupted = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertNotSame(0, $interrupted['exit_code']);
+        $checkpoints = glob($this->state . '/push/*/session.json') ?: [];
+        $this->assertCount(1, $checkpoints);
+        $checkpoint = json_decode( (string) file_get_contents($checkpoints[0]), true);
+        $this->assertIsArray($checkpoint);
+        $this->assertSame(base64_encode('offset-gap.bin'), $checkpoint['current']['path_b64'] ?? null);
+
+        // Simulate a sender checkpoint ahead of the target. The rejection must
+        // reconcile from status rather than trusting this attempted cursor.
+        $checkpoint['current']['accepted_bytes'] = 1;
+        file_put_contents($checkpoints[0], json_encode($checkpoint));
+        $status_requests_before_resume = $this->endpoint_count('staged_session_status');
+
+        $resumed = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $resumed['exit_code'], $resumed['stderr']);
+        $this->assertSame('target starts with no bytes', file_get_contents($this->target . '/offset-gap.bin'));
+        $this->assertGreaterThan($status_requests_before_resume, $this->endpoint_count('staged_session_status'));
+    }
+
+    public function testOffsetGapResumesFromTheTargetConfirmedDeleteCursor(): void {
+        $this->write_source('delete-offset-gap.txt', 'delete this');
+        $initial = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertSame(0, $initial['exit_code'], $initial['stderr']);
+
+        unlink($this->source . '/delete-offset-gap.txt');
+        $this->reject_upload_marker = $this->case_root . '/rejected-before-delete-offset-gap';
+        $this->configure_server();
+        $interrupted = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertNotSame(0, $interrupted['exit_code']);
+        $checkpoints = glob($this->state . '/push/*/session.json') ?: [];
+        $this->assertCount(1, $checkpoints);
+        $checkpoint = json_decode( (string) file_get_contents($checkpoints[0]), true);
+        $this->assertIsArray($checkpoint);
+
+        // Simulate a sender checkpoint one byte ahead of an empty target
+        // delete stream. Status must rewind the one local/wire cursor.
+        $checkpoint['delete_offset'] = 1;
+        file_put_contents($checkpoints[0], json_encode($checkpoint));
+        $status_requests_before_resume = $this->endpoint_count('staged_session_status');
+
+        $resumed = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $resumed['exit_code'], $resumed['stderr']);
+        $this->assertFileDoesNotExist($this->target . '/delete-offset-gap.txt');
+        $this->assertGreaterThan($status_requests_before_resume, $this->endpoint_count('staged_session_status'));
+    }
+
+    public function testCheckpointAtDeleteEofReconcilesBeforeCompletion(): void {
+        $path = 'delete-completion-offset-gap.txt';
+        $this->write_source($path, 'delete this too');
+        $initial = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertSame(0, $initial['exit_code'], $initial['stderr']);
+
+        unlink($this->source . '/' . $path);
+        $this->reject_upload_marker = $this->case_root . '/rejected-before-delete-completion-offset-gap';
+        $this->configure_server();
+        $interrupted = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertNotSame(0, $interrupted['exit_code']);
+        $checkpoints = glob($this->state . '/push/*/session.json') ?: [];
+        $delete_streams = glob($this->state . '/push/*/local-delete-stream.bin') ?: [];
+        $this->assertCount(1, $checkpoints);
+        $this->assertCount(1, $delete_streams);
+        $checkpoint = json_decode( (string) file_get_contents($checkpoints[0]), true);
+        $this->assertIsArray($checkpoint);
+
+        // Simulate a checkpoint which falsely says the complete delete stream
+        // reached the target. Signed status must rewind to zero and upload the
+        // pending raw bytes before completion can be declared.
+        $checkpoint['delete_offset'] = filesize($delete_streams[0]);
+        file_put_contents($checkpoints[0], json_encode($checkpoint));
+
+        $resumed = $this->run_cli('push', ['--source-root=' . $this->source]);
+
+        $this->assertSame(0, $resumed['exit_code'], $resumed['stderr']);
+        $this->assertFileDoesNotExist($this->target . '/' . $path);
+        $this->assertGreaterThanOrEqual(1, $this->endpoint_count('staged_session_status'));
     }
 
     public function testCliPushDeliversInitialAndDeltaTreesThroughTheRealRouter(): void {
@@ -969,58 +1182,81 @@ final class MultipartPushTest extends TestCase {
     }
 
     public function testSameSizeSourceEditDuringLostResponseRestartsAtZeroInsteadOfBuildingAHybridFile(): void {
-        $this->pause_after_upload_marker = $this->case_root . '/upload-accepted';
-        $this->resume_upload_response_marker = $this->case_root . '/resume-upload-response';
-        $this->configure_server();
         $source_path = $this->source . '/changed-during-response.bin';
         $old_contents = str_repeat('old-', 200);
         $new_contents = str_repeat('new-', 200);
         file_put_contents($source_path, $old_contents);
         $old_ctime = (int) lstat($source_path)['ctime'];
 
-        $entry = realpath(__DIR__ . '/../../importer/import.php');
-        $this->assertNotFalse($entry);
-        $process = proc_open([
-            PHP_BINARY,
-            $entry,
-            'push',
-            self::$base_url,
-            '--state-dir=' . $this->state,
-            '--secret=' . self::SECRET,
-            '--allow-http',
-            '--source-root=' . $this->source,
-        ], [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $this->case_root);
-        $this->assertIsResource($process);
+        $result = $this->run_push_while_first_upload_response_is_paused(function () use ($source_path, $new_contents, $old_ctime): void {
+            $new_ctime = $old_ctime;
+            for ($attempt = 0; $attempt < 4 && $new_ctime === $old_ctime; ++$attempt) {
+                sleep(1);
+                file_put_contents($source_path, $new_contents);
+                clearstatcache(true, $source_path);
+                $new_ctime = (int) lstat($source_path)['ctime'];
+            }
+            $this->assertNotSame($old_ctime, $new_ctime, 'The filesystem did not expose a ctime change for the same-size edit.');
+        });
 
-        for ($attempt = 0; $attempt < 100 && !is_file($this->pause_after_upload_marker); ++$attempt) {
-            usleep(100000);
-        }
-        $this->assertFileExists($this->pause_after_upload_marker, 'The target never accepted the old source version.');
-        $new_ctime = $old_ctime;
-        for ($attempt = 0; $attempt < 4 && $new_ctime === $old_ctime; ++$attempt) {
-            sleep(1);
-            file_put_contents($source_path, $new_contents);
-            clearstatcache(true, $source_path);
-            $new_ctime = (int) lstat($source_path)['ctime'];
-        }
-        $this->assertNotSame($old_ctime, $new_ctime, 'The filesystem did not expose a ctime change for the same-size edit.');
-        file_put_contents($this->resume_upload_response_marker, "resume\n");
-
-        $stdout = stream_get_contents($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
-        fclose($pipes[1]);
-        fclose($pipes[2]);
-        $exit_code = proc_close($process);
-        $lines = array_values(array_filter(preg_split('/\R/', trim((string) $stdout)) ?: [], static function (string $line): bool {
-            return $line !== '';
-        }));
-        $result = $lines === [] ? null : json_decode((string) end($lines), true);
-
-        $this->assertSame(0, $exit_code, (string) $stderr);
-        $this->assertSame('complete', is_array($result) ? ($result['status'] ?? null) : null);
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('complete', $result['json']['status'] ?? null);
         $this->assertSame($new_contents, file_get_contents($this->target . '/changed-during-response.bin'));
         $this->assertNotSame($old_contents, file_get_contents($this->target . '/changed-during-response.bin'));
         $this->assertGreaterThanOrEqual(1, $this->endpoint_count('staged_session_status'));
+    }
+
+    public function testSourceGrowthDuringLostResponseRestartsAtZeroInsteadOfAppendingVersions(): void {
+        $source_path = $this->source . '/grown-during-response.bin';
+        $old_contents = str_repeat('old-', 200);
+        $new_contents = str_repeat('new-version-', 120);
+        file_put_contents($source_path, $old_contents);
+
+        $result = $this->run_push_while_first_upload_response_is_paused(static function () use ($source_path, $new_contents): void {
+            file_put_contents($source_path, $new_contents);
+        });
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('complete', $result['json']['status'] ?? null);
+        $this->assertSame($new_contents, file_get_contents($this->target . '/grown-during-response.bin'));
+        $this->assertNotSame($old_contents, file_get_contents($this->target . '/grown-during-response.bin'));
+        $this->assertGreaterThanOrEqual(1, $this->endpoint_count('staged_session_status'));
+    }
+
+    public function testSourceShrinkDuringLostResponseRestartsAtZeroInsteadOfKeepingAnOldSuffix(): void {
+        $source_path = $this->source . '/shrunk-during-response.bin';
+        $old_contents = str_repeat('old-version-', 120);
+        $new_contents = str_repeat('new-', 100);
+        file_put_contents($source_path, $old_contents);
+
+        $result = $this->run_push_while_first_upload_response_is_paused(static function () use ($source_path, $new_contents): void {
+            file_put_contents($source_path, $new_contents);
+        });
+
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $this->assertSame('complete', $result['json']['status'] ?? null);
+        $this->assertSame($new_contents, file_get_contents($this->target . '/shrunk-during-response.bin'));
+        $this->assertNotSame($old_contents, file_get_contents($this->target . '/shrunk-during-response.bin'));
+        $this->assertGreaterThanOrEqual(1, $this->endpoint_count('staged_session_status'));
+    }
+
+    public function testSourceDeletionDuringLostResponseDiscardsTheStalePrivateSession(): void {
+        $source_path = $this->source . '/deleted-during-response.bin';
+        file_put_contents($source_path, str_repeat('delete-me-', 100));
+
+        $result = $this->run_push_while_first_upload_response_is_paused(static function () use ($source_path): void {
+            unlink($source_path);
+        });
+
+        $this->assertNotSame(0, $result['exit_code']);
+        $this->assertStringContainsString('Source changed structurally during push', $result['stderr']);
+        $this->assertFileDoesNotExist($this->target . '/deleted-during-response.bin');
+        $this->assertSame([], glob($this->state . '/push/*/session.json') ?: []);
+
+        $resumed = $this->run_cli('push', ['--source-root=' . $this->source]);
+        $this->assertSame(0, $resumed['exit_code'], $resumed['stderr']);
+        $this->assertSame('complete', $resumed['json']['status'] ?? null);
+        $this->assertFileDoesNotExist($this->target . '/deleted-during-response.bin');
     }
 
     public function testAbortKeepsLocalStateUntilTheTargetConfirmsDiscard(): void {
@@ -1059,6 +1295,57 @@ final class MultipartPushTest extends TestCase {
         $this->assertStringContainsString('same-filesystem rename', $result['stderr']);
         $this->assertFileDoesNotExist($this->target . '/must-not-arrive.txt');
         $this->assertSame(1, $this->endpoint_count('staged_session_create'));
+    }
+
+    /** @return array{exit_code:int,stdout:string,stderr:string,json:array<string,mixed>} */
+    private function run_push_while_first_upload_response_is_paused(callable $mutate_source): array {
+        $this->pause_after_upload_marker = $this->case_root . '/upload-accepted';
+        $this->resume_upload_response_marker = $this->case_root . '/resume-upload-response';
+        $this->configure_server();
+        $entry = realpath(__DIR__ . '/../../importer/import.php');
+        $this->assertNotFalse($entry);
+        $process = proc_open([
+            PHP_BINARY,
+            $entry,
+            'push',
+            self::$base_url,
+            '--state-dir=' . $this->state,
+            '--secret=' . self::SECRET,
+            '--allow-http',
+            '--source-root=' . $this->source,
+        ], [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $this->case_root);
+        $this->assertIsResource($process);
+
+        for ($attempt = 0; $attempt < 100 && !is_file($this->pause_after_upload_marker); ++$attempt) {
+            usleep(100000);
+        }
+        $this->assertFileExists($this->pause_after_upload_marker, 'The target never accepted the old source version.');
+        $mutation_error = null;
+        try {
+            $mutate_source();
+        } catch (\Throwable $error) {
+            $mutation_error = $error;
+        }
+        file_put_contents($this->resume_upload_response_marker, "resume\n");
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit_code = proc_close($process);
+        if ($mutation_error !== null) {
+            throw $mutation_error;
+        }
+        $lines = array_values(array_filter(preg_split('/\R/', trim( (string) $stdout)) ?: [], static function (string $line): bool {
+            return $line !== '';
+        }));
+        $decoded = $lines === [] ? null : json_decode( (string) end($lines), true);
+        return [
+            'exit_code' => $exit_code,
+            'stdout' => (string) $stdout,
+            'stderr' => (string) $stderr,
+            'json' => is_array($decoded) ? $decoded : [],
+        ];
     }
 
     /** @param string[] $extra_options @return array{exit_code:int,stdout:string,stderr:string,json:array<string,mixed>} */
@@ -1141,7 +1428,7 @@ final class MultipartPushTest extends TestCase {
     private function configure_server(): void {
         file_put_contents(self::$config_path, json_encode([
             'staging_dir' => $this->storage,
-            'secret' => self::SECRET,
+            'secret' => $this->server_secret,
             'apply_target_root' => $this->target,
             // Make the real CLI split the large file into several MIME parts.
             'max_frame_bytes' => $this->max_frame_bytes,
@@ -1159,6 +1446,11 @@ final class MultipartPushTest extends TestCase {
             'reject_upload_marker' => $this->reject_upload_marker,
             'drop_discard_response_marker' => $this->drop_discard_response_marker,
             'make_checkpoint_unremovable_after_discard' => $this->make_checkpoint_unremovable_after_discard,
+            'busy_response_limits' => $this->busy_response_limits,
+            'busy_response_counter_dir' => $this->case_root,
+            'control_fault' => $this->control_fault,
+            'redirect_url' => self::$base_url,
+            'too_large_upload_responses' => $this->too_large_upload_responses,
             'apply_protected_paths' => $this->apply_protected_paths,
             'local_state_dir' => $this->state,
         ]));
@@ -1293,6 +1585,49 @@ if ((\$_GET['endpoint'] ?? null) === 'staged_session_status'
     file_put_contents(\$config['negative_delete_status_marker'], "returned negative delete_bytes\\n");
     echo \$response_body;
     return true;
+}
+\$endpoint = \$_GET['endpoint'] ?? null;
+\$busy_response_limits = \$config['busy_response_limits'] ?? [];
+if (is_string(\$endpoint) && is_array(\$busy_response_limits) && isset(\$busy_response_limits[\$endpoint])) {
+    \$counter_path = (string) \$config['busy_response_counter_dir'] . '/busy-' . \$endpoint . '.count';
+    \$attempt = (int) @file_get_contents(\$counter_path) + 1;
+    file_put_contents(\$counter_path, (string) \$attempt);
+    if (\$attempt <= (int) \$busy_response_limits[\$endpoint]) {
+        http_response_code(423);
+        header('Content-Type: application/json');
+        echo json_encode([
+            'status' => 'error',
+            'reason' => 'busy',
+            'detail' => 'The test endpoint is busy.',
+            'send_next_request' => false,
+        ]);
+        return true;
+    }
+}
+if (\$endpoint === 'staged_session_create' && (\$config['control_fault'] ?? null) === 'redirect') {
+    http_response_code(307);
+    header('Location: ' . (string) \$config['redirect_url']);
+    return true;
+}
+if (\$endpoint === 'staged_session_create' && (\$config['control_fault'] ?? null) === 'malformed') {
+    header('Content-Type: text/plain');
+    echo 'not a JSON response';
+    return true;
+}
+if (\$endpoint === 'staged_session_upload' && (int) (\$config['too_large_upload_responses'] ?? 0) > 0) {
+    \$counter_path = (string) \$config['busy_response_counter_dir'] . '/forced-413.count';
+    \$attempt = (int) @file_get_contents(\$counter_path) + 1;
+    file_put_contents(\$counter_path, (string) \$attempt);
+    if (\$attempt <= (int) \$config['too_large_upload_responses']) {
+        http_response_code(413);
+        header('Content-Type: application/json');
+        echo json_encode([
+            'status' => 'error',
+            'reason' => 'request_too_large',
+            'post_max_bytes' => 4 * 1024 * 1024,
+        ]);
+        return true;
+    }
 }
 if ((\$_GET['endpoint'] ?? null) === 'staged_session_upload'
     && is_string(\$config['reject_upload_marker'] ?? null)

--- a/tests/StagedApplySessionTest.php
+++ b/tests/StagedApplySessionTest.php
@@ -78,13 +78,32 @@ final class StagedApplySessionTest extends TestCase {
         try {
             $session->next_change();
             $this->fail('An offset gap was accepted.');
-        } catch (InvalidArgumentException $exception) {
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('offset_gap', $exception->get_error_code());
             $this->assertStringContainsString('Start at offset 0', $exception->getMessage());
         } finally {
             $session->finish_upload();
             fclose($input);
         }
         $this->assertFileDoesNotExist($session->get_session_directory() . '/work/files/must-not-be-read.bin');
+    }
+
+    public function testDeleteOffsetGapHasTheSameRecoverableProtocolReason(): void {
+        $session = $this->session('23232323232323232323232323232323');
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '1',
+                ],
+                'body' => "gone\0",
+            ]]);
+            $this->fail('A delete offset gap was accepted.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('offset_gap', $exception->get_error_code());
+            $this->assertStringContainsString('target has stored 0 bytes', $exception->getMessage());
+        }
     }
 
     public function testProtectedAndInvalidPathsNeverReachStaging(): void {

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -148,6 +148,9 @@
     },
     "push-pull-roundtrip": {
       "port": 8128
+    },
+    "push-busy": {
+      "port": 8129
     }
   }
 }

--- a/tests/e2e/tests/import-53-push-direct-apply.test.js
+++ b/tests/e2e/tests/import-53-push-direct-apply.test.js
@@ -104,7 +104,7 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
         }
     });
 
-    it('covers the real file, symlink, empty-directory, and structural transitions', () => {
+    it('seeds independently reported file, symlink, empty, and structural transitions', () => {
         rmSync(join(sourceRoot, 'push-fixture'), { recursive: true, force: true });
         const fixture = join(sourceRoot, 'push-fixture');
         writeSource(sourceRoot, 'push-fixture/file-to-file', 'old');
@@ -122,30 +122,123 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
         writeSource(sourceRoot, 'push-fixture/structural-stays/old', 'old');
         assertPush(runPush(site, sourceRoot, stateDir));
 
-        writeFileSync(join(fixture, 'file-to-file'), 'new-value');
-        rmSync(join(fixture, 'file-to-symlink'));
-        symlinkSync('target-b', join(fixture, 'file-to-symlink'));
-        rmSync(join(fixture, 'symlink-to-file'));
-        writeFileSync(join(fixture, 'symlink-to-file'), 'new');
-        rmSync(join(fixture, 'symlink-to-symlink'));
-        symlinkSync('target-b', join(fixture, 'symlink-to-symlink'));
-        replaceWithFile(join(fixture, 'directory-to-file'), 'new');
-        replaceWithSymlink(join(fixture, 'directory-to-symlink'), 'target-b');
-        replaceWithEmptyDirectory(join(fixture, 'directory-to-empty'));
-        replaceWithEmptyDirectory(join(fixture, 'file-to-empty'));
-        replaceWithEmptyDirectory(join(fixture, 'symlink-to-empty'));
-        replaceWithStructuralDirectory(join(fixture, 'file-to-structural'));
-        replaceWithStructuralDirectory(join(fixture, 'symlink-to-structural'));
-        writeFileSync(join(fixture, 'empty-to-structural/child'), 'new');
-        rmSync(join(fixture, 'structural-stays/old'));
-        writeFileSync(join(fixture, 'structural-stays/new'), 'new');
+        assert.deepEqual(logicalTree(fixture), logicalTree(targetFixture));
+    });
+
+    it('applies a file-to-file transition', () => {
+        writeFileSync(join(sourceRoot, 'push-fixture/file-to-file'), 'new-value');
         assertPush(runPush(site, sourceRoot, stateDir));
 
-        assert.deepEqual(logicalTree(fixture), logicalTree(targetFixture));
+        assert.ok(lstatSync(join(targetFixture, 'file-to-file')).isFile());
         assert.equal(readFileSync(join(targetFixture, 'file-to-file'), 'utf8'), 'new-value');
+    });
+
+    it('applies a file-to-symlink transition', () => {
+        const path = join(sourceRoot, 'push-fixture/file-to-symlink');
+        rmSync(path);
+        symlinkSync('target-b', path);
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'file-to-symlink')).isSymbolicLink());
         assert.equal(readlinkSync(join(targetFixture, 'file-to-symlink')), 'target-b');
+    });
+
+    it('applies a symlink-to-file transition', () => {
+        const path = join(sourceRoot, 'push-fixture/symlink-to-file');
+        rmSync(path);
+        writeFileSync(path, 'new');
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'symlink-to-file')).isFile());
         assert.equal(readFileSync(join(targetFixture, 'symlink-to-file'), 'utf8'), 'new');
+    });
+
+    it('applies a symlink-to-symlink transition', () => {
+        const path = join(sourceRoot, 'push-fixture/symlink-to-symlink');
+        rmSync(path);
+        symlinkSync('target-b', path);
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'symlink-to-symlink')).isSymbolicLink());
         assert.equal(readlinkSync(join(targetFixture, 'symlink-to-symlink')), 'target-b');
+    });
+
+    it('applies a directory-to-file transition', () => {
+        replaceWithFile(join(sourceRoot, 'push-fixture/directory-to-file'), 'new');
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'directory-to-file')).isFile());
+        assert.equal(readFileSync(join(targetFixture, 'directory-to-file'), 'utf8'), 'new');
+    });
+
+    it('applies a directory-to-symlink transition', () => {
+        replaceWithSymlink(join(sourceRoot, 'push-fixture/directory-to-symlink'), 'target-b');
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'directory-to-symlink')).isSymbolicLink());
+        assert.equal(readlinkSync(join(targetFixture, 'directory-to-symlink')), 'target-b');
+    });
+
+    it('applies a directory-to-empty-directory transition', () => {
+        replaceWithEmptyDirectory(join(sourceRoot, 'push-fixture/directory-to-empty'));
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'directory-to-empty')).isDirectory());
+        assert.deepEqual(readdirSync(join(targetFixture, 'directory-to-empty')), []);
+    });
+
+    it('applies a file-to-empty-directory transition', () => {
+        replaceWithEmptyDirectory(join(sourceRoot, 'push-fixture/file-to-empty'));
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'file-to-empty')).isDirectory());
+        assert.deepEqual(readdirSync(join(targetFixture, 'file-to-empty')), []);
+    });
+
+    it('applies a symlink-to-empty-directory transition', () => {
+        replaceWithEmptyDirectory(join(sourceRoot, 'push-fixture/symlink-to-empty'));
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'symlink-to-empty')).isDirectory());
+        assert.deepEqual(readdirSync(join(targetFixture, 'symlink-to-empty')), []);
+    });
+
+    it('applies a file-to-structural-directory transition', () => {
+        replaceWithStructuralDirectory(join(sourceRoot, 'push-fixture/file-to-structural'));
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'file-to-structural')).isDirectory());
+        assert.equal(readFileSync(join(targetFixture, 'file-to-structural/child'), 'utf8'), 'new');
+    });
+
+    it('applies a symlink-to-structural-directory transition', () => {
+        replaceWithStructuralDirectory(join(sourceRoot, 'push-fixture/symlink-to-structural'));
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'symlink-to-structural')).isDirectory());
+        assert.equal(readFileSync(join(targetFixture, 'symlink-to-structural/child'), 'utf8'), 'new');
+    });
+
+    it('applies an empty-to-structural-directory transition', () => {
+        writeFileSync(join(sourceRoot, 'push-fixture/empty-to-structural/child'), 'new');
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'empty-to-structural')).isDirectory());
+        assert.equal(readFileSync(join(targetFixture, 'empty-to-structural/child'), 'utf8'), 'new');
+    });
+
+    it('updates children below a structural directory', () => {
+        rmSync(join(sourceRoot, 'push-fixture/structural-stays/old'));
+        writeFileSync(join(sourceRoot, 'push-fixture/structural-stays/new'), 'new');
+        assertPush(runPush(site, sourceRoot, stateDir));
+
+        assert.ok(lstatSync(join(targetFixture, 'structural-stays')).isDirectory());
+        assert.ok(!existsSync(join(targetFixture, 'structural-stays/old')));
+        assert.equal(readFileSync(join(targetFixture, 'structural-stays/new'), 'utf8'), 'new');
+        assert.deepEqual(
+            logicalTree(join(sourceRoot, 'push-fixture')),
+            logicalTree(targetFixture),
+        );
     });
 
     it('replaces and recursively deletes symlinks without touching their referent', () => {
@@ -207,10 +300,15 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
         assert.notEqual(interrupted.exitCode, 0, `process interruption did not stop the active push: ${interrupted.stderr}`);
         assert.ok(existsSync(join(targetRoot, '.maintenance')), 'owned maintenance marker did not survive process death');
         assert.ok(!existsSync(oldDirectory), 'deletion had not completed before positive installation began');
-        const activeSessions = readdirSync(join(stagingDir, 'apply-sessions')).filter((name) => /^[a-f0-9]{32}$/.test(name));
+        const sessionsDir = join(stagingDir, 'apply-sessions');
+        const activeSessions = activeSessionDirectories(sessionsDir);
         assert.equal(activeSessions.length, 1);
+        // The killed sender can leave one bounded target request finishing, so
+        // start at the stable sessions root while it consumes the work queue.
         assert.ok(
-            recursiveNames(join(stagingDir, 'apply-sessions', activeSessions[0], 'work', 'files')).length > 0,
+            execFileSync('sudo', [
+                'find', sessionsDir, '-path', `${activeSessions[0]}/work/files/*`, '-print0', '-quit',
+            ]).length > 0,
             'process interruption left no pending staged values to resume',
         );
 
@@ -238,7 +336,8 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
         const different = await uploadDelete(site, sessionId, 0, Buffer.from('other\0'));
         assert.equal(different.response.status, 400);
         const gap = await uploadDelete(site, sessionId, 999, Buffer.from('later\0'));
-        assert.equal(gap.response.status, 400);
+        assert.equal(gap.response.status, 409);
+        assert.equal(gap.body.reason, 'offset_gap');
         const status = await stagedRequest(site, 'GET', 'staged_session_status', { session_id: sessionId });
         assert.equal(status.body.delete_bytes, Buffer.byteLength('first\0partial\0'));
 
@@ -256,7 +355,7 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
         rmSync(join(sourceRoot, 'push-fixture'), { recursive: true, force: true });
         writeSource(sourceRoot, 'push-fixture/live-drift/file.bin', 'x'.repeat(10 * 1024 * 1024));
         let running = startPush(site, sourceRoot, stateDir);
-        await waitFor(() => sessionWorkExists(stagingDir, 'partial', 'push-fixture/live-drift/file.bin'), 60000, 'partial staged file was not observable');
+        await waitFor(() => sessionWorkExists(stagingDir, 'files', 'push-fixture/live-drift/file.bin'), 60000, 'staged file was not observable before commit');
         process.kill(running.child.pid, 'SIGSTOP');
         execFileSync('sudo', ['mkdir', '-p', join(targetFixture, 'live-drift')]);
         execFileSync('sudo', ['sh', '-c', `printf drift > ${shellQuote(join(targetFixture, 'live-drift/file.bin'))}`]);
@@ -271,7 +370,7 @@ describe.sequential('Import: direct push apply', { timeout: 300000 }, () => {
         execFileSync('sudo', ['mkdir', '-p', join(targetRoot, 'outside-conflict')]);
         execFileSync('sudo', ['sh', '-c', `printf safe > ${shellQuote(join(targetRoot, 'outside-conflict/sentinel'))}`]);
         running = startPush(site, sourceRoot, stateDir);
-        await waitFor(() => sessionWorkExists(stagingDir, 'partial', 'push-fixture/conflict-parent/file.bin'), 60000, 'conflicting path was not staged');
+        await waitFor(() => sessionWorkExists(stagingDir, 'files', 'push-fixture/conflict-parent/file.bin'), 60000, 'conflicting path was not staged before commit');
         process.kill(running.child.pid, 'SIGSTOP');
         execFileSync('sudo', ['ln', '-s', '../outside-conflict', join(targetFixture, 'conflict-parent')]);
         process.kill(running.child.pid, 'SIGCONT');
@@ -371,12 +470,12 @@ describe.sequential('Import: cross-device push refusal', { timeout: 180000 }, ()
         assert.notEqual(
             lstatSync('/srv/reprint-e2e-staging').dev,
             lstatSync(getSiteDir('push-cross-device')).dev,
-            'cross-device Docker test requires --tmpfs /srv/reprint-e2e-staging',
+            'cross-device test requires a separate filesystem at /srv/reprint-e2e-staging',
         );
         assert.notEqual(
             lstatSync(join(getSiteDir('push-mounted-parent'), 'mounted-parent')).dev,
             lstatSync(getSiteDir('push-mounted-parent')).dev,
-            'mount-boundary Docker test requires --tmpfs /srv/e2e-sites/push-mounted-parent/mounted-parent',
+            'mount-boundary test requires a separate filesystem at /srv/e2e-sites/push-mounted-parent/mounted-parent',
         );
         caseRoot = createTempDir('e2e-push-cross-device');
     });
@@ -397,7 +496,7 @@ describe.sequential('Import: cross-device push refusal', { timeout: 180000 }, ()
         assert.ok(!existsSync(join(getSiteDir('push-cross-device'), 'must-not-arrive')));
         const sessions = '/srv/reprint-e2e-staging/push-cross-device/apply-sessions';
         if (existsSync(sessions)) {
-            assert.equal(readdirSync(sessions).filter((name) => /^[a-f0-9]{32}$/.test(name)).length, 0);
+            assert.equal(activeSessionDirectories(sessions).length, 0);
         }
     });
 
@@ -523,15 +622,7 @@ function recursiveNames(root) {
     const names = [];
     for (const name of entries) {
         const path = join(root, name);
-        let stat;
-        try {
-            stat = lstatSync(path);
-        } catch (error) {
-            // The killed sender can leave one bounded target request finishing
-            // while this observes the pending queue it is consuming.
-            if (error.code === 'ENOENT') continue;
-            throw error;
-        }
+        const stat = lstatSync(path);
         names.push(name);
         if (stat.isDirectory()) names.push(...recursiveNames(path));
     }
@@ -578,12 +669,15 @@ async function waitFor(predicate, timeout, message) {
 function sessionWorkExists(stagingDir, workType, path) {
     const sessionsDir = join(stagingDir, 'apply-sessions');
     if (!existsSync(sessionsDir)) return false;
-    for (const session of readdirSync(sessionsDir)) {
-        if (/^[a-f0-9]{32}$/.test(session) && existsSync(join(sessionsDir, session, 'work', workType, path))) {
-            return true;
-        }
-    }
-    return false;
+    return execFileSync('sudo', [
+        'find', sessionsDir, '-path', `*/work/${workType}/${path}`, '-print0', '-quit',
+    ]).length > 0;
+}
+
+function activeSessionDirectories(sessionsDir) {
+    return execFileSync('sudo', [
+        'find', sessionsDir, '-mindepth', '1', '-maxdepth', '1', '-type', 'd', '-print0',
+    ]).toString().split('\0').filter((path) => /\/[a-f0-9]{32}$/.test(path));
 }
 
 async function stagedRequest(site, method, endpoint, parameters, body = null, contentType = null) {

--- a/tests/e2e/tests/import-54-pull-seeded-push.test.js
+++ b/tests/e2e/tests/import-54-pull-seeded-push.test.js
@@ -253,8 +253,9 @@ describeSupportedPush('Import: pull-seeded full-root push', { timeout: 300000 },
         running.child.kill('SIGKILL');
         const interrupted = await running.completed;
         assert.notEqual(interrupted.exitCode, 0);
+        // Invalidation removes the baseline first. SIGKILL may land before the
+        // identity unlink, but an identity cannot authorize a missing snapshot.
         assert.ok(!existsSync(join(journal, 'last-sync-local-files.jsonl')));
-        assert.ok(!existsSync(join(journal, 'last-sync-local-files.identity.json')));
     });
 
     it('pull restart republishes only after eventual completion', () => {

--- a/tests/e2e/tests/import-55-push-busy.test.js
+++ b/tests/e2e/tests/import-55-push-busy.test.js
@@ -1,0 +1,336 @@
+/**
+ * Test 55: recoverable staged-push contention
+ *
+ * Holds the real exporter flock files or creates the real discard tombstone
+ * from a second process. The public CLI must retry boundedly without a
+ * production interruption hook or an injected transport.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync,
+} from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { createHmac, randomBytes } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    cleanupTempDir, createTempDir, getSiteDir, getSiteSecret, getSiteUrl, runPush,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+import { HmacClient } from '../lib/hmac-client.js';
+
+const IMPORTER_PATH = join(import.meta.dirname, '..', '..', '..', 'importer', 'import.php');
+const PHP_BINARY = process.env.PHP_BINARY || 'php';
+const PHP_VERSION_ID = Number(execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION_ID;'], { encoding: 'utf8' }));
+// PHP.wasm cannot hold the exporter's host-filesystem flock. Native push lanes
+// run this suite across the supported exporter/importer pairings instead.
+const describeNativePushContention = PHP_VERSION_ID >= 80100 && !process.env.PLAYGROUND_PHP_VERSION
+    ? describe.sequential
+    : describe.skip;
+
+describeNativePushContention('Import: recoverable push contention', { timeout: 180000 }, () => {
+    const site = 'push-busy';
+    const targetRoot = getSiteDir(site);
+    const stagingDir = join(targetRoot, '.reprint-staging');
+    const createLock = join(stagingDir, 'apply-sessions/create.lock');
+    const targetLock = join(stagingDir, 'apply-sessions/target.lock');
+    let caseRoot;
+    let persistedCreation;
+    let persistedCommit;
+    let persistedDiscard;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            afterConfig: async (siteDir) => configureStaging(siteDir, stagingDir),
+        });
+        configureStaging(targetRoot, stagingDir);
+        execFileSync('sudo', ['rm', '-rf', join(targetRoot, 'busy-fixture'), stagingDir]);
+        execFileSync('sudo', ['mkdir', '-p', stagingDir]);
+        execFileSync('sudo', ['chown', '-R', 'nginx:nginx', stagingDir]);
+        caseRoot = createTempDir('e2e-push-busy');
+    });
+
+    afterAll(() => {
+        execFileSync('sudo', ['rm', '-rf', stagingDir]);
+        cleanupTempDir(caseRoot);
+    });
+
+    it('recovers automatically when session creation becomes available', async () => {
+        const scenario = createScenario(caseRoot, 'transient-create', 'created after contention');
+        const held = await holdFlock(createLock, caseRoot, 1200);
+        const started = Date.now();
+
+        const result = runPush(site, scenario.source, scenario.state);
+        await held.completed;
+
+        assertPush(result);
+        assert.ok(Date.now() - started >= 900, 'push did not encounter the held creation lock');
+        assert.equal(readFileSync(join(targetRoot, scenario.path), 'utf8'), scenario.contents);
+    });
+
+    it('fails boundedly when session creation stays busy', async () => {
+        const scenario = createScenario(caseRoot, 'persistent-create', 'resume this creation');
+        const held = await holdFlock(createLock, caseRoot);
+
+        const result = runPush(site, scenario.source, scenario.state);
+        held.release();
+        await held.completed;
+
+        assertBoundedBusyFailure(result);
+        const checkpoint = readCheckpoint(scenario.state);
+        assert.equal(checkpoint.phase, 'creating');
+        assert.equal(checkpoint.session_id, null);
+        assert.ok(typeof checkpoint.create_token === 'string');
+        assert.ok(!existsSync(join(targetRoot, scenario.path)));
+        persistedCreation = { ...scenario, createToken: checkpoint.create_token };
+    });
+
+    it('restarts from the creation checkpoint and recovers a busy upload', async () => {
+        assert.ok(persistedCreation, 'persistent creation scenario did not run');
+        const created = await stagedRequest(site, 'POST', 'staged_session_create', {
+            create_token: persistedCreation.createToken,
+        });
+        assert.equal(created.response.status, 201);
+        const sessionLock = join(stagingDir, 'apply-sessions', created.body.session_id, 'lock');
+        const held = await holdFlock(sessionLock, caseRoot, 1400);
+        const started = Date.now();
+
+        const result = runPush(site, persistedCreation.source, persistedCreation.state);
+        await held.completed;
+
+        assertPush(result);
+        assert.ok(Date.now() - started >= 1000, 'push did not encounter the held upload lock');
+        assert.equal(readFileSync(join(targetRoot, persistedCreation.path), 'utf8'), persistedCreation.contents);
+        assert.ok(!existsSync(checkpointPath(persistedCreation.state)));
+    });
+
+    it('recovers automatically when commit coordination becomes available', async () => {
+        const scenario = createScenario(caseRoot, 'transient-commit', 'committed after contention');
+        const held = await holdFlock(targetLock, caseRoot, 1400);
+        const started = Date.now();
+
+        const result = runPush(site, scenario.source, scenario.state);
+        await held.completed;
+
+        assertPush(result);
+        assert.ok(Date.now() - started >= 1000, 'push did not encounter the held commit lock');
+        assert.equal(readFileSync(join(targetRoot, scenario.path), 'utf8'), scenario.contents);
+    });
+
+    it('fails boundedly when commit coordination stays busy', async () => {
+        const scenario = createScenario(caseRoot, 'persistent-commit', 'resume this commit');
+        const held = await holdFlock(targetLock, caseRoot);
+
+        const result = runPush(site, scenario.source, scenario.state);
+        held.release();
+        await held.completed;
+
+        assertBoundedBusyFailure(result);
+        const checkpoint = readCheckpoint(scenario.state);
+        assert.equal(checkpoint.phase, 'committing');
+        assert.ok(!existsSync(join(targetRoot, scenario.path)));
+        persistedCommit = scenario;
+    });
+
+    it('restarts commit from its confirmed checkpoint after contention clears', () => {
+        assert.ok(persistedCommit, 'persistent commit scenario did not run');
+
+        const result = runPush(site, persistedCommit.source, persistedCommit.state);
+
+        assertPush(result);
+        assert.equal(readFileSync(join(targetRoot, persistedCommit.path), 'utf8'), persistedCommit.contents);
+        assert.ok(!existsSync(checkpointPath(persistedCommit.state)));
+    });
+
+    it('recovers automatically when discard contention clears', async () => {
+        const scenario = createScenario(caseRoot, 'transient-discard', 'cleaned after contention');
+        const held = await holdFlock(createLock, caseRoot, 600);
+        const running = startPush(site, scenario.source, scenario.state);
+        await waitFor(() => checkpointExists(scenario.state), 30000, 'push did not persist its create token');
+        const checkpoint = readCheckpoint(scenario.state);
+        const tombstone = discardTombstone(stagingDir, checkpoint.create_token, getSiteSecret(site));
+        execFileSync('sudo', ['mkdir', '-p', tombstone]);
+        await held.completed;
+        await waitFor(
+            () => checkpointExists(scenario.state) && readCheckpoint(scenario.state).phase === 'cleaning',
+            60000,
+            'push did not reach discard cleanup',
+        );
+        await sleep(500);
+        execFileSync('sudo', ['rm', '-rf', tombstone]);
+
+        const result = await running.completed;
+
+        assertPush(result);
+        assert.equal(readFileSync(join(targetRoot, scenario.path), 'utf8'), scenario.contents);
+        assert.ok(!existsSync(checkpointPath(scenario.state)));
+    });
+
+    it('fails boundedly when discard stays busy', async () => {
+        const scenario = createScenario(caseRoot, 'persistent-discard', 'resume this cleanup');
+        const held = await holdFlock(createLock, caseRoot, 600);
+        const running = startPush(site, scenario.source, scenario.state);
+        await waitFor(() => checkpointExists(scenario.state), 30000, 'push did not persist its create token');
+        const checkpoint = readCheckpoint(scenario.state);
+        const tombstone = discardTombstone(stagingDir, checkpoint.create_token, getSiteSecret(site));
+        execFileSync('sudo', ['mkdir', '-p', tombstone]);
+        await held.completed;
+
+        const result = await running.completed;
+
+        assertBoundedBusyFailure(result);
+        assert.equal(readCheckpoint(scenario.state).phase, 'cleaning');
+        assert.equal(readFileSync(join(targetRoot, scenario.path), 'utf8'), scenario.contents);
+        persistedDiscard = { ...scenario, tombstone };
+    });
+
+    it('restarts cleanup from its confirmed checkpoint after contention clears', () => {
+        assert.ok(persistedDiscard, 'persistent discard scenario did not run');
+        execFileSync('sudo', ['rm', '-rf', persistedDiscard.tombstone]);
+
+        const result = runPush(site, persistedDiscard.source, persistedDiscard.state);
+
+        assertPush(result);
+        assert.equal(readFileSync(join(targetRoot, persistedDiscard.path), 'utf8'), persistedDiscard.contents);
+        assert.ok(!existsSync(checkpointPath(persistedDiscard.state)));
+    });
+});
+
+function createScenario(caseRoot, name, contents) {
+    const source = join(caseRoot, name, 'source');
+    const state = join(caseRoot, name, 'state');
+    const path = `busy-fixture/${name}.txt`;
+    mkdirSync(join(source, 'busy-fixture'), { recursive: true });
+    mkdirSync(state, { recursive: true });
+    writeFileSync(join(source, path), contents);
+    return { source, state, path, contents };
+}
+
+async function holdFlock(lockPath, caseRoot, milliseconds = null) {
+    const ready = join(caseRoot, `lock-ready-${randomBytes(8).toString('hex')}`);
+    const release = join(caseRoot, `lock-release-${randomBytes(8).toString('hex')}`);
+    execFileSync('sudo', ['mkdir', '-p', dirname(lockPath)]);
+    execFileSync('sudo', ['chown', 'nginx:nginx', dirname(lockPath)]);
+    execFileSync('sudo', ['touch', lockPath]);
+    execFileSync('sudo', ['chown', 'nginx:nginx', lockPath]);
+    const script = [
+        '$handle = fopen($argv[1], "c+b");',
+        'if ($handle === false || !flock($handle, LOCK_EX)) { exit(2); }',
+        'file_put_contents($argv[2], "ready\\n");',
+        'if ($argv[3] === "") { while (!is_file($argv[4])) { usleep(10000); } }',
+        'else { usleep((int) $argv[3]); }',
+        'flock($handle, LOCK_UN);',
+        'fclose($handle);',
+    ].join(' ');
+    const child = spawn('sudo', [
+        'php', '-r', script, lockPath, ready,
+        milliseconds === null ? '' : String(milliseconds * 1000), release,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (data) => { stderr += data; });
+    const completed = new Promise((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', (exitCode) => {
+            try {
+                assert.equal(exitCode, 0, `lock holder failed: ${stderr}`);
+                execFileSync('sudo', ['rm', '-f', ready, release]);
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+    await waitFor(() => existsSync(ready), 10000, `could not acquire ${lockPath}`);
+    return {
+        completed,
+        release: () => writeFileSync(release, 'release\n'),
+    };
+}
+
+function checkpointPath(state) {
+    const pushRoot = join(state, 'push');
+    const sites = readdirSync(pushRoot);
+    assert.equal(sites.length, 1, `expected one push state directory below ${pushRoot}`);
+    return join(pushRoot, sites[0], 'session.json');
+}
+
+function checkpointExists(state) {
+    try {
+        return existsSync(checkpointPath(state));
+    } catch {
+        return false;
+    }
+}
+
+function readCheckpoint(state) {
+    return JSON.parse(readFileSync(checkpointPath(state), 'utf8'));
+}
+
+function discardTombstone(stagingDir, createToken, secret) {
+    const sessionId = createHmac('sha256', secret)
+        .update(`reprint-multipart-push-create-v1:${createToken}`)
+        .digest('hex')
+        .slice(0, 32);
+    return join(stagingDir, 'apply-sessions', `.discarding-${sessionId}`);
+}
+
+function assertPush(result) {
+    assert.equal(result.exitCode, 0, `push failed\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+}
+
+function assertBoundedBusyFailure(result) {
+    assert.notEqual(result.exitCode, 0, 'persistent busy unexpectedly completed');
+    assert.match(result.stderr, /remained busy after 5 attempts/);
+    assert.doesNotMatch(result.stderr, /"status"\s*:\s*"retry"/);
+}
+
+function startPush(site, sourceRoot, stateDir) {
+    const child = spawn(PHP_BINARY, [
+        IMPORTER_PATH, 'push', getSiteUrl(site),
+        `--state-dir=${stateDir}`, `--source-root=${sourceRoot}`,
+        `--secret=${getSiteSecret(site)}`, '--allow-http',
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data) => { stdout += data; });
+    child.stderr.on('data', (data) => { stderr += data; });
+    const completed = new Promise((resolve) => {
+        child.on('close', (exitCode) => resolve({ exitCode, stdout, stderr }));
+    });
+    return { child, completed };
+}
+
+async function stagedRequest(site, method, endpoint, parameters) {
+    const url = new URL(getSiteUrl(site));
+    url.searchParams.set('endpoint', endpoint);
+    for (const [name, value] of Object.entries(parameters)) url.searchParams.set(name, value);
+    const headers = new HmacClient(getSiteSecret(site)).getEnvelopeAuthHeaders(method, url.toString());
+    const response = await fetch(url, { method, headers });
+    return { response, body: await response.json() };
+}
+
+async function waitFor(predicate, timeout, message) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        if (predicate()) return;
+        await sleep(5);
+    }
+    assert.fail(message);
+}
+
+function configureStaging(siteDir, stagingDir) {
+    const configPath = join(siteDir, 'wp-config.php');
+    let config = readFileSync(configPath, 'utf8');
+    const definition = `define('SITE_EXPORT_STAGING_DIR', '${stagingDir}');`;
+    if (/define\('SITE_EXPORT_STAGING_DIR'/.test(config)) {
+        config = config.replace(/define\('SITE_EXPORT_STAGING_DIR'[^\n]+/, definition);
+    } else {
+        config = config.replace("if ( ! defined( 'ABSPATH' ) )", definition + "\nif ( ! defined( 'ABSPATH' ) )");
+    }
+    execFileSync('sudo', ['tee', configPath], { input: config, stdio: ['pipe', 'ignore', 'inherit'] });
+    execFileSync('sudo', ['chown', 'nginx:nginx', configPath]);
+    execFileSync('sudo', ['mkdir', '-p', stagingDir]);
+    execFileSync('sudo', ['chown', '-R', 'nginx:nginx', stagingDir]);
+}

--- a/tests/e2e/tests/import-56-compatibility-smoke.test.js
+++ b/tests/e2e/tests/import-56-compatibility-smoke.test.js
@@ -1,0 +1,102 @@
+/**
+ * Test 56: importer/exporter compatibility smoke coverage
+ *
+ * Supported importer runtimes perform a real pull from the configured
+ * exporter. PHP 7.4 and 8.0 run the same public push command and prove the
+ * runtime requirement is reported before any network request is attempted.
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn, execFileSync } from 'node:child_process';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    cleanupTempDir, createTempDir, fsRootDir, getSiteDir, getSiteSecret, getSiteUrl,
+    IMPORTER_PATH, PHP_BINARY, runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const importerVersionId = Number(execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION_ID;'], { encoding: 'utf8' }));
+const pushIsSupported = importerVersionId >= 80100;
+
+describe('Import: compatibility smoke', { timeout: 180000 }, () => {
+    it.skipIf(!pushIsSupported)('preflights and pulls with the configured importer and exporter PHP versions', async () => {
+        await ensureSite('basic');
+        const stateDir = createTempDir('e2e-compatibility-pull');
+        try {
+            const url = `${getSiteUrl('basic')}&directory=${getSiteDir('basic')}`;
+            const preflight = runImporter(url, stateDir, 'preflight', { secret: getSiteSecret('basic') });
+            assert.equal(preflight.exitCode, 0, preflight.stderr);
+            const result = runImporter(
+                url,
+                stateDir,
+                'files-pull',
+                { secret: getSiteSecret('basic') },
+            );
+
+            assert.equal(result.exitCode, 0, result.stderr);
+            assert.ok(existsSync(join(fsRootDir(stateDir), getSiteDir('basic'), 'index.php')),
+                'The compatibility pull omitted the WordPress entry point.');
+        } finally {
+            cleanupTempDir(stateDir);
+        }
+    });
+
+    it.skipIf(pushIsSupported)('reports the PHP 8.1 requirement before making a request', async () => {
+        const caseRoot = mkdtempSync(join(tmpdir(), 'reprint-push-requirement-'));
+        const sourceRoot = join(caseRoot, 'source');
+        const stateDir = join(caseRoot, 'state');
+        mkdirSync(sourceRoot);
+        writeFileSync(join(sourceRoot, 'file.txt'), 'unsupported runtime');
+        let acceptedConnections = 0;
+        const server = createServer((socket) => {
+            ++acceptedConnections;
+            socket.end("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        });
+        await new Promise((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, '127.0.0.1', resolve);
+        });
+        const address = server.address();
+        assert.ok(address && typeof address === 'object');
+
+        try {
+            const child = spawn(PHP_BINARY, [
+                IMPORTER_PATH,
+                'push',
+                `http://127.0.0.1:${address.port}/?reprint-api`,
+                `--source-root=${sourceRoot}`,
+                `--state-dir=${stateDir}`,
+                '--secret=compatibility-secret',
+                '--allow-http',
+            ], { stdio: ['ignore', 'pipe', 'pipe'] });
+            let stdout = '';
+            let stderr = '';
+            child.stdout.on('data', (chunk) => { stdout += chunk; });
+            child.stderr.on('data', (chunk) => { stderr += chunk; });
+            const exitCode = await new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                    child.kill('SIGKILL');
+                    reject(new Error('Unsupported-runtime push did not exit within 30 seconds.'));
+                }, 30000);
+                child.once('error', (error) => {
+                    clearTimeout(timeout);
+                    reject(error);
+                });
+                child.once('exit', (code) => {
+                    clearTimeout(timeout);
+                    resolve(code);
+                });
+            });
+
+            assert.notEqual(exitCode, 0, stdout);
+            assert.match(stderr, /reprint push requires PHP 8\.1 or newer/);
+            assert.equal(acceptedConnections, 0, 'The unsupported importer contacted the target before reporting its runtime requirement.');
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+            rmSync(caseRoot, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
A push now waits through transient target contention and stops after five consecutive recoverable responses. A locked target no longer aborts a resumable transfer on the first `busy` response or leaves an upload retry unbounded.

Upload and control responses now use one protocol-reason classifier. `busy` and `offset_gap` are the only recoverable target rejections. Upload recovery reads signed target status, seeks the raw delete stream or file to that confirmed cursor, and resets the retry budget only after confirmed progress. Persistent contention exits as a failure with the local checkpoint intact. Authentication failures, redirects, malformed responses, live-tree conflicts, and cross-device rejection remain terminal. File and delete offset gaps now use the same `offset_gap` reason and HTTP 409 response.

The E2E workflow now has separate core, network/interruption, privileged-filesystem, and compatibility-smoke jobs. The privileged job mounts bounded tmpfs filesystems and the tests assert the device boundary instead of skipping it. Compatibility lanes run a named real preflight/pull case on supported importers and prove PHP 7.4/8.0 reject push before opening a connection.

Tests: full Import PHPUnit suite, 460 tests and 1,765 assertions with 6 environment skips; focused push/session/help suites, 69 tests and 751 assertions with 2 environment skips; exporter multipart/session suites, 52 tests and 1,917 assertions; pull-seeded-push E2E, 15 tests. On the final head, core E2E ran 333 cases with 6 skips, network/interruption ran 85 with 20 filter skips, privileged-filesystem ran 41 with 21 filter skips, and Playground ran 452 with 10 skips. All ten compatibility-smoke lanes, PHP 8.1–8.4 PHPUnit, PHPStan, PHPCompatibility, PHP 7.2/7.4 parsing, Actionlint, YAML parsing, PHPCS count comparison, and `git diff --check` passed.
