### PR TITLE
[Push] Keep one unfinished value outside completed work

### DIFF
--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -749,9 +749,10 @@ final class Site_Export_Push_Session {
      * Reads the durable description of the unfinished work value.
      *
      * A push receives or publishes one work value at a time. Its identity and
-     * phase are stored in `work/inflight.json`; unfinished file bytes are stored
-     * in `work/inflight.data`. This method reads both records before upload,
-     * status, or commit decides what work is safe to perform.
+     * phase are stored in `work/inflight.json`; unfinished file bytes, when
+     * applicable, are stored separately in `work/inflight.data`. This method
+     * reads the record before upload, status, or commit decides what work is
+     * safe to perform.
      *
      * The JSON record is the authority for whether work is in flight. Callers
      * use its type and phase to decide whether they can receive more bytes,
@@ -828,7 +829,8 @@ final class Site_Export_Push_Session {
      *
      * The caller has already validated Content-Length against the document-root
      * part ceiling. This method validates the file-specific headers, enforces the
-     * work-confirmed resume offset, streams the body into the partial file,
+     * work-confirmed resume offset, streams the body into the in-flight data
+     * file,
      * and promotes the file atomically inside the private reprint directory only when the
      * declared total size has been reached.
      *
@@ -859,7 +861,7 @@ final class Site_Export_Push_Session {
             throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but no matching in-flight file exists. Start at offset 0.');
         }
         if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished staged value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
+            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished work value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
         }
         if ($inflight === null || $offset === 0) {
             if ($inflight !== null && $this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
@@ -943,7 +945,7 @@ final class Site_Export_Push_Session {
         $this->finish_published_inflight();
         $inflight = $this->read_inflight();
         if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished staged value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
+            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished work value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
         }
         $identity = $this->lstat_path($target);
         if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
@@ -998,7 +1000,7 @@ final class Site_Export_Push_Session {
         $this->finish_published_inflight();
         $inflight = $this->read_inflight();
         if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished staged value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
+            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished work value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
         }
         $identity = $this->lstat_path($target);
         if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
@@ -1943,8 +1945,12 @@ final class Site_Export_Push_Session {
      *     commit_cursor?:list<array{component_b64:string}>,
      *     deleted_files?:int,
      *     installed_files?:int,
-     *     non_recoverable_commit_failure?:array{reason:string,detail:string,context:array<string,mixed>}
-     * } $value Push metadata or commit checkpoint object to persist.
+     *     non_recoverable_commit_failure?:array{reason:string,detail:string,context:array<string,mixed>},
+     *     path_b64?:string,
+     *     type?:string,
+     *     total_bytes?:int,
+     *     target_b64?:string
+     * } $value Push metadata, commit checkpoint, or in-flight work record to persist.
      */
     private function write_json(string $path, array $value): void {
         $contents = json_encode($value, JSON_UNESCAPED_SLASHES);

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -748,16 +748,16 @@ final class Site_Export_Push_Session {
     /**
      * Reads and validates the durable description of the unfinished work value.
      *
-     * A push session has no path-shaped partial tree. Instead, one JSON object
-     * identifies the work value which is being received or published, while the
-     * fixed data file holds unfinished file bytes. This method reads those two
-     * records together so callers never treat bytes without metadata, or metadata
-     * with an incompatible data file, as resumable work.
+     * A push receives or publishes one work value at a time. Its identity and
+     * phase are stored in `work/inflight.json`; unfinished file bytes are stored
+     * in `work/inflight.data`. This method reads both records before upload,
+     * status, or commit decides what work is safe to perform.
      *
-     * The returned object is deliberately still an array at this boundary: JSON
-     * is untrusted until every key, discriminant, path, phase, and size relation
-     * has been checked. A missing metadata file means there is no unfinished
-     * value only when the fixed data file is absent as well.
+     * The JSON record is untrusted durable state. This method validates its
+     * exact keys, path, type, phase, and file-size relation before returning it.
+     * Missing metadata means that no work is in flight only when the data file
+     * is absent as well. A data file without metadata is corrupt state, not a
+     * resume cursor.
      *
      * @return array<string,mixed>|null The validated unfinished value, or null
      *                                  when the session has no unfinished work.

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -746,57 +746,22 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Reads and validates the durable description of the unfinished work value.
+     * Reads the durable description of the unfinished work value.
      *
      * A push receives or publishes one work value at a time. Its identity and
      * phase are stored in `work/inflight.json`; unfinished file bytes are stored
      * in `work/inflight.data`. This method reads both records before upload,
      * status, or commit decides what work is safe to perform.
      *
-     * The JSON record is untrusted durable state. This method validates its
-     * exact keys, path, type, phase, and file-size relation before returning it.
-     * Missing metadata means that no work is in flight only when the data file
-     * is absent as well. A data file without metadata is corrupt state, not a
-     * resume cursor.
+     * The JSON record is the authority for whether work is in flight. Callers
+     * use its type and phase to decide whether they can receive more bytes,
+     * publish the completed value, or begin commit work. A missing record means
+     * there is no unfinished value.
      *
-     * @return array<string,mixed>|null The validated unfinished value, or null
-     *                                  when the session has no unfinished work.
+     * @return array{version:1,phase:'preparing'|'receiving'|'publishing',path_b64:string,type:'file',total_bytes:int}|array{version:1,phase:'preparing'|'publishing',path_b64:string,type:'directory'}|array{version:1,phase:'preparing'|'publishing',path_b64:string,type:'symlink',target_b64:string}|null In-flight work, or null when none exists.
      */
     private function read_inflight(): ?array {
-        $inflight = $this->read_json($this->work_inflight_path);
-        $data = $this->lstat_path($this->work_inflight_data_path);
-        if ($inflight === null) {
-            if ($data !== null) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight data exists without metadata.');
-            }
-            return null;
-        }
-        if (($inflight['version'] ?? null) !== 1 || !is_string($inflight['phase'] ?? null) || !is_string($inflight['path_b64'] ?? null) || !is_string($inflight['type'] ?? null)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight metadata has an invalid shape.');
-        }
-        $path = base64_decode($inflight['path_b64'], true);
-        if ($path === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight metadata path is not valid base64.');
-        }
-        $this->validate_path($path);
-        if ($inflight['type'] === 'file' && isset($inflight['total_bytes']) && is_int($inflight['total_bytes']) && $inflight['total_bytes'] >= 0
-            && in_array($inflight['phase'], ['preparing', 'receiving', 'publishing'], true) && count($inflight) === 5) {
-            if ($data !== null && $data['type'] !== 'file') {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight data is not a regular file.');
-            }
-            if ($inflight['phase'] === 'receiving' && ($data === null || $data['size'] > $inflight['total_bytes'])) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Receiving in-flight data has an invalid size.');
-            }
-            return $inflight;
-        }
-        if ($inflight['type'] === 'directory' && in_array($inflight['phase'], ['preparing', 'publishing'], true) && count($inflight) === 4 && $data === null) {
-            return $inflight;
-        }
-        if ($inflight['type'] === 'symlink' && in_array($inflight['phase'], ['preparing', 'publishing'], true)
-            && is_string($inflight['target_b64'] ?? null) && base64_decode($inflight['target_b64'], true) !== false && count($inflight) === 5 && $data === null) {
-            return $inflight;
-        }
-        throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight metadata has an invalid state.');
+        return $this->read_json($this->work_inflight_path);
     }
 
     /**

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -335,8 +335,8 @@ final class Site_Export_Push_Session {
      *
      * Returning true means the complete part has been accepted into the work
      * directory and get_current_change() describes the resulting work state.
-     * A file part may leave that file partial, so true does not mean the logical
-     * file or the complete multipart request is finished.
+     * A file part may leave its value in the fixed in-flight slot, so true does
+     * not mean the logical file or the complete multipart request is finished.
      *
      * Returning false means the closing multipart boundary was consumed. EOF
      * in a header, body, or boundary throws instead, so truncation is never
@@ -746,9 +746,21 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Reads the durable description of the one unfinished work value.
+     * Reads and validates the durable description of the unfinished work value.
      *
-     * @return array<string,mixed>|null
+     * A push session has no path-shaped partial tree. Instead, one JSON object
+     * identifies the work value which is being received or published, while the
+     * fixed data file holds unfinished file bytes. This method reads those two
+     * records together so callers never treat bytes without metadata, or metadata
+     * with an incompatible data file, as resumable work.
+     *
+     * The returned object is deliberately still an array at this boundary: JSON
+     * is untrusted until every key, discriminant, path, phase, and size relation
+     * has been checked. A missing metadata file means there is no unfinished
+     * value only when the fixed data file is absent as well.
+     *
+     * @return array<string,mixed>|null The validated unfinished value, or null
+     *                                  when the session has no unfinished work.
      */
     private function read_inflight(): ?array {
         $inflight = $this->read_json($this->work_inflight_path);
@@ -788,7 +800,17 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Finishes a completed publication before another operation observes it.
+     * Finishes a publication which crossed its durable publication boundary.
+     *
+     * Publishing metadata is written before the completed work value changes.
+     * That ordering lets a later upload, status request, or commit distinguish a
+     * crash before publication from a crash after the data-file rename. When the
+     * fixed data file remains it is authoritative and is renamed into work/files.
+     * When it has already been consumed, the completed value is checked as the
+     * durable evidence of publication. Only then is the in-flight metadata
+     * removed.
+     *
+     * @return void
      */
     private function finish_published_inflight(): void {
         $inflight = $this->read_inflight();

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -13,9 +13,8 @@ if (!class_exists('Site_Export_Push_Exception', false)) {
  * Receives push work privately, then commits its deletes and files directly.
  *
  * `work/files/` is both the completed work tree and the work-file queue.
- * Incomplete file bytes live under `work/partial/`, but both trees represent
- * one logical path namespace: a value in either tree cannot hide or contain a
- * value in the other.
+ * One unfinished value is recorded in `work/inflight.json`; unfinished file
+ * bytes live in `work/inflight.data` rather than in a second path-shaped tree.
  * Successful file installation consumes each entry. Deletes remain raw NUL-delimited
  * bytes in `work/deletes`; their confirmed cursor is the file's actual size.
  * Commit persists only one delete, one work-files descendant, and a path-depth-bounded
@@ -52,7 +51,9 @@ final class Site_Export_Push_Session {
     /** @var string */
     private $work_files_directory;
     /** @var string */
-    private $work_partial_directory;
+    private $work_inflight_path;
+    /** @var string */
+    private $work_inflight_data_path;
     /** @var string */
     private $work_deletes_path;
     /** @var string */
@@ -123,7 +124,8 @@ final class Site_Export_Push_Session {
         $this->push_lock_path = $this->push_directory . '/push.lock';
         $this->work_dir = $this->push_directory . '/work';
         $this->work_files_directory = $this->work_dir . '/files';
-        $this->work_partial_directory = $this->work_dir . '/partial';
+        $this->work_inflight_path = $this->work_dir . '/inflight.json';
+        $this->work_inflight_data_path = $this->work_dir . '/inflight.data';
         $this->work_deletes_path = $this->work_dir . '/deletes';
         $this->maintenance_copy_path = $this->work_dir . '/maintenance.php';
     }
@@ -172,7 +174,7 @@ final class Site_Export_Push_Session {
             if (file_exists($push_session->push_directory) || is_link($push_session->push_directory)) {
                 return $push_session;
             }
-            if (!@mkdir($push_session->work_files_directory, 0700, true) || !@mkdir($push_session->work_partial_directory, 0700, true)) {
+            if (!@mkdir($push_session->work_files_directory, 0700, true)) {
                 self::remove_tree($push_session->push_directory);
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create the push work directories.');
             }
@@ -475,15 +477,21 @@ final class Site_Export_Push_Session {
      */
     public function get_status(?string $path = null): array {
         return $this->with_push_lock(function () use ($path): array {
+            $this->finish_published_inflight();
             $reported_path = null;
             if ($path !== null) {
                 $this->validate_path($path);
-                $partial = $this->work_partial_directory . '/' . $path;
                 $complete = $this->work_files_directory . '/' . $path;
-                $this->ensure_private_parent($partial, false);
                 $this->ensure_private_parent($complete, false);
-                $complete_identity = $this->lstat_path($complete);
-                if ($complete_identity !== null) {
+                $inflight = $this->read_inflight();
+                if ($inflight !== null && base64_decode($inflight['path_b64'], true) === $path) {
+                    $reported_path = [
+                        'path_b64' => base64_encode($path),
+                        'state' => 'partial',
+                        'type' => $inflight['type'],
+                        'accepted_bytes' => $inflight['type'] === 'file' && $inflight['phase'] === 'receiving' ? $this->file_size($this->work_inflight_data_path) : 0,
+                    ];
+                } elseif (($complete_identity = $this->lstat_path($complete)) !== null) {
                     $reported_path = [
                         'path_b64' => base64_encode($path),
                         'state' => 'complete',
@@ -491,20 +499,7 @@ final class Site_Export_Push_Session {
                         'accepted_bytes' => $complete_identity['type'] === 'file' ? $complete_identity['size'] : 0,
                     ];
                 } else {
-                    $partial_identity = $this->lstat_path($partial);
-                    if ($partial_identity !== null) {
-                        if ($partial_identity['type'] !== 'file') {
-                            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Partial work path ' . base64_encode($path) . ' is not a regular file.');
-                        }
-                        $reported_path = [
-                            'path_b64' => base64_encode($path),
-                            'state' => 'partial',
-                            'type' => 'file',
-                            'accepted_bytes' => $partial_identity['size'],
-                        ];
-                    } else {
-                        $reported_path = ['path_b64' => base64_encode($path), 'state' => 'missing', 'accepted_bytes' => 0];
-                    }
+                    $reported_path = ['path_b64' => base64_encode($path), 'state' => 'missing', 'accepted_bytes' => 0];
                 }
             }
             $commit_state = $this->read_json($this->commit_json_path);
@@ -566,8 +561,9 @@ final class Site_Export_Push_Session {
                         throw new InvalidArgumentException('A nonempty delete stream must end in NUL before commit; the final record is unterminated.');
                     }
                 }
-                if ($this->first_tree_entry($this->work_partial_directory) !== null) {
-                    throw new InvalidArgumentException('Commit cannot begin while work/partial still contains an incomplete file.');
+                $this->finish_published_inflight();
+                if ($this->read_inflight() !== null) {
+                    throw new InvalidArgumentException('Commit cannot begin while an unfinished work value remains.');
                 }
                 $commit_state = [
                     'version' => 3,
@@ -750,7 +746,98 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Accepts one file MIME part into work/partial or work/files.
+     * Reads the durable description of the one unfinished work value.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function read_inflight(): ?array {
+        $inflight = $this->read_json($this->work_inflight_path);
+        $data = $this->lstat_path($this->work_inflight_data_path);
+        if ($inflight === null) {
+            if ($data !== null) {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight data exists without metadata.');
+            }
+            return null;
+        }
+        if (($inflight['version'] ?? null) !== 1 || !is_string($inflight['phase'] ?? null) || !is_string($inflight['path_b64'] ?? null) || !is_string($inflight['type'] ?? null)) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight metadata has an invalid shape.');
+        }
+        $path = base64_decode($inflight['path_b64'], true);
+        if ($path === false) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight metadata path is not valid base64.');
+        }
+        $this->validate_path($path);
+        if ($inflight['type'] === 'file' && isset($inflight['total_bytes']) && is_int($inflight['total_bytes']) && $inflight['total_bytes'] >= 0
+            && in_array($inflight['phase'], ['preparing', 'receiving', 'publishing'], true) && count($inflight) === 5) {
+            if ($data !== null && $data['type'] !== 'file') {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight data is not a regular file.');
+            }
+            if ($inflight['phase'] === 'receiving' && ($data === null || $data['size'] > $inflight['total_bytes'])) {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Receiving in-flight data has an invalid size.');
+            }
+            return $inflight;
+        }
+        if ($inflight['type'] === 'directory' && in_array($inflight['phase'], ['preparing', 'publishing'], true) && count($inflight) === 4 && $data === null) {
+            return $inflight;
+        }
+        if ($inflight['type'] === 'symlink' && in_array($inflight['phase'], ['preparing', 'publishing'], true)
+            && is_string($inflight['target_b64'] ?? null) && base64_decode($inflight['target_b64'], true) !== false && count($inflight) === 5 && $data === null) {
+            return $inflight;
+        }
+        throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight metadata has an invalid state.');
+    }
+
+    /**
+     * Finishes a completed publication before another operation observes it.
+     */
+    private function finish_published_inflight(): void {
+        $inflight = $this->read_inflight();
+        if ($inflight === null || $inflight['phase'] !== 'publishing') {
+            return;
+        }
+        $path = base64_decode($inflight['path_b64'], true);
+        $work_path = $this->work_files_directory . '/' . $path;
+        $work_identity = $this->lstat_path($work_path);
+        if ($inflight['type'] === 'file') {
+            $data = $this->lstat_path($this->work_inflight_data_path);
+            if ($data !== null) {
+                if ($data['type'] !== 'file' || $data['size'] !== $inflight['total_bytes']) {
+                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Publishing in-flight data has an invalid size.');
+                }
+                $this->ensure_private_parent($work_path);
+                if ($work_identity !== null) {
+                    $this->remove_work_path($work_path);
+                }
+                if (!@rename($this->work_inflight_data_path, $work_path)) {
+                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish in-flight file data.');
+                }
+            } elseif ($work_identity === null || $work_identity['type'] !== 'file' || $work_identity['size'] !== $inflight['total_bytes']) {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Published in-flight data has no completed file.');
+            }
+        } elseif ($inflight['type'] === 'directory') {
+            if ($work_identity === null) {
+                $this->ensure_private_parent($work_path);
+                if (!@mkdir($work_path, 0700)) {
+                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the in-flight directory.');
+                }
+            } elseif ($work_identity['type'] !== 'directory') {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Published in-flight directory has an incompatible completed value.');
+            }
+        } elseif ($work_identity === null) {
+            $this->ensure_private_parent($work_path);
+            if (!@symlink(base64_decode($inflight['target_b64'], true), $work_path)) {
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the in-flight symlink.');
+            }
+        } elseif ($work_identity['type'] !== 'symlink' || @readlink($work_path) !== base64_decode($inflight['target_b64'], true)) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Published in-flight symlink has an incompatible completed value.');
+        }
+        if (!@unlink($this->work_inflight_path)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear published in-flight metadata.');
+        }
+    }
+
+    /**
+     * Accepts one file MIME part through the durable in-flight slot.
      *
      * The caller has already validated Content-Length against the document-root
      * part ceiling. This method validates the file-specific headers, enforces the
@@ -770,96 +857,89 @@ final class Site_Export_Push_Session {
         if ($offset > $total_bytes || $part_bytes > $total_bytes - $offset) {
             throw new InvalidArgumentException('File part for ' . base64_encode($path) . ' exceeds its declared total of ' . $total_bytes . ' bytes.');
         }
-        $partial_path = $this->work_partial_directory . '/' . $path;
+        $this->finish_published_inflight();
+        $inflight = $this->read_inflight();
         $complete_path = $this->work_files_directory . '/' . $path;
-        $this->ensure_private_parent($partial_path);
-        $this->ensure_private_parent($complete_path);
-
         $complete = $this->lstat_path($complete_path);
-        if ($complete !== null) {
-            if ($offset !== 0 && $complete['type'] === 'file' && $complete['size'] === $total_bytes && $offset === $total_bytes && $part_bytes === 0) {
-                if ($this->read_current_upload_body_piece() !== null) {
-                    throw new LogicException('Multipart processor exposed file bytes for an empty completed-file replay.');
-                }
-                $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => $total_bytes];
-                return;
+        if ($inflight === null && $complete !== null && $complete['type'] === 'file' && $complete['size'] === $total_bytes && $offset === $total_bytes && $part_bytes === 0) {
+            if ($this->read_current_upload_body_piece() !== null) {
+                throw new LogicException('Multipart processor exposed file bytes for an empty completed-file replay.');
             }
-            if ($offset !== 0) {
-                throw new Site_Export_Push_Exception(
-                    self::ERROR_OFFSET_GAP,
-                    'Completed work file ' . base64_encode($path) . ' can only be restarted at offset 0.'
-                );
+            $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => $total_bytes];
+            return;
+        }
+        if ($inflight === null && $offset !== 0) {
+            throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but no matching in-flight file exists. Start at offset 0.');
+        }
+        if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
+            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished staged value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
+        }
+        if ($inflight === null || $offset === 0) {
+            if ($inflight !== null && $this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard in-flight file data for restart.');
             }
-            if ($complete['type'] === 'directory' && $this->first_directory_entry($complete_path) !== null) {
-                throw new InvalidArgumentException('Work file ' . base64_encode($path) . ' conflicts with work descendants.');
+            $inflight = ['version' => 1, 'phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'file', 'total_bytes' => $total_bytes];
+            $this->write_json($this->work_inflight_path, $inflight);
+            $handle = @fopen($this->work_inflight_data_path, 'wb');
+            if ($handle === false) {
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create in-flight file data for ' . base64_encode($path) . '.');
             }
-        }
-
-        $partial = $this->lstat_path($partial_path);
-        if ($partial !== null && $partial['type'] === 'directory' && $this->first_directory_entry($partial_path) !== null) {
-            throw new InvalidArgumentException('Work file ' . base64_encode($path) . ' conflicts with partial descendants.');
-        }
-        if ($partial !== null && !in_array($partial['type'], ['file', 'directory'], true)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The partial path for ' . base64_encode($path) . ' is a ' . $partial['type'] . ', not a regular file.');
-        }
-        if ($complete !== null) {
-            $this->remove_work_path($complete_path);
-        }
-        if ($partial !== null && $partial['type'] === 'directory') {
-            $this->remove_work_path($partial_path);
-            $partial = null;
-        }
-        $actual_bytes = $partial === null ? 0 : $partial['size'];
-        if ($offset === 0 && $actual_bytes !== 0) {
-            if (!@unlink($partial_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not restart partial file ' . base64_encode($path) . ' at offset 0.');
-            }
+            fclose($handle);
+            $inflight['phase'] = 'receiving';
+            $this->write_json($this->work_inflight_path, $inflight);
             $actual_bytes = 0;
-        } elseif ($offset !== $actual_bytes) {
-            throw new Site_Export_Push_Exception(
-                self::ERROR_OFFSET_GAP,
-                'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but work/partial contains ' . $actual_bytes . ' bytes. Start at offset 0 or resume at the actual size.'
-            );
+        } else {
+            if ($inflight['type'] !== 'file' || $inflight['phase'] !== 'receiving' || $inflight['total_bytes'] !== $total_bytes) {
+                throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'In-flight file ' . base64_encode($path) . ' must be restarted at offset 0.');
+            }
+            $actual_bytes = $this->file_size($this->work_inflight_data_path);
+            if ($offset !== $actual_bytes) {
+                throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but in-flight data contains ' . $actual_bytes . ' bytes.');
+            }
         }
-
-        $handle = @fopen($partial_path, $actual_bytes === 0 ? 'wb' : 'ab');
+        $handle = @fopen($this->work_inflight_data_path, 'ab');
         if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open partial file ' . base64_encode($path) . ' for work.');
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open in-flight file data for ' . base64_encode($path) . '.');
         }
         $received = 0;
         try {
-            while (true) {
-                $piece = $this->read_current_upload_body_piece();
-                if ($piece === null) {
-                    break;
-                }
+            while (($piece = $this->read_current_upload_body_piece()) !== null) {
                 $received += strlen($piece);
-                $this->write_all($handle, $piece, 'partial file ' . base64_encode($path));
+                $this->write_all($handle, $piece, 'in-flight file data ' . base64_encode($path));
             }
             if (!fflush($handle)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not flush partial file ' . base64_encode($path) . '.');
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not flush in-flight file data ' . base64_encode($path) . '.');
             }
         } finally {
             fclose($handle);
         }
         $accepted_bytes = $actual_bytes + $received;
         if ($accepted_bytes === $total_bytes) {
-            if (!@rename($partial_path, $complete_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not promote completed work file ' . base64_encode($path) . '.');
+            $inflight['phase'] = 'publishing';
+            $this->write_json($this->work_inflight_path, $inflight);
+            $this->ensure_private_parent($complete_path);
+            if (($existing = $this->lstat_path($complete_path)) !== null) {
+                $this->remove_work_path($complete_path);
             }
-            $commit_state = 'complete';
+            if (!@rename($this->work_inflight_data_path, $complete_path)) {
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish completed staged file ' . base64_encode($path) . '.');
+            }
+            if (!@unlink($this->work_inflight_path)) {
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear published in-flight metadata for ' . base64_encode($path) . '.');
+            }
+            $state = 'complete';
         } else {
-            $commit_state = 'partial';
+            $state = 'partial';
         }
-        $this->current_change = ['path_b64' => base64_encode($path), 'state' => $commit_state, 'type' => 'file', 'accepted_bytes' => $accepted_bytes];
+        $this->current_change = ['path_b64' => base64_encode($path), 'state' => $state, 'type' => 'file', 'accepted_bytes' => $accepted_bytes];
     }
 
     /**
      * Accepts one explicit empty-directory MIME part.
      *
      * Directory parts have no body. They create or refresh an empty directory in
-     * the completed work tree, but they reject conflicts with already work
-     * descendants because a single work path cannot be both a leaf value and a
+     * the completed staging tree, but they reject conflicts with already staged
+     * descendants because a single staged path cannot be both a leaf value and a
      * structural parent.
      *
      * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-directory-path:string} $headers
@@ -872,26 +952,36 @@ final class Site_Export_Push_Session {
             throw new InvalidArgumentException('Multipart directory part must have Content-Length 0.');
         }
         $path = $this->decode_path_header($headers, 'x-directory-path');
-        $work_path = $this->work_files_directory . '/' . $path;
-        $partial = $this->work_partial_directory . '/' . $path;
-        $this->ensure_private_parent($work_path);
-        $this->ensure_private_parent($partial, false);
-        $identity = $this->lstat_path($work_path);
-        $partial_identity = $this->lstat_path($partial);
-        if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($work_path) !== null) {
-            throw new InvalidArgumentException('Explicit empty directory ' . base64_encode($path) . ' conflicts with work descendants.');
+        $target = $this->work_files_directory . '/' . $path;
+        $this->finish_published_inflight();
+        $inflight = $this->read_inflight();
+        if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
+            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished staged value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
         }
-        if ($partial_identity !== null && $partial_identity['type'] === 'directory' && $this->first_directory_entry($partial) !== null) {
-            throw new InvalidArgumentException('Explicit empty directory ' . base64_encode($path) . ' conflicts with partial descendants.');
+        $identity = $this->lstat_path($target);
+        if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
+            throw new InvalidArgumentException('Explicit empty directory ' . base64_encode($path) . ' conflicts with staged descendants.');
         }
-        if ($identity !== null && $identity['type'] !== 'directory') {
-            $this->remove_work_path($work_path);
+        if ($inflight === null && $identity !== null && $identity['type'] === 'directory') {
+            $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0];
+            return;
         }
-        if ($partial_identity !== null) {
-            $this->remove_work_path($partial);
+        $inflight = ['version' => 1, 'phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'directory'];
+        $this->write_json($this->work_inflight_path, $inflight);
+        if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
         }
-        if (!is_dir($work_path) && !@mkdir($work_path, 0777)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create an explicit empty work directory ' . base64_encode($path) . '.');
+        if ($identity !== null) {
+            $this->remove_work_path($target);
+        }
+        $inflight['phase'] = 'publishing';
+        $this->write_json($this->work_inflight_path, $inflight);
+        $this->ensure_private_parent($target);
+        if (!is_dir($target) && !@mkdir($target, 0777)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not stage explicit empty directory ' . base64_encode($path) . '.');
+        }
+        if (!@unlink($this->work_inflight_path)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear published in-flight metadata for ' . base64_encode($path) . '.');
         }
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0];
     }
@@ -900,8 +990,8 @@ final class Site_Export_Push_Session {
      * Accepts one symlink MIME part.
      *
      * Symlink parts carry their target in a base64 header and have an empty
-     * body. The work value replaces any previous leaf at the same private path
-     * and rejects directory conflicts that would orphan already work children.
+     * body. The staged value replaces any previous leaf at the same private path
+     * and rejects directory conflicts that would orphan already staged children.
      *
      * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-symlink-path:string,x-symlink-target:string} $headers
      *     Normalized symlink part headers.
@@ -913,30 +1003,40 @@ final class Site_Export_Push_Session {
             throw new InvalidArgumentException('Multipart symlink part must have Content-Length 0.');
         }
         $path = $this->decode_path_header($headers, 'x-symlink-path');
-        $symlink_target = $this->decode_path_header($headers, 'x-symlink-target', false);
-        if ($symlink_target === '' || strlen($symlink_target) > self::MAX_PATH_BYTES || strpos($symlink_target, "\0") !== false) {
-            throw new InvalidArgumentException('Symlink destination must contain between 1 and ' . self::MAX_PATH_BYTES . ' bytes without NUL.');
+        $target_value = $this->decode_path_header($headers, 'x-symlink-target', false);
+        if ($target_value === '' || strlen($target_value) > self::MAX_PATH_BYTES || strpos($target_value, "\0") !== false) {
+            throw new InvalidArgumentException('Symlink target must contain between 1 and ' . self::MAX_PATH_BYTES . ' bytes without NUL.');
         }
-        $work_path = $this->work_files_directory . '/' . $path;
-        $partial = $this->work_partial_directory . '/' . $path;
-        $this->ensure_private_parent($work_path);
-        $this->ensure_private_parent($partial, false);
-        $identity = $this->lstat_path($work_path);
-        $partial_identity = $this->lstat_path($partial);
-        if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($work_path) !== null) {
-            throw new InvalidArgumentException('Work symlink ' . base64_encode($path) . ' conflicts with work descendants.');
+        $target = $this->work_files_directory . '/' . $path;
+        $this->finish_published_inflight();
+        $inflight = $this->read_inflight();
+        if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
+            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'An unfinished staged value already occupies the in-flight slot: ' . $inflight['path_b64'] . '.');
         }
-        if ($partial_identity !== null && $partial_identity['type'] === 'directory' && $this->first_directory_entry($partial) !== null) {
-            throw new InvalidArgumentException('Work symlink ' . base64_encode($path) . ' conflicts with partial descendants.');
+        $identity = $this->lstat_path($target);
+        if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
+            throw new InvalidArgumentException('Staged symlink ' . base64_encode($path) . ' conflicts with staged descendants.');
+        }
+        if ($inflight === null && $identity !== null && $identity['type'] === 'symlink' && @readlink($target) === $target_value) {
+            $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0];
+            return;
+        }
+        $inflight = ['version' => 1, 'phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'symlink', 'target_b64' => base64_encode($target_value)];
+        $this->write_json($this->work_inflight_path, $inflight);
+        if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
         }
         if ($identity !== null) {
-            $this->remove_work_path($work_path);
+            $this->remove_work_path($target);
         }
-        if ($partial_identity !== null) {
-            $this->remove_work_path($partial);
+        $inflight['phase'] = 'publishing';
+        $this->write_json($this->work_inflight_path, $inflight);
+        $this->ensure_private_parent($target);
+        if (!@symlink($target_value, $target)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not stage symlink ' . base64_encode($path) . '.');
         }
-        if (!@symlink($symlink_target, $work_path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create a work symlink ' . base64_encode($path) . '.');
+        if (!@unlink($this->work_inflight_path)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear published in-flight metadata for ' . base64_encode($path) . '.');
         }
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0];
     }
@@ -945,7 +1045,7 @@ final class Site_Export_Push_Session {
      * Accepts one segment of the raw NUL-delimited delete stream.
      *
      * The delete stream is append-only, but lost responses may cause callers to
-     * replay bytes already stored in the work delete stream. Overlapping bytes must match
+     * replay bytes already stored by the target. Overlapping bytes must match
      * exactly; new bytes are validated record-by-record before they are flushed.
      * A completion declaration records that no more delete bytes may be added.
      *
@@ -1610,45 +1710,6 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Finds whether a tree contains any work.
-     *
-     * Empty directories can be structural commit-cursor entries rather than
-     * logical values. This descends through such directories until it sees a
-     * leaf value or a directory with its own non-empty descendant.
-     *
-     * @param string $directory Absolute private directory path.
-     * @return string|null Entry name proving pending work exists, or null.
-     */
-    private function first_tree_entry(string $directory): ?string {
-        $handle = @opendir($directory);
-        if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read directory ' . $directory . '.');
-        }
-        try {
-            while (true) {
-                $entry = readdir($handle);
-                if ($entry === false) {
-                    break;
-                }
-                if ($entry === '.' || $entry === '..') {
-                    continue;
-                }
-                $path = $directory . '/' . $entry;
-                $identity = $this->lstat_path($path);
-                if ($identity === null) {
-                    continue;
-                }
-                if ($identity['type'] !== 'directory' || $this->first_tree_entry($path) !== null) {
-                    return $entry;
-                }
-            }
-        } finally {
-            closedir($handle);
-        }
-        return null;
-    }
-
-    /**
      * Returns a work leaf path below a structural directory.
      *
      * When a document-root structural ancestor conflicts, reporting only the ancestor can
@@ -1786,7 +1847,7 @@ final class Site_Export_Push_Session {
             throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push session ' . $this->push_session_id . ' is busy. Retry the request.');
         }
         try {
-            foreach ([$this->push_directory, $this->work_dir, $this->work_files_directory, $this->work_partial_directory] as $directory) {
+            foreach ([$this->push_directory, $this->work_dir, $this->work_files_directory] as $directory) {
                 $identity = $this->lstat_path($directory);
                 if ($identity === null || $identity['type'] !== 'directory') {
                     throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push directory is missing or not real: ' . $directory . '.');
@@ -1798,7 +1859,7 @@ final class Site_Export_Push_Session {
                     throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push file is missing or not regular: ' . $file . '.');
                 }
             }
-            foreach ([$this->commit_json_path, $this->maintenance_copy_path] as $optional_file) {
+            foreach ([$this->commit_json_path, $this->maintenance_copy_path, $this->work_inflight_path, $this->work_inflight_data_path] as $optional_file) {
                 $identity = $this->lstat_path($optional_file);
                 if ($identity !== null && $identity['type'] !== 'file') {
                     throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Optional push file has an unsupported type: ' . $optional_file . '.');
@@ -2220,7 +2281,7 @@ final class Site_Export_Push_Session {
     /**
      * Creates or validates private structural parents for a work path.
      *
-     * Only work/files and work/partial paths are accepted. Missing parents are
+     * Only work/files paths are accepted. Missing parents are
      * created when requested; existing parents must be real directories so a
      * work leaf, link, or external path cannot become a container for another
      * value.
@@ -2231,14 +2292,14 @@ final class Site_Export_Push_Session {
     private function ensure_private_parent(string $path, bool $create_missing = true): void {
         $parent = dirname($path);
         $root = null;
-        foreach ([$this->work_files_directory, $this->work_partial_directory] as $candidate) {
+        foreach ([$this->work_files_directory] as $candidate) {
             if ($parent === $candidate || strpos($parent . '/', $candidate . '/') === 0) {
                 $root = $candidate;
                 break;
             }
         }
         if ($root === null) {
-            throw new LogicException('Private work path escaped work/files and work/partial.');
+            throw new LogicException('Private work path escaped work/files.');
         }
         if ($parent === $root) {
             return;

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -29,6 +29,16 @@ final class PushSessionTest extends TestCase {
         $this->assertSame(['operation' => 'receive'], $exception->get_context());
     }
 
+    public function testNewPushSessionHasOneCompletedTreeAndNoPartialTree(): void {
+        $push_session = $this->push_session('10101010101010101010101010101010');
+        $work_directory = $push_session->get_push_directory() . '/work';
+
+        $this->assertDirectoryExists($work_directory . '/files');
+        $this->assertFileDoesNotExist($work_directory . '/partial');
+        $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+        $this->assertFileDoesNotExist($work_directory . '/inflight.data');
+    }
+
     public function testPartialFileProgressComesFromTheFileAndOffsetZeroRestartsIt(): void {
         $push_session = $this->push_session('11111111111111111111111111111111');
         $this->push_parts($push_session, [[

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -527,6 +527,23 @@ final class PushSessionTest extends TestCase {
             ],
             'body' => 'a',
         ]]);
+
+        $this->assertSame(
+            ['path_b64' => base64_encode('missing'), 'state' => 'missing', 'accepted_bytes' => 0],
+            $push_session->get_status('missing')['path']
+        );
+        $this->assertSame('partial', $push_session->get_status($raw_path)['path']['state']);
+        $this->assertSame(1, $push_session->get_status($raw_path)['path']['accepted_bytes']);
+
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode($raw_path),
+                'X-File-Size' => '2',
+                'X-Chunk-Offset' => '1',
+            ],
+            'body' => 'b',
+        ]]);
         $this->push_parts($push_session, [
             [
                 'headers' => [
@@ -554,12 +571,6 @@ final class PushSessionTest extends TestCase {
             ],
         ]);
 
-        $this->assertSame(
-            ['path_b64' => base64_encode('missing'), 'state' => 'missing', 'accepted_bytes' => 0],
-            $push_session->get_status('missing')['path']
-        );
-        $this->assertSame('partial', $push_session->get_status($raw_path)['path']['state']);
-        $this->assertSame(1, $push_session->get_status($raw_path)['path']['accepted_bytes']);
         $this->assertSame('file', $push_session->get_status('empty.bin')['path']['type']);
         $this->assertSame('directory', $push_session->get_status('empty-directory')['path']['type']);
         $this->assertSame('symlink', $push_session->get_status('link')['path']['type']);
@@ -792,6 +803,43 @@ final class PushSessionTest extends TestCase {
         $this->assertSame('new', file_get_contents($work_directory . '/files/same-size.txt'));
         $this->assertFileDoesNotExist($work_directory . '/inflight.json');
         $this->assertFileDoesNotExist($work_directory . '/inflight.data');
+    }
+
+    public function testStatusFinishesPublishedFileAfterItsDataWasRenamed(): void {
+        $push_session = $this->push_session('45454545454545454545454545454545');
+        $work_directory = $push_session->get_push_directory() . '/work';
+        file_put_contents($work_directory . '/files/renamed.txt', 'new');
+        file_put_contents($work_directory . '/inflight.json', json_encode([
+            'version' => 1,
+            'phase' => 'publishing',
+            'path_b64' => base64_encode('renamed.txt'),
+            'type' => 'file',
+            'total_bytes' => 3,
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertSame('complete', $push_session->get_status('renamed.txt')['path']['state']);
+        $this->assertSame('new', file_get_contents($work_directory . '/files/renamed.txt'));
+        $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+    }
+
+    public function testCommitFinishesPublishedFileBeforeWritingItsCheckpoint(): void {
+        $push_session = $this->push_session('46464646464646464646464646464646');
+        $work_directory = $push_session->get_push_directory() . '/work';
+        file_put_contents($work_directory . '/inflight.data', 'new');
+        file_put_contents($work_directory . '/inflight.json', json_encode([
+            'version' => 1,
+            'phase' => 'publishing',
+            'path_b64' => base64_encode('commit.txt'),
+            'type' => 'file',
+            'total_bytes' => 3,
+        ], JSON_THROW_ON_ERROR));
+        $this->complete_work_deletes($push_session);
+
+        $push_session->commit(1);
+
+        $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+        $this->assertSame('new', file_get_contents($work_directory . '/files/commit.txt'));
+        $this->assertFileExists($push_session->get_push_directory() . '/commit.json');
     }
 
     public function testCheckpointMustContainEveryFieldReadByCommit(): void {

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -511,7 +511,7 @@ final class PushSessionTest extends TestCase {
 
             $this->assertSame('complete', $push_session->get_status('changing')['path']['state']);
             $this->assertSame($type, $push_session->get_status('changing')['path']['type']);
-            $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/partial/changing');
+            $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/inflight.data');
         }
     }
 
@@ -622,10 +622,10 @@ final class PushSessionTest extends TestCase {
             try {
                 $this->push_parts($push_session, [['headers' => $headers, 'body' => '']]);
                 $this->fail('A partial file became the parent of a completed ' . $type . '.');
-            } catch (InvalidArgumentException $exception) {
-                $this->assertStringContainsString('parent', $exception->getMessage());
+            } catch (Site_Export_Push_Exception $exception) {
+                $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
-            $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/partial/parent'));
+            $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
             $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/files/parent/child');
         }
     }
@@ -668,10 +668,10 @@ final class PushSessionTest extends TestCase {
             try {
                 $this->push_parts($push_session, [['headers' => $headers, 'body' => $body]]);
                 $this->fail('A completed ' . $type . ' hid a partial descendant.');
-            } catch (InvalidArgumentException $exception) {
-                $this->assertStringContainsString('descendant', $exception->getMessage());
+            } catch (Site_Export_Push_Exception $exception) {
+                $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
-            $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/partial/parent/child'));
+            $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
         }
     }
 

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -753,26 +753,6 @@ final class PushSessionTest extends TestCase {
         $this->assertFileDoesNotExist($this->docroot . '/unfinished.txt');
     }
 
-    public function testInFlightMetadataRejectsAnExtraKeyBeforeStatusReadsWork(): void {
-        $push_session = $this->push_session('45454545454545454545454545454545');
-        $work_directory = $push_session->get_push_directory() . '/work';
-        file_put_contents($work_directory . '/inflight.json', json_encode([
-            'version' => 1,
-            'phase' => 'preparing',
-            'path_b64' => base64_encode('unsafe.txt'),
-            'type' => 'file',
-            'total_bytes' => 1,
-            'unexpected' => true,
-        ], JSON_THROW_ON_ERROR));
-
-        try {
-            $push_session->get_status('unsafe.txt');
-            $this->fail('In-flight metadata with an extra key was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
-            $this->assertSame('corrupted_push_state', $exception->get_error_code());
-        }
-    }
-
     public function testStatusFinishesPublishedDirectoryAndSymlinkWork(): void {
         foreach (['directory', 'symlink'] as $index => $type) {
             $push_session = $this->push_session(sprintf('%032x', 60 + $index));
@@ -812,18 +792,6 @@ final class PushSessionTest extends TestCase {
         $this->assertSame('new', file_get_contents($work_directory . '/files/same-size.txt'));
         $this->assertFileDoesNotExist($work_directory . '/inflight.json');
         $this->assertFileDoesNotExist($work_directory . '/inflight.data');
-    }
-
-    public function testMetadataFreeInFlightDataIsCorruptState(): void {
-        $push_session = $this->push_session('24242424242424242424242424242424');
-        file_put_contents($push_session->get_push_directory() . '/work/inflight.data', 'orphaned');
-
-        try {
-            $push_session->get_status();
-            $this->fail('In-flight data without metadata was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
-            $this->assertSame('corrupted_push_state', $exception->get_error_code());
-        }
     }
 
     public function testCheckpointMustContainEveryFieldReadByCommit(): void {

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -675,6 +675,126 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testOnlyTheMatchingPathCanUseTheInFlightSlot(): void {
+        $push_session = $this->push_session('77777777777777777777777777777777');
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('first.txt'),
+                'X-File-Size' => '2',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'a',
+        ]]);
+
+        try {
+            $this->push_file($push_session, 'second.txt', 'b');
+            $this->fail('A different path replaced unfinished work.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
+        }
+
+        $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
+        $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/files/second.txt');
+    }
+
+    public function testInFlightFileStatusShadowsThePreviousCompletedFile(): void {
+        $push_session = $this->push_session('67676767676767676767676767676767');
+        $this->push_file($push_session, 'same-size.txt', 'old');
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('same-size.txt'),
+                'X-File-Size' => '3',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'n',
+        ]]);
+
+        $status = $push_session->get_status('same-size.txt')['path'];
+        $this->assertSame('partial', $status['state']);
+        $this->assertSame('file', $status['type']);
+        $this->assertSame(1, $status['accepted_bytes']);
+        $this->assertSame('old', file_get_contents($push_session->get_push_directory() . '/work/files/same-size.txt'));
+
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('same-size.txt'),
+                'X-File-Size' => '3',
+                'X-Chunk-Offset' => '1',
+            ],
+            'body' => 'ew',
+        ]]);
+        $this->assertSame('new', file_get_contents($push_session->get_push_directory() . '/work/files/same-size.txt'));
+    }
+
+    public function testCommitRejectsUnfinishedWorkBeforeWritingACheckpoint(): void {
+        $push_session = $this->push_session('56565656565656565656565656565656');
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('unfinished.txt'),
+                'X-File-Size' => '2',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'x',
+        ]]);
+        $this->complete_work_deletes($push_session);
+
+        try {
+            $push_session->commit(1);
+            $this->fail('Commit accepted unfinished work.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('unfinished', $exception->getMessage());
+        }
+
+        $this->assertFileDoesNotExist($push_session->get_push_directory() . '/commit.json');
+        $this->assertFileDoesNotExist($this->docroot . '/unfinished.txt');
+    }
+
+    public function testInFlightMetadataRejectsAnExtraKeyBeforeStatusReadsWork(): void {
+        $push_session = $this->push_session('45454545454545454545454545454545');
+        $work_directory = $push_session->get_push_directory() . '/work';
+        file_put_contents($work_directory . '/inflight.json', json_encode([
+            'version' => 1,
+            'phase' => 'preparing',
+            'path_b64' => base64_encode('unsafe.txt'),
+            'type' => 'file',
+            'total_bytes' => 1,
+            'unexpected' => true,
+        ], JSON_THROW_ON_ERROR));
+
+        try {
+            $push_session->get_status('unsafe.txt');
+            $this->fail('In-flight metadata with an extra key was accepted.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('corrupted_push_state', $exception->get_error_code());
+        }
+    }
+
+    public function testStatusFinishesPublishedDirectoryAndSymlinkWork(): void {
+        foreach (['directory', 'symlink'] as $index => $type) {
+            $push_session = $this->push_session(sprintf('%032x', 60 + $index));
+            $work_directory = $push_session->get_push_directory() . '/work';
+            $inflight = [
+                'version' => 1,
+                'phase' => 'publishing',
+                'path_b64' => base64_encode($type . '-value'),
+                'type' => $type,
+            ];
+            if ($type === 'symlink') {
+                $inflight['target_b64'] = base64_encode('../target');
+            }
+            file_put_contents($work_directory . '/inflight.json', json_encode($inflight, JSON_THROW_ON_ERROR));
+
+            $status = $push_session->get_status($type . '-value')['path'];
+            $this->assertSame('complete', $status['state']);
+            $this->assertSame($type, $status['type']);
+            $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+        }
+    }
+
     public function testCheckpointMustContainEveryFieldReadByCommit(): void {
         $push_session = $this->push_session(sprintf('%032x', 400));
         $this->complete_work_deletes($push_session);

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -795,6 +795,37 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testStatusFinishesPublishedFileDataWithoutAcceptingTheOldValue(): void {
+        $push_session = $this->push_session('34343434343434343434343434343434');
+        $work_directory = $push_session->get_push_directory() . '/work';
+        file_put_contents($work_directory . '/files/same-size.txt', 'old');
+        file_put_contents($work_directory . '/inflight.data', 'new');
+        file_put_contents($work_directory . '/inflight.json', json_encode([
+            'version' => 1,
+            'phase' => 'publishing',
+            'path_b64' => base64_encode('same-size.txt'),
+            'type' => 'file',
+            'total_bytes' => 3,
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertSame('complete', $push_session->get_status('same-size.txt')['path']['state']);
+        $this->assertSame('new', file_get_contents($work_directory . '/files/same-size.txt'));
+        $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+        $this->assertFileDoesNotExist($work_directory . '/inflight.data');
+    }
+
+    public function testMetadataFreeInFlightDataIsCorruptState(): void {
+        $push_session = $this->push_session('24242424242424242424242424242424');
+        file_put_contents($push_session->get_push_directory() . '/work/inflight.data', 'orphaned');
+
+        try {
+            $push_session->get_status();
+            $this->fail('In-flight data without metadata was accepted.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('corrupted_push_state', $exception->get_error_code());
+        }
+    }
+
     public function testCheckpointMustContainEveryFieldReadByCommit(): void {
         $push_session = $this->push_session(sprintf('%032x', 400));
         $this->complete_work_deletes($push_session);


### PR DESCRIPTION
Removes the concept of `work/partial/` file tree for saving in-progress file uploads,
and replaces it with a single `work/inflight.data` file where the current byte stream
is buffered. It also introduces `work/inflight.json` for the metadata of that currently
buffered file, e.g. its path, expected filesize etc.

## Background

Before this PR, push data was written to both `work/files/` and `work/partial/`.
This data model enabled representing invalid states where the two trees couldn't
be reconciled. This PR removes this entire class of possible errors by only having
a single work tree.

## This change

`inflight.json` records the one value currently being received or published.
`inflight.data` holds that value's unfinished file bytes, and its actual size
is the resume cursor. A matching file can resume or restart at offset zero;
a directory or symlink can replace the current value at that same path. Another
path is rejected until the current value is complete.

## Testing

There's no easy way to test this change. Review the tests and rely on CI.
