### PR TITLE
[Push] Commit filesystem deltas from durable staged sessions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-feature/multipart-push-transport",
+            "version": "dev-feature/staged-apply-session",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "4b864d3ae9fd88c93db4b5012436600779f25204"
+                "reference": "9842c5d9852a9c3ecd768de88b9652181ef2d1ee"
             },
             "require": {
                 "php": ">=7.2",
@@ -385,6 +385,8 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-multipart-processor.php",
+                    "src/class-staged-apply-exception.php",
+                    "src/class-staged-apply-session.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"
                 ],

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -23,6 +23,8 @@
             "src/class-hmac-server.php",
             "src/class-http-server.php",
             "src/class-multipart-processor.php",
+            "src/class-staged-apply-exception.php",
+            "src/class-staged-apply-session.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"
         ],

--- a/packages/reprint-exporter/src/class-staged-apply-exception.php
+++ b/packages/reprint-exporter/src/class-staged-apply-exception.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Reports a classified failure in the staged-apply lifecycle.
+ *
+ * PHP reserves Throwable::getCode() for an integer. Staged apply failures use
+ * stable, descriptive strings because the endpoint returns the same value in
+ * its JSON `reason` field. Keeping that classification in a separate property
+ * also prevents an unrelated RuntimeException with a coincidentally equal
+ * native code from being presented as a recoverable protocol condition.
+ *
+ * Only failures which have a deliberate staged-apply classification use this
+ * exception. An ordinary RuntimeException remains unclassified and is exposed
+ * by the endpoint as `session_rejected` rather than leaking an accidental code.
+ */
+final class Site_Export_Staged_Apply_Exception extends RuntimeException {
+
+    /**
+     * Stable machine-readable classification selected by the throwing class.
+     *
+     * This is distinct from the human-readable exception message. Endpoint
+     * code uses it to select an HTTP status and copies it unchanged into the
+     * authenticated response's `reason` field.
+     *
+     * @var string
+     */
+    private $error_code;
+
+    /** @var array<string,mixed> Protocol fields which describe the observed failure. */
+    private $context;
+
+    /**
+     * Creates a staged-apply failure with separate machine and human context.
+     *
+     * The machine-readable value comes first so a throw site names its recovery
+     * class before giving instance-specific detail. It is retrieved with
+     * get_error_code(), never Throwable::getCode().
+     *
+     * @param string $error_code Stable machine-readable staged-apply reason.
+     * @param string $message Human-readable statement of the violated condition.
+     * @param array<string,mixed> $context Additional authenticated response fields.
+     */
+    public function __construct(string $error_code, string $message, array $context = []) {
+        parent::__construct($message);
+        $this->error_code = $error_code;
+        $this->context = $context;
+    }
+
+    /**
+     * Returns the stable reason used to classify this staged-apply failure.
+     *
+     * @return string Machine-readable error code suitable for a JSON `reason`.
+     */
+    public function get_error_code(): string {
+        return $this->error_code;
+    }
+
+    /** @return array<string,mixed> Structured fields safe to copy into the JSON response. */
+    public function get_context(): array {
+        return $this->context;
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-apply-exception.php
+++ b/packages/reprint-exporter/src/class-staged-apply-exception.php
@@ -47,7 +47,10 @@ final class Site_Export_Staged_Apply_Exception extends RuntimeException {
      *
      * @param string $error_code Stable machine-readable staged-apply reason.
      * @param string $message Human-readable statement of the violated condition.
-     * @param array<string,mixed> $context Additional authenticated response fields.
+     * @param array<string,mixed> $context Additional authenticated response
+     *     fields. Common keys are operation, path_b64, conflict_path_b64,
+     *     expected_live_types, observed_live_identity, staging_device,
+     *     live_device, staged_type, and detail.
      */
     public function __construct(string $error_code, string $message, array $context = []) {
         parent::__construct($message);
@@ -73,6 +76,9 @@ final class Site_Export_Staged_Apply_Exception extends RuntimeException {
      * retryable.
      *
      * @return array<string,mixed> Structured fields safe to copy into JSON.
+     *     Common keys are operation, path_b64, conflict_path_b64,
+     *     expected_live_types, observed_live_identity, staging_device,
+     *     live_device, staged_type, and detail.
      */
     public function get_context(): array {
         return $this->context;

--- a/packages/reprint-exporter/src/class-staged-apply-exception.php
+++ b/packages/reprint-exporter/src/class-staged-apply-exception.php
@@ -26,7 +26,16 @@ final class Site_Export_Staged_Apply_Exception extends RuntimeException {
      */
     private $error_code;
 
-    /** @var array<string,mixed> Protocol fields which describe the observed failure. */
+    /**
+     * Protocol fields which describe the observed failure.
+     *
+     * These values are copied into the authenticated JSON response alongside
+     * the stable reason. They are deliberately separate from the message so
+     * callers can inspect structured details such as conflicting paths or
+     * observed filesystem identities without parsing prose.
+     *
+     * @var array<string,mixed>
+     */
     private $context;
 
     /**
@@ -55,7 +64,16 @@ final class Site_Export_Staged_Apply_Exception extends RuntimeException {
         return $this->error_code;
     }
 
-    /** @return array<string,mixed> Structured fields safe to copy into the JSON response. */
+    /**
+     * Returns structured details for the authenticated failure response.
+     *
+     * The array contains only values supplied by staged-apply throw sites. It
+     * may be empty for simple classified failures, but when present it names
+     * the exact observed condition that made the request unrecoverable or
+     * retryable.
+     *
+     * @return array<string,mixed> Structured fields safe to copy into JSON.
+     */
     public function get_context(): array {
         return $this->context;
     }

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -754,7 +754,6 @@ final class Site_Export_Staged_Apply_Session {
         if ($offset > $total_bytes || $part_bytes > $total_bytes - $offset) {
             throw new InvalidArgumentException('File part for ' . base64_encode($path) . ' exceeds its declared total of ' . $total_bytes . ' bytes.');
         }
-        $this->assert_target_parent_same_filesystem($path);
         $partial_path = $this->private_path($this->partial_dir, $path);
         $complete_path = $this->private_path($this->files_dir, $path);
         $this->ensure_private_parent($partial_path);
@@ -807,13 +806,7 @@ final class Site_Export_Staged_Apply_Session {
                     break;
                 }
                 $received += strlen($piece);
-                if ($received > $part_bytes) {
-                    throw new LogicException('Multipart processor exposed more file bytes than Content-Length.');
-                }
                 $this->write_all($handle, $piece, 'partial file ' . base64_encode($path));
-            }
-            if ($received !== $part_bytes) {
-                throw new LogicException('Multipart processor exposed ' . $received . ' file bytes for Content-Length ' . $part_bytes . '.');
             }
             if (!fflush($handle)) {
                 throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not flush partial file ' . base64_encode($path) . '.');
@@ -850,7 +843,6 @@ final class Site_Export_Staged_Apply_Session {
             throw new InvalidArgumentException('Multipart directory part must have Content-Length 0.');
         }
         $path = $this->decode_path_header($headers, 'x-directory-path');
-        $this->assert_target_parent_same_filesystem($path);
         $target = $this->private_path($this->files_dir, $path);
         $this->ensure_private_parent($target);
         $identity = $this->path_identity($target);
@@ -886,7 +878,6 @@ final class Site_Export_Staged_Apply_Session {
         if ($target_value === '' || strlen($target_value) > self::MAX_PATH_BYTES || strpos($target_value, "\0") !== false) {
             throw new InvalidArgumentException('Symlink target must contain between 1 and ' . self::MAX_PATH_BYTES . ' bytes without NUL.');
         }
-        $this->assert_target_parent_same_filesystem($path);
         $target = $this->private_path($this->files_dir, $path);
         $this->ensure_private_parent($target);
         $identity = $this->path_identity($target);
@@ -973,9 +964,6 @@ final class Site_Export_Staged_Apply_Session {
                     $piece_offset = $overlap;
                 }
                 if ($piece_offset < strlen($piece)) {
-                    if ($position !== $stored_bytes) {
-                        throw new LogicException('Delete-list append did not begin at the actual stored size.');
-                    }
                     $append = substr($piece, $piece_offset);
                     $append_length = strlen($append);
                     for ($index = 0; $index < $append_length; ++$index) {
@@ -984,7 +972,6 @@ final class Site_Export_Staged_Apply_Session {
                                 throw new InvalidArgumentException('Delete-list parts may not contain an empty deletion record.');
                             }
                             $this->validate_path($trailing_path);
-                            $this->assert_target_parent_same_filesystem($trailing_path);
                             $trailing_path = '';
                             continue;
                         }
@@ -1172,10 +1159,47 @@ final class Site_Export_Staged_Apply_Session {
         $entry = $this->first_directory_entry($staged_directory);
         if ($entry === null) {
             if ($stack_size === 0) {
-                $this->finish_commit($state);
+                if ($state['current_deletion_b64'] !== null || $state['traversal_stack'] !== []) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion with active bounded work state.');
+                }
+                if ( (int) $state['delete_offset'] !== $this->file_size($this->deletes_path)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion before consuming the complete delete stream.');
+                }
+                if ($this->first_directory_entry($this->files_dir) !== null) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion while work/files still contains pending values.');
+                }
+                $maintenance_live_path = $this->target_path('.maintenance');
+                $maintenance_identity = $this->path_identity($maintenance_live_path);
+                if ($maintenance_identity !== null) {
+                    if (!$this->maintenance_marker_is_owned($maintenance_live_path, $state['maintenance_token'])) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'The session-owned maintenance marker was replaced by another owner.');
+                    }
+                    if (!@unlink($maintenance_live_path)) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the session-owned WordPress maintenance marker.');
+                    }
+                }
+                if ($this->path_identity($this->maintenance_identity_path) !== null && !@unlink($this->maintenance_identity_path)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the private maintenance ownership marker.');
+                }
+                $state['phase'] = 'complete';
+                $this->write_json($this->commit_path, $state);
+                $this->release_target();
                 return;
             }
-            $this->cleanup_structural_directory($state, $parent_path, $staged_directory);
+            $this->assert_live_ancestors($parent_path, 'install', 'directory');
+            $live = $this->path_identity($this->target_path($parent_path));
+            if ($live === null || $live['type'] !== 'directory') {
+                $this->throw_live_tree_changed('install', $parent_path, $parent_path, 'directory', ['directory'], $live);
+            }
+            $state['current_installation'] = ['path_b64' => base64_encode($parent_path), 'expected_type' => 'directory'];
+            $this->write_json($this->commit_path, $state);
+            if (!@rmdir($staged_directory)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not consume empty structural staging directory ' . base64_encode($parent_path) . '.');
+            }
+            $state['current_installation'] = null;
+            array_pop($state['traversal_stack']);
+            ++$state['values_applied'];
+            $this->write_json($this->commit_path, $state);
             return;
         }
 
@@ -1189,71 +1213,28 @@ final class Site_Export_Staged_Apply_Session {
         if ($identity['type'] === 'directory' && $this->first_directory_entry($staged_path) !== null) {
             $state['traversal_stack'][] = ['component_b64' => base64_encode($entry)];
             $this->write_json($this->commit_path, $state);
-            $this->prepare_structural_directory($path, $this->first_staged_leaf_path($staged_path, $path));
+            $requested_path = $this->first_staged_leaf_path($staged_path, $path);
+            $parent_device = $this->assert_live_ancestors($path, 'install', 'directory');
+            $live_path = $this->target_path($path);
+            $live = $this->path_identity($live_path);
+            if ($live === null) {
+                if (!@mkdir($live_path, 0777) && !is_dir($live_path)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create structural live directory ' . base64_encode($path) . '.');
+                }
+                $live = $this->path_identity($live_path);
+            }
+            if ($live === null || $live['type'] !== 'directory') {
+                $this->throw_live_tree_changed('install', $requested_path, $path, 'directory', ['absent', 'directory'], $live);
+            }
+            if ($live['dev'] !== $parent_device || $live['dev'] !== $this->staging_device()) {
+                $this->throw_cross_device('install', $path, $this->staging_device(), $live['dev']);
+            }
             return;
         }
         if (!in_array($identity['type'], ['file', 'directory', 'symlink'], true)) {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Staged path ' . base64_encode($path) . ' has unsupported type ' . $identity['type'] . '.');
         }
         $this->install_staged_value($state, $path, $identity['type'], false);
-    }
-
-    /**
-     * Consumes one empty structural directory after its children were applied.
-     *
-     * Structural directories are not logical staged values by themselves; they
-     * exist so descendants can be reached in a depth-first traversal. Removing
-     * one is still checkpointed as current installation state so recovery can
-     * distinguish it from a leaf rename.
-     *
-     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
-     * @param string $path Target-relative structural directory path.
-     * @param string $staged_path Absolute path to the empty private directory.
-     */
-    private function cleanup_structural_directory(array &$state, string $path, string $staged_path): void {
-        $this->assert_live_ancestors($path, 'install', 'directory');
-        $live = $this->path_identity($this->target_path($path));
-        if ($live === null || $live['type'] !== 'directory') {
-            $this->throw_live_tree_changed('install', $path, $path, 'directory', ['directory'], $live);
-        }
-        $state['current_installation'] = ['path_b64' => base64_encode($path), 'expected_type' => 'directory'];
-        $this->write_json($this->commit_path, $state);
-        if (!@rmdir($staged_path)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not consume empty structural staging directory ' . base64_encode($path) . '.');
-        }
-        $state['current_installation'] = null;
-        array_pop($state['traversal_stack']);
-        ++$state['values_applied'];
-        $this->write_json($this->commit_path, $state);
-    }
-
-    /**
-     * Ensures a live structural directory exists before descending into it.
-     *
-     * A directory with staged descendants may already exist, may need to be
-     * created, or may have drifted into an incompatible value. The requested
-     * leaf path is used in drift reports so users see which staged value forced
-     * the structural ancestor check.
-     *
-     * @param string $path Target-relative structural directory path.
-     * @param string $requested_path Staged descendant that required this parent.
-     */
-    private function prepare_structural_directory(string $path, string $requested_path): void {
-        $parent_device = $this->assert_live_ancestors($path, 'install', 'directory');
-        $live_path = $this->target_path($path);
-        $live = $this->path_identity($live_path);
-        if ($live === null) {
-            if (!@mkdir($live_path, 0777) && !is_dir($live_path)) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create structural live directory ' . base64_encode($path) . '.');
-            }
-            $live = $this->path_identity($live_path);
-        }
-        if ($live === null || $live['type'] !== 'directory') {
-            $this->throw_live_tree_changed('install', $requested_path, $path, 'directory', ['absent', 'directory'], $live);
-        }
-        if ($live['dev'] !== $parent_device || $live['dev'] !== $this->staging_device()) {
-            $this->throw_cross_device('install', $path, $this->staging_device(), $live['dev']);
-        }
     }
 
     /**
@@ -1375,44 +1356,6 @@ final class Site_Export_Staged_Apply_Session {
     }
 
     /**
-     * Marks commit complete after all delete and install queues are empty.
-     *
-     * Completion is written only after the delete cursor reaches the actual
-     * stream size, work/files has no remaining staged values, and the
-     * session-owned maintenance marker has been removed. Releasing the target
-     * after the complete checkpoint lets later sessions start.
-     *
-     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
-     */
-    private function finish_commit(array &$state): void {
-        if ($state['current_deletion_b64'] !== null || $state['current_installation'] !== null || $state['traversal_stack'] !== []) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion with active bounded work state.');
-        }
-        if ( (int) $state['delete_offset'] !== $this->file_size($this->deletes_path)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion before consuming the complete delete stream.');
-        }
-        if ($this->first_directory_entry($this->files_dir) !== null) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion while work/files still contains pending values.');
-        }
-        $maintenance_live_path = $this->target_path('.maintenance');
-        $maintenance_identity = $this->path_identity($maintenance_live_path);
-        if ($maintenance_identity !== null) {
-            if (!$this->maintenance_marker_is_owned($maintenance_live_path, $state['maintenance_token'])) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'The session-owned maintenance marker was replaced by another owner.');
-            }
-            if (!@unlink($maintenance_live_path)) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the session-owned WordPress maintenance marker.');
-            }
-        }
-        if ($this->path_identity($this->maintenance_identity_path) !== null && !@unlink($this->maintenance_identity_path)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the private maintenance ownership marker.');
-        }
-        $state['phase'] = 'complete';
-        $this->write_json($this->commit_path, $state);
-        $this->release_target();
-    }
-
-    /**
      * Validates existing live ancestors without following a symlink.
      *
      * @return int|null Device of the nearest real parent, or null when a
@@ -1451,45 +1394,6 @@ final class Site_Export_Staged_Apply_Session {
             $device = $identity['dev'];
         }
         return $device;
-    }
-
-    /**
-     * Rejects separately mounted nearest live parents before staging a value.
-     *
-     * Upload is allowed before maintenance mode, but it must not accept work
-     * that later cannot be renamed into place. This walks existing ancestors
-     * only until the first missing or non-directory parent because commit will
-     * perform the full live-drift validation under maintenance.
-     *
-     * @param string $path Target-relative path being staged.
-     */
-    private function assert_target_parent_same_filesystem(string $path): void {
-        $staging_device = $this->staging_device();
-        $root = $this->path_identity($this->target_root);
-        if ($root === null || $root['type'] !== 'directory') {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The managed live root is no longer a real directory.');
-        }
-        if ($root['dev'] !== $staging_device) {
-            $this->throw_cross_device('stage', $path, $staging_device, $root['dev']);
-        }
-        $absolute = $this->target_root;
-        $device = $root['dev'];
-        $segments = explode('/', $path);
-        array_pop($segments);
-        foreach ($segments as $segment) {
-            $absolute .= ( $absolute === '/' ? '' : '/' ) . $segment;
-            $identity = $this->path_identity($absolute);
-            if ($identity === null) {
-                break;
-            }
-            if ($identity['dev'] !== $device || $identity['dev'] !== $staging_device) {
-                $this->throw_cross_device('stage', $path, $staging_device, $identity['dev']);
-            }
-            if ($identity['type'] !== 'directory') {
-                break;
-            }
-            $device = $identity['dev'];
-        }
     }
 
     /**
@@ -2016,11 +1920,11 @@ final class Site_Export_Staged_Apply_Session {
             }
             $this->decode_commit_path($installation['path_b64'], 'current installation');
         }
-        if (!is_array($state['traversal_stack'] ?? null) || count($state['traversal_stack']) > self::MAX_PATH_BYTES) {
+        if (!is_array($state['traversal_stack'] ?? null)) {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid traversal stack.');
         }
         foreach ($state['traversal_stack'] as $frame) {
-            if (!is_array($frame) || array_keys($frame) !== ['component_b64'] || !is_string($frame['component_b64'])) {
+            if (!is_array($frame) || !is_string($frame['component_b64'] ?? null)) {
                 throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid structural traversal frame.');
             }
         }

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -1,0 +1,2125 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Session errors become authenticated API JSON, never HTML output.
+
+if (!class_exists('Site_Export_Multipart_Processor', false)) {
+    require_once __DIR__ . '/class-multipart-processor.php';
+}
+if (!class_exists('Site_Export_Staged_Apply_Exception', false)) {
+    require_once __DIR__ . '/class-staged-apply-exception.php';
+}
+
+/**
+ * Stages a push privately, then deletes and installs its values directly.
+ *
+ * `work/files/` is both the completed staging tree and the positive-work queue.
+ * Successful installation consumes each entry. Deletes remain raw NUL-delimited
+ * bytes in `work/deletes`; their confirmed cursor is the file's actual size.
+ * Commit persists only one deletion, one installation, and a path-depth-bounded
+ * traversal stack. It never builds a candidate tree, action plan, backup, path
+ * index, or second queue.
+ */
+final class Site_Export_Staged_Apply_Session {
+
+    public const ERROR_BUSY = 'busy';
+    public const ERROR_OFFSET_GAP = 'offset_gap';
+    public const ERROR_SESSION_NOT_FOUND = 'session_not_found';
+    public const ERROR_RETRYABLE_IO = 'retryable_io_error';
+    public const ERROR_COMMIT_REQUIRED = 'commit_required';
+    public const ERROR_LIVE_TREE_CHANGED = 'live_tree_changed';
+    public const ERROR_INVALID_STATE = 'invalid_session_state';
+    public const ERROR_CROSS_DEVICE_FILESYSTEM = 'cross_device_filesystem';
+
+    private const MAX_PATH_BYTES = 4096;
+    private const MAX_METADATA_BYTES = 1048576;
+    private const DISCARD_ENTRY_LIMIT = 256;
+
+    /** @var string */
+    private $storage_dir;
+    /** @var string */
+    private $target_root;
+    /** @var string */
+    private $session_id;
+    /** @var string[] */
+    private $protected_paths;
+    /** @var string */
+    private $session_dir;
+    /** @var string */
+    private $work_dir;
+    /** @var string */
+    private $files_dir;
+    /** @var string */
+    private $partial_dir;
+    /** @var string */
+    private $deletes_path;
+    /** @var string */
+    private $session_metadata_path;
+    /** @var string */
+    private $commit_path;
+    /** @var string */
+    private $lock_path;
+    /** @var string */
+    private $maintenance_identity_path;
+
+    /** @var resource|null */
+    private $upload_lock = null;
+    /** @var resource|null */
+    private $upload_input = null;
+    /** @var Site_Export_Multipart_Processor|null */
+    private $upload_processor = null;
+    /** @var bool */
+    private $current_upload_part_ended = false;
+    /** @var array<string,mixed>|null */
+    private $current_change = null;
+    /** @var int */
+    private $maximum_upload_part_bytes = PHP_INT_MAX;
+
+    /**
+     * Normalizes one session's policy and derives its private paths.
+     *
+     * Factory methods canonicalize the storage and target roots before they
+     * reach this constructor. The constructor then establishes the invariant
+     * shared by every session handle: protected paths are safe, sorted, and
+     * unique, and storage below the managed root protects itself from push.
+     * No filesystem state is read or changed here.
+     *
+     * @param string[] $protected_paths Target-relative paths which push must
+     *                                  never stage, delete, or replace.
+     */
+    private function __construct(string $storage_dir, string $target_root, string $session_id, array $protected_paths) {
+        $this->storage_dir = rtrim($storage_dir, '/');
+        $this->target_root = $target_root === '/' ? '/' : rtrim($target_root, '/');
+        $this->session_id = $session_id;
+        $this->protected_paths = self::normalize_protected_paths(
+            self::protect_session_storage($storage_dir, $this->target_root, $protected_paths)
+        );
+        $this->session_dir = $this->storage_dir . '/apply-sessions/' . $session_id;
+        $this->session_metadata_path = $this->session_dir . '/session.json';
+        $this->commit_path = $this->session_dir . '/commit.json';
+        $this->lock_path = $this->session_dir . '/lock';
+        $this->work_dir = $this->session_dir . '/work';
+        $this->files_dir = $this->work_dir . '/files';
+        $this->partial_dir = $this->work_dir . '/partial';
+        $this->deletes_path = $this->work_dir . '/deletes';
+        $this->maintenance_identity_path = $this->work_dir . '/maintenance.php';
+    }
+
+    /**
+     * Creates or idempotently reopens one private apply session.
+     *
+     * The empty staging tree is created before its device is compared with the
+     * managed root. A mismatch removes the new session before any multipart
+     * bytes can be accepted. That device check necessarily stats the new tree;
+     * successful creation and metadata writes are otherwise trusted instead
+     * of being followed by a complete layout scan.
+     *
+     * Replaying the same session id returns a handle to the existing workspace.
+     * Its durable layout and immutable metadata are validated under the session
+     * lock by the first upload, status, or commit operation. Keeping that check
+     * at the operation boundary avoids reading the same layout before and after
+     * its lock is acquired.
+     *
+     * @param string $storage_dir Durable private storage on the target filesystem.
+     * @param string $target_root Managed live directory receiving committed values.
+     * @param string[] $protected_paths Target-relative paths which push must preserve.
+     * @param string $session_id Stable lowercase hexadecimal session identity.
+     * @return self New or existing session handle.
+     */
+    public static function create(string $storage_dir, string $target_root, array $protected_paths, string $session_id): self {
+        self::require_session_id($session_id);
+        $storage_dir = self::require_directory($storage_dir, 'session storage', true);
+        $target_root = self::require_directory($target_root, 'apply target root', false);
+        $session = new self($storage_dir, $target_root, $session_id, $protected_paths);
+        $sessions_dir = $storage_dir . '/apply-sessions';
+        if (!@mkdir($sessions_dir, 0700)) {
+            if (!is_dir($sessions_dir)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create staged apply sessions directory ' . $sessions_dir . '.');
+            }
+            $sessions_dir = self::require_directory($sessions_dir, 'staged apply sessions', false);
+        }
+        $creation_lock = @fopen($sessions_dir . '/create.lock', 'c+b');
+        if ($creation_lock === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open the staged apply creation lock.');
+        }
+        try {
+            if (!flock($creation_lock, LOCK_EX | LOCK_NB)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Staged apply session creation is busy. Retry the create request.');
+            }
+            if (file_exists($session->session_dir) || is_link($session->session_dir)) {
+                return $session;
+            }
+            if (!@mkdir($session->files_dir, 0700, true) || !@mkdir($session->partial_dir, 0700, true)) {
+                self::remove_tree($session->session_dir);
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create the staged apply workspace directories.');
+            }
+            if (@file_put_contents($session->lock_path, '') === false || @file_put_contents($session->deletes_path, '') === false) {
+                self::remove_tree($session->session_dir);
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create staged apply session control files.');
+            }
+            try {
+                $session->assert_same_filesystem($session->files_dir, $session->target_root, 'stage', '');
+            } catch (Throwable $exception) {
+                self::remove_tree($session->session_dir);
+                throw $exception;
+            }
+            $session->write_json($session->session_metadata_path, [
+                'version' => 2,
+                'session_id' => $session_id,
+                'target_root_b64' => base64_encode($target_root),
+                'protected_paths_b64' => array_map('base64_encode', $session->protected_paths),
+                'delete_upload_complete' => false,
+            ]);
+            return $session;
+        } finally {
+            flock($creation_lock, LOCK_UN);
+            fclose($creation_lock);
+        }
+    }
+
+    /**
+     * Creates a handle for a session which will be validated when it is used.
+     *
+     * This method canonicalizes the configured roots but deliberately does not
+     * inspect the session workspace. Upload, status, and commit acquire the
+     * session lock and then validate its complete layout, immutable metadata,
+     * and same-filesystem relationship exactly once for that operation.
+     *
+     * @param string $storage_dir Durable private session storage.
+     * @param string $target_root Managed live directory.
+     * @param string $session_id Lowercase hexadecimal session identity.
+     * @param string[] $protected_paths Target-relative paths which push must preserve.
+     * @return self Session handle; the session may prove missing or invalid
+     *              when its first operation acquires the lock.
+     */
+    public static function open(string $storage_dir, string $target_root, string $session_id, array $protected_paths): self {
+        self::require_session_id($session_id);
+        $storage_dir = self::require_directory($storage_dir, 'session storage', false);
+        $target_root = self::require_directory($target_root, 'apply target root', false);
+        return new self($storage_dir, $target_root, $session_id, $protected_paths);
+    }
+
+    /**
+     * Removes private session work without requiring the old target configuration.
+     *
+     * Discard validates the workspace under its session lock, but it does not
+     * require current protected paths or the target root to match immutable
+     * session metadata. That exception is intentional: operators must still be
+     * able to remove abandoned private work after configuration changes.
+     *
+     * @param string $storage_dir Durable private session storage.
+     * @param string $target_root Currently configured managed live directory.
+     * @param string $session_id Lowercase hexadecimal session identity.
+     * @param string[] $protected_paths Currently configured protected paths.
+     * @return bool True when the workspace and any discard tombstone are gone.
+     */
+    public static function discard(string $storage_dir, string $target_root, string $session_id, array $protected_paths): bool {
+        self::require_session_id($session_id);
+        $storage_dir = self::require_directory($storage_dir, 'session storage', false);
+        $target_root = self::require_directory($target_root, 'apply target root', false);
+        return ( new self($storage_dir, $target_root, $session_id, $protected_paths) )->discard_workspace();
+    }
+
+    public function get_session_id(): string {
+        return $this->session_id;
+    }
+
+    public function get_session_directory(): string {
+        return $this->session_dir;
+    }
+
+    /**
+     * Opens one caller-driven multipart request without reading its body.
+     *
+     * The session lock remains held until finish_upload() is called, so no
+     * status, commit, discard, or second upload can observe a partly processed
+     * MIME part. The supplied processor owns the request boundary and parser
+     * state. The byte limit applies to each part's declared Content-Length,
+     * not to the complete HTTP request.
+     *
+     * A session which has started commit is closed to further uploads. This
+     * method validates that condition before any bytes are read from $input.
+     *
+     * @param resource $input Blocking stream containing one multipart request.
+     * @param Site_Export_Multipart_Processor $processor Parser configured with
+     *                                                   the request boundary.
+     * @param int $maximum_part_bytes Largest Content-Length accepted for one part.
+     *
+     * @throws LogicException If another upload is already open on this object.
+     * @throws InvalidArgumentException If the stream or part limit is invalid.
+     * @throws Site_Export_Staged_Apply_Exception If the session is busy,
+     *     malformed, unavailable, or already committing.
+     */
+    public function accept_upload($input, Site_Export_Multipart_Processor $processor, int $maximum_part_bytes = PHP_INT_MAX): void {
+        if ($this->upload_lock !== null) {
+            throw new LogicException('A staged apply upload is already open; call finish_upload() first.');
+        }
+        if (!is_resource($input)) {
+            throw new InvalidArgumentException('Staged apply multipart input must be a readable stream resource; received ' . gettype($input) . '.');
+        }
+        if ($maximum_part_bytes <= 0) {
+            throw new InvalidArgumentException('Multipart part byte limit must be greater than zero.');
+        }
+        $lock = $this->acquire_session_lock();
+        try {
+            $this->assert_session_configuration();
+            if (is_file($this->commit_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_COMMIT_REQUIRED, 'Uploads are closed because this staged apply session is committing.');
+            }
+            $this->upload_lock = $lock;
+            $this->upload_input = $input;
+            $this->upload_processor = $processor;
+            $this->current_upload_part_ended = false;
+            $this->current_change = null;
+            $this->maximum_upload_part_bytes = $maximum_part_bytes;
+        } catch (Throwable $exception) {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+            throw $exception;
+        }
+    }
+
+    /**
+     * Reads and records the next change from the active multipart upload.
+     *
+     * Each MIME part describes one file chunk, directory, symlink, or segment
+     * of the raw deletion stream. File bodies pass through the multipart
+     * processor in bounded pieces instead of being collected in memory. One
+     * call interprets exactly one complete part and does not begin interpreting
+     * the following part before returning.
+     *
+     * Returning true means the complete part has been accepted into the target
+     * workspace and get_current_change() describes the resulting target state.
+     * A file part may leave that file partial, so true does not mean the logical
+     * file or the complete multipart request is finished.
+     *
+     * Returning false means the closing multipart boundary was consumed. EOF
+     * in a header, body, or boundary throws instead, so truncation is never
+     * reported as normal completion.
+     *
+     * accept_upload() must be called first. The caller must eventually call
+     * finish_upload(), including after an exception, to release the session
+     * lock and clear the request state.
+     *
+     * @return bool True when one complete part was accepted, false after the
+     *              multipart request closed cleanly.
+     *
+     * @throws LogicException If no upload is active or parser state is inconsistent.
+     * @throws InvalidArgumentException If the part violates the push protocol.
+     * @throws RuntimeException If the request is truncated or the target
+     *     cannot record the part.
+     */
+    public function next_change(): bool {
+        if ($this->upload_lock === null || $this->upload_input === null || $this->upload_processor === null) {
+            throw new LogicException('Accept an upload before reading changes.');
+        }
+        $this->current_change = null;
+        $this->current_upload_part_ended = false;
+        try {
+            if (!$this->next_upload_token()) {
+                return false;
+            }
+            if ($this->upload_processor->get_token_type() !== Site_Export_Multipart_Processor::TOKEN_PART_START) {
+                throw new LogicException('Expected a multipart part-start token before the next change.');
+            }
+            $headers = $this->upload_processor->get_current_headers();
+            $part_bytes = $this->require_non_negative_header($headers, 'content-length');
+            if ($part_bytes > $this->maximum_upload_part_bytes) {
+                throw new InvalidArgumentException('Multipart part Content-Length ' . $part_bytes . ' exceeds the target maximum of ' . $this->maximum_upload_part_bytes . ' bytes.');
+            }
+            $type = $headers['x-chunk-type'] ?? null;
+            if (!is_string($type) || !in_array($type, ['file', 'directory', 'symlink', 'delete-list'], true)) {
+                throw new InvalidArgumentException('Multipart X-Chunk-Type must be file, directory, symlink, or delete-list; observed ' . json_encode($type) . '.');
+            }
+            if ($type === 'file') {
+                $this->stage_file_part($headers, $part_bytes);
+            } elseif ($type === 'directory') {
+                $this->stage_directory_part($headers, $part_bytes);
+            } elseif ($type === 'symlink') {
+                $this->stage_symlink_part($headers, $part_bytes);
+            } else {
+                $this->stage_delete_list_part($headers, $part_bytes);
+            }
+            $unread = $this->read_current_upload_body_piece();
+            if ($unread !== null) {
+                throw new LogicException('The multipart part handler left ' . strlen($unread) . ' body bytes unread.');
+            }
+            return true;
+        } catch (Throwable $exception) {
+            $this->upload_input = null;
+            $this->upload_processor = null;
+            $this->current_change = null;
+            throw $exception;
+        }
+    }
+
+    /**
+     * Closes the active upload and releases its session lock.
+     *
+     * This method does not drain or validate the remainder of the multipart
+     * request. A caller may therefore stop after any complete part when a
+     * request budget is exhausted; a later request resumes from workspace
+     * state. It must also be called after next_change() throws.
+     *
+     * @throws LogicException If no upload is active.
+     */
+    public function finish_upload(): void {
+        if ($this->upload_lock === null) {
+            throw new LogicException('No staged apply upload is open; call accept_upload() first.');
+        }
+        $lock = $this->upload_lock;
+        $this->upload_lock = null;
+        $this->upload_input = null;
+        $this->upload_processor = null;
+        $this->current_upload_part_ended = false;
+        $this->current_change = null;
+        $this->maximum_upload_part_bytes = PHP_INT_MAX;
+        flock($lock, LOCK_UN);
+        fclose($lock);
+    }
+
+    /**
+     * Returns the target state published by the latest accepted MIME part.
+     *
+     * The value is meaningful only after next_change() returns true. Calling
+     * next_change() again clears the previous value before processing, and
+     * finish_upload() clears it when the request closes.
+     *
+     * @return array<string,mixed>|null Accepted type, state, byte cursor, and
+     *                                  path when applicable, or null when no
+     *                                  result is current.
+     */
+    public function get_current_change(): ?array {
+        return $this->current_change;
+    }
+
+    /**
+     * Reports target-confirmed session progress and selected path cursors.
+     *
+     * Senders use this snapshot after a lost response or process restart. It
+     * derives every cursor from the target workspace rather than echoing a
+     * sender's claimed offset. Calling it with no paths returns only session
+     * progress; it never enumerates the complete positive-work tree.
+     *
+     * Requested paths are returned in the same order, encoded as path_b64 so
+     * arbitrary filesystem bytes remain representable. Each path is reported
+     * as one of:
+     *
+     *  - missing, with an accepted_bytes cursor of zero;
+     *  - partial, with the regular file's actual stored byte size; or
+     *  - complete, with its file, directory, or symlink type and a file-size
+     *    cursor where applicable.
+     *
+     * The session-level result contains the session id, the current uploading,
+     * deleting, applying, or complete phase, the actual delete-stream byte
+     * size, and whether its completion was explicitly declared. The complete
+     * snapshot is read while holding the session lock.
+     *
+     * @param string[] $paths Raw target-relative path byte strings to inspect.
+     * @return array<string,mixed> Target-confirmed session and path progress.
+     *
+     * @throws InvalidArgumentException If a requested path is unsafe.
+     * @throws Site_Export_Staged_Apply_Exception If the session is busy,
+     *     unavailable, corrupt, or no longer matches the target configuration.
+     */
+    public function get_status(array $paths = []): array {
+        return $this->with_session_lock(function () use ($paths): array {
+            $reported_paths = [];
+            foreach ($paths as $path) {
+                $this->validate_path($path);
+                $partial = $this->private_path($this->partial_dir, $path);
+                $complete = $this->private_path($this->files_dir, $path);
+                $this->ensure_private_parent($partial, false);
+                $this->ensure_private_parent($complete, false);
+                $complete_identity = $this->path_identity($complete);
+                if ($complete_identity !== null) {
+                    $reported_paths[] = [
+                        'path_b64' => base64_encode($path),
+                        'state' => 'complete',
+                        'type' => $complete_identity['type'],
+                        'accepted_bytes' => $complete_identity['type'] === 'file' ? $complete_identity['size'] : 0,
+                    ];
+                    continue;
+                }
+                $partial_identity = $this->path_identity($partial);
+                if ($partial_identity !== null) {
+                    if ($partial_identity['type'] !== 'file') {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Partial staging path ' . base64_encode($path) . ' is not a regular file.');
+                    }
+                    $reported_paths[] = [
+                        'path_b64' => base64_encode($path),
+                        'state' => 'partial',
+                        'type' => 'file',
+                        'accepted_bytes' => $partial_identity['size'],
+                    ];
+                    continue;
+                }
+                $reported_paths[] = ['path_b64' => base64_encode($path), 'state' => 'missing', 'accepted_bytes' => 0];
+            }
+            $commit = $this->read_json($this->commit_path);
+            if (is_array($commit)) {
+                $this->require_valid_commit_state($commit);
+            }
+            return [
+                'session_id' => $this->session_id,
+                'phase' => is_array($commit) ? $commit['phase'] : 'uploading',
+                'delete_bytes' => $this->file_size($this->deletes_path),
+                'delete_upload_complete' => $this->delete_upload_is_complete(),
+                'paths' => $reported_paths,
+            ];
+        });
+    }
+
+    /**
+     * Advances bounded delete or install work under maintenance.
+     *
+     * @return array<string,mixed>
+     */
+    public function commit(int $maximum_steps = 1): array {
+        if ($maximum_steps <= 0) {
+            throw new InvalidArgumentException('The staged apply commit step limit must be greater than zero.');
+        }
+        return $this->with_session_lock(function () use ($maximum_steps): array {
+            $state = $this->read_json($this->commit_path);
+            if ($state === null) {
+                $state = $this->start_commit();
+            } else {
+                $this->require_valid_commit_state($state);
+            }
+            if (isset($state['terminal_error'])) {
+                $this->throw_terminal_error($state['terminal_error']);
+            }
+            if ($state['phase'] === 'complete') {
+                return $this->commit_result($state);
+            }
+            $this->claim_target();
+            $this->publish_or_refresh_maintenance_marker($state);
+            try {
+                for ($step = 0; $step < $maximum_steps && $state['phase'] !== 'complete'; ++$step) {
+                    if ($state['phase'] === 'deleting') {
+                        $this->advance_deletion($state);
+                    } else {
+                        $this->advance_installation($state);
+                    }
+                }
+            } catch (Site_Export_Staged_Apply_Exception $exception) {
+                if (in_array($exception->get_error_code(), [self::ERROR_LIVE_TREE_CHANGED, self::ERROR_CROSS_DEVICE_FILESYSTEM], true)) {
+                    $state['terminal_error'] = [
+                        'reason' => $exception->get_error_code(),
+                        'detail' => $exception->getMessage(),
+                        'context' => $exception->get_context(),
+                    ];
+                    $this->write_json($this->commit_path, $state);
+                }
+                throw $exception;
+            }
+            return $this->commit_result($state);
+        });
+    }
+
+    /**
+     * Advances bounded cleanup of an upload-only or completed workspace.
+     *
+     * A session which has begun an incomplete commit remains recovery state and
+     * cannot be discarded. An eligible session is atomically renamed to a
+     * private tombstone before entries are removed, so a lost response or later
+     * request resumes cleanup without making the old session addressable again.
+     *
+     * @return bool True when cleanup is complete, false when the bounded entry
+     *              limit left tombstone work for another call.
+     */
+    public function discard_workspace(): bool {
+        $discarding_session_dir = $this->storage_dir . '/apply-sessions/.discarding-' . $this->session_id;
+        if ($this->path_identity($this->session_dir) === null) {
+            return $this->discard_tombstone($discarding_session_dir);
+        }
+        $lock = $this->acquire_session_lock();
+        try {
+            $state = $this->read_json($this->commit_path);
+            if (is_array($state)) {
+                $this->require_valid_commit_state($state);
+                if ($state['phase'] !== 'complete') {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_COMMIT_REQUIRED, 'Live mutation has begun. Resume commit instead of discarding this session.');
+                }
+            }
+            if (file_exists($discarding_session_dir) || is_link($discarding_session_dir)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'A discard tombstone already exists for staged apply session ' . $this->session_id . '.');
+            }
+            if (!@rename($this->session_dir, $discarding_session_dir)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not publish the staged apply discard tombstone.');
+            }
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+        $this->release_target();
+        return $this->discard_tombstone($discarding_session_dir);
+    }
+
+    // Upload helpers follow the public lifecycle so readers encounter behavior
+    // before the multipart implementation details.
+
+    private function read_current_upload_body_piece(): ?string {
+        if ($this->current_upload_part_ended) {
+            return null;
+        }
+        if (!$this->next_upload_token()) {
+            throw new LogicException('Multipart input closed before the current part-end token.');
+        }
+        $type = $this->upload_processor->get_token_type();
+        if ($type === Site_Export_Multipart_Processor::TOKEN_BODY) {
+            return $this->upload_processor->get_current_body_piece();
+        }
+        if ($type === Site_Export_Multipart_Processor::TOKEN_PART_END) {
+            $this->current_upload_part_ended = true;
+            return null;
+        }
+        throw new LogicException('Expected multipart body or part-end; received ' . json_encode($type) . '.');
+    }
+
+    private function next_upload_token(): bool {
+        while (!$this->upload_processor->next_token()) {
+            if ($this->upload_processor->is_complete()) {
+                return false;
+            }
+            if (!$this->upload_processor->paused_at_incomplete_input()) {
+                throw new LogicException('Multipart processor stopped without completing or requesting input.');
+            }
+            $bytes = fread($this->upload_input, Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES);
+            if ($bytes === false) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read the multipart upload request body.');
+            }
+            if ($bytes === '') {
+                $this->upload_processor->finish_input();
+                return false;
+            }
+            $this->upload_processor->append_bytes($bytes);
+        }
+        return true;
+    }
+
+    /** @param array<string,string> $headers */
+    private function stage_file_part(array $headers, int $part_bytes): void {
+        $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-file-path', 'x-file-size', 'x-chunk-offset'], 'file');
+        $path = $this->decode_path_header($headers, 'x-file-path');
+        $total_bytes = $this->require_non_negative_header($headers, 'x-file-size');
+        $offset = $this->require_non_negative_header($headers, 'x-chunk-offset');
+        if ($offset > $total_bytes || $part_bytes > $total_bytes - $offset) {
+            throw new InvalidArgumentException('File part for ' . base64_encode($path) . ' exceeds its declared total of ' . $total_bytes . ' bytes.');
+        }
+        $this->assert_target_parent_same_filesystem($path);
+        $partial_path = $this->private_path($this->partial_dir, $path);
+        $complete_path = $this->private_path($this->files_dir, $path);
+        $this->ensure_private_parent($partial_path);
+        $this->ensure_private_parent($complete_path);
+
+        $complete = $this->path_identity($complete_path);
+        if ($complete !== null) {
+            if ($offset === 0) {
+                $this->remove_private_entry($complete_path);
+            } elseif ($complete['type'] === 'file' && $complete['size'] === $total_bytes && $offset === $total_bytes && $part_bytes === 0) {
+                if ($this->read_current_upload_body_piece() !== null) {
+                    throw new LogicException('Multipart processor exposed file bytes for an empty completed-file replay.');
+                }
+                $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => $total_bytes];
+                return;
+            } else {
+                throw new Site_Export_Staged_Apply_Exception(
+                    self::ERROR_OFFSET_GAP,
+                    'Completed staged file ' . base64_encode($path) . ' can only be restarted at offset 0.'
+                );
+            }
+        }
+
+        $partial = $this->path_identity($partial_path);
+        if ($partial !== null && $partial['type'] !== 'file') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The partial path for ' . base64_encode($path) . ' is a ' . $partial['type'] . ', not a regular file.');
+        }
+        $actual_bytes = $partial === null ? 0 : $partial['size'];
+        if ($offset === 0 && $actual_bytes !== 0) {
+            if (!@unlink($partial_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not restart partial file ' . base64_encode($path) . ' at offset 0.');
+            }
+            $actual_bytes = 0;
+        } elseif ($offset !== $actual_bytes) {
+            throw new Site_Export_Staged_Apply_Exception(
+                self::ERROR_OFFSET_GAP,
+                'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but work/partial contains ' . $actual_bytes . ' bytes. Start at offset 0 or resume at the actual size.'
+            );
+        }
+
+        $handle = @fopen($partial_path, $actual_bytes === 0 ? 'wb' : 'ab');
+        if ($handle === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open partial file ' . base64_encode($path) . ' for staging.');
+        }
+        $received = 0;
+        try {
+            while (true) {
+                $piece = $this->read_current_upload_body_piece();
+                if ($piece === null) {
+                    break;
+                }
+                $received += strlen($piece);
+                if ($received > $part_bytes) {
+                    throw new LogicException('Multipart processor exposed more file bytes than Content-Length.');
+                }
+                $this->write_all($handle, $piece, 'partial file ' . base64_encode($path));
+            }
+            if ($received !== $part_bytes) {
+                throw new LogicException('Multipart processor exposed ' . $received . ' file bytes for Content-Length ' . $part_bytes . '.');
+            }
+            if (!fflush($handle)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not flush partial file ' . base64_encode($path) . '.');
+            }
+        } finally {
+            fclose($handle);
+        }
+        $accepted_bytes = $actual_bytes + $received;
+        if ($accepted_bytes === $total_bytes) {
+            $this->rename_private($partial_path, $complete_path, 'promote completed staged file ' . base64_encode($path));
+            $state = 'complete';
+        } else {
+            $state = 'partial';
+        }
+        $this->current_change = ['path_b64' => base64_encode($path), 'state' => $state, 'type' => 'file', 'accepted_bytes' => $accepted_bytes];
+    }
+
+    /** @param array<string,string> $headers */
+    private function stage_directory_part(array $headers, int $part_bytes): void {
+        $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-directory-path'], 'directory');
+        if ($part_bytes !== 0 || $this->read_current_upload_body_piece() !== null) {
+            throw new InvalidArgumentException('Multipart directory part must have Content-Length 0.');
+        }
+        $path = $this->decode_path_header($headers, 'x-directory-path');
+        $this->assert_target_parent_same_filesystem($path);
+        $target = $this->private_path($this->files_dir, $path);
+        $this->ensure_private_parent($target);
+        $identity = $this->path_identity($target);
+        if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
+            throw new InvalidArgumentException('Explicit empty directory ' . base64_encode($path) . ' conflicts with staged descendants.');
+        }
+        if ($identity !== null && $identity['type'] !== 'directory') {
+            $this->remove_private_entry($target);
+        }
+        if (!is_dir($target) && !@mkdir($target, 0777)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not stage explicit empty directory ' . base64_encode($path) . '.');
+        }
+        $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0];
+    }
+
+    /** @param array<string,string> $headers */
+    private function stage_symlink_part(array $headers, int $part_bytes): void {
+        $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-symlink-path', 'x-symlink-target'], 'symlink');
+        if ($part_bytes !== 0 || $this->read_current_upload_body_piece() !== null) {
+            throw new InvalidArgumentException('Multipart symlink part must have Content-Length 0.');
+        }
+        $path = $this->decode_path_header($headers, 'x-symlink-path');
+        $target_value = $this->decode_path_header($headers, 'x-symlink-target', false);
+        if ($target_value === '' || strlen($target_value) > self::MAX_PATH_BYTES || strpos($target_value, "\0") !== false) {
+            throw new InvalidArgumentException('Symlink target must contain between 1 and ' . self::MAX_PATH_BYTES . ' bytes without NUL.');
+        }
+        $this->assert_target_parent_same_filesystem($path);
+        $target = $this->private_path($this->files_dir, $path);
+        $this->ensure_private_parent($target);
+        $identity = $this->path_identity($target);
+        if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
+            throw new InvalidArgumentException('Staged symlink ' . base64_encode($path) . ' conflicts with staged descendants.');
+        }
+        if ($identity !== null) {
+            $this->remove_private_entry($target);
+        }
+        if (!@symlink($target_value, $target)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not stage symlink ' . base64_encode($path) . '.');
+        }
+        $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0];
+    }
+
+    /** @param array<string,string> $headers */
+    private function stage_delete_list_part(array $headers, int $part_bytes): void {
+        $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-delete-offset', 'x-delete-complete'], 'delete-list');
+        $offset = $this->require_non_negative_header($headers, 'x-delete-offset');
+        $complete = ( $headers['x-delete-complete'] ?? null ) === '1';
+        if (isset($headers['x-delete-complete']) && !$complete) {
+            throw new InvalidArgumentException('Multipart X-Delete-Complete must be 1 when present.');
+        }
+        if ($this->delete_upload_is_complete() && ( !$complete || $offset !== $this->file_size($this->deletes_path) || $part_bytes !== 0 )) {
+            throw new InvalidArgumentException('Delete upload is already complete; only its empty completion declaration may be replayed.');
+        }
+        $handle = @fopen($this->deletes_path, 'r+b');
+        if ($handle === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open the raw staged delete stream.');
+        }
+        try {
+            $stored_bytes = $this->file_size_from_handle($handle, 'staged delete stream');
+            if ($offset > $stored_bytes) {
+                throw new Site_Export_Staged_Apply_Exception(
+                    self::ERROR_OFFSET_GAP,
+                    'Delete-list part starts at offset ' . $offset . ', but the target has stored ' . $stored_bytes . ' bytes.'
+                );
+            }
+            $position = $offset;
+            $trailing_path = $this->read_delete_trailing_path($handle, $stored_bytes);
+            while (true) {
+                $piece = $this->read_current_upload_body_piece();
+                if ($piece === null) {
+                    break;
+                }
+                $piece_offset = 0;
+                $overlap = min(strlen($piece), max(0, $stored_bytes - $position));
+                if ($overlap > 0) {
+                    if (fseek($handle, $position) !== 0) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not seek within the staged delete stream for replay validation.');
+                    }
+                    $stored = $this->read_exact($handle, $overlap, 'staged delete replay');
+                    if (!hash_equals($stored, substr($piece, 0, $overlap))) {
+                        throw new InvalidArgumentException('Delete-list replay differs from bytes already stored at offset ' . $position . '.');
+                    }
+                    $position += $overlap;
+                    $piece_offset = $overlap;
+                }
+                if ($piece_offset < strlen($piece)) {
+                    if ($position !== $stored_bytes) {
+                        throw new LogicException('Delete-list append did not begin at the actual stored size.');
+                    }
+                    $append = substr($piece, $piece_offset);
+                    $trailing_path = $this->validate_appended_delete_bytes($trailing_path, $append);
+                    if (fseek($handle, 0, SEEK_END) !== 0) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not seek to the staged delete stream end.');
+                    }
+                    $this->write_all($handle, $append, 'staged delete stream');
+                    $stored_bytes += strlen($append);
+                    $position += strlen($append);
+                    if (!fflush($handle)) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not flush the staged delete stream.');
+                    }
+                }
+            }
+            if ($complete && $position !== $stored_bytes) {
+                throw new InvalidArgumentException('Delete completion must be declared at the actual stored size of ' . $stored_bytes . ' bytes.');
+            }
+        } finally {
+            fclose($handle);
+        }
+        if ($complete) {
+            $this->mark_delete_upload_complete();
+        }
+        $this->current_change = ['state' => $complete ? 'complete' : 'partial', 'type' => 'delete-list', 'accepted_bytes' => $stored_bytes];
+    }
+
+    /** @return array<string,mixed> */
+    private function start_commit(): array {
+        if (!$this->delete_upload_is_complete()) {
+            throw new InvalidArgumentException('Commit requires an explicit completed delete upload declaration.');
+        }
+        $delete_bytes = $this->file_size($this->deletes_path);
+        if ($delete_bytes > 0) {
+            $handle = @fopen($this->deletes_path, 'rb');
+            if ($handle === false || fseek($handle, -1, SEEK_END) !== 0) {
+                if (is_resource($handle)) {
+                    fclose($handle);
+                }
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not inspect the final staged delete byte.');
+            }
+            $last_byte = fread($handle, 1);
+            fclose($handle);
+            if ($last_byte !== "\0") {
+                throw new InvalidArgumentException('A nonempty delete stream must end in NUL before commit; the final record is unterminated.');
+            }
+        }
+        if ($this->first_tree_entry($this->partial_dir) !== null) {
+            throw new InvalidArgumentException('Commit cannot begin while work/partial still contains an incomplete file.');
+        }
+        $state = [
+            'version' => 2,
+            'phase' => 'deleting',
+            'delete_offset' => 0,
+            'current_deletion_b64' => null,
+            'current_installation' => null,
+            'traversal_stack' => [],
+            'maintenance_token' => bin2hex(random_bytes(16)),
+            'deletions_applied' => 0,
+            'values_applied' => 0,
+        ];
+        $this->write_json($this->commit_path, $state);
+        return $state;
+    }
+
+    /** @param array<string,mixed> $state */
+    private function advance_deletion(array &$state): void {
+        if ($state['current_deletion_b64'] === null) {
+            $record = $this->read_delete_record( (int) $state['delete_offset']);
+            if ($record === null) {
+                $state['phase'] = 'applying';
+                $this->write_json($this->commit_path, $state);
+                return;
+            }
+            $state['current_deletion_b64'] = base64_encode($record['path']);
+            $this->write_json($this->commit_path, $state);
+            return;
+        }
+
+        $path = $this->decode_commit_path($state['current_deletion_b64'], 'current deletion');
+        $this->validate_path($path);
+        $parent_device = $this->assert_live_ancestors($path, 'delete');
+        if ($parent_device !== null) {
+            $target = $this->target_path($path);
+            $identity = $this->path_identity($target);
+            if ($identity !== null) {
+                if (!in_array($identity['type'], ['file', 'directory', 'symlink'], true)) {
+                    $this->throw_live_tree_changed('delete', $path, $path, null, ['absent', 'file', 'directory', 'symlink'], $identity);
+                }
+                if ($identity['dev'] !== $parent_device) {
+                    $this->throw_cross_device('delete', $path, $this->staging_device(), $identity['dev']);
+                }
+                $this->delete_one_entry($target, $path, $path, $parent_device);
+            }
+            if ($this->path_identity($target) !== null) {
+                return;
+            }
+        }
+        $state['delete_offset'] += strlen($path) + 1;
+        $state['current_deletion_b64'] = null;
+        ++$state['deletions_applied'];
+        $this->write_json($this->commit_path, $state);
+    }
+
+    /**
+     * Removes at most one leaf or empty directory below one planned root.
+     *
+     * @param string $requested_path Delete root used in conflict responses.
+     */
+    private function delete_one_entry(string $absolute_path, string $relative_path, string $requested_path, int $parent_device): void {
+        $identity = $this->path_identity($absolute_path);
+        if ($identity === null) {
+            return;
+        }
+        if ($identity['dev'] !== $parent_device) {
+            $this->throw_cross_device('delete', $relative_path, $this->staging_device(), $identity['dev']);
+        }
+        if ($identity['type'] === 'file' || $identity['type'] === 'symlink') {
+            if (!@unlink($absolute_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove live ' . $identity['type'] . ' ' . base64_encode($relative_path) . '.');
+            }
+            return;
+        }
+        if ($identity['type'] !== 'directory') {
+            $this->throw_live_tree_changed('delete', $requested_path, $relative_path, null, ['file', 'directory', 'symlink'], $identity);
+        }
+        $entry = $this->first_directory_entry($absolute_path);
+        if ($entry === null) {
+            if (!@rmdir($absolute_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove empty live directory ' . base64_encode($relative_path) . '.');
+            }
+            return;
+        }
+        $child_relative = $relative_path . '/' . $entry;
+        $this->delete_one_entry($absolute_path . '/' . $entry, $child_relative, $requested_path, $identity['dev']);
+    }
+
+    /** @param array<string,mixed> $state */
+    private function advance_installation(array &$state): void {
+        if ($state['current_installation'] !== null) {
+            $this->resolve_current_installation($state);
+            return;
+        }
+
+        $stack_size = count($state['traversal_stack']);
+        if ($stack_size === 0) {
+            $parent_path = '';
+            $staged_directory = $this->files_dir;
+        } else {
+            $parent_path = $this->traversal_path($state['traversal_stack']);
+            $staged_directory = $this->private_path($this->files_dir, $parent_path);
+        }
+        $entry = $this->first_directory_entry($staged_directory);
+        if ($entry === null) {
+            if ($stack_size === 0) {
+                $this->finish_commit($state);
+                return;
+            }
+            $this->cleanup_structural_directory($state, $parent_path, $staged_directory);
+            return;
+        }
+
+        $path = $parent_path === '' ? $entry : $parent_path . '/' . $entry;
+        $this->validate_path($path);
+        $staged_path = $this->private_path($this->files_dir, $path);
+        $identity = $this->path_identity($staged_path);
+        if ($identity === null) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Selected staged path disappeared before installation: ' . base64_encode($path) . '.');
+        }
+        if ($identity['type'] === 'directory' && $this->first_directory_entry($staged_path) !== null) {
+            $state['traversal_stack'][] = ['component_b64' => base64_encode($entry)];
+            $this->write_json($this->commit_path, $state);
+            $this->prepare_structural_directory($path, $this->first_staged_leaf_path($staged_path, $path));
+            return;
+        }
+        if (!in_array($identity['type'], ['file', 'directory', 'symlink'], true)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Staged path ' . base64_encode($path) . ' has unsupported type ' . $identity['type'] . '.');
+        }
+        $this->install_staged_value($state, $path, $identity['type'], false);
+    }
+
+    /** @param array<string,mixed> $state */
+    private function cleanup_structural_directory(array &$state, string $path, string $staged_path): void {
+        $this->assert_live_ancestors($path, 'install', 'directory');
+        $live = $this->path_identity($this->target_path($path));
+        if ($live === null || $live['type'] !== 'directory') {
+            $this->throw_live_tree_changed('install', $path, $path, 'directory', ['directory'], $live);
+        }
+        $state['current_installation'] = ['path_b64' => base64_encode($path), 'expected_type' => 'directory'];
+        $this->write_json($this->commit_path, $state);
+        if (!@rmdir($staged_path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not consume empty structural staging directory ' . base64_encode($path) . '.');
+        }
+        $state['current_installation'] = null;
+        array_pop($state['traversal_stack']);
+        ++$state['values_applied'];
+        $this->write_json($this->commit_path, $state);
+    }
+
+    private function prepare_structural_directory(string $path, string $requested_path): void {
+        $parent_device = $this->assert_live_ancestors($path, 'install', 'directory');
+        $live_path = $this->target_path($path);
+        $live = $this->path_identity($live_path);
+        if ($live === null) {
+            if (!@mkdir($live_path, 0777) && !is_dir($live_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create structural live directory ' . base64_encode($path) . '.');
+            }
+            $live = $this->path_identity($live_path);
+        }
+        if ($live === null || $live['type'] !== 'directory') {
+            $this->throw_live_tree_changed('install', $requested_path, $path, 'directory', ['absent', 'directory'], $live);
+        }
+        if ($live['dev'] !== $parent_device || $live['dev'] !== $this->staging_device()) {
+            $this->throw_cross_device('install', $path, $this->staging_device(), $live['dev']);
+        }
+    }
+
+    /** @param array<string,mixed> $state */
+    private function install_staged_value(array &$state, string $path, string $expected_type, bool $recovering): void {
+        $staged_path = $this->private_path($this->files_dir, $path);
+        $staged = $this->path_identity($staged_path);
+        if ($staged === null || $staged['type'] !== $expected_type) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Staged ' . $expected_type . ' ' . base64_encode($path) . ' is not present for installation.');
+        }
+        $parent_device = $this->assert_live_ancestors($path, 'install', $expected_type);
+        $live_path = $this->target_path($path);
+        $live = $this->path_identity($live_path);
+        $expected_live_types = $expected_type === 'directory' ? ['absent'] : ['absent', 'file', 'symlink'];
+        $observed_type = $live === null ? 'absent' : $live['type'];
+        if (!in_array($observed_type, $expected_live_types, true)) {
+            $this->throw_live_tree_changed('install', $path, $path, $expected_type, $expected_live_types, $live);
+        }
+        if ($parent_device !== $staged['dev']) {
+            $this->throw_cross_device('install', $path, $staged['dev'], $parent_device);
+        }
+        if (!$recovering) {
+            $state['current_installation'] = ['path_b64' => base64_encode($path), 'expected_type' => $expected_type];
+            $this->write_json($this->commit_path, $state);
+        }
+        $this->rename_into_live($staged_path, $live_path, $path, $staged['dev'], $parent_device);
+        $state['current_installation'] = null;
+        ++$state['values_applied'];
+        $this->write_json($this->commit_path, $state);
+    }
+
+    /** @param array<string,mixed> $state */
+    private function resolve_current_installation(array &$state): void {
+        $installation = $state['current_installation'];
+        $path = $this->decode_commit_path($installation['path_b64'], 'current installation');
+        $expected_type = $installation['expected_type'];
+        $stack_size = count($state['traversal_stack']);
+        $structural_cleanup = false;
+        if ($stack_size > 0) {
+            $structural_cleanup = hash_equals(
+                $this->traversal_path($state['traversal_stack']),
+                $path
+            );
+        }
+        $staged_path = $this->private_path($this->files_dir, $path);
+        $staged = $this->path_identity($staged_path);
+
+        if ($structural_cleanup) {
+            $this->assert_live_ancestors($path, 'install', 'directory');
+            $live = $this->path_identity($this->target_path($path));
+            if ($staged !== null) {
+                if ($staged['type'] !== 'directory' || $this->first_directory_entry($staged_path) !== null) {
+                    $this->throw_live_tree_changed('install', $path, $path, 'directory', ['directory'], $live);
+                }
+                if ($live === null || $live['type'] !== 'directory') {
+                    $this->throw_live_tree_changed('install', $path, $path, 'directory', ['directory'], $live);
+                }
+                if (!@rmdir($staged_path)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not finish structural staging cleanup for ' . base64_encode($path) . '.');
+                }
+            } elseif ($live === null || $live['type'] !== 'directory') {
+                $this->throw_live_tree_changed('install', $path, $path, 'directory', ['directory'], $live);
+            }
+            $state['current_installation'] = null;
+            array_pop($state['traversal_stack']);
+            ++$state['values_applied'];
+            $this->write_json($this->commit_path, $state);
+            return;
+        }
+
+        if ($staged !== null) {
+            $this->install_staged_value($state, $path, $expected_type, true);
+            return;
+        }
+        $this->assert_live_ancestors($path, 'install', $expected_type);
+        $live = $this->path_identity($this->target_path($path));
+        if ($live === null || $live['type'] !== $expected_type) {
+            $this->throw_live_tree_changed('install', $path, $path, $expected_type, [$expected_type], $live);
+        }
+        $state['current_installation'] = null;
+        ++$state['values_applied'];
+        $this->write_json($this->commit_path, $state);
+    }
+
+    /** @param array<string,mixed> $state */
+    private function finish_commit(array &$state): void {
+        if ($state['current_deletion_b64'] !== null || $state['current_installation'] !== null || $state['traversal_stack'] !== []) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion with active bounded work state.');
+        }
+        if ( (int) $state['delete_offset'] !== $this->file_size($this->deletes_path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion before consuming the complete delete stream.');
+        }
+        if ($this->first_directory_entry($this->files_dir) !== null) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion while work/files still contains pending values.');
+        }
+        $this->remove_owned_maintenance_marker($state);
+        $state['phase'] = 'complete';
+        $this->write_json($this->commit_path, $state);
+        $this->release_target();
+    }
+
+    /** @param array<string,mixed> $state @return array<string,mixed> */
+    private function commit_result(array $state): array {
+        $complete = $state['phase'] === 'complete';
+        return [
+            'phase' => $state['phase'],
+            'send_next_request' => !$complete,
+        ];
+    }
+
+    /** @param array<string,mixed> $terminal_error */
+    private function throw_terminal_error(array $terminal_error): void {
+        throw new Site_Export_Staged_Apply_Exception(
+            $terminal_error['reason'],
+            $terminal_error['detail'],
+            $terminal_error['context']
+        );
+    }
+
+    /**
+     * Validates existing live ancestors without following a symlink.
+     *
+     * @return int|null Device of the nearest real parent, or null when a
+     *                  deletion root is already absent below a missing parent.
+     */
+    private function assert_live_ancestors(string $path, string $operation, ?string $staged_type = null): ?int {
+        $root = $this->path_identity($this->target_root);
+        if ($root === null || $root['type'] !== 'directory') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The managed live root is no longer a real directory.');
+        }
+        $staging_device = $this->staging_device();
+        if ($root['dev'] !== $staging_device) {
+            $this->throw_cross_device($operation, $path, $staging_device, $root['dev']);
+        }
+        $device = $root['dev'];
+        $absolute = $this->target_root;
+        $relative = '';
+        $segments = explode('/', $path);
+        array_pop($segments);
+        foreach ($segments as $segment) {
+            $relative = $relative === '' ? $segment : $relative . '/' . $segment;
+            $absolute .= ( $absolute === '/' ? '' : '/' ) . $segment;
+            $identity = $this->path_identity($absolute);
+            if ($identity === null) {
+                if ($operation === 'delete') {
+                    return null;
+                }
+                $this->throw_live_tree_changed($operation, $path, $relative, $staged_type, ['directory'], null);
+            }
+            if ($identity['type'] !== 'directory') {
+                $this->throw_live_tree_changed($operation, $path, $relative, $staged_type, ['directory'], $identity);
+            }
+            if ($identity['dev'] !== $device) {
+                $this->throw_cross_device($operation, $relative, $staging_device, $identity['dev']);
+            }
+            $device = $identity['dev'];
+        }
+        return $device;
+    }
+
+    /** Rejects separately mounted nearest live parents before maintenance starts. */
+    private function assert_target_parent_same_filesystem(string $path): void {
+        $staging_device = $this->staging_device();
+        $root = $this->path_identity($this->target_root);
+        if ($root === null || $root['type'] !== 'directory') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The managed live root is no longer a real directory.');
+        }
+        if ($root['dev'] !== $staging_device) {
+            $this->throw_cross_device('stage', $path, $staging_device, $root['dev']);
+        }
+        $absolute = $this->target_root;
+        $device = $root['dev'];
+        $segments = explode('/', $path);
+        array_pop($segments);
+        foreach ($segments as $segment) {
+            $absolute .= ( $absolute === '/' ? '' : '/' ) . $segment;
+            $identity = $this->path_identity($absolute);
+            if ($identity === null) {
+                break;
+            }
+            if ($identity['dev'] !== $device || $identity['dev'] !== $staging_device) {
+                $this->throw_cross_device('stage', $path, $staging_device, $identity['dev']);
+            }
+            if ($identity['type'] !== 'directory') {
+                break;
+            }
+            $device = $identity['dev'];
+        }
+    }
+
+    private function rename_into_live(string $staged_path, string $live_path, string $relative_path, int $staging_device, int $live_device): void {
+        error_clear_last();
+        if (@rename($staged_path, $live_path)) {
+            return;
+        }
+        $last_error = error_get_last();
+        $message = is_array($last_error) ? $last_error['message'] : '';
+        $observed_live = $this->path_identity($live_path);
+        if ($observed_live !== null && $observed_live['dev'] !== $staging_device) {
+            $this->throw_cross_device('install', $relative_path, $staging_device, $observed_live['dev']);
+        }
+        if (stripos($message, 'cross-device') !== false || stripos($message, 'exdev') !== false) {
+            $this->throw_cross_device('install', $relative_path, $staging_device, $live_device);
+        }
+        throw new Site_Export_Staged_Apply_Exception(
+            self::ERROR_RETRYABLE_IO,
+            'Could not rename staged ' . base64_encode($relative_path) . ' directly into the live tree'
+            . ( $message === '' ? '.' : ': ' . $message )
+        );
+    }
+
+    /**
+     * @param string[] $expected_live_types
+     * @param array<string,mixed>|null $observed_identity
+     */
+    private function throw_live_tree_changed(
+        string $operation,
+        string $path,
+        string $conflict_path,
+        ?string $staged_type,
+        array $expected_live_types,
+        ?array $observed_identity
+    ): void {
+        $detail = 'Refusing the operation because the observed live filesystem state is incompatible. The conflicting path was left untouched.';
+        $context = [
+            'operation' => $operation,
+            'path_b64' => base64_encode($path),
+            'conflict_path_b64' => base64_encode($conflict_path),
+            'expected_live_types' => $expected_live_types,
+            'observed_live_identity' => $observed_identity === null ? ['type' => 'absent'] : $observed_identity,
+            'detail' => $detail,
+        ];
+        if ($staged_type !== null) {
+            $context['staged_type'] = $staged_type;
+        }
+        throw new Site_Export_Staged_Apply_Exception(self::ERROR_LIVE_TREE_CHANGED, $detail, $context);
+    }
+
+    private function throw_cross_device(string $operation, string $path, int $staging_device, int $live_device): void {
+        $detail = 'The staged value and live destination are on different filesystems. This push requires same-filesystem rename and has no copy fallback.';
+        throw new Site_Export_Staged_Apply_Exception(self::ERROR_CROSS_DEVICE_FILESYSTEM, $detail, [
+            'operation' => $operation,
+            'path_b64' => base64_encode($path),
+            'staging_device' => $staging_device,
+            'live_device' => $live_device,
+            'detail' => $detail,
+        ]);
+    }
+
+    private function assert_same_filesystem(string $staging_path, string $live_path, string $operation, string $relative_path): void {
+        $staging = $this->path_identity($staging_path);
+        $live = $this->path_identity($live_path);
+        if ($staging === null || $live === null) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not determine the staging and live filesystem devices.');
+        }
+        if ($staging['dev'] !== $live['dev']) {
+            $this->throw_cross_device($operation, $relative_path, $staging['dev'], $live['dev']);
+        }
+    }
+
+    private function staging_device(): int {
+        $identity = $this->path_identity($this->files_dir);
+        if ($identity === null || $identity['type'] !== 'directory') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'work/files is not a real staging directory.');
+        }
+        return $identity['dev'];
+    }
+
+    /** @return array<string,mixed>|null */
+    private function read_delete_record(int $offset): ?array {
+        $size = $this->file_size($this->deletes_path);
+        if ($offset === $size) {
+            return null;
+        }
+        if ($offset < 0 || $offset > $size) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Delete-consumption offset ' . $offset . ' is outside the ' . $size . '-byte stream.');
+        }
+        $handle = @fopen($this->deletes_path, 'rb');
+        if ($handle === false || fseek($handle, $offset) !== 0) {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not seek to the confirmed delete-consumption offset.');
+        }
+        $path = '';
+        $path_bytes = 0;
+        try {
+            while ($path_bytes <= self::MAX_PATH_BYTES) {
+                $byte = fread($handle, 1);
+                if ($byte === false) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read the staged delete stream.');
+                }
+                if ($byte === '') {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged delete stream ended before its NUL record terminator.');
+                }
+                if ($byte === "\0") {
+                    if ($path === '') {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged delete stream contains an empty record at offset ' . $offset . '.');
+                    }
+                    $this->validate_path($path);
+                    return ['path' => $path];
+                }
+                $path .= $byte;
+                ++$path_bytes;
+            }
+        } finally {
+            fclose($handle);
+        }
+        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'A staged delete path exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
+    }
+
+    /** @param resource $handle */
+    private function read_delete_trailing_path($handle, int $stored_bytes): string {
+        if ($stored_bytes === 0) {
+            return '';
+        }
+        $suffix_bytes = min($stored_bytes, self::MAX_PATH_BYTES + 1);
+        if (fseek($handle, $stored_bytes - $suffix_bytes) !== 0) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not inspect the staged delete-stream suffix.');
+        }
+        $suffix = $this->read_exact($handle, $suffix_bytes, 'staged delete-stream suffix');
+        $last_nul = strrpos($suffix, "\0");
+        $trailing = $last_nul === false ? $suffix : substr($suffix, $last_nul + 1);
+        if ($last_nul === false && $stored_bytes > self::MAX_PATH_BYTES) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The incomplete staged delete path already exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
+        }
+        return $trailing;
+    }
+
+    private function validate_appended_delete_bytes(string $trailing_path, string $bytes): string {
+        $length = strlen($bytes);
+        for ($index = 0; $index < $length; ++$index) {
+            if ($bytes[$index] === "\0") {
+                if ($trailing_path === '') {
+                    throw new InvalidArgumentException('Delete-list parts may not contain an empty deletion record.');
+                }
+                $this->validate_path($trailing_path);
+                $this->assert_target_parent_same_filesystem($trailing_path);
+                $trailing_path = '';
+                continue;
+            }
+            $trailing_path .= $bytes[$index];
+            if (strlen($trailing_path) > self::MAX_PATH_BYTES) {
+                throw new InvalidArgumentException('Delete-list path exceeds the maximum of ' . self::MAX_PATH_BYTES . ' bytes.');
+            }
+        }
+        return $trailing_path;
+    }
+
+    /** @param resource $handle */
+    private function read_exact($handle, int $bytes, string $description): string {
+        $result = '';
+        $result_bytes = 0;
+        while ($result_bytes < $bytes) {
+            $piece = fread($handle, $bytes - $result_bytes);
+            if ($piece === false || $piece === '') {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read complete ' . $description . '; expected ' . $bytes . ' bytes and observed ' . $result_bytes . '.');
+            }
+            $result .= $piece;
+            $result_bytes += strlen($piece);
+        }
+        return $result;
+    }
+
+    /** @return string|null */
+    private function first_directory_entry(string $directory): ?string {
+        $handle = @opendir($directory);
+        if ($handle === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read directory ' . $directory . '.');
+        }
+        try {
+            while (true) {
+                $entry = readdir($handle);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry !== '.' && $entry !== '..') {
+                    return $entry;
+                }
+            }
+        } finally {
+            closedir($handle);
+        }
+        return null;
+    }
+
+    /** Returns a non-directory descendant, ignoring empty structural parents. */
+    private function first_tree_entry(string $directory): ?string {
+        $handle = @opendir($directory);
+        if ($handle === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read directory ' . $directory . '.');
+        }
+        try {
+            while (true) {
+                $entry = readdir($handle);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $path = $directory . '/' . $entry;
+                $identity = $this->path_identity($path);
+                if ($identity === null) {
+                    continue;
+                }
+                if ($identity['type'] !== 'directory' || $this->first_tree_entry($path) !== null) {
+                    return $entry;
+                }
+            }
+        } finally {
+            closedir($handle);
+        }
+        return null;
+    }
+
+    /** Returns one staged leaf so a structural-ancestor conflict names requested work. */
+    private function first_staged_leaf_path(string $directory, string $relative_path): string {
+        $entry = $this->first_directory_entry($directory);
+        if ($entry === null) {
+            return $relative_path;
+        }
+        $child_path = $relative_path . '/' . $entry;
+        $identity = $this->path_identity($directory . '/' . $entry);
+        if ($identity !== null && $identity['type'] === 'directory') {
+            return $this->first_staged_leaf_path($directory . '/' . $entry, $child_path);
+        }
+        return $child_path;
+    }
+
+    private function publish_or_refresh_maintenance_marker(array $state): void {
+        $token = $state['maintenance_token'];
+        $live_path = $this->target_path('.maintenance');
+        $identity = $this->path_identity($live_path);
+        if ($identity !== null && !$this->maintenance_marker_is_owned($live_path, $token)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'A foreign WordPress maintenance marker already exists. Retry after its owner removes it.');
+        }
+        $contents = $this->maintenance_marker_contents($token);
+        $this->write_atomic_file($this->maintenance_identity_path, $contents, 0600);
+        $this->write_atomic_file($live_path, $contents, 0644);
+    }
+
+    private function maintenance_marker_contents(string $token): string {
+        return "<?php\n"
+            . "\$reprint_staged_apply_request = (isset(\$_GET['reprint-api']) || isset(\$_GET['site-export-api']))\n"
+            . "    && isset(\$_GET['endpoint']) && is_string(\$_GET['endpoint'])\n"
+            . "    && strpos(\$_GET['endpoint'], 'staged_session_') === 0;\n"
+            . "if (!\$reprint_staged_apply_request) {\n"
+            . "    \$upgrading = " . time() . ";\n"
+            . "}\n"
+            . "unset(\$reprint_staged_apply_request);\n"
+            . "// reprint-staged-session:" . $this->session_id . ':' . $token . "\n";
+    }
+
+    private function maintenance_marker_is_owned(string $path, string $token): bool {
+        $contents = @file_get_contents($path, false, null, 0, 512);
+        return is_string($contents)
+            && strpos($contents, '// reprint-staged-session:' . $this->session_id . ':' . $token . "\n") !== false;
+    }
+
+    /** Marker removal remains retryable and precedes the complete checkpoint. */
+    private function remove_owned_maintenance_marker(array $state): void {
+        $live_path = $this->target_path('.maintenance');
+        $identity = $this->path_identity($live_path);
+        if ($identity !== null) {
+            if (!$this->maintenance_marker_is_owned($live_path, $state['maintenance_token'])) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'The session-owned maintenance marker was replaced by another owner.');
+            }
+            if (!@unlink($live_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the session-owned WordPress maintenance marker.');
+            }
+        }
+        if ($this->path_identity($this->maintenance_identity_path) !== null && !@unlink($this->maintenance_identity_path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the private maintenance ownership marker.');
+        }
+    }
+
+    private function claim_target(): void {
+        $this->with_target_lock(function (): void {
+            $active_path = $this->storage_dir . '/apply-sessions/target.active';
+            $active = @file_get_contents($active_path);
+            if (is_string($active) && trim($active) !== '' && trim($active) !== $this->session_id) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Another staged apply session is already committing this target: ' . trim($active) . '.');
+            }
+            $this->write_atomic_file($active_path, $this->session_id . "\n", 0600);
+        });
+    }
+
+    private function release_target(): void {
+        $this->with_target_lock(function (): void {
+            $active_path = $this->storage_dir . '/apply-sessions/target.active';
+            $active = @file_get_contents($active_path);
+            if (!is_string($active) || trim($active) !== $this->session_id) {
+                return;
+            }
+            if (!@unlink($active_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not release the staged apply target coordinator.');
+            }
+        });
+    }
+
+    private function with_target_lock(callable $callback): void {
+        $lock = @fopen($this->storage_dir . '/apply-sessions/target.lock', 'c+b');
+        if ($lock === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open the staged apply target coordinator lock.');
+        }
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'The staged apply target coordinator is busy. Retry the request.');
+            }
+            $callback();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Runs one callback against a validated session while holding its lock.
+     *
+     * The workspace layout is checked by acquire_session_lock(). Immutable
+     * session identity and the same-filesystem requirement are then checked
+     * before the callback can read or mutate session state.
+     *
+     * @return mixed Callback result.
+     */
+    private function with_session_lock(callable $callback) {
+        $lock = $this->acquire_session_lock();
+        try {
+            $this->assert_session_configuration();
+            return $callback();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Locks one existing session after checking only the paths needed to do so safely.
+     *
+     * The complete durable workspace is validated after the lock is held. This
+     * avoids trusting a pre-lock snapshot while also rejecting an already
+     * malformed session or lock path before fopen() is called.
+     *
+     * @return resource Exclusive session lock owned by the caller.
+     */
+    private function acquire_session_lock() {
+        $session_identity = $this->path_identity($this->session_dir);
+        if ($session_identity === null) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_SESSION_NOT_FOUND, 'The staged apply session does not exist: ' . $this->session_id . '.');
+        }
+        if ($session_identity['type'] !== 'directory') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged apply session path is not a real directory: ' . $this->session_dir . '.');
+        }
+        $lock_identity = $this->path_identity($this->lock_path);
+        if ($lock_identity === null || $lock_identity['type'] !== 'file') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged apply session lock is missing or not regular: ' . $this->lock_path . '.');
+        }
+
+        $lock = @fopen($this->lock_path, 'r+b');
+        if ($lock === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open the staged apply session lock.');
+        }
+        if (!flock($lock, LOCK_EX | LOCK_NB)) {
+            fclose($lock);
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Staged apply session ' . $this->session_id . ' is busy. Retry the request.');
+        }
+        try {
+            $this->assert_workspace_layout();
+        } catch (Throwable $exception) {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+            throw $exception;
+        }
+        return $lock;
+    }
+
+    /**
+     * Verifies that durable session identity still matches this server configuration.
+     *
+     * Discard deliberately omits this check: private work may need cleanup
+     * after the target or protected-path configuration has changed. Upload,
+     * status, and commit must agree with the immutable session metadata and
+     * retain the same-filesystem guarantee under which the session was made.
+     */
+    private function assert_session_configuration(): void {
+        $this->read_session_metadata();
+        $this->assert_same_filesystem($this->files_dir, $this->target_root, 'stage', '');
+    }
+
+    /** @return array<string,mixed>|null */
+    private function read_json(string $path): ?array {
+        $identity = $this->path_identity($path);
+        if ($identity === null) {
+            return null;
+        }
+        if ($identity['type'] !== 'file' || $identity['size'] > self::MAX_METADATA_BYTES) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Metadata file ' . $path . ' is not a bounded regular file.');
+        }
+        $contents = @file_get_contents($path);
+        if (!is_string($contents)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read metadata file ' . $path . '.');
+        }
+        $decoded = json_decode($contents, true);
+        if (!is_array($decoded)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Metadata file ' . $path . ' does not contain a JSON object.');
+        }
+        return $decoded;
+    }
+
+    /** @param array<string,mixed> $value */
+    private function write_json(string $path, array $value): void {
+        $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
+        if (!is_string($contents)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Could not encode bounded staged apply metadata.');
+        }
+        if (strlen($contents) > self::MAX_METADATA_BYTES) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Encoded staged apply metadata exceeds the maximum of ' . self::MAX_METADATA_BYTES . ' bytes.');
+        }
+        $this->write_atomic_file($path, $contents, 0600);
+    }
+
+    private function write_atomic_file(string $path, string $contents, int $permissions): void {
+        $temporary = $path . '.tmp-' . $this->session_id;
+        if ($this->path_identity($temporary) !== null && !@unlink($temporary)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not clear temporary metadata file ' . $temporary . '.');
+        }
+        $handle = @fopen($temporary, 'xb');
+        if ($handle === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create temporary metadata file ' . $temporary . '.');
+        }
+        try {
+            $this->write_all($handle, $contents, 'metadata file ' . $path);
+            if (!fflush($handle)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not flush temporary metadata file ' . $temporary . '.');
+            }
+        } finally {
+            fclose($handle);
+        }
+        @chmod($temporary, $permissions);
+        if (!@rename($temporary, $path)) {
+            @unlink($temporary);
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not publish metadata file ' . $path . '.');
+        }
+    }
+
+    /** @param resource $handle */
+    private function write_all($handle, string $contents, string $description): void {
+        $offset = 0;
+        $length = strlen($contents);
+        while ($offset < $length) {
+            $written = fwrite($handle, substr($contents, $offset));
+            if (!is_int($written) || $written <= 0) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not finish writing ' . $description . '; wrote ' . $offset . ' of ' . $length . ' bytes.');
+            }
+            $offset += $written;
+        }
+    }
+
+    /** @param array<string,mixed> $state */
+    private function require_valid_commit_state(array $state): void {
+        if (( $state['version'] ?? null ) !== 2) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an unsupported version.');
+        }
+        if (!in_array($state['phase'] ?? null, ['deleting', 'applying', 'complete'], true)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid phase.');
+        }
+        foreach (['delete_offset', 'deletions_applied', 'values_applied'] as $field) {
+            if (!isset($state[$field]) || !is_int($state[$field]) || $state[$field] < 0) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint field ' . $field . ' must be a non-negative integer.');
+            }
+        }
+        if (!is_string($state['maintenance_token'] ?? null) || preg_match('/^[a-f0-9]{32}$/D', $state['maintenance_token']) !== 1) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid maintenance token.');
+        }
+        if (( $state['current_deletion_b64'] ?? null ) !== null) {
+            $this->decode_commit_path($state['current_deletion_b64'], 'current deletion');
+        }
+        $installation = $state['current_installation'] ?? null;
+        if ($installation !== null) {
+            if (!is_array($installation) || !is_string($installation['path_b64'] ?? null)
+                || !in_array($installation['expected_type'] ?? null, ['file', 'directory', 'symlink'], true)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid current installation.');
+            }
+            $this->decode_commit_path($installation['path_b64'], 'current installation');
+        }
+        if (!is_array($state['traversal_stack'] ?? null) || count($state['traversal_stack']) > self::MAX_PATH_BYTES) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid traversal stack.');
+        }
+        foreach ($state['traversal_stack'] as $frame) {
+            if (!is_array($frame) || array_keys($frame) !== ['component_b64'] || !is_string($frame['component_b64'])) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid structural traversal frame.');
+            }
+        }
+        $this->traversal_path($state['traversal_stack']);
+        if (isset($state['terminal_error'])) {
+            $error = $state['terminal_error'];
+            if (!is_array($error) || !in_array($error['reason'] ?? null, [self::ERROR_LIVE_TREE_CHANGED, self::ERROR_CROSS_DEVICE_FILESYSTEM], true)
+                || !is_string($error['detail'] ?? null) || !is_array($error['context'] ?? null)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an invalid terminal error.');
+            }
+        }
+    }
+
+    private function decode_commit_path($encoded, string $description): string {
+        if (!is_string($encoded)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit ' . $description . ' path is not base64 text.');
+        }
+        $path = base64_decode($encoded, true);
+        if (!is_string($path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit ' . $description . ' path is not valid base64.');
+        }
+        $this->validate_path($path);
+        return $path;
+    }
+
+    /** @param array<int,array<string,mixed>> $stack */
+    private function traversal_path(array $stack): string {
+        $path = '';
+        foreach ($stack as $frame) {
+            $encoded = $frame['component_b64'] ?? null;
+            $component = is_string($encoded) ? base64_decode($encoded, true) : false;
+            if (!is_string($component) || $component === '' || strpos($component, '/') !== false) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit traversal frame does not contain one valid base64 path component.');
+            }
+            $path = $path === '' ? $component : $path . '/' . $component;
+            if (strlen($path) > self::MAX_PATH_BYTES) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit traversal path exceeds the maximum of ' . self::MAX_PATH_BYTES . ' bytes.');
+            }
+        }
+        if ($path !== '') {
+            $this->validate_path($path);
+        }
+        return $path;
+    }
+
+    private function assert_workspace_layout(): void {
+        foreach ([$this->session_dir, $this->work_dir, $this->files_dir, $this->partial_dir] as $directory) {
+            $identity = $this->path_identity($directory);
+            if ($identity === null || $identity['type'] !== 'directory') {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Required staged apply directory is missing or not real: ' . $directory . '.');
+            }
+        }
+        foreach ([$this->session_metadata_path, $this->lock_path, $this->deletes_path] as $file) {
+            $identity = $this->path_identity($file);
+            if ($identity === null || $identity['type'] !== 'file') {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Required staged apply file is missing or not regular: ' . $file . '.');
+            }
+        }
+        foreach ([$this->commit_path, $this->maintenance_identity_path] as $optional_file) {
+            $identity = $this->path_identity($optional_file);
+            if ($identity !== null && $identity['type'] !== 'file') {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Optional staged apply file has an unsupported type: ' . $optional_file . '.');
+            }
+        }
+    }
+
+    private function read_session_metadata(): void {
+        $metadata = $this->read_json($this->session_metadata_path);
+        if (!is_array($metadata) || ( $metadata['version'] ?? null ) !== 2 || ( $metadata['session_id'] ?? null ) !== $this->session_id
+            || !is_bool($metadata['delete_upload_complete'] ?? null)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata has an unsupported version or session identity.');
+        }
+        $target = base64_decode( (string) ( $metadata['target_root_b64'] ?? '' ), true);
+        $protected = [];
+        foreach (( $metadata['protected_paths_b64'] ?? [] ) as $encoded) {
+            $decoded = is_string($encoded) ? base64_decode($encoded, true) : false;
+            if (!is_string($decoded)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata contains an invalid protected path.');
+            }
+            $protected[] = $decoded;
+        }
+        if ($target !== $this->target_root || $protected !== $this->protected_paths) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata does not match the current apply configuration.');
+        }
+    }
+
+    private function delete_upload_is_complete(): bool {
+        $metadata = $this->read_json($this->session_metadata_path);
+        if (!is_array($metadata) || !is_bool($metadata['delete_upload_complete'] ?? null)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata has no valid delete-upload completion state.');
+        }
+        return $metadata['delete_upload_complete'];
+    }
+
+    private function mark_delete_upload_complete(): void {
+        $metadata = $this->read_json($this->session_metadata_path);
+        if (!is_array($metadata)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata is missing while completing the delete upload.');
+        }
+        $metadata['delete_upload_complete'] = true;
+        $this->write_json($this->session_metadata_path, $metadata);
+    }
+
+    private function validate_path(string $path): void {
+        if ($path === '' || strlen($path) > self::MAX_PATH_BYTES || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('Target-relative path must contain between 1 and ' . self::MAX_PATH_BYTES . ' safe bytes; observed ' . base64_encode($path) . '.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException('Target-relative path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
+            }
+        }
+        if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
+            throw new InvalidArgumentException('Protected target-relative path cannot be changed: ' . base64_encode($path) . '.');
+        }
+        foreach ($this->protected_paths as $protected_path) {
+            if ($path === $protected_path || strpos($path, $protected_path . '/') === 0 || strpos($protected_path, $path . '/') === 0) {
+                throw new InvalidArgumentException('Protected target-relative path cannot be changed: ' . base64_encode($path) . '.');
+            }
+        }
+    }
+
+    /** @param array<string,string> $headers */
+    private function decode_path_header(array $headers, string $header, bool $is_target_path = true): string {
+        $encoded = $headers[$header] ?? null;
+        if (!is_string($encoded) || $encoded === '') {
+            throw new InvalidArgumentException('Multipart part requires a non-empty ' . $header . ' header.');
+        }
+        $decoded = base64_decode($encoded, true);
+        if (!is_string($decoded)) {
+            throw new InvalidArgumentException('Multipart header ' . $header . ' is not valid base64.');
+        }
+        if ($is_target_path) {
+            $this->validate_path($decoded);
+        }
+        return $decoded;
+    }
+
+    /** @param array<string,string> $headers @param string[] $allowed */
+    private function require_only_headers(array $headers, array $allowed, string $type): void {
+        foreach ($headers as $name => $value) {
+            if (!in_array($name, $allowed, true)) {
+                throw new InvalidArgumentException('Multipart ' . $type . ' part does not allow header ' . json_encode($name) . '.');
+            }
+        }
+    }
+
+    /** @param array<string,string> $headers */
+    private function require_non_negative_header(array $headers, string $header): int {
+        $value = $headers[$header] ?? null;
+        if (!is_string($value) || $value === '' || preg_match('/^[0-9]+$/D', $value) !== 1) {
+            throw new InvalidArgumentException('Multipart header ' . $header . ' must be a non-negative decimal integer; observed ' . json_encode($value) . '.');
+        }
+        $integer = (int) $value;
+        if ($integer < 0 || ( (string) $integer !== ltrim($value, '0') && !preg_match('/^0+$/D', $value) )) {
+            throw new InvalidArgumentException('Multipart header ' . $header . ' exceeds the supported integer range; observed ' . json_encode($value) . '.');
+        }
+        return $integer;
+    }
+
+    private function target_path(string $relative_path): string {
+        return $this->target_root . ( $this->target_root === '/' ? '' : '/' ) . $relative_path;
+    }
+
+    private function private_path(string $root, string $relative_path): string {
+        return $root . '/' . $relative_path;
+    }
+
+    /** Creates missing private structural parents and rejects links or files. */
+    private function ensure_private_parent(string $path, bool $create_missing = true): void {
+        $parent = dirname($path);
+        $root = null;
+        foreach ([$this->files_dir, $this->partial_dir] as $candidate) {
+            if ($parent === $candidate || strpos($parent . '/', $candidate . '/') === 0) {
+                $root = $candidate;
+                break;
+            }
+        }
+        if ($root === null) {
+            throw new LogicException('Private staged path escaped work/files and work/partial.');
+        }
+        if ($parent === $root) {
+            return;
+        }
+        $relative = substr($parent, strlen($root) + 1);
+        $current = $root;
+        foreach (explode('/', $relative) as $segment) {
+            $current .= '/' . $segment;
+            $identity = $this->path_identity($current);
+            if ($identity === null) {
+                if (!$create_missing) {
+                    return;
+                }
+                if (!@mkdir($current, 0700)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create private structural staging directory ' . $current . '.');
+                }
+                continue;
+            }
+            if ($identity['type'] !== 'directory') {
+                throw new InvalidArgumentException('A staged ' . $identity['type'] . ' cannot be used as the parent of another path.');
+            }
+        }
+    }
+
+    /** @return array<string,mixed>|null */
+    private function path_identity(string $path): ?array {
+        clearstatcache(true, $path);
+        $stat = @lstat($path);
+        if (!is_array($stat)) {
+            return null;
+        }
+        $type_bits = ( (int) ( $stat['mode'] ?? 0 ) ) & 0170000;
+        if ($type_bits === 0100000) {
+            $type = 'file';
+        } elseif ($type_bits === 0040000) {
+            $type = 'directory';
+        } elseif ($type_bits === 0120000) {
+            $type = 'symlink';
+        } else {
+            $type = 'other';
+        }
+        return [
+            'type' => $type,
+            'dev' => (int) ( $stat['dev'] ?? 0 ),
+            'ino' => (int) ( $stat['ino'] ?? 0 ),
+            'size' => (int) ( $stat['size'] ?? 0 ),
+            'ctime' => (int) ( $stat['ctime'] ?? 0 ),
+        ];
+    }
+
+    private function remove_private_entry(string $path): void {
+        $identity = $this->path_identity($path);
+        if ($identity === null) {
+            return;
+        }
+        if ($identity['type'] === 'directory') {
+            if ($this->first_directory_entry($path) !== null) {
+                throw new InvalidArgumentException('A staged directory with descendants cannot be replaced by another logical value.');
+            }
+            if (!@rmdir($path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove an empty private staged directory.');
+            }
+            return;
+        }
+        if (!@unlink($path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove a private staged ' . $identity['type'] . '.');
+        }
+    }
+
+    private function rename_private(string $source, string $destination, string $description): void {
+        if (!@rename($source, $destination)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not ' . $description . '.');
+        }
+    }
+
+    private function file_size(string $path): int {
+        $identity = $this->path_identity($path);
+        if ($identity === null || $identity['type'] !== 'file') {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Expected a regular file at ' . $path . '.');
+        }
+        return $identity['size'];
+    }
+
+    /** @param resource $handle */
+    private function file_size_from_handle($handle, string $description): int {
+        $stat = fstat($handle);
+        if (!is_array($stat) || !isset($stat['size'])) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not determine the actual size of ' . $description . '.');
+        }
+        return (int) $stat['size'];
+    }
+
+    private function discard_tombstone(string $tombstone): bool {
+        if (!is_dir($tombstone)) {
+            return true;
+        }
+        $lock_path = $tombstone . '/lock';
+        $lock = @fopen($lock_path, 'r+b');
+        if ($lock === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open the staged apply discard tombstone lock.');
+        }
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Staged apply discard cleanup is busy. Retry discard.');
+            }
+            $remaining_entries = self::DISCARD_ENTRY_LIMIT;
+            $empty = self::discard_directory_entries($tombstone, $remaining_entries, true);
+            if (!$empty) {
+                return false;
+            }
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+        if (!@unlink($lock_path) || !@rmdir($tombstone)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the completed staged apply discard tombstone.');
+        }
+        return true;
+    }
+
+    /**
+     * Returns one configured directory as a canonical real path.
+     *
+     * Newly created session storage uses mode 0700 deliberately. PHP's default
+     * 0777 mode, even after a typical umask, can expose staged site contents to
+     * other system accounts. Existing configured directories keep their mode.
+     */
+    private static function require_directory(string $path, string $description, bool $create): string {
+        if ($path === '' || $path[0] !== '/') {
+            throw new InvalidArgumentException('The ' . $description . ' must be an absolute directory; observed ' . json_encode($path) . '.');
+        }
+        if ($create && !is_dir($path) && !@mkdir($path, 0700, true) && !is_dir($path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not create ' . $description . ' directory ' . $path . '.');
+        }
+        $real_path = realpath($path);
+        if ($real_path === false || !is_dir($real_path) || is_link($path)) {
+            throw new InvalidArgumentException('The ' . $description . ' is not a real directory: ' . $path . '.');
+        }
+        return $real_path === '/' ? '/' : rtrim($real_path, '/');
+    }
+
+    /** @param string[] $protected_paths @return string[] */
+    private static function protect_session_storage(string $storage_dir, string $target_root, array $protected_paths): array {
+        if ($storage_dir === $target_root) {
+            throw new InvalidArgumentException('Staged apply session storage must not be the apply target root itself.');
+        }
+        $target_prefix = $target_root === '/' ? '/' : $target_root . '/';
+        if (strpos($storage_dir . '/', $target_prefix) === 0) {
+            $relative_storage = ltrim(substr($storage_dir, strlen($target_root)), '/');
+            if ($relative_storage !== '') {
+                $protected_paths[] = $relative_storage;
+            }
+        }
+        return $protected_paths;
+    }
+
+    private static function require_session_id(string $session_id): void {
+        if (preg_match('/^[a-f0-9]{32}$/D', $session_id) !== 1) {
+            throw new InvalidArgumentException('Staged apply session id must be a 32-character lowercase hexadecimal string.');
+        }
+    }
+
+    /** @param string[] $protected_paths @return string[] */
+    private static function normalize_protected_paths(array $protected_paths): array {
+        $normalized = [];
+        foreach ($protected_paths as $path) {
+            if (!is_string($path) || $path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+                throw new InvalidArgumentException('Each protected staged apply path must be a non-empty safe relative path.');
+            }
+            foreach (explode('/', $path) as $segment) {
+                if ($segment === '' || $segment === '.' || $segment === '..') {
+                    throw new InvalidArgumentException('Protected staged apply path is unsafe: ' . base64_encode($path) . '.');
+                }
+            }
+            $normalized[] = $path;
+        }
+        sort($normalized, SORT_STRING);
+        return array_values(array_unique($normalized));
+    }
+
+    private static function discard_directory_entries(string $directory_path, int &$remaining_entries, bool $preserve_lock = false): bool {
+        $handle = @opendir($directory_path);
+        if ($handle === false) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read staged apply discard directory: ' . $directory_path . '.');
+        }
+        try {
+            while (true) {
+                $entry = readdir($handle);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry === '.' || $entry === '..' || ( $preserve_lock && $entry === 'lock' )) {
+                    continue;
+                }
+                if ($remaining_entries === 0) {
+                    return false;
+                }
+                $entry_path = $directory_path . '/' . $entry;
+                clearstatcache(true, $entry_path);
+                $stat = @lstat($entry_path);
+                if (!is_array($stat)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Staged apply discard entry disappeared during cleanup: ' . $entry_path . '.');
+                }
+                $type = ( (int) ( $stat['mode'] ?? 0 ) ) & 0170000;
+                if ($type === 0040000) {
+                    if (!self::discard_directory_entries($entry_path, $remaining_entries)) {
+                        return false;
+                    }
+                    if ($remaining_entries === 0) {
+                        return false;
+                    }
+                    if (!@rmdir($entry_path)) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove staged apply discard directory: ' . $entry_path . '.');
+                    }
+                } elseif (!@unlink($entry_path)) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove staged apply discard entry: ' . $entry_path . '.');
+                }
+                --$remaining_entries;
+            }
+        } finally {
+            closedir($handle);
+        }
+        return true;
+    }
+
+    private static function remove_tree(string $path): void {
+        clearstatcache(true, $path);
+        $stat = @lstat($path);
+        if (!is_array($stat)) {
+            return;
+        }
+        $type = ( (int) ( $stat['mode'] ?? 0 ) ) & 0170000;
+        if ($type === 0040000) {
+            $handle = @opendir($path);
+            if ($handle === false) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read staged apply directory for removal: ' . $path . '.');
+            }
+            try {
+                while (true) {
+                    $entry = readdir($handle);
+                    if ($entry === false) {
+                        break;
+                    }
+                    if ($entry !== '.' && $entry !== '..') {
+                        self::remove_tree($path . '/' . $entry);
+                    }
+                }
+            } finally {
+                closedir($handle);
+            }
+            if (!@rmdir($path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove staged apply directory ' . $path . '.');
+            }
+            return;
+        }
+        if (!@unlink($path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove staged apply entry ' . $path . '.');
+        }
+    }
+}

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -438,12 +438,13 @@ final class Site_Export_Staged_Apply_Session {
      *
      * Senders use this snapshot after a lost response or process restart. It
      * derives every cursor from the target workspace rather than echoing a
-     * sender's claimed offset. Calling it with no paths returns only session
+     * sender's claimed offset. Calling it without a path returns only session
      * progress; it never enumerates the complete positive-work tree.
      *
-     * Requested paths are returned in the same order, encoded as path_b64 so
-     * arbitrary filesystem bytes remain representable. Each path is reported
-     * as one of:
+     * The optional path is the one in-flight file whose upload response was
+     * lost. Delete-list resume does not need a path; use delete_bytes from the
+     * session-level result. The path status is encoded as path_b64 so arbitrary
+     * filesystem bytes remain representable. It is reported as one of:
      *
      *  - missing, with an accepted_bytes cursor of zero;
      *  - partial, with the regular file's actual stored byte size; or
@@ -452,20 +453,21 @@ final class Site_Export_Staged_Apply_Session {
      *
      * The session-level result contains the session id, the current uploading,
      * deleting, applying, or complete phase, the actual delete-stream byte
-     * size, and whether its completion was explicitly declared. The complete
-     * snapshot is read while holding the session lock.
+     * size, whether its completion was explicitly declared, and a path status
+     * when a path was requested. The complete snapshot is read while holding
+     * the session lock.
      *
-     * @param string[] $paths Raw target-relative path byte strings to inspect.
+     * @param string|null $path Raw target-relative path byte string to inspect.
      * @return array<string,mixed> Target-confirmed session and path progress.
      *
-     * @throws InvalidArgumentException If a requested path is unsafe.
+     * @throws InvalidArgumentException If the requested path is unsafe.
      * @throws Site_Export_Staged_Apply_Exception If the session is busy,
      *     unavailable, corrupt, or no longer matches the target configuration.
      */
-    public function get_status(array $paths = []): array {
-        return $this->with_session_lock(function () use ($paths): array {
-            $reported_paths = [];
-            foreach ($paths as $path) {
+    public function get_status(?string $path = null): array {
+        return $this->with_session_lock(function () use ($path): array {
+            $reported_path = null;
+            if ($path !== null) {
                 $this->validate_path($path);
                 $partial = $this->private_path($this->partial_dir, $path);
                 $complete = $this->private_path($this->files_dir, $path);
@@ -473,28 +475,28 @@ final class Site_Export_Staged_Apply_Session {
                 $this->ensure_private_parent($complete, false);
                 $complete_identity = $this->path_identity($complete);
                 if ($complete_identity !== null) {
-                    $reported_paths[] = [
+                    $reported_path = [
                         'path_b64' => base64_encode($path),
                         'state' => 'complete',
                         'type' => $complete_identity['type'],
                         'accepted_bytes' => $complete_identity['type'] === 'file' ? $complete_identity['size'] : 0,
                     ];
-                    continue;
-                }
-                $partial_identity = $this->path_identity($partial);
-                if ($partial_identity !== null) {
-                    if ($partial_identity['type'] !== 'file') {
-                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Partial staging path ' . base64_encode($path) . ' is not a regular file.');
+                } else {
+                    $partial_identity = $this->path_identity($partial);
+                    if ($partial_identity !== null) {
+                        if ($partial_identity['type'] !== 'file') {
+                            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Partial staging path ' . base64_encode($path) . ' is not a regular file.');
+                        }
+                        $reported_path = [
+                            'path_b64' => base64_encode($path),
+                            'state' => 'partial',
+                            'type' => 'file',
+                            'accepted_bytes' => $partial_identity['size'],
+                        ];
+                    } else {
+                        $reported_path = ['path_b64' => base64_encode($path), 'state' => 'missing', 'accepted_bytes' => 0];
                     }
-                    $reported_paths[] = [
-                        'path_b64' => base64_encode($path),
-                        'state' => 'partial',
-                        'type' => 'file',
-                        'accepted_bytes' => $partial_identity['size'],
-                    ];
-                    continue;
                 }
-                $reported_paths[] = ['path_b64' => base64_encode($path), 'state' => 'missing', 'accepted_bytes' => 0];
             }
             $commit = $this->read_json($this->commit_path);
             if (is_array($commit)) {
@@ -505,7 +507,7 @@ final class Site_Export_Staged_Apply_Session {
                 'phase' => is_array($commit) ? $commit['phase'] : 'uploading',
                 'delete_bytes' => $this->file_size($this->deletes_path),
                 'delete_upload_complete' => $this->delete_upload_is_complete(),
-                'paths' => $reported_paths,
+                'path' => $reported_path,
             ];
         });
     }

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -90,9 +90,30 @@ final class Site_Export_Staged_Apply_Session {
         $this->storage_dir = rtrim($storage_dir, '/');
         $this->target_root = $target_root === '/' ? '/' : rtrim($target_root, '/');
         $this->session_id = $session_id;
-        $this->protected_paths = self::normalize_protected_paths(
-            self::protect_session_storage($storage_dir, $this->target_root, $protected_paths)
-        );
+        if ($storage_dir === $this->target_root) {
+            throw new InvalidArgumentException('Staged apply session storage must not be the apply target root itself.');
+        }
+        $target_prefix = $this->target_root === '/' ? '/' : $this->target_root . '/';
+        if (strpos($storage_dir . '/', $target_prefix) === 0) {
+            $relative_storage = ltrim(substr($storage_dir, strlen($this->target_root)), '/');
+            if ($relative_storage !== '') {
+                $protected_paths[] = $relative_storage;
+            }
+        }
+        $normalized_protected_paths = [];
+        foreach ($protected_paths as $path) {
+            if (!is_string($path) || $path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+                throw new InvalidArgumentException('Each protected staged apply path must be a non-empty safe relative path.');
+            }
+            foreach (explode('/', $path) as $segment) {
+                if ($segment === '' || $segment === '.' || $segment === '..') {
+                    throw new InvalidArgumentException('Protected staged apply path is unsafe: ' . base64_encode($path) . '.');
+                }
+            }
+            $normalized_protected_paths[] = $path;
+        }
+        sort($normalized_protected_paths, SORT_STRING);
+        $this->protected_paths = array_values(array_unique($normalized_protected_paths));
         $this->session_dir = $this->storage_dir . '/apply-sessions/' . $session_id;
         $this->session_metadata_path = $this->session_dir . '/session.json';
         $this->commit_path = $this->session_dir . '/commit.json';
@@ -219,10 +240,30 @@ final class Site_Export_Staged_Apply_Session {
         return ( new self($storage_dir, $target_root, $session_id, $protected_paths) )->discard_workspace();
     }
 
+    /**
+     * Returns the immutable identity assigned to this staged apply session.
+     *
+     * The session id is the caller-provided lowercase hexadecimal token used
+     * in upload, status, commit, and discard endpoints. It is not re-read from
+     * disk here; operations that depend on durable state validate the matching
+     * metadata while holding the session lock.
+     *
+     * @return string Session id used in public protocol responses and paths.
+     */
     public function get_session_id(): string {
         return $this->session_id;
     }
 
+    /**
+     * Returns the private workspace directory derived for this session.
+     *
+     * This is an implementation path under the configured staged-apply storage
+     * directory. The method is used by tests and endpoint code that need to
+     * inspect or remove the private workspace; it does not imply that the
+     * directory currently exists or has passed layout validation.
+     *
+     * @return string Absolute path to the session's private directory.
+     */
     public function get_session_directory(): string {
         return $this->session_dir;
     }
@@ -470,9 +511,22 @@ final class Site_Export_Staged_Apply_Session {
     }
 
     /**
-     * Advances bounded delete or install work under maintenance.
+     * Advances a bounded amount of live-tree mutation for this session.
      *
-     * @return array<string,mixed>
+     * Commit starts only after the delete upload has been explicitly closed and
+     * every staged file is complete. The first call creates a durable checkpoint
+     * and claims the target so no other session can mutate the same live tree.
+     * Subsequent calls resume from that checkpoint, refresh the WordPress
+     * maintenance marker, and perform at most $maximum_steps units of delete or
+     * install work before returning.
+     *
+     * Live-tree drift and cross-device destinations are terminal for the
+     * session: the failure is written into the commit checkpoint and replayed on
+     * later calls. Retryable I/O failures are not terminal, so a later call can
+     * retry the same bounded step from the durable state.
+     *
+     * @param int $maximum_steps Maximum delete/install steps to attempt.
+     * @return array<string,mixed> Current phase and whether another request is needed.
      */
     public function commit(int $maximum_steps = 1): array {
         if ($maximum_steps <= 0) {
@@ -481,18 +535,80 @@ final class Site_Export_Staged_Apply_Session {
         return $this->with_session_lock(function () use ($maximum_steps): array {
             $state = $this->read_json($this->commit_path);
             if ($state === null) {
-                $state = $this->start_commit();
+                if (!$this->delete_upload_is_complete()) {
+                    throw new InvalidArgumentException('Commit requires an explicit completed delete upload declaration.');
+                }
+                $delete_bytes = $this->file_size($this->deletes_path);
+                if ($delete_bytes > 0) {
+                    $handle = @fopen($this->deletes_path, 'rb');
+                    if ($handle === false || fseek($handle, -1, SEEK_END) !== 0) {
+                        if (is_resource($handle)) {
+                            fclose($handle);
+                        }
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not inspect the final staged delete byte.');
+                    }
+                    $last_byte = fread($handle, 1);
+                    fclose($handle);
+                    if ($last_byte !== "\0") {
+                        throw new InvalidArgumentException('A nonempty delete stream must end in NUL before commit; the final record is unterminated.');
+                    }
+                }
+                if ($this->first_tree_entry($this->partial_dir) !== null) {
+                    throw new InvalidArgumentException('Commit cannot begin while work/partial still contains an incomplete file.');
+                }
+                $state = [
+                    'version' => 2,
+                    'phase' => 'deleting',
+                    'delete_offset' => 0,
+                    'current_deletion_b64' => null,
+                    'current_installation' => null,
+                    'traversal_stack' => [],
+                    'maintenance_token' => bin2hex(random_bytes(16)),
+                    'deletions_applied' => 0,
+                    'values_applied' => 0,
+                ];
+                $this->write_json($this->commit_path, $state);
             } else {
                 $this->require_valid_commit_state($state);
             }
             if (isset($state['terminal_error'])) {
-                $this->throw_terminal_error($state['terminal_error']);
+                throw new Site_Export_Staged_Apply_Exception(
+                    $state['terminal_error']['reason'],
+                    $state['terminal_error']['detail'],
+                    $state['terminal_error']['context']
+                );
             }
             if ($state['phase'] === 'complete') {
-                return $this->commit_result($state);
+                return [
+                    'phase' => $state['phase'],
+                    'send_next_request' => false,
+                ];
             }
-            $this->claim_target();
-            $this->publish_or_refresh_maintenance_marker($state);
+            $this->with_target_lock(function (): void {
+                $active_path = $this->storage_dir . '/apply-sessions/target.active';
+                $active = @file_get_contents($active_path);
+                if (is_string($active) && trim($active) !== '' && trim($active) !== $this->session_id) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Another staged apply session is already committing this target: ' . trim($active) . '.');
+                }
+                $this->write_atomic_file($active_path, $this->session_id . "\n", 0600);
+            });
+            $maintenance_token = $state['maintenance_token'];
+            $maintenance_live_path = $this->target_path('.maintenance');
+            $maintenance_identity = $this->path_identity($maintenance_live_path);
+            if ($maintenance_identity !== null && !$this->maintenance_marker_is_owned($maintenance_live_path, $maintenance_token)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'A foreign WordPress maintenance marker already exists. Retry after its owner removes it.');
+            }
+            $maintenance_contents = "<?php\n"
+                . "\$reprint_staged_apply_request = (isset(\$_GET['reprint-api']) || isset(\$_GET['site-export-api']))\n"
+                . "    && isset(\$_GET['endpoint']) && is_string(\$_GET['endpoint'])\n"
+                . "    && strpos(\$_GET['endpoint'], 'staged_session_') === 0;\n"
+                . "if (!\$reprint_staged_apply_request) {\n"
+                . "    \$upgrading = " . time() . ";\n"
+                . "}\n"
+                . "unset(\$reprint_staged_apply_request);\n"
+                . "// reprint-staged-session:" . $this->session_id . ':' . $maintenance_token . "\n";
+            $this->write_atomic_file($this->maintenance_identity_path, $maintenance_contents, 0600);
+            $this->write_atomic_file($maintenance_live_path, $maintenance_contents, 0644);
             try {
                 for ($step = 0; $step < $maximum_steps && $state['phase'] !== 'complete'; ++$step) {
                     if ($state['phase'] === 'deleting') {
@@ -512,7 +628,10 @@ final class Site_Export_Staged_Apply_Session {
                 }
                 throw $exception;
             }
-            return $this->commit_result($state);
+            return [
+                'phase' => $state['phase'],
+                'send_next_request' => $state['phase'] !== 'complete',
+            ];
         });
     }
 
@@ -555,9 +674,17 @@ final class Site_Export_Staged_Apply_Session {
         return $this->discard_tombstone($discarding_session_dir);
     }
 
-    // Upload helpers follow the public lifecycle so readers encounter behavior
-    // before the multipart implementation details.
-
+    /**
+     * Returns the next body fragment for the current multipart part.
+     *
+     * The multipart processor may expose a body in several bounded fragments,
+     * followed by a PART_END token. This method hides that token transition
+     * from the part-specific staging code: a string means bytes still belong to
+     * the current part, and null means the declared Content-Length has been
+     * satisfied. It never reads into the next part.
+     *
+     * @return string|null Current body bytes, or null after the part end.
+     */
     private function read_current_upload_body_piece(): ?string {
         if ($this->current_upload_part_ended) {
             return null;
@@ -576,6 +703,16 @@ final class Site_Export_Staged_Apply_Session {
         throw new LogicException('Expected multipart body or part-end; received ' . json_encode($type) . '.');
     }
 
+    /**
+     * Advances the multipart processor, feeding it bounded request bytes.
+     *
+     * The processor is drained before each new fread(), so this method
+     * preserves the streaming contract: at most one request fragment and one
+     * exposed token are live at a time. Clean completion returns false; a
+     * truncated request is reported by finish_input().
+     *
+     * @return bool True when a processor token is current, false after close.
+     */
     private function next_upload_token(): bool {
         while (!$this->upload_processor->next_token()) {
             if ($this->upload_processor->is_complete()) {
@@ -597,7 +734,18 @@ final class Site_Export_Staged_Apply_Session {
         return true;
     }
 
-    /** @param array<string,string> $headers */
+    /**
+     * Accepts one file MIME part into work/partial or work/files.
+     *
+     * The caller has already validated Content-Length against the target's part
+     * ceiling. This method validates the file-specific headers, enforces the
+     * target-confirmed resume offset, streams the body into the partial file,
+     * and promotes the file atomically inside private storage only when the
+     * declared total size has been reached.
+     *
+     * @param array<string,string> $headers Normalized headers for the part.
+     * @param int $part_bytes Declared Content-Length for this file chunk.
+     */
     private function stage_file_part(array $headers, int $part_bytes): void {
         $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-file-path', 'x-file-size', 'x-chunk-offset'], 'file');
         $path = $this->decode_path_header($headers, 'x-file-path');
@@ -675,7 +823,9 @@ final class Site_Export_Staged_Apply_Session {
         }
         $accepted_bytes = $actual_bytes + $received;
         if ($accepted_bytes === $total_bytes) {
-            $this->rename_private($partial_path, $complete_path, 'promote completed staged file ' . base64_encode($path));
+            if (!@rename($partial_path, $complete_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not promote completed staged file ' . base64_encode($path) . '.');
+            }
             $state = 'complete';
         } else {
             $state = 'partial';
@@ -683,7 +833,17 @@ final class Site_Export_Staged_Apply_Session {
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => $state, 'type' => 'file', 'accepted_bytes' => $accepted_bytes];
     }
 
-    /** @param array<string,string> $headers */
+    /**
+     * Accepts one explicit empty-directory MIME part.
+     *
+     * Directory parts have no body. They create or refresh an empty directory in
+     * the completed staging tree, but they reject conflicts with already staged
+     * descendants because a single staged path cannot be both a leaf value and a
+     * structural parent.
+     *
+     * @param array<string,string> $headers Normalized headers for the part.
+     * @param int $part_bytes Declared Content-Length, which must be zero.
+     */
     private function stage_directory_part(array $headers, int $part_bytes): void {
         $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-directory-path'], 'directory');
         if ($part_bytes !== 0 || $this->read_current_upload_body_piece() !== null) {
@@ -706,7 +866,16 @@ final class Site_Export_Staged_Apply_Session {
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0];
     }
 
-    /** @param array<string,string> $headers */
+    /**
+     * Accepts one symlink MIME part.
+     *
+     * Symlink parts carry their target in a base64 header and have an empty
+     * body. The staged value replaces any previous leaf at the same private path
+     * and rejects directory conflicts that would orphan already staged children.
+     *
+     * @param array<string,string> $headers Normalized headers for the part.
+     * @param int $part_bytes Declared Content-Length, which must be zero.
+     */
     private function stage_symlink_part(array $headers, int $part_bytes): void {
         $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-symlink-path', 'x-symlink-target'], 'symlink');
         if ($part_bytes !== 0 || $this->read_current_upload_body_piece() !== null) {
@@ -733,7 +902,17 @@ final class Site_Export_Staged_Apply_Session {
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0];
     }
 
-    /** @param array<string,string> $headers */
+    /**
+     * Accepts one segment of the raw NUL-delimited delete stream.
+     *
+     * The delete stream is append-only, but lost responses may cause callers to
+     * replay bytes already stored by the target. Overlapping bytes must match
+     * exactly; new bytes are validated record-by-record before they are flushed.
+     * A completion declaration records that no more delete bytes may be added.
+     *
+     * @param array<string,string> $headers Normalized headers for the part.
+     * @param int $part_bytes Declared Content-Length for this delete segment.
+     */
     private function stage_delete_list_part(array $headers, int $part_bytes): void {
         $this->require_only_headers($headers, ['content-length', 'content-type', 'x-chunk-type', 'x-delete-offset', 'x-delete-complete'], 'delete-list');
         $offset = $this->require_non_negative_header($headers, 'x-delete-offset');
@@ -749,7 +928,11 @@ final class Site_Export_Staged_Apply_Session {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not open the raw staged delete stream.');
         }
         try {
-            $stored_bytes = $this->file_size_from_handle($handle, 'staged delete stream');
+            $delete_stat = fstat($handle);
+            if (!is_array($delete_stat) || !isset($delete_stat['size'])) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not determine the actual size of staged delete stream.');
+            }
+            $stored_bytes = (int) $delete_stat['size'];
             if ($offset > $stored_bytes) {
                 throw new Site_Export_Staged_Apply_Exception(
                     self::ERROR_OFFSET_GAP,
@@ -757,7 +940,20 @@ final class Site_Export_Staged_Apply_Session {
                 );
             }
             $position = $offset;
-            $trailing_path = $this->read_delete_trailing_path($handle, $stored_bytes);
+            if ($stored_bytes === 0) {
+                $trailing_path = '';
+            } else {
+                $suffix_bytes = min($stored_bytes, self::MAX_PATH_BYTES + 1);
+                if (fseek($handle, $stored_bytes - $suffix_bytes) !== 0) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not inspect the staged delete-stream suffix.');
+                }
+                $suffix = $this->read_exact($handle, $suffix_bytes, 'staged delete-stream suffix');
+                $last_nul = strrpos($suffix, "\0");
+                $trailing_path = $last_nul === false ? $suffix : substr($suffix, $last_nul + 1);
+                if ($last_nul === false && $stored_bytes > self::MAX_PATH_BYTES) {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The incomplete staged delete path already exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
+                }
+            }
             while (true) {
                 $piece = $this->read_current_upload_body_piece();
                 if ($piece === null) {
@@ -781,7 +977,22 @@ final class Site_Export_Staged_Apply_Session {
                         throw new LogicException('Delete-list append did not begin at the actual stored size.');
                     }
                     $append = substr($piece, $piece_offset);
-                    $trailing_path = $this->validate_appended_delete_bytes($trailing_path, $append);
+                    $append_length = strlen($append);
+                    for ($index = 0; $index < $append_length; ++$index) {
+                        if ($append[$index] === "\0") {
+                            if ($trailing_path === '') {
+                                throw new InvalidArgumentException('Delete-list parts may not contain an empty deletion record.');
+                            }
+                            $this->validate_path($trailing_path);
+                            $this->assert_target_parent_same_filesystem($trailing_path);
+                            $trailing_path = '';
+                            continue;
+                        }
+                        $trailing_path .= $append[$index];
+                        if (strlen($trailing_path) > self::MAX_PATH_BYTES) {
+                            throw new InvalidArgumentException('Delete-list path exceeds the maximum of ' . self::MAX_PATH_BYTES . ' bytes.');
+                        }
+                    }
                     if (fseek($handle, 0, SEEK_END) !== 0) {
                         throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not seek to the staged delete stream end.');
                     }
@@ -800,61 +1011,72 @@ final class Site_Export_Staged_Apply_Session {
             fclose($handle);
         }
         if ($complete) {
-            $this->mark_delete_upload_complete();
+            $metadata = $this->read_json($this->session_metadata_path);
+            if (!is_array($metadata)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata is missing while completing the delete upload.');
+            }
+            $metadata['delete_upload_complete'] = true;
+            $this->write_json($this->session_metadata_path, $metadata);
         }
         $this->current_change = ['state' => $complete ? 'complete' : 'partial', 'type' => 'delete-list', 'accepted_bytes' => $stored_bytes];
     }
 
-    /** @return array<string,mixed> */
-    private function start_commit(): array {
-        if (!$this->delete_upload_is_complete()) {
-            throw new InvalidArgumentException('Commit requires an explicit completed delete upload declaration.');
-        }
-        $delete_bytes = $this->file_size($this->deletes_path);
-        if ($delete_bytes > 0) {
-            $handle = @fopen($this->deletes_path, 'rb');
-            if ($handle === false || fseek($handle, -1, SEEK_END) !== 0) {
-                if (is_resource($handle)) {
-                    fclose($handle);
-                }
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not inspect the final staged delete byte.');
-            }
-            $last_byte = fread($handle, 1);
-            fclose($handle);
-            if ($last_byte !== "\0") {
-                throw new InvalidArgumentException('A nonempty delete stream must end in NUL before commit; the final record is unterminated.');
-            }
-        }
-        if ($this->first_tree_entry($this->partial_dir) !== null) {
-            throw new InvalidArgumentException('Commit cannot begin while work/partial still contains an incomplete file.');
-        }
-        $state = [
-            'version' => 2,
-            'phase' => 'deleting',
-            'delete_offset' => 0,
-            'current_deletion_b64' => null,
-            'current_installation' => null,
-            'traversal_stack' => [],
-            'maintenance_token' => bin2hex(random_bytes(16)),
-            'deletions_applied' => 0,
-            'values_applied' => 0,
-        ];
-        $this->write_json($this->commit_path, $state);
-        return $state;
-    }
-
-    /** @param array<string,mixed> $state */
+    /**
+     * Performs one bounded deletion step from the durable commit checkpoint.
+     *
+     * The first call for a record copies the next NUL-delimited path from the
+     * raw delete stream into `current_deletion_b64`. A later call removes at
+     * most one leaf or empty directory beneath that root and advances the byte
+     * cursor only after the live path is confirmed absent.
+     *
+     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     */
     private function advance_deletion(array &$state): void {
         if ($state['current_deletion_b64'] === null) {
-            $record = $this->read_delete_record( (int) $state['delete_offset']);
-            if ($record === null) {
+            $delete_offset = (int) $state['delete_offset'];
+            $delete_size = $this->file_size($this->deletes_path);
+            if ($delete_offset === $delete_size) {
                 $state['phase'] = 'applying';
                 $this->write_json($this->commit_path, $state);
                 return;
             }
-            $state['current_deletion_b64'] = base64_encode($record['path']);
-            $this->write_json($this->commit_path, $state);
-            return;
+            if ($delete_offset < 0 || $delete_offset > $delete_size) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Delete-consumption offset ' . $delete_offset . ' is outside the ' . $delete_size . '-byte stream.');
+            }
+            $handle = @fopen($this->deletes_path, 'rb');
+            if ($handle === false || fseek($handle, $delete_offset) !== 0) {
+                if (is_resource($handle)) {
+                    fclose($handle);
+                }
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not seek to the confirmed delete-consumption offset.');
+            }
+            $path = '';
+            $path_bytes = 0;
+            try {
+                while ($path_bytes <= self::MAX_PATH_BYTES) {
+                    $byte = fread($handle, 1);
+                    if ($byte === false) {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read the staged delete stream.');
+                    }
+                    if ($byte === '') {
+                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged delete stream ended before its NUL record terminator.');
+                    }
+                    if ($byte === "\0") {
+                        if ($path === '') {
+                            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged delete stream contains an empty record at offset ' . $delete_offset . '.');
+                        }
+                        $this->validate_path($path);
+                        $state['current_deletion_b64'] = base64_encode($path);
+                        $this->write_json($this->commit_path, $state);
+                        return;
+                    }
+                    $path .= $byte;
+                    ++$path_bytes;
+                }
+            } finally {
+                fclose($handle);
+            }
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'A staged delete path exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
         }
 
         $path = $this->decode_commit_path($state['current_deletion_b64'], 'current deletion');
@@ -885,7 +1107,15 @@ final class Site_Export_Staged_Apply_Session {
     /**
      * Removes at most one leaf or empty directory below one planned root.
      *
-     * @param string $requested_path Delete root used in conflict responses.
+     * Directories are drained depth-first so each commit step is bounded and
+     * recoverable. The requested root is kept separate from the recursive
+     * relative path so drift responses can name both the user-requested delete
+     * and the nested path that actually conflicted.
+     *
+     * @param string $absolute_path Current live filesystem path to inspect.
+     * @param string $relative_path Target-relative path matching $absolute_path.
+     * @param string $requested_path Original delete root used in conflicts.
+     * @param int $parent_device Device id expected for the current entry.
      */
     private function delete_one_entry(string $absolute_path, string $relative_path, string $requested_path, int $parent_device): void {
         $identity = $this->path_identity($absolute_path);
@@ -915,7 +1145,16 @@ final class Site_Export_Staged_Apply_Session {
         $this->delete_one_entry($absolute_path . '/' . $entry, $child_relative, $requested_path, $identity['dev']);
     }
 
-    /** @param array<string,mixed> $state */
+    /**
+     * Performs one bounded installation or traversal step.
+     *
+     * The completed staging tree is its own queue. This method walks it
+     * depth-first, creating structural live directories before their children,
+     * installing one leaf value per step, and consuming empty structural staging
+     * directories after their descendants have been applied.
+     *
+     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     */
     private function advance_installation(array &$state): void {
         if ($state['current_installation'] !== null) {
             $this->resolve_current_installation($state);
@@ -959,7 +1198,18 @@ final class Site_Export_Staged_Apply_Session {
         $this->install_staged_value($state, $path, $identity['type'], false);
     }
 
-    /** @param array<string,mixed> $state */
+    /**
+     * Consumes one empty structural directory after its children were applied.
+     *
+     * Structural directories are not logical staged values by themselves; they
+     * exist so descendants can be reached in a depth-first traversal. Removing
+     * one is still checkpointed as current installation state so recovery can
+     * distinguish it from a leaf rename.
+     *
+     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     * @param string $path Target-relative structural directory path.
+     * @param string $staged_path Absolute path to the empty private directory.
+     */
     private function cleanup_structural_directory(array &$state, string $path, string $staged_path): void {
         $this->assert_live_ancestors($path, 'install', 'directory');
         $live = $this->path_identity($this->target_path($path));
@@ -977,6 +1227,17 @@ final class Site_Export_Staged_Apply_Session {
         $this->write_json($this->commit_path, $state);
     }
 
+    /**
+     * Ensures a live structural directory exists before descending into it.
+     *
+     * A directory with staged descendants may already exist, may need to be
+     * created, or may have drifted into an incompatible value. The requested
+     * leaf path is used in drift reports so users see which staged value forced
+     * the structural ancestor check.
+     *
+     * @param string $path Target-relative structural directory path.
+     * @param string $requested_path Staged descendant that required this parent.
+     */
     private function prepare_structural_directory(string $path, string $requested_path): void {
         $parent_device = $this->assert_live_ancestors($path, 'install', 'directory');
         $live_path = $this->target_path($path);
@@ -995,7 +1256,19 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    /** @param array<string,mixed> $state */
+    /**
+     * Renames one completed staged value into the live tree.
+     *
+     * Before rename, the checkpoint records the exact path and expected type so
+     * recovery can tell whether the staged value still needs installation or
+     * the live tree already contains the committed value. Only same-filesystem
+     * renames are allowed; copy fallback would break the direct-install model.
+     *
+     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     * @param string $path Target-relative value path.
+     * @param string $expected_type Staged type expected at $path.
+     * @param bool $recovering Whether current_installation is already durable.
+     */
     private function install_staged_value(array &$state, string $path, string $expected_type, bool $recovering): void {
         $staged_path = $this->private_path($this->files_dir, $path);
         $staged = $this->path_identity($staged_path);
@@ -1017,13 +1290,38 @@ final class Site_Export_Staged_Apply_Session {
             $state['current_installation'] = ['path_b64' => base64_encode($path), 'expected_type' => $expected_type];
             $this->write_json($this->commit_path, $state);
         }
-        $this->rename_into_live($staged_path, $live_path, $path, $staged['dev'], $parent_device);
+        error_clear_last();
+        if (!@rename($staged_path, $live_path)) {
+            $last_error = error_get_last();
+            $message = is_array($last_error) ? $last_error['message'] : '';
+            $observed_live = $this->path_identity($live_path);
+            if ($observed_live !== null && $observed_live['dev'] !== $staged['dev']) {
+                $this->throw_cross_device('install', $path, $staged['dev'], $observed_live['dev']);
+            }
+            if (stripos($message, 'cross-device') !== false || stripos($message, 'exdev') !== false) {
+                $this->throw_cross_device('install', $path, $staged['dev'], $parent_device);
+            }
+            throw new Site_Export_Staged_Apply_Exception(
+                self::ERROR_RETRYABLE_IO,
+                'Could not rename staged ' . base64_encode($path) . ' directly into the live tree'
+                . ( $message === '' ? '.' : ': ' . $message )
+            );
+        }
         $state['current_installation'] = null;
         ++$state['values_applied'];
         $this->write_json($this->commit_path, $state);
     }
 
-    /** @param array<string,mixed> $state */
+    /**
+     * Resolves a checkpointed installation after an interrupted commit call.
+     *
+     * The staged value may still be present, meaning the rename or structural
+     * cleanup must be retried, or it may already have been consumed and only
+     * the live tree needs to be verified. The method clears the checkpoint only
+     * after the expected live result is confirmed.
+     *
+     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     */
     private function resolve_current_installation(array &$state): void {
         $installation = $state['current_installation'];
         $path = $this->decode_commit_path($installation['path_b64'], 'current installation');
@@ -1076,7 +1374,16 @@ final class Site_Export_Staged_Apply_Session {
         $this->write_json($this->commit_path, $state);
     }
 
-    /** @param array<string,mixed> $state */
+    /**
+     * Marks commit complete after all delete and install queues are empty.
+     *
+     * Completion is written only after the delete cursor reaches the actual
+     * stream size, work/files has no remaining staged values, and the
+     * session-owned maintenance marker has been removed. Releasing the target
+     * after the complete checkpoint lets later sessions start.
+     *
+     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     */
     private function finish_commit(array &$state): void {
         if ($state['current_deletion_b64'] !== null || $state['current_installation'] !== null || $state['traversal_stack'] !== []) {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion with active bounded work state.');
@@ -1087,28 +1394,22 @@ final class Site_Export_Staged_Apply_Session {
         if ($this->first_directory_entry($this->files_dir) !== null) {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit reached completion while work/files still contains pending values.');
         }
-        $this->remove_owned_maintenance_marker($state);
+        $maintenance_live_path = $this->target_path('.maintenance');
+        $maintenance_identity = $this->path_identity($maintenance_live_path);
+        if ($maintenance_identity !== null) {
+            if (!$this->maintenance_marker_is_owned($maintenance_live_path, $state['maintenance_token'])) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'The session-owned maintenance marker was replaced by another owner.');
+            }
+            if (!@unlink($maintenance_live_path)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the session-owned WordPress maintenance marker.');
+            }
+        }
+        if ($this->path_identity($this->maintenance_identity_path) !== null && !@unlink($this->maintenance_identity_path)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the private maintenance ownership marker.');
+        }
         $state['phase'] = 'complete';
         $this->write_json($this->commit_path, $state);
         $this->release_target();
-    }
-
-    /** @param array<string,mixed> $state @return array<string,mixed> */
-    private function commit_result(array $state): array {
-        $complete = $state['phase'] === 'complete';
-        return [
-            'phase' => $state['phase'],
-            'send_next_request' => !$complete,
-        ];
-    }
-
-    /** @param array<string,mixed> $terminal_error */
-    private function throw_terminal_error(array $terminal_error): void {
-        throw new Site_Export_Staged_Apply_Exception(
-            $terminal_error['reason'],
-            $terminal_error['detail'],
-            $terminal_error['context']
-        );
     }
 
     /**
@@ -1152,7 +1453,16 @@ final class Site_Export_Staged_Apply_Session {
         return $device;
     }
 
-    /** Rejects separately mounted nearest live parents before maintenance starts. */
+    /**
+     * Rejects separately mounted nearest live parents before staging a value.
+     *
+     * Upload is allowed before maintenance mode, but it must not accept work
+     * that later cannot be renamed into place. This walks existing ancestors
+     * only until the first missing or non-directory parent because commit will
+     * perform the full live-drift validation under maintenance.
+     *
+     * @param string $path Target-relative path being staged.
+     */
     private function assert_target_parent_same_filesystem(string $path): void {
         $staging_device = $this->staging_device();
         $root = $this->path_identity($this->target_root);
@@ -1182,27 +1492,6 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    private function rename_into_live(string $staged_path, string $live_path, string $relative_path, int $staging_device, int $live_device): void {
-        error_clear_last();
-        if (@rename($staged_path, $live_path)) {
-            return;
-        }
-        $last_error = error_get_last();
-        $message = is_array($last_error) ? $last_error['message'] : '';
-        $observed_live = $this->path_identity($live_path);
-        if ($observed_live !== null && $observed_live['dev'] !== $staging_device) {
-            $this->throw_cross_device('install', $relative_path, $staging_device, $observed_live['dev']);
-        }
-        if (stripos($message, 'cross-device') !== false || stripos($message, 'exdev') !== false) {
-            $this->throw_cross_device('install', $relative_path, $staging_device, $live_device);
-        }
-        throw new Site_Export_Staged_Apply_Exception(
-            self::ERROR_RETRYABLE_IO,
-            'Could not rename staged ' . base64_encode($relative_path) . ' directly into the live tree'
-            . ( $message === '' ? '.' : ': ' . $message )
-        );
-    }
-
     /**
      * @param string[] $expected_live_types
      * @param array<string,mixed>|null $observed_identity
@@ -1230,6 +1519,19 @@ final class Site_Export_Staged_Apply_Session {
         throw new Site_Export_Staged_Apply_Exception(self::ERROR_LIVE_TREE_CHANGED, $detail, $context);
     }
 
+    /**
+     * Raises the terminal same-filesystem violation used by push commit.
+     *
+     * Staged apply intentionally has no copy fallback. Copying would turn a
+     * bounded rename step into an unbounded transfer and could leave partially
+     * copied live files after interruption, so any device mismatch becomes a
+     * classified terminal error.
+     *
+     * @param string $operation Stage, delete, or install operation being checked.
+     * @param string $path Target-relative path associated with the mismatch.
+     * @param int $staging_device Device id of the private staging filesystem.
+     * @param int $live_device Device id observed in the live tree.
+     */
     private function throw_cross_device(string $operation, string $path, int $staging_device, int $live_device): void {
         $detail = 'The staged value and live destination are on different filesystems. This push requires same-filesystem rename and has no copy fallback.';
         throw new Site_Export_Staged_Apply_Exception(self::ERROR_CROSS_DEVICE_FILESYSTEM, $detail, [
@@ -1241,6 +1543,19 @@ final class Site_Export_Staged_Apply_Session {
         ]);
     }
 
+    /**
+     * Verifies that two concrete paths are on the same device.
+     *
+     * This is used when creating or opening a session, where both paths must
+     * already exist and lstat() can supply device ids directly. Later per-path
+     * checks use the live ancestor walkers because the final destination may
+     * not exist yet.
+     *
+     * @param string $staging_path Existing private staging path.
+     * @param string $live_path Existing live-tree path.
+     * @param string $operation Operation name to report on failure.
+     * @param string $relative_path Target-relative path to report on failure.
+     */
     private function assert_same_filesystem(string $staging_path, string $live_path, string $operation, string $relative_path): void {
         $staging = $this->path_identity($staging_path);
         $live = $this->path_identity($live_path);
@@ -1252,6 +1567,15 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
+    /**
+     * Returns the device id of the completed staging tree root.
+     *
+     * All direct installs must remain on this device. Reading it from work/files
+     * rather than cached constructor state keeps recovery honest if the private
+     * workspace was moved or corrupted between requests.
+     *
+     * @return int Device id reported by lstat().
+     */
     private function staging_device(): int {
         $identity = $this->path_identity($this->files_dir);
         if ($identity === null || $identity['type'] !== 'directory') {
@@ -1260,88 +1584,18 @@ final class Site_Export_Staged_Apply_Session {
         return $identity['dev'];
     }
 
-    /** @return array<string,mixed>|null */
-    private function read_delete_record(int $offset): ?array {
-        $size = $this->file_size($this->deletes_path);
-        if ($offset === $size) {
-            return null;
-        }
-        if ($offset < 0 || $offset > $size) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Delete-consumption offset ' . $offset . ' is outside the ' . $size . '-byte stream.');
-        }
-        $handle = @fopen($this->deletes_path, 'rb');
-        if ($handle === false || fseek($handle, $offset) !== 0) {
-            if (is_resource($handle)) {
-                fclose($handle);
-            }
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not seek to the confirmed delete-consumption offset.');
-        }
-        $path = '';
-        $path_bytes = 0;
-        try {
-            while ($path_bytes <= self::MAX_PATH_BYTES) {
-                $byte = fread($handle, 1);
-                if ($byte === false) {
-                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not read the staged delete stream.');
-                }
-                if ($byte === '') {
-                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged delete stream ended before its NUL record terminator.');
-                }
-                if ($byte === "\0") {
-                    if ($path === '') {
-                        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The staged delete stream contains an empty record at offset ' . $offset . '.');
-                    }
-                    $this->validate_path($path);
-                    return ['path' => $path];
-                }
-                $path .= $byte;
-                ++$path_bytes;
-            }
-        } finally {
-            fclose($handle);
-        }
-        throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'A staged delete path exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
-    }
-
-    /** @param resource $handle */
-    private function read_delete_trailing_path($handle, int $stored_bytes): string {
-        if ($stored_bytes === 0) {
-            return '';
-        }
-        $suffix_bytes = min($stored_bytes, self::MAX_PATH_BYTES + 1);
-        if (fseek($handle, $stored_bytes - $suffix_bytes) !== 0) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not inspect the staged delete-stream suffix.');
-        }
-        $suffix = $this->read_exact($handle, $suffix_bytes, 'staged delete-stream suffix');
-        $last_nul = strrpos($suffix, "\0");
-        $trailing = $last_nul === false ? $suffix : substr($suffix, $last_nul + 1);
-        if ($last_nul === false && $stored_bytes > self::MAX_PATH_BYTES) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'The incomplete staged delete path already exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
-        }
-        return $trailing;
-    }
-
-    private function validate_appended_delete_bytes(string $trailing_path, string $bytes): string {
-        $length = strlen($bytes);
-        for ($index = 0; $index < $length; ++$index) {
-            if ($bytes[$index] === "\0") {
-                if ($trailing_path === '') {
-                    throw new InvalidArgumentException('Delete-list parts may not contain an empty deletion record.');
-                }
-                $this->validate_path($trailing_path);
-                $this->assert_target_parent_same_filesystem($trailing_path);
-                $trailing_path = '';
-                continue;
-            }
-            $trailing_path .= $bytes[$index];
-            if (strlen($trailing_path) > self::MAX_PATH_BYTES) {
-                throw new InvalidArgumentException('Delete-list path exceeds the maximum of ' . self::MAX_PATH_BYTES . ' bytes.');
-            }
-        }
-        return $trailing_path;
-    }
-
-    /** @param resource $handle */
+    /**
+     * Reads an exact number of bytes from a stream or reports a precise short read.
+     *
+     * Delete replay validation and suffix inspection rely on exact byte counts.
+     * Returning partial data would corrupt offset accounting, so short reads
+     * are classified as retryable I/O failures naming the observed length.
+     *
+     * @param resource $handle Open stream positioned at the first byte to read.
+     * @param int $bytes Number of bytes required.
+     * @param string $description Human-readable stream description for errors.
+     * @return string Bytes read from the stream.
+     */
     private function read_exact($handle, int $bytes, string $description): string {
         $result = '';
         $result_bytes = 0;
@@ -1356,7 +1610,16 @@ final class Site_Export_Staged_Apply_Session {
         return $result;
     }
 
-    /** @return string|null */
+    /**
+     * Returns the first child name in a directory without following children.
+     *
+     * The method is used only to distinguish empty directories from ones with
+     * descendants. It returns the raw directory entry name so callers can build
+     * their own private or live path without allocating a full listing.
+     *
+     * @param string $directory Absolute directory path.
+     * @return string|null First child name, or null when the directory is empty.
+     */
     private function first_directory_entry(string $directory): ?string {
         $handle = @opendir($directory);
         if ($handle === false) {
@@ -1378,7 +1641,16 @@ final class Site_Export_Staged_Apply_Session {
         return null;
     }
 
-    /** Returns a non-directory descendant, ignoring empty structural parents. */
+    /**
+     * Finds whether a tree contains any non-empty staged work.
+     *
+     * Empty directories can be structural traversal artifacts rather than
+     * logical values. This descends through such directories until it sees a
+     * leaf value or a directory with its own non-empty descendant.
+     *
+     * @param string $directory Absolute private directory path.
+     * @return string|null Entry name proving pending work exists, or null.
+     */
     private function first_tree_entry(string $directory): ?string {
         $handle = @opendir($directory);
         if ($handle === false) {
@@ -1408,7 +1680,17 @@ final class Site_Export_Staged_Apply_Session {
         return null;
     }
 
-    /** Returns one staged leaf so a structural-ancestor conflict names requested work. */
+    /**
+     * Returns a staged leaf path below a structural directory.
+     *
+     * When a live structural ancestor conflicts, reporting only the ancestor can
+     * hide which staged value required it. This walks to one descendant so the
+     * error can name requested work rather than only the traversal directory.
+     *
+     * @param string $directory Absolute staged directory being traversed.
+     * @param string $relative_path Target-relative path for that directory.
+     * @return string Target-relative descendant or the original path if empty.
+     */
     private function first_staged_leaf_path(string $directory, string $relative_path): string {
         $entry = $this->first_directory_entry($directory);
         if ($entry === null) {
@@ -1422,64 +1704,30 @@ final class Site_Export_Staged_Apply_Session {
         return $child_path;
     }
 
-    private function publish_or_refresh_maintenance_marker(array $state): void {
-        $token = $state['maintenance_token'];
-        $live_path = $this->target_path('.maintenance');
-        $identity = $this->path_identity($live_path);
-        if ($identity !== null && !$this->maintenance_marker_is_owned($live_path, $token)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'A foreign WordPress maintenance marker already exists. Retry after its owner removes it.');
-        }
-        $contents = $this->maintenance_marker_contents($token);
-        $this->write_atomic_file($this->maintenance_identity_path, $contents, 0600);
-        $this->write_atomic_file($live_path, $contents, 0644);
-    }
-
-    private function maintenance_marker_contents(string $token): string {
-        return "<?php\n"
-            . "\$reprint_staged_apply_request = (isset(\$_GET['reprint-api']) || isset(\$_GET['site-export-api']))\n"
-            . "    && isset(\$_GET['endpoint']) && is_string(\$_GET['endpoint'])\n"
-            . "    && strpos(\$_GET['endpoint'], 'staged_session_') === 0;\n"
-            . "if (!\$reprint_staged_apply_request) {\n"
-            . "    \$upgrading = " . time() . ";\n"
-            . "}\n"
-            . "unset(\$reprint_staged_apply_request);\n"
-            . "// reprint-staged-session:" . $this->session_id . ':' . $token . "\n";
-    }
-
+    /**
+     * Checks whether a live .maintenance file belongs to this commit token.
+     *
+     * The marker may be a normal WordPress maintenance file created by another
+     * process. Only files containing this session's ownership comment are safe
+     * to refresh or remove; foreign markers keep the target busy.
+     *
+     * @param string $path Absolute live .maintenance path.
+     * @param string $token Commit checkpoint's maintenance token.
+     * @return bool Whether the marker contains this session's ownership line.
+     */
     private function maintenance_marker_is_owned(string $path, string $token): bool {
         $contents = @file_get_contents($path, false, null, 0, 512);
         return is_string($contents)
             && strpos($contents, '// reprint-staged-session:' . $this->session_id . ':' . $token . "\n") !== false;
     }
 
-    /** Marker removal remains retryable and precedes the complete checkpoint. */
-    private function remove_owned_maintenance_marker(array $state): void {
-        $live_path = $this->target_path('.maintenance');
-        $identity = $this->path_identity($live_path);
-        if ($identity !== null) {
-            if (!$this->maintenance_marker_is_owned($live_path, $state['maintenance_token'])) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'The session-owned maintenance marker was replaced by another owner.');
-            }
-            if (!@unlink($live_path)) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the session-owned WordPress maintenance marker.');
-            }
-        }
-        if ($this->path_identity($this->maintenance_identity_path) !== null && !@unlink($this->maintenance_identity_path)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not remove the private maintenance ownership marker.');
-        }
-    }
-
-    private function claim_target(): void {
-        $this->with_target_lock(function (): void {
-            $active_path = $this->storage_dir . '/apply-sessions/target.active';
-            $active = @file_get_contents($active_path);
-            if (is_string($active) && trim($active) !== '' && trim($active) !== $this->session_id) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Another staged apply session is already committing this target: ' . trim($active) . '.');
-            }
-            $this->write_atomic_file($active_path, $this->session_id . "\n", 0600);
-        });
-    }
-
+    /**
+     * Releases this session's target-wide commit claim if it still owns it.
+     *
+     * The active marker is advisory state protected by the target lock. Missing
+     * or foreign contents are left untouched so cleanup cannot erase another
+     * session's claim after an operator or retry changed target ownership.
+     */
     private function release_target(): void {
         $this->with_target_lock(function (): void {
             $active_path = $this->storage_dir . '/apply-sessions/target.active';
@@ -1493,6 +1741,16 @@ final class Site_Export_Staged_Apply_Session {
         });
     }
 
+    /**
+     * Runs a callback while holding the target-wide coordinator lock.
+     *
+     * This lock serializes the small `target.active` file shared by all apply
+     * sessions for one storage directory. It is intentionally separate from a
+     * session lock so a committing session can block other committers without
+     * blocking their upload/status cleanup paths.
+     *
+     * @param callable $callback Critical section to execute while locked.
+     */
     private function with_target_lock(callable $callback): void {
         $lock = @fopen($this->storage_dir . '/apply-sessions/target.lock', 'c+b');
         if ($lock === false) {
@@ -1560,7 +1818,24 @@ final class Site_Export_Staged_Apply_Session {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_BUSY, 'Staged apply session ' . $this->session_id . ' is busy. Retry the request.');
         }
         try {
-            $this->assert_workspace_layout();
+            foreach ([$this->session_dir, $this->work_dir, $this->files_dir, $this->partial_dir] as $directory) {
+                $identity = $this->path_identity($directory);
+                if ($identity === null || $identity['type'] !== 'directory') {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Required staged apply directory is missing or not real: ' . $directory . '.');
+                }
+            }
+            foreach ([$this->session_metadata_path, $this->lock_path, $this->deletes_path] as $file) {
+                $identity = $this->path_identity($file);
+                if ($identity === null || $identity['type'] !== 'file') {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Required staged apply file is missing or not regular: ' . $file . '.');
+                }
+            }
+            foreach ([$this->commit_path, $this->maintenance_identity_path] as $optional_file) {
+                $identity = $this->path_identity($optional_file);
+                if ($identity !== null && $identity['type'] !== 'file') {
+                    throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Optional staged apply file has an unsupported type: ' . $optional_file . '.');
+                }
+            }
         } catch (Throwable $exception) {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -1578,11 +1853,36 @@ final class Site_Export_Staged_Apply_Session {
      * retain the same-filesystem guarantee under which the session was made.
      */
     private function assert_session_configuration(): void {
-        $this->read_session_metadata();
+        $metadata = $this->read_json($this->session_metadata_path);
+        if (!is_array($metadata) || ( $metadata['version'] ?? null ) !== 2 || ( $metadata['session_id'] ?? null ) !== $this->session_id
+            || !is_bool($metadata['delete_upload_complete'] ?? null)) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata has an unsupported version or session identity.');
+        }
+        $target = base64_decode( (string) ( $metadata['target_root_b64'] ?? '' ), true);
+        $protected = [];
+        foreach (( $metadata['protected_paths_b64'] ?? [] ) as $encoded) {
+            $decoded = is_string($encoded) ? base64_decode($encoded, true) : false;
+            if (!is_string($decoded)) {
+                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata contains an invalid protected path.');
+            }
+            $protected[] = $decoded;
+        }
+        if ($target !== $this->target_root || $protected !== $this->protected_paths) {
+            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata does not match the current apply configuration.');
+        }
         $this->assert_same_filesystem($this->files_dir, $this->target_root, 'stage', '');
     }
 
-    /** @return array<string,mixed>|null */
+    /**
+     * Reads a bounded JSON object from private session metadata.
+     *
+     * Missing files return null so callers can distinguish optional checkpoints
+     * from malformed ones. Existing files must be regular, within the metadata
+     * size ceiling, and decode to a JSON object.
+     *
+     * @param string $path Absolute metadata file path.
+     * @return array<string,mixed>|null Decoded object, or null if absent.
+     */
     private function read_json(string $path): ?array {
         $identity = $this->path_identity($path);
         if ($identity === null) {
@@ -1602,7 +1902,16 @@ final class Site_Export_Staged_Apply_Session {
         return $decoded;
     }
 
-    /** @param array<string,mixed> $value */
+    /**
+     * Atomically writes one bounded JSON metadata object.
+     *
+     * JSON is encoded without slash escaping because metadata contains many
+     * filesystem paths already protected by base64 where necessary. The encoded
+     * object must fit the same ceiling enforced by read_json().
+     *
+     * @param string $path Absolute metadata file path.
+     * @param array<string,mixed> $value JSON object to persist.
+     */
     private function write_json(string $path, array $value): void {
         $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
         if (!is_string($contents)) {
@@ -1614,6 +1923,17 @@ final class Site_Export_Staged_Apply_Session {
         $this->write_atomic_file($path, $contents, 0600);
     }
 
+    /**
+     * Writes a private file through a session-specific temporary path and rename.
+     *
+     * The temporary name includes the session id so concurrent sessions updating
+     * shared coordinator files do not collide before the target lock serializes
+     * the final rename. Permissions are applied before publication.
+     *
+     * @param string $path Absolute destination path.
+     * @param string $contents Complete file contents to write.
+     * @param int $permissions File mode applied to the temporary file.
+     */
     private function write_atomic_file(string $path, string $contents, int $permissions): void {
         $temporary = $path . '.tmp-' . $this->session_id;
         if ($this->path_identity($temporary) !== null && !@unlink($temporary)) {
@@ -1638,7 +1958,17 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    /** @param resource $handle */
+    /**
+     * Writes every byte of a string to an already opened stream.
+     *
+     * fwrite() may accept only part of a string. This loops until all bytes are
+     * written and reports the exact completed count if the stream stops making
+     * progress, preventing silent truncation of staged payloads or metadata.
+     *
+     * @param resource $handle Writable stream.
+     * @param string $contents Bytes to write.
+     * @param string $description Human-readable destination for errors.
+     */
     private function write_all($handle, string $contents, string $description): void {
         $offset = 0;
         $length = strlen($contents);
@@ -1651,7 +1981,15 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    /** @param array<string,mixed> $state */
+    /**
+     * Validates the durable commit checkpoint schema before it drives mutation.
+     *
+     * Every field that controls delete offsets, traversal, maintenance
+     * ownership, or pending installation is checked before use. This keeps a
+     * corrupt checkpoint from being interpreted as live-tree authority.
+     *
+     * @param array<string,mixed> $state Decoded commit checkpoint.
+     */
     private function require_valid_commit_state(array $state): void {
         if (( $state['version'] ?? null ) !== 2) {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit checkpoint has an unsupported version.');
@@ -1696,6 +2034,17 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
+    /**
+     * Decodes and validates a base64 path stored in a commit checkpoint.
+     *
+     * Checkpoints store arbitrary filesystem bytes as base64 to remain valid
+     * JSON. This method rejects missing, malformed, or unsafe paths before they
+     * are used to select live filesystem work.
+     *
+     * @param mixed $encoded Candidate base64 value from metadata.
+     * @param string $description Field name used in error messages.
+     * @return string Decoded target-relative path.
+     */
     private function decode_commit_path($encoded, string $description): string {
         if (!is_string($encoded)) {
             throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Commit ' . $description . ' path is not base64 text.');
@@ -1708,7 +2057,16 @@ final class Site_Export_Staged_Apply_Session {
         return $path;
     }
 
-    /** @param array<int,array<string,mixed>> $stack */
+    /**
+     * Reconstructs the target-relative traversal path from checkpoint frames.
+     *
+     * Each frame stores exactly one base64 path component. The method validates
+     * each component independently, rebuilds the slash-separated path, and then
+     * applies the normal target-relative path rules to the result.
+     *
+     * @param array<int,array<string,mixed>> $stack Traversal frames.
+     * @return string Target-relative path for the current traversal directory.
+     */
     private function traversal_path(array $stack): string {
         $path = '';
         foreach ($stack as $frame) {
@@ -1728,47 +2086,15 @@ final class Site_Export_Staged_Apply_Session {
         return $path;
     }
 
-    private function assert_workspace_layout(): void {
-        foreach ([$this->session_dir, $this->work_dir, $this->files_dir, $this->partial_dir] as $directory) {
-            $identity = $this->path_identity($directory);
-            if ($identity === null || $identity['type'] !== 'directory') {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Required staged apply directory is missing or not real: ' . $directory . '.');
-            }
-        }
-        foreach ([$this->session_metadata_path, $this->lock_path, $this->deletes_path] as $file) {
-            $identity = $this->path_identity($file);
-            if ($identity === null || $identity['type'] !== 'file') {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Required staged apply file is missing or not regular: ' . $file . '.');
-            }
-        }
-        foreach ([$this->commit_path, $this->maintenance_identity_path] as $optional_file) {
-            $identity = $this->path_identity($optional_file);
-            if ($identity !== null && $identity['type'] !== 'file') {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Optional staged apply file has an unsupported type: ' . $optional_file . '.');
-            }
-        }
-    }
-
-    private function read_session_metadata(): void {
-        $metadata = $this->read_json($this->session_metadata_path);
-        if (!is_array($metadata) || ( $metadata['version'] ?? null ) !== 2 || ( $metadata['session_id'] ?? null ) !== $this->session_id
-            || !is_bool($metadata['delete_upload_complete'] ?? null)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata has an unsupported version or session identity.');
-        }
-        $target = base64_decode( (string) ( $metadata['target_root_b64'] ?? '' ), true);
-        $protected = [];
-        foreach (( $metadata['protected_paths_b64'] ?? [] ) as $encoded) {
-            $decoded = is_string($encoded) ? base64_decode($encoded, true) : false;
-            if (!is_string($decoded)) {
-                throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata contains an invalid protected path.');
-            }
-            $protected[] = $decoded;
-        }
-        if ($target !== $this->target_root || $protected !== $this->protected_paths) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata does not match the current apply configuration.');
-        }
-    }
-
+    /**
+     * Reads whether the sender explicitly closed the delete stream.
+     *
+     * A zero-byte or currently stored delete stream is not enough to commit:
+     * the sender must declare completion so the target knows no later request
+     * will append more deletion records.
+     *
+     * @return bool True once a delete-list part declared completion.
+     */
     private function delete_upload_is_complete(): bool {
         $metadata = $this->read_json($this->session_metadata_path);
         if (!is_array($metadata) || !is_bool($metadata['delete_upload_complete'] ?? null)) {
@@ -1777,15 +2103,16 @@ final class Site_Export_Staged_Apply_Session {
         return $metadata['delete_upload_complete'];
     }
 
-    private function mark_delete_upload_complete(): void {
-        $metadata = $this->read_json($this->session_metadata_path);
-        if (!is_array($metadata)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_INVALID_STATE, 'Session metadata is missing while completing the delete upload.');
-        }
-        $metadata['delete_upload_complete'] = true;
-        $this->write_json($this->session_metadata_path, $metadata);
-    }
-
+    /**
+     * Validates one target-relative path accepted by staged apply.
+     *
+     * Paths are byte strings carried through base64 on the wire. They must be
+     * relative, bounded, free of NUL/backslash and dot segments, outside the
+     * WordPress maintenance marker, and not equal to or an ancestor/descendant
+     * of a protected path.
+     *
+     * @param string $path Target-relative raw path bytes.
+     */
     private function validate_path(string $path): void {
         if ($path === '' || strlen($path) > self::MAX_PATH_BYTES || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
             throw new InvalidArgumentException('Target-relative path must contain between 1 and ' . self::MAX_PATH_BYTES . ' safe bytes; observed ' . base64_encode($path) . '.');
@@ -1805,7 +2132,19 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    /** @param array<string,string> $headers */
+    /**
+     * Decodes a base64 path header from one multipart part.
+     *
+     * Target paths are validated immediately because they select private and
+     * live filesystem locations. Symlink target values can be arbitrary relative
+     * strings, so callers can disable target-path validation and apply their
+     * own symlink-target rules instead.
+     *
+     * @param array<string,string> $headers Normalized part headers.
+     * @param string $header Header name to read.
+     * @param bool $is_target_path Whether to apply target path validation.
+     * @return string Decoded header bytes.
+     */
     private function decode_path_header(array $headers, string $header, bool $is_target_path = true): string {
         $encoded = $headers[$header] ?? null;
         if (!is_string($encoded) || $encoded === '') {
@@ -1821,7 +2160,17 @@ final class Site_Export_Staged_Apply_Session {
         return $decoded;
     }
 
-    /** @param array<string,string> $headers @param string[] $allowed */
+    /**
+     * Rejects unexpected headers for a multipart part type.
+     *
+     * The staged apply protocol is deliberately narrow. Extra headers are not
+     * ignored because a misspelled required header or a future unsupported
+     * option should fail at the boundary instead of silently changing meaning.
+     *
+     * @param array<string,string> $headers Normalized headers to inspect.
+     * @param string[] $allowed Lowercase header names allowed for this part.
+     * @param string $type Human-readable part type for errors.
+     */
     private function require_only_headers(array $headers, array $allowed, string $type): void {
         foreach ($headers as $name => $value) {
             if (!in_array($name, $allowed, true)) {
@@ -1830,7 +2179,17 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    /** @param array<string,string> $headers */
+    /**
+     * Reads a non-negative decimal integer header.
+     *
+     * Header values arrive as strings. This validates the decimal grammar and
+     * rejects values that overflow PHP's integer range rather than silently
+     * wrapping offsets, sizes, or Content-Length values.
+     *
+     * @param array<string,string> $headers Normalized headers to inspect.
+     * @param string $header Header name to read.
+     * @return int Parsed non-negative integer.
+     */
     private function require_non_negative_header(array $headers, string $header): int {
         $value = $headers[$header] ?? null;
         if (!is_string($value) || $value === '' || preg_match('/^[0-9]+$/D', $value) !== 1) {
@@ -1843,15 +2202,46 @@ final class Site_Export_Staged_Apply_Session {
         return $integer;
     }
 
+    /**
+     * Joins the managed live root with one validated relative path.
+     *
+     * The caller is responsible for validate_path() where the value originates.
+     * This method only preserves correct slash handling for both `/` and normal
+     * directory roots.
+     *
+     * @param string $relative_path Target-relative path.
+     * @return string Absolute path in the live tree.
+     */
     private function target_path(string $relative_path): string {
         return $this->target_root . ( $this->target_root === '/' ? '' : '/' ) . $relative_path;
     }
 
+    /**
+     * Joins a private staging root with one validated relative path.
+     *
+     * Private roots are always ordinary directories below the session workspace,
+     * so slash handling is simpler than target_path(). The caller still owns
+     * validation of the relative path and parent containment checks.
+     *
+     * @param string $root Absolute private root path.
+     * @param string $relative_path Target-relative path.
+     * @return string Absolute private staging path.
+     */
     private function private_path(string $root, string $relative_path): string {
         return $root . '/' . $relative_path;
     }
 
-    /** Creates missing private structural parents and rejects links or files. */
+    /**
+     * Creates or validates private structural parents for a staged path.
+     *
+     * Only work/files and work/partial paths are accepted. Missing parents are
+     * created when requested; existing parents must be real directories so a
+     * staged leaf, link, or external path cannot become a container for another
+     * value.
+     *
+     * @param string $path Absolute private path whose parent is required.
+     * @param bool $create_missing Whether absent parent directories are created.
+     */
     private function ensure_private_parent(string $path, bool $create_missing = true): void {
         $parent = dirname($path);
         $root = null;
@@ -1887,7 +2277,16 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    /** @return array<string,mixed>|null */
+    /**
+     * Returns the lstat identity of one filesystem path.
+     *
+     * lstat() is used deliberately so symlinks are classified as symlinks
+     * rather than followed. The returned shape is the only filesystem identity
+     * copied into drift reports and status responses.
+     *
+     * @param string $path Absolute path to inspect.
+     * @return array<string,mixed>|null Type, device, inode, size, and ctime, or null if absent.
+     */
     private function path_identity(string $path): ?array {
         clearstatcache(true, $path);
         $stat = @lstat($path);
@@ -1913,6 +2312,15 @@ final class Site_Export_Staged_Apply_Session {
         ];
     }
 
+    /**
+     * Removes one staged private leaf or empty directory.
+     *
+     * A directory with descendants represents structural state for other staged
+     * paths and cannot be replaced by a different logical value. Files,
+     * symlinks, and other leaf-like entries are unlinked without following them.
+     *
+     * @param string $path Absolute private staging path.
+     */
     private function remove_private_entry(string $path): void {
         $identity = $this->path_identity($path);
         if ($identity === null) {
@@ -1932,12 +2340,16 @@ final class Site_Export_Staged_Apply_Session {
         }
     }
 
-    private function rename_private(string $source, string $destination, string $description): void {
-        if (!@rename($source, $destination)) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not ' . $description . '.');
-        }
-    }
-
+    /**
+     * Returns the current size of a required regular file.
+     *
+     * The size is read through path_identity() so the path is lstat() checked
+     * and symlinks are not followed. Missing files or non-files indicate corrupt
+     * staged apply state.
+     *
+     * @param string $path Absolute file path.
+     * @return int Current byte size.
+     */
     private function file_size(string $path): int {
         $identity = $this->path_identity($path);
         if ($identity === null || $identity['type'] !== 'file') {
@@ -1946,15 +2358,17 @@ final class Site_Export_Staged_Apply_Session {
         return $identity['size'];
     }
 
-    /** @param resource $handle */
-    private function file_size_from_handle($handle, string $description): int {
-        $stat = fstat($handle);
-        if (!is_array($stat) || !isset($stat['size'])) {
-            throw new Site_Export_Staged_Apply_Exception(self::ERROR_RETRYABLE_IO, 'Could not determine the actual size of ' . $description . '.');
-        }
-        return (int) $stat['size'];
-    }
-
+    /**
+     * Advances bounded cleanup of a renamed discard tombstone.
+     *
+     * Discard first renames a session so it is no longer addressable by its
+     * public id. This method then removes at most DISCARD_ENTRY_LIMIT entries
+     * while holding the tombstone's own lock, preserving that lock until the
+     * final empty-directory removal.
+     *
+     * @param string $tombstone Absolute tombstone directory path.
+     * @return bool True when the tombstone is gone, false when work remains.
+     */
     private function discard_tombstone(string $tombstone): bool {
         if (!is_dir($tombstone)) {
             return true;
@@ -1989,6 +2403,11 @@ final class Site_Export_Staged_Apply_Session {
      * Newly created session storage uses mode 0700 deliberately. PHP's default
      * 0777 mode, even after a typical umask, can expose staged site contents to
      * other system accounts. Existing configured directories keep their mode.
+     *
+     * @param string $path Absolute directory path from configuration.
+     * @param string $description Human-readable name for validation errors.
+     * @param bool $create Whether the directory may be created if missing.
+     * @return string Canonical absolute directory path without trailing slash.
      */
     private static function require_directory(string $path, string $description, bool $create): string {
         if ($path === '' || $path[0] !== '/') {
@@ -2004,45 +2423,33 @@ final class Site_Export_Staged_Apply_Session {
         return $real_path === '/' ? '/' : rtrim($real_path, '/');
     }
 
-    /** @param string[] $protected_paths @return string[] */
-    private static function protect_session_storage(string $storage_dir, string $target_root, array $protected_paths): array {
-        if ($storage_dir === $target_root) {
-            throw new InvalidArgumentException('Staged apply session storage must not be the apply target root itself.');
-        }
-        $target_prefix = $target_root === '/' ? '/' : $target_root . '/';
-        if (strpos($storage_dir . '/', $target_prefix) === 0) {
-            $relative_storage = ltrim(substr($storage_dir, strlen($target_root)), '/');
-            if ($relative_storage !== '') {
-                $protected_paths[] = $relative_storage;
-            }
-        }
-        return $protected_paths;
-    }
-
+    /**
+     * Validates the public session id grammar.
+     *
+     * Session ids are used in URLs, directory names, lock files, and ownership
+     * comments. Restricting them to lowercase hexadecimal keeps those contexts
+     * unambiguous and avoids any path normalization concerns.
+     *
+     * @param string $session_id Caller-provided session id.
+     */
     private static function require_session_id(string $session_id): void {
         if (preg_match('/^[a-f0-9]{32}$/D', $session_id) !== 1) {
             throw new InvalidArgumentException('Staged apply session id must be a 32-character lowercase hexadecimal string.');
         }
     }
 
-    /** @param string[] $protected_paths @return string[] */
-    private static function normalize_protected_paths(array $protected_paths): array {
-        $normalized = [];
-        foreach ($protected_paths as $path) {
-            if (!is_string($path) || $path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
-                throw new InvalidArgumentException('Each protected staged apply path must be a non-empty safe relative path.');
-            }
-            foreach (explode('/', $path) as $segment) {
-                if ($segment === '' || $segment === '.' || $segment === '..') {
-                    throw new InvalidArgumentException('Protected staged apply path is unsafe: ' . base64_encode($path) . '.');
-                }
-            }
-            $normalized[] = $path;
-        }
-        sort($normalized, SORT_STRING);
-        return array_values(array_unique($normalized));
-    }
-
+    /**
+     * Removes a bounded number of entries from a discard directory tree.
+     *
+     * The counter is shared through recursive calls so one discard request has a
+     * hard work limit no matter how deeply nested the tombstone is. The top
+     * level may preserve its lock file until all other entries are gone.
+     *
+     * @param string $directory_path Absolute directory currently being drained.
+     * @param int $remaining_entries Remaining unlink/rmdir operations allowed.
+     * @param bool $preserve_lock Whether to keep a child named `lock`.
+     * @return bool True when this directory is empty enough to remove.
+     */
     private static function discard_directory_entries(string $directory_path, int &$remaining_entries, bool $preserve_lock = false): bool {
         $handle = @opendir($directory_path);
         if ($handle === false) {
@@ -2088,6 +2495,15 @@ final class Site_Export_Staged_Apply_Session {
         return true;
     }
 
+    /**
+     * Recursively removes a newly created private tree after setup failure.
+     *
+     * This is used only before a session becomes usable, when cleanup should be
+     * immediate rather than bounded by discard semantics. It uses lstat() and
+     * unlink/rmdir so symlinks are removed as links and never traversed.
+     *
+     * @param string $path Absolute private path to remove if it exists.
+     */
     private static function remove_tree(string $path): void {
         clearstatcache(true, $path);
         $stat = @lstat($path);

--- a/packages/reprint-exporter/src/class-staged-apply-session.php
+++ b/packages/reprint-exporter/src/class-staged-apply-session.php
@@ -83,8 +83,8 @@ final class Site_Export_Staged_Apply_Session {
      * unique, and storage below the managed root protects itself from push.
      * No filesystem state is read or changed here.
      *
-     * @param string[] $protected_paths Target-relative paths which push must
-     *                                  never stage, delete, or replace.
+     * @param list<string> $protected_paths Target-relative paths which push
+     *                                      must never stage, delete, or replace.
      */
     private function __construct(string $storage_dir, string $target_root, string $session_id, array $protected_paths) {
         $this->storage_dir = rtrim($storage_dir, '/');
@@ -142,7 +142,7 @@ final class Site_Export_Staged_Apply_Session {
      *
      * @param string $storage_dir Durable private storage on the target filesystem.
      * @param string $target_root Managed live directory receiving committed values.
-     * @param string[] $protected_paths Target-relative paths which push must preserve.
+     * @param list<string> $protected_paths Target-relative paths which push must preserve.
      * @param string $session_id Stable lowercase hexadecimal session identity.
      * @return self New or existing session handle.
      */
@@ -208,7 +208,7 @@ final class Site_Export_Staged_Apply_Session {
      * @param string $storage_dir Durable private session storage.
      * @param string $target_root Managed live directory.
      * @param string $session_id Lowercase hexadecimal session identity.
-     * @param string[] $protected_paths Target-relative paths which push must preserve.
+     * @param list<string> $protected_paths Target-relative paths which push must preserve.
      * @return self Session handle; the session may prove missing or invalid
      *              when its first operation acquires the lock.
      */
@@ -230,7 +230,7 @@ final class Site_Export_Staged_Apply_Session {
      * @param string $storage_dir Durable private session storage.
      * @param string $target_root Currently configured managed live directory.
      * @param string $session_id Lowercase hexadecimal session identity.
-     * @param string[] $protected_paths Currently configured protected paths.
+     * @param list<string> $protected_paths Currently configured protected paths.
      * @return bool True when the workspace and any discard tombstone are gone.
      */
     public static function discard(string $storage_dir, string $target_root, string $session_id, array $protected_paths): bool {
@@ -425,9 +425,9 @@ final class Site_Export_Staged_Apply_Session {
      * next_change() again clears the previous value before processing, and
      * finish_upload() clears it when the request closes.
      *
-     * @return array<string,mixed>|null Accepted type, state, byte cursor, and
-     *                                  path when applicable, or null when no
-     *                                  result is current.
+     * @return array{state:string,type:string,accepted_bytes:int,path_b64?:string}|null
+     *     Accepted type, state, byte cursor, and path when applicable, or null
+     *     when no result is current.
      */
     public function get_current_change(): ?array {
         return $this->current_change;
@@ -458,7 +458,13 @@ final class Site_Export_Staged_Apply_Session {
      * the session lock.
      *
      * @param string|null $path Raw target-relative path byte string to inspect.
-     * @return array<string,mixed> Target-confirmed session and path progress.
+     * @return array{
+     *     session_id:string,
+     *     phase:string,
+     *     delete_bytes:int,
+     *     delete_upload_complete:bool,
+     *     path:array{path_b64:string,state:string,accepted_bytes:int,type?:string}|null
+     * } Target-confirmed session and optional path progress.
      *
      * @throws InvalidArgumentException If the requested path is unsafe.
      * @throws Site_Export_Staged_Apply_Exception If the session is busy,
@@ -519,7 +525,7 @@ final class Site_Export_Staged_Apply_Session {
      * every staged file is complete. The first call creates a durable checkpoint
      * and claims the target so no other session can mutate the same live tree.
      * Subsequent calls resume from that checkpoint, refresh the WordPress
-     * maintenance marker, and perform at most $maximum_steps units of delete or
+     * maintenance marker, and perform at most $maximum_entries units of delete or
      * install work before returning.
      *
      * Live-tree drift and cross-device destinations are terminal for the
@@ -527,14 +533,16 @@ final class Site_Export_Staged_Apply_Session {
      * later calls. Retryable I/O failures are not terminal, so a later call can
      * retry the same bounded step from the durable state.
      *
-     * @param int $maximum_steps Maximum delete/install steps to attempt.
-     * @return array<string,mixed> Current phase and whether another request is needed.
+     * @param int $maximum_entries Maximum bounded commit entries to process in this call.
+     * @return array{phase:string,send_next_request:bool,entries_processed:int}
+     *     Current phase, whether another request is needed, and entries
+     *     processed by this call.
      */
-    public function commit(int $maximum_steps = 1): array {
-        if ($maximum_steps <= 0) {
-            throw new InvalidArgumentException('The staged apply commit step limit must be greater than zero.');
+    public function commit(int $maximum_entries = 1): array {
+        if ($maximum_entries <= 0) {
+            throw new InvalidArgumentException('The staged apply commit entry limit must be greater than zero.');
         }
-        return $this->with_session_lock(function () use ($maximum_steps): array {
+        return $this->with_session_lock(function () use ($maximum_entries): array {
             $state = $this->read_json($this->commit_path);
             if ($state === null) {
                 if (!$this->delete_upload_is_complete()) {
@@ -584,6 +592,7 @@ final class Site_Export_Staged_Apply_Session {
                 return [
                     'phase' => $state['phase'],
                     'send_next_request' => false,
+                    'entries_processed' => 0,
                 ];
             }
             $this->with_target_lock(function (): void {
@@ -612,7 +621,7 @@ final class Site_Export_Staged_Apply_Session {
             $this->write_atomic_file($this->maintenance_identity_path, $maintenance_contents, 0600);
             $this->write_atomic_file($maintenance_live_path, $maintenance_contents, 0644);
             try {
-                for ($step = 0; $step < $maximum_steps && $state['phase'] !== 'complete'; ++$step) {
+                for ($entries_processed = 0; $entries_processed < $maximum_entries && $state['phase'] !== 'complete'; ++$entries_processed) {
                     if ($state['phase'] === 'deleting') {
                         $this->advance_deletion($state);
                     } else {
@@ -633,6 +642,7 @@ final class Site_Export_Staged_Apply_Session {
             return [
                 'phase' => $state['phase'],
                 'send_next_request' => $state['phase'] !== 'complete',
+                'entries_processed' => $entries_processed,
             ];
         });
     }
@@ -745,7 +755,8 @@ final class Site_Export_Staged_Apply_Session {
      * and promotes the file atomically inside private storage only when the
      * declared total size has been reached.
      *
-     * @param array<string,string> $headers Normalized headers for the part.
+     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-file-path:string,x-file-size:string,x-chunk-offset:string} $headers
+     *     Normalized file part headers.
      * @param int $part_bytes Declared Content-Length for this file chunk.
      */
     private function stage_file_part(array $headers, int $part_bytes): void {
@@ -836,7 +847,8 @@ final class Site_Export_Staged_Apply_Session {
      * descendants because a single staged path cannot be both a leaf value and a
      * structural parent.
      *
-     * @param array<string,string> $headers Normalized headers for the part.
+     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-directory-path:string} $headers
+     *     Normalized directory part headers.
      * @param int $part_bytes Declared Content-Length, which must be zero.
      */
     private function stage_directory_part(array $headers, int $part_bytes): void {
@@ -867,7 +879,8 @@ final class Site_Export_Staged_Apply_Session {
      * body. The staged value replaces any previous leaf at the same private path
      * and rejects directory conflicts that would orphan already staged children.
      *
-     * @param array<string,string> $headers Normalized headers for the part.
+     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-symlink-path:string,x-symlink-target:string} $headers
+     *     Normalized symlink part headers.
      * @param int $part_bytes Declared Content-Length, which must be zero.
      */
     private function stage_symlink_part(array $headers, int $part_bytes): void {
@@ -903,7 +916,8 @@ final class Site_Export_Staged_Apply_Session {
      * exactly; new bytes are validated record-by-record before they are flushed.
      * A completion declaration records that no more delete bytes may be added.
      *
-     * @param array<string,string> $headers Normalized headers for the part.
+     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-delete-offset:string,x-delete-complete?:string} $headers
+     *     Normalized delete-list part headers.
      * @param int $part_bytes Declared Content-Length for this delete segment.
      */
     private function stage_delete_list_part(array $headers, int $part_bytes): void {
@@ -1018,7 +1032,17 @@ final class Site_Export_Staged_Apply_Session {
      * most one leaf or empty directory beneath that root and advances the byte
      * cursor only after the live path is confirmed absent.
      *
-     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     * @param array{
+     *     phase:string,
+     *     delete_offset:int,
+     *     current_deletion_b64:?string,
+     *     current_installation:?array{path_b64:string,expected_type:string},
+     *     traversal_stack:list<array{component_b64:string}>,
+     *     maintenance_token:string,
+     *     deletions_applied:int,
+     *     values_applied:int,
+     *     terminal_error?:array{reason:string,detail:string,context:array<string,mixed>}
+     * } $state Commit checkpoint, mutated in place.
      */
     private function advance_deletion(array &$state): void {
         if ($state['current_deletion_b64'] === null) {
@@ -1142,7 +1166,17 @@ final class Site_Export_Staged_Apply_Session {
      * installing one leaf value per step, and consuming empty structural staging
      * directories after their descendants have been applied.
      *
-     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     * @param array{
+     *     phase:string,
+     *     delete_offset:int,
+     *     current_deletion_b64:?string,
+     *     current_installation:?array{path_b64:string,expected_type:string},
+     *     traversal_stack:list<array{component_b64:string}>,
+     *     maintenance_token:string,
+     *     deletions_applied:int,
+     *     values_applied:int,
+     *     terminal_error?:array{reason:string,detail:string,context:array<string,mixed>}
+     * } $state Commit checkpoint, mutated in place.
      */
     private function advance_installation(array &$state): void {
         if ($state['current_installation'] !== null) {
@@ -1247,7 +1281,11 @@ final class Site_Export_Staged_Apply_Session {
      * the live tree already contains the committed value. Only same-filesystem
      * renames are allowed; copy fallback would break the direct-install model.
      *
-     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     * @param array{
+     *     current_installation:?array{path_b64:string,expected_type:string},
+     *     traversal_stack:list<array{component_b64:string}>,
+     *     values_applied:int
+     * } $state Commit checkpoint, mutated in place.
      * @param string $path Target-relative value path.
      * @param string $expected_type Staged type expected at $path.
      * @param bool $recovering Whether current_installation is already durable.
@@ -1303,7 +1341,11 @@ final class Site_Export_Staged_Apply_Session {
      * the live tree needs to be verified. The method clears the checkpoint only
      * after the expected live result is confirmed.
      *
-     * @param array<string,mixed> $state Commit checkpoint, mutated in place.
+     * @param array{
+     *     current_installation:?array{path_b64:string,expected_type:string},
+     *     traversal_stack:list<array{component_b64:string}>,
+     *     values_applied:int
+     * } $state Commit checkpoint, mutated in place.
      */
     private function resolve_current_installation(array &$state): void {
         $installation = $state['current_installation'];
@@ -1399,8 +1441,10 @@ final class Site_Export_Staged_Apply_Session {
     }
 
     /**
-     * @param string[] $expected_live_types
-     * @param array<string,mixed>|null $observed_identity
+     * @param list<string> $expected_live_types Live identity types accepted at
+     *                                          the conflicting path.
+     * @param array{type:string,dev:int,ino:int,size:int,ctime:int}|null $observed_identity
+     *     Observed live filesystem identity, or null when absent.
      */
     private function throw_live_tree_changed(
         string $operation,
@@ -1787,7 +1831,8 @@ final class Site_Export_Staged_Apply_Session {
      * size ceiling, and decode to a JSON object.
      *
      * @param string $path Absolute metadata file path.
-     * @return array<string,mixed>|null Decoded object, or null if absent.
+     * @return array<string,mixed>|null Decoded caller-specific object, or null
+     *                                  if absent.
      */
     private function read_json(string $path): ?array {
         $identity = $this->path_identity($path);
@@ -1816,7 +1861,22 @@ final class Site_Export_Staged_Apply_Session {
      * object must fit the same ceiling enforced by read_json().
      *
      * @param string $path Absolute metadata file path.
-     * @param array<string,mixed> $value JSON object to persist.
+     * @param array{
+     *     version?:int,
+     *     session_id?:string,
+     *     target_root_b64?:string,
+     *     protected_paths_b64?:list<string>,
+     *     delete_upload_complete?:bool,
+     *     phase?:string,
+     *     delete_offset?:int,
+     *     current_deletion_b64?:?string,
+     *     current_installation?:?array{path_b64:string,expected_type:string},
+     *     traversal_stack?:list<array{component_b64:string}>,
+     *     maintenance_token?:string,
+     *     deletions_applied?:int,
+     *     values_applied?:int,
+     *     terminal_error?:array{reason:string,detail:string,context:array<string,mixed>}
+     * } $value Session metadata or commit checkpoint object to persist.
      */
     private function write_json(string $path, array $value): void {
         $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
@@ -1894,7 +1954,18 @@ final class Site_Export_Staged_Apply_Session {
      * ownership, or pending installation is checked before use. This keeps a
      * corrupt checkpoint from being interpreted as live-tree authority.
      *
-     * @param array<string,mixed> $state Decoded commit checkpoint.
+     * @param array{
+     *     version?:mixed,
+     *     phase?:mixed,
+     *     delete_offset?:mixed,
+     *     deletions_applied?:mixed,
+     *     values_applied?:mixed,
+     *     maintenance_token?:mixed,
+     *     current_deletion_b64?:mixed,
+     *     current_installation?:mixed,
+     *     traversal_stack?:mixed,
+     *     terminal_error?:mixed
+     * } $state Decoded commit checkpoint.
      */
     private function require_valid_commit_state(array $state): void {
         if (( $state['version'] ?? null ) !== 2) {
@@ -1970,7 +2041,7 @@ final class Site_Export_Staged_Apply_Session {
      * each component independently, rebuilds the slash-separated path, and then
      * applies the normal target-relative path rules to the result.
      *
-     * @param array<int,array<string,mixed>> $stack Traversal frames.
+     * @param list<array{component_b64:string}> $stack Traversal frames.
      * @return string Target-relative path for the current traversal directory.
      */
     private function traversal_path(array $stack): string {
@@ -2046,7 +2117,7 @@ final class Site_Export_Staged_Apply_Session {
      * strings, so callers can disable target-path validation and apply their
      * own symlink-target rules instead.
      *
-     * @param array<string,string> $headers Normalized part headers.
+     * @param array<string,string> $headers Normalized part headers keyed by lowercase header name.
      * @param string $header Header name to read.
      * @param bool $is_target_path Whether to apply target path validation.
      * @return string Decoded header bytes.
@@ -2073,8 +2144,9 @@ final class Site_Export_Staged_Apply_Session {
      * ignored because a misspelled required header or a future unsupported
      * option should fail at the boundary instead of silently changing meaning.
      *
-     * @param array<string,string> $headers Normalized headers to inspect.
-     * @param string[] $allowed Lowercase header names allowed for this part.
+     * @param array<string,string> $headers Normalized headers to inspect, keyed
+     *                                      by lowercase header name.
+     * @param list<string> $allowed Lowercase header names allowed for this part.
      * @param string $type Human-readable part type for errors.
      */
     private function require_only_headers(array $headers, array $allowed, string $type): void {
@@ -2092,7 +2164,8 @@ final class Site_Export_Staged_Apply_Session {
      * rejects values that overflow PHP's integer range rather than silently
      * wrapping offsets, sizes, or Content-Length values.
      *
-     * @param array<string,string> $headers Normalized headers to inspect.
+     * @param array<string,string> $headers Normalized headers to inspect, keyed
+     *                                      by lowercase header name.
      * @param string $header Header name to read.
      * @return int Parsed non-negative integer.
      */
@@ -2191,7 +2264,8 @@ final class Site_Export_Staged_Apply_Session {
      * copied into drift reports and status responses.
      *
      * @param string $path Absolute path to inspect.
-     * @return array<string,mixed>|null Type, device, inode, size, and ctime, or null if absent.
+     * @return array{type:string,dev:int,ino:int,size:int,ctime:int}|null Type,
+     *     device, inode, size, and ctime, or null if absent.
      */
     private function path_identity(string $path): ?array {
         clearstatcache(true, $path);

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-feature/multipart-push-transport",
+            "version": "dev-feature/staged-apply-session",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "4b864d3ae9fd88c93db4b5012436600779f25204"
+                "reference": "9842c5d9852a9c3ecd768de88b9652181ef2d1ee"
             },
             "require": {
                 "php": ">=7.2",
@@ -385,6 +385,8 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-multipart-processor.php",
+                    "src/class-staged-apply-exception.php",
+                    "src/class-staged-apply-session.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"
                 ],

--- a/tests/DirectDeleteThenInstallTest.php
+++ b/tests/DirectDeleteThenInstallTest.php
@@ -1,0 +1,756 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class DirectDeleteThenInstallTest extends TestCase {
+
+    private string $root;
+    private string $target;
+    private string $storage;
+
+    protected function setUp(): void {
+        $this->root = sys_get_temp_dir() . '/direct-apply-' . bin2hex(random_bytes(8));
+        $this->target = $this->root . '/target';
+        $this->storage = $this->root . '/storage';
+        mkdir($this->target, 0700, true);
+        mkdir($this->storage, 0700, true);
+    }
+
+    protected function tearDown(): void {
+        $this->remove_tree($this->root);
+    }
+
+    public function testCommitDeletesBeforeInstallingAndConsumesTheStagingTree(): void {
+        mkdir($this->target . '/tree', 0700, true);
+        file_put_contents($this->target . '/tree/old.txt', 'old');
+
+        $session = $this->session('11111111111111111111111111111111');
+        $this->stage($session, [
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '0',
+                ],
+                'body' => "tree\0",
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('tree/new.txt'),
+                    'X-File-Size' => '3',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'new',
+            ],
+        ]);
+        $this->complete_delete_upload($session);
+
+        $saw_deleted_before_install = false;
+        do {
+            $result = $session->commit(1);
+            if (!file_exists($this->target . '/tree/old.txt') && !file_exists($this->target . '/tree/new.txt')) {
+                $saw_deleted_before_install = true;
+            }
+        } while ($result['send_next_request']);
+
+        $this->assertTrue($saw_deleted_before_install);
+        $this->assertSame('new', file_get_contents($this->target . '/tree/new.txt'));
+        $this->assertSame([], $this->directory_entries($session->get_session_directory() . '/work/files'));
+        $this->assertFileDoesNotExist($session->get_session_directory() . '/work/prepared');
+        $this->assertFileDoesNotExist($session->get_session_directory() . '/work/backups');
+        $this->assertFileDoesNotExist($session->get_session_directory() . '/work/commit');
+        $this->assertFileDoesNotExist($session->get_session_directory() . '/work/staged.jsonl');
+    }
+
+    public function testDeleteUploadAcceptsReplayAndContinuesFromItsActualRawSize(): void {
+        $session = $this->session('22222222222222222222222222222222');
+        $first = "first\0partial";
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => $first,
+        ]]);
+
+        $replay_and_continue = $first . "-path\0";
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => $replay_and_continue,
+        ]]);
+
+        $this->assertSame(
+            $replay_and_continue,
+            file_get_contents($session->get_session_directory() . '/work/deletes')
+        );
+    }
+
+    public function testDeleteUploadRejectsOffsetGapsAndDifferingReplayBytes(): void {
+        $session = $this->session('33333333333333333333333333333333');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => "first\0",
+        ]]);
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '99',
+                ],
+                'body' => "later\0",
+            ]]);
+            $this->fail('An offset gap was accepted.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame(Site_Export_Staged_Apply_Session::ERROR_OFFSET_GAP, $exception->get_error_code());
+            $this->assertStringContainsString('offset 99', $exception->getMessage());
+            $this->assertStringContainsString('6 bytes', $exception->getMessage());
+        }
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '0',
+                ],
+                'body' => "other\0",
+            ]]);
+            $this->fail('Differing replay bytes were accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('replay differs', $exception->getMessage());
+        }
+
+        $this->assertSame("first\0", file_get_contents($session->get_session_directory() . '/work/deletes'));
+    }
+
+    public function testDeleteUploadRequiresAnOffsetAndRejectsEmptyRecords(): void {
+        $session = $this->session('00110011001100110011001100110011');
+        try {
+            $this->stage($session, [[
+                'headers' => ['X-Chunk-Type' => 'delete-list'],
+                'body' => "path\0",
+            ]]);
+            $this->fail('A delete part without X-Delete-Offset was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('x-delete-offset', $exception->getMessage());
+        }
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '0',
+                ],
+                'body' => "path\0\0",
+            ]]);
+            $this->fail('An empty delete record was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('empty deletion record', $exception->getMessage());
+        }
+        $this->assertSame('', file_get_contents($session->get_session_directory() . '/work/deletes'));
+    }
+
+    public function testDeletePathLimitIsEnforcedAcrossRequestsWithoutTruncatingAcceptedBytes(): void {
+        $session = $this->session('00220022002200220022002200220022');
+        $prefix = str_repeat('a', 4090);
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => $prefix,
+        ]]);
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '4090',
+                ],
+                'body' => '1234567',
+            ]]);
+            $this->fail('A delete path longer than the cross-request limit was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('4096 bytes', $exception->getMessage());
+        }
+
+        $this->assertSame($prefix, file_get_contents($session->get_session_directory() . '/work/deletes'));
+    }
+
+    public function testReopenUsesTheActualDeleteFileSizeAndAcceptsReplayContinuation(): void {
+        $session = $this->session('00330033003300330033003300330033');
+        $stored = "first\0part";
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => $stored,
+        ]]);
+
+        $reopened = $this->reopen($session);
+        $this->assertSame(strlen($stored), $reopened->get_status()['delete_bytes']);
+        $complete = "first\0partial\0";
+        $this->stage($reopened, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => $complete,
+        ]]);
+
+        $this->assertSame($complete, file_get_contents($session->get_session_directory() . '/work/deletes'));
+    }
+
+    public function testCommitRequiresTheDeleteCompletionDeclaration(): void {
+        $session = $this->session('00440044004400440044004400440044');
+        try {
+            $session->commit(1);
+            $this->fail('Commit began without a completed delete upload declaration.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('explicit completed delete upload', $exception->getMessage());
+        }
+
+        $this->complete_delete_upload($session);
+        $this->commit_all($session);
+    }
+
+    public function testCommitRejectsAnUnterminatedDeleteRecordWithoutTruncatingIt(): void {
+        $session = $this->session('44444444444444444444444444444444');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => 'unfinished',
+        ]]);
+        $this->complete_delete_upload($session);
+
+        try {
+            $session->commit(1);
+            $this->fail('Commit accepted an unterminated delete record.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('end in NUL', $exception->getMessage());
+        }
+
+        $this->assertSame('unfinished', file_get_contents($session->get_session_directory() . '/work/deletes'));
+    }
+
+    public function testModeTransportIsRejected(): void {
+        $session = $this->session('55555555555555555555555555555555');
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('mode.txt'),
+                    'X-File-Size' => '1',
+                    'X-Chunk-Offset' => '0',
+                    'X-File-Mode' => '0600',
+                ],
+                'body' => 'x',
+            ]]);
+            $this->fail('A file mode header was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('does not allow header', $exception->getMessage());
+        }
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory-mode',
+                    'X-Directory-Path' => base64_encode('directory'),
+                    'X-Directory-Mode' => '0700',
+                ],
+                'body' => '',
+            ]]);
+            $this->fail('A directory-mode part was accepted.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('file, directory, symlink, or delete-list', $exception->getMessage());
+        }
+    }
+
+    public function testFileAndSymlinkReplaceCompatibleLiveValuesWithoutDeleteRecords(): void {
+        file_put_contents($this->target . '/file', 'old file');
+        file_put_contents($this->target . '/outside-sentinel', 'safe');
+        symlink('outside-sentinel', $this->target . '/link');
+
+        $session = $this->session('66666666666666666666666666666666');
+        $this->stage($session, [
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('file'),
+                    'X-File-Size' => '3',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'new',
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'symlink',
+                    'X-Symlink-Path' => base64_encode('link'),
+                    'X-Symlink-Target' => base64_encode('new-target'),
+                ],
+                'body' => '',
+            ],
+        ]);
+
+        $this->commit_all($session);
+
+        $this->assertSame('new', file_get_contents($this->target . '/file'));
+        $this->assertTrue(is_link($this->target . '/link'));
+        $this->assertSame('new-target', readlink($this->target . '/link'));
+        $this->assertSame('safe', file_get_contents($this->target . '/outside-sentinel'));
+    }
+
+    public function testExplicitEmptyAndStructuralDirectoriesRemainDistinctPendingValues(): void {
+        $session = $this->session('00550055005500550055005500550055');
+        $this->stage($session, [
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('empty'),
+                ],
+                'body' => '',
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('structural/child.txt'),
+                    'X-File-Size' => '5',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'child',
+            ],
+        ]);
+        $this->commit_all($session);
+
+        $this->assertDirectoryExists($this->target . '/empty');
+        $this->assertSame([], $this->directory_entries($this->target . '/empty'));
+        $this->assertSame('child', file_get_contents($this->target . '/structural/child.txt'));
+    }
+
+    public function testExplicitEmptyDirectoryUsesTheTargetProcessUmask(): void {
+        $previous_umask = umask(0027);
+        try {
+            $session = $this->session('abababababababababababababababab');
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('empty'),
+                ],
+                'body' => '',
+            ]]);
+            $this->commit_all($session);
+
+            clearstatcache(true, $this->target . '/empty');
+            $this->assertSame(0750, fileperms($this->target . '/empty') & 0777);
+        } finally {
+            umask($previous_umask);
+        }
+    }
+
+    public function testObservedSymlinkAncestorStopsCommitAndLeavesMaintenanceActive(): void {
+        mkdir($this->target . '/outside', 0700, true);
+        file_put_contents($this->target . '/outside/sentinel', 'safe');
+
+        $session = $this->session('77777777777777777777777777777777');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('parent/file.txt'),
+                'X-File-Size' => '3',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'new',
+        ]]);
+        symlink('outside', $this->target . '/parent');
+
+        try {
+            $this->commit_all($session);
+            $this->fail('A symlink ancestor was traversed.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('live_tree_changed', $exception->get_error_code());
+            $this->assertSame('parent/file.txt', base64_decode($exception->get_context()['path_b64'], true));
+            $this->assertSame('parent', base64_decode($exception->get_context()['conflict_path_b64'], true));
+        }
+
+        $this->assertSame('safe', file_get_contents($this->target . '/outside/sentinel'));
+        $this->assertFileExists($this->target . '/.maintenance');
+    }
+
+    public function testCommitCheckpointContainsOnlyBoundedBase64PathState(): void {
+        $session = $this->session('88888888888888888888888888888888');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode("tree/line\nbreak"),
+                'X-File-Size' => '1',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'x',
+        ]]);
+        $this->complete_delete_upload($session);
+
+        $session->commit(1);
+        $checkpoint = json_decode((string) file_get_contents($session->get_session_directory() . '/commit.json'), true);
+
+        $this->assertIsArray($checkpoint);
+        $this->assertContains($checkpoint['phase'], ['deleting', 'applying', 'complete']);
+        $this->assertArrayHasKey('delete_offset', $checkpoint);
+        $this->assertArrayHasKey('current_deletion_b64', $checkpoint);
+        $this->assertArrayHasKey('current_installation', $checkpoint);
+        $this->assertArrayHasKey('traversal_stack', $checkpoint);
+        $this->assertArrayNotHasKey('actions_count', $checkpoint);
+        $this->assertArrayNotHasKey('prepare_offset', $checkpoint);
+        $this->assertArrayNotHasKey('transition', $checkpoint);
+        $checkpoint_keys = array_keys($checkpoint);
+        sort($checkpoint_keys, SORT_STRING);
+        $this->assertSame([
+            'current_deletion_b64',
+            'current_installation',
+            'delete_offset',
+            'deletions_applied',
+            'maintenance_token',
+            'phase',
+            'traversal_stack',
+            'values_applied',
+            'version',
+        ], $checkpoint_keys);
+        $this->assertStringNotContainsString("line\nbreak", (string) file_get_contents($session->get_session_directory() . '/commit.json'));
+    }
+
+    public function testDeepTraversalCheckpointGrowsWithPathLengthRatherThanEveryPathPrefix(): void {
+        $session = $this->session('89898989898989898989898989898989');
+        $directory_depth = 300;
+        $path = implode('/', array_fill(0, $directory_depth, 'd')) . '/leaf.txt';
+        $this->stage_file($session, $path, 'value');
+        $this->complete_delete_upload($session);
+
+        $session->commit($directory_depth + 1);
+        $checkpoint_path = $session->get_session_directory() . '/commit.json';
+        $checkpoint = $this->checkpoint($session);
+
+        $this->assertCount($directory_depth, $checkpoint['traversal_stack']);
+        $this->assertLessThan(32768, filesize($checkpoint_path));
+        foreach ($checkpoint['traversal_stack'] as $frame) {
+            $this->assertSame(['component_b64'], array_keys($frame));
+            $this->assertSame('d', base64_decode($frame['component_b64'], true));
+        }
+
+        $this->commit_all($this->reopen($session));
+        $this->assertSame('value', file_get_contents($this->target . '/' . $path));
+    }
+
+    public function testInterruptedInstallationWithStagedEntryPresentRemainsPending(): void {
+        $session = $this->session('99999999999999999999999999999999');
+        $this->stage_file($session, 'pending.txt', 'new');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $this->set_current_installation($session, 'pending.txt', 'file');
+
+        $reopened = $this->reopen($session);
+        $this->commit_all($reopened);
+
+        $this->assertSame('new', file_get_contents($this->target . '/pending.txt'));
+        $this->assertFileDoesNotExist($session->get_session_directory() . '/work/files/pending.txt');
+    }
+
+    public function testInterruptedInstallationWithExpectedLiveTypeCompletes(): void {
+        $session = $this->session('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->stage_file($session, 'installed.txt', 'new');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $this->set_current_installation($session, 'installed.txt', 'file');
+        rename(
+            $session->get_session_directory() . '/work/files/installed.txt',
+            $this->target . '/installed.txt'
+        );
+
+        $this->commit_all($this->reopen($session));
+
+        $this->assertSame('new', file_get_contents($this->target . '/installed.txt'));
+    }
+
+    public function testInterruptedInstallationRejectsASymlinkAncestorBeforeInspectingTheDestination(): void {
+        mkdir($this->target . '/outside', 0700, true);
+        file_put_contents($this->target . '/outside/installed.txt', 'outside');
+        $session = $this->session('abababababababababababababababab');
+        $this->stage_file($session, 'parent/installed.txt', 'new');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $this->set_current_installation($session, 'parent/installed.txt', 'file');
+        unlink($session->get_session_directory() . '/work/files/parent/installed.txt');
+        symlink('outside', $this->target . '/parent');
+
+        try {
+            $this->reopen($session)->commit(1);
+            $this->fail('Interrupted installation followed a symlink ancestor.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('live_tree_changed', $exception->get_error_code());
+            $this->assertSame('parent/installed.txt', base64_decode($exception->get_context()['path_b64'], true));
+            $this->assertSame('parent', base64_decode($exception->get_context()['conflict_path_b64'], true));
+        }
+
+        $this->assertSame('outside', file_get_contents($this->target . '/outside/installed.txt'));
+        $this->assertFileExists($this->target . '/.maintenance');
+    }
+
+    public function testInterruptedInstallationWithBothEntriesAbsentIsTerminal(): void {
+        $session = $this->session('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+        $this->stage_file($session, 'missing.txt', 'new');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $this->set_current_installation($session, 'missing.txt', 'file');
+        unlink($session->get_session_directory() . '/work/files/missing.txt');
+
+        try {
+            $this->reopen($session)->commit(1);
+            $this->fail('Missing staged and live entries were treated as installed.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('live_tree_changed', $exception->get_error_code());
+            $this->assertSame('absent', $exception->get_context()['observed_live_identity']['type']);
+        }
+
+        $this->assertFileExists($this->target . '/.maintenance');
+    }
+
+    public function testInterruptedInstallationWithIncompatibleLiveTypeIsTerminal(): void {
+        $session = $this->session('cccccccccccccccccccccccccccccccc');
+        $this->stage_file($session, 'conflict', 'new');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $this->set_current_installation($session, 'conflict', 'file');
+        unlink($session->get_session_directory() . '/work/files/conflict');
+        mkdir($this->target . '/conflict');
+
+        try {
+            $this->reopen($session)->commit(1);
+            $this->fail('An incompatible live directory completed a file installation.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('live_tree_changed', $exception->get_error_code());
+            $this->assertSame('directory', $exception->get_context()['observed_live_identity']['type']);
+        }
+
+        $this->assertDirectoryExists($this->target . '/conflict');
+        $this->assertFileExists($this->target . '/.maintenance');
+    }
+
+    public function testStructuralDirectoryResumesAfterLiveCreation(): void {
+        $session = $this->session('dddddddddddddddddddddddddddddddd');
+        $this->stage_file($session, 'tree/child.txt', 'child');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $session->commit(1);
+
+        $checkpoint = $this->checkpoint($session);
+        $this->assertSame('tree', base64_decode($checkpoint['traversal_stack'][0]['component_b64'], true));
+        $this->assertDirectoryExists($this->target . '/tree');
+
+        $this->commit_all($this->reopen($session));
+        $this->assertSame('child', file_get_contents($this->target . '/tree/child.txt'));
+    }
+
+    public function testStructuralCleanupResumesAfterStagingDirectoryWasRemoved(): void {
+        $session = $this->session('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+        $this->stage_file($session, 'tree/child.txt', 'child');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+        $session->commit(1);
+        $session->commit(1);
+        $this->assertSame([], $this->directory_entries($session->get_session_directory() . '/work/files/tree'));
+
+        $this->set_current_installation($session, 'tree', 'directory');
+        rmdir($session->get_session_directory() . '/work/files/tree');
+
+        $this->commit_all($this->reopen($session));
+
+        $this->assertSame('child', file_get_contents($this->target . '/tree/child.txt'));
+        $this->assertSame([], $this->directory_entries($session->get_session_directory() . '/work/files'));
+    }
+
+    public function testRecursiveDeletionUnlinksChildSymlinksWithoutFollowingThem(): void {
+        mkdir($this->target . '/outside', 0700, true);
+        file_put_contents($this->target . '/outside/sentinel', 'safe');
+        mkdir($this->target . '/delete-root', 0700);
+        symlink('../outside', $this->target . '/delete-root/link');
+
+        $session = $this->session('ffffffffffffffffffffffffffffffff');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => "delete-root\0",
+        ]]);
+        $this->commit_all($session);
+
+        $this->assertFileDoesNotExist($this->target . '/delete-root');
+        $this->assertSame('safe', file_get_contents($this->target . '/outside/sentinel'));
+    }
+
+    public function testDeletionBelowAMissingAncestorIsAlreadyComplete(): void {
+        $session = $this->session('abcdefabcdefabcdefabcdefabcdefab');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => "missing/child\0",
+        ]]);
+
+        $this->commit_all($session);
+
+        $this->assertSame('complete', $session->get_status()['phase']);
+        $this->assertFileDoesNotExist($this->target . '/.maintenance');
+    }
+
+    public function testIncompatibleLiveDirectoryIsLeftUntouchedAndTerminal(): void {
+        mkdir($this->target . '/conflict', 0700);
+        file_put_contents($this->target . '/conflict/sentinel', 'safe');
+        $session = $this->session('1234567890abcdef1234567890abcdef');
+        $this->stage_file($session, 'conflict', 'new');
+
+        try {
+            $this->commit_all($session);
+            $this->fail('A staged file replaced an incompatible live directory.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('live_tree_changed', $exception->get_error_code());
+            $this->assertSame(['absent', 'file', 'symlink'], $exception->get_context()['expected_live_types']);
+        }
+
+        $this->assertSame('safe', file_get_contents($this->target . '/conflict/sentinel'));
+        $this->assertFileExists($this->target . '/.maintenance');
+        try {
+            $session->commit(1);
+            $this->fail('A terminal session allowed a force retry.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('live_tree_changed', $exception->get_error_code());
+        }
+    }
+
+    private function session(string $id): Site_Export_Staged_Apply_Session {
+        return Site_Export_Staged_Apply_Session::create(
+            $this->storage,
+            $this->target,
+            ['wp-content/plugins/reprint'],
+            $id
+        );
+    }
+
+    private function reopen(Site_Export_Staged_Apply_Session $session): Site_Export_Staged_Apply_Session {
+        return Site_Export_Staged_Apply_Session::open(
+            $this->storage,
+            $this->target,
+            $session->get_session_id(),
+            ['wp-content/plugins/reprint']
+        );
+    }
+
+    private function stage_file(Site_Export_Staged_Apply_Session $session, string $path, string $contents): void {
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode($path),
+                'X-File-Size' => (string) strlen($contents),
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => $contents,
+        ]]);
+    }
+
+    /** @return array<string,mixed> */
+    private function checkpoint(Site_Export_Staged_Apply_Session $session): array {
+        $checkpoint = json_decode(
+            (string) file_get_contents($session->get_session_directory() . '/commit.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertIsArray($checkpoint);
+        return $checkpoint;
+    }
+
+    private function set_current_installation(Site_Export_Staged_Apply_Session $session, string $path, string $type): void {
+        $checkpoint = $this->checkpoint($session);
+        $checkpoint['current_installation'] = ['path_b64' => base64_encode($path), 'expected_type' => $type];
+        file_put_contents(
+            $session->get_session_directory() . '/commit.json',
+            json_encode($checkpoint, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+    }
+
+    /** @param array<int,array{headers:array<string,string>,body:string}> $parts */
+    private function stage(Site_Export_Staged_Apply_Session $session, array $parts): void {
+        $boundary = 'test-boundary';
+        $body = '';
+        foreach ($parts as $part) {
+            $body .= '--' . $boundary . "\r\n";
+            foreach ($part['headers'] as $name => $value) {
+                $body .= $name . ': ' . $value . "\r\n";
+            }
+            $body .= 'Content-Length: ' . strlen($part['body']) . "\r\n\r\n";
+            $body .= $part['body'] . "\r\n";
+        }
+        $body .= '--' . $boundary . "--\r\n";
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body);
+        rewind($input);
+        $session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        try {
+            while ($session->next_change()) {
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+    }
+
+    private function commit_all(Site_Export_Staged_Apply_Session $session): void {
+        if (!$session->get_status()['delete_upload_complete']) {
+            $this->complete_delete_upload($session);
+        }
+        do {
+            $result = $session->commit(2);
+        } while ($result['send_next_request']);
+    }
+
+    private function complete_delete_upload(Site_Export_Staged_Apply_Session $session): void {
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => (string) $session->get_status()['delete_bytes'],
+                'X-Delete-Complete' => '1',
+            ],
+            'body' => '',
+        ]]);
+    }
+
+    /** @return string[] */
+    private function directory_entries(string $path): array {
+        return array_values(array_diff(scandir($path) ?: [], ['.', '..']));
+    }
+
+    private function remove_tree(string $path): void {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->remove_tree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/DirectDeleteThenInstallTest.php
+++ b/tests/DirectDeleteThenInstallTest.php
@@ -62,6 +62,23 @@ final class DirectDeleteThenInstallTest extends TestCase {
         $this->assertFileDoesNotExist($session->get_session_directory() . '/work/staged.jsonl');
     }
 
+    public function testCommitProcessesMultipleEntriesInOneCall(): void {
+        $session = $this->session('12121212121212121212121212121212');
+        $this->stage_file($session, 'first.txt', 'one');
+        $this->stage_file($session, 'second.txt', 'two');
+        $this->stage_file($session, 'third.txt', 'three');
+        $this->complete_delete_upload($session);
+
+        $result = $session->commit(16);
+
+        $this->assertSame('complete', $result['phase']);
+        $this->assertFalse($result['send_next_request']);
+        $this->assertGreaterThan(1, $result['entries_processed']);
+        $this->assertSame('one', file_get_contents($this->target . '/first.txt'));
+        $this->assertSame('two', file_get_contents($this->target . '/second.txt'));
+        $this->assertSame('three', file_get_contents($this->target . '/third.txt'));
+    }
+
     public function testDeleteUploadAcceptsReplayAndContinuesFromItsActualRawSize(): void {
         $session = $this->session('22222222222222222222222222222222');
         $first = "first\0partial";

--- a/tests/StagedApplySessionTest.php
+++ b/tests/StagedApplySessionTest.php
@@ -1,0 +1,316 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class StagedApplySessionTest extends TestCase {
+
+    private string $root;
+    private string $target;
+    private string $storage;
+
+    protected function setUp(): void {
+        $this->root = sys_get_temp_dir() . '/multipart-apply-' . bin2hex(random_bytes(8));
+        $this->target = $this->root . '/target';
+        $this->storage = $this->root . '/storage';
+        mkdir($this->target, 0700, true);
+        mkdir($this->storage, 0700, true);
+    }
+
+    protected function tearDown(): void {
+        $this->remove_tree($this->root);
+    }
+
+    public function testClassifiedExceptionKeepsProtocolReasonAndContextSeparateFromThrowableCode(): void {
+        $exception = new Site_Export_Staged_Apply_Exception('busy', 'The session is busy.', ['operation' => 'stage']);
+
+        $this->assertSame('busy', $exception->get_error_code());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame('The session is busy.', $exception->getMessage());
+        $this->assertSame(['operation' => 'stage'], $exception->get_context());
+    }
+
+    public function testPartialFileProgressComesFromTheFileAndOffsetZeroRestartsIt(): void {
+        $session = $this->session('11111111111111111111111111111111');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('upload.bin'),
+                'X-File-Size' => '6',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'old',
+        ]]);
+        $this->assertSame(3, $session->get_status(['upload.bin'])['paths'][0]['accepted_bytes']);
+
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('upload.bin'),
+                'X-File-Size' => '3',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'new',
+        ]]);
+        $status = $session->get_status(['upload.bin']);
+        $this->assertSame('complete', $status['paths'][0]['state']);
+        $this->assertSame(3, $status['paths'][0]['accepted_bytes']);
+
+        $this->commit_all($session);
+        $this->assertSame('new', file_get_contents($this->target . '/upload.bin'));
+    }
+
+    public function testInvalidPartStopsBeforeTheFollowingPartIsRead(): void {
+        $session = $this->session('22222222222222222222222222222222');
+        $boundary = 'test-boundary';
+        $body = '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: file\r\n"
+            . 'X-File-Path: ' . base64_encode('bad.bin') . "\r\n"
+            . "X-File-Size: 2\r\nX-Chunk-Offset: 1\r\nContent-Length: 1\r\n\r\nx\r\n"
+            . '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: file\r\n"
+            . 'X-File-Path: ' . base64_encode('must-not-be-read.bin') . "\r\n"
+            . "X-File-Size: 1\r\nX-Chunk-Offset: 0\r\nContent-Length: 1\r\n\r\ny\r\n"
+            . '--' . $boundary . "--\r\n";
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body);
+        rewind($input);
+        $session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        try {
+            $session->next_change();
+            $this->fail('An offset gap was accepted.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('offset_gap', $exception->get_error_code());
+            $this->assertStringContainsString('Start at offset 0', $exception->getMessage());
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+        $this->assertFileDoesNotExist($session->get_session_directory() . '/work/files/must-not-be-read.bin');
+    }
+
+    public function testDeleteOffsetGapHasTheSameRecoverableProtocolReason(): void {
+        $session = $this->session('23232323232323232323232323232323');
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '1',
+                ],
+                'body' => "gone\0",
+            ]]);
+            $this->fail('A delete offset gap was accepted.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('offset_gap', $exception->get_error_code());
+            $this->assertStringContainsString('target has stored 0 bytes', $exception->getMessage());
+        }
+    }
+
+    public function testProtectedAndInvalidPathsNeverReachStaging(): void {
+        $invalid_paths = ['', '/absolute', '.', '..', 'a/../b', "nul\0path", 'wp-content/plugins/reprint/keep.php', '.maintenance'];
+        foreach ($invalid_paths as $index => $path) {
+            $session = $this->session(sprintf('%032x', $index + 10));
+            try {
+                $this->stage($session, [[
+                    'headers' => [
+                        'X-Chunk-Type' => 'file',
+                        'X-File-Path' => base64_encode($path),
+                        'X-File-Size' => '1',
+                        'X-Chunk-Offset' => '0',
+                    ],
+                    'body' => 'x',
+                ]]);
+                $this->fail('Unsafe path was staged: ' . base64_encode($path));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertNotSame('', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testStorageBelowTargetIsProtectedAndRootCanBeReopened(): void {
+        $storage = $this->target . '/private-staging';
+        $session = Site_Export_Staged_Apply_Session::create($storage, $this->target, [], str_repeat('a', 32));
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('private-staging/escape.php'),
+                    'X-File-Size' => '1',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'x',
+            ]]);
+            $this->fail('Session storage was writable through the push target.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('Protected', $exception->getMessage());
+        }
+
+        $root_session = Site_Export_Staged_Apply_Session::create($this->storage, '/', [], str_repeat('b', 32));
+        $reopened = Site_Export_Staged_Apply_Session::open($this->storage, '/', $root_session->get_session_id(), []);
+        $this->assertSame($root_session->get_session_directory(), $reopened->get_session_directory());
+    }
+
+    public function testCompletedStagedSymlinkCannotBecomeAnotherStagedPathsParent(): void {
+        $session = $this->session('33333333333333333333333333333333');
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'symlink',
+                'X-Symlink-Path' => base64_encode('parent'),
+                'X-Symlink-Target' => base64_encode('../outside'),
+            ],
+            'body' => '',
+        ]]);
+
+        try {
+            $this->stage($session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('parent/child'),
+                    'X-File-Size' => '1',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'x',
+            ]]);
+            $this->fail('A staged symlink was traversed as a private parent.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('cannot be used as the parent', $exception->getMessage());
+        }
+    }
+
+    public function testForeignMaintenanceStopsBeforeMutationAndOwnedMarkerRefreshes(): void {
+        $session = $this->session('44444444444444444444444444444444');
+        $this->stage_file($session, 'pending.txt', 'new');
+        file_put_contents($this->target . '/.maintenance', "<?php\n\$upgrading = 1;\n");
+        $this->complete_delete_upload($session);
+
+        try {
+            $session->commit(1);
+            $this->fail('A foreign maintenance marker was replaced.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('busy', $exception->get_error_code());
+        }
+        $this->assertFileDoesNotExist($this->target . '/pending.txt');
+        unlink($this->target . '/.maintenance');
+
+        $session->commit(1);
+        $first = file_get_contents($this->target . '/.maintenance');
+        $marker_blocks_request = function (array $query): bool {
+            $previous_query = $_GET;
+            $_GET = $query;
+            try {
+                include $this->target . '/.maintenance';
+                return isset($upgrading);
+            } finally {
+                $_GET = $previous_query;
+            }
+        };
+        $this->assertTrue($marker_blocks_request([]));
+        $this->assertTrue($marker_blocks_request(['reprint-api' => '', 'endpoint' => 'preflight']));
+        $this->assertFalse($marker_blocks_request(['reprint-api' => '', 'endpoint' => 'staged_session_commit']));
+        sleep(1);
+        $session->commit(1);
+        $second = file_get_contents($this->target . '/.maintenance');
+        $this->assertNotSame($first, $second);
+        $this->commit_all($session);
+        $this->assertFileDoesNotExist($this->target . '/.maintenance');
+    }
+
+    public function testCommitCannotBeDiscardedUntilItCompletes(): void {
+        $session = $this->session('55555555555555555555555555555555');
+        $this->stage_file($session, 'pending.txt', 'x');
+        $this->complete_delete_upload($session);
+        $session->commit(1);
+
+        try {
+            $session->discard_workspace();
+            $this->fail('An active direct apply was discarded.');
+        } catch (Site_Export_Staged_Apply_Exception $exception) {
+            $this->assertSame('commit_required', $exception->get_error_code());
+        }
+
+        $this->commit_all($session);
+        $this->assertTrue($session->discard_workspace());
+    }
+
+    private function session(string $id): Site_Export_Staged_Apply_Session {
+        return Site_Export_Staged_Apply_Session::create(
+            $this->storage,
+            $this->target,
+            ['wp-content/plugins/reprint'],
+            $id
+        );
+    }
+
+    private function stage_file(Site_Export_Staged_Apply_Session $session, string $path, string $contents): void {
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode($path),
+                'X-File-Size' => (string) strlen($contents),
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => $contents,
+        ]]);
+    }
+
+    /** @param array<int,array{headers:array<string,string>,body:string}> $parts */
+    private function stage(Site_Export_Staged_Apply_Session $session, array $parts): void {
+        $boundary = 'test-boundary';
+        $body = '';
+        foreach ($parts as $part) {
+            $body .= '--' . $boundary . "\r\n";
+            foreach ($part['headers'] as $name => $value) {
+                $body .= $name . ': ' . $value . "\r\n";
+            }
+            $body .= 'Content-Length: ' . strlen($part['body']) . "\r\n\r\n" . $part['body'] . "\r\n";
+        }
+        $body .= '--' . $boundary . "--\r\n";
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body);
+        rewind($input);
+        $session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        try {
+            while ($session->next_change()) {
+            }
+        } finally {
+            $session->finish_upload();
+            fclose($input);
+        }
+    }
+
+    private function commit_all(Site_Export_Staged_Apply_Session $session): void {
+        if (!$session->get_status()['delete_upload_complete']) {
+            $this->complete_delete_upload($session);
+        }
+        do {
+            $result = $session->commit(4);
+        } while ($result['send_next_request']);
+    }
+
+    private function complete_delete_upload(Site_Export_Staged_Apply_Session $session): void {
+        $this->stage($session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => (string) $session->get_status()['delete_bytes'],
+                'X-Delete-Complete' => '1',
+            ],
+            'body' => '',
+        ]]);
+    }
+
+    private function remove_tree(string $path): void {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->remove_tree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/StagedApplySessionTest.php
+++ b/tests/StagedApplySessionTest.php
@@ -40,7 +40,7 @@ final class StagedApplySessionTest extends TestCase {
             ],
             'body' => 'old',
         ]]);
-        $this->assertSame(3, $session->get_status(['upload.bin'])['paths'][0]['accepted_bytes']);
+        $this->assertSame(3, $session->get_status('upload.bin')['path']['accepted_bytes']);
 
         $this->stage($session, [[
             'headers' => [
@@ -51,9 +51,9 @@ final class StagedApplySessionTest extends TestCase {
             ],
             'body' => 'new',
         ]]);
-        $status = $session->get_status(['upload.bin']);
-        $this->assertSame('complete', $status['paths'][0]['state']);
-        $this->assertSame(3, $status['paths'][0]['accepted_bytes']);
+        $status = $session->get_status('upload.bin');
+        $this->assertSame('complete', $status['path']['state']);
+        $this->assertSame(3, $status['path']['accepted_bytes']);
 
         $this->commit_all($session);
         $this->assertSame('new', file_get_contents($this->target . '/upload.bin'));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,5 +30,13 @@ if (!class_exists('Site_Export_Multipart_Processor', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-multipart-processor.php';
 }
 
+if (!class_exists('Site_Export_Staged_Apply_Exception', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply-exception.php';
+}
+
+if (!class_exists('Site_Export_Staged_Apply_Session', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-staged-apply-session.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -25,12 +25,14 @@
         </testsuite>
         <testsuite name="Export Utility Tests">
             <file>BuildPdoDsnTest.php</file>
+            <file>DirectDeleteThenInstallTest.php</file>
             <file>ExportHttpServerTest.php</file>
             <file>FileIndexDedupTest.php</file>
             <file>FileIndexSkipDefaultsTest.php</file>
             <file>HmacServerTest.php</file>
             <file>MultipartProcessorTest.php</file>
             <file>SiteExportSecretTest.php</file>
+            <file>StagedApplySessionTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>


### PR DESCRIPTION
Filesystem changes can now be staged durably and committed under a session lock without allowing corrupt persistent state to drive live-tree mutation.

`Site_Export_Staged_Apply_Session` accepts and records one complete MIME part at a time, protects its own storage, resumes from durable offsets, and commits raw deletions before direct installation. Configured roots are checked once, the complete workspace is validated once after locking, and successful creation is trusted instead of repeatedly re-proving the same layout. The public stepping and status APIs now document their lifecycle, return values, and failure behavior.

Stack: #347 → **#348** → #349

## Testing

- Staged apply suites: 34 tests, 723 assertions
- PHPCompatibility on PHP 7.2+
- PHPStan
