### PR TITLE
[Push] Add bounded multipart parsing and streaming upload

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-feature/multipart-push-sync",
+            "version": "dev-feature/multipart-push-transport",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "193505f22c9b4310695a08e490687d3547adfba3"
+                "reference": "4b864d3ae9fd88c93db4b5012436600779f25204"
             },
             "require": {
                 "php": ">=7.2",
@@ -384,6 +384,7 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
+                    "src/class-multipart-processor.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"
                 ],

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -22,6 +22,7 @@
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
             "src/class-http-server.php",
+            "src/class-multipart-processor.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"
         ],

--- a/packages/reprint-exporter/src/class-multipart-processor.php
+++ b/packages/reprint-exporter/src/class-multipart-processor.php
@@ -1,0 +1,750 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol errors become CLI or authenticated API values, never HTML output.
+
+/**
+ * Incrementally processes the strict multipart/mixed format used by Reprint.
+ *
+ * The processor is independent of the transport which supplies its bytes. A
+ * cURL response callback can append each received fragment, while an HTTP
+ * endpoint can append bounded reads from php://input. In both cases the caller
+ * drains tokens synchronously before appending another fragment:
+ *
+ *     $multipart->append_bytes($bytes);
+ *     while ($multipart->next_token()) {
+ *         if ($multipart->get_token_type() === Site_Export_Multipart_Processor::TOKEN_BODY) {
+ *             fwrite($output, $multipart->get_current_body_piece());
+ *         }
+ *     }
+ *
+ * A part produces one PART_START token, zero or more BODY tokens, and one
+ * PART_END token. PART_START exposes the complete normalized header map. BODY
+ * exposes at most MAX_INPUT_FRAGMENT_BYTES and remains current only until
+ * next_token() is called again. PART_END means every byte declared by
+ * Content-Length was supplied; the following call validates the CRLF and next
+ * boundary before it can expose another part.
+ *
+ * Reprint deliberately uses a narrower grammar than general Internet MIME.
+ * Every part requires a decimal Content-Length, all syntax uses CRLF, header
+ * names are unique, and the request or response begins with its first boundary
+ * and ends with its closing boundary. Reprint has emitted this form since its
+ * first multipart exporter. Requiring a length makes arbitrary file bytes
+ * unambiguous: the processor never searches a binary body for a delimiter and
+ * can distinguish truncation from a clean close.
+ *
+ * next_token() returns false both when more bytes are required and after the
+ * closing boundary. paused_at_incomplete_input() and is_complete() distinguish
+ * those states. Once the transport reaches EOF, finish_input() verifies that a
+ * complete closing boundary was seen; incomplete syntax or body data throws.
+ * The processor retains only one bounded input fragment, one bounded header
+ * block, and one current body token. It never accumulates a complete part.
+ */
+final class Site_Export_Multipart_Processor {
+
+    /** Token which exposes the normalized headers of a newly opened part. */
+    public const TOKEN_PART_START = 'part-start';
+
+    /** Token which exposes one bounded piece of the current part body. */
+    public const TOKEN_BODY = 'body';
+
+    /** Token which confirms that the current part's declared body is complete. */
+    public const TOKEN_PART_END = 'part-end';
+
+    /**
+     * Maximum bytes accepted by one append_bytes() call or exposed as one body token.
+     *
+     * Pull drains every cURL fragment immediately and push reads php://input
+     * using this ceiling. The shared limit prevents either caller from turning
+     * a streamed part into an unbounded in-memory string.
+     */
+    public const MAX_INPUT_FRAGMENT_BYTES = 262144;
+
+    /**
+     * Maximum bytes accepted in a boundary parameter.
+     *
+     * RFC 2046 recommends boundaries no longer than 70 characters. This also
+     * bounds the delimiter retained while syntax is split across input reads.
+     */
+    private const MAX_BOUNDARY_BYTES = 70;
+
+    /**
+     * Maximum bytes accepted in one boundary or physical header line.
+     *
+     * The count excludes CRLF. An unterminated line is rejected as soon as it
+     * can no longer fit within this bound.
+     */
+    public const MAX_HEADER_LINE_BYTES = 8192;
+
+    /**
+     * Maximum aggregate bytes accepted for one part's headers, including CRLF.
+     *
+     * This bounds both ordinary header fields and folded continuation lines
+     * before the processor exposes any body bytes.
+     */
+    private const MAX_HEADER_BYTES = 32768;
+
+    /**
+     * Maximum number of distinct headers accepted on one part.
+     *
+     * Duplicate names are rejected, so this is also the maximum number of
+     * entries retained in $current_headers.
+     */
+    private const MAX_HEADERS = 32;
+
+    /** Processor state which expects an opening or closing delimiter line. */
+    private const STATE_BOUNDARY = 0;
+
+    /** Processor state which accumulates the current part's bounded header block. */
+    private const STATE_HEADERS = 1;
+
+    /** Processor state which emits exactly the current part's declared body bytes. */
+    private const STATE_BODY = 2;
+
+    /** Processor state entered after a syntactically complete closing boundary. */
+    private const STATE_COMPLETE = 3;
+
+    /**
+     * Complete delimiter token derived from the validated boundary parameter.
+     *
+     * The stored value includes the required leading `--` and is compared only
+     * with CRLF-terminated syntax lines. Part bodies are framed by their
+     * Content-Length and are never searched for this byte sequence.
+     *
+     * @var string
+     */
+    private $delimiter;
+
+    /**
+     * Bytes not yet consumed by the current processor state.
+     *
+     * The caller may append only after next_token() pauses, so this contains at
+     * most one bounded fragment plus a small split syntax tail.
+     *
+     * @var string
+     */
+    private $buffer = '';
+
+    /**
+     * Grammar state describing which multipart construct must be consumed next.
+     *
+     * It advances from a boundary to headers to the declared body, then returns
+     * to a boundary until the closing delimiter makes the processor complete.
+     *
+     * @var int One of the STATE_* constants.
+     */
+    private $state = self::STATE_BOUNDARY;
+
+    /**
+     * Whether the next delimiter must be preceded by the completed body's CRLF.
+     *
+     * The opening boundary starts at byte zero; every later boundary follows
+     * exactly the number of body bytes declared by Content-Length and a CRLF.
+     *
+     * @var bool
+     */
+    private $requires_part_terminator = false;
+
+    /**
+     * Whether the transport has declared that no more bytes can arrive.
+     *
+     * This becomes true only through finish_input(), after the caller has
+     * drained every token available from the final input fragment.
+     *
+     * @var bool
+     */
+    private $input_finished = false;
+
+    /**
+     * Whether next_token() needs another input fragment to make progress.
+     *
+     * append_bytes() is permitted only in this state, which prevents callers
+     * from accumulating several unread transport fragments in $buffer.
+     *
+     * @var bool
+     */
+    private $paused_at_incomplete_input = true;
+
+    /**
+     * Token exposed by the most recent successful next_token() call.
+     *
+     * Null means the processor is between tokens, paused for another fragment,
+     * or complete. Token and value getters reject access in that state so a
+     * caller cannot accidentally reuse information from an earlier part.
+     *
+     * @var string|null One of the TOKEN_* constants when a token is current.
+     */
+    private $current_token_type = null;
+
+    /**
+     * Lowercase, unique headers belonging to the current part.
+     *
+     * The map is available on PART_START, BODY, and PART_END tokens. It is
+     * replaced only after the next opening boundary has been validated.
+     *
+     * @var array<string,string>
+     */
+    private $current_headers = [];
+
+    /**
+     * Body bytes exposed by the current TOKEN_BODY token.
+     *
+     * This contains at most one bounded input fragment and is cleared before
+     * the processor advances. Callers therefore consume or hand off each piece
+     * without the processor retaining the complete part body.
+     *
+     * @var string
+     */
+    private $current_body_piece = '';
+
+    /**
+     * Aggregate physical header bytes consumed for the current part.
+     *
+     * The count includes each line's CRLF, including folded continuations and
+     * the empty line ending the block. It enforces a whole-header ceiling in
+     * addition to the limit on any single physical line.
+     *
+     * @var int
+     */
+    private $current_header_bytes = 0;
+
+    /**
+     * Normalized name of the header field currently being unfolded.
+     *
+     * A field stays pending until another header or the empty terminator line
+     * arrives, because intervening continuation lines belong to the same
+     * logical value. Null means no field has begun for the current part.
+     *
+     * @var string|null
+     */
+    private $pending_header_name = null;
+
+    /**
+     * Physical value bytes accumulated for $pending_header_name.
+     *
+     * Leading whitespace after the colon is removed only when the completed
+     * field is stored. Continuation-line whitespace remains intact while their
+     * separating CRLF bytes are omitted according to MIME unfolding.
+     *
+     * @var string
+     */
+    private $pending_header_value = '';
+
+    /**
+     * Number of declared body bytes not yet exposed through TOKEN_BODY.
+     *
+     * It is initialized from the validated decimal Content-Length and reduced
+     * by exactly each emitted piece. Reaching zero emits TOKEN_PART_END before
+     * the following CRLF and boundary are parsed.
+     *
+     * @var int
+     */
+    private $remaining_body_bytes = 0;
+
+    /**
+     * Creates a processor positioned before the opening multipart boundary.
+     *
+     * @param string $boundary MIME boundary token without the leading `--`.
+     *
+     * @throws InvalidArgumentException If the boundary is empty, overlong, or
+     *     contains bytes which cannot appear safely in a delimiter line.
+     */
+    public function __construct(string $boundary) {
+        self::validate_boundary($boundary);
+        $this->delimiter = '--' . $boundary;
+    }
+
+    /**
+     * Returns the validated boundary from a multipart/mixed Content-Type value.
+     *
+     * Media types and parameter names are matched case-insensitively. Both the
+     * token and quoted forms emitted by HTTP implementations are accepted:
+     *
+     *     multipart/mixed; boundary=reprint-0123
+     *     Multipart/Mixed; boundary="reprint-0123"
+     *
+     * The returned value excludes the delimiter's leading `--`. A missing,
+     * empty, repeated, overlong, or unsafe boundary is rejected before any body
+     * bytes are accepted.
+     *
+     * @param string $content_type Complete Content-Type header value.
+     * @return string Validated MIME boundary token.
+     *
+     * @throws InvalidArgumentException If the media type or boundary is invalid.
+     */
+    public static function boundary_from_content_type(string $content_type): string {
+        $segments = explode(';', $content_type);
+        $media_type = strtolower(trim( (string) array_shift($segments)));
+        if ($media_type !== 'multipart/mixed') {
+            throw new InvalidArgumentException(
+                'Expected Content-Type multipart/mixed; received ' . self::describe_bytes($content_type) . '.'
+            );
+        }
+
+        $boundary = null;
+        foreach ($segments as $segment) {
+            $equals = strpos($segment, '=');
+            if ($equals === false || strtolower(trim(substr($segment, 0, $equals))) !== 'boundary') {
+                continue;
+            }
+            if ($boundary !== null) {
+                throw new InvalidArgumentException('Multipart Content-Type contains more than one boundary parameter.');
+            }
+            $value = trim(substr($segment, $equals + 1));
+            if (strlen($value) >= 2 && $value[0] === '"' && substr($value, -1) === '"') {
+                $value = substr($value, 1, -1);
+            }
+            $boundary = $value;
+        }
+
+        if (!is_string($boundary) || $boundary === '') {
+            throw new InvalidArgumentException('Multipart Content-Type requires a non-empty boundary parameter.');
+        }
+        self::validate_boundary($boundary);
+        return $boundary;
+    }
+
+    /**
+     * Appends one bounded transport fragment after the processor requests input.
+     *
+     * Call next_token() until it returns false before appending the next
+     * fragment. This obligation keeps unread network or request-body fragments
+     * from accumulating in memory.
+     *
+     * @param string $bytes Next raw multipart bytes from the transport.
+     *
+     * @throws LogicException If unread tokens remain, input already ended, or
+     *     the closing boundary was already consumed.
+     * @throws InvalidArgumentException If the fragment exceeds
+     *     MAX_INPUT_FRAGMENT_BYTES.
+     */
+    public function append_bytes(string $bytes): void {
+        if ($this->input_finished) {
+            throw new LogicException('Cannot append multipart bytes after finish_input().');
+        }
+        if ($this->state === self::STATE_COMPLETE) {
+            throw new LogicException('Cannot append multipart bytes after the closing boundary.');
+        }
+        if (!$this->paused_at_incomplete_input || $this->current_token_type !== null) {
+            throw new LogicException('Call next_token() until the multipart processor requests more input before appending bytes.');
+        }
+        $fragment_bytes = strlen($bytes);
+        if ($fragment_bytes > self::MAX_INPUT_FRAGMENT_BYTES) {
+            throw new InvalidArgumentException(
+                'Multipart input fragment contains ' . $fragment_bytes . ' bytes; the maximum is '
+                . self::MAX_INPUT_FRAGMENT_BYTES . ' bytes.'
+            );
+        }
+        $this->buffer .= $bytes;
+        $this->paused_at_incomplete_input = false;
+    }
+
+    /**
+     * Advances to the next part-start, body, or part-end token.
+     *
+     * True means the token getters describe one current token. False means
+     * either append_bytes() must supply another fragment or the closing
+     * boundary is complete; inspect paused_at_incomplete_input() and
+     * is_complete() to distinguish those states.
+     *
+     * @return bool True when a token is current, false when paused or complete.
+     *
+     * @throws InvalidArgumentException If multipart syntax or headers are invalid.
+     */
+    public function next_token(): bool {
+        $this->current_token_type = null;
+        $this->current_body_piece = '';
+        $this->paused_at_incomplete_input = false;
+
+        while (true) {
+            if ($this->state === self::STATE_COMPLETE) {
+                return false;
+            }
+
+            if ($this->state === self::STATE_BOUNDARY) {
+                if (!$this->parse_boundary()) {
+                    $this->paused_at_incomplete_input = true;
+                    return false;
+                }
+                continue;
+            }
+
+            if ($this->state === self::STATE_HEADERS) {
+                if (!$this->parse_headers()) {
+                    $this->paused_at_incomplete_input = true;
+                    return false;
+                }
+                return true;
+            }
+
+            if ($this->remaining_body_bytes === 0) {
+                $this->state = self::STATE_BOUNDARY;
+                $this->requires_part_terminator = true;
+                $this->current_token_type = self::TOKEN_PART_END;
+                return true;
+            }
+            if ($this->buffer === '') {
+                $this->paused_at_incomplete_input = true;
+                return false;
+            }
+
+            $body_bytes = min(
+                $this->remaining_body_bytes,
+                strlen($this->buffer),
+                self::MAX_INPUT_FRAGMENT_BYTES
+            );
+            $this->current_body_piece = substr($this->buffer, 0, $body_bytes);
+            $this->buffer = (string) substr($this->buffer, $body_bytes);
+            $this->remaining_body_bytes -= $body_bytes;
+            $this->current_token_type = self::TOKEN_BODY;
+            return true;
+        }
+    }
+
+    /**
+     * Verifies that the exhausted transport ended after a closing boundary.
+     *
+     * The caller must first drain next_token() until it returns false. A clean
+     * close makes this method idempotent. EOF in a body, header, delimiter, or
+     * the CRLF between a body and its boundary is reported as truncation.
+     *
+     * @throws LogicException If a current token or unread fragment remains.
+     * @throws RuntimeException If EOF arrived before the multipart close.
+     */
+    public function finish_input(): void {
+        if ($this->input_finished) {
+            return;
+        }
+        $has_unread_fragment = !$this->paused_at_incomplete_input && $this->state !== self::STATE_COMPLETE;
+        if ($this->current_token_type !== null || $has_unread_fragment) {
+            throw new LogicException('Call next_token() until it stops before finishing multipart input.');
+        }
+        $this->input_finished = true;
+        if ($this->state === self::STATE_COMPLETE) {
+            return;
+        }
+        if ($this->state === self::STATE_BODY) {
+            throw new RuntimeException(
+                'The multipart body ended before its declared Content-Length; '
+                . $this->remaining_body_bytes . ' bytes remain.'
+            );
+        }
+        if ($this->state === self::STATE_HEADERS) {
+            throw new RuntimeException(
+                'The multipart body ended while reading a part header block with '
+                . strlen($this->buffer) . ' buffered bytes.'
+            );
+        }
+        if ($this->requires_part_terminator) {
+            throw new RuntimeException(
+                'The multipart body ended before the CRLF and boundary following a part body; '
+                . strlen($this->buffer) . ' separator bytes were available.'
+            );
+        }
+        throw new RuntimeException(
+            'The multipart body ended before its closing boundary with '
+            . strlen($this->buffer) . ' buffered bytes.'
+        );
+    }
+
+    /**
+     * Indicates whether next_token() stopped because it needs another fragment.
+     *
+     * @return bool True when append_bytes() may supply more input.
+     */
+    public function paused_at_incomplete_input(): bool {
+        return $this->paused_at_incomplete_input && !$this->input_finished;
+    }
+
+    /**
+     * Indicates whether a syntactically complete closing boundary was consumed.
+     *
+     * @return bool True after the multipart message has cleanly closed.
+     */
+    public function is_complete(): bool {
+        return $this->state === self::STATE_COMPLETE;
+    }
+
+    /**
+     * Returns the type of the token exposed by the latest successful next_token().
+     *
+     * @return string One of the TOKEN_* constants.
+     *
+     * @throws LogicException If no token is current.
+     */
+    public function get_token_type(): string {
+        if ($this->current_token_type === null) {
+            throw new LogicException('No multipart token is current; call next_token() first.');
+        }
+        return $this->current_token_type;
+    }
+
+    /**
+     * Returns the normalized headers belonging to the current part token.
+     *
+     * Header names are lowercase and unique. Folded physical lines have their
+     * CRLF removed; leading whitespace after a colon is discarded while
+     * continuation whitespace and trailing value whitespace are preserved.
+     *
+     * @return array<string,string> Current part headers by lowercase name.
+     *
+     * @throws LogicException If no part token is current.
+     */
+    public function get_current_headers(): array {
+        if ($this->current_token_type === null) {
+            throw new LogicException('No multipart part token is current; call next_token() first.');
+        }
+        return $this->current_headers;
+    }
+
+    /**
+     * Returns the bytes exposed by the current body token.
+     *
+     * The returned string is replaced on the next next_token() call. Callers
+     * should write or otherwise consume it before advancing.
+     *
+     * @return string Non-empty bounded body fragment.
+     *
+     * @throws LogicException If the current token is not TOKEN_BODY.
+     */
+    public function get_current_body_piece(): string {
+        if ($this->current_token_type !== self::TOKEN_BODY) {
+            throw new LogicException('The current multipart token does not contain body bytes.');
+        }
+        return $this->current_body_piece;
+    }
+
+    /**
+     * Consumes one exact opening or closing delimiter line when available.
+     *
+     * @return bool True after a complete delimiter transition, false when its
+     *     bytes are split across the next input fragment.
+     *
+     * @throws InvalidArgumentException If the separator or delimiter is invalid.
+     */
+    private function parse_boundary(): bool {
+        if ($this->requires_part_terminator) {
+            if (strlen($this->buffer) < 2) {
+                return false;
+            }
+            $separator = substr($this->buffer, 0, 2);
+            if ($separator !== "\r\n") {
+                throw new InvalidArgumentException(
+                    'A multipart part body must be followed by CRLF before its boundary; received '
+                    . self::describe_bytes($separator) . '.'
+                );
+            }
+            $this->buffer = (string) substr($this->buffer, 2);
+            $this->requires_part_terminator = false;
+        }
+
+        $boundary_line = $this->read_syntax_line('the multipart boundary');
+        if ($boundary_line === null) {
+            return false;
+        }
+        if ($boundary_line === $this->delimiter . '--') {
+            if ($this->buffer !== '') {
+                throw new InvalidArgumentException(
+                    'Multipart data contains ' . strlen($this->buffer) . ' bytes after the closing boundary.'
+                );
+            }
+            $this->state = self::STATE_COMPLETE;
+            $this->current_headers = [];
+            return true;
+        }
+        if ($boundary_line !== $this->delimiter) {
+            throw new InvalidArgumentException(
+                'Expected multipart boundary "' . $this->delimiter . '"; received '
+                . self::describe_bytes($boundary_line) . '.'
+            );
+        }
+
+        $this->state = self::STATE_HEADERS;
+        $this->current_headers = [];
+        $this->current_header_bytes = 0;
+        $this->pending_header_name = null;
+        $this->pending_header_value = '';
+        return true;
+    }
+
+    /**
+     * Consumes header lines until one complete normalized header map is ready.
+     *
+     * @return bool True after exposing TOKEN_PART_START, false when the next
+     *     physical header line is split across input fragments.
+     *
+     * @throws InvalidArgumentException If a line, field, duplicate, aggregate,
+     *     or required Content-Length violates the Reprint grammar.
+     */
+    private function parse_headers(): bool {
+        while (true) {
+            $line = $this->read_syntax_line('a multipart part header');
+            if ($line === null) {
+                return false;
+            }
+            $this->current_header_bytes += strlen($line) + 2;
+            if ($this->current_header_bytes > self::MAX_HEADER_BYTES) {
+                throw new InvalidArgumentException(
+                    'Multipart part headers exceed ' . self::MAX_HEADER_BYTES . ' bytes; received '
+                    . $this->current_header_bytes . ' bytes.'
+                );
+            }
+
+            if ($line !== '' && ( $line[0] === ' ' || $line[0] === "\t" )) {
+                if ($this->pending_header_name === null) {
+                    throw new InvalidArgumentException('Multipart part header continuation has no preceding header field.');
+                }
+                // MIME unfolding removes the physical CRLF but preserves the
+                // continuation's whitespace as part of the logical value.
+                $this->pending_header_value .= $line;
+                continue;
+            }
+
+            $this->store_pending_header();
+            if ($line === '') {
+                $content_length = $this->current_headers['content-length'] ?? null;
+                if (!is_string($content_length) || !preg_match('/^(?:0|[1-9][0-9]*)$/D', $content_length)) {
+                    $received_content_length = is_string($content_length)
+                        ? self::describe_bytes($content_length)
+                        : 'no Content-Length header';
+                    throw new InvalidArgumentException(
+                        'Every Reprint multipart part requires a non-negative integer Content-Length; received '
+                        . $received_content_length . '.'
+                    );
+                }
+                $maximum_integer = (string) PHP_INT_MAX;
+                if (strlen($content_length) > strlen($maximum_integer)
+                    || ( strlen($content_length) === strlen($maximum_integer)
+                        && strcmp($content_length, $maximum_integer) > 0 )) {
+                    throw new InvalidArgumentException(
+                        'Multipart part Content-Length exceeds this runtime\'s integer range: ' . $content_length . '.'
+                    );
+                }
+                $this->remaining_body_bytes = (int) $content_length;
+                $this->state = self::STATE_BODY;
+                $this->current_token_type = self::TOKEN_PART_START;
+                return true;
+            }
+
+            $colon = strpos($line, ':');
+            if ($colon === false || $colon === 0) {
+                throw new InvalidArgumentException(
+                    'Malformed multipart part header ' . self::describe_bytes($line) . '.'
+                );
+            }
+            $name = substr($line, 0, $colon);
+            if (!preg_match('/^[!#$%&\'\*+\-.^_`|~0-9A-Za-z]+$/D', $name)) {
+                throw new InvalidArgumentException(
+                    'Multipart part has invalid header name ' . self::describe_bytes($name) . '.'
+                );
+            }
+            $this->pending_header_name = strtolower($name);
+            $this->pending_header_value = substr($line, $colon + 1);
+        }
+    }
+
+    /**
+     * Publishes the pending physical field into the unique normalized map.
+     *
+     * A field remains pending while continuation lines arrive. It is stored
+     * only when the next field or the header-block terminator is complete, so
+     * continuation lines do not consume the distinct-header count.
+     *
+     * @throws InvalidArgumentException If the field repeats a name or exceeds
+     *     the maximum distinct-header count.
+     */
+    private function store_pending_header(): void {
+        if ($this->pending_header_name === null) {
+            return;
+        }
+        $current_header_count = count($this->current_headers);
+        if ($current_header_count >= self::MAX_HEADERS) {
+            $received_header_count = $current_header_count + 1;
+            throw new InvalidArgumentException(
+                'Multipart part has more than ' . self::MAX_HEADERS . ' headers; received '
+                . $received_header_count . '.'
+            );
+        }
+        if (isset($this->current_headers[$this->pending_header_name])) {
+            throw new InvalidArgumentException(
+                'Multipart part repeats header ' . json_encode($this->pending_header_name) . '.'
+            );
+        }
+        $this->current_headers[$this->pending_header_name] = ltrim($this->pending_header_value, " \t");
+        $this->pending_header_name = null;
+        $this->pending_header_value = '';
+    }
+
+    /**
+     * Removes one required CRLF-terminated syntax line from the input buffer.
+     *
+     * @param string $description Human-readable construct named in failures.
+     * @return string|null Line without CRLF, or null when the line is incomplete.
+     *
+     * @throws InvalidArgumentException If LF is bare or the physical line
+     *     exceeds the fixed line limit before its CRLF arrives.
+     */
+    private function read_syntax_line(string $description): ?string {
+        $line_feed = strpos($this->buffer, "\n");
+        if ($line_feed === false) {
+            if (strlen($this->buffer) > self::MAX_HEADER_LINE_BYTES + 1) {
+                throw new InvalidArgumentException(
+                    'Multipart ' . $description . ' exceeds ' . self::MAX_HEADER_LINE_BYTES
+                    . ' bytes or is missing CRLF; buffered ' . strlen($this->buffer) . ' bytes.'
+                );
+            }
+            return null;
+        }
+        if ($line_feed === 0 || $this->buffer[$line_feed - 1] !== "\r") {
+            throw new InvalidArgumentException('Multipart ' . $description . ' must end with CRLF, not bare LF.');
+        }
+        $line_bytes = $line_feed - 1;
+        if ($line_bytes > self::MAX_HEADER_LINE_BYTES) {
+            throw new InvalidArgumentException(
+                'Multipart ' . $description . ' exceeds ' . self::MAX_HEADER_LINE_BYTES
+                . ' bytes; received ' . $line_bytes . ' bytes.'
+            );
+        }
+        $line = substr($this->buffer, 0, $line_bytes);
+        $this->buffer = (string) substr($this->buffer, $line_feed + 1);
+        return $line;
+    }
+
+    /**
+     * Validates a boundary before it is interpolated into delimiter lines.
+     *
+     * The accepted punctuation is MIME's bcharsnospace set. Spaces are
+     * deliberately excluded even in a quoted parameter because Reprint never
+     * emits them and the narrower set makes line interpretation unambiguous.
+     *
+     * @param string $boundary Boundary token without leading `--`.
+     *
+     * @throws InvalidArgumentException If the token is empty, overlong, or unsafe.
+     */
+    private static function validate_boundary(string $boundary): void {
+        if ($boundary === '' || strlen($boundary) > self::MAX_BOUNDARY_BYTES) {
+            throw new InvalidArgumentException(
+                'Multipart boundary must contain between 1 and ' . self::MAX_BOUNDARY_BYTES
+                . ' bytes; received ' . strlen($boundary) . ' bytes.'
+            );
+        }
+        if (!preg_match("/^[0-9A-Za-z'()+_,.\\/:=?-]+$/D", $boundary)) {
+            throw new InvalidArgumentException(
+                'Multipart boundary contains unsupported characters: ' . self::describe_bytes($boundary) . '.'
+            );
+        }
+    }
+
+    /**
+     * Formats arbitrary protocol bytes without assuming they are valid UTF-8.
+     *
+     * JSON keeps ordinary header values readable. Hexadecimal remains lossless
+     * when malformed input contains bytes which json_encode() cannot represent.
+     *
+     * @param string $bytes Raw value observed on the multipart wire.
+     * @return string Quoted JSON text or a hexadecimal byte string.
+     */
+    private static function describe_bytes(string $bytes): string {
+        $json = json_encode($bytes);
+        return $json === false ? '0x' . bin2hex($bytes) : $json;
+    }
+}

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -146,8 +146,8 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
      *
      *    https://github.com/curl/curl/blob/462244447e8ba3a53b1ba9f0ba7baa52d8777daa/lib/mime.c#L1179-L1236
      *
-     * Also, most chunks declare their Content-Length, so the client may skip the
-     * boundary matching entirely and just consume that many bytes.
+     * Also, every chunk declares its Content-Length, so the client never needs
+     * to search arbitrary body bytes for the boundary.
      */
     $boundary = "boundary-" . bin2hex(random_bytes(16));
     $can_send_headers = !headers_sent();

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -1,0 +1,1056 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Transport errors are CLI/API values, never HTML output.
+
+/**
+ * Streams a caller-driven multipart/mixed upload over one live HTTP request.
+ *
+ * The client opens a signed target upload, pauses its cURL read callback until
+ * the caller supplies a part, and resumes the transfer only long enough to send
+ * that part. send_part() does not queue future work: when it returns true,
+ * libcurl has consumed the complete MIME prefix, payload, and suffix through
+ * the active transfer. The caller can then drop that one payload string, read
+ * the next bounded source piece, and call send_part() again.
+ *
+ * Example:
+ *
+ *     if (!$client->start_upload_request($session_id)) {
+ *         throw new RuntimeException($client->get_last_error());
+ *     }
+ *
+ *     while ($offset < $total_bytes) {
+ *         $maximum = $client->next_file_body_bytes($path, $total_bytes, $offset, $mode);
+ *         if ($maximum === 0) {
+ *             break;
+ *         }
+ *         $payload = read_source_piece($path, $offset, $maximum);
+ *         if (!$client->send_part([
+ *             'type' => 'file',
+ *             'path' => $path,
+ *             'total_bytes' => $total_bytes,
+ *             'offset' => $offset,
+ *             'payload' => $payload,
+ *         ])) {
+ *             break;
+ *         }
+ *         $offset += strlen($payload);
+ *     }
+ *
+ *     $result = $client->finish_request();
+ *
+ * Three limits describe different dimensions. `chunk_bytes` bounds the one
+ * payload string held in memory, `max_part_bytes` is the target's maximum
+ * Content-Length for one MIME part, and PushRequestSizer bounds the decoded
+ * entity body containing many parts. MIME delimiter and header bytes count
+ * against that request-body budget; HTTP headers and transfer framing do not.
+ *
+ * A curl_multi handle outlives individual requests so libcurl may reuse its
+ * connection. The active easy handle exists only from start_upload_request()
+ * through finish_request(). Timeouts are per phase rather than total-transfer
+ * deadlines: connection establishment, lack of upload progress, and lack of
+ * finish/response progress after the closing boundary is queued. A slow
+ * connection which continues moving bytes is allowed to continue.
+ *
+ * Pausing from a PHP cURL read callback is reliable only on PHP 8.1 and newer;
+ * older bindings interpret CURL_READFUNC_PAUSE as end-of-body and silently
+ * truncate the upload. The constructor enforces that runtime requirement while
+ * this source file remains PHP 7.4 parseable for import.php's pull commands.
+ */
+class MultipartPushStreamClient
+{
+    /** @var string Exporter API URL used as the base of every signed request target. */
+    private string $base_url;
+
+    /** @var Site_Export_HMAC_Client Signs the exact method and URL before transfer. */
+    private Site_Export_HMAC_Client $hmac_client;
+
+    /** @var PushRequestSizer Learns the decoded entity-body budget across requests. */
+    private PushRequestSizer $request_sizer;
+
+    /** @var int Maximum caller file bytes held in one payload string. */
+    private int $chunk_bytes;
+
+    /** @var int Target-advertised maximum Content-Length for one MIME part. */
+    private int $max_part_bytes;
+
+    /** @var int Seconds allowed to establish a request and open its upload body. */
+    private int $connect_timeout;
+
+    /** @var int Seconds allowed with no multipart bytes consumed by libcurl. */
+    private int $stall_timeout;
+
+    /** @var int Seconds allowed without finish/response progress after the close is queued. */
+    private int $response_timeout;
+
+    /**
+     * cURL easy handle for the currently open upload request.
+     *
+     * Null outside the start_upload_request()/finish_request() lifecycle.
+     *
+     * @var resource|object|null
+     */
+    private $curl_handle = null;
+
+    /**
+     * Long-lived cURL multi handle which preserves libcurl's connection cache.
+     *
+     * @var resource|object|null
+     */
+    private $multi_handle = null;
+
+    /** @var string Random boundary token for the currently open MIME body. */
+    private string $boundary = '';
+
+    /**
+     * MIME framing waiting to be returned by the cURL read callback.
+     *
+     * For a part this contains its boundary, header block, and header/body
+     * separator, which are drained before the payload. At request completion
+     * it contains the closing boundary instead.
+     */
+    private string $outbound_prefix = '';
+
+    /** @var string One caller-supplied body piece currently being transmitted. */
+    private string $outbound_payload = '';
+
+    /** @var string Pending CRLF which terminates the current part body. */
+    private string $outbound_suffix = '';
+
+    /** @var int Next byte offset in $outbound_payload requested by libcurl. */
+    private int $outbound_payload_offset = 0;
+
+    /** @var bool Whether the read callback should return EOF after pending bytes. */
+    private bool $body_complete = false;
+
+    /** @var bool Whether libcurl has entered the upload read callback for this request. */
+    private bool $curl_requested_body = false;
+
+    /** @var bool Whether curl_multi reported terminal completion for the easy handle. */
+    private bool $transfer_finished = false;
+
+    /** @var string|null cURL or phase-timeout detail captured for result classification. */
+    private ?string $transfer_error = null;
+
+    /** @var int Total prefix, payload, and suffix bytes consumed by the read callback. */
+    private int $outbound_consumed_bytes = 0;
+
+    /** @var int Decoded MIME entity-body bytes charged for completed parts and close. */
+    private int $body_bytes_sent = 0;
+
+    /** @var int Complete MIME parts transmitted in the current request. */
+    private int $parts_sent = 0;
+
+    /** @var string|null Setup failure exposed when start_upload_request() returns false. */
+    private ?string $last_error = null;
+
+    /**
+     * Configures one reusable connection context and its independent limits.
+     *
+     * Construction fails on PHP versions whose curl binding cannot pause a
+     * read callback without terminating the upload. HTTP is rejected unless
+     * `allow_http` is explicitly true.
+     *
+     * Null optional values are treated as absent by the constructor's defaults.
+     *
+     * @param array<string,mixed> $options {
+     *     Transport, authentication, and limit options.
+     *
+     *     @type string $base_url Required exporter API URL. Must use HTTPS
+     *         unless `allow_http` is true.
+     *     @type Site_Export_HMAC_Client $hmac_client Required signer for the
+     *         exact method and request URL.
+     *     @type bool $allow_http Whether to permit an explicit HTTP base URL.
+     *         Default false.
+     *     @type PushRequestSizer $request_sizer Request-body sizing state to
+     *         reuse. Defaults to a new sizer.
+     *     @type int|float|string $chunk_bytes Maximum caller payload bytes held
+     *         in memory. A positive numeric value is cast to int. Default 4 MiB.
+     *     @type int|float|string $max_part_bytes Maximum Content-Length for one
+     *         MIME part. A positive numeric value is cast to int. Default PHP_INT_MAX.
+     *     @type int|float|string $connect_timeout Seconds allowed to establish
+     *         the request and open its body. Default 30.
+     *     @type int|float|string $stall_timeout Seconds allowed with no upload
+     *         bytes consumed by cURL. Default 60.
+     *     @type int|float|string $response_timeout Seconds allowed without
+     *         finish or response progress. Default 300.
+     * }
+     *
+     * @throws InvalidArgumentException If required or non-null configuration
+     *     is invalid or insecure.
+     * @throws RuntimeException If PHP cannot support paused upload callbacks.
+     */
+    public function __construct(array $options)
+    {
+        if (PHP_VERSION_ID < 80100) {
+            throw new RuntimeException(
+                'reprint push requires PHP 8.1 or newer: streaming request bodies need CURL_READFUNC_PAUSE, '
+                . 'which older PHP curl bindings interpret as end-of-body. See https://github.com/WordPress/reprint/issues/327.'
+            );
+        }
+        $base_url = $options['base_url'] ?? null;
+        if (!is_string($base_url) || $base_url === '') {
+            throw new InvalidArgumentException('MultipartPushStreamClient requires a non-empty base_url option.');
+        }
+        $scheme = strtolower((string) parse_url($base_url, PHP_URL_SCHEME));
+        $allow_http = $options['allow_http'] ?? false;
+        if (!is_bool($allow_http) || ($scheme !== 'https' && $scheme !== 'http') || ($scheme === 'http' && !$allow_http)) {
+            throw new InvalidArgumentException(
+                'Push base_url must be https://, unless allow_http is true for an explicit http:// target.'
+            );
+        }
+        $hmac_client = $options['hmac_client'] ?? null;
+        if (!$hmac_client instanceof Site_Export_HMAC_Client) {
+            throw new InvalidArgumentException('MultipartPushStreamClient requires a Site_Export_HMAC_Client.');
+        }
+        $this->base_url = rtrim($base_url, '?&');
+        $this->hmac_client = $hmac_client;
+        $this->request_sizer = $options['request_sizer'] ?? new PushRequestSizer();
+        if (!$this->request_sizer instanceof PushRequestSizer) {
+            throw new InvalidArgumentException('request_sizer must be a PushRequestSizer.');
+        }
+
+        $this->chunk_bytes = $this->positive_int_option($options, 'chunk_bytes', 4 * 1024 * 1024);
+        $this->max_part_bytes = $this->positive_int_option($options, 'max_part_bytes', PHP_INT_MAX);
+        $this->connect_timeout = $this->positive_int_option($options, 'connect_timeout', 30);
+        $this->stall_timeout = $this->positive_int_option($options, 'stall_timeout', 60);
+        $this->response_timeout = $this->positive_int_option($options, 'response_timeout', 300);
+    }
+
+    /**
+     * Starts one signed upload request for the supplied target-owned session id.
+     *
+     * This resets all per-request state, generates a fresh MIME boundary, adds
+     * the easy handle to the reusable multi handle, and pumps until libcurl asks
+     * for body bytes. At that point the read callback is paused with no payload
+     * queued and the caller may begin send_part() calls.
+     *
+     * Redirects are not followed because the HMAC covers this exact target URL.
+     * The Expect header is explicitly disabled: PHP's development server never
+     * answers `100 Continue`, which would otherwise consume the full phase
+     * timeout before any body bytes move.
+     *
+     * @param string $session_id Target-issued 32-character hexadecimal id.
+     *
+     * @return bool False when connection setup failed; get_last_error()
+     *     explains why.
+     *
+     * @throws InvalidArgumentException If the session id is malformed.
+     * @throws RuntimeException If another upload request is already open.
+     */
+    public function start_upload_request(string $session_id): bool
+    {
+        if ($this->curl_handle !== null) {
+            throw new RuntimeException('An upload request is already open; call finish_request() first.');
+        }
+        if (preg_match('/^[a-f0-9]{32}$/D', $session_id) !== 1) {
+            throw new InvalidArgumentException('Target session_id must be a 32-character lowercase hexadecimal value.');
+        }
+        $this->boundary = 'reprint-' . bin2hex(random_bytes(16));
+        $this->outbound_prefix = '';
+        $this->outbound_payload = '';
+        $this->outbound_suffix = '';
+        $this->outbound_payload_offset = 0;
+        $this->body_complete = false;
+        $this->curl_requested_body = false;
+        $this->transfer_finished = false;
+        $this->transfer_error = null;
+        $this->outbound_consumed_bytes = 0;
+        $this->body_bytes_sent = 0;
+        $this->parts_sent = 0;
+        $this->last_error = null;
+
+        $request_url = $this->endpoint_url('staged_session_upload', ['session_id' => $session_id]);
+        $headers = $this->hmac_client->get_envelope_auth_headers('POST', $request_url);
+        $headers['Content-Type'] = 'multipart/mixed; boundary=' . $this->boundary;
+        $header_lines = [];
+        foreach ($headers as $name => $value) {
+            $header_lines[] = $name . ': ' . $value;
+        }
+        // php -S never answers 100-continue. Sending the request head then
+        // one bounded body is more useful than stalling every local test and
+        // every compatible host for an interim response it will not send.
+        $header_lines[] = 'Expect:';
+
+        $this->curl_handle = curl_init($request_url);
+        if (function_exists('reprint_apply_curl_proxy_from_env')) {
+            reprint_apply_curl_proxy_from_env($this->curl_handle);
+        }
+        if (function_exists('reprint_apply_curl_ca_bundle')) {
+            reprint_apply_curl_ca_bundle($this->curl_handle);
+        }
+        curl_setopt_array($this->curl_handle, [
+            CURLOPT_UPLOAD => true,
+            CURLOPT_CUSTOMREQUEST => 'POST',
+            CURLOPT_HTTPHEADER => $header_lines,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_CONNECTTIMEOUT => $this->connect_timeout,
+            CURLOPT_READFUNCTION => function ($curl_handle, $stream, int $length) {
+                $this->curl_requested_body = true;
+                if ($this->outbound_prefix !== '') {
+                    return $this->consume_string('outbound_prefix', $length);
+                }
+                if ($this->outbound_payload_offset < strlen($this->outbound_payload)) {
+                    $piece = substr($this->outbound_payload, $this->outbound_payload_offset, $length);
+                    $this->outbound_payload_offset += strlen($piece);
+                    $this->outbound_consumed_bytes += strlen($piece);
+                    if ($this->outbound_payload_offset >= strlen($this->outbound_payload)) {
+                        $this->outbound_payload = '';
+                        $this->outbound_payload_offset = 0;
+                    }
+                    return $piece;
+                }
+                if ($this->outbound_suffix !== '') {
+                    return $this->consume_string('outbound_suffix', $length);
+                }
+                if ($this->body_complete) {
+                    return '';
+                }
+                return CURL_READFUNC_PAUSE;
+            },
+        ]);
+
+        if ($this->multi_handle === null) {
+            $this->multi_handle = curl_multi_init();
+        }
+        curl_multi_add_handle($this->multi_handle, $this->curl_handle);
+        $deadline = microtime(true) + $this->connect_timeout;
+        while (!$this->curl_requested_body && !$this->transfer_finished) {
+            if (microtime(true) > $deadline) {
+                $this->transfer_error = 'Timed out after ' . $this->connect_timeout . 's opening the multipart upload request.';
+                break;
+            }
+            $this->pump_transfer();
+        }
+        if (!$this->curl_requested_body) {
+            $this->last_error = $this->transfer_error ?? 'The multipart upload ended before the request body opened.';
+            curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
+            $this->curl_handle = null;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Sends one already-read bounded multipart part over the active transfer.
+     *
+     * Headers are computed from strlen($part['payload']), so a short source read
+     * produces a smaller truthful frame rather than a body shorter than its
+     * declared Content-Length. The method first verifies that the complete MIME
+     * part and closing delimiter fit the current request-body budget. If they do,
+     * it resumes cURL and pumps until every byte of this part has been consumed
+     * or the transfer ends/stalls.
+     *
+     * False before transmission means the caller should close this request and
+     * retry the same logical part in another one. False after a transport failure
+     * has an indeterminate target outcome; finish_request() classifies the
+     * response and the high-level driver reconciles target status before reuse.
+     *
+     * @param array<string,mixed> $part {
+     *     One multipart part to send.
+     *
+     *     @type string $type Required. `file`, `directory`, `symlink`, or
+     *         `delete-list`.
+     *     @type string $payload Required raw body bytes. Must be empty for a
+     *         directory or symlink.
+     *     @type string $path Required target-relative path for a file,
+     *         directory, or symlink.
+     *     @type int $total_bytes Required complete source size for a file.
+     *     @type int $offset Required target-confirmed byte offset for a file or
+     *         delete list.
+     *     @type string $target Required raw link target for a symlink. Must be
+     *         non-empty and contain no NUL byte.
+     *     @type bool $complete Optional delete-list completion declaration.
+     * }
+     * @return bool True after the complete part was supplied to libcurl; false
+     *     when it did not fit or the transfer stopped before completion.
+     *
+     * @throws InvalidArgumentException If part type, payload, or metadata is invalid.
+     * @throws RuntimeException If no upload request is open.
+     */
+    public function send_part(array $part): bool
+    {
+        if ($this->curl_handle === null) {
+            throw new RuntimeException('No upload request is open; call start_upload_request() before send_part().');
+        }
+        if ($this->transfer_finished) {
+            return false;
+        }
+        $payload = $part['payload'] ?? null;
+        if (!is_string($payload)) {
+            throw new InvalidArgumentException('Multipart push part payload must be a string.');
+        }
+        $headers = $this->part_headers($part, strlen($payload));
+        $prefix = '--' . $this->boundary . "\r\n";
+        foreach ($headers as $name => $value) {
+            $prefix .= $name . ': ' . $value . "\r\n";
+        }
+        $prefix .= "\r\n";
+
+        $part_body_bytes = strlen($prefix) + strlen($payload) + 2;
+        if ($this->body_bytes_sent + $part_body_bytes + $this->closing_boundary_bytes() > $this->request_sizer->request_body_bytes()) {
+            return false;
+        }
+
+        $this->outbound_prefix = $prefix;
+        $this->outbound_payload = $payload;
+        $this->outbound_payload_offset = 0;
+        $this->outbound_suffix = "\r\n";
+        curl_pause($this->curl_handle, CURLPAUSE_CONT);
+
+        $seen_bytes = $this->outbound_consumed_bytes;
+        $last_progress_at = microtime(true);
+        while (($this->outbound_prefix !== '' || $this->outbound_payload !== '' || $this->outbound_suffix !== '') && !$this->transfer_finished) {
+            if ($seen_bytes !== $this->outbound_consumed_bytes) {
+                $seen_bytes = $this->outbound_consumed_bytes;
+                $last_progress_at = microtime(true);
+            } elseif (microtime(true) - $last_progress_at > $this->stall_timeout) {
+                $this->transfer_error = 'The multipart upload stalled: no bytes moved for ' . $this->stall_timeout . 's.';
+                $this->transfer_finished = true;
+                break;
+            }
+            $this->pump_transfer();
+        }
+        if ($this->outbound_prefix !== '' || $this->outbound_payload !== '' || $this->outbound_suffix !== '') {
+            $this->outbound_prefix = '';
+            $this->outbound_payload = '';
+            $this->outbound_suffix = '';
+            $this->outbound_payload_offset = 0;
+            return false;
+        }
+        $this->body_bytes_sent += $part_body_bytes;
+        ++$this->parts_sent;
+        return true;
+    }
+
+    /**
+     * Returns the safe maximum for the caller's next file read.
+     *
+     * The result is bounded by the in-memory chunk limit, target part limit,
+     * and remaining decoded entity-body budget after reserving worst-case MIME
+     * headers and the closing boundary. The path, total size, and offset are
+     * encoded exactly as send_part() will encode them. Zero means the caller
+     * should finish this request before reading more source bytes.
+     *
+     * @param string $path Raw target-relative file path.
+     * @param int $total_bytes Current source file size.
+     * @param int $offset Target-confirmed offset for the next piece.
+     * @return int Maximum payload bytes to read, or zero when no part fits.
+     *
+     * @throws InvalidArgumentException If total or offset is inconsistent.
+     * @throws RuntimeException If no upload request is open.
+     */
+    public function next_file_body_bytes(string $path, int $total_bytes, int $offset): int
+    {
+        if ($this->curl_handle === null) {
+            throw new RuntimeException('No upload request is open; call start_upload_request() before next_file_body_bytes().');
+        }
+        if ($total_bytes < 0 || $offset < 0 || $offset > $total_bytes) {
+            throw new InvalidArgumentException('File part total and offset must be non-negative and offset must not exceed total.');
+        }
+        return $this->next_body_bytes([
+            'type' => 'file',
+            'path' => $path,
+            'total_bytes' => $total_bytes,
+            'offset' => $offset,
+            'payload' => '',
+        ]);
+    }
+
+    /**
+     * Returns the safe maximum for the next raw delete-stream read.
+     *
+     * @param int $offset Target-confirmed raw delete-stream byte offset.
+     * @return int Maximum payload bytes to read, or zero when no part fits.
+     */
+    public function next_delete_body_bytes(int $offset): int
+    {
+        if ($this->curl_handle === null) {
+            throw new RuntimeException('No upload request is open; call start_upload_request() before next_delete_body_bytes().');
+        }
+        if ($offset < 0) {
+            throw new InvalidArgumentException('Delete-list offset must be non-negative.');
+        }
+        return $this->next_body_bytes([
+            'type' => 'delete-list',
+            'offset' => $offset,
+            'payload' => '',
+        ]);
+    }
+
+    /**
+     * Calculates body capacity from an empty file or delete-list descriptor.
+     *
+     * @param array<string,mixed> $part {
+     *     Header fields for the next body whose payload has not been read.
+     *
+     *     @type string $type Required. `file` or `delete-list`.
+     *     @type string $payload Required empty string used only for header sizing.
+     *     @type string $path Required target-relative path for a file.
+     *     @type int $total_bytes Required complete source size for a file.
+     *     @type int $offset Required target-confirmed byte offset.
+     * }
+     * @return int Maximum body bytes allowed after MIME overhead and the close.
+     */
+    private function next_body_bytes(array $part): int
+    {
+        // Reserve enough digits for a PHP integer Content-Length plus all
+        // headers; the actual part is charged after send_part().
+        $headers = $this->part_headers($part, 0);
+        $headers['Content-Length'] = (string) PHP_INT_MAX;
+        $overhead = strlen('--' . $this->boundary . "\r\n\r\n\r\n") + 2;
+        foreach ($headers as $name => $value) {
+            $overhead += strlen($name) + 2 + strlen($value) + 2;
+        }
+        $remaining = $this->request_sizer->request_body_bytes()
+            - $this->body_bytes_sent
+            - $overhead
+            - $this->closing_boundary_bytes();
+        return max(0, min($this->chunk_bytes, $this->max_part_bytes, $remaining));
+    }
+
+    /**
+     * Indicates whether the current request has ended or only its close still fits.
+     *
+     * This is a quick lifecycle check after a successful send. Callers preparing
+     * a file should still use next_file_body_bytes(), which accounts for that
+     * particular part's MIME headers.
+     *
+     * @return bool True after transport completion or request-budget exhaustion.
+     *
+     * @throws RuntimeException If no upload request is open.
+     */
+    public function should_finish_request(): bool
+    {
+        if ($this->curl_handle === null) {
+            throw new RuntimeException('No upload request is open; call start_upload_request() before should_finish_request().');
+        }
+        return $this->transfer_finished
+            || $this->body_bytes_sent + $this->closing_boundary_bytes() >= $this->request_sizer->request_body_bytes();
+    }
+
+    /**
+     * Finishes the MIME body, waits for the response, and closes the easy handle.
+     *
+     * When the transfer is still active, this queues the closing boundary and
+     * signals EOF only after cURL consumes it. The finish phase has its own
+     * no-progress timer beginning when that closing boundary is queued, not a
+     * total deadline measured from request start. Redirects,
+     * structured target rejections, HTTP 413, invalid JSON, and cURL failures are
+     * converted into stable `complete`, `retry`, or `failed` results.
+     *
+     * A 413 permanently lowers the learned sizing ceiling. Other ambiguous
+     * request failures shrink temporarily. An accepted request records sizing
+     * success only if at least one part was sent; an accepted empty request is
+     * not evidence that a larger body would succeed.
+     *
+     * The result contains these keys:
+     *
+     * - `status`: `complete`, `retry`, or `failed`.
+     * - `reason`: machine-readable failure classification, or null on success.
+     * - `detail`: human-readable failure detail, or null when none was supplied.
+     * - `response`: decoded target JSON, or null when no usable JSON arrived.
+     * - `parts_sent`: complete MIME parts supplied in this request.
+     * - `body_bytes_sent`: MIME entity-body bytes accounted for this request.
+     *
+     * @return array{
+     *     status:string,
+     *     reason:?string,
+     *     detail:?string,
+     *     response:?array<string,mixed>,
+     *     parts_sent:int,
+     *     body_bytes_sent:int
+     * } Classified request result and transmission counters.
+     *
+     * @throws RuntimeException If no upload request is open.
+     */
+    public function finish_request(): array
+    {
+        if ($this->curl_handle === null) {
+            throw new RuntimeException('No upload request is open; call start_upload_request() before finish_request().');
+        }
+        if (!$this->transfer_finished) {
+            $this->outbound_prefix = '--' . $this->boundary . "--\r\n";
+            $this->body_bytes_sent += strlen($this->outbound_prefix);
+            $this->outbound_payload = '';
+            $this->outbound_suffix = '';
+            $this->body_complete = true;
+            curl_pause($this->curl_handle, CURLPAUSE_CONT);
+            $seen_outbound_bytes = $this->outbound_consumed_bytes;
+            $seen_inbound_bytes = (float) curl_getinfo($this->curl_handle, CURLINFO_SIZE_DOWNLOAD)
+                + (int) curl_getinfo($this->curl_handle, CURLINFO_HEADER_SIZE);
+            $last_progress_at = microtime(true);
+            while (!$this->transfer_finished) {
+                $this->pump_transfer();
+                $inbound_bytes = (float) curl_getinfo($this->curl_handle, CURLINFO_SIZE_DOWNLOAD)
+                    + (int) curl_getinfo($this->curl_handle, CURLINFO_HEADER_SIZE);
+                if ($seen_outbound_bytes !== $this->outbound_consumed_bytes || $seen_inbound_bytes !== $inbound_bytes) {
+                    $seen_outbound_bytes = $this->outbound_consumed_bytes;
+                    $seen_inbound_bytes = $inbound_bytes;
+                    $last_progress_at = microtime(true);
+                } elseif (microtime(true) - $last_progress_at > $this->response_timeout) {
+                    $this->transfer_error = 'The multipart request finish phase stalled: no upload or response bytes moved for ' . $this->response_timeout . 's.';
+                    break;
+                }
+            }
+        }
+
+        $http_code = (int) curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
+        $redirect_url = (string) curl_getinfo($this->curl_handle, CURLINFO_REDIRECT_URL);
+        $body = (string) curl_multi_getcontent($this->curl_handle);
+        curl_multi_remove_handle($this->multi_handle, $this->curl_handle);
+        $this->curl_handle = null;
+
+        if (in_array($http_code, [301, 302, 303, 307, 308], true)) {
+            return [
+                'status' => 'failed',
+                'reason' => 'redirected',
+                'detail' => $redirect_url === ''
+                    ? 'The target redirected the upload. Use its final URL as the push base_url.'
+                    : 'The target redirected to ' . $redirect_url . '. Use that address as the push base_url.',
+                'response' => null,
+                'parts_sent' => $this->parts_sent,
+                'body_bytes_sent' => $this->body_bytes_sent,
+            ];
+        }
+        $decoded = json_decode($body, true);
+        if ($http_code === 413) {
+            $reported_limit = is_array($decoded) ? ($decoded['post_max_bytes'] ?? null) : null;
+            $decision = $this->request_sizer->record_too_large(is_numeric($reported_limit) ? (int) $reported_limit : null);
+            return [
+                'status' => $decision['action'] === 'give_up' ? 'failed' : 'retry',
+                'reason' => 'request_too_large',
+                'detail' => is_array($decoded) ? null : 'HTTP 413 Request Entity Too Large.',
+                'response' => is_array($decoded) ? $decoded : null,
+                'parts_sent' => $this->parts_sent,
+                'body_bytes_sent' => $this->body_bytes_sent,
+            ];
+        }
+        if (!is_array($decoded)) {
+            if ($body !== '') {
+                return [
+                    'status' => 'failed',
+                    'reason' => 'malformed_response',
+                    'detail' => 'Invalid JSON response (HTTP ' . $http_code . '): ' . substr($body, 0, 160),
+                    'response' => null,
+                    'parts_sent' => $this->parts_sent,
+                    'body_bytes_sent' => $this->body_bytes_sent,
+                ];
+            }
+            $decision = $this->request_sizer->record_request_failure();
+            return [
+                'status' => $decision['action'] === 'give_up' ? 'failed' : 'retry',
+                'reason' => $decision['action'] === 'give_up' ? 'request_size_exhausted' : 'request_failed',
+                'detail' => $this->transfer_error ?? 'Invalid JSON response (HTTP ' . $http_code . '): ' . substr($body, 0, 160),
+                'response' => null,
+                'parts_sent' => $this->parts_sent,
+                'body_bytes_sent' => $this->body_bytes_sent,
+            ];
+        }
+        $decoded['http_code'] = $http_code;
+        $result = $this->classify_response($decoded, ['accepted']);
+        if ($result['status'] !== 'complete') {
+            return $result;
+        }
+        if ($this->parts_sent > 0) {
+            $this->request_sizer->record_success();
+        }
+        return $result;
+    }
+
+    /**
+     * Sends one signed control request and decodes its JSON response.
+     *
+     * Control calls use a no-progress timeout rather than a total-transfer
+     * deadline and refuse redirects so signatures are never replayed elsewhere.
+     *
+     * @param string $method GET or POST.
+     * @param string $endpoint Protocol endpoint query value.
+     * @param array<string,mixed> $parameters Endpoint-specific query parameters.
+     *     Their keys are encoded and signed but are not interpreted here.
+     * @param string[] $expected_statuses Successful protocol statuses for this endpoint.
+     * @return array{
+     *     status:string,
+     *     reason:?string,
+     *     detail:?string,
+     *     response:array<string,mixed>,
+     *     parts_sent:int,
+     *     body_bytes_sent:int
+     * } Response classification. Keys have the meanings documented by finish_request().
+     *
+     * @throws InvalidArgumentException If the method is unsupported.
+     * @throws RuntimeException If transport, redirect, or JSON decoding fails.
+     */
+    public function control_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
+    {
+        $method = strtoupper($method);
+        if (!in_array($method, ['GET', 'POST'], true)) {
+            throw new InvalidArgumentException('Multipart push control method must be GET or POST.');
+        }
+        if ($expected_statuses === [] || count(array_filter($expected_statuses, 'is_string')) !== count($expected_statuses)) {
+            throw new InvalidArgumentException('Multipart push control requests require one or more string success statuses.');
+        }
+        $url = $this->endpoint_url($endpoint, $parameters);
+        $headers = $this->hmac_client->get_envelope_auth_headers($method, $url);
+        $lines = ['Accept: application/json', 'Expect:'];
+        foreach ($headers as $name => $value) {
+            $lines[] = $name . ': ' . $value;
+        }
+        $handle = curl_init($url);
+        if (function_exists('reprint_apply_curl_proxy_from_env')) {
+            reprint_apply_curl_proxy_from_env($handle);
+        }
+        if (function_exists('reprint_apply_curl_ca_bundle')) {
+            reprint_apply_curl_ca_bundle($handle);
+        }
+        curl_setopt_array($handle, [
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_POST => $method === 'POST',
+            CURLOPT_POSTFIELDS => $method === 'POST' ? '' : null,
+            CURLOPT_HTTPHEADER => $lines,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_CONNECTTIMEOUT => $this->connect_timeout,
+            // A control request has a bounded response, but it must not use
+            // CURLOPT_TIMEOUT: that is a total-transfer deadline and kills
+            // a slow connection that is still moving bytes. libcurl's low
+            // speed timer is a stall timeout instead.
+            CURLOPT_LOW_SPEED_LIMIT => 1,
+            CURLOPT_LOW_SPEED_TIME => $this->response_timeout,
+        ]);
+        $body = curl_exec($handle);
+        $error = curl_error($handle);
+        $http_code = (int) curl_getinfo($handle, CURLINFO_HTTP_CODE);
+        $redirect_url = (string) curl_getinfo($handle, CURLINFO_REDIRECT_URL);
+        curl_close($handle);
+        if (in_array($http_code, [301, 302, 303, 307, 308], true)) {
+            throw new RuntimeException('The target redirected to ' . ($redirect_url === '' ? 'another address' : $redirect_url) . '. Use that address as the push base_url.');
+        }
+        if (!is_string($body)) {
+            throw new RuntimeException('Push control request failed: ' . ($error === '' ? 'no response' : $error) . '.');
+        }
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            throw new RuntimeException('Push control request returned invalid JSON (HTTP ' . $http_code . '): ' . substr($body, 0, 160));
+        }
+        $decoded['http_code'] = $http_code;
+        return $this->classify_response($decoded, $expected_statuses);
+    }
+
+    /**
+     * Returns learned request-sizing state suitable for the local checkpoint.
+     *
+     * The returned checkpoint contains:
+     *
+     * - `request_body_bytes`: current decoded entity-body budget.
+     * - `ceiling_bytes`: learned session ceiling, or null while unknown.
+     * - `growth_holdoff_remaining`: accepted requests still required before growth.
+     *
+     * @return array{
+     *     request_body_bytes:int,
+     *     ceiling_bytes:?int,
+     *     growth_holdoff_remaining:int
+     * } Serializable PushRequestSizer state.
+     */
+    public function get_request_sizer_state(): array
+    {
+        return $this->request_sizer->get_state();
+    }
+
+    /**
+     * Applies target-reported entity-body ceilings to future upload requests.
+     *
+     * Null and non-positive candidates are ignored by PushRequestSizer; useful
+     * limits may only lower the learned session ceiling.
+     *
+     * @param array<int,int|float|string|null> $limits Remote byte-limit
+     *     candidates. Numeric values are cast to integers; null and non-positive
+     *     values are ignored.
+     */
+    public function apply_reported_limits(array $limits): void
+    {
+        $this->request_sizer->apply_reported_limits($limits);
+    }
+
+    /**
+     * Lowers the maximum payload bytes allowed in one MIME part.
+     *
+     * A create response owns this ceiling. It limits one part, while the request
+     * sizer separately limits the complete decoded entity body. Repeated calls
+     * can only tighten the current value.
+     *
+     * @param int $max_part_bytes Positive target-advertised part limit.
+     *
+     * @throws InvalidArgumentException If the limit is not positive.
+     */
+    public function set_max_part_bytes(int $max_part_bytes): void
+    {
+        if ($max_part_bytes <= 0) {
+            throw new InvalidArgumentException('max_part_bytes must be a positive integer.');
+        }
+        $this->max_part_bytes = min($this->max_part_bytes, $max_part_bytes);
+    }
+
+    /**
+     * Returns why the most recent start_upload_request() could not open a body.
+     *
+     * The value is reset at the start of each request. Errors after body setup
+     * are instead returned by finish_request().
+     *
+     * @return string|null Setup failure detail, or null when none is recorded.
+     */
+    public function get_last_error(): ?string
+    {
+        return $this->last_error;
+    }
+
+    /**
+     * Encodes and validates the protocol headers for one already-read payload.
+     *
+     * Paths and symlink targets are base64 because filesystem byte strings are
+     * not necessarily valid UTF-8. Content-Length is always derived from the
+     * payload already in hand. Metadata parts require empty bodies. Delete-list
+     * payloads may end within a NUL-delimited record and resume in a later part.
+     *
+     * `$part` supports the following keys:
+     *
+     * - `type`: required `file`, `directory`, `symlink`, or `delete-list`.
+     * - `path`: required for file, directory, and symlink parts.
+     * - `total_bytes`: required complete source size for a file.
+     * - `offset`: required target-confirmed offset for a file or delete list.
+     * - `target`: required raw link target for a symlink.
+     * - `complete`: optional delete-list completion declaration.
+     * - `payload`: supplied by send_part(); only its separately computed byte
+     *   count is used here.
+     *
+     * The returned map always contains `X-Chunk-Type` and `Content-Length`.
+     * File parts add `X-File-Path`, `X-File-Size`, and `X-Chunk-Offset`;
+     * directories add `X-Directory-Path`; symlinks add `X-Symlink-Path` and
+     * `X-Symlink-Target`; delete lists add `X-Delete-Offset`, optionally
+     * `X-Delete-Complete`, and an octet-stream `Content-Type`.
+     *
+     * @param array<string,mixed> $part Part descriptor using the keys above.
+     * @param int $payload_bytes Exact strlen() of its payload.
+     * @return array<string,string> Type-specific MIME headers in wire spelling.
+     *
+     * @throws InvalidArgumentException If type-specific fields are invalid.
+     */
+    private function part_headers(array $part, int $payload_bytes): array
+    {
+        if ($payload_bytes > $this->max_part_bytes) {
+            throw new InvalidArgumentException(
+                'Multipart part payload is ' . $payload_bytes . ' bytes but the target maximum is '
+                . $this->max_part_bytes . ' bytes.'
+            );
+        }
+        $type = $part['type'] ?? null;
+        if (!is_string($type) || !in_array($type, ['file', 'directory', 'symlink', 'delete-list'], true)) {
+            throw new InvalidArgumentException('Multipart push part type must be file, directory, symlink, or delete-list.');
+        }
+        $headers = ['X-Chunk-Type' => $type];
+        if ($type === 'file') {
+            $path = $this->non_empty_string_part_field($part, 'path', 'file');
+            $total = $part['total_bytes'] ?? null;
+            $offset = $part['offset'] ?? null;
+            if (!is_int($total) || !is_int($offset) || $total < 0 || $offset < 0 || $offset + $payload_bytes > $total) {
+                throw new InvalidArgumentException('File part must have non-negative total_bytes and offset that contain its payload.');
+            }
+            $headers['X-File-Path'] = base64_encode($path);
+            $headers['X-File-Size'] = (string) $total;
+            $headers['X-Chunk-Offset'] = (string) $offset;
+        } elseif ($type === 'directory') {
+            if ($payload_bytes !== 0) {
+                throw new InvalidArgumentException('Directory parts must have an empty body.');
+            }
+            $headers['X-Directory-Path'] = base64_encode($this->non_empty_string_part_field($part, 'path', $type));
+        } elseif ($type === 'symlink') {
+            if ($payload_bytes !== 0) {
+                throw new InvalidArgumentException('Symlink parts must have an empty body.');
+            }
+            $headers['X-Symlink-Path'] = base64_encode($this->non_empty_string_part_field($part, 'path', 'symlink'));
+            $target = $part['target'] ?? null;
+            if (!is_string($target) || $target === '' || strpos($target, "\0") !== false) {
+                throw new InvalidArgumentException('Symlink part target must be a non-empty string without NUL.');
+            }
+            $headers['X-Symlink-Target'] = base64_encode($target);
+        } else {
+            $offset = $part['offset'] ?? null;
+            if (!is_int($offset) || $offset < 0) {
+                throw new InvalidArgumentException('Delete-list parts require a non-negative target-confirmed offset.');
+            }
+            $headers['X-Delete-Offset'] = (string) $offset;
+            if (!empty($part['complete'])) {
+                $headers['X-Delete-Complete'] = '1';
+            }
+            $headers['Content-Type'] = 'application/octet-stream';
+        }
+        $headers['Content-Length'] = (string) $payload_bytes;
+        return $headers;
+    }
+
+    /**
+     * Returns one required non-empty string from a part descriptor.
+     *
+     * @param array<string,mixed> $part Part descriptor containing the key named
+     *     by `$field`.
+     * @param string $field Required array key.
+     * @param string $type Part type named in validation errors.
+     * @return string Validated field value.
+     *
+     * @throws InvalidArgumentException If the field is absent or empty.
+     */
+    private function non_empty_string_part_field(array $part, string $field, string $type): string
+    {
+        $value = $part[$field] ?? null;
+        if (!is_string($value) || $value === '') {
+            throw new InvalidArgumentException($type . ' part field ' . $field . ' must be a non-empty string.');
+        }
+        return $value;
+    }
+
+    /**
+     * Builds the exact query URL which is later covered by envelope HMAC.
+     *
+     * @param string $endpoint Protocol endpoint value.
+     * @param array<string,mixed> $parameters Endpoint-specific request-target
+     *     values. Keys are encoded verbatim; this method adds `endpoint`.
+     * @return string RFC 3986-encoded target URL.
+     */
+    private function endpoint_url(string $endpoint, array $parameters): string
+    {
+        $parameters = array_merge(['endpoint' => $endpoint], $parameters);
+        return $this->base_url . (strpos($this->base_url, '?') === false ? '?' : '&') . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * Returns decoded entity-body bytes reserved for the current closing delimiter.
+     *
+     * @return int Boundary token, final `--`, and CRLF byte count.
+     */
+    private function closing_boundary_bytes(): int
+    {
+        return strlen('--' . $this->boundary . "--\r\n");
+    }
+
+    /**
+     * Consumes one pending upload field and advances the stall-progress counter.
+     *
+     * Payload uses an offset to avoid repeatedly copying a shrinking large
+     * string; the prefix and suffix are tiny syntax strings and use this helper.
+     *
+     * @param string $property Pending string property requested by cURL.
+     * @param int $length Maximum bytes requested by the read callback.
+     * @return string Next bytes supplied to cURL.
+     */
+    private function consume_string(string $property, int $length): string
+    {
+        $value = $this->$property;
+        $piece = substr($value, 0, $length);
+        $this->$property = (string) substr($value, strlen($piece));
+        $this->outbound_consumed_bytes += strlen($piece);
+        return $piece;
+    }
+
+    /**
+     * Advances libcurl once and records terminal transfer state.
+     *
+     * curl_multi_select() waits only 50 ms when no completion is available, so
+     * caller loops can enforce their phase-specific progress deadlines without
+     * turning those deadlines into CURLOPT_TIMEOUT total-transfer limits.
+     */
+    private function pump_transfer(): void
+    {
+        do {
+            $status = curl_multi_exec($this->multi_handle, $active);
+        } while ($status === CURLM_CALL_MULTI_PERFORM);
+        while (($message = curl_multi_info_read($this->multi_handle)) !== false) {
+            if ($message['msg'] === CURLMSG_DONE) {
+                $this->transfer_finished = true;
+                if ($message['result'] !== CURLE_OK) {
+                    $this->transfer_error = curl_error($this->curl_handle) ?: curl_strerror((int) $message['result']);
+                }
+            }
+        }
+        if (!$this->transfer_finished) {
+            curl_multi_select($this->multi_handle, 0.05);
+        }
+    }
+
+    /**
+     * Returns a positive integer option, distinguishing absence from invalid input.
+     *
+     * Numeric strings are accepted because CLI arguments and persisted state may
+     * supply them. A present invalid value throws rather than silently choosing
+     * the default.
+     *
+     * @param array<string,mixed> $options Constructor option map documented by
+     *     __construct(). This helper reads `chunk_bytes`, `max_part_bytes`,
+     *     `connect_timeout`, `stall_timeout`, or `response_timeout` as selected
+     *     by `$name`.
+     * @param string $name Option key.
+     * @param int $default Value used only when the key is absent.
+     * @return int Validated positive integer.
+     */
+    private function positive_int_option(array $options, string $name, int $default): int
+    {
+        $value = $options[$name] ?? $default;
+        if (!is_numeric($value) || (int) $value <= 0) {
+            throw new InvalidArgumentException($name . ' must be a positive integer.');
+        }
+        return (int) $value;
+    }
+
+    /**
+     * Classifies every decoded upload and control response by protocol reason.
+     *
+     * `busy` and `offset_gap` are recoverable because a later request can use
+     * the target-confirmed cursor. Every other rejection is terminal; HTTP
+     * status alone never promotes an unknown reason into a retry.
+     *
+     * Classification reads these response keys:
+     *
+     * - `status`: target protocol status compared with `$expected_statuses`.
+     * - `reason`: optional machine-readable rejection reason. Only `busy` and
+     *   `offset_gap` are retryable.
+     * - `detail`: optional human-readable rejection detail.
+     * - `http_code`: observed HTTP status used when no detail was supplied.
+     *
+     * All other endpoint-specific keys are retained unchanged in `response`.
+     *
+     * @param array<string,mixed> $response Decoded target response containing
+     *     the classification keys above.
+     * @param string[] $expected_statuses Successful statuses for this request.
+     * @return array{
+     *     status:string,
+     *     reason:?string,
+     *     detail:?string,
+     *     response:array<string,mixed>,
+     *     parts_sent:int,
+     *     body_bytes_sent:int
+     * } Stable result whose keys are documented by finish_request().
+     */
+    private function classify_response(array $response, array $expected_statuses): array
+    {
+        if (in_array($response['status'] ?? null, $expected_statuses, true)) {
+            return [
+                'status' => 'complete',
+                'reason' => null,
+                'detail' => null,
+                'response' => $response,
+                'parts_sent' => $this->parts_sent,
+                'body_bytes_sent' => $this->body_bytes_sent,
+            ];
+        }
+        $reason = is_string($response['reason'] ?? null) ? $response['reason'] : 'unexpected_response';
+        return [
+            'status' => in_array($reason, ['busy', 'offset_gap'], true) ? 'retry' : 'failed',
+            'reason' => $reason,
+            'detail' => is_string($response['detail'] ?? null)
+                ? $response['detail']
+                : 'HTTP ' . (int) ($response['http_code'] ?? 0),
+            'response' => $response,
+            'parts_sent' => $this->parts_sent,
+            'body_bytes_sent' => $this->body_bytes_sent,
+        ];
+    }
+}

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-feature/multipart-push-sync",
+            "version": "dev-feature/multipart-push-transport",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "193505f22c9b4310695a08e490687d3547adfba3"
+                "reference": "4b864d3ae9fd88c93db4b5012436600779f25204"
             },
             "require": {
                 "php": ">=7.2",
@@ -384,6 +384,7 @@
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
+                    "src/class-multipart-processor.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"
                 ],

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -1,0 +1,481 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Site_Export_HMAC_Client;
+use MultipartPushStreamClient;
+use PushRequestSizer;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php';
+
+final class MultipartPushStreamClientTest extends TestCase {
+
+    private const SECRET = 'multipart-stream-client-test-secret';
+
+    public function testSendPartPutsMultipartBytesOnTheWireBeforeFinishRequest(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 4,
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('a', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $received = $this->read_available($connection);
+        $this->assertStringContainsString('POST /?reprint-api=1&endpoint=staged_session_upload&session_id=', $received);
+        $this->assertStringNotContainsString('Expect: 100-continue', $received);
+
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'streamed.bin',
+            'total_bytes' => 3,
+            'offset' => 0,
+            'payload' => "a\0b",
+        ]));
+        $received .= $this->read_available($connection);
+        $this->assertStringContainsString('Content-Type: multipart/mixed; boundary=reprint-', $received);
+        $this->assertStringContainsString('X-Chunk-Type: file', $received);
+        $this->assertStringContainsString("a\0b", $received, 'The raw part payload is on the network before finish_request().');
+        $this->assertTrue($client->send_part([
+            'type' => 'delete-list',
+            'offset' => 7,
+            'payload' => "gone\0",
+        ]));
+        $received .= $this->read_available($connection);
+        $this->assertStringContainsString('X-Chunk-Type: delete-list', $received);
+        $this->assertStringContainsString('X-Delete-Offset: 7', $received);
+
+        $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+        fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(2, $result['parts_sent']);
+    }
+
+    public function testTargetPartLimitBoundsTheNextSourceRead(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 64,
+            'max_part_bytes' => 7,
+            'connect_timeout' => 2,
+        ]);
+        $this->assertTrue($client->start_upload_request(str_repeat('b', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->read_available($connection);
+        $this->assertSame(7, $client->next_file_body_bytes('bounded.bin', 100, 0));
+
+        fclose($connection);
+        fclose($listener);
+        $client->finish_request();
+    }
+
+    public function testNextSourceReadAndPartOmitModeTransport(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $request_sizer = new PushRequestSizer([
+            'floor_bytes' => 512,
+            'start_bytes' => 512,
+            'max_bytes' => 512,
+        ]);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'request_sizer' => $request_sizer,
+            'chunk_bytes' => 1024,
+            'connect_timeout' => 2,
+        ]);
+        $this->assertTrue($client->start_upload_request(str_repeat('d', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->read_available($connection);
+
+        $maximum = $client->next_file_body_bytes('mode.bin', 1000, 0);
+        $this->assertGreaterThan(0, $maximum);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'mode.bin',
+            'total_bytes' => 1000,
+            'offset' => 0,
+            'payload' => str_repeat('x', $maximum),
+        ]));
+        $received = $this->read_available($connection);
+        $this->assertStringNotContainsString('X-File-Mode', $received);
+
+        $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+        fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+        fclose($connection);
+        fclose($listener);
+        $this->assertSame('complete', $client->finish_request()['status']);
+    }
+
+    public function testPlainHttpRequiresAnExplicitOptIn(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('allow_http is true');
+        new MultipartPushStreamClient([
+            'base_url' => 'http://example.test/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+        ]);
+    }
+
+    public function testRawHttp413LearnsASmallerRequestCeilingWithoutRequiringJson(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('c', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->read_available($connection);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'too-large.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        fwrite($connection, "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('retry', $result['status']);
+        $this->assertSame('request_too_large', $result['reason']);
+        $this->assertSame('HTTP 413 Request Entity Too Large.', $result['detail']);
+        $this->assertLessThan(32 * 1024 * 1024, $client->get_request_sizer_state()['request_body_bytes']);
+    }
+
+    public function testMalformedNonemptyUploadResponseIsTerminal(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('e', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->read_available($connection);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'malformed-response.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $response = '<html>not json</html>';
+        fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('malformed_response', $result['reason']);
+        $this->assertStringContainsString('Invalid JSON response', $result['detail']);
+    }
+
+    public function testZeroProgressUploadStallStopsWithoutATotalTransferTimeout(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 16 * 1024 * 1024,
+            'connect_timeout' => 2,
+            'stall_timeout' => 1,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('f', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $started = microtime(true);
+        $sent = $client->send_part([
+            'type' => 'file',
+            'path' => 'stalled.bin',
+            'total_bytes' => 16 * 1024 * 1024,
+            'offset' => 0,
+            'payload' => str_repeat('x', 16 * 1024 * 1024),
+        ]);
+        $elapsed = microtime(true) - $started;
+        $result = $client->finish_request();
+        fclose($connection);
+        fclose($listener);
+
+        $this->assertFalse($sent);
+        $this->assertGreaterThanOrEqual(0.9, $elapsed);
+        $this->assertLessThan(3.0, $elapsed);
+        $this->assertSame('retry', $result['status']);
+        $this->assertSame('request_failed', $result['reason']);
+        $this->assertStringContainsString('no bytes moved for 1s', $result['detail']);
+    }
+
+    public function testResponseWaitTimeoutStartsAfterTheClosingBoundary(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 1,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('1', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'waiting.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $started = microtime(true);
+        $result = $client->finish_request();
+        $elapsed = microtime(true) - $started;
+        fclose($connection);
+        fclose($listener);
+
+        $this->assertGreaterThanOrEqual(0.9, $elapsed);
+        $this->assertLessThan(3.0, $elapsed);
+        $this->assertSame('retry', $result['status']);
+        $this->assertSame('request_failed', $result['reason']);
+        $this->assertStringContainsString('no upload or response bytes moved for 1s', $result['detail']);
+    }
+
+    public function testSlowContinuousResponseProgressMayExceedTheResponseTimeout(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Slow wire coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_blocking($connection, false);
+            $deadline = microtime(true) + 10;
+            $received = '';
+            $closing = null;
+            while (!feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (is_string($piece) && $piece !== '') {
+                    $received .= $piece;
+                    if ($closing === null && preg_match('/boundary=(reprint-[a-f0-9]+)/', $received, $matches) === 1) {
+                        $closing = '--' . $matches[1] . "--\r\n";
+                    }
+                    if ($closing !== null && strpos($received, $closing) !== false) {
+                        break;
+                    }
+                } elseif (microtime(true) > $deadline) {
+                    exit(3);
+                } else {
+                    usleep(1000);
+                }
+            }
+            $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+            fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n");
+            foreach (str_split($response, 8) as $piece) {
+                if (@fwrite($connection, $piece) === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(4);
+                }
+                usleep(350000);
+            }
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 1,
+        ]);
+        $this->assertTrue($client->start_upload_request(str_repeat('3', 32)));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'slow-response.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $started = microtime(true);
+        $result = $client->finish_request();
+        $elapsed = microtime(true) - $started;
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertGreaterThan(1.0, $elapsed);
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+    }
+
+    public function testSlowContinuousUploadProgressMayExceedTheStallTimeout(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Slow wire coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_blocking($connection, false);
+            $deadline = microtime(true) + 15;
+            $received = '';
+            $closing = null;
+            $tail = '';
+            while (!feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    if (microtime(true) > $deadline) {
+                        exit(3);
+                    }
+                    usleep(1000);
+                    continue;
+                }
+                if ($closing === null) {
+                    $received .= $piece;
+                    if (preg_match('/boundary=(reprint-[a-f0-9]+)/', $received, $matches) === 1) {
+                        $closing = '--' . $matches[1] . "--\r\n";
+                        $tail = substr($received, -strlen($closing));
+                        $received = '';
+                    }
+                } else {
+                    $tail .= $piece;
+                }
+                usleep(2000);
+                if ($closing !== null) {
+                    if (strpos($tail, $closing) !== false) {
+                        break;
+                    }
+                    $tail = substr($tail, -strlen($closing));
+                }
+            }
+            $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+            fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 8 * 1024 * 1024,
+            'connect_timeout' => 2,
+            'stall_timeout' => 1,
+            'response_timeout' => 5,
+        ]);
+        $started = microtime(true);
+        $this->assertTrue($client->start_upload_request(str_repeat('2', 32)));
+        $sent = $client->send_part([
+            'type' => 'file',
+            'path' => 'slow-progress.bin',
+            'total_bytes' => 8 * 1024 * 1024,
+            'offset' => 0,
+            'payload' => str_repeat('x', 8 * 1024 * 1024),
+        ]);
+        $result = $client->finish_request();
+        $elapsed = microtime(true) - $started;
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertGreaterThan(1.0, $elapsed);
+        $this->assertTrue($sent, (string) json_encode($result));
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+    }
+
+    private function read_available($connection): string {
+        stream_set_blocking($connection, false);
+        $received = '';
+        $deadline = microtime(true) + 2;
+        do {
+            $piece = fread($connection, 65536);
+            if (is_string($piece) && $piece !== '') {
+                $received .= $piece;
+                $deadline = microtime(true) + 0.1;
+            } elseif (microtime(true) < $deadline) {
+                usleep(1000);
+            }
+        } while (microtime(true) < $deadline);
+        return $received;
+    }
+}

--- a/tests/MultipartProcessorTest.php
+++ b/tests/MultipartProcessorTest.php
@@ -1,0 +1,401 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MultipartProcessorTest extends TestCase {
+
+    public function testProcessesBinaryPartsAtEveryPossibleSingleSplit(): void {
+        $boundary = 'split-boundary';
+        $binary = implode('', array_map('chr', range(0, 255)))
+            . "\r\n--{$boundary}\r\ninside\r\n";
+        $message = $this->multipart($boundary, [
+            [
+                'headers' => ['X-Chunk-Type' => 'file'],
+                'body' => $binary,
+            ],
+            [
+                'headers' => ['X-Chunk-Type' => 'directory'],
+                'body' => '',
+            ],
+        ]);
+
+        $message_bytes = strlen($message);
+        for ($split = 1; $split < $message_bytes; ++$split) {
+            $parts = $this->collect_parts($boundary, [
+                substr($message, 0, $split),
+                substr($message, $split),
+            ]);
+            $this->assertSame($binary, $parts[0]['body'], 'Failed at byte split ' . $split . '.');
+            $this->assertSame('file', $parts[0]['headers']['x-chunk-type']);
+            $this->assertSame('', $parts[1]['body']);
+            $this->assertSame('directory', $parts[1]['headers']['x-chunk-type']);
+        }
+    }
+
+    public function testEmitsLargeBodiesInBoundedPiecesWithoutWaitingForPartEnd(): void {
+        $boundary = 'large';
+        $body = str_repeat('0123456789abcdef', 65536);
+        $message = $this->multipart($boundary, [[
+            'headers' => ['X-Chunk-Type' => 'file'],
+            'body' => $body,
+        ]]);
+        $processor = new Site_Export_Multipart_Processor($boundary);
+        $body_bytes = 0;
+        $body_tokens = 0;
+        $largest_token = 0;
+        $message_bytes = strlen($message);
+        for ($offset = 0; $offset < $message_bytes; $offset += 8192) {
+            $processor->append_bytes(substr($message, $offset, 8192));
+            while ($processor->next_token()) {
+                if ($processor->get_token_type() !== Site_Export_Multipart_Processor::TOKEN_BODY) {
+                    continue;
+                }
+                $piece = $processor->get_current_body_piece();
+                $body_bytes += strlen($piece);
+                ++$body_tokens;
+                $largest_token = max($largest_token, strlen($piece));
+            }
+        }
+        $processor->finish_input();
+
+        $this->assertSame(strlen($body), $body_bytes);
+        $this->assertGreaterThan(1, $body_tokens);
+        $this->assertLessThanOrEqual(
+            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES,
+            $largest_token
+        );
+    }
+
+    public function testUnfoldsHeadersSplitOneByteAtATime(): void {
+        $message = "--x\r\n"
+            . "X-Description: first\r\n"
+            . " second\r\n"
+            . "\tthird\r\n"
+            . "Content-Length:\r\n"
+            . " 3\r\n\r\n"
+            . "abc\r\n--x--\r\n";
+        $fragments = str_split($message, 1);
+        $parts = $this->collect_parts('x', $fragments);
+
+        $this->assertSame("first second\tthird", $parts[0]['headers']['x-description']);
+        $this->assertSame('3', $parts[0]['headers']['content-length']);
+        $this->assertSame('abc', $parts[0]['body']);
+    }
+
+    public function testClosingBoundaryWithoutPartsIsComplete(): void {
+        $processor = new Site_Export_Multipart_Processor('empty');
+        $processor->append_bytes("--empty--\r\n");
+
+        $this->assertFalse($processor->next_token());
+        $this->assertTrue($processor->is_complete());
+        $this->assertFalse($processor->paused_at_incomplete_input());
+        $processor->finish_input();
+    }
+
+    public function testPauseAndResumeStatesDistinguishIncompleteInputFromCompletion(): void {
+        $processor = new Site_Export_Multipart_Processor('pause');
+        $processor->append_bytes('--pau');
+
+        $this->assertFalse($processor->next_token());
+        $this->assertTrue($processor->paused_at_incomplete_input());
+        $this->assertFalse($processor->is_complete());
+
+        $processor->append_bytes("se--\r\n");
+        $this->assertFalse($processor->next_token());
+        $this->assertFalse($processor->paused_at_incomplete_input());
+        $this->assertTrue($processor->is_complete());
+    }
+
+    public function testParsesOnlyValidatedMultipartMixedContentTypes(): void {
+        $this->assertSame(
+            'plain-boundary',
+            Site_Export_Multipart_Processor::boundary_from_content_type(
+                'multipart/mixed; boundary=plain-boundary'
+            )
+        );
+        $this->assertSame(
+            'quoted-boundary',
+            Site_Export_Multipart_Processor::boundary_from_content_type(
+                'Multipart/Mixed; charset=binary; boundary="quoted-boundary"'
+            )
+        );
+
+        try {
+            Site_Export_Multipart_Processor::boundary_from_content_type('multipart/form-data; boundary=x');
+            $this->fail('A non-multipart/mixed media type was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('Expected Content-Type multipart/mixed', $exception->getMessage());
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('more than one boundary');
+        Site_Export_Multipart_Processor::boundary_from_content_type(
+            'multipart/mixed; boundary=one; boundary=two'
+        );
+    }
+
+    /** @return array<string,array{0:string,1:string}> */
+    public static function invalid_content_types(): array {
+        return [
+            'missing boundary' => ['multipart/mixed; charset=binary', 'requires a non-empty boundary'],
+            'empty boundary' => ['multipart/mixed; boundary=""', 'requires a non-empty boundary'],
+            'unsafe boundary' => ['multipart/mixed; boundary="line break"', 'unsupported characters'],
+            'oversized boundary' => ['multipart/mixed; boundary=' . str_repeat('x', 71), 'between 1 and 70 bytes'],
+        ];
+    }
+
+    #[DataProvider('invalid_content_types')]
+    public function testRejectsInvalidMultipartMixedBoundaries(string $content_type, string $expected_message): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expected_message);
+        Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
+    }
+
+    /** @return array<string,array{0:string,1:string}> */
+    public static function invalid_grammar(): array {
+        return [
+            'bare LF' => ["--x\nContent-Length: 0\n\n--x--\n", 'CRLF'],
+            'missing content length' => ["--x\r\nX-Test: value\r\n\r\nbody\r\n--x--\r\n", 'Content-Length'],
+            'non-numeric content length' => ["--x\r\nContent-Length: unknown\r\n\r\n", 'Content-Length'],
+            'negative content length' => ["--x\r\nContent-Length: -1\r\n\r\n", 'Content-Length'],
+            'duplicate content length' => ["--x\r\nContent-Length: 0\r\nContent-Length: 1\r\n\r\n", 'repeats header'],
+            'malformed header' => ["--x\r\nNot-A-Header\r\nContent-Length: 0\r\n\r\n\r\n--x--\r\n", 'Malformed'],
+            'invalid header name' => ["--x\r\nBad Name: value\r\nContent-Length: 0\r\n\r\n\r\n--x--\r\n", 'invalid header name'],
+            'whitespace before colon' => ["--x\r\nX-Test : value\r\nContent-Length: 0\r\n\r\n\r\n--x--\r\n", 'invalid header name'],
+            'control byte before length' => ["--x\r\nContent-Length:\0 0\r\n\r\n\r\n--x--\r\n", 'Content-Length'],
+            'extra body byte before boundary' => ["--x\r\nContent-Length: 2\r\n\r\nabc\r\n--x--\r\n", 'followed by CRLF'],
+            'preamble' => ["not multipart\r\n--x--\r\n", 'Expected multipart boundary'],
+            'trailing data' => ["--x--\r\nnot an epilogue", 'after the closing boundary'],
+        ];
+    }
+
+    #[DataProvider('invalid_grammar')]
+    public function testRejectsFormsOutsideTheReprintGrammar(string $message, string $expected_message): void {
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes($message);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expected_message);
+        while ($processor->next_token()) {
+            $processor->get_token_type();
+        }
+    }
+
+    /** @return array<string,array{0:string,1:string}> */
+    public static function truncated_messages(): array {
+        return [
+            'opening boundary' => ['--x', 'closing boundary'],
+            'header block' => ["--x\r\nContent-Len", 'header block'],
+            'part body' => ["--x\r\nContent-Length: 4\r\n\r\nab", '2 bytes remain'],
+            'separator after body' => ["--x\r\nContent-Length: 2\r\n\r\nab", 'CRLF and boundary'],
+            'closing boundary' => ["--x\r\nContent-Length: 0\r\n\r\n\r\n--x", 'closing boundary'],
+        ];
+    }
+
+    #[DataProvider('truncated_messages')]
+    public function testFinishInputRejectsEveryIncompleteState(string $message, string $expected_message): void {
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes($message);
+        while ($processor->next_token()) {
+            $processor->get_token_type();
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expected_message);
+        $processor->finish_input();
+    }
+
+    public function testRejectsAContinuationBeforeAHeaderAndBoundsTheAggregate(): void {
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes("--x\r\n orphan\r\nContent-Length: 0\r\n\r\n");
+        try {
+            while ($processor->next_token()) {
+                $processor->get_token_type();
+            }
+            $this->fail('An orphan header continuation was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('continuation', $exception->getMessage());
+        }
+
+        $processor = new Site_Export_Multipart_Processor('x');
+        $message = "--x\r\nX-Large: " . str_repeat('a', 8100) . "\r\n"
+            . str_repeat(' ' . str_repeat('b', 8100) . "\r\n", 4)
+            . "Content-Length: 0\r\n\r\n";
+        $message_bytes = strlen($message);
+        for ($offset = 0; $offset < $message_bytes; $offset += 8192) {
+            $processor->append_bytes(substr($message, $offset, 8192));
+            try {
+                while ($processor->next_token()) {
+                    $processor->get_token_type();
+                }
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('headers exceed 32768 bytes', $exception->getMessage());
+                return;
+            }
+        }
+        $this->fail('An aggregate header block beyond 32768 bytes was accepted.');
+    }
+
+    public function testAcceptsHeaderBoundsExactlyAndRejectsOneByteOrOneHeaderMore(): void {
+        $header_prefix = 'X-Large: ';
+        $maximum_line = $header_prefix . str_repeat('a', 8192 - strlen($header_prefix));
+        $parts = $this->collect_parts('x', [
+            "--x\r\n{$maximum_line}\r\nContent-Length: 0\r\n\r\n\r\n--x--\r\n",
+        ]);
+        $this->assertSame(8192 - strlen($header_prefix), strlen($parts[0]['headers']['x-large']));
+
+        $maximum_aggregate_headers = 'X-A: ' . str_repeat('a', 8187) . "\r\n"
+            . ' ' . str_repeat('b', 8191) . "\r\n"
+            . ' ' . str_repeat('c', 8191) . "\r\n"
+            . ' ' . str_repeat('d', 8162) . "\r\n"
+            . "Content-Length: 0\r\n\r\n";
+        $parts = $this->collect_parts('x', [
+            "--x\r\n" . $maximum_aggregate_headers . "\r\n--x--\r\n",
+        ]);
+        $this->assertArrayHasKey('x-a', $parts[0]['headers']);
+
+        $headers = [];
+        for ($header = 0; $header < 31; ++$header) {
+            $headers['X-Header-' . $header] = 'value';
+        }
+        $parts = $this->collect_parts('x', [$this->multipart('x', [[
+            'headers' => $headers,
+            'body' => '',
+        ]])]);
+        $this->assertCount(32, $parts[0]['headers']);
+
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes(
+            "--x\r\n" . $maximum_line . "a\r\nContent-Length: 0\r\n\r\n"
+        );
+        try {
+            while ($processor->next_token()) {
+                $processor->get_token_type();
+            }
+            $this->fail('A physical header line one byte above the limit was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('exceeds 8192 bytes', $exception->getMessage());
+        }
+
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes(
+            "--x\r\n" . str_replace(str_repeat('d', 8162), str_repeat('d', 8163), $maximum_aggregate_headers)
+        );
+        try {
+            while ($processor->next_token()) {
+                $processor->get_token_type();
+            }
+            $this->fail('A header block one byte above the aggregate limit was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('headers exceed 32768 bytes', $exception->getMessage());
+        }
+
+        $headers['X-Header-31'] = 'value';
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('more than 32 headers');
+        $this->collect_parts('x', [$this->multipart('x', [[
+            'headers' => $headers,
+            'body' => '',
+        ]])]);
+    }
+
+    public function testRequiresEachAppendedFragmentToBeDrainedAndBounded(): void {
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes('--x');
+        try {
+            $processor->append_bytes("--\r\n");
+            $this->fail('A second fragment was accepted before the first was drained.');
+        } catch (LogicException $exception) {
+            $this->assertStringContainsString('next_token', $exception->getMessage());
+        }
+
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes(
+            "--x\r\nContent-Length: "
+            . Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+            . "\r\n\r\n"
+        );
+        $this->assertTrue($processor->next_token());
+        $this->assertSame(Site_Export_Multipart_Processor::TOKEN_PART_START, $processor->get_token_type());
+        $this->assertFalse($processor->next_token());
+        $processor->append_bytes(str_repeat('a', Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES));
+        $this->assertTrue($processor->next_token());
+        $this->assertSame(
+            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES,
+            strlen($processor->get_current_body_piece())
+        );
+        $this->assertTrue($processor->next_token());
+        $this->assertSame(Site_Export_Multipart_Processor::TOKEN_PART_END, $processor->get_token_type());
+        $this->assertFalse($processor->next_token());
+        $processor->append_bytes("\r\n--x--\r\n");
+        $this->assertFalse($processor->next_token());
+        $processor->finish_input();
+
+        $processor = new Site_Export_Multipart_Processor('x');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage( (string) Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES);
+        $processor->append_bytes(str_repeat('a', Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1));
+    }
+
+    public function testRejectsContentLengthOutsideTheRuntimeIntegerRange(): void {
+        $too_large = (string) PHP_INT_MAX . '0';
+        $processor = new Site_Export_Multipart_Processor('x');
+        $processor->append_bytes("--x\r\nContent-Length: {$too_large}\r\n\r\n");
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('integer range');
+        while ($processor->next_token()) {
+            $processor->get_token_type();
+        }
+    }
+
+    /**
+     * Collects complete parts while feeding caller-selected transport fragments.
+     *
+     * @param string[] $fragments Raw input fragments in wire order.
+     * @return array<int,array{headers:array<string,string>,body:string}>
+     */
+    private function collect_parts(string $boundary, array $fragments): array {
+        $processor = new Site_Export_Multipart_Processor($boundary);
+        $parts = [];
+        $current = null;
+        foreach ($fragments as $fragment) {
+            $processor->append_bytes($fragment);
+            while ($processor->next_token()) {
+                $token_type = $processor->get_token_type();
+                if ($token_type === Site_Export_Multipart_Processor::TOKEN_PART_START) {
+                    $current = [
+                        'headers' => $processor->get_current_headers(),
+                        'body' => '',
+                    ];
+                } elseif ($token_type === Site_Export_Multipart_Processor::TOKEN_BODY) {
+                    $current['body'] .= $processor->get_current_body_piece();
+                } elseif ($token_type === Site_Export_Multipart_Processor::TOKEN_PART_END) {
+                    $parts[] = $current;
+                    $current = null;
+                }
+            }
+        }
+        $processor->finish_input();
+        return $parts;
+    }
+
+    /**
+     * Builds the canonical Reprint multipart form with a length on every part.
+     *
+     * @param array<int,array{headers:array<string,string>,body:string}> $parts
+     */
+    private function multipart(string $boundary, array $parts): string {
+        $message = '';
+        foreach ($parts as $part) {
+            $message .= '--' . $boundary . "\r\n";
+            foreach ($part['headers'] as $name => $value) {
+                $message .= $name . ': ' . $value . "\r\n";
+            }
+            $message .= 'Content-Length: ' . strlen($part['body']) . "\r\n\r\n";
+            $message .= $part['body'] . "\r\n";
+        }
+        return $message . '--' . $boundary . "--\r\n";
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,5 +26,9 @@ if (!class_exists('Site_Export_HTTP_Server', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-http-server.php';
 }
 
+if (!class_exists('Site_Export_Multipart_Processor', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-multipart-processor.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -29,6 +29,7 @@
             <file>FileIndexDedupTest.php</file>
             <file>FileIndexSkipDefaultsTest.php</file>
             <file>HmacServerTest.php</file>
+            <file>MultipartProcessorTest.php</file>
             <file>SiteExportSecretTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">


### PR DESCRIPTION
The stack now has one strict multipart grammar and one caller-driven streaming upload client without coupling either implementation to the pull pipeline.

`Site_Export_Multipart_Processor` validates boundaries and headers, enforces declared body lengths and parser limits, and exposes bodies in bounded fragments. `MultipartPushStreamClient` writes each completed part to the live request before returning and classifies target responses without buffering a request body. The pull-side `import.php` integration follows in #349.

Stack: **#347** → #348 → #349

## Testing

- Multipart processor, upload client, and PHP 7.4 parseability: 42 tests, 1,895 assertions
- Existing pull parser and file streaming coverage: 42 tests, 98 assertions
- PHPCompatibility: exporter on PHP 7.2+, importer on PHP 7.4+
- PHPStan
