### PR TITLE
[Push] Expose authenticated push operations without buffering uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ On the **migration source** side:
  - ext-zlib — deflate_init/deflate_add for gzip streaming
  - ext-pdo + ext-pdo_mysql — database access (already in composer.json)
 
+Hosts exposing the push endpoints must set `display_errors=Off` at PHP
+startup, through `php.ini`, `.user.ini`, or the PHP-FPM pool configuration.
+`log_errors=On` is recommended so startup failures remain available to
+operators. PHP and the web server can reject an oversized request before the
+exporter runs, so those responses are not guaranteed to use the push JSON
+protocol. The sender accepts a bare HTTP 413 and learns a smaller request
+ceiling from it.
+
 On the **migration target** side:
 
  - PHP 7.4+

--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/push-commit-language",
+            "version": "dev-adamziel/authenticated-push-endpoints",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "6a5cbcf2ac9d0b34789819f01ccb00033b67581a"
+                "reference": "2050e07227a82c058c6267c5e8b3e77d0cd4dbdc"
             },
             "require": {
                 "php": ">=7.2",
@@ -385,7 +385,9 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-multipart-processor.php",
+                    "src/class-push-configuration-exception.php",
                     "src/class-push-exception.php",
+                    "src/class-push-endpoints.php",
                     "src/class-push-session.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -109,21 +109,55 @@ still being prepared or received, so it traverses completed work files only.
 more cleanup remains and must be retried. A push with a commit in progress is
 not removable; its next commit request resumes the durable cursor instead.
 
+## Push HTTP operations
+
+The production exporter router exposes five authenticated operations. Control
+and upload requests use the envelope signature described above, so
+`push_upload` passes `php://input` directly to the multipart processor instead
+of reading the complete request for authentication.
+
+- `POST push_create` creates or reopens the caller's 32-character lowercase
+  hexadecimal `push_session_id`. It returns
+  `{status:"created",push_session_id:string,max_part_bytes:int,post_max_bytes:int|null}`.
+  The two limits describe different dimensions: one part and the complete
+  decoded request body. The endpoint enforces the request-body limit while
+  reading bounded fragments, including chunked requests without
+  `Content-Length`.
+- `POST push_upload` accepts `multipart/mixed`. It returns
+  `{status:"accepted",push_session_id:string,changes_accepted:int,last_change:change|null}`,
+  where `change` is exactly the `get_current_change()` file, directory,
+  symlink, or delete-list union. Only the latest change is retained for the
+  response; request memory does not grow with the number of parts.
+- `GET push_status` accepts an optional base64 `path_b64`. It returns
+  `status:"accepted"` together with the exact `get_status()` object: push
+  session phase, `work_deletes_bytes`, `work_deletes_complete`, and the
+  requested path's missing, partial, or complete receiver-confirmed state.
+- `POST push_commit` performs a server-bounded call to `commit()`. It returns
+  `{status:"accepted",push_session_id:string,phase:"deleting_files"|"installing_files"|"complete",send_next_request:bool,entries_processed:int}`.
+  The sender repeats it while `send_next_request` is true.
+- `POST push_remove` performs one bounded remove step. It returns
+  `{status:"accepted",push_session_id:string,removed:bool}`. The sender repeats
+  it while `removed` is false.
+
+The WordPress plugin stores push work in a document-root-specific private
+directory beside the resolved `ABSPATH` document root unless its embedder
+supplies `reprint_directory`.
+Configured reprint directories must remain outside the document root; the HTTP
+endpoints reject an inside path because they do not yet apply the indexing and
+web-access protections described below. The plugin always excludes its own
+directory from push. An embedding router must likewise choose its reprint
+directory and excluded paths as server configuration; request parameters cannot
+select either one.
+
 ## Where reprint stores its own data on the remote
 
 The remote is configured with one storage path for everything reprint keeps:
-the private push directory and any commit bookkeeping. Preferably outside the document
-root. When the host only allows writing inside the document root:
-
-- the file indexer never lists anything under it. `storage_path` is the
-  server's own setting, so every index request knows it — including a
-   pulling peer's, which never scans this site's push work,
-- the deletion step refuses to touch anything under it,
-- an `.htaccess` (deny-all) and an empty `index.php` are written into
-  it. That is all that can be done from inside the directory: Apache
-  honors the deny rules, nginx ignores both files and loses nothing by
-  their presence. Do not keep this directory inside the document root
-  unless the host offers nowhere else to write.
+the private push directory and any commit bookkeeping. The current push HTTP
+endpoints require this path to be outside the document root. They do not yet
+exclude an inside path from every file index or write web-server access guards,
+so endpoint construction rejects that configuration instead of exposing private
+push work. A host which cannot write outside the document root is not supported
+until those protections exist.
 
 ## Commit
 

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -118,11 +118,15 @@ of reading the complete request for authentication.
 
 - `POST push_create` creates or reopens the caller's 32-character lowercase
   hexadecimal `push_session_id`. It returns
-  `{status:"created",push_session_id:string,max_part_bytes:int,post_max_bytes:int|null}`.
+  `{status:"created",push_session_id:string,max_part_bytes:int,post_max_bytes:int|null,excluded_paths_b64:string[]}`.
   The two limits describe different dimensions: one part and the complete
   decoded request body. The endpoint enforces the request-body limit while
   reading bounded fragments, including chunked requests without
-  `Content-Length`.
+  `Content-Length`. `excluded_paths_b64` is the normalized, sorted, immutable
+  server policy stored for the push session; base64 preserves arbitrary path
+  bytes which JSON cannot represent directly. A sender consuming this field
+  must omit indexed paths equal to, below, or ancestors of any advertised
+  exclusion.
 - `POST push_upload` accepts `multipart/mixed`. It returns
   `{status:"accepted",push_session_id:string,changes_accepted:int,last_change:change|null}`,
   where `change` is exactly the `get_current_change()` file, directory,
@@ -139,15 +143,28 @@ of reading the complete request for authentication.
   `{status:"accepted",push_session_id:string,removed:bool}`. The sender repeats
   it while `removed` is false.
 
-The WordPress plugin stores push work in a document-root-specific private
-directory beside the resolved `ABSPATH` document root unless its embedder
-supplies `reprint_directory`.
+Push deployments must set `display_errors=Off` at PHP startup through
+`php.ini`, `.user.ini`, or the PHP-FPM pool configuration; changing it after
+the request starts is too late for PHP's own `post_max_size` warning.
+`log_errors=On` is recommended. When the endpoint code receives an oversized
+request it returns a classified push JSON failure, but PHP or the web server
+may reject a request before the exporter runs and that response need not use
+the push JSON protocol. The sender therefore also treats a bare HTTP 413 as
+`request_too_large` and learns a smaller request ceiling.
+
+The WordPress plugin manages the trusted `docroot` supplied by its embedder, or
+the web server's `DOCUMENT_ROOT` by default. The path must resolve to an existing
+directory. `ABSPATH` remains the default only for pull endpoints because it may
+point at a separate shared WordPress core tree. Push work lives in a
+document-root-specific private directory beside the canonical managed document
+root unless its embedder supplies `reprint_directory`.
 Configured reprint directories must remain outside the document root; the HTTP
 endpoints reject an inside path because they do not yet apply the indexing and
-web-access protections described below. The plugin always excludes its own
-directory from push. An embedding router must likewise choose its reprint
-directory and excluded paths as server configuration; request parameters cannot
-select either one.
+web-access protections described below. The plugin always excludes its logical
+installed directory from push, including when that directory is a symlink to a
+physical target outside the document root. An embedding router must likewise
+choose its document root, reprint directory, and excluded paths as server
+configuration; request parameters cannot select any of them.
 
 ## Where reprint stores its own data on the remote
 

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -117,31 +117,34 @@ and upload requests use the envelope signature described above, so
 of reading the complete request for authentication.
 
 - `POST push_create` creates or reopens the caller's 32-character lowercase
-  hexadecimal `push_session_id`. It returns
-  `{status:"created",push_session_id:string,max_part_bytes:int,post_max_bytes:int|null,excluded_paths_b64:string[]}`.
-  The two limits describe different dimensions: one part and the complete
-  decoded request body. The endpoint enforces the request-body limit while
-  reading bounded fragments, including chunked requests without
-  `Content-Length`. `excluded_paths_b64` is the normalized, sorted, immutable
-  server policy stored for the push session; base64 preserves arbitrary path
-  bytes which JSON cannot represent directly. A sender consuming this field
-  must omit indexed paths equal to, below, or ancestors of any advertised
-  exclusion.
-- `POST push_upload` accepts `multipart/mixed`. It returns
-  `{status:"accepted",push_session_id:string,changes_accepted:int,last_change:change|null}`,
-  where `change` is exactly the `get_current_change()` file, directory,
-  symlink, or delete-list union. Only the latest change is retained for the
+  hexadecimal `push_session_id`. A successful response contains `status`,
+  `push_session_id`, `max_part_bytes`, `post_max_bytes`, and
+  `excluded_paths_b64`. The two limits describe different dimensions: one
+  multipart part and the complete decoded request body. The endpoint enforces
+  the request-body limit while reading bounded fragments, including chunked
+  requests without `Content-Length`. `excluded_paths_b64` is the normalized,
+  sorted, immutable server policy stored for the push session; base64 preserves
+  arbitrary path bytes which JSON cannot represent directly. A sender
+  consuming this field must omit indexed paths equal to, below, or ancestors
+  of any advertised exclusion.
+- `POST push_upload` accepts `multipart/mixed`. A successful response contains
+  `status`, `push_session_id`, `changes_accepted`, and `last_change`. The last
+  change is null for an empty request. Otherwise it contains `state`, `type`,
+  and `accepted_bytes`, plus `path_b64` for a file, directory, or symlink. A
+  delete-list change has no path. Only the latest change is retained for the
   response; request memory does not grow with the number of parts.
-- `GET push_status` accepts an optional base64 `path_b64`. It returns
-  `status:"accepted"` together with the exact `get_status()` object: push
-  session phase, `work_deletes_bytes`, `work_deletes_complete`, and the
-  requested path's missing, partial, or complete receiver-confirmed state.
-- `POST push_commit` performs a server-bounded call to `commit()`. It returns
-  `{status:"accepted",push_session_id:string,phase:"deleting_files"|"installing_files"|"complete",send_next_request:bool,entries_processed:int}`.
-  The sender repeats it while `send_next_request` is true.
-- `POST push_remove` performs one bounded remove step. It returns
-  `{status:"accepted",push_session_id:string,removed:bool}`. The sender repeats
-  it while `removed` is false.
+- `GET push_status` accepts an optional base64 `path_b64`. A successful
+  response contains `status`, `push_session_id`, `phase`,
+  `work_deletes_bytes`, `work_deletes_complete`, and `path`. The path is null
+  when none was requested. Otherwise it contains `path_b64`, `state`, and
+  `accepted_bytes`; a non-missing path also contains `type`.
+- `POST push_commit` performs one server-bounded commit call. A successful
+  response contains `status`, `push_session_id`, `phase`,
+  `send_next_request`, and `entries_processed`. The sender repeats it while
+  `send_next_request` is true.
+- `POST push_remove` performs one bounded remove step. A successful response
+  contains `status`, `push_session_id`, and `removed`. The sender repeats it
+  while `removed` is false.
 
 Push deployments must set `display_errors=Off` at PHP startup through
 `php.ini`, `.user.ini`, or the PHP-FPM pool configuration; changing it after
@@ -152,18 +155,21 @@ may reject a request before the exporter runs and that response need not use
 the push JSON protocol. The sender therefore also treats a bare HTTP 413 as
 `request_too_large` and learns a smaller request ceiling.
 
-The WordPress plugin manages the trusted `docroot` supplied by its embedder, or
-the web server's `DOCUMENT_ROOT` by default. The path must resolve to an existing
-directory. `ABSPATH` remains the default only for pull endpoints because it may
-point at a separate shared WordPress core tree. Push work lives in a
-document-root-specific private directory beside the canonical managed document
-root unless its embedder supplies `reprint_directory`.
+The WordPress plugin passes the platform-supplied `docroot` to push endpoints,
+defaulting to the web server's `DOCUMENT_ROOT`. A platform supplies the complete
+trusted API-options array through the early `site_export_api_options` filter; a
+direct embedder passes the same array to `_site_export_handle_api_request()`.
+The document-root path must resolve to an existing directory. `ABSPATH` remains
+the default only for pull endpoints because it may point at a separate shared
+WordPress core tree. Push work lives in a document-root-specific private
+directory beside the canonical document root unless server configuration
+supplies `reprint_directory`.
 Configured reprint directories must remain outside the document root; the HTTP
 endpoints reject an inside path because they do not yet apply the indexing and
 web-access protections described below. The plugin always excludes its logical
 installed directory from push, including when that directory is a symlink to a
-physical target outside the document root. An embedding router must likewise
-choose its document root, reprint directory, and excluded paths as server
+physical target outside the document root. A platform hook or embedding router
+must choose its document root, reprint directory, and excluded paths as server
 configuration; request parameters cannot select any of them.
 
 ## Where reprint stores its own data on the remote

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -14,8 +14,8 @@ messages, or pull-request descriptions.
 - **Work files**, **in-flight work**, and **work deletes** are the only durable
   work owned by a push session. Work files are complete values. In-flight work
   is the one value currently being received or published.
-- **Commit** consumes work deletes and work files. It never names another
-  lifecycle operation.
+- **Commit** consumes work deletes and work files; it does not create or remove
+  a push session.
 - **Remove** deletes a push directory in bounded calls.
 
 ## PHP names
@@ -58,10 +58,10 @@ is the only path-shaped work tree. The shared `.reprint/push/` directory contain
 `push-create.lock`, `commit-state`, `commit-state.lock`, and bounded removal
 tombstones named `.removing-<push-session-id>/`.
 
-`push-create.lock` is the lifecycle lock. Create and every bounded remove call
-acquire it non-blockingly. Remove holds it while inspecting and renaming the
-live push directory and while performing one tombstone cleanup step, so create
-cannot recreate the same push session until that cleanup finishes.
+`push-create.lock` is the create/remove lock. Create and every bounded remove
+call acquire it non-blockingly. Remove holds it while inspecting and renaming
+the live push directory and while performing one tombstone cleanup step, so
+create cannot recreate the same push session until that cleanup finishes.
 
 `inflight.json` records the path and type of the one in-flight work value.
 File records use `preparing`, `receiving`, or `publishing` and also contain

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -84,10 +84,11 @@ development. There are no compatibility aliases or migration paths.
 The work-upload endpoint is `push_upload` and its push-session parameter is
 `push_session_id`. Endpoint names and endpoint prefixes begin with `push_`.
 JSON responses use `push_session_id`, `receiving_work`, and
-`work_deletes_bytes`. The stable classified failures are
+`work_deletes_bytes`. Push-session failures are
 `lock_acquisition_failure`, `offset_gap`, `push_not_found`, `filesystem_error`,
 `commit_required`, `unexpected_docroot_mutation`, `corrupted_push_state`, and
-`same_device`.
+`same_device`. Authentication and request-boundary failures are `auth_failed`,
+`not_configured`, `invalid_request`, and `request_too_large`.
 
 The document-root `.maintenance` file identifies its owner with the push
 session ID. `commit.json` stores no separate maintenance value.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -58,6 +58,11 @@ is the only path-shaped work tree. The shared `.reprint/push/` directory contain
 `push-create.lock`, `commit-state`, `commit-state.lock`, and bounded removal
 tombstones named `.removing-<push-session-id>/`.
 
+`push-create.lock` is the lifecycle lock. Create and every bounded remove call
+acquire it non-blockingly. Remove holds it while inspecting and renaming the
+live push directory and while performing one tombstone cleanup step, so create
+cannot recreate the same push session until that cleanup finishes.
+
 `inflight.json` records the path and type of the one in-flight work value.
 File records use `preparing`, `receiving`, or `publishing` and also contain
 `total_bytes`. Directory and symlink records use `preparing` or `publishing`;

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -23,7 +23,9 @@
             "src/class-hmac-server.php",
             "src/class-http-server.php",
             "src/class-multipart-processor.php",
+            "src/class-push-configuration-exception.php",
             "src/class-push-exception.php",
+            "src/class-push-endpoints.php",
             "src/class-push-session.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -2,6 +2,10 @@
 
 use function WordPress\Reprint\Exporter\parse_size;
 
+if (!class_exists('Site_Export_Push_Configuration_Exception', false)) {
+    require_once __DIR__ . '/class-push-configuration-exception.php';
+}
+
 /**
  * HTTP dispatcher for the Site Export API.
  */
@@ -22,11 +26,20 @@ final class Site_Export_HTTP_Server {
     /** @var string|null */
     private $default_directory;
 
+    /** @var Site_Export_Push_Endpoints|null */
+    private $push_endpoints;
+
     /** @var string[] Endpoints dispatched without a resource budget. */
-    private $no_budget_endpoints = ['preflight'];
+    private $no_budget_endpoints = [
+        'preflight',
+        'push_create',
+        'push_upload',
+        'push_status',
+        'push_commit',
+        'push_remove',
+    ];
 
     public function __construct(array $options = []) {
-        $this->handlers = $options['handlers'] ?? $this->default_handlers();
         $this->budget_factory = $options['budget_factory'] ?? [$this, 'default_budget_factory'];
         $this->body_reader = $options['body_reader'] ?? static function (): string {
             $body = file_get_contents('php://input');
@@ -34,16 +47,39 @@ final class Site_Export_HTTP_Server {
         };
         $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
         $this->default_directory = $options['default_directory'] ?? null;
-
+        $this->push_endpoints = null;
+        if (array_key_exists('push', $options)) {
+            try {
+                if (!is_array($options['push'])) {
+                    throw new InvalidArgumentException('The push HTTP server option must be an array.');
+                }
+                if (!class_exists('Site_Export_Push_Endpoints', false)) {
+                    require_once __DIR__ . '/class-push-endpoints.php';
+                }
+                $this->push_endpoints = new Site_Export_Push_Endpoints($options['push']);
+            } catch (InvalidArgumentException $exception) {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This rethrows a trusted configuration error; it does not render output.
+                throw new Site_Export_Push_Configuration_Exception(
+                    $exception->getMessage(),
+                    0,
+                    $exception
+                );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            }
+        }
+        $this->handlers = $options['handlers'] ?? $this->default_handlers();
     }
 
     public function handle_request(array $request = []): void {
         $server = $request['server'] ?? $_SERVER;
         $get = $request['get'] ?? $_GET;
         $post = $request['post'] ?? $_POST;
+        // push_upload validates Content-Type itself and streams php://input.
+        // Reading a mislabeled JSON body here would buffer the complete upload.
+        $is_push_upload = ( $get['endpoint'] ?? null ) === 'push_upload';
         $body = array_key_exists('body', $request)
             ? (string) $request['body']
-            : ( $this->is_json_content_type($server) ? call_user_func($this->body_reader) : '' );
+            : ( !$is_push_upload && $this->is_json_content_type($server) ? call_user_func($this->body_reader) : '' );
         $config = $request['config'] ?? $this->parse_http_config(
             $get,
             $post,
@@ -129,6 +165,7 @@ final class Site_Export_HTTP_Server {
      * or their own authentication must do that before calling this method.
      *
      * @param array<string, mixed> $options Forwarded to the constructor.
+     * @throws Exception If request parsing or endpoint dispatch fails.
      */
     public static function serve(array $options = []): void {
         // endpoint_preflight is defined by export.php — use it as a
@@ -286,13 +323,21 @@ final class Site_Export_HTTP_Server {
      * @return array<string, callable>
      */
     private function default_handlers(): array {
-        return [
+        $handlers = [
             'file_index' => 'endpoint_file_index',
             'file_fetch' => 'endpoint_file_fetch',
             'sql_chunk' => 'endpoint_sql_chunk',
             'db_index' => 'endpoint_db_index',
             'preflight' => 'endpoint_preflight',
         ];
+        if ($this->push_endpoints !== null) {
+            $handlers['push_create'] = [$this->push_endpoints, 'create'];
+            $handlers['push_upload'] = [$this->push_endpoints, 'upload'];
+            $handlers['push_status'] = [$this->push_endpoints, 'status'];
+            $handlers['push_commit'] = [$this->push_endpoints, 'commit'];
+            $handlers['push_remove'] = [$this->push_endpoints, 'remove'];
+        }
+        return $handlers;
     }
 
     private function is_json_content_type(array $server): bool {

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -11,6 +11,14 @@ if (!class_exists('Site_Export_Push_Configuration_Exception', false)) {
  */
 final class Site_Export_HTTP_Server {
 
+    private const PUSH_ENDPOINT_METHODS = [
+        'push_create' => 'create',
+        'push_upload' => 'upload',
+        'push_status' => 'status',
+        'push_commit' => 'commit',
+        'push_remove' => 'remove',
+    ];
+
     /** @var array<string, callable> */
     private $handlers;
 
@@ -28,16 +36,6 @@ final class Site_Export_HTTP_Server {
 
     /** @var Site_Export_Push_Endpoints|null */
     private $push_endpoints;
-
-    /** @var string[] Endpoints dispatched without a resource budget. */
-    private $no_budget_endpoints = [
-        'preflight',
-        'push_create',
-        'push_upload',
-        'push_status',
-        'push_commit',
-        'push_remove',
-    ];
 
     public function __construct(array $options = []) {
         $this->budget_factory = $options['budget_factory'] ?? [$this, 'default_budget_factory'];
@@ -307,7 +305,7 @@ final class Site_Export_HTTP_Server {
         }
 
         $handler = $this->handlers[$endpoint];
-        if (in_array($endpoint, $this->no_budget_endpoints, true)) {
+        if ($endpoint === 'preflight' || self::is_push_endpoint($endpoint)) {
             call_user_func($handler, $config);
             return;
         }
@@ -317,6 +315,10 @@ final class Site_Export_HTTP_Server {
         }
 
         call_user_func($handler, $config, $budget);
+    }
+
+    public static function is_push_endpoint(string $endpoint): bool {
+        return isset(self::PUSH_ENDPOINT_METHODS[$endpoint]);
     }
 
     /**
@@ -331,11 +333,9 @@ final class Site_Export_HTTP_Server {
             'preflight' => 'endpoint_preflight',
         ];
         if ($this->push_endpoints !== null) {
-            $handlers['push_create'] = [$this->push_endpoints, 'create'];
-            $handlers['push_upload'] = [$this->push_endpoints, 'upload'];
-            $handlers['push_status'] = [$this->push_endpoints, 'status'];
-            $handlers['push_commit'] = [$this->push_endpoints, 'commit'];
-            $handlers['push_remove'] = [$this->push_endpoints, 'remove'];
+            foreach (self::PUSH_ENDPOINT_METHODS as $endpoint => $method) {
+                $handlers[$endpoint] = [$this->push_endpoints, $method];
+            }
         }
         return $handlers;
     }

--- a/packages/reprint-exporter/src/class-push-configuration-exception.php
+++ b/packages/reprint-exporter/src/class-push-configuration-exception.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * Reports invalid server-owned push endpoint configuration.
+ */
+final class Site_Export_Push_Configuration_Exception extends InvalidArgumentException {
+}

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -161,12 +161,14 @@ final class Site_Export_Push_Endpoints {
      *
      * This operation is idempotent for the same push session ID and immutable
      * server configuration. A successful response reports the independent
-     * multipart-part and decoded request-body limits the sender must apply.
+     * multipart-part and decoded request-body limits the sender must apply,
+     * plus the normalized server-owned excluded paths stored for the session.
      *
      * Emits HTTP 200 with:
      *
      *     {status:"created", push_session_id:string,
-     *      max_part_bytes:int, post_max_bytes:int|null}
+     *      max_part_bytes:int, post_max_bytes:int|null,
+     *      excluded_paths_b64:string[]}
      *
      * @param array $config {
      *     Create request parameters.
@@ -194,6 +196,7 @@ final class Site_Export_Push_Endpoints {
                 'push_session_id' => $push_session_id,
                 'max_part_bytes' => $this->maximum_part_bytes,
                 'post_max_bytes' => $this->post_max_bytes,
+                'excluded_paths_b64' => array_map('base64_encode', $this->excluded_paths),
             ]);
         } catch (Throwable $exception) {
             $this->respond_to_failure($exception);
@@ -537,6 +540,9 @@ final class Site_Export_Push_Endpoints {
      */
     private function respond(int $http_code, array $body): void {
         http_response_code($http_code);
+        header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+        header('Pragma: no-cache');
+        header('Expires: 0');
         header('Content-Type: application/json');
         $json = json_encode($body);
         if ($json === false) {

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -1,7 +1,7 @@
 <?php
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped,WordPress.Security.EscapeOutput.OutputNotEscaped -- Authenticated protocol responses are JSON, never HTML output.
-// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- HTTP grammar and receiver validation require the exact request bytes.
+// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- Multipart parsing and request-body byte accounting require the request bytes unchanged.
 
 use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
@@ -46,7 +46,7 @@ final class Site_Export_Push_Endpoints {
     private $post_max_bytes;
 
     /**
-     * Configures the server-owned push roots and request limits.
+     * Stores the server-supplied push directories, path policy, and limits.
      *
      * Missing numeric options use bounded defaults. Present numeric options
      * must be positive so a malformed server configuration cannot silently
@@ -56,7 +56,7 @@ final class Site_Export_Push_Endpoints {
      *     Trusted endpoint configuration.
      *
      *     @type string $reprint_directory Required private reprint directory.
-     *     @type string $docroot Required managed document-root directory.
+     *     @type string $docroot Required document-root directory.
      *     @type list<string> $excluded_paths Required document-root-relative
      *         paths which push must preserve.
      *     @type int|float|string $maximum_part_bytes Maximum Content-Length
@@ -162,13 +162,15 @@ final class Site_Export_Push_Endpoints {
      * This operation is idempotent for the same push session ID and immutable
      * server configuration. A successful response reports the independent
      * multipart-part and decoded request-body limits the sender must apply,
-     * plus the normalized server-owned excluded paths stored for the session.
+     * plus the normalized excluded paths stored in push metadata.
      *
-     * Emits HTTP 200 with:
+     * The HTTP 200 response has these fields:
      *
-     *     {status:"created", push_session_id:string,
-     *      max_part_bytes:int, post_max_bytes:int|null,
-     *      excluded_paths_b64:string[]}
+     * - `status`: `created`.
+     * - `push_session_id`: the caller-supplied ID.
+     * - `max_part_bytes`: the maximum multipart-part Content-Length.
+     * - `post_max_bytes`: the decoded request-body limit, or null.
+     * - `excluded_paths_b64`: the stored excluded paths in base64.
      *
      * @param array $config {
      *     Create request parameters.
@@ -179,18 +181,14 @@ final class Site_Export_Push_Endpoints {
      */
     public function create(array $config): void {
         try {
-            $this->require_method('POST');
-            $push_session_id = $this->require_push_session_id($config);
-            $push_session = Site_Export_Push_Session::create(
+            $this->assert_request_method('POST');
+            $push_session_id = $this->read_push_session_id($config);
+            Site_Export_Push_Session::create(
                 $this->reprint_directory,
                 $this->docroot,
                 $this->excluded_paths,
                 $push_session_id
             );
-            // create() deliberately defers validation when the directory
-            // already exists. An endpoint success must not bless stale or
-            // incompatible durable state, so validate it under the push lock.
-            $push_session->get_status();
             $this->respond(200, [
                 'status' => 'created',
                 'push_session_id' => $push_session_id,
@@ -211,15 +209,16 @@ final class Site_Export_Push_Endpoints {
      * the latest receiver-confirmed change, so response memory does not grow
      * with the number of parts in the request.
      *
-     * Emits HTTP 200 with one of these `last_change` branches, or null for an
-     * empty request:
+     * The HTTP 200 response has `status`, `push_session_id`,
+     * `changes_accepted`, and `last_change`. An empty request reports null for
+     * `last_change`. Otherwise `last_change` contains:
      *
-     *     {status:"accepted", push_session_id:string, changes_accepted:int,
-     *      last_change:
-     *        {path_b64:string,state:"partial"|"complete",type:"file",accepted_bytes:int}
-     *        | {path_b64:string,state:"complete",type:"directory"|"symlink",accepted_bytes:0}
-     *        | {state:"partial"|"complete",type:"delete-list",accepted_bytes:int}
-     *        | null}
+     * - `state`: `partial` or `complete`.
+     * - `type`: `file`, `directory`, `symlink`, or `delete-list`.
+     * - `accepted_bytes`: receiver-confirmed bytes; zero for directories and
+     *   symlinks.
+     * - `path_b64`: the base64 path for files, directories, and symlinks. A
+     *   delete-list change has no path.
      *
      * @param array $config {
      *     Upload request parameters.
@@ -233,8 +232,8 @@ final class Site_Export_Push_Endpoints {
         $push_session = null;
         $upload_open = false;
         try {
-            $this->require_method('POST');
-            $push_session_id = $this->require_push_session_id($config);
+            $this->assert_request_method('POST');
+            $push_session_id = $this->read_push_session_id($config);
             $content_type = (string) ( $_SERVER['CONTENT_TYPE'] ?? '' );
             $boundary = Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
             $declared_request_bytes = $_SERVER['CONTENT_LENGTH'] ?? null;
@@ -276,7 +275,17 @@ final class Site_Export_Push_Endpoints {
             $last_change = null;
             while ($push_session->next_change()) {
                 ++$changes_accepted;
-                $last_change = $push_session->get_current_change();
+                $current_change = $push_session->get_current_change();
+                if ($current_change === null) {
+                    throw new LogicException('An accepted multipart part did not publish its receiver-confirmed change.');
+                }
+                $last_change = [];
+                if (array_key_exists('path_b64', $current_change)) {
+                    $last_change['path_b64'] = $current_change['path_b64'];
+                }
+                $last_change['state'] = $current_change['state'];
+                $last_change['type'] = $current_change['type'];
+                $last_change['accepted_bytes'] = $current_change['accepted_bytes'];
             }
             $push_session->finish_upload();
             $upload_open = false;
@@ -306,18 +315,17 @@ final class Site_Export_Push_Endpoints {
      * relative path. The receiver reads actual work state under the push lock;
      * it never echoes a sender-supplied cursor.
      *
-     * Emits HTTP 200 with the exact Site_Export_Push_Session::get_status()
-     * object plus `status:"accepted"`:
+     * The HTTP 200 response has these fields:
      *
-     *     {status:"accepted",push_session_id:string,
-     *      phase:"receiving_work"|"deleting_files"|"installing_files"|"complete",
-     *      work_deletes_bytes:int,work_deletes_complete:bool,
-     *      path:null
-     *        | {path_b64:string,state:"missing",accepted_bytes:0}
-     *        | {path_b64:string,state:"partial",type:"file",accepted_bytes:int}
-     *        | {path_b64:string,state:"partial",type:"directory"|"symlink",accepted_bytes:0}
-     *        | {path_b64:string,state:"complete",type:"file",accepted_bytes:int}
-     *        | {path_b64:string,state:"complete",type:"directory"|"symlink",accepted_bytes:0}}
+     * - `status`: `accepted`.
+     * - `push_session_id`: the requested push session.
+     * - `phase`: `receiving_work`, `deleting_files`, `installing_files`, or
+     *   `complete`.
+     * - `work_deletes_bytes`: receiver-confirmed delete-list bytes.
+     * - `work_deletes_complete`: whether the sender closed the delete list.
+     * - `path`: null when no path was requested. Otherwise it contains
+     *   `path_b64`, `state`, and `accepted_bytes`; non-missing paths also have
+     *   `type`.
      *
      * @param array $config {
      *     Status request parameters.
@@ -330,8 +338,8 @@ final class Site_Export_Push_Endpoints {
      */
     public function status(array $config): void {
         try {
-            $this->require_method('GET');
-            $push_session_id = $this->require_push_session_id($config);
+            $this->assert_request_method('GET');
+            $push_session_id = $this->read_push_session_id($config);
             $path = null;
             if (array_key_exists('path_b64', $config)) {
                 if (!is_string($config['path_b64'])) {
@@ -348,10 +356,26 @@ final class Site_Export_Push_Endpoints {
                 $push_session_id,
                 $this->excluded_paths
             );
-            $this->respond(200, array_merge(
-                ['status' => 'accepted'],
-                $push_session->get_status($path)
-            ));
+            $push_status = $push_session->get_status($path);
+            $path_status = null;
+            if ($push_status['path'] !== null) {
+                $path_status = [
+                    'path_b64' => $push_status['path']['path_b64'],
+                    'state' => $push_status['path']['state'],
+                ];
+                if (array_key_exists('type', $push_status['path'])) {
+                    $path_status['type'] = $push_status['path']['type'];
+                }
+                $path_status['accepted_bytes'] = $push_status['path']['accepted_bytes'];
+            }
+            $this->respond(200, [
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'phase' => $push_status['phase'],
+                'work_deletes_bytes' => $push_status['work_deletes_bytes'],
+                'work_deletes_complete' => $push_status['work_deletes_complete'],
+                'path' => $path_status,
+            ]);
         } catch (Throwable $exception) {
             $this->respond_to_failure($exception);
         }
@@ -360,15 +384,13 @@ final class Site_Export_Push_Endpoints {
     /**
      * Advances bounded commit work for one push session.
      *
-     * The server-owned entry limit controls each call. Senders repeat this
+     * The configured maximum commit-entry count bounds each call. Senders repeat this
      * operation while `send_next_request` is true; a repeated request after an
      * indeterminate response resumes the receiver's durable commit checkpoint.
      *
-     * Emits HTTP 200 with:
-     *
-     *     {status:"accepted",push_session_id:string,
-     *      phase:"deleting_files"|"installing_files"|"complete",
-     *      send_next_request:bool,entries_processed:int}
+     * The HTTP 200 response has `status`, `push_session_id`, `phase`,
+     * `send_next_request`, and `entries_processed`. `phase` is
+     * `deleting_files`, `installing_files`, or `complete`.
      *
      * @param array $config {
      *     Commit request parameters.
@@ -379,8 +401,8 @@ final class Site_Export_Push_Endpoints {
      */
     public function commit(array $config): void {
         try {
-            $this->require_method('POST');
-            $push_session_id = $this->require_push_session_id($config);
+            $this->assert_request_method('POST');
+            $push_session_id = $this->read_push_session_id($config);
             $push_session = Site_Export_Push_Session::open(
                 $this->reprint_directory,
                 $this->docroot,
@@ -388,10 +410,13 @@ final class Site_Export_Push_Endpoints {
                 $this->excluded_paths
             );
             $commit = $push_session->commit($this->maximum_commit_entries);
-            $this->respond(200, array_merge([
+            $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
-            ], $commit));
+                'phase' => $commit['phase'],
+                'send_next_request' => $commit['send_next_request'],
+                'entries_processed' => $commit['entries_processed'],
+            ]);
         } catch (Throwable $exception) {
             $this->respond_to_failure($exception);
         }
@@ -404,9 +429,7 @@ final class Site_Export_Push_Endpoints {
      * Repeating the operation after a lost response is safe: a missing push
      * directory and completed removal tombstone report true.
      *
-     * Emits HTTP 200 with:
-     *
-     *     {status:"accepted",push_session_id:string,removed:bool}
+     * The HTTP 200 response has `status`, `push_session_id`, and `removed`.
      *
      * @param array $config {
      *     Remove request parameters.
@@ -417,9 +440,9 @@ final class Site_Export_Push_Endpoints {
      */
     public function remove(array $config): void {
         try {
-            $this->require_method('POST');
-            $push_session_id = $this->require_push_session_id($config);
-            $removed = Site_Export_Push_Session::remove(
+            $this->assert_request_method('POST');
+            $push_session_id = $this->read_push_session_id($config);
+            $remove_complete = Site_Export_Push_Session::remove(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
@@ -428,7 +451,7 @@ final class Site_Export_Push_Endpoints {
             $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
-                'removed' => $removed,
+                'removed' => $remove_complete,
             ]);
         } catch (Throwable $exception) {
             $this->respond_to_failure($exception);
@@ -436,13 +459,13 @@ final class Site_Export_Push_Endpoints {
     }
 
     /**
-     * Requires the exact HTTP method assigned to an endpoint.
+     * Rejects a request whose HTTP method does not match the endpoint.
      *
      * @param string $expected_method Uppercase protocol method.
      *
      * @throws InvalidArgumentException If the current request uses another method.
      */
-    private function require_method(string $expected_method): void {
+    private function assert_request_method(string $expected_method): void {
         $observed_method = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ));
         if ($observed_method !== $expected_method) {
             throw new InvalidArgumentException(
@@ -455,7 +478,7 @@ final class Site_Export_Push_Endpoints {
      * Reads the required push session identity from request parameters.
      *
      * Site_Export_Push_Session performs the canonical 32-character lowercase
-     * hexadecimal validation. This method only rejects missing or non-string
+     * hexadecimal grammar check. This method only rejects missing or non-string
      * values before a factory method is selected.
      *
      * @param array $config {
@@ -468,7 +491,7 @@ final class Site_Export_Push_Endpoints {
      *
      * @throws InvalidArgumentException If `push_session_id` is not a string.
      */
-    private function require_push_session_id(array $config): string {
+    private function read_push_session_id(array $config): string {
         $push_session_id = $config['push_session_id'] ?? null;
         if (!is_string($push_session_id)) {
             throw new InvalidArgumentException('push_session_id must be a string.');
@@ -479,9 +502,11 @@ final class Site_Export_Push_Endpoints {
     /**
      * Maps a push exception onto its stable protocol reason and HTTP status.
      *
-     * Classified context is copied without rewriting its keys. Invalid or
-     * malformed request data receives `invalid_request`; unexpected failures
-     * receive `filesystem_error` without exposing a PHP trace.
+     * The response owns its public fields instead of copying an exception's
+     * internal context. A streamed request-size rejection deliberately exposes
+     * its observed decoded byte count. Invalid or malformed request data
+     * receives `invalid_request`; unexpected failures receive
+     * `filesystem_error` without exposing a PHP trace.
      *
      * @param Throwable $exception Failure raised while handling an endpoint.
      */
@@ -501,12 +526,16 @@ final class Site_Export_Push_Endpoints {
             ) {
                 $http_code = 500;
             }
-            $response = array_merge([
+            $response = [
                 'status' => 'rejected',
                 'reason' => $reason,
                 'detail' => $exception->getMessage(),
-            ], $exception->get_context());
+            ];
             if ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
+                $context = $exception->get_context();
+                if (is_int($context['observed_request_body_bytes'] ?? null)) {
+                    $response['observed_request_body_bytes'] = $context['observed_request_body_bytes'];
+                }
                 $response['post_max_bytes'] = $this->post_max_bytes;
             }
             $this->respond($http_code, $response);

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -1,0 +1,549 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped,WordPress.Security.EscapeOutput.OutputNotEscaped -- Authenticated protocol responses are JSON, never HTML output.
+// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- HTTP grammar and receiver validation require the exact request bytes.
+
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\normalize_excluded_paths;
+use function WordPress\Reprint\Exporter\normalize_path;
+use function WordPress\Reprint\Exporter\parse_size;
+use function WordPress\Reprint\Exporter\path_is_within_root;
+
+/**
+ * Exposes push-session operations through the exporter HTTP dispatcher.
+ *
+ * The endpoint configuration is supplied by the server, not by request
+ * parameters. It fixes the reprint directory, document root, excluded paths,
+ * maximum multipart part size, and bounded commit work for every request.
+ * Authentication happens in the embedding router before these methods run.
+ *
+ * Upload requests pass php://input directly to Site_Export_Push_Session. The
+ * endpoint retains only the latest accepted change while the receiver reads
+ * each multipart part in bounded fragments; it never buffers the request body
+ * or a list of all parts.
+ */
+final class Site_Export_Push_Endpoints {
+
+    private const DEFAULT_MAXIMUM_PART_BYTES = 4194304;
+    private const DEFAULT_MAXIMUM_COMMIT_ENTRIES = 256;
+
+    /** @var string */
+    private $reprint_directory;
+
+    /** @var string */
+    private $docroot;
+
+    /** @var list<string> */
+    private $excluded_paths;
+
+    /** @var int */
+    private $maximum_part_bytes;
+
+    /** @var int */
+    private $maximum_commit_entries;
+
+    /** @var int|null */
+    private $post_max_bytes;
+
+    /**
+     * Configures the server-owned push roots and request limits.
+     *
+     * Missing numeric options use bounded defaults. Present numeric options
+     * must be positive so a malformed server configuration cannot silently
+     * change the protocol limit.
+     *
+     * @param array $options {
+     *     Trusted endpoint configuration.
+     *
+     *     @type string $reprint_directory Required private reprint directory.
+     *     @type string $docroot Required managed document-root directory.
+     *     @type list<string> $excluded_paths Required document-root-relative
+     *         paths which push must preserve.
+     *     @type int|float|string $maximum_part_bytes Maximum Content-Length
+     *         accepted for one multipart part. Default 4 MiB.
+     *     @type int|float|string $maximum_commit_entries Maximum entries one
+     *         commit request may process. Default 256.
+     *     @type int|float|string|null $post_max_bytes Decoded request-body
+     *         limit enforced and reported to senders. Defaults to PHP's
+     *         post_max_size; null means PHP reports no positive limit.
+     * }
+     * @phpstan-param array{
+     *     reprint_directory?:mixed,
+     *     docroot?:mixed,
+     *     excluded_paths?:mixed,
+     *     maximum_part_bytes?:mixed,
+     *     maximum_commit_entries?:mixed,
+     *     post_max_bytes?:mixed
+     * } $options
+     *
+     * @throws InvalidArgumentException If required configuration is absent or
+     *     a present numeric limit is not positive.
+     */
+    public function __construct(array $options) {
+        $reprint_directory = $options['reprint_directory'] ?? null;
+        $docroot = $options['docroot'] ?? null;
+        $excluded_paths = $options['excluded_paths'] ?? null;
+        if (!is_string($reprint_directory) || $reprint_directory === '') {
+            throw new InvalidArgumentException('Push endpoints require a non-empty reprint_directory option.');
+        }
+        if (!is_string($docroot) || $docroot === '') {
+            throw new InvalidArgumentException('Push endpoints require a non-empty docroot option.');
+        }
+        if (!is_array($excluded_paths)) {
+            throw new InvalidArgumentException('Push endpoints require an excluded_paths array.');
+        }
+        $excluded_paths = normalize_excluded_paths($excluded_paths);
+
+        assert_valid_path($reprint_directory, 'Push endpoint reprint_directory');
+        assert_valid_path($docroot, 'Push endpoint docroot');
+        $normalized_reprint_directory = normalize_path($reprint_directory);
+        $canonical_reprint_directory = realpath($normalized_reprint_directory);
+        if ($canonical_reprint_directory === false) {
+            $missing_components = [];
+            $existing_ancestor = $normalized_reprint_directory;
+            $canonical_existing_ancestor = realpath($existing_ancestor);
+            while ($canonical_existing_ancestor === false) {
+                array_unshift($missing_components, basename($existing_ancestor));
+                $parent = dirname($existing_ancestor);
+                if ($parent === $existing_ancestor) {
+                    break;
+                }
+                $existing_ancestor = $parent;
+                $canonical_existing_ancestor = realpath($existing_ancestor);
+            }
+            $canonical_reprint_directory = $canonical_existing_ancestor === false
+                ? $normalized_reprint_directory
+                : normalize_path($canonical_existing_ancestor . '/' . implode('/', $missing_components));
+        }
+        $canonical_docroot = realpath($docroot);
+        if ($canonical_docroot === false) {
+            $canonical_docroot = normalize_path($docroot);
+        }
+        if ($canonical_docroot === '/' || path_is_within_root($canonical_reprint_directory, $canonical_docroot)) {
+            throw new InvalidArgumentException(
+                'Push endpoints require reprint_directory ' . json_encode($reprint_directory)
+                . ' to be outside docroot ' . json_encode($docroot) . '; observed it inside that document root.'
+            );
+        }
+
+        $maximum_part_bytes = $options['maximum_part_bytes'] ?? self::DEFAULT_MAXIMUM_PART_BYTES;
+        $maximum_commit_entries = $options['maximum_commit_entries'] ?? self::DEFAULT_MAXIMUM_COMMIT_ENTRIES;
+        if (!is_numeric($maximum_part_bytes) || (int) $maximum_part_bytes <= 0) {
+            throw new InvalidArgumentException('maximum_part_bytes must be a positive integer.');
+        }
+        if (!is_numeric($maximum_commit_entries) || (int) $maximum_commit_entries <= 0) {
+            throw new InvalidArgumentException('maximum_commit_entries must be a positive integer.');
+        }
+
+        if (array_key_exists('post_max_bytes', $options)) {
+            $post_max_bytes = $options['post_max_bytes'];
+            if ($post_max_bytes !== null && ( !is_numeric($post_max_bytes) || (int) $post_max_bytes <= 0 )) {
+                throw new InvalidArgumentException('post_max_bytes must be null or a positive integer.');
+            }
+            $this->post_max_bytes = $post_max_bytes === null ? null : (int) $post_max_bytes;
+        } else {
+            $post_max_size = ini_get('post_max_size');
+            $parsed_post_max_bytes = is_string($post_max_size) && $post_max_size !== ''
+                ? parse_size($post_max_size)
+                : 0;
+            $this->post_max_bytes = $parsed_post_max_bytes > 0 ? $parsed_post_max_bytes : null;
+        }
+
+        $this->reprint_directory = $reprint_directory;
+        $this->docroot = $docroot;
+        $this->excluded_paths = $excluded_paths;
+        $this->maximum_part_bytes = (int) $maximum_part_bytes;
+        $this->maximum_commit_entries = (int) $maximum_commit_entries;
+    }
+
+    /**
+     * Creates or reopens the caller-named push session.
+     *
+     * This operation is idempotent for the same push session ID and immutable
+     * server configuration. A successful response reports the independent
+     * multipart-part and decoded request-body limits the sender must apply.
+     *
+     * Emits HTTP 200 with:
+     *
+     *     {status:"created", push_session_id:string,
+     *      max_part_bytes:int, post_max_bytes:int|null}
+     *
+     * @param array $config {
+     *     Create request parameters.
+     *
+     *     @type string $push_session_id Caller-named push session ID.
+     * }
+     * @phpstan-param array<string,mixed> $config
+     */
+    public function create(array $config): void {
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $push_session = Site_Export_Push_Session::create(
+                $this->reprint_directory,
+                $this->docroot,
+                $this->excluded_paths,
+                $push_session_id
+            );
+            // create() deliberately defers validation when the directory
+            // already exists. An endpoint success must not bless stale or
+            // incompatible durable state, so validate it under the push lock.
+            $push_session->get_status();
+            $this->respond(200, [
+                'status' => 'created',
+                'push_session_id' => $push_session_id,
+                'max_part_bytes' => $this->maximum_part_bytes,
+                'post_max_bytes' => $this->post_max_bytes,
+            ]);
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Streams one multipart request into an existing push session.
+     *
+     * The request must be POST multipart/mixed with one valid boundary. Each
+     * part is accepted before the next part is read. The response retains only
+     * the latest receiver-confirmed change, so response memory does not grow
+     * with the number of parts in the request.
+     *
+     * Emits HTTP 200 with one of these `last_change` branches, or null for an
+     * empty request:
+     *
+     *     {status:"accepted", push_session_id:string, changes_accepted:int,
+     *      last_change:
+     *        {path_b64:string,state:"partial"|"complete",type:"file",accepted_bytes:int}
+     *        | {path_b64:string,state:"complete",type:"directory"|"symlink",accepted_bytes:0}
+     *        | {state:"partial"|"complete",type:"delete-list",accepted_bytes:int}
+     *        | null}
+     *
+     * @param array $config {
+     *     Upload request parameters.
+     *
+     *     @type string $push_session_id Existing push session ID.
+     * }
+     * @phpstan-param array<string,mixed> $config
+     */
+    public function upload(array $config): void {
+        $input = null;
+        $push_session = null;
+        $upload_open = false;
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $content_type = (string) ( $_SERVER['CONTENT_TYPE'] ?? '' );
+            $boundary = Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
+            $declared_request_bytes = $_SERVER['CONTENT_LENGTH'] ?? null;
+            if (
+                $this->post_max_bytes !== null
+                && is_numeric($declared_request_bytes)
+                && (int) $declared_request_bytes > $this->post_max_bytes
+            ) {
+                $this->respond(413, [
+                    'status' => 'rejected',
+                    'reason' => 'request_too_large',
+                    'detail' => 'The decoded request body declares ' . (int) $declared_request_bytes
+                        . ' bytes, exceeding the target post_max_size of ' . $this->post_max_bytes . ' bytes.',
+                    'post_max_bytes' => $this->post_max_bytes,
+                ]);
+                return;
+            }
+            $input = fopen('php://input', 'rb');
+            if ($input === false) {
+                throw new Site_Export_Push_Exception(
+                    Site_Export_Push_Session::ERROR_FILESYSTEM,
+                    'Could not open the multipart upload request body.'
+                );
+            }
+            $push_session = Site_Export_Push_Session::open(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $push_session->accept_upload(
+                $input,
+                new Site_Export_Multipart_Processor($boundary),
+                $this->maximum_part_bytes,
+                $this->post_max_bytes ?? PHP_INT_MAX
+            );
+            $upload_open = true;
+            $changes_accepted = 0;
+            $last_change = null;
+            while ($push_session->next_change()) {
+                ++$changes_accepted;
+                $last_change = $push_session->get_current_change();
+            }
+            $push_session->finish_upload();
+            $upload_open = false;
+            fclose($input);
+            $input = null;
+            $this->respond(200, [
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'changes_accepted' => $changes_accepted,
+                'last_change' => $last_change,
+            ]);
+        } catch (Throwable $exception) {
+            if ($upload_open && $push_session instanceof Site_Export_Push_Session) {
+                $push_session->finish_upload();
+            }
+            if (is_resource($input)) {
+                fclose($input);
+            }
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Reports receiver-confirmed progress for a push session and optional path.
+     *
+     * `path_b64`, when supplied, is strict base64 for the raw document-root-
+     * relative path. The receiver reads actual work state under the push lock;
+     * it never echoes a sender-supplied cursor.
+     *
+     * Emits HTTP 200 with the exact Site_Export_Push_Session::get_status()
+     * object plus `status:"accepted"`:
+     *
+     *     {status:"accepted",push_session_id:string,
+     *      phase:"receiving_work"|"deleting_files"|"installing_files"|"complete",
+     *      work_deletes_bytes:int,work_deletes_complete:bool,
+     *      path:null
+     *        | {path_b64:string,state:"missing",accepted_bytes:0}
+     *        | {path_b64:string,state:"partial",type:"file",accepted_bytes:int}
+     *        | {path_b64:string,state:"partial",type:"directory"|"symlink",accepted_bytes:0}
+     *        | {path_b64:string,state:"complete",type:"file",accepted_bytes:int}
+     *        | {path_b64:string,state:"complete",type:"directory"|"symlink",accepted_bytes:0}}
+     *
+     * @param array $config {
+     *     Status request parameters.
+     *
+     *     @type string $push_session_id Existing push session ID.
+     *     @type string $path_b64 Optional. Base64-encoded path whose
+     *                           receiver-confirmed state should be reported.
+     * }
+     * @phpstan-param array<string,mixed> $config
+     */
+    public function status(array $config): void {
+        try {
+            $this->require_method('GET');
+            $push_session_id = $this->require_push_session_id($config);
+            $path = null;
+            if (array_key_exists('path_b64', $config)) {
+                if (!is_string($config['path_b64'])) {
+                    throw new InvalidArgumentException('path_b64 must be base64 text.');
+                }
+                $path = base64_decode($config['path_b64'], true);
+                if ($path === false) {
+                    throw new InvalidArgumentException('path_b64 must be valid base64 text.');
+                }
+            }
+            $push_session = Site_Export_Push_Session::open(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $this->respond(200, array_merge(
+                ['status' => 'accepted'],
+                $push_session->get_status($path)
+            ));
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Advances bounded commit work for one push session.
+     *
+     * The server-owned entry limit controls each call. Senders repeat this
+     * operation while `send_next_request` is true; a repeated request after an
+     * indeterminate response resumes the receiver's durable commit checkpoint.
+     *
+     * Emits HTTP 200 with:
+     *
+     *     {status:"accepted",push_session_id:string,
+     *      phase:"deleting_files"|"installing_files"|"complete",
+     *      send_next_request:bool,entries_processed:int}
+     *
+     * @param array $config {
+     *     Commit request parameters.
+     *
+     *     @type string $push_session_id Existing push session ID.
+     * }
+     * @phpstan-param array<string,mixed> $config
+     */
+    public function commit(array $config): void {
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $push_session = Site_Export_Push_Session::open(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $commit = $push_session->commit($this->maximum_commit_entries);
+            $this->respond(200, array_merge([
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+            ], $commit));
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Performs one bounded removal step for a push session.
+     *
+     * A false `removed` value means the sender must call this operation again.
+     * Repeating the operation after a lost response is safe: a missing push
+     * directory and completed removal tombstone report true.
+     *
+     * Emits HTTP 200 with:
+     *
+     *     {status:"accepted",push_session_id:string,removed:bool}
+     *
+     * @param array $config {
+     *     Remove request parameters.
+     *
+     *     @type string $push_session_id Existing push session ID.
+     * }
+     * @phpstan-param array<string,mixed> $config
+     */
+    public function remove(array $config): void {
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $removed = Site_Export_Push_Session::remove(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $this->respond(200, [
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'removed' => $removed,
+            ]);
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Requires the exact HTTP method assigned to an endpoint.
+     *
+     * @param string $expected_method Uppercase protocol method.
+     *
+     * @throws InvalidArgumentException If the current request uses another method.
+     */
+    private function require_method(string $expected_method): void {
+        $observed_method = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ));
+        if ($observed_method !== $expected_method) {
+            throw new InvalidArgumentException(
+                'Push endpoint requires ' . $expected_method . '; observed ' . ( $observed_method === '' ? 'no request method' : $observed_method ) . '.'
+            );
+        }
+    }
+
+    /**
+     * Reads the required push session identity from request parameters.
+     *
+     * Site_Export_Push_Session performs the canonical 32-character lowercase
+     * hexadecimal validation. This method only rejects missing or non-string
+     * values before a factory method is selected.
+     *
+     * @param array $config {
+     *     Endpoint request parameters.
+     *
+     *     @type string $push_session_id Caller-supplied push session ID.
+     * }
+     * @phpstan-param array<string,mixed> $config
+     * @return string Caller-supplied push session ID.
+     *
+     * @throws InvalidArgumentException If `push_session_id` is not a string.
+     */
+    private function require_push_session_id(array $config): string {
+        $push_session_id = $config['push_session_id'] ?? null;
+        if (!is_string($push_session_id)) {
+            throw new InvalidArgumentException('push_session_id must be a string.');
+        }
+        return $push_session_id;
+    }
+
+    /**
+     * Maps a push exception onto its stable protocol reason and HTTP status.
+     *
+     * Classified context is copied without rewriting its keys. Invalid or
+     * malformed request data receives `invalid_request`; unexpected failures
+     * receive `filesystem_error` without exposing a PHP trace.
+     *
+     * @param Throwable $exception Failure raised while handling an endpoint.
+     */
+    private function respond_to_failure(Throwable $exception): void {
+        if ($exception instanceof Site_Export_Push_Exception) {
+            $reason = $exception->get_error_code();
+            $http_code = 409;
+            if ($reason === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND) {
+                $http_code = 404;
+            } elseif ($reason === Site_Export_Push_Session::ERROR_LOCK_ACQUISITION_FAILURE) {
+                $http_code = 423;
+            } elseif ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
+                $http_code = 413;
+            } elseif (
+                $reason === Site_Export_Push_Session::ERROR_FILESYSTEM
+                || $reason === Site_Export_Push_Session::ERROR_CORRUPTED_PUSH_STATE
+            ) {
+                $http_code = 500;
+            }
+            $response = array_merge([
+                'status' => 'rejected',
+                'reason' => $reason,
+                'detail' => $exception->getMessage(),
+            ], $exception->get_context());
+            if ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
+                $response['post_max_bytes'] = $this->post_max_bytes;
+            }
+            $this->respond($http_code, $response);
+            return;
+        }
+        if (
+            $exception instanceof InvalidArgumentException
+            || $exception instanceof RuntimeException
+        ) {
+            $this->respond(400, [
+                'status' => 'rejected',
+                'reason' => 'invalid_request',
+                'detail' => $exception->getMessage(),
+            ]);
+            return;
+        }
+        $this->respond(500, [
+            'status' => 'rejected',
+            'reason' => Site_Export_Push_Session::ERROR_FILESYSTEM,
+            'detail' => 'The push endpoint failed while processing the request.',
+        ]);
+    }
+
+    /**
+     * Emits one complete JSON protocol response.
+     *
+     * @param int $http_code HTTP status code.
+     * @param array $body Exact endpoint-specific response object whose keys
+     *                    are documented by the calling endpoint.
+     * @phpstan-param array<string,mixed> $body
+     */
+    private function respond(int $http_code, array $body): void {
+        http_response_code($http_code);
+        header('Content-Type: application/json');
+        $json = json_encode($body);
+        if ($json === false) {
+            http_response_code(500);
+            echo '{"status":"rejected","reason":"filesystem_error","detail":"Could not encode the push response."}';
+            return;
+        }
+        echo $json;
+    }
+}

--- a/packages/reprint-exporter/src/class-push-exception.php
+++ b/packages/reprint-exporter/src/class-push-exception.php
@@ -10,8 +10,8 @@
  * native code from being presented as a recoverable protocol condition.
  *
  * Only failures which have a deliberate push or commit classification use this
- * exception. An ordinary RuntimeException remains unclassified and is exposed
- * by the endpoint as `session_rejected` rather than leaking an accidental code.
+ * exception. An ordinary RuntimeException remains unclassified and follows the
+ * endpoint's `invalid_request` handling rather than leaking an accidental code.
  */
 final class Site_Export_Push_Exception extends RuntimeException {
 

--- a/packages/reprint-exporter/src/class-push-exception.php
+++ b/packages/reprint-exporter/src/class-push-exception.php
@@ -50,7 +50,8 @@ final class Site_Export_Push_Exception extends RuntimeException {
      * @param array<string,mixed> $context Additional authenticated response
      *     fields. Common keys are operation, path_b64, conflict_path_b64,
      *     expected_docroot_types, observed_docroot_identity, work_device,
-     *     document-root_device, work_type, and detail.
+     *     document-root_device, work_type, observed_request_body_bytes, and
+     *     detail.
      */
     public function __construct(string $error_code, string $message, array $context = []) {
         parent::__construct($message);
@@ -78,7 +79,8 @@ final class Site_Export_Push_Exception extends RuntimeException {
      * @return array<string,mixed> Structured fields safe to copy into JSON.
      *     Common keys are operation, path_b64, conflict_path_b64,
      *     expected_docroot_types, observed_docroot_identity, work_device,
-     *     document-root_device, work_type, and detail.
+     *     document-root_device, work_type, observed_request_body_bytes, and
+     *     detail.
      */
     public function get_context(): array {
         return $this->context;

--- a/packages/reprint-exporter/src/class-push-exception.php
+++ b/packages/reprint-exporter/src/class-push-exception.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Reports a classified failure in the push and commit lifecycle.
+ * Reports a classified push-session failure.
  *
  * PHP reserves Throwable::getCode() for an integer. Push and commit failures use
  * stable, descriptive strings because the endpoint returns the same value in
@@ -27,12 +27,12 @@ final class Site_Export_Push_Exception extends RuntimeException {
     private $error_code;
 
     /**
-     * Protocol fields which describe the observed failure.
+     * Structured observations which describe the failure.
      *
-     * These values are copied into the authenticated JSON response alongside
-     * the stable reason. They are deliberately separate from the message so
-     * callers can inspect structured details such as conflicting paths or
-     * observed filesystem identities without parsing prose.
+     * These values are deliberately separate from the message so commit can
+     * persist non-recoverable evidence and callers can inspect it without
+     * parsing prose. An HTTP endpoint must choose its public fields explicitly;
+     * exception context is not a response schema.
      *
      * @var array<string,mixed>
      */
@@ -47,11 +47,10 @@ final class Site_Export_Push_Exception extends RuntimeException {
      *
      * @param string $error_code Stable machine-readable push or commit reason.
      * @param string $message Human-readable statement of the violated condition.
-     * @param array<string,mixed> $context Additional authenticated response
-     *     fields. Common keys are operation, path_b64, conflict_path_b64,
+     * @param array<string,mixed> $context Structured observations. Common keys
+     *     are operation, path_b64, conflict_path_b64,
      *     expected_docroot_types, observed_docroot_identity, work_device,
-     *     document-root_device, work_type, observed_request_body_bytes, and
-     *     detail.
+     *     docroot_device, work_type, and observed_request_body_bytes.
      */
     public function __construct(string $error_code, string $message, array $context = []) {
         parent::__construct($message);
@@ -69,18 +68,17 @@ final class Site_Export_Push_Exception extends RuntimeException {
     }
 
     /**
-     * Returns structured details for the authenticated failure response.
+     * Returns structured observations recorded by the throw site.
      *
      * The array contains only values supplied by push or commit throw sites. It
      * may be empty for simple classified failures, but when present it names
      * the exact observed condition that made the request non-recoverable or
      * recoverable.
      *
-     * @return array<string,mixed> Structured fields safe to copy into JSON.
-     *     Common keys are operation, path_b64, conflict_path_b64,
-     *     expected_docroot_types, observed_docroot_identity, work_device,
-     *     document-root_device, work_type, observed_request_body_bytes, and
-     *     detail.
+     * @return array<string,mixed> Structured observations. Common keys are
+     *     operation, path_b64, conflict_path_b64, expected_docroot_types,
+     *     observed_docroot_identity, work_device, docroot_device, work_type,
+     *     and observed_request_body_bytes.
      */
     public function get_context(): array {
         return $this->context;

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -176,20 +176,15 @@ final class Site_Export_Push_Session {
         $reprint_directory = self::require_directory($reprint_directory, 'reprint directory', true);
         $docroot = self::require_directory($docroot, 'document root', false);
         $push_session = new self($reprint_directory, $docroot, $push_session_id, $excluded_paths);
-        $push_parent_directory = $reprint_directory . '/.reprint/push';
-        if (!@mkdir($push_parent_directory, 0700, true)) {
-            if (!is_dir($push_parent_directory)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create push sessions directory ' . $push_parent_directory . '.');
-            }
-            $push_parent_directory = self::require_directory($push_parent_directory, 'push sessions', false);
-        }
-        $creation_lock = @fopen($push_parent_directory . '/push-create.lock', 'c+b');
-        if ($creation_lock === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the push creation lock.');
-        }
+        $push_parent_directory = self::require_push_parent_directory($reprint_directory);
+        $lifecycle_lock = self::acquire_lifecycle_lock($push_parent_directory, 'create');
         try {
-            if (!flock($creation_lock, LOCK_EX | LOCK_NB)) {
-                throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push session creation is busy. Retry the create request.');
+            $removing_push_directory = $push_parent_directory . '/.removing-' . $push_session_id;
+            if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
+                throw new Site_Export_Push_Exception(
+                    self::ERROR_LOCK_ACQUISITION_FAILURE,
+                    'Push session removal is incomplete. Retry create after remove finishes.'
+                );
             }
             if (file_exists($push_session->push_directory) || is_link($push_session->push_directory)) {
                 return $push_session;
@@ -216,8 +211,8 @@ final class Site_Export_Push_Session {
             ]);
             return $push_session;
         } finally {
-            flock($creation_lock, LOCK_UN);
-            fclose($creation_lock);
+            flock($lifecycle_lock, LOCK_UN);
+            fclose($lifecycle_lock);
         }
     }
 
@@ -724,27 +719,34 @@ final class Site_Export_Push_Session {
      *              limit left tombstone work for another call.
      */
     public function remove_push_directory(): bool {
-        $removing_push_directory = $this->reprint_directory . '/.reprint/push/.removing-' . $this->push_session_id;
-        if ($this->lstat_path($this->push_directory) === null) {
-            return $this->remove_tombstone($removing_push_directory);
-        }
-        $lock = $this->acquire_push_lock();
+        $push_parent_directory = self::require_push_parent_directory($this->reprint_directory);
+        $removing_push_directory = $push_parent_directory . '/.removing-' . $this->push_session_id;
+        $lifecycle_lock = self::acquire_lifecycle_lock($push_parent_directory, 'remove');
         try {
-            $commit_state = $this->read_json($this->commit_json_path);
-            if ($commit_state !== null && $commit_state['phase'] !== 'complete') {
-                throw new Site_Export_Push_Exception(self::ERROR_COMMIT_REQUIRED, 'Document-root mutation has begun. Resume commit instead of removing this push session.');
+            if ($this->lstat_path($this->push_directory) === null) {
+                return $this->remove_tombstone($removing_push_directory);
             }
-            if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
-                throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A remove tombstone already exists for push session ' . $this->push_session_id . '.');
+            $lock = $this->acquire_push_lock();
+            try {
+                $commit_state = $this->read_json($this->commit_json_path);
+                if ($commit_state !== null && $commit_state['phase'] !== 'complete') {
+                    throw new Site_Export_Push_Exception(self::ERROR_COMMIT_REQUIRED, 'Document-root mutation has begun. Resume commit instead of removing this push session.');
+                }
+                if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
+                    throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A remove tombstone already exists for push session ' . $this->push_session_id . '.');
+                }
+                if (!@rename($this->push_directory, $removing_push_directory)) {
+                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the push removal tombstone.');
+                }
+            } finally {
+                flock($lock, LOCK_UN);
+                fclose($lock);
             }
-            if (!@rename($this->push_directory, $removing_push_directory)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the push removal tombstone.');
-            }
+            return $this->remove_tombstone($removing_push_directory);
         } finally {
-            flock($lock, LOCK_UN);
-            fclose($lock);
+            flock($lifecycle_lock, LOCK_UN);
+            fclose($lifecycle_lock);
         }
-        return $this->remove_tombstone($removing_push_directory);
     }
 
     /**
@@ -789,39 +791,62 @@ final class Site_Export_Push_Session {
     private function next_upload_token(): bool {
         while (!$this->upload_processor->next_token()) {
             if ($this->upload_processor->is_complete()) {
+                $trailing_bytes = $this->read_upload_request_fragment();
+                if ($trailing_bytes !== '') {
+                    throw new InvalidArgumentException(
+                        'Multipart data contains ' . strlen($trailing_bytes) . ' bytes after the closing boundary.'
+                    );
+                }
+                $this->upload_processor->finish_input();
                 return false;
             }
             if (!$this->upload_processor->paused_at_incomplete_input()) {
                 throw new LogicException('Multipart processor stopped without completing or requesting input.');
             }
-            $maximum_fragment_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
-            $remaining_request_body_bytes = PHP_INT_MAX;
-            if ($this->maximum_upload_request_body_bytes !== PHP_INT_MAX) {
-                $remaining_request_body_bytes = $this->maximum_upload_request_body_bytes - $this->upload_request_body_bytes_read;
-                $maximum_fragment_bytes = min($maximum_fragment_bytes, $remaining_request_body_bytes + 1);
-            }
-            $bytes = fread($this->upload_input, $maximum_fragment_bytes);
-            if ($bytes === false) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read the multipart upload request body.');
-            }
+            $bytes = $this->read_upload_request_fragment();
             if ($bytes === '') {
                 $this->upload_processor->finish_input();
                 return false;
             }
-            $fragment_bytes = strlen($bytes);
-            if ($fragment_bytes > $remaining_request_body_bytes) {
-                $observed_request_body_bytes = $this->upload_request_body_bytes_read + $fragment_bytes;
-                throw new Site_Export_Push_Exception(
-                    self::ERROR_REQUEST_TOO_LARGE,
-                    'The decoded request body reached ' . $observed_request_body_bytes
-                    . ' bytes, exceeding the target post_max_size of '
-                    . $this->maximum_upload_request_body_bytes . ' bytes.'
-                );
-            }
-            $this->upload_request_body_bytes_read += $fragment_bytes;
             $this->upload_processor->append_bytes($bytes);
         }
         return true;
+    }
+
+    /**
+     * Reads and accounts for one bounded decoded request-body fragment.
+     *
+     * When a request-body limit remains, the extra byte in the read size proves
+     * the exact observed size which crossed it without buffering another chunk.
+     * EOF is returned as an empty string so the multipart caller can finish the
+     * processor in both incomplete and complete parser states.
+     *
+     * @return string Next bounded request-body fragment, or an empty string at EOF.
+     */
+    private function read_upload_request_fragment(): string {
+        $maximum_fragment_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        $remaining_request_body_bytes = PHP_INT_MAX;
+        if ($this->maximum_upload_request_body_bytes !== PHP_INT_MAX) {
+            $remaining_request_body_bytes = $this->maximum_upload_request_body_bytes - $this->upload_request_body_bytes_read;
+            $maximum_fragment_bytes = min($maximum_fragment_bytes, $remaining_request_body_bytes + 1);
+        }
+        $bytes = fread($this->upload_input, $maximum_fragment_bytes);
+        if ($bytes === false) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read the multipart upload request body.');
+        }
+        $fragment_bytes = strlen($bytes);
+        if ($fragment_bytes > $remaining_request_body_bytes) {
+            $observed_request_body_bytes = $this->upload_request_body_bytes_read + $fragment_bytes;
+            throw new Site_Export_Push_Exception(
+                self::ERROR_REQUEST_TOO_LARGE,
+                'The decoded request body reached ' . $observed_request_body_bytes
+                . ' bytes, exceeding the target post_max_size of '
+                . $this->maximum_upload_request_body_bytes . ' bytes.',
+                ['observed_request_body_bytes' => $observed_request_body_bytes]
+            );
+        }
+        $this->upload_request_body_bytes_read += $fragment_bytes;
+        return $bytes;
     }
 
     /**
@@ -1466,6 +1491,7 @@ final class Site_Export_Push_Session {
             $work_identity = $this->lstat_path($work_path);
 
             if ($structural_cleanup) {
+                $this->validate_structural_path($path);
                 $this->require_docroot_ancestors($path, 'install', 'directory');
                 $docroot_identity = $this->lstat_path($this->docroot_path($path));
                 if ($work_identity !== null) {
@@ -1487,6 +1513,7 @@ final class Site_Export_Push_Session {
                 return;
             }
 
+            $this->validate_path($path);
             if ($work_identity !== null) {
                 $this->install_work_value($commit_state, $path, $expected_type, true);
                 return;
@@ -1557,13 +1584,14 @@ final class Site_Export_Push_Session {
         }
 
         $path = $parent_path === '' ? $entry : $parent_path . '/' . $entry;
-        $this->validate_path($path);
+        $this->validate_path_syntax($path);
         $work_path = $this->work_files_directory . '/' . $path;
         $identity = $this->lstat_path($work_path);
         if ($identity === null) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Selected work path disappeared before installing_files: ' . base64_encode($path) . '.');
         }
         if ($identity['type'] === 'directory' && $this->first_directory_entry($work_path) !== null) {
+            $this->validate_structural_path($path);
             $commit_state['commit_cursor'][] = ['component_b64' => base64_encode($entry)];
             $this->write_json($this->commit_json_path, $commit_state);
             $requested_path = $this->first_work_files_descendant_path($work_path, $path);
@@ -1584,6 +1612,7 @@ final class Site_Export_Push_Session {
             }
             return;
         }
+        $this->validate_path($path);
         if (!in_array($identity['type'], ['file', 'directory', 'symlink'], true)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Work path ' . base64_encode($path) . ' has unsupported type ' . $identity['type'] . '.');
         }
@@ -2186,8 +2215,9 @@ final class Site_Export_Push_Session {
      * Decodes and validates a base64 path stored in a commit checkpoint.
      *
      * Checkpoints store arbitrary filesystem bytes as base64 to remain valid
-     * JSON. This method rejects missing, malformed, or unsafe paths before they
-     * are used to select document-root filesystem work.
+     * JSON. This method rejects missing, malformed, or grammatically unsafe
+     * paths. Its caller applies the requested-value or structural-directory
+     * excluded-path policy before any document-root mutation.
      *
      * @param mixed $encoded Candidate base64 value from metadata.
      * @param string $description Field name used in error messages.
@@ -2201,7 +2231,7 @@ final class Site_Export_Push_Session {
         if (!is_string($path)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit ' . $description . ' path is not valid base64.');
         }
-        $this->validate_path($path);
+        $this->validate_path_syntax($path);
         return $path;
     }
 
@@ -2210,7 +2240,7 @@ final class Site_Export_Push_Session {
      *
      * Each frame stores exactly one base64 path component. The method validates
      * each component independently, rebuilds the slash-separated path, and then
-     * applies the normal document-root-relative path rules to the result.
+     * applies the implicit structural-directory path rules to the result.
      *
      * @param array $stack {
      *     Commit cursor frames.
@@ -2234,7 +2264,7 @@ final class Site_Export_Push_Session {
             }
         }
         if ($path !== '') {
-            $this->validate_path($path);
+            $this->validate_structural_path($path);
         }
         return $path;
     }
@@ -2262,25 +2292,56 @@ final class Site_Export_Push_Session {
      * Paths are byte strings carried through base64 on the wire. They must be
      * relative, bounded, free of NUL/backslash and dot segments, outside the
      * WordPress maintenance marker, and not equal to or an ancestor/descendant
-     * of a excluded path.
+     * of an excluded path.
      *
      * @param string $path Document-root-relative raw path bytes.
      */
     private function validate_path(string $path): void {
-        if ($path === '' || strlen($path) > self::MAX_PATH_BYTES || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
-            throw new InvalidArgumentException('Document-root-relative path must contain between 1 and ' . self::MAX_PATH_BYTES . ' safe bytes; observed ' . base64_encode($path) . '.');
-        }
-        foreach (explode('/', $path) as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..') {
-                throw new InvalidArgumentException('Document-root-relative path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
-            }
-        }
+        $this->validate_path_syntax($path);
         if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
             throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
         }
         foreach ($this->excluded_paths as $excluded_path) {
             if ($path === $excluded_path || strpos($path, $excluded_path . '/') === 0 || strpos($excluded_path, $path . '/') === 0) {
                 throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
+            }
+        }
+    }
+
+    /**
+     * Validates one implicit structural work-tree directory.
+     *
+     * A structural directory is traversed only to reach requested descendant
+     * work. It may therefore be an ancestor of an excluded path when the work
+     * lies in an unrelated sibling, but it must never equal or descend from an
+     * excluded path itself.
+     *
+     * @param string $path Document-root-relative structural directory path.
+     */
+    private function validate_structural_path(string $path): void {
+        $this->validate_path_syntax($path);
+        if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
+            throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
+        }
+        foreach ($this->excluded_paths as $excluded_path) {
+            if ($path === $excluded_path || strpos($path, $excluded_path . '/') === 0) {
+                throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
+            }
+        }
+    }
+
+    /**
+     * Validates path grammar without applying the excluded-path policy.
+     *
+     * @param string $path Document-root-relative raw path bytes.
+     */
+    private function validate_path_syntax(string $path): void {
+        if ($path === '' || strlen($path) > self::MAX_PATH_BYTES || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('Document-root-relative path must contain between 1 and ' . self::MAX_PATH_BYTES . ' safe bytes; observed ' . base64_encode($path) . '.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException('Document-root-relative path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
             }
         }
     }
@@ -2360,9 +2421,9 @@ final class Site_Export_Push_Session {
     /**
      * Joins the managed document root with one validated relative path.
      *
-     * The caller is responsible for validate_path() where the value originates.
-     * This method only preserves correct slash handling for both `/` and normal
-     * directory roots.
+     * The caller applies the appropriate requested-value or structural-path
+     * validation where the value originates. This method only preserves correct
+     * slash handling for both `/` and normal directory roots.
      *
      * @param string $relative_path Document-root-relative path.
      * @return string Absolute path in the document root.
@@ -2505,6 +2566,50 @@ final class Site_Export_Push_Session {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Expected a regular file at ' . $path . '.');
         }
         return $identity['size'];
+    }
+
+    /**
+     * Creates or validates the directory shared by every push session.
+     *
+     * Create and remove both establish this directory before acquiring the
+     * lifecycle lock. This lets an idempotent remove coordinate with a create
+     * even when no push session or tombstone currently exists.
+     *
+     * @param string $reprint_directory Canonical private reprint directory.
+     * @return string Canonical push parent directory.
+     */
+    private static function require_push_parent_directory(string $reprint_directory): string {
+        $push_parent_directory = $reprint_directory . '/.reprint/push';
+        if (!@mkdir($push_parent_directory, 0700, true) && !is_dir($push_parent_directory)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create push sessions directory ' . $push_parent_directory . '.');
+        }
+        return self::require_directory($push_parent_directory, 'push sessions', false);
+    }
+
+    /**
+     * Acquires the cross-session lock for one create or bounded remove call.
+     *
+     * The historical filename remains `push-create.lock`, but the lock covers
+     * creation and every bounded removal step so create cannot race a
+     * live-directory rename or an unfinished removal tombstone.
+     *
+     * @param string $push_parent_directory Canonical push parent directory.
+     * @param string $operation Current `create` or `remove` operation.
+     * @return resource Exclusively locked lifecycle handle.
+     */
+    private static function acquire_lifecycle_lock(string $push_parent_directory, string $operation) {
+        $lifecycle_lock = @fopen($push_parent_directory . '/push-create.lock', 'c+b');
+        if ($lifecycle_lock === false) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the push lifecycle lock for ' . $operation . '.');
+        }
+        if (!flock($lifecycle_lock, LOCK_EX | LOCK_NB)) {
+            fclose($lifecycle_lock);
+            throw new Site_Export_Push_Exception(
+                self::ERROR_LOCK_ACQUISITION_FAILURE,
+                'Push session lifecycle is busy. Retry the ' . $operation . ' request.'
+            );
+        }
+        return $lifecycle_lock;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -116,8 +116,9 @@ final class Site_Export_Push_Session {
      *
      * Factory methods canonicalize the reprint directory and document root before they
      * reach this constructor. The constructor then establishes the invariant
-     * shared by every push-session handle: excluded paths are safe, sorted, and
-     * unique, and a reprint directory below the document root protects itself from push.
+     * shared by every push-session handle: excluded paths are valid
+     * document-root-relative paths in sorted, unique order, and a reprint
+     * directory below the document root protects itself from push.
      * No filesystem state is read or changed here.
      *
      * @param list<string> $excluded_paths Document-root-relative paths which a push
@@ -154,19 +155,19 @@ final class Site_Export_Push_Session {
      * Creates or idempotently reopens one private push session.
      *
      * The empty work tree is created before its device is compared with the
-     * managed root. A mismatch removes the new push session before any multipart
+     * document root. A mismatch removes the new push session before any multipart
      * bytes can be accepted. That device check necessarily stats the new tree;
      * successful creation and metadata writes are otherwise trusted instead
      * of being followed by a complete layout scan.
      *
-     * Replaying the same push session ID returns a handle to the existing push directory.
-     * Its durable layout and immutable metadata are validated under the push
-     * lock by the first upload, status, or commit operation. Keeping that check
-     * at the operation boundary avoids reading the same layout before and after
-     * its lock is acquired.
+     * Replaying the same push session ID validates the existing directory's
+     * durable layout, immutable metadata, and same-filesystem relationship
+     * under its push lock before returning the handle. The create/remove lock
+     * remains held during that validation, so remove cannot rename the directory
+     * between the existing-directory check and the push-lock acquisition.
      *
      * @param string $reprint_directory Durable private reprint directory on the document-root filesystem.
-     * @param string $docroot Managed document-root directory receiving committed values.
+     * @param string $docroot Document-root directory receiving committed values.
      * @param list<string> $excluded_paths Document-root-relative paths which a push must preserve.
      * @param string $push_session_id Stable lowercase hexadecimal push session ID.
      * @return self New or existing push-session handle.
@@ -176,10 +177,10 @@ final class Site_Export_Push_Session {
         $reprint_directory = self::require_directory($reprint_directory, 'reprint directory', true);
         $docroot = self::require_directory($docroot, 'document root', false);
         $push_session = new self($reprint_directory, $docroot, $push_session_id, $excluded_paths);
-        $push_parent_directory = self::require_push_parent_directory($reprint_directory);
-        $lifecycle_lock = self::acquire_lifecycle_lock($push_parent_directory, 'create');
+        $push_sessions_directory = self::create_push_sessions_directory($reprint_directory);
+        $create_remove_lock = self::acquire_create_remove_lock($push_sessions_directory, 'create');
         try {
-            $removing_push_directory = $push_parent_directory . '/.removing-' . $push_session_id;
+            $removing_push_directory = $push_sessions_directory . '/.removing-' . $push_session_id;
             if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
                 throw new Site_Export_Push_Exception(
                     self::ERROR_LOCK_ACQUISITION_FAILURE,
@@ -187,6 +188,9 @@ final class Site_Export_Push_Session {
                 );
             }
             if (file_exists($push_session->push_directory) || is_link($push_session->push_directory)) {
+                // Lock acquisition checks the durable layout; with_push_lock()
+                // then checks immutable configuration before this callback.
+                $push_session->with_push_lock(static function (): void {});
                 return $push_session;
             }
             if (!@mkdir($push_session->work_files_directory, 0700, true)) {
@@ -211,8 +215,8 @@ final class Site_Export_Push_Session {
             ]);
             return $push_session;
         } finally {
-            flock($lifecycle_lock, LOCK_UN);
-            fclose($lifecycle_lock);
+            flock($create_remove_lock, LOCK_UN);
+            fclose($create_remove_lock);
         }
     }
 
@@ -225,7 +229,7 @@ final class Site_Export_Push_Session {
      * and same-filesystem relationship exactly once for that operation.
      *
      * @param string $reprint_directory Durable private reprint directory.
-     * @param string $docroot Managed document-root directory.
+     * @param string $docroot Document-root directory.
      * @param string $push_session_id Lowercase hexadecimal push session ID.
      * @param list<string> $excluded_paths Document-root-relative paths which a push must preserve.
      * @return self Push-session handle; the push session may prove missing or invalid
@@ -247,7 +251,7 @@ final class Site_Export_Push_Session {
      * able to remove abandoned private work after configuration changes.
      *
      * @param string $reprint_directory Durable private reprint directory.
-     * @param string $docroot Currently configured managed document-root directory.
+     * @param string $docroot Currently configured document-root directory.
      * @param string $push_session_id Lowercase hexadecimal push session ID.
      * @param list<string> $excluded_paths Currently configured excluded paths.
      * @return bool True when the push directory and any remove tombstone are gone.
@@ -533,7 +537,8 @@ final class Site_Export_Push_Session {
      *     path:PathStatus|null
      * }
      *
-     * @throws InvalidArgumentException If the requested path is unsafe.
+     * @throws InvalidArgumentException If the requested path is reserved or
+     *     overlaps an excluded path.
      * @throws Site_Export_Push_Exception If the push session is busy,
      *     unavailable, corrupt, or no longer matches the document-root configuration.
      */
@@ -542,7 +547,7 @@ final class Site_Export_Push_Session {
             $this->finish_published_inflight();
             $reported_path = null;
             if ($path !== null) {
-                $this->validate_path($path);
+                $this->assert_path_does_not_overlap_excluded_paths($path);
                 $complete = $this->work_files_directory . '/' . $path;
                 $this->ensure_private_parent($complete, false);
                 $inflight = $this->read_inflight();
@@ -719,9 +724,9 @@ final class Site_Export_Push_Session {
      *              limit left tombstone work for another call.
      */
     public function remove_push_directory(): bool {
-        $push_parent_directory = self::require_push_parent_directory($this->reprint_directory);
-        $removing_push_directory = $push_parent_directory . '/.removing-' . $this->push_session_id;
-        $lifecycle_lock = self::acquire_lifecycle_lock($push_parent_directory, 'remove');
+        $push_sessions_directory = self::create_push_sessions_directory($this->reprint_directory);
+        $removing_push_directory = $push_sessions_directory . '/.removing-' . $this->push_session_id;
+        $create_remove_lock = self::acquire_create_remove_lock($push_sessions_directory, 'remove');
         try {
             if ($this->lstat_path($this->push_directory) === null) {
                 return $this->remove_tombstone($removing_push_directory);
@@ -744,8 +749,8 @@ final class Site_Export_Push_Session {
             }
             return $this->remove_tombstone($removing_push_directory);
         } finally {
-            flock($lifecycle_lock, LOCK_UN);
-            fclose($lifecycle_lock);
+            flock($create_remove_lock, LOCK_UN);
+            fclose($create_remove_lock);
         }
     }
 
@@ -1275,7 +1280,7 @@ final class Site_Export_Push_Session {
                             if ($trailing_path === '') {
                                 throw new InvalidArgumentException('Delete-list parts may not contain an empty delete record.');
                             }
-                            $this->validate_path($trailing_path);
+                            $this->assert_path_does_not_overlap_excluded_paths($trailing_path);
                             $trailing_path = '';
                             continue;
                         }
@@ -1369,7 +1374,7 @@ final class Site_Export_Push_Session {
                         if ($path === '') {
                             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The work delete stream contains an empty record at offset ' . $work_deletes_byte_offset . '.');
                         }
-                        $this->validate_path($path);
+                        $this->assert_path_does_not_overlap_excluded_paths($path);
                         $commit_state['current_delete_path'] = base64_encode($path);
                         $this->write_json($this->commit_json_path, $commit_state);
                         return;
@@ -1384,7 +1389,7 @@ final class Site_Export_Push_Session {
         }
 
         $path = $this->decode_commit_path($commit_state['current_delete_path'], 'current delete');
-        $this->validate_path($path);
+        $this->assert_path_does_not_overlap_excluded_paths($path);
         $parent_device = $this->require_docroot_ancestors($path, 'delete');
         if ($parent_device !== null) {
             $docroot_value_path = $this->docroot_path($path);
@@ -1452,9 +1457,9 @@ final class Site_Export_Push_Session {
      * Performs one bounded installing_files or commit-cursor step.
      *
      * The completed work tree is its own queue. This method walks it
-     * depth-first, creating structural document-root directories before their children,
-     * installing one leaf value per step, and consuming empty structural work
-     * directories after their descendants have been committed.
+     * depth-first, creating document-root ancestor directories before their
+     * children, installing one leaf value per step, and consuming empty work
+     * ancestor directories after their descendants have been committed.
      *
      * @param array $commit_state {
      *     Commit checkpoint, mutated in place.
@@ -1474,24 +1479,24 @@ final class Site_Export_Push_Session {
     private function advance_installing_files(array &$commit_state): void {
         if ($commit_state['current_work_files_descendant'] !== null) {
             /*
-             * A checkpoint may survive either side of a rename or structural
-             * cleanup. The work value may still be present and need retrying,
-             * or it may already be consumed and require verification in the
-             * document root. Resolve that evidence before selecting any new work.
+             * A checkpoint may survive either side of a rename or work ancestor
+             * directory cleanup. The work value may still be present and need
+             * retrying, or it may already be consumed and require verification
+             * in the document root. Resolve that evidence before selecting any new work.
              */
             $current_work_files_descendant = $commit_state['current_work_files_descendant'];
             $path = $this->decode_commit_path($current_work_files_descendant['path_b64'], 'current installing_files');
             $expected_type = $current_work_files_descendant['expected_type'];
             $stack_size = count($commit_state['commit_cursor']);
-            $structural_cleanup = false;
+            $work_ancestor_directory_cleanup = false;
             if ($stack_size > 0) {
-                $structural_cleanup = $this->commit_cursor_path($commit_state['commit_cursor']) === $path;
+                $work_ancestor_directory_cleanup = $this->commit_cursor_path($commit_state['commit_cursor']) === $path;
             }
             $work_path = $this->work_files_directory . '/' . $path;
             $work_identity = $this->lstat_path($work_path);
 
-            if ($structural_cleanup) {
-                $this->validate_structural_path($path);
+            if ($work_ancestor_directory_cleanup) {
+                $this->assert_path_is_not_excluded($path);
                 $this->require_docroot_ancestors($path, 'install', 'directory');
                 $docroot_identity = $this->lstat_path($this->docroot_path($path));
                 if ($work_identity !== null) {
@@ -1502,7 +1507,7 @@ final class Site_Export_Push_Session {
                         $this->throw_unexpected_docroot_mutation('install', $path, $path, 'directory', ['directory'], $docroot_identity);
                     }
                     if (!@rmdir($work_path)) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not finish structural work cleanup for ' . base64_encode($path) . '.');
+                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not finish work ancestor directory cleanup for ' . base64_encode($path) . '.');
                     }
                 } elseif ($docroot_identity === null || $docroot_identity['type'] !== 'directory') {
                     $this->throw_unexpected_docroot_mutation('install', $path, $path, 'directory', ['directory'], $docroot_identity);
@@ -1513,7 +1518,7 @@ final class Site_Export_Push_Session {
                 return;
             }
 
-            $this->validate_path($path);
+            $this->assert_path_does_not_overlap_excluded_paths($path);
             if ($work_identity !== null) {
                 $this->install_work_value($commit_state, $path, $expected_type, true);
                 return;
@@ -1575,7 +1580,7 @@ final class Site_Export_Push_Session {
             $commit_state['current_work_files_descendant'] = ['path_b64' => base64_encode($parent_path), 'expected_type' => 'directory'];
             $this->write_json($this->commit_json_path, $commit_state);
             if (!@rmdir($work_directory_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not consume empty structural work directory ' . base64_encode($parent_path) . '.');
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not consume empty work ancestor directory ' . base64_encode($parent_path) . '.');
             }
             $commit_state['current_work_files_descendant'] = null;
             array_pop($commit_state['commit_cursor']);
@@ -1584,14 +1589,14 @@ final class Site_Export_Push_Session {
         }
 
         $path = $parent_path === '' ? $entry : $parent_path . '/' . $entry;
-        $this->validate_path_syntax($path);
+        $this->assert_path_not_reserved($path);
         $work_path = $this->work_files_directory . '/' . $path;
         $identity = $this->lstat_path($work_path);
         if ($identity === null) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Selected work path disappeared before installing_files: ' . base64_encode($path) . '.');
         }
         if ($identity['type'] === 'directory' && $this->first_directory_entry($work_path) !== null) {
-            $this->validate_structural_path($path);
+            $this->assert_path_is_not_excluded($path);
             $commit_state['commit_cursor'][] = ['component_b64' => base64_encode($entry)];
             $this->write_json($this->commit_json_path, $commit_state);
             $requested_path = $this->first_work_files_descendant_path($work_path, $path);
@@ -1600,7 +1605,7 @@ final class Site_Export_Push_Session {
             $docroot_identity = $this->lstat_path($docroot_value_path);
             if ($docroot_identity === null) {
                 if (!@mkdir($docroot_value_path, 0777) && !is_dir($docroot_value_path)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create structural document-root directory ' . base64_encode($path) . '.');
+                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create document-root ancestor directory ' . base64_encode($path) . '.');
                 }
                 $docroot_identity = $this->lstat_path($docroot_value_path);
             }
@@ -1612,7 +1617,7 @@ final class Site_Export_Push_Session {
             }
             return;
         }
-        $this->validate_path($path);
+        $this->assert_path_does_not_overlap_excluded_paths($path);
         if (!in_array($identity['type'], ['file', 'directory', 'symlink'], true)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Work path ' . base64_encode($path) . ' has unsupported type ' . $identity['type'] . '.');
         }
@@ -1697,7 +1702,7 @@ final class Site_Export_Push_Session {
     private function require_docroot_ancestors(string $path, string $operation, ?string $work_identity_type = null): ?int {
         $root = $this->lstat_path($this->docroot);
         if ($root === null || $root['type'] !== 'directory') {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The managed document root is no longer a real directory.');
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The document root is no longer a real directory.');
         }
         $work_device = $this->work_device();
         if ($root['dev'] !== $work_device) {
@@ -1758,7 +1763,6 @@ final class Site_Export_Push_Session {
             'conflict_path_b64' => base64_encode($conflict_path),
             'expected_docroot_types' => $expected_docroot_types,
             'observed_docroot_identity' => $observed_identity === null ? ['type' => 'absent'] : $observed_identity,
-            'detail' => $detail,
         ];
         if ($work_identity_type !== null) {
             $context['work_type'] = $work_identity_type;
@@ -1786,7 +1790,6 @@ final class Site_Export_Push_Session {
             'path_b64' => base64_encode($path),
             'work_device' => $work_device,
             'docroot_device' => $docroot_device,
-            'detail' => $detail,
         ]);
     }
 
@@ -1889,11 +1892,12 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Returns a work leaf path below a structural directory.
+     * Returns a work leaf path below a work ancestor directory.
      *
-     * When a document-root structural ancestor conflicts, reporting only the ancestor can
-     * hide which work value required it. This walks to one descendant so the
-     * error can name requested work rather than only the commit-cursor directory.
+     * When a document-root ancestor directory conflicts, reporting only the
+     * ancestor can hide which work value required it. This walks to one
+     * descendant so the error can name requested work rather than only the
+     * commit-cursor directory.
      *
      * @param string $directory Absolute work directory being traversed.
      * @param string $relative_path Document-root-relative path for that directory.
@@ -2057,7 +2061,7 @@ final class Site_Export_Push_Session {
      *
      * Remove deliberately omits this check: private work may need cleanup
      * after the document-root or excluded-path configuration has changed.
-     * Upload, status, and commit must agree with the immutable push metadata
+     * Create, upload, status, and commit must agree with the immutable push metadata
      * and retain the same-device guarantee under which the push was made.
      */
     private function assert_push_configuration(): void {
@@ -2215,8 +2219,8 @@ final class Site_Export_Push_Session {
      * Decodes and validates a base64 path stored in a commit checkpoint.
      *
      * Checkpoints store arbitrary filesystem bytes as base64 to remain valid
-     * JSON. This method rejects missing, malformed, or grammatically unsafe
-     * paths. Its caller applies the requested-value or structural-directory
+     * JSON. This method rejects missing, malformed, or receiver-reserved path
+     * forms. Its caller applies the requested-value or work-ancestor-directory
      * excluded-path policy before any document-root mutation.
      *
      * @param mixed $encoded Candidate base64 value from metadata.
@@ -2231,7 +2235,7 @@ final class Site_Export_Push_Session {
         if (!is_string($path)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit ' . $description . ' path is not valid base64.');
         }
-        $this->validate_path_syntax($path);
+        $this->assert_path_not_reserved($path);
         return $path;
     }
 
@@ -2240,7 +2244,7 @@ final class Site_Export_Push_Session {
      *
      * Each frame stores exactly one base64 path component. The method validates
      * each component independently, rebuilds the slash-separated path, and then
-     * applies the implicit structural-directory path rules to the result.
+     * applies the implicit work-ancestor-directory path rules to the result.
      *
      * @param array $stack {
      *     Commit cursor frames.
@@ -2264,7 +2268,7 @@ final class Site_Export_Push_Session {
             }
         }
         if ($path !== '') {
-            $this->validate_structural_path($path);
+            $this->assert_path_is_not_excluded($path);
         }
         return $path;
     }
@@ -2287,62 +2291,100 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Validates one document-root-relative path accepted by a push.
+     * Rejects a requested value which would overlap an excluded path.
      *
-     * Paths are byte strings carried through base64 on the wire. They must be
-     * relative, bounded, free of NUL/backslash and dot segments, outside the
-     * WordPress maintenance marker, and not equal to or an ancestor/descendant
-     * of an excluded path.
+     * Requested files, directories, symlinks, and delete roots may not equal,
+     * descend from, or contain an excluded path. Work ancestor directories use
+     * assert_path_is_not_excluded() because an unrelated sibling may still need
+     * to traverse an ancestor of an excluded path.
      *
      * @param string $path Document-root-relative raw path bytes.
      */
-    private function validate_path(string $path): void {
-        $this->validate_path_syntax($path);
-        if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
-            throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
-        }
+    private function assert_path_does_not_overlap_excluded_paths(string $path): void {
+        $this->assert_path_is_not_excluded($path);
         foreach ($this->excluded_paths as $excluded_path) {
-            if ($path === $excluded_path || strpos($path, $excluded_path . '/') === 0 || strpos($excluded_path, $path . '/') === 0) {
-                throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
+            if (strpos($excluded_path, $path . '/') === 0) {
+                throw new InvalidArgumentException(
+                    'Excluded document-root-relative path ' . base64_encode($excluded_path)
+                    . ' is contained by the requested path, which cannot be changed: '
+                    . base64_encode($path) . '.'
+                );
             }
         }
     }
 
     /**
-     * Validates one implicit structural work-tree directory.
+     * Rejects a path equal to or below an excluded path.
      *
-     * A structural directory is traversed only to reach requested descendant
-     * work. It may therefore be an ancestor of an excluded path when the work
-     * lies in an unrelated sibling, but it must never equal or descend from an
-     * excluded path itself.
+     * A work ancestor directory is traversed only to reach requested descendant
+     * work. It may be an ancestor of an excluded path when the work lies in an
+     * unrelated sibling, but it must never equal or descend from an excluded
+     * path itself.
      *
-     * @param string $path Document-root-relative structural directory path.
+     * @param string $path Document-root-relative path.
      */
-    private function validate_structural_path(string $path): void {
-        $this->validate_path_syntax($path);
-        if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
-            throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
-        }
+    private function assert_path_is_not_excluded(string $path): void {
+        $this->assert_path_not_reserved($path);
         foreach ($this->excluded_paths as $excluded_path) {
-            if ($path === $excluded_path || strpos($path, $excluded_path . '/') === 0) {
-                throw new InvalidArgumentException('Excluded document-root-relative path cannot be changed: ' . base64_encode($path) . '.');
+            if ($path === $excluded_path) {
+                throw new InvalidArgumentException(
+                    'Excluded document-root-relative path cannot be changed: '
+                    . base64_encode($path) . '.'
+                );
+            }
+            if (strpos($path, $excluded_path . '/') === 0) {
+                throw new InvalidArgumentException(
+                    'Excluded document-root-relative path ' . base64_encode($excluded_path)
+                    . ' contains the requested descendant, which cannot be changed: '
+                    . base64_encode($path) . '.'
+                );
             }
         }
     }
 
     /**
-     * Validates path grammar without applying the excluded-path policy.
+     * Rejects path forms reserved by the receiver.
+     *
+     * Paths are arbitrary byte strings carried as base64 on the wire, but the
+     * receiver reserves forms which are empty, exceed the bounded path length,
+     * are absolute, contain NUL or backslash bytes, contain empty or dot path
+     * components, or address the WordPress maintenance marker.
      *
      * @param string $path Document-root-relative raw path bytes.
      */
-    private function validate_path_syntax(string $path): void {
-        if ($path === '' || strlen($path) > self::MAX_PATH_BYTES || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
-            throw new InvalidArgumentException('Document-root-relative path must contain between 1 and ' . self::MAX_PATH_BYTES . ' safe bytes; observed ' . base64_encode($path) . '.');
+    private function assert_path_not_reserved(string $path): void {
+        if ($path === '') {
+            throw new InvalidArgumentException('Document-root-relative path must not be empty.');
+        }
+        $path_bytes = strlen($path);
+        if ($path_bytes > self::MAX_PATH_BYTES) {
+            throw new InvalidArgumentException(
+                'Document-root-relative path exceeds the maximum of '
+                . self::MAX_PATH_BYTES . ' bytes; observed ' . $path_bytes . '.'
+            );
+        }
+        if ($path[0] === '/') {
+            throw new InvalidArgumentException('Document-root-relative path must not be absolute: ' . base64_encode($path) . '.');
+        }
+        if (strpos($path, "\0") !== false) {
+            throw new InvalidArgumentException('Document-root-relative path must not contain a NUL byte: ' . base64_encode($path) . '.');
+        }
+        if (strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('Document-root-relative path must not contain a backslash: ' . base64_encode($path) . '.');
         }
         foreach (explode('/', $path) as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..') {
-                throw new InvalidArgumentException('Document-root-relative path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
+            if ($segment === '') {
+                throw new InvalidArgumentException('Document-root-relative path must not contain an empty component: ' . base64_encode($path) . '.');
             }
+            if ($segment === '.') {
+                throw new InvalidArgumentException('Document-root-relative path must not contain a dot component: ' . base64_encode($path) . '.');
+            }
+            if ($segment === '..') {
+                throw new InvalidArgumentException('Document-root-relative path must not contain a parent component: ' . base64_encode($path) . '.');
+            }
+        }
+        if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
+            throw new InvalidArgumentException('The WordPress maintenance marker path is reserved: ' . base64_encode($path) . '.');
         }
     }
 
@@ -2369,7 +2411,7 @@ final class Site_Export_Push_Session {
             throw new InvalidArgumentException('Multipart header ' . $header . ' is not valid base64.');
         }
         if ($is_docroot_path) {
-            $this->validate_path($decoded);
+            $this->assert_path_does_not_overlap_excluded_paths($decoded);
         }
         return $decoded;
     }
@@ -2419,9 +2461,9 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Joins the managed document root with one validated relative path.
+     * Joins the document root with one document-root-relative path.
      *
-     * The caller applies the appropriate requested-value or structural-path
+     * The caller applies the appropriate requested-value or work-ancestor-path
      * validation where the value originates. This method only preserves correct
      * slash handling for both `/` and normal directory roots.
      *
@@ -2433,7 +2475,7 @@ final class Site_Export_Push_Session {
     }
 
     /**
-     * Creates or validates private structural parents for a work path.
+     * Creates or validates private work ancestor directories for a work path.
      *
      * Only work/files paths are accepted. Missing parents are
      * created when requested; existing parents must be real directories so a
@@ -2468,7 +2510,7 @@ final class Site_Export_Push_Session {
                     return;
                 }
                 if (!@mkdir($current, 0700)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create private structural work directory ' . $current . '.');
+                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create private work ancestor directory ' . $current . '.');
                 }
                 continue;
             }
@@ -2525,9 +2567,9 @@ final class Site_Export_Push_Session {
     /**
      * Removes one work private leaf or empty directory.
      *
-     * A directory with descendants represents structural state for other work
-     * paths and cannot be replaced by a different logical value. Files,
-     * symlinks, and other leaf-like entries are unlinked without following them.
+     * A directory with descendants is a work ancestor directory for other paths
+     * and cannot be replaced by a different logical value. Files, symlinks, and
+     * other leaf-like entries are unlinked without following them.
      *
      * @param string $path Absolute private work path.
      */
@@ -2571,19 +2613,19 @@ final class Site_Export_Push_Session {
     /**
      * Creates or validates the directory shared by every push session.
      *
-     * Create and remove both establish this directory before acquiring the
-     * lifecycle lock. This lets an idempotent remove coordinate with a create
-     * even when no push session or tombstone currently exists.
+     * Create and remove both establish this directory before acquiring their
+     * shared lock. This lets an idempotent remove coordinate with a create even
+     * when no push session or tombstone currently exists.
      *
      * @param string $reprint_directory Canonical private reprint directory.
-     * @return string Canonical push parent directory.
+     * @return string Canonical push sessions directory.
      */
-    private static function require_push_parent_directory(string $reprint_directory): string {
-        $push_parent_directory = $reprint_directory . '/.reprint/push';
-        if (!@mkdir($push_parent_directory, 0700, true) && !is_dir($push_parent_directory)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create push sessions directory ' . $push_parent_directory . '.');
+    private static function create_push_sessions_directory(string $reprint_directory): string {
+        $push_sessions_directory = $reprint_directory . '/.reprint/push';
+        if (!@mkdir($push_sessions_directory, 0700, true) && !is_dir($push_sessions_directory)) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create push sessions directory ' . $push_sessions_directory . '.');
         }
-        return self::require_directory($push_parent_directory, 'push sessions', false);
+        return self::require_directory($push_sessions_directory, 'push sessions', false);
     }
 
     /**
@@ -2593,23 +2635,23 @@ final class Site_Export_Push_Session {
      * creation and every bounded removal step so create cannot race a
      * live-directory rename or an unfinished removal tombstone.
      *
-     * @param string $push_parent_directory Canonical push parent directory.
+     * @param string $push_sessions_directory Canonical push sessions directory.
      * @param string $operation Current `create` or `remove` operation.
-     * @return resource Exclusively locked lifecycle handle.
+     * @return resource Exclusively locked create/remove handle.
      */
-    private static function acquire_lifecycle_lock(string $push_parent_directory, string $operation) {
-        $lifecycle_lock = @fopen($push_parent_directory . '/push-create.lock', 'c+b');
-        if ($lifecycle_lock === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the push lifecycle lock for ' . $operation . '.');
+    private static function acquire_create_remove_lock(string $push_sessions_directory, string $operation) {
+        $create_remove_lock = @fopen($push_sessions_directory . '/push-create.lock', 'c+b');
+        if ($create_remove_lock === false) {
+            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open push-create.lock for the ' . $operation . ' request.');
         }
-        if (!flock($lifecycle_lock, LOCK_EX | LOCK_NB)) {
-            fclose($lifecycle_lock);
+        if (!flock($create_remove_lock, LOCK_EX | LOCK_NB)) {
+            fclose($create_remove_lock);
             throw new Site_Export_Push_Exception(
                 self::ERROR_LOCK_ACQUISITION_FAILURE,
-                'Push session lifecycle is busy. Retry the ' . $operation . ' request.'
+                'Another create or remove request holds push-create.lock. Retry the ' . $operation . ' request.'
             );
         }
-        return $lifecycle_lock;
+        return $create_remove_lock;
     }
 
     /**

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -2,6 +2,8 @@
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Push errors become authenticated API JSON, never HTML output.
 
+use function WordPress\Reprint\Exporter\normalize_excluded_paths;
+
 if (!class_exists('Site_Export_Multipart_Processor', false)) {
     require_once __DIR__ . '/class-multipart-processor.php';
 }
@@ -57,6 +59,7 @@ final class Site_Export_Push_Session {
     public const ERROR_UNEXPECTED_DOCROOT_MUTATION = 'unexpected_docroot_mutation';
     public const ERROR_CORRUPTED_PUSH_STATE = 'corrupted_push_state';
     public const ERROR_SAME_DEVICE = 'same_device';
+    public const ERROR_REQUEST_TOO_LARGE = 'request_too_large';
 
     private const MAX_PATH_BYTES = 4096;
     private const MAX_METADATA_BYTES = 1048576;
@@ -103,6 +106,10 @@ final class Site_Export_Push_Session {
     private $current_change = null;
     /** @var int */
     private $maximum_upload_part_bytes = PHP_INT_MAX;
+    /** @var int */
+    private $maximum_upload_request_body_bytes = PHP_INT_MAX;
+    /** @var int */
+    private $upload_request_body_bytes_read = 0;
 
     /**
      * Normalizes one push session's policy and derives its private paths.
@@ -130,20 +137,7 @@ final class Site_Export_Push_Session {
                 $excluded_paths[] = $relative_reprint_directory;
             }
         }
-        $normalized_excluded_paths = [];
-        foreach ($excluded_paths as $path) {
-            if (!is_string($path) || $path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
-                throw new InvalidArgumentException('Each excluded path must be a non-empty safe relative path.');
-            }
-            foreach (explode('/', $path) as $segment) {
-                if ($segment === '' || $segment === '.' || $segment === '..') {
-                    throw new InvalidArgumentException('Excluded path is unsafe: ' . base64_encode($path) . '.');
-                }
-            }
-            $normalized_excluded_paths[] = $path;
-        }
-        sort($normalized_excluded_paths, SORT_STRING);
-        $this->excluded_paths = array_values(array_unique($normalized_excluded_paths));
+        $this->excluded_paths = normalize_excluded_paths($excluded_paths);
         $this->push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
         $this->push_json_path = $this->push_directory . '/push.json';
         $this->commit_json_path = $this->push_directory . '/commit.json';
@@ -304,8 +298,9 @@ final class Site_Export_Push_Session {
      * The push lock remains held until finish_upload() is called, so no
      * status, commit, remove, or second upload can observe a partly processed
      * MIME part. The supplied processor owns the request boundary and parser
-     * state. The byte limit applies to each part's declared Content-Length,
-     * not to the complete HTTP request.
+     * state. The two byte limits remain independent: one applies to each part's
+     * declared Content-Length, and one applies to all decoded request-body bytes
+     * read from the supplied stream.
      *
      * A push session which has started commit is closed to further uploads. This
      * method validates that condition before any bytes are read from $input.
@@ -314,13 +309,21 @@ final class Site_Export_Push_Session {
      * @param Site_Export_Multipart_Processor $processor Parser configured with
      *                                                   the request boundary.
      * @param int $maximum_part_bytes Largest Content-Length accepted for one part.
+     * @param int $maximum_request_body_bytes Largest decoded request body accepted.
+     *                                        Defaults to unlimited for direct callers.
      *
      * @throws LogicException If another upload is already open on this object.
-     * @throws InvalidArgumentException If the stream or part limit is invalid.
+     * @throws InvalidArgumentException If the stream or either byte limit is invalid.
      * @throws Site_Export_Push_Exception If the push session is busy,
-     *     malformed, unavailable, or already committing.
+     *     malformed, unavailable, already committing, or the decoded request
+     *     body exceeds its byte limit.
      */
-    public function accept_upload($input, Site_Export_Multipart_Processor $processor, int $maximum_part_bytes = PHP_INT_MAX): void {
+    public function accept_upload(
+        $input,
+        Site_Export_Multipart_Processor $processor,
+        int $maximum_part_bytes = PHP_INT_MAX,
+        int $maximum_request_body_bytes = PHP_INT_MAX
+    ): void {
         if ($this->upload_lock !== null) {
             throw new LogicException('A push upload is already open; call finish_upload() first.');
         }
@@ -329,6 +332,12 @@ final class Site_Export_Push_Session {
         }
         if ($maximum_part_bytes <= 0) {
             throw new InvalidArgumentException('Multipart part byte limit must be greater than zero.');
+        }
+        if ($maximum_request_body_bytes <= 0) {
+            throw new InvalidArgumentException(
+                'Multipart request-body byte limit must be greater than zero; received '
+                . $maximum_request_body_bytes . '.'
+            );
         }
         $lock = $this->acquire_push_lock();
         try {
@@ -342,6 +351,8 @@ final class Site_Export_Push_Session {
             $this->current_upload_part_ended = false;
             $this->current_change = null;
             $this->maximum_upload_part_bytes = $maximum_part_bytes;
+            $this->maximum_upload_request_body_bytes = $maximum_request_body_bytes;
+            $this->upload_request_body_bytes_read = 0;
         } catch (Throwable $exception) {
             flock($lock, LOCK_UN);
             fclose($lock);
@@ -444,6 +455,8 @@ final class Site_Export_Push_Session {
         $this->current_upload_part_ended = false;
         $this->current_change = null;
         $this->maximum_upload_part_bytes = PHP_INT_MAX;
+        $this->maximum_upload_request_body_bytes = PHP_INT_MAX;
+        $this->upload_request_body_bytes_read = 0;
         flock($lock, LOCK_UN);
         fclose($lock);
     }
@@ -781,7 +794,13 @@ final class Site_Export_Push_Session {
             if (!$this->upload_processor->paused_at_incomplete_input()) {
                 throw new LogicException('Multipart processor stopped without completing or requesting input.');
             }
-            $bytes = fread($this->upload_input, Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES);
+            $maximum_fragment_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+            $remaining_request_body_bytes = PHP_INT_MAX;
+            if ($this->maximum_upload_request_body_bytes !== PHP_INT_MAX) {
+                $remaining_request_body_bytes = $this->maximum_upload_request_body_bytes - $this->upload_request_body_bytes_read;
+                $maximum_fragment_bytes = min($maximum_fragment_bytes, $remaining_request_body_bytes + 1);
+            }
+            $bytes = fread($this->upload_input, $maximum_fragment_bytes);
             if ($bytes === false) {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read the multipart upload request body.');
             }
@@ -789,6 +808,17 @@ final class Site_Export_Push_Session {
                 $this->upload_processor->finish_input();
                 return false;
             }
+            $fragment_bytes = strlen($bytes);
+            if ($fragment_bytes > $remaining_request_body_bytes) {
+                $observed_request_body_bytes = $this->upload_request_body_bytes_read + $fragment_bytes;
+                throw new Site_Export_Push_Exception(
+                    self::ERROR_REQUEST_TOO_LARGE,
+                    'The decoded request body reached ' . $observed_request_body_bytes
+                    . ' bytes, exceeding the target post_max_size of '
+                    . $this->maximum_upload_request_body_bytes . ' bytes.'
+                );
+            }
+            $this->upload_request_body_bytes_read += $fragment_bytes;
             $this->upload_processor->append_bytes($bytes);
         }
         return true;

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -184,6 +184,32 @@ function normalize_path(string $path): string
 }
 
 /**
+ * Validates, sorts, and deduplicates document-root-relative excluded paths.
+ *
+ * @param string[] $excluded_paths Paths which a push must not change.
+ * @phpstan-param array<mixed> $excluded_paths
+ * @return list<string> Safe excluded paths in bytewise order.
+ */
+function normalize_excluded_paths(array $excluded_paths): array
+{
+    $normalized_excluded_paths = [];
+    foreach ($excluded_paths as $path) {
+        if (!is_string($path) || $path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('Each excluded path must be a non-empty safe relative path.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Base64 keeps arbitrary path bytes safe in exception text; nothing is rendered here.
+                throw new InvalidArgumentException('Excluded path is unsafe: ' . base64_encode($path) . '.');
+            }
+        }
+        $normalized_excluded_paths[] = $path;
+    }
+    sort($normalized_excluded_paths, SORT_STRING);
+    return array_values(array_unique($normalized_excluded_paths));
+}
+
+/**
  * Returns true when $path is equal to $root or strictly under it.
  */
 function path_is_within_root(string $path, string $root): bool

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -184,23 +184,44 @@ function normalize_path(string $path): string
 }
 
 /**
- * Validates, sorts, and deduplicates document-root-relative excluded paths.
+ * Normalizes document-root-relative excluded paths.
+ *
+ * Rejects non-string, empty, absolute, NUL-containing, backslash-containing,
+ * and empty/dot/parent-component paths, then sorts and deduplicates them.
  *
  * @param string[] $excluded_paths Paths which a push must not change.
  * @phpstan-param array<mixed> $excluded_paths
- * @return list<string> Safe excluded paths in bytewise order.
+ * @return list<string> Validated excluded paths in bytewise order.
  */
 function normalize_excluded_paths(array $excluded_paths): array
 {
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These validation exceptions are never rendered, and arbitrary path bytes are represented as base64.
     $normalized_excluded_paths = [];
     foreach ($excluded_paths as $path) {
-        if (!is_string($path) || $path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
-            throw new InvalidArgumentException('Each excluded path must be a non-empty safe relative path.');
+        if (!is_string($path)) {
+            throw new InvalidArgumentException('Each excluded path must be a string; observed ' . gettype($path) . '.');
+        }
+        if ($path === '') {
+            throw new InvalidArgumentException('Excluded path must not be empty.');
+        }
+        if ($path[0] === '/') {
+            throw new InvalidArgumentException('Excluded path must be document-root-relative: ' . base64_encode($path) . '.');
+        }
+        if (strpos($path, "\0") !== false) {
+            throw new InvalidArgumentException('Excluded path must not contain a NUL byte: ' . base64_encode($path) . '.');
+        }
+        if (strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('Excluded path must not contain a backslash: ' . base64_encode($path) . '.');
         }
         foreach (explode('/', $path) as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..') {
-                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Base64 keeps arbitrary path bytes safe in exception text; nothing is rendered here.
-                throw new InvalidArgumentException('Excluded path is unsafe: ' . base64_encode($path) . '.');
+            if ($segment === '') {
+                throw new InvalidArgumentException('Excluded path must not contain an empty component: ' . base64_encode($path) . '.');
+            }
+            if ($segment === '.') {
+                throw new InvalidArgumentException('Excluded path must not contain a dot component: ' . base64_encode($path) . '.');
+            }
+            if ($segment === '..') {
+                throw new InvalidArgumentException('Excluded path must not contain a parent component: ' . base64_encode($path) . '.');
             }
         }
         $normalized_excluded_paths[] = $path;
@@ -208,6 +229,7 @@ function normalize_excluded_paths(array $excluded_paths): array
     sort($normalized_excluded_paths, SORT_STRING);
     return array_values(array_unique($normalized_excluded_paths));
 }
+// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
 /**
  * Returns true when $path is equal to $root or strictly under it.

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -567,7 +567,7 @@ class MultipartPushStreamClient
      *     @type int         $body_bytes_sent MIME entity-body bytes sent.
      * }
      * @phpstan-return array{
-     *     status:string,
+     *     status:'complete'|'retry'|'failed',
      *     reason:?string,
      *     detail:?string,
      *     response:?array<string,mixed>,
@@ -633,7 +633,9 @@ class MultipartPushStreamClient
             return [
                 'status' => $decision['action'] === 'give_up' ? 'failed' : 'retry',
                 'reason' => 'request_too_large',
-                'detail' => is_array($decoded) ? null : 'HTTP 413 Request Entity Too Large.',
+                'detail' => is_array($decoded) && is_string($decoded['detail'] ?? null)
+                    ? $decoded['detail']
+                    : 'HTTP 413 Request Entity Too Large.',
                 'response' => is_array($decoded) ? $decoded : null,
                 'parts_sent' => $this->parts_sent,
                 'body_bytes_sent' => $this->body_bytes_sent,
@@ -696,7 +698,7 @@ class MultipartPushStreamClient
      *     @type int         $body_bytes_sent MIME entity-body bytes sent.
      * }
      * @phpstan-return array{
-     *     status:string,
+     *     status:'complete'|'retry'|'failed',
      *     reason:?string,
      *     detail:?string,
      *     response:array<string,mixed>,
@@ -1039,15 +1041,16 @@ class MultipartPushStreamClient
     /**
      * Classifies every decoded upload and control response by protocol reason.
      *
-     * `busy` and `offset_gap` are recoverable because a later request can use
-     * the receiver-confirmed cursor. Every other rejection fails the request; HTTP
-     * status alone never promotes an unknown reason into a retry.
+     * `lock_acquisition_failure` and `offset_gap` are recoverable because a
+     * later request can retry the locked operation or use the receiver-
+     * confirmed cursor. Every other rejection fails the request; HTTP status
+     * alone never promotes an unknown reason into a retry.
      *
      * Classification reads these response keys:
      *
      * - `status`: target protocol status compared with `$expected_statuses`.
-     * - `reason`: optional machine-readable rejection reason. Only `busy` and
-     *   `offset_gap` are recoverable.
+     * - `reason`: optional machine-readable rejection reason. Only
+     *   `lock_acquisition_failure` and `offset_gap` are recoverable.
      * - `detail`: optional human-readable rejection detail.
      * - `http_code`: observed HTTP status used when no detail was supplied.
      *
@@ -1069,7 +1072,7 @@ class MultipartPushStreamClient
      *     @type int         $body_bytes_sent MIME entity-body bytes sent.
      * }
      * @phpstan-return array{
-     *     status:string,
+     *     status:'complete'|'retry'|'failed',
      *     reason:?string,
      *     detail:?string,
      *     response:array<string,mixed>,
@@ -1091,7 +1094,7 @@ class MultipartPushStreamClient
         }
         $reason = is_string($response['reason'] ?? null) ? $response['reason'] : 'unexpected_response';
         return [
-            'status' => in_array($reason, ['busy', 'offset_gap'], true) ? 'retry' : 'failed',
+            'status' => in_array($reason, ['lock_acquisition_failure', 'offset_gap'], true) ? 'retry' : 'failed',
             'reason' => $reason,
             'detail' => is_string($response['detail'] ?? null)
                 ? $response['detail']

--- a/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
@@ -191,9 +191,8 @@ class PushRequestSizer
      *
      * The failed size caps the session ceiling so growth cannot retry it.
      * When the server reported its actual limit — the push_upload endpoint's
-     * 413 carries max_frame_bytes, which it derives from its request-size
-     * limits — the ceiling drops below that limit directly instead of
-     * probing downward.
+     * 413 carries post_max_bytes, the decoded request-body limit — the ceiling
+     * drops below that limit directly instead of probing downward.
      *
      * @param int|null $reported_max_bytes Server-reported request limit, if any.
      * @return array {

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -22,6 +22,40 @@ When a request arrives at `https://example.com/?reprint-api` (or the legacy `?si
 
 This gives us a clean execution environment while using WordPress's front controller as the entry point.
 
+### Platform configuration
+
+The bundled WordPress entry point passes the result of the
+`site_export_api_options` filter to the export handler. A platform must
+register this filter before the regular Reprint Exporter plugin file loads;
+registering it on `plugins_loaded` is too late. A must-use plugin is the usual
+place to register it:
+
+```php
+add_filter('site_export_api_options', static function (array $options): array {
+    $options['docroot'] = '/srv/www/public';
+    $options['reprint_directory'] = '/srv/www/.reprint';
+    return $options;
+});
+```
+
+The supported options are:
+
+- `authenticate` — a callback that authenticates every non-preflight API
+  request instead of the built-in HMAC verifier. For a push request, this
+  callback must authenticate from request metadata without reading or
+  buffering `php://input`; the endpoint streams that body after authentication.
+- `docroot` — the document root for push. It must resolve to an
+  existing directory and defaults to `$_SERVER['DOCUMENT_ROOT']`.
+- `reprint_directory` — the private push storage directory outside `docroot`.
+  It defaults to a document-root-specific sibling directory.
+- `excluded_paths` — document-root-relative paths that push must preserve. The
+  exporter plugin directory is also preserved automatically when it is below
+  `docroot`.
+- `maximum_part_bytes` — the maximum `Content-Length` accepted for one push
+  upload part. It defaults to 4 MiB.
+- `maximum_commit_entries` — the maximum number of bounded entries processed
+  by one `push_commit` request. It defaults to 256.
+
 ## Using as a library
 
 The export engine can be embedded in another PHP project without the WordPress plugin wrapper. Require `lib.php` instead of `index.php` — it defines constants and functions but does not handle any HTTP requests or check any URLs.
@@ -48,6 +82,10 @@ if ($myRouter->matches('/export')) {
     ]);
 }
 ```
+
+`_site_export_handle_api_request()` accepts the same options documented under
+Platform configuration. Direct `lib.php` embedders pass them as the function's
+array argument and do not use the WordPress filter.
 
 `lib.php` defines these constants (using WordPress's `plugin_dir_path`):
 

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/push-commit-language",
+            "version": "dev-adamziel/authenticated-push-endpoints",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "6a5cbcf2ac9d0b34789819f01ccb00033b67581a"
+                "reference": "2050e07227a82c058c6267c5e8b3e77d0cd4dbdc"
             },
             "require": {
                 "php": ">=7.2",
@@ -385,7 +385,9 @@
                     "src/class-hmac-server.php",
                     "src/class-http-server.php",
                     "src/class-multipart-processor.php",
+                    "src/class-push-configuration-exception.php",
                     "src/class-push-exception.php",
+                    "src/class-push-endpoints.php",
                     "src/class-push-session.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/reprint-exporter-wp/index.php
+++ b/reprint-exporter-wp/index.php
@@ -19,7 +19,24 @@ require_once __DIR__ . '/lib.php';
 // compatibility with clients pinned to earlier plugin versions.
 // New integrations should use `?reprint-api`.
 if (isset($_GET['reprint-api']) || isset($_GET['site-export-api'])) {
-    _site_export_handle_api_request();
+    /**
+     * Filters the endpoint configuration supplied by the WordPress plugin.
+     *
+     * Platforms must register this filter before regular plugins load, for
+     * example from a must-use plugin.
+     *
+     * @param array $site_export_api_options Endpoint configuration overrides.
+     */
+    $site_export_api_options = apply_filters('site_export_api_options', []);
+    if (!is_array($site_export_api_options)) {
+        _site_export_push_error(
+            503,
+            'not_configured',
+            'The site_export_api_options filter must return an array; observed '
+            . gettype($site_export_api_options) . '.'
+        );
+    }
+    _site_export_handle_api_request($site_export_api_options);
     exit;
 }
 

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -44,7 +44,7 @@ function _site_export_error(int $code, string $message): void {
  * the push response discriminator here instead of the legacy export error
  * object.
  *
- * Emits `{status:"rejected",reason:string,detail:string}`.
+ * The response contains `status` (`rejected`), `reason`, and `detail`.
  *
  * @param int $http_code HTTP status code.
  * @param string $reason Machine-readable push failure reason.
@@ -213,21 +213,24 @@ function _site_export_default_authenticate(): void {
  * and the database layer (including the SQLite db.php drop-in when present)
  * are all available.
  *
+ * The bundled plugin passes the `site_export_api_options` filter result here.
+ * A direct library embedder supplies the same trusted options array itself.
+ *
  * @param array $options {
  *     Optional endpoint configuration overrides.
  *
  *     @type callable $authenticate Optional. Authenticates the request.
  *                                  Defaults to _site_export_default_authenticate().
- *     @type string $docroot Optional. Managed document root for push. Defaults
+ *     @type string $docroot Optional. Document root for push. Defaults
  *                           to the server's DOCUMENT_ROOT. The configured path
  *                           must resolve to an existing directory.
  *     @type string $reprint_directory Optional. Private push storage path
- *                                     outside the managed document root.
+ *                                     outside the document root.
  *                                     Defaults to a document-root-specific sibling.
  *     @type string[] $excluded_paths Optional. Document-root-relative paths
  *                                    push must preserve. The exporter plugin
  *                                    directory is always included when it is
- *                                    below the managed document root.
+ *                                    below the document root.
  *     @type int $maximum_part_bytes Optional. Maximum Content-Length for one
  *                                   push upload part. Defaults to 4 MiB.
  *     @type int $maximum_commit_entries Optional. Maximum bounded entries one
@@ -361,7 +364,7 @@ function _site_export_handle_api_request(array $options = []): void {
     try {
         $server_options = ['default_directory' => ABSPATH];
         if (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
-            // Push manages the web server's document root. ABSPATH remains the
+            // Push changes the web server's document root. ABSPATH remains the
             // pull default because it may point at a separate shared core tree.
             if (array_key_exists('docroot', $options)) {
                 $configured_docroot = $options['docroot'];
@@ -414,7 +417,7 @@ function _site_export_handle_api_request(array $options = []): void {
                     $logical_plugin_relative_path = substr($logical_plugin_directory, $docroot_relative_offset);
                 } else {
                     // WP_PLUGIN_DIR may itself be a symlink alias into the
-                    // managed root. Resolve that parent, but keep the
+                    // document root. Resolve that parent, but keep the
                     // registered plugin subdirectory lexical so its installed
                     // path survives a final symlink to the outside target.
                     $canonical_wordpress_plugin_directory = realpath( (string) WP_PLUGIN_DIR );
@@ -438,7 +441,7 @@ function _site_export_handle_api_request(array $options = []): void {
                         || rtrim($resolved_logical_plugin_directory, '/\\') !== $plugin_directory
                     ) {
                         throw new Site_Export_Push_Configuration_Exception(
-                            'WordPress reports the Reprint Exporter plugin inside the managed document root at '
+                            'WordPress reports the Reprint Exporter plugin inside the document root at '
                             . json_encode($logical_plugin_directory_to_verify)
                             . ', but that path does not resolve to SITE_EXPORT_PLUGIN_DIR '
                             . json_encode(SITE_EXPORT_PLUGIN_DIR) . '.'

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -38,6 +38,40 @@ function _site_export_error(int $code, string $message): void {
 }
 
 /**
+ * Sends one classified push-protocol failure and terminates the request.
+ *
+ * Failures raised before an endpoint method can format its own response use
+ * the push response discriminator here instead of the legacy export error
+ * object.
+ *
+ * Emits `{status:"rejected",reason:string,detail:string}`.
+ *
+ * @param int $http_code HTTP status code.
+ * @param string $reason Machine-readable push failure reason.
+ * @param string $detail Human-readable violated condition.
+ */
+function _site_export_push_error(int $http_code, string $reason, string $detail): void {
+    http_response_code($http_code);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'status' => 'rejected',
+        'reason' => $reason,
+        'detail' => $detail,
+    ]);
+    exit;
+}
+
+/**
+ * Returns whether an endpoint uses the push authentication and error contract.
+ *
+ * @param string $endpoint Exact endpoint query value.
+ * @return bool Whether this is a registered push endpoint.
+ */
+function _site_export_is_push_endpoint(string $endpoint): bool {
+    return in_array($endpoint, ['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'], true);
+}
+
+/**
  * Resolve and load the exporter package runtime.
  *
  * Supports both plugin release bundles (with reprint-exporter-wp/vendor/) and
@@ -186,9 +220,31 @@ function _site_export_default_authenticate(): void {
  * and the database layer (including the SQLite db.php drop-in when present)
  * are all available.
  *
- * @param array $options Optional overrides:
- *   - 'authenticate' (callable): Called to authenticate the request.
- *        Defaults to _site_export_default_authenticate().
+ * @param array $options {
+ *     Optional endpoint configuration overrides.
+ *
+ *     @type callable $authenticate Optional. Authenticates the request.
+ *                                  Defaults to _site_export_default_authenticate().
+ *     @type string $reprint_directory Optional. Private push storage path
+ *                                     outside the resolved ABSPATH document
+ *                                     root. Defaults to a document-root-specific sibling.
+ *     @type string[] $excluded_paths Optional. Document-root-relative paths
+ *                                    push must preserve. The exporter plugin
+ *                                    directory is always included when it is
+ *                                    below ABSPATH.
+ *     @type int $maximum_part_bytes Optional. Maximum Content-Length for one
+ *                                   push upload part. Defaults to 4 MiB.
+ *     @type int $maximum_commit_entries Optional. Maximum bounded entries one
+ *                                       push_commit request processes. Defaults
+ *                                       to 256.
+ * }
+ * @phpstan-param array{
+ *     authenticate?:callable,
+ *     reprint_directory?:string,
+ *     excluded_paths?:string[],
+ *     maximum_part_bytes?:int,
+ *     maximum_commit_entries?:int
+ * } $options
  */
 function _site_export_handle_api_request(array $options = []): void {
     // Revert WordPress error display settings (wp_debug_mode may
@@ -250,17 +306,46 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    // push_upload authenticates inside its handler: the default handler
-    // here buffers the whole request body to hash it, which a chunk upload
-    // cannot afford. The upload route verifies the signed headers first and
-    // hashes the body as it streams. A custom authenticate callable still
-    // runs for every endpoint — its embedder owns that tradeoff.
+    // Push requests use envelope authentication: the signature covers the
+    // method and exact request target while TLS protects the streamed body.
+    // The legacy verifier hashes php://input and remains only for the existing
+    // pull endpoints with bounded command bodies. A custom authenticate
+    // callable still runs for every endpoint; its embedder owns that policy.
     // filter_input, not WP sanitizers: lib.php also runs without WordPress
     // bootstrapped (hosts that route the API from their own index.php).
     $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
+    } elseif (_site_export_is_push_endpoint($endpoint)) {
+        if (_site_export_has_secret_file()) {
+            $secret = _site_export_get_file_secret();
+            if (empty($secret)) {
+                _site_export_push_error(503, 'not_configured', 'Invalid secret.php configuration. Remove it or replace it with a valid shared secret.');
+            }
+        } else {
+            $secret = _site_export_get_option_secret();
+        }
+        if (empty($secret) || !is_string($secret)) {
+            _site_export_push_error(503, 'not_configured', 'Configure the shared secret in WordPress admin under Tools > Reprint Exporter.');
+        }
+        if (!class_exists('Site_Export_HMAC_Server')) {
+            _site_export_load_exporter_runtime();
+        }
+        if (!class_exists('Site_Export_HMAC_Server')) {
+            _site_export_push_error(500, 'filesystem_error', 'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.');
+        }
+        // These exact request-line values are covered by the HMAC; WordPress
+        // slashing or sanitization would verify a different target.
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+        $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+        $request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
+        $hmac_server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
+        $auth_error = $hmac_server->verify_envelope($_SERVER, $request_method, $request_target);
+        if ($auth_error !== null) {
+            _site_export_push_error(403, 'auth_failed', $auth_error);
+        }
     } else {
         _site_export_default_authenticate();
     }
@@ -277,8 +362,56 @@ function _site_export_handle_api_request(array $options = []): void {
 
     // -- Dispatch --
     try {
-        Site_Export_HTTP_Server::serve(['default_directory' => ABSPATH]);
+        $server_options = ['default_directory' => ABSPATH];
+        if (_site_export_is_push_endpoint($endpoint)) {
+            // Resolve ABSPATH before deriving its sibling so a symlinked
+            // document root cannot place private push storage inside itself.
+            $canonical_docroot = realpath(ABSPATH);
+            $docroot = rtrim($canonical_docroot === false ? ABSPATH : $canonical_docroot, '/\\');
+            $reprint_directory = $options['reprint_directory'] ?? (
+                dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
+            );
+            $excluded_paths = $options['excluded_paths'] ?? [];
+            if (!is_array($excluded_paths)) {
+                throw new Site_Export_Push_Configuration_Exception('excluded_paths must be an array.');
+            }
+            $canonical_plugin_directory = realpath(SITE_EXPORT_PLUGIN_DIR);
+            $plugin_directory = rtrim($canonical_plugin_directory === false ? SITE_EXPORT_PLUGIN_DIR : $canonical_plugin_directory, '/\\');
+            $docroot_prefix = $docroot . DIRECTORY_SEPARATOR;
+            if (strpos($plugin_directory . DIRECTORY_SEPARATOR, $docroot_prefix) === 0) {
+                $relative_plugin_directory = str_replace('\\', '/', substr($plugin_directory, strlen($docroot_prefix)));
+                if ($relative_plugin_directory !== '') {
+                    $excluded_paths[] = $relative_plugin_directory;
+                }
+            }
+            $push_options = [
+                'reprint_directory' => $reprint_directory,
+                'docroot' => $docroot,
+                'excluded_paths' => $excluded_paths,
+            ];
+            if (array_key_exists('maximum_part_bytes', $options)) {
+                $push_options['maximum_part_bytes'] = $options['maximum_part_bytes'];
+            }
+            if (array_key_exists('maximum_commit_entries', $options)) {
+                $push_options['maximum_commit_entries'] = $options['maximum_commit_entries'];
+            }
+            $server_options['push'] = $push_options;
+        }
+        Site_Export_HTTP_Server::serve($server_options);
     } catch (Exception $e) {
+        if (_site_export_is_push_endpoint($endpoint)) {
+            if ($e instanceof Site_Export_Push_Configuration_Exception) {
+                _site_export_push_error(503, 'not_configured', $e->getMessage());
+            }
+            if ($e instanceof InvalidArgumentException) {
+                _site_export_push_error(400, 'invalid_request', $e->getMessage());
+            }
+            _site_export_push_error(
+                500,
+                'filesystem_error',
+                'The push endpoint failed while processing the request.'
+            );
+        }
         if (!headers_sent()) {
             http_response_code(400);
             header('Content-Type: application/json');

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -52,6 +52,9 @@ function _site_export_error(int $code, string $message): void {
  */
 function _site_export_push_error(int $http_code, string $reason, string $detail): void {
     http_response_code($http_code);
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header('Expires: 0');
     header('Content-Type: application/json');
     echo json_encode([
         'status' => 'rejected',
@@ -59,16 +62,6 @@ function _site_export_push_error(int $http_code, string $reason, string $detail)
         'detail' => $detail,
     ]);
     exit;
-}
-
-/**
- * Returns whether an endpoint uses the push authentication and error contract.
- *
- * @param string $endpoint Exact endpoint query value.
- * @return bool Whether this is a registered push endpoint.
- */
-function _site_export_is_push_endpoint(string $endpoint): bool {
-    return in_array($endpoint, ['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'], true);
 }
 
 /**
@@ -225,13 +218,16 @@ function _site_export_default_authenticate(): void {
  *
  *     @type callable $authenticate Optional. Authenticates the request.
  *                                  Defaults to _site_export_default_authenticate().
+ *     @type string $docroot Optional. Managed document root for push. Defaults
+ *                           to the server's DOCUMENT_ROOT. The configured path
+ *                           must resolve to an existing directory.
  *     @type string $reprint_directory Optional. Private push storage path
- *                                     outside the resolved ABSPATH document
- *                                     root. Defaults to a document-root-specific sibling.
+ *                                     outside the managed document root.
+ *                                     Defaults to a document-root-specific sibling.
  *     @type string[] $excluded_paths Optional. Document-root-relative paths
  *                                    push must preserve. The exporter plugin
  *                                    directory is always included when it is
- *                                    below ABSPATH.
+ *                                    below the managed document root.
  *     @type int $maximum_part_bytes Optional. Maximum Content-Length for one
  *                                   push upload part. Defaults to 4 MiB.
  *     @type int $maximum_commit_entries Optional. Maximum bounded entries one
@@ -240,6 +236,7 @@ function _site_export_default_authenticate(): void {
  * }
  * @phpstan-param array{
  *     authenticate?:callable,
+ *     docroot?:string,
  *     reprint_directory?:string,
  *     excluded_paths?:string[],
  *     maximum_part_bytes?:int,
@@ -317,7 +314,7 @@ function _site_export_handle_api_request(array $options = []): void {
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
-    } elseif (_site_export_is_push_endpoint($endpoint)) {
+    } elseif (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
         if (_site_export_has_secret_file()) {
             $secret = _site_export_get_file_secret();
             if (empty($secret)) {
@@ -363,11 +360,30 @@ function _site_export_handle_api_request(array $options = []): void {
     // -- Dispatch --
     try {
         $server_options = ['default_directory' => ABSPATH];
-        if (_site_export_is_push_endpoint($endpoint)) {
-            // Resolve ABSPATH before deriving its sibling so a symlinked
-            // document root cannot place private push storage inside itself.
-            $canonical_docroot = realpath(ABSPATH);
-            $docroot = rtrim($canonical_docroot === false ? ABSPATH : $canonical_docroot, '/\\');
+        if (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
+            // Push manages the web server's document root. ABSPATH remains the
+            // pull default because it may point at a separate shared core tree.
+            if (array_key_exists('docroot', $options)) {
+                $configured_docroot = $options['docroot'];
+            } else {
+                // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted server configuration and must retain exact filesystem bytes.
+                $configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+            }
+            if (!is_string($configured_docroot) || $configured_docroot === '') {
+                throw new Site_Export_Push_Configuration_Exception(
+                    'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed '
+                    . json_encode($configured_docroot) . '.'
+                );
+            }
+            $canonical_docroot = realpath($configured_docroot);
+            if ($canonical_docroot === false || !is_dir($canonical_docroot)) {
+                throw new Site_Export_Push_Configuration_Exception(
+                    'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed '
+                    . json_encode($configured_docroot) . '.'
+                );
+            }
+            $docroot = $canonical_docroot === '/' ? '/' : rtrim($canonical_docroot, '/\\');
+            $lexical_docroot = \WordPress\Reprint\Exporter\normalize_path(str_replace('\\', '/', $configured_docroot));
             $reprint_directory = $options['reprint_directory'] ?? (
                 dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
             );
@@ -377,12 +393,67 @@ function _site_export_handle_api_request(array $options = []): void {
             }
             $canonical_plugin_directory = realpath(SITE_EXPORT_PLUGIN_DIR);
             $plugin_directory = rtrim($canonical_plugin_directory === false ? SITE_EXPORT_PLUGIN_DIR : $canonical_plugin_directory, '/\\');
-            $docroot_prefix = $docroot . DIRECTORY_SEPARATOR;
-            if (strpos($plugin_directory . DIRECTORY_SEPARATOR, $docroot_prefix) === 0) {
-                $relative_plugin_directory = str_replace('\\', '/', substr($plugin_directory, strlen($docroot_prefix)));
-                if ($relative_plugin_directory !== '') {
-                    $excluded_paths[] = $relative_plugin_directory;
+            $docroot_relative_offset = $docroot === '/' ? 1 : strlen($docroot) + 1;
+            $logical_plugin_path_added = false;
+            if (defined('WP_PLUGIN_DIR') && function_exists('plugin_basename')) {
+                // Keep the registered installation path lexical until its
+                // document-root-relative name is known. realpath() would turn a
+                // symlinked plugin into its outside target and omit protection.
+                $registered_plugin_file = str_replace('\\', '/', plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'));
+                $registered_plugin_directory = dirname($registered_plugin_file);
+                $logical_plugin_directory = \WordPress\Reprint\Exporter\normalize_path(
+                    str_replace('\\', '/', (string) WP_PLUGIN_DIR)
+                    . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
+                );
+                $logical_plugin_directory_to_verify = $logical_plugin_directory;
+                $logical_plugin_relative_path = null;
+                if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $lexical_docroot)) {
+                    $lexical_docroot_relative_offset = $lexical_docroot === '/' ? 1 : strlen($lexical_docroot) + 1;
+                    $logical_plugin_relative_path = substr($logical_plugin_directory, $lexical_docroot_relative_offset);
+                } elseif (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $docroot)) {
+                    $logical_plugin_relative_path = substr($logical_plugin_directory, $docroot_relative_offset);
+                } else {
+                    // WP_PLUGIN_DIR may itself be a symlink alias into the
+                    // managed root. Resolve that parent, but keep the
+                    // registered plugin subdirectory lexical so its installed
+                    // path survives a final symlink to the outside target.
+                    $canonical_wordpress_plugin_directory = realpath( (string) WP_PLUGIN_DIR );
+                    if ($canonical_wordpress_plugin_directory !== false) {
+                        $logical_plugin_directory_from_canonical_parent = \WordPress\Reprint\Exporter\normalize_path(
+                            str_replace('\\', '/', $canonical_wordpress_plugin_directory)
+                            . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
+                        );
+                        if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory_from_canonical_parent, $docroot)) {
+                            $logical_plugin_relative_path = substr($logical_plugin_directory_from_canonical_parent, $docroot_relative_offset);
+                            $logical_plugin_directory_to_verify = $logical_plugin_directory_from_canonical_parent;
+                        }
+                    }
                 }
+                if ($logical_plugin_relative_path !== null) {
+                    $resolved_logical_plugin_directory = realpath($logical_plugin_directory_to_verify);
+                    if (
+                        $logical_plugin_relative_path === ''
+                        || $resolved_logical_plugin_directory === false
+                        || $canonical_plugin_directory === false
+                        || rtrim($resolved_logical_plugin_directory, '/\\') !== $plugin_directory
+                    ) {
+                        throw new Site_Export_Push_Configuration_Exception(
+                            'WordPress reports the Reprint Exporter plugin inside the managed document root at '
+                            . json_encode($logical_plugin_directory_to_verify)
+                            . ', but that path does not resolve to SITE_EXPORT_PLUGIN_DIR '
+                            . json_encode(SITE_EXPORT_PLUGIN_DIR) . '.'
+                        );
+                    }
+                    $excluded_paths[] = $logical_plugin_relative_path;
+                    $logical_plugin_path_added = true;
+                }
+            }
+            if (
+                !$logical_plugin_path_added
+                && \WordPress\Reprint\Exporter\path_is_within_root($plugin_directory, $docroot)
+                && $plugin_directory !== $docroot
+            ) {
+                $excluded_paths[] = str_replace('\\', '/', substr($plugin_directory, $docroot_relative_offset));
             }
             $push_options = [
                 'reprint_directory' => $reprint_directory,
@@ -399,7 +470,7 @@ function _site_export_handle_api_request(array $options = []): void {
         }
         Site_Export_HTTP_Server::serve($server_options);
     } catch (Exception $e) {
-        if (_site_export_is_push_endpoint($endpoint)) {
+        if (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
             if ($e instanceof Site_Export_Push_Configuration_Exception) {
                 _site_export_push_error(503, 'not_configured', $e->getMessage());
             }

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -128,7 +128,7 @@ final class ExportHttpServerTest extends TestCase
         }
     }
 
-    public function testDefaultPushHandlersUseTheCorrespondingMethods(): void
+    public function testDefaultHandlersMatchPushEndpointMethodRegistry(): void
     {
         $root = sys_get_temp_dir() . '/export-http-server-' . bin2hex(random_bytes(6));
         $docroot = $root . '/docroot';
@@ -268,7 +268,7 @@ final class ExportHttpServerTest extends TestCase
         ]], $calls);
     }
 
-    public function testInvalidPushOptionsUseTheConfigurationException(): void
+    public function testNonArrayPushOptionsThrowConfigurationException(): void
     {
         $this->expectException(Site_Export_Push_Configuration_Exception::class);
         $this->expectExceptionMessage('The push HTTP server option must be an array.');

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -111,6 +111,93 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame(['from' => 'file_index'], $calls[0][1]);
     }
 
+    public function testClassifiesOnlyTheRegisteredPushEndpoints(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+
+        $this->assertTrue(
+            is_callable([$server, 'is_push_endpoint']),
+            'The HTTP server must expose its push endpoint classification.'
+        );
+
+        foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'] as $endpoint) {
+            $this->assertTrue($server->is_push_endpoint($endpoint), $endpoint);
+        }
+        foreach (['preflight', 'file_index', 'unknown'] as $endpoint) {
+            $this->assertFalse($server->is_push_endpoint($endpoint), $endpoint);
+        }
+    }
+
+    public function testDefaultPushHandlersUseTheCorrespondingMethods(): void
+    {
+        $root = sys_get_temp_dir() . '/export-http-server-' . bin2hex(random_bytes(6));
+        $docroot = $root . '/docroot';
+        $reprint_directory = $root . '/reprint';
+        mkdir($docroot, 0700, true);
+        mkdir($reprint_directory, 0700);
+
+        try {
+            $server = new Site_Export_HTTP_Server([
+                'push' => [
+                    'reprint_directory' => $reprint_directory,
+                    'docroot' => $docroot,
+                    'excluded_paths' => [],
+                ],
+            ]);
+            $handlers_property = new ReflectionProperty(Site_Export_HTTP_Server::class, 'handlers');
+            $handlers_property->setAccessible(true);
+            $handlers = $handlers_property->getValue($server);
+            $registered_push_endpoint_methods = [];
+            foreach ($handlers as $endpoint => $handler) {
+                if (strpos($endpoint, 'push_') !== 0) {
+                    continue;
+                }
+                $this->assertIsArray($handler);
+                $this->assertInstanceOf(Site_Export_Push_Endpoints::class, $handler[0]);
+                $registered_push_endpoint_methods[$endpoint] = $handler[1];
+            }
+
+            $this->assertSame([
+                'push_create' => 'create',
+                'push_upload' => 'upload',
+                'push_status' => 'status',
+                'push_commit' => 'commit',
+                'push_remove' => 'remove',
+            ], $registered_push_endpoint_methods);
+        } finally {
+            rmdir($reprint_directory);
+            rmdir($docroot);
+            rmdir($root);
+        }
+    }
+
+    public function testDispatchRoutesEveryPushEndpointWithoutCreatingABudget(): void
+    {
+        $push_endpoints = ['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'];
+        $calls = [];
+        $handlers = [];
+        foreach ($push_endpoints as $endpoint) {
+            $handlers[$endpoint] = static function (array $config) use (&$calls): void {
+                $calls[] = $config['endpoint'];
+            };
+        }
+        $budget_creations = 0;
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => $handlers,
+            'budget_factory' => static function () use (&$budget_creations): array {
+                ++$budget_creations;
+                return [];
+            },
+        ]);
+
+        foreach ($push_endpoints as $endpoint) {
+            $server->dispatch(['endpoint' => $endpoint]);
+        }
+
+        $this->assertSame($push_endpoints, $calls);
+        $this->assertSame(0, $budget_creations);
+    }
+
     public function testDispatchRejectsUnknownEndpoints(): void
     {
         $server = new Site_Export_HTTP_Server([

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -145,4 +145,47 @@ final class ExportHttpServerTest extends TestCase
 
         $this->assertSame([['endpoint' => 'preflight']], $calls);
     }
+
+    public function testPushUploadNeverReadsAJsonRequestBody(): void
+    {
+        $body_reads = 0;
+        $calls = [];
+        $server = new Site_Export_HTTP_Server([
+            'body_reader' => static function () use (&$body_reads): string {
+                ++$body_reads;
+                return '{"body_parameter":"must-not-be-read"}';
+            },
+            'handlers' => [
+                'push_upload' => static function (array $config) use (&$calls): void {
+                    $calls[] = $config;
+                },
+            ],
+        ]);
+
+        $server->handle_request([
+            'get' => [
+                'endpoint' => 'push_upload',
+                'push_session_id' => str_repeat('a', 32),
+            ],
+            'post' => [],
+            'server' => [
+                'REQUEST_METHOD' => 'POST',
+                'CONTENT_TYPE' => 'application/json',
+            ],
+        ]);
+
+        $this->assertSame(0, $body_reads);
+        $this->assertSame([[
+            'endpoint' => 'push_upload',
+            'push_session_id' => str_repeat('a', 32),
+        ]], $calls);
+    }
+
+    public function testInvalidPushOptionsUseTheConfigurationException(): void
+    {
+        $this->expectException(Site_Export_Push_Configuration_Exception::class);
+        $this->expectExceptionMessage('The push HTTP server option must be an array.');
+
+        new Site_Export_HTTP_Server(['push' => null]);
+    }
 }

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -185,6 +185,51 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertLessThan(32 * 1024 * 1024, $client->get_request_sizer_state()['request_body_bytes']);
     }
 
+    public function testStructured413AppliesPostMaxBytesAndPreservesDetail(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+
+        $this->assertTrue($client->start_upload_request(str_repeat('4', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $this->read_available($connection);
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'structured-too-large.bin',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $response = (string) json_encode([
+            'status' => 'rejected',
+            'reason' => 'request_too_large',
+            'detail' => 'The decoded request body reached 16777217 bytes, exceeding the target post_max_size of 16777216 bytes.',
+            'post_max_bytes' => 16 * 1024 * 1024,
+        ]);
+        fwrite($connection, "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response) . "\r\nConnection: close\r\n\r\n" . $response);
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('retry', $result['status']);
+        $this->assertSame('request_too_large', $result['reason']);
+        $this->assertSame('The decoded request body reached 16777217 bytes, exceeding the target post_max_size of 16777216 bytes.', $result['detail']);
+        $this->assertSame(16 * 1024 * 1024, $result['response']['post_max_bytes']);
+        $this->assertLessThan(16 * 1024 * 1024, $client->get_request_sizer_state()['request_body_bytes']);
+    }
+
     public function testMalformedNonemptyUploadResponseIsTerminal(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -335,7 +335,7 @@ final class PushCommitTest extends TestCase {
         $this->assertSame('safe', file_get_contents($this->docroot . '/outside-sentinel'));
     }
 
-    public function testExplicitEmptyAndStructuralDirectoriesRemainDistinctPendingValues(): void {
+    public function testExplicitEmptyAndWorkAncestorDirectoriesRemainDistinctPendingValues(): void {
         $push_session = $this->push_session('00550055005500550055005500550055');
         $this->push_parts($push_session, [
             [
@@ -348,7 +348,7 @@ final class PushCommitTest extends TestCase {
             [
                 'headers' => [
                     'X-Chunk-Type' => 'file',
-                    'X-File-Path' => base64_encode('structural/child.txt'),
+                    'X-File-Path' => base64_encode('work-ancestor/child.txt'),
                     'X-File-Size' => '5',
                     'X-Chunk-Offset' => '0',
                 ],
@@ -359,7 +359,7 @@ final class PushCommitTest extends TestCase {
 
         $this->assertDirectoryExists($this->docroot . '/empty');
         $this->assertSame([], $this->directory_entries($this->docroot . '/empty'));
-        $this->assertSame('child', file_get_contents($this->docroot . '/structural/child.txt'));
+        $this->assertSame('child', file_get_contents($this->docroot . '/work-ancestor/child.txt'));
     }
 
     public function testExplicitEmptyDirectoryUsesTheDocumentRootProcessUmask(): void {
@@ -564,7 +564,7 @@ final class PushCommitTest extends TestCase {
         $this->assertFileExists($this->docroot . '/.maintenance');
     }
 
-    public function testStructuralDirectoryResumesAfterDocumentRootCreation(): void {
+    public function testInstallingFilesResumesAfterCreatingADocumentRootAncestorDirectory(): void {
         $push_session = $this->push_session('dddddddddddddddddddddddddddddddd');
         $this->push_file($push_session, 'tree/child.txt', 'child');
         $this->complete_work_deletes($push_session);
@@ -579,7 +579,7 @@ final class PushCommitTest extends TestCase {
         $this->assertSame('child', file_get_contents($this->docroot . '/tree/child.txt'));
     }
 
-    public function testStructuralCleanupResumesAfterWorkDirectoryWasRemoved(): void {
+    public function testWorkAncestorDirectoryCleanupResumesAfterTheDirectoryWasRemoved(): void {
         $push_session = $this->push_session('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
         $this->push_file($push_session, 'tree/child.txt', 'child');
         $this->complete_work_deletes($push_session);

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -123,27 +123,37 @@ final class PushEndpointsTest extends TestCase {
         ]));
         $upload = $client->finish_request();
         $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
-        $this->assertSame(8, $upload['response']['changes_accepted']);
         $this->assertSame([
-            'state' => 'complete',
-            'type' => 'delete-list',
-            'accepted_bytes' => strlen($delete_payload),
-        ], $upload['response']['last_change']);
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'changes_accepted' => 8,
+            'last_change' => [
+                'state' => 'complete',
+                'type' => 'delete-list',
+                'accepted_bytes' => strlen($delete_payload),
+            ],
+            'http_code' => 200,
+        ], $upload['response']);
 
         $status = $client->control_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
             'path_b64' => base64_encode('nested/file.bin'),
         ], ['accepted']);
         $this->assertSame('complete', $status['status'], (string) json_encode($status));
-        $this->assertSame('receiving_work', $status['response']['phase']);
-        $this->assertSame(strlen($delete_payload), $status['response']['work_deletes_bytes']);
-        $this->assertTrue($status['response']['work_deletes_complete']);
         $this->assertSame([
-            'path_b64' => base64_encode('nested/file.bin'),
-            'state' => 'complete',
-            'type' => 'file',
-            'accepted_bytes' => 8,
-        ], $status['response']['path']);
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'phase' => 'receiving_work',
+            'work_deletes_bytes' => strlen($delete_payload),
+            'work_deletes_complete' => true,
+            'path' => [
+                'path_b64' => base64_encode('nested/file.bin'),
+                'state' => 'complete',
+                'type' => 'file',
+                'accepted_bytes' => 8,
+            ],
+            'http_code' => 200,
+        ], $status['response']);
 
         $commit_requests = 0;
         do {
@@ -151,6 +161,20 @@ final class PushEndpointsTest extends TestCase {
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+            $this->assertSame([
+                'status',
+                'push_session_id',
+                'phase',
+                'send_next_request',
+                'entries_processed',
+                'http_code',
+            ], array_keys($commit['response']));
+            $this->assertSame('accepted', $commit['response']['status']);
+            $this->assertSame($push_session_id, $commit['response']['push_session_id']);
+            $this->assertContains($commit['response']['phase'], ['deleting_files', 'installing_files', 'complete']);
+            $this->assertIsBool($commit['response']['send_next_request']);
+            $this->assertIsInt($commit['response']['entries_processed']);
+            $this->assertSame(200, $commit['response']['http_code']);
             ++$commit_requests;
         } while ($commit['response']['send_next_request']);
 
@@ -173,13 +197,19 @@ final class PushEndpointsTest extends TestCase {
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
+            $this->assertSame([
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'removed' => $remove['response']['removed'],
+                'http_code' => 200,
+            ], $remove['response']);
         } while (!$remove['response']['removed']);
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
         clearstatcache(true, $push_directory);
         $this->assertDirectoryDoesNotExist($push_directory);
     }
 
-    public function testPushRemoveReportsLifecycleLockContentionWithoutRenamingTheLiveDirectory(): void
+    public function testPushRemoveReportsCreateRemoveLockContentionWithoutRenamingTheLiveDirectory(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('c', 32);
@@ -188,8 +218,8 @@ final class PushEndpointsTest extends TestCase {
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
-        $push_parent_directory = dirname($push_directory);
-        $lock_process = $this->startLockProcess($push_parent_directory . '/push-create.lock');
+        $push_sessions_directory = dirname($push_directory);
+        $lock_process = $this->startLockProcess($push_sessions_directory . '/push-create.lock');
 
         try {
             $remove = $client->control_request('POST', 'push_remove', [
@@ -204,7 +234,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(423, $remove['response']['http_code']);
         clearstatcache(true, $push_directory);
         $this->assertDirectoryExists($push_directory);
-        $this->assertDirectoryDoesNotExist($push_parent_directory . '/.removing-' . $push_session_id);
+        $this->assertDirectoryDoesNotExist($push_sessions_directory . '/.removing-' . $push_session_id);
     }
 
     public function testRemovalTombstoneBlocksCreateAndConvergesThroughHttpEndpoints(): void
@@ -232,14 +262,18 @@ final class PushEndpointsTest extends TestCase {
         }
 
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
-        $push_parent_directory = dirname($push_directory);
-        $tombstone = $push_parent_directory . '/.removing-' . $push_session_id;
+        $push_sessions_directory = dirname($push_directory);
+        $tombstone = $push_sessions_directory . '/.removing-' . $push_session_id;
         $first_remove = $client->control_request('POST', 'push_remove', [
             'push_session_id' => $push_session_id,
         ], ['accepted']);
         $this->assertSame('complete', $first_remove['status'], (string) json_encode($first_remove));
-        $this->assertSame(200, $first_remove['response']['http_code']);
-        $this->assertFalse($first_remove['response']['removed']);
+        $this->assertSame([
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'removed' => false,
+            'http_code' => 200,
+        ], $first_remove['response']);
         clearstatcache(true, $push_directory);
         clearstatcache(true, $tombstone);
         $this->assertDirectoryDoesNotExist($push_directory);
@@ -256,7 +290,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_directory);
         $this->assertDirectoryExists($tombstone);
 
-        $lock_process = $this->startLockProcess($push_parent_directory . '/push-create.lock');
+        $lock_process = $this->startLockProcess($push_sessions_directory . '/push-create.lock');
         try {
             $blocked_remove = $client->control_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
@@ -278,15 +312,24 @@ final class PushEndpointsTest extends TestCase {
             ++$remove_requests;
             $this->assertLessThan(10, $remove_requests, 'Bounded HTTP removal did not converge.');
             $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
-            $this->assertSame(200, $remove['response']['http_code']);
+            $this->assertSame([
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'removed' => $remove['response']['removed'],
+                'http_code' => 200,
+            ], $remove['response']);
         } while (!$remove['response']['removed']);
 
         $repeated_remove = $client->control_request('POST', 'push_remove', [
             'push_session_id' => $push_session_id,
         ], ['accepted']);
         $this->assertSame('complete', $repeated_remove['status'], (string) json_encode($repeated_remove));
-        $this->assertSame(200, $repeated_remove['response']['http_code']);
-        $this->assertTrue($repeated_remove['response']['removed']);
+        $this->assertSame([
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'removed' => true,
+            'http_code' => 200,
+        ], $repeated_remove['response']);
         clearstatcache(true, $tombstone);
         $this->assertDirectoryDoesNotExist($tombstone);
 
@@ -342,6 +385,56 @@ final class PushEndpointsTest extends TestCase {
             JSON_THROW_ON_ERROR
         );
         $this->assertSame($expected_excluded_paths_b64, $push_metadata['excluded_paths_b64']);
+    }
+
+    public function testUploadAndMissingPathStatusExposeOnlyDocumentedFields(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('b', 32);
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $upload = $this->sendUploadRequest($client, $push_session_id, [[
+            'type' => 'file',
+            'path' => 'value.txt',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]]);
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+        $this->assertSame([
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'changes_accepted' => 1,
+            'last_change' => [
+                'path_b64' => base64_encode('value.txt'),
+                'state' => 'complete',
+                'type' => 'file',
+                'accepted_bytes' => 1,
+            ],
+            'http_code' => 200,
+        ], $upload['response']);
+
+        $status = $client->control_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+            'path_b64' => base64_encode('missing.txt'),
+        ], ['accepted']);
+        $this->assertSame('complete', $status['status'], (string) json_encode($status));
+        $this->assertSame([
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'phase' => 'receiving_work',
+            'work_deletes_bytes' => 0,
+            'work_deletes_complete' => false,
+            'path' => [
+                'path_b64' => base64_encode('missing.txt'),
+                'state' => 'missing',
+                'accepted_bytes' => 0,
+            ],
+            'http_code' => 200,
+        ], $status['response']);
     }
 
     public function testUploadReportsDeclaredRequestBodyLimitOn413(): void
@@ -409,14 +502,14 @@ final class PushEndpointsTest extends TestCase {
         ], $upload['response']);
     }
 
-    public function testChunkedUploadValidatesEofAfterTheClosingBoundaryAtTheFragmentLimit(): void
+    public function testChunkedUploadDistinguishesEofTrailingDataAndRequestLimitAtTheFragmentBoundary(): void
     {
-        $request_limit = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        $maximum_request_body_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
-            'maximum_part_bytes' => $request_limit,
+            'maximum_part_bytes' => $maximum_request_body_bytes,
         ]);
-        [$server_process, $server_pipes, $base_url] = $this->startServer($request_limit);
+        [$server_process, $server_pipes, $base_url] = $this->startServer($maximum_request_body_bytes);
 
         try {
             $client = $this->newClient(self::SECRET, $base_url);
@@ -425,11 +518,11 @@ final class PushEndpointsTest extends TestCase {
                 'push_session_id' => $clean_push_session_id,
             ], ['created']);
             $this->assertSame('complete', $clean_create['status'], (string) json_encode($clean_create));
-            $this->assertSame($request_limit, $clean_create['response']['post_max_bytes']);
+            $this->assertSame($maximum_request_body_bytes, $clean_create['response']['post_max_bytes']);
 
             $boundary = 'endpoint-fragment-limit';
             $suffix = "\r\n--" . $boundary . "--\r\n";
-            $payload_bytes = $request_limit;
+            $payload_bytes = $maximum_request_body_bytes;
             do {
                 $previous_payload_bytes = $payload_bytes;
                 $prefix = '--' . $boundary . "\r\n"
@@ -438,10 +531,10 @@ final class PushEndpointsTest extends TestCase {
                     . 'X-File-Size: ' . $payload_bytes . "\r\n"
                     . "X-Chunk-Offset: 0\r\n"
                     . 'Content-Length: ' . $payload_bytes . "\r\n\r\n";
-                $payload_bytes = $request_limit - strlen($prefix) - strlen($suffix);
+                $payload_bytes = $maximum_request_body_bytes - strlen($prefix) - strlen($suffix);
             } while ($payload_bytes !== $previous_payload_bytes);
             $multipart_body = $prefix . str_repeat('x', $payload_bytes) . $suffix;
-            $this->assertSame($request_limit, strlen($multipart_body));
+            $this->assertSame($maximum_request_body_bytes, strlen($multipart_body));
 
             $clean_upload = $this->sendChunkedUploadRequest(
                 $base_url,
@@ -467,14 +560,14 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame(413, $over_limit_upload['http_code'], (string) json_encode($over_limit_upload));
             $this->assertSame('rejected', $over_limit_upload['response']['status']);
             $this->assertSame('request_too_large', $over_limit_upload['response']['reason']);
-            $this->assertSame($request_limit + 1, $over_limit_upload['response']['observed_request_body_bytes']);
-            $this->assertSame($request_limit, $over_limit_upload['response']['post_max_bytes']);
+            $this->assertSame($maximum_request_body_bytes + 1, $over_limit_upload['response']['observed_request_body_bytes']);
+            $this->assertSame($maximum_request_body_bytes, $over_limit_upload['response']['post_max_bytes']);
         } finally {
             $this->stopServer($server_process, $server_pipes);
         }
 
-        $larger_request_limit = $request_limit * 2;
-        [$server_process, $server_pipes, $base_url] = $this->startServer($larger_request_limit);
+        $larger_maximum_request_body_bytes = $maximum_request_body_bytes * 2;
+        [$server_process, $server_pipes, $base_url] = $this->startServer($larger_maximum_request_body_bytes);
         try {
             $client = $this->newClient(self::SECRET, $base_url);
             $trailing_byte_push_session_id = str_repeat('2', 32);
@@ -482,7 +575,7 @@ final class PushEndpointsTest extends TestCase {
                 'push_session_id' => $trailing_byte_push_session_id,
             ], ['created']);
             $this->assertSame('complete', $create['status'], (string) json_encode($create));
-            $this->assertSame($larger_request_limit, $create['response']['post_max_bytes']);
+            $this->assertSame($larger_maximum_request_body_bytes, $create['response']['post_max_bytes']);
 
             $trailing_byte_upload = $this->sendChunkedUploadRequest(
                 $base_url,
@@ -526,7 +619,42 @@ final class PushEndpointsTest extends TestCase {
         $this->assertStringNotContainsString('invariant', $body);
     }
 
-    public function testMalformedPredispatchCursorUsesInvalidRequestResponse(): void
+    public function testFailureResponseDoesNotExposeInternalExceptionContext(): void
+    {
+        $endpoints = new Site_Export_Push_Endpoints([
+            'reprint_directory' => $this->reprint_directory,
+            'docroot' => $this->docroot,
+            'excluded_paths' => [],
+        ]);
+        $respond_to_failure = new ReflectionMethod($endpoints, 'respond_to_failure');
+        $respond_to_failure->setAccessible(true);
+        http_response_code(200);
+        ob_start();
+        $respond_to_failure->invoke(
+            $endpoints,
+            new Site_Export_Push_Exception(
+                Site_Export_Push_Session::ERROR_SAME_DEVICE,
+                'The work and document-root filesystems differ.',
+                [
+                    'status' => 'context-status',
+                    'reason' => 'context-reason',
+                    'detail' => 'context-detail',
+                    'operation' => 'install',
+                    'path_b64' => base64_encode('private-path'),
+                ]
+            )
+        );
+        $body = (string) ob_get_clean();
+
+        $this->assertSame(409, http_response_code());
+        $this->assertSame([
+            'status' => 'rejected',
+            'reason' => 'same_device',
+            'detail' => 'The work and document-root filesystems differ.',
+        ], json_decode($body, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    public function testInvalidBase64CursorReturnsInvalidRequestBeforePushDispatch(): void
     {
         $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
             'push_session_id' => str_repeat('9', 32),
@@ -586,7 +714,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertArrayNotHasKey('trace', $response['response']);
     }
 
-    public function testPushCreateRejectsInvalidServerDocumentRoot(): void
+    public function testPushCreateRejectsNonexistentDocumentRootServerVariable(): void
     {
         $this->writeDocrootConfiguration([
             'document_root' => $this->root . '/missing-document-root',
@@ -622,7 +750,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
-    public function testExplicitManagedDocumentRootOverridesServerDocumentRoot(): void
+    public function testPlatformDocrootOptionOverridesDocumentRootServerVariable(): void
     {
         $explicit_docroot = $this->root . '/explicit-document-root';
         mkdir($explicit_docroot, 0700);
@@ -674,7 +802,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($wordpress_root_reprint_directory);
     }
 
-    public function testInvalidExcludedPathsConfigurationUsesNotConfiguredResponse(): void
+    public function testParentSegmentInExcludedPathReturnsNotConfigured(): void
     {
         $this->writeExcludedPaths(['../bad']);
         $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
@@ -683,7 +811,7 @@ final class PushEndpointsTest extends TestCase {
 
         $this->assertSame('failed', $response['status']);
         $this->assertSame('not_configured', $response['reason']);
-        $this->assertSame('Excluded path is unsafe: Li4vYmFk.', $response['detail']);
+        $this->assertSame('Excluded path must not contain a parent component: Li4vYmFk.', $response['detail']);
         $this->assertSame(503, $response['response']['http_code']);
         $this->assertArrayNotHasKey('trace', $response['response']);
     }
@@ -789,7 +917,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame($plugin_entrypoint_hash, hash_file('sha256', $physical_plugin_directory . '/index.php'));
     }
 
-    public function testPullEndpointDoesNotValidatePushConfiguration(): void
+    public function testPreflightDoesNotConstructPushEndpoints(): void
     {
         file_put_contents($this->reprint_configuration_path, $this->docroot . '/invalid-push-directory');
         $url = $this->base_url . '&endpoint=preflight';
@@ -822,7 +950,14 @@ final class PushEndpointsTest extends TestCase {
         ], self::SECRET);
 
         $this->assertSame(200, $status['http_code'], $status['body']);
-        $this->assertSame('accepted', json_decode($status['body'], true, 512, JSON_THROW_ON_ERROR)['status']);
+        $this->assertSame([
+            'status' => 'accepted',
+            'push_session_id' => $push_session_id,
+            'phase' => 'receiving_work',
+            'work_deletes_bytes' => 0,
+            'work_deletes_complete' => false,
+            'path' => null,
+        ], json_decode($status['body'], true, 512, JSON_THROW_ON_ERROR));
         $this->assertNoCacheHeaders($status['headers']);
     }
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1,0 +1,532 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-importer/src/import.php';
+require_once __DIR__ . '/../packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php';
+
+final class PushEndpointsTest extends TestCase {
+
+    private const SECRET = 'real-push-endpoint-test-secret';
+    private const POST_MAX_BYTES = 8192;
+
+    /** @var resource|null */
+    private $server_process;
+
+    /** @var resource[] */
+    private array $server_pipes = [];
+
+    private string $root;
+    private string $docroot;
+    private string $docroot_link;
+    private string $reprint_directory;
+    private string $reprint_configuration_path;
+    private string $excluded_paths_configuration_path;
+    private string $base_url;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Push endpoint E2E requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $this->root = sys_get_temp_dir() . '/push-endpoints-' . bin2hex(random_bytes(6));
+        $this->docroot = $this->root . '/docroot';
+        $this->docroot_link = $this->root . '/docroot-link';
+        $this->reprint_directory = $this->root . '/reprint';
+        $this->reprint_configuration_path = $this->root . '/reprint-directory';
+        $this->excluded_paths_configuration_path = $this->root . '/excluded-paths.json';
+        mkdir($this->docroot, 0700, true);
+        symlink($this->docroot, $this->docroot_link);
+        mkdir($this->reprint_directory, 0700, true);
+        file_put_contents($this->reprint_configuration_path, $this->reprint_directory);
+        file_put_contents($this->excluded_paths_configuration_path, json_encode(['preserved']));
+        file_put_contents($this->docroot . '/remove.txt', 'old');
+        mkdir($this->docroot . '/preserved');
+        file_put_contents($this->docroot . '/preserved/value.txt', 'keep');
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        fclose($listener);
+        $router = realpath(__DIR__ . '/fixtures/push-endpoint-router.php');
+        $this->assertNotFalse($router);
+        $environment = array_merge($_ENV, [
+            'REPRINT_PUSH_TEST_SECRET' => self::SECRET,
+            'REPRINT_PUSH_TEST_DOCROOT' => $this->docroot_link,
+            'REPRINT_PUSH_TEST_DIRECTORY_CONFIG' => $this->reprint_configuration_path,
+            'REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG' => $this->excluded_paths_configuration_path,
+        ]);
+        $server_log_path = $this->root . '/server.log';
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['file', $server_log_path, 'a'],
+            2 => ['file', $server_log_path, 'a'],
+        ];
+        // PHP enforces post_max_size before the router can disable display_errors,
+        // so disable it at startup to keep the endpoint's 413 body valid JSON.
+        // Send process output to a file so repeated suppressed filesystem
+        // notices cannot fill a pipe and block the server response.
+        $process = proc_open([PHP_BINARY, '-d', 'display_errors=0', '-d', 'post_max_size=' . self::POST_MAX_BYTES, '-S', $address, $router], $descriptors, $pipes, dirname($router), $environment);
+        $this->assertIsResource($process);
+        $this->server_process = $process;
+        $this->server_pipes = $pipes;
+        fclose($this->server_pipes[0]);
+        unset($this->server_pipes[0]);
+        $deadline = microtime(true) + 5;
+        do {
+            $connection = @stream_socket_client('tcp://' . $address, $connect_error, $connect_error_message, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                $this->base_url = 'http://' . $address . '/?reprint-api=1';
+                return;
+            }
+            usleep(20000);
+        } while (microtime(true) < $deadline);
+        $server_log = file_get_contents($server_log_path);
+        $this->fail('Push endpoint test server did not start: ' . $server_log);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            foreach ($this->server_pipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->server_process);
+        }
+        if (isset($this->root)) {
+            $this->removeTree($this->root);
+        }
+        parent::tearDown();
+    }
+
+    public function testSignedEndpointsReceiveManyChangesCommitAndRemove(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('a', 32);
+
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->assertSame([
+            'status' => 'created',
+            'push_session_id' => $push_session_id,
+            'max_part_bytes' => 4,
+            'post_max_bytes' => self::POST_MAX_BYTES,
+            'http_code' => 200,
+        ], $create['response']);
+        $client->set_max_part_bytes($create['response']['max_part_bytes']);
+        $client->apply_reported_limits([$create['response']['post_max_bytes']]);
+
+        $this->assertTrue($client->start_upload_request($push_session_id));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'nested/file.bin',
+            'total_bytes' => 8,
+            'offset' => 0,
+            'payload' => "ab\0c",
+        ]));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'nested/file.bin',
+            'total_bytes' => 8,
+            'offset' => 4,
+            'payload' => 'defg',
+        ]));
+        $this->assertTrue($client->send_part([
+            'type' => 'directory',
+            'path' => 'empty-directory',
+            'payload' => '',
+        ]));
+        $this->assertTrue($client->send_part([
+            'type' => 'symlink',
+            'path' => 'file-link',
+            'target' => 'nested/file.bin',
+            'payload' => '',
+        ]));
+        $delete_payload = "remove.txt\0";
+        $delete_offset = 0;
+        foreach (str_split($delete_payload, 4) as $delete_piece) {
+            $this->assertTrue($client->send_part([
+                'type' => 'delete-list',
+                'offset' => $delete_offset,
+                'payload' => $delete_piece,
+            ]));
+            $delete_offset += strlen($delete_piece);
+        }
+        $this->assertTrue($client->send_part([
+            'type' => 'delete-list',
+            'offset' => $delete_offset,
+            'complete' => true,
+            'payload' => '',
+        ]));
+        $upload = $client->finish_request();
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+        $this->assertSame(8, $upload['response']['changes_accepted']);
+        $this->assertSame([
+            'state' => 'complete',
+            'type' => 'delete-list',
+            'accepted_bytes' => strlen($delete_payload),
+        ], $upload['response']['last_change']);
+
+        $status = $client->control_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+            'path_b64' => base64_encode('nested/file.bin'),
+        ], ['accepted']);
+        $this->assertSame('complete', $status['status'], (string) json_encode($status));
+        $this->assertSame('receiving_work', $status['response']['phase']);
+        $this->assertSame(strlen($delete_payload), $status['response']['work_deletes_bytes']);
+        $this->assertTrue($status['response']['work_deletes_complete']);
+        $this->assertSame([
+            'path_b64' => base64_encode('nested/file.bin'),
+            'state' => 'complete',
+            'type' => 'file',
+            'accepted_bytes' => 8,
+        ], $status['response']['path']);
+
+        $commit_requests = 0;
+        do {
+            $commit = $client->control_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+            ++$commit_requests;
+        } while ($commit['response']['send_next_request']);
+
+        $this->assertGreaterThan(1, $commit_requests, 'The one-entry endpoint budget must require repeated commit calls.');
+        $this->assertSame('complete', $commit['response']['phase']);
+        $this->assertFileDoesNotExist($this->docroot . '/remove.txt');
+        $this->assertSame("ab\0cdefg", file_get_contents($this->docroot . '/nested/file.bin'));
+        $this->assertDirectoryExists($this->docroot . '/empty-directory');
+        $this->assertSame([], array_values(array_diff(scandir($this->docroot . '/empty-directory') ?: [], ['.', '..'])));
+        $this->assertTrue(is_link($this->docroot . '/file-link'));
+        $this->assertSame('nested/file.bin', readlink($this->docroot . '/file-link'));
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+
+        do {
+            $remove = $client->control_request('POST', 'push_remove', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
+        } while (!$remove['response']['removed']);
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+    }
+
+    public function testUploadReportsDeclaredRequestBodyLimitOn413(): void
+    {
+        $push_session_id = str_repeat('d', 32);
+        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $curl_headers = ['Content-Type: multipart/mixed; boundary=oversized-endpoint-test'];
+        foreach ($headers as $name => $value) {
+            $curl_headers[] = $name . ': ' . $value;
+        }
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => str_repeat('x', self::POST_MAX_BYTES + 1),
+            CURLOPT_HTTPHEADER => $curl_headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(413, curl_getinfo($handle, CURLINFO_HTTP_CODE), $body);
+        curl_close($handle);
+
+        $this->assertSame([
+            'status' => 'rejected',
+            'reason' => 'request_too_large',
+            'detail' => 'The decoded request body declares 8193 bytes, exceeding the target post_max_size of 8192 bytes.',
+            'post_max_bytes' => self::POST_MAX_BYTES,
+        ], json_decode($body, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    public function testChunkedUploadEnforcesDecodedRequestBodyLimitWhileStreaming(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('f', 32);
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->assertSame(self::POST_MAX_BYTES, $create['response']['post_max_bytes']);
+
+        // MultipartPushStreamClient uses CURLOPT_UPLOAD without a known body
+        // length, so this reaches the production router as chunked transport.
+        $this->assertTrue($client->start_upload_request($push_session_id));
+        for ($part = 0; $part < 200; ++$part) {
+            if (!$client->send_part([
+                'type' => 'directory',
+                'path' => 'request-limit-' . $part,
+                'payload' => '',
+            ])) {
+                break;
+            }
+        }
+
+        $upload = $client->finish_request();
+        $this->assertGreaterThan(self::POST_MAX_BYTES, $upload['body_bytes_sent']);
+        $this->assertSame('request_too_large', $upload['reason'], (string) json_encode($upload));
+        $this->assertSame('The decoded request body reached 8193 bytes, exceeding the target post_max_size of 8192 bytes.', $upload['detail']);
+        $this->assertSame([
+            'status' => 'rejected',
+            'reason' => 'request_too_large',
+            'detail' => 'The decoded request body reached 8193 bytes, exceeding the target post_max_size of 8192 bytes.',
+            'post_max_bytes' => self::POST_MAX_BYTES,
+        ], $upload['response']);
+    }
+
+    public function testLogicExceptionUsesGenericServerFailureResponse(): void
+    {
+        $endpoints = new Site_Export_Push_Endpoints([
+            'reprint_directory' => $this->reprint_directory,
+            'docroot' => $this->docroot,
+            'excluded_paths' => [],
+        ]);
+        $respond_to_failure = new ReflectionMethod($endpoints, 'respond_to_failure');
+        $respond_to_failure->setAccessible(true);
+        http_response_code(200);
+        ob_start();
+        $respond_to_failure->invoke($endpoints, new LogicException('Internal multipart invariant failed.'));
+        $body = (string) ob_get_clean();
+
+        $this->assertSame(500, http_response_code());
+        $this->assertSame([
+            'status' => 'rejected',
+            'reason' => 'filesystem_error',
+            'detail' => 'The push endpoint failed while processing the request.',
+        ], json_decode($body, true, 512, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('invariant', $body);
+    }
+
+    public function testMalformedPredispatchCursorUsesInvalidRequestResponse(): void
+    {
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => str_repeat('9', 32),
+            'cursor' => 'not-base64',
+        ], ['created']);
+
+        $this->assertSame('failed', $response['status']);
+        $this->assertSame('invalid_request', $response['reason']);
+        $this->assertSame('Cursor must be base64-encoded. Received invalid base64: not-base64', $response['detail']);
+        $this->assertSame(400, $response['response']['http_code']);
+        $this->assertArrayNotHasKey('trace', $response['response']);
+    }
+
+    public function testEndpointConfigurationRejectsReprintDirectoryInsideDocumentRoot(): void
+    {
+        $symlink_parent = $this->root . '/symlink-parent';
+        mkdir($symlink_parent, 0700);
+        symlink($this->docroot, $symlink_parent . '/docroot-link');
+        $reprint_directories = [
+            $this->docroot,
+            $this->docroot . '/missing-reprint-directory',
+            $symlink_parent . '/docroot-link/missing-reprint-directory',
+        ];
+
+        foreach ($reprint_directories as $reprint_directory) {
+            try {
+                new Site_Export_Push_Endpoints([
+                    'reprint_directory' => $reprint_directory,
+                    'docroot' => $this->docroot,
+                    'excluded_paths' => [],
+                ]);
+                $this->fail('Push endpoints accepted reprint_directory ' . json_encode($reprint_directory) . ' inside the document root.');
+            } catch (InvalidArgumentException $exception) {
+                $this->assertSame(
+                    'Push endpoints require reprint_directory ' . json_encode($reprint_directory)
+                    . ' to be outside docroot ' . json_encode($this->docroot) . '; observed it inside that document root.',
+                    $exception->getMessage()
+                );
+            }
+        }
+
+        $configured_reprint_directory = $this->docroot . '/router-reprint-directory';
+        file_put_contents($this->reprint_configuration_path, $configured_reprint_directory);
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => str_repeat('e', 32),
+        ], ['created']);
+        $this->assertSame('failed', $response['status']);
+        $this->assertSame('not_configured', $response['reason']);
+        $canonical_docroot = realpath($this->docroot);
+        $this->assertIsString($canonical_docroot);
+        $this->assertSame(
+            'Push endpoints require reprint_directory ' . json_encode($configured_reprint_directory)
+            . ' to be outside docroot ' . json_encode($canonical_docroot) . '; observed it inside that document root.',
+            $response['detail']
+        );
+        $this->assertSame(503, $response['response']['http_code']);
+        $this->assertArrayNotHasKey('trace', $response['response']);
+    }
+
+    public function testDefaultPushDirectoryIsSiblingOfCanonicalDocumentRoot(): void
+    {
+        file_put_contents($this->reprint_configuration_path, '');
+        $push_session_id = str_repeat('7', 32);
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+
+        $this->assertSame('complete', $response['status'], (string) json_encode($response));
+        $canonical_docroot = realpath($this->docroot);
+        $this->assertIsString($canonical_docroot);
+        $default_reprint_directory = dirname($canonical_docroot)
+            . '/.reprint-' . substr(hash('sha256', $canonical_docroot), 0, 12);
+        $this->assertDirectoryExists($default_reprint_directory . '/.reprint/push/' . $push_session_id);
+    }
+
+    public function testInvalidExcludedPathsConfigurationUsesNotConfiguredResponse(): void
+    {
+        file_put_contents($this->excluded_paths_configuration_path, json_encode(['../bad']));
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => str_repeat('8', 32),
+        ], ['created']);
+
+        $this->assertSame('failed', $response['status']);
+        $this->assertSame('not_configured', $response['reason']);
+        $this->assertSame('Excluded path is unsafe: Li4vYmFk.', $response['detail']);
+        $this->assertSame(503, $response['response']['http_code']);
+        $this->assertArrayNotHasKey('trace', $response['response']);
+    }
+
+    public function testPullEndpointDoesNotValidatePushConfiguration(): void
+    {
+        file_put_contents($this->reprint_configuration_path, $this->docroot . '/invalid-push-directory');
+        $url = $this->base_url . '&endpoint=preflight';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_curl_headers();
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(200, curl_getinfo($handle, CURLINFO_HTTP_CODE), $body);
+        curl_close($handle);
+
+        $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertArrayHasKey('ok', $response);
+        $this->assertStringNotContainsString('Push endpoints require', $body);
+    }
+
+    public function testEndpointGuardsRejectWrongMethodContentTypeAndAuthentication(): void
+    {
+        $push_session_id = str_repeat('b', 32);
+        $client = $this->newClient(self::SECRET);
+
+        $wrong_method = $client->control_request('GET', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('failed', $wrong_method['status']);
+        $this->assertSame('invalid_request', $wrong_method['reason']);
+        $this->assertSame('Push endpoint requires POST; observed GET.', $wrong_method['detail']);
+
+        $wrong_secret = $this->newClient('not-the-server-secret');
+        $authentication = $wrong_secret->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('failed', $authentication['status']);
+        $this->assertSame('auth_failed', $authentication['reason']);
+        $this->assertStringContainsString('HMAC signature verification failed', $authentication['detail']);
+
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status']);
+        $push_lock = fopen($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.lock', 'c+b');
+        $this->assertIsResource($push_lock);
+        $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
+        $lock_contention = $client->control_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('retry', $lock_contention['status']);
+        $this->assertSame('lock_acquisition_failure', $lock_contention['reason']);
+        flock($push_lock, LOCK_UN);
+        fclose($push_lock);
+
+        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $curl_headers = ['Content-Type: application/json'];
+        foreach ($headers as $name => $value) {
+            $curl_headers[] = $name . ': ' . $value;
+        }
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => '{}',
+            CURLOPT_HTTPHEADER => $curl_headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(400, curl_getinfo($handle, CURLINFO_HTTP_CODE));
+        curl_close($handle);
+        $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('invalid_request', $response['reason']);
+        $this->assertStringContainsString('multipart/mixed', $response['detail']);
+
+        $boundary = 'truncated-endpoint-test';
+        $truncated_body = '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: file\r\n"
+            . 'X-File-Path: ' . base64_encode('truncated.txt') . "\r\n"
+            . "X-File-Size: 1\r\n"
+            . "X-Chunk-Offset: 0\r\n"
+            . "Content-Length: 1\r\n\r\n"
+            . 'x';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $curl_headers = ['Content-Type: multipart/mixed; boundary=' . $boundary];
+        foreach ($headers as $name => $value) {
+            $curl_headers[] = $name . ': ' . $value;
+        }
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $truncated_body,
+            CURLOPT_HTTPHEADER => $curl_headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(400, curl_getinfo($handle, CURLINFO_HTTP_CODE));
+        curl_close($handle);
+        $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('invalid_request', $response['reason']);
+        $this->assertStringContainsString('multipart body ended before', $response['detail']);
+    }
+
+    private function newClient(string $secret): MultipartPushStreamClient
+    {
+        return new MultipartPushStreamClient([
+            'base_url' => $this->base_url,
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client($secret),
+            'chunk_bytes' => 4,
+            'connect_timeout' => 3,
+            'stall_timeout' => 3,
+            'response_timeout' => 5,
+        ]);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -20,9 +20,10 @@ final class PushEndpointsTest extends TestCase {
 
     private string $root;
     private string $docroot;
-    private string $docroot_link;
+    private string $wordpress_root;
     private string $reprint_directory;
     private string $reprint_configuration_path;
+    private string $docroot_configuration_path;
     private string $excluded_paths_configuration_path;
     private string $base_url;
 
@@ -33,72 +34,28 @@ final class PushEndpointsTest extends TestCase {
             $this->markTestSkipped('Push endpoint E2E requires PHP curl with CURL_READFUNC_PAUSE support.');
         }
         $this->root = sys_get_temp_dir() . '/push-endpoints-' . bin2hex(random_bytes(6));
-        $this->docroot = $this->root . '/docroot';
-        $this->docroot_link = $this->root . '/docroot-link';
+        $this->docroot = $this->root . '/site';
+        $this->wordpress_root = $this->docroot . '/__wp__';
         $this->reprint_directory = $this->root . '/reprint';
         $this->reprint_configuration_path = $this->root . '/reprint-directory';
+        $this->docroot_configuration_path = $this->root . '/docroot-configuration.json';
         $this->excluded_paths_configuration_path = $this->root . '/excluded-paths.json';
-        mkdir($this->docroot, 0700, true);
-        symlink($this->docroot, $this->docroot_link);
+        mkdir($this->wordpress_root, 0700, true);
         mkdir($this->reprint_directory, 0700, true);
         file_put_contents($this->reprint_configuration_path, $this->reprint_directory);
-        file_put_contents($this->excluded_paths_configuration_path, json_encode(['preserved']));
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+        ]);
+        $this->writeExcludedPaths(['preserved']);
         file_put_contents($this->docroot . '/remove.txt', 'old');
         mkdir($this->docroot . '/preserved');
         file_put_contents($this->docroot . '/preserved/value.txt', 'keep');
-        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
-        $this->assertNotFalse($listener, (string) $error);
-        $address = stream_socket_get_name($listener, false);
-        fclose($listener);
-        $router = realpath(__DIR__ . '/fixtures/push-endpoint-router.php');
-        $this->assertNotFalse($router);
-        $environment = array_merge($_ENV, [
-            'REPRINT_PUSH_TEST_SECRET' => self::SECRET,
-            'REPRINT_PUSH_TEST_DOCROOT' => $this->docroot_link,
-            'REPRINT_PUSH_TEST_DIRECTORY_CONFIG' => $this->reprint_configuration_path,
-            'REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG' => $this->excluded_paths_configuration_path,
-        ]);
-        $server_log_path = $this->root . '/server.log';
-        $descriptors = [
-            0 => ['pipe', 'r'],
-            1 => ['file', $server_log_path, 'a'],
-            2 => ['file', $server_log_path, 'a'],
-        ];
-        // PHP enforces post_max_size before the router can disable display_errors,
-        // so disable it at startup to keep the endpoint's 413 body valid JSON.
-        // Send process output to a file so repeated suppressed filesystem
-        // notices cannot fill a pipe and block the server response.
-        $process = proc_open([PHP_BINARY, '-d', 'display_errors=0', '-d', 'post_max_size=' . self::POST_MAX_BYTES, '-S', $address, $router], $descriptors, $pipes, dirname($router), $environment);
-        $this->assertIsResource($process);
-        $this->server_process = $process;
-        $this->server_pipes = $pipes;
-        fclose($this->server_pipes[0]);
-        unset($this->server_pipes[0]);
-        $deadline = microtime(true) + 5;
-        do {
-            $connection = @stream_socket_client('tcp://' . $address, $connect_error, $connect_error_message, 0.1);
-            if (is_resource($connection)) {
-                fclose($connection);
-                $this->base_url = 'http://' . $address . '/?reprint-api=1';
-                return;
-            }
-            usleep(20000);
-        } while (microtime(true) < $deadline);
-        $server_log = file_get_contents($server_log_path);
-        $this->fail('Push endpoint test server did not start: ' . $server_log);
+        [$this->server_process, $this->server_pipes, $this->base_url] = $this->startServer(self::POST_MAX_BYTES);
     }
 
     protected function tearDown(): void
     {
-        if (is_resource($this->server_process)) {
-            proc_terminate($this->server_process);
-            foreach ($this->server_pipes as $pipe) {
-                if (is_resource($pipe)) {
-                    fclose($pipe);
-                }
-            }
-            proc_close($this->server_process);
-        }
+        $this->stopServer($this->server_process, $this->server_pipes);
         if (isset($this->root)) {
             $this->removeTree($this->root);
         }
@@ -114,13 +71,11 @@ final class PushEndpointsTest extends TestCase {
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
-        $this->assertSame([
-            'status' => 'created',
-            'push_session_id' => $push_session_id,
-            'max_part_bytes' => 4,
-            'post_max_bytes' => self::POST_MAX_BYTES,
-            'http_code' => 200,
-        ], $create['response']);
+        $this->assertSame('created', $create['response']['status']);
+        $this->assertSame($push_session_id, $create['response']['push_session_id']);
+        $this->assertSame(4, $create['response']['max_part_bytes']);
+        $this->assertSame(self::POST_MAX_BYTES, $create['response']['post_max_bytes']);
+        $this->assertSame(200, $create['response']['http_code']);
         $client->set_max_part_bytes($create['response']['max_part_bytes']);
         $client->apply_reported_limits([$create['response']['post_max_bytes']]);
 
@@ -208,6 +163,10 @@ final class PushEndpointsTest extends TestCase {
         $this->assertTrue(is_link($this->docroot . '/file-link'));
         $this->assertSame('nested/file.bin', readlink($this->docroot . '/file-link'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertFileDoesNotExist($this->wordpress_root . '/nested/file.bin');
+        $this->assertDirectoryDoesNotExist($this->wordpress_root . '/empty-directory');
+        $this->assertDirectoryExists($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+        $this->assertSame(dirname($this->docroot), dirname($this->reprint_directory));
 
         do {
             $remove = $client->control_request('POST', 'push_remove', [
@@ -215,7 +174,174 @@ final class PushEndpointsTest extends TestCase {
             ], ['accepted']);
             $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
         } while (!$remove['response']['removed']);
-        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+        $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
+        clearstatcache(true, $push_directory);
+        $this->assertDirectoryDoesNotExist($push_directory);
+    }
+
+    public function testPushRemoveReportsLifecycleLockContentionWithoutRenamingTheLiveDirectory(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('c', 32);
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
+        $push_parent_directory = dirname($push_directory);
+        $lock_process = $this->startLockProcess($push_parent_directory . '/push-create.lock');
+
+        try {
+            $remove = $client->control_request('POST', 'push_remove', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+        } finally {
+            $this->stopLockProcess($lock_process);
+        }
+
+        $this->assertSame('retry', $remove['status'], (string) json_encode($remove));
+        $this->assertSame('lock_acquisition_failure', $remove['reason']);
+        $this->assertSame(423, $remove['response']['http_code']);
+        clearstatcache(true, $push_directory);
+        $this->assertDirectoryExists($push_directory);
+        $this->assertDirectoryDoesNotExist($push_parent_directory . '/.removing-' . $push_session_id);
+    }
+
+    public function testRemovalTombstoneBlocksCreateAndConvergesThroughHttpEndpoints(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('d', 32);
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $directory_parts = [];
+        for ($index = 0; $index < 270; ++$index) {
+            $directory_parts[] = [
+                'type' => 'directory',
+                'path' => 'remove-entry-' . $index,
+                'payload' => '',
+            ];
+            if (count($directory_parts) === 15 || $index === 269) {
+                $upload = $this->sendUploadRequest($client, $push_session_id, $directory_parts);
+                $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+                $this->assertSame(count($directory_parts), $upload['parts_sent']);
+                $directory_parts = [];
+            }
+        }
+
+        $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
+        $push_parent_directory = dirname($push_directory);
+        $tombstone = $push_parent_directory . '/.removing-' . $push_session_id;
+        $first_remove = $client->control_request('POST', 'push_remove', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $first_remove['status'], (string) json_encode($first_remove));
+        $this->assertSame(200, $first_remove['response']['http_code']);
+        $this->assertFalse($first_remove['response']['removed']);
+        clearstatcache(true, $push_directory);
+        clearstatcache(true, $tombstone);
+        $this->assertDirectoryDoesNotExist($push_directory);
+        $this->assertDirectoryExists($tombstone);
+
+        $blocked_create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('retry', $blocked_create['status'], (string) json_encode($blocked_create));
+        $this->assertSame('lock_acquisition_failure', $blocked_create['reason']);
+        $this->assertSame(423, $blocked_create['response']['http_code']);
+        clearstatcache(true, $push_directory);
+        clearstatcache(true, $tombstone);
+        $this->assertDirectoryDoesNotExist($push_directory);
+        $this->assertDirectoryExists($tombstone);
+
+        $lock_process = $this->startLockProcess($push_parent_directory . '/push-create.lock');
+        try {
+            $blocked_remove = $client->control_request('POST', 'push_remove', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+        } finally {
+            $this->stopLockProcess($lock_process);
+        }
+        $this->assertSame('retry', $blocked_remove['status'], (string) json_encode($blocked_remove));
+        $this->assertSame('lock_acquisition_failure', $blocked_remove['reason']);
+        $this->assertSame(423, $blocked_remove['response']['http_code']);
+        clearstatcache(true, $tombstone);
+        $this->assertDirectoryExists($tombstone);
+
+        $remove_requests = 0;
+        do {
+            $remove = $client->control_request('POST', 'push_remove', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            ++$remove_requests;
+            $this->assertLessThan(10, $remove_requests, 'Bounded HTTP removal did not converge.');
+            $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
+            $this->assertSame(200, $remove['response']['http_code']);
+        } while (!$remove['response']['removed']);
+
+        $repeated_remove = $client->control_request('POST', 'push_remove', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $repeated_remove['status'], (string) json_encode($repeated_remove));
+        $this->assertSame(200, $repeated_remove['response']['http_code']);
+        $this->assertTrue($repeated_remove['response']['removed']);
+        clearstatcache(true, $tombstone);
+        $this->assertDirectoryDoesNotExist($tombstone);
+
+        $recreated = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $recreated['status'], (string) json_encode($recreated));
+        $this->assertSame(200, $recreated['response']['http_code']);
+        clearstatcache(true, $push_directory);
+        $this->assertDirectoryExists($push_directory);
+    }
+
+    public function testPushCreateReportsNormalizedExcludedPathsWhenCreatingAndReopening(): void
+    {
+        $excluded_paths = [
+            'z-last',
+            "non-utf8-\xff",
+            'a-first',
+            'z-last',
+        ];
+        $this->writeExcludedPaths($excluded_paths);
+        $expected_excluded_paths_b64 = array_map('base64_encode', [
+            'a-first',
+            "non-utf8-\xff",
+            'z-last',
+        ]);
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('1', 32);
+
+        $created = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $reopened = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+
+        $expected_response = [
+            'status' => 'created',
+            'push_session_id' => $push_session_id,
+            'max_part_bytes' => 4,
+            'post_max_bytes' => self::POST_MAX_BYTES,
+            'excluded_paths_b64' => $expected_excluded_paths_b64,
+            'http_code' => 200,
+        ];
+        $this->assertSame('complete', $created['status'], (string) json_encode($created));
+        $this->assertSame($expected_response, $created['response']);
+        $this->assertSame('complete', $reopened['status'], (string) json_encode($reopened));
+        $this->assertSame($expected_response, $reopened['response']);
+        $push_metadata = json_decode(
+            (string) file_get_contents($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame($expected_excluded_paths_b64, $push_metadata['excluded_paths_b64']);
     }
 
     public function testUploadReportsDeclaredRequestBodyLimitOn413(): void
@@ -278,8 +404,103 @@ final class PushEndpointsTest extends TestCase {
             'status' => 'rejected',
             'reason' => 'request_too_large',
             'detail' => 'The decoded request body reached 8193 bytes, exceeding the target post_max_size of 8192 bytes.',
+            'observed_request_body_bytes' => self::POST_MAX_BYTES + 1,
             'post_max_bytes' => self::POST_MAX_BYTES,
         ], $upload['response']);
+    }
+
+    public function testChunkedUploadValidatesEofAfterTheClosingBoundaryAtTheFragmentLimit(): void
+    {
+        $request_limit = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => $request_limit,
+        ]);
+        [$server_process, $server_pipes, $base_url] = $this->startServer($request_limit);
+
+        try {
+            $client = $this->newClient(self::SECRET, $base_url);
+            $clean_push_session_id = str_repeat('0', 32);
+            $clean_create = $client->control_request('POST', 'push_create', [
+                'push_session_id' => $clean_push_session_id,
+            ], ['created']);
+            $this->assertSame('complete', $clean_create['status'], (string) json_encode($clean_create));
+            $this->assertSame($request_limit, $clean_create['response']['post_max_bytes']);
+
+            $boundary = 'endpoint-fragment-limit';
+            $suffix = "\r\n--" . $boundary . "--\r\n";
+            $payload_bytes = $request_limit;
+            do {
+                $previous_payload_bytes = $payload_bytes;
+                $prefix = '--' . $boundary . "\r\n"
+                    . "X-Chunk-Type: file\r\n"
+                    . 'X-File-Path: ' . base64_encode('fragment-limit.bin') . "\r\n"
+                    . 'X-File-Size: ' . $payload_bytes . "\r\n"
+                    . "X-Chunk-Offset: 0\r\n"
+                    . 'Content-Length: ' . $payload_bytes . "\r\n\r\n";
+                $payload_bytes = $request_limit - strlen($prefix) - strlen($suffix);
+            } while ($payload_bytes !== $previous_payload_bytes);
+            $multipart_body = $prefix . str_repeat('x', $payload_bytes) . $suffix;
+            $this->assertSame($request_limit, strlen($multipart_body));
+
+            $clean_upload = $this->sendChunkedUploadRequest(
+                $base_url,
+                $clean_push_session_id,
+                $boundary,
+                $multipart_body
+            );
+            $this->assertSame(200, $clean_upload['http_code'], (string) json_encode($clean_upload));
+            $this->assertSame('accepted', $clean_upload['response']['status']);
+
+            $over_limit_push_session_id = str_repeat('1', 32);
+            $over_limit_create = $client->control_request('POST', 'push_create', [
+                'push_session_id' => $over_limit_push_session_id,
+            ], ['created']);
+            $this->assertSame('complete', $over_limit_create['status'], (string) json_encode($over_limit_create));
+            $over_limit_upload = $this->sendChunkedUploadRequest(
+                $base_url,
+                $over_limit_push_session_id,
+                $boundary,
+                $multipart_body,
+                'y'
+            );
+            $this->assertSame(413, $over_limit_upload['http_code'], (string) json_encode($over_limit_upload));
+            $this->assertSame('rejected', $over_limit_upload['response']['status']);
+            $this->assertSame('request_too_large', $over_limit_upload['response']['reason']);
+            $this->assertSame($request_limit + 1, $over_limit_upload['response']['observed_request_body_bytes']);
+            $this->assertSame($request_limit, $over_limit_upload['response']['post_max_bytes']);
+        } finally {
+            $this->stopServer($server_process, $server_pipes);
+        }
+
+        $larger_request_limit = $request_limit * 2;
+        [$server_process, $server_pipes, $base_url] = $this->startServer($larger_request_limit);
+        try {
+            $client = $this->newClient(self::SECRET, $base_url);
+            $trailing_byte_push_session_id = str_repeat('2', 32);
+            $create = $client->control_request('POST', 'push_create', [
+                'push_session_id' => $trailing_byte_push_session_id,
+            ], ['created']);
+            $this->assertSame('complete', $create['status'], (string) json_encode($create));
+            $this->assertSame($larger_request_limit, $create['response']['post_max_bytes']);
+
+            $trailing_byte_upload = $this->sendChunkedUploadRequest(
+                $base_url,
+                $trailing_byte_push_session_id,
+                $boundary,
+                $multipart_body,
+                'y'
+            );
+            $this->assertSame(400, $trailing_byte_upload['http_code'], (string) json_encode($trailing_byte_upload));
+            $this->assertSame('rejected', $trailing_byte_upload['response']['status']);
+            $this->assertSame('invalid_request', $trailing_byte_upload['response']['reason']);
+            $this->assertStringContainsString(
+                'bytes after the closing boundary',
+                $trailing_byte_upload['response']['detail']
+            );
+        } finally {
+            $this->stopServer($server_process, $server_pipes);
+        }
     }
 
     public function testLogicExceptionUsesGenericServerFailureResponse(): void
@@ -365,9 +586,75 @@ final class PushEndpointsTest extends TestCase {
         $this->assertArrayNotHasKey('trace', $response['response']);
     }
 
+    public function testPushCreateRejectsInvalidServerDocumentRoot(): void
+    {
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->root . '/missing-document-root',
+        ]);
+
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => str_repeat('4', 32),
+        ], ['created']);
+
+        $this->assertSame('failed', $response['status'], (string) json_encode($response));
+        $this->assertSame('not_configured', $response['reason']);
+        $this->assertSame(503, $response['response']['http_code']);
+        $this->assertArrayNotHasKey('trace', $response['response']);
+    }
+
+    public function testPushCreateRejectsMissingServerDocumentRootWithoutFallingBackToWordPressRoot(): void
+    {
+        $this->writeDocrootConfiguration([]);
+        $push_session_id = str_repeat('a', 32);
+
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+
+        $this->assertSame('failed', $response['status'], (string) json_encode($response));
+        $this->assertSame('not_configured', $response['reason']);
+        $this->assertSame(
+            'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed null.',
+            $response['detail']
+        );
+        $this->assertSame(503, $response['response']['http_code']);
+        $this->assertDirectoryExists($this->wordpress_root);
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+    }
+
+    public function testExplicitManagedDocumentRootOverridesServerDocumentRoot(): void
+    {
+        $explicit_docroot = $this->root . '/explicit-document-root';
+        mkdir($explicit_docroot, 0700);
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->root . '/missing-server-document-root',
+            'docroot' => $explicit_docroot,
+        ]);
+        $push_session_id = str_repeat('5', 32);
+
+        $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+
+        $this->assertSame('complete', $response['status'], (string) json_encode($response));
+        $push_metadata = json_decode(
+            (string) file_get_contents($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame(realpath($explicit_docroot), base64_decode($push_metadata['docroot_b64'], true));
+        $this->assertNotSame(realpath($this->docroot), base64_decode($push_metadata['docroot_b64'], true));
+    }
+
     public function testDefaultPushDirectoryIsSiblingOfCanonicalDocumentRoot(): void
     {
         file_put_contents($this->reprint_configuration_path, '');
+        $document_root_link = $this->root . '/document-root-link';
+        symlink($this->docroot, $document_root_link);
+        $this->writeDocrootConfiguration([
+            'document_root' => $document_root_link,
+        ]);
         $push_session_id = str_repeat('7', 32);
         $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
@@ -379,11 +666,17 @@ final class PushEndpointsTest extends TestCase {
         $default_reprint_directory = dirname($canonical_docroot)
             . '/.reprint-' . substr(hash('sha256', $canonical_docroot), 0, 12);
         $this->assertDirectoryExists($default_reprint_directory . '/.reprint/push/' . $push_session_id);
+        $lexical_document_root_reprint_directory = dirname($document_root_link)
+            . '/.reprint-' . substr(hash('sha256', $document_root_link), 0, 12);
+        $this->assertDirectoryDoesNotExist($lexical_document_root_reprint_directory);
+        $wordpress_root_reprint_directory = $this->docroot
+            . '/.reprint-' . substr(hash('sha256', (string) realpath($this->wordpress_root)), 0, 12);
+        $this->assertDirectoryDoesNotExist($wordpress_root_reprint_directory);
     }
 
     public function testInvalidExcludedPathsConfigurationUsesNotConfiguredResponse(): void
     {
-        file_put_contents($this->excluded_paths_configuration_path, json_encode(['../bad']));
+        $this->writeExcludedPaths(['../bad']);
         $response = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
             'push_session_id' => str_repeat('8', 32),
         ], ['created']);
@@ -393,6 +686,107 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('Excluded path is unsafe: Li4vYmFk.', $response['detail']);
         $this->assertSame(503, $response['response']['http_code']);
         $this->assertArrayNotHasKey('trace', $response['response']);
+    }
+
+    public function testSymlinkedPluginLogicalPathIsExcludedFromPush(): void
+    {
+        $physical_plugin_directory = realpath(dirname(__DIR__) . '/reprint-exporter-wp');
+        $this->assertIsString($physical_plugin_directory);
+        $plugins_directory = $this->docroot . '/wp-content/plugins';
+        $plugins_directory_alias = $this->root . '/plugins-directory-alias';
+        $logical_plugin_path = 'wp-content/plugins/reprint';
+        $logical_plugin_directory = $this->docroot . '/' . $logical_plugin_path;
+        mkdir($plugins_directory, 0700, true);
+        symlink($plugins_directory, $plugins_directory_alias);
+        symlink($physical_plugin_directory, $logical_plugin_directory);
+        $this->assertNotSame($plugins_directory_alias, $plugins_directory);
+        $this->assertNotSame($plugins_directory_alias, realpath($this->docroot));
+        $canonical_plugins_directory = realpath($plugins_directory);
+        $this->assertIsString($canonical_plugins_directory);
+        $this->assertSame($canonical_plugins_directory, realpath($plugins_directory_alias));
+        $plugin_entrypoint_hash = hash_file('sha256', $physical_plugin_directory . '/index.php');
+        $this->assertIsString($plugin_entrypoint_hash);
+        $this->writeExcludedPaths([]);
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'wp_plugin_dir' => $plugins_directory_alias,
+            'plugin_basename' => 'reprint/index.php',
+            'maximum_part_bytes' => 1024,
+        ]);
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('6', 32);
+
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->assertSame([
+            'status' => 'created',
+            'push_session_id' => $push_session_id,
+            'max_part_bytes' => 1024,
+            'post_max_bytes' => self::POST_MAX_BYTES,
+            'excluded_paths_b64' => [base64_encode($logical_plugin_path)],
+            'http_code' => 200,
+        ], $create['response']);
+
+        $upload_plugin = $this->sendUploadRequest($client, $push_session_id, [[
+            'type' => 'directory',
+            'path' => $logical_plugin_path,
+            'payload' => '',
+        ]]);
+        $this->assertSame('failed', $upload_plugin['status'], (string) json_encode($upload_plugin));
+        $this->assertSame('invalid_request', $upload_plugin['reason']);
+        $this->assertStringContainsString('Excluded document-root-relative path', $upload_plugin['detail']);
+
+        $delete_plugin = $this->sendUploadRequest($client, $push_session_id, [[
+            'type' => 'delete-list',
+            'offset' => 0,
+            'complete' => true,
+            'payload' => $logical_plugin_path . "\0",
+        ]]);
+        $this->assertSame('failed', $delete_plugin['status'], (string) json_encode($delete_plugin));
+        $this->assertSame('invalid_request', $delete_plugin['reason']);
+        $this->assertStringContainsString('Excluded document-root-relative path', $delete_plugin['detail']);
+
+        $upload_plugin_parent = $this->sendUploadRequest($client, $push_session_id, [[
+            'type' => 'directory',
+            'path' => 'wp-content/plugins',
+            'payload' => '',
+        ]]);
+        $this->assertSame('failed', $upload_plugin_parent['status'], (string) json_encode($upload_plugin_parent));
+        $this->assertSame('invalid_request', $upload_plugin_parent['reason']);
+        $this->assertStringContainsString('Excluded document-root-relative path', $upload_plugin_parent['detail']);
+
+        $sibling_path = 'wp-content/plugins/other/file.php';
+        $upload_sibling = $this->sendUploadRequest($client, $push_session_id, [
+            [
+                'type' => 'file',
+                'path' => $sibling_path,
+                'total_bytes' => 4,
+                'offset' => 0,
+                'payload' => 'safe',
+            ],
+            [
+                'type' => 'delete-list',
+                'offset' => 0,
+                'complete' => true,
+                'payload' => '',
+            ],
+        ]);
+        $this->assertSame('complete', $upload_sibling['status'], (string) json_encode($upload_sibling));
+        $this->assertSame(2, $upload_sibling['parts_sent']);
+        do {
+            $commit = $client->control_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        } while ($commit['response']['send_next_request']);
+
+        $this->assertSame('safe', file_get_contents($this->docroot . '/' . $sibling_path));
+        $this->assertTrue(is_link($logical_plugin_directory));
+        $this->assertSame($physical_plugin_directory, readlink($logical_plugin_directory));
+        $this->assertSame($physical_plugin_directory, realpath($logical_plugin_directory));
+        $this->assertSame($plugin_entrypoint_hash, hash_file('sha256', $physical_plugin_directory . '/index.php'));
     }
 
     public function testPullEndpointDoesNotValidatePushConfiguration(): void
@@ -413,6 +807,34 @@ final class PushEndpointsTest extends TestCase {
         $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
         $this->assertArrayHasKey('ok', $response);
         $this->assertStringNotContainsString('Push endpoints require', $body);
+    }
+
+    public function testSuccessfulPushResponseSendsNoCacheHeaders(): void
+    {
+        $push_session_id = str_repeat('2', 32);
+        $create = $this->newClient(self::SECRET)->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $status = $this->sendControlRequestWithHeaders('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+        ], self::SECRET);
+
+        $this->assertSame(200, $status['http_code'], $status['body']);
+        $this->assertSame('accepted', json_decode($status['body'], true, 512, JSON_THROW_ON_ERROR)['status']);
+        $this->assertNoCacheHeaders($status['headers']);
+    }
+
+    public function testPushAuthenticationFailureSendsNoCacheHeaders(): void
+    {
+        $authentication_failure = $this->sendControlRequestWithHeaders('POST', 'push_create', [
+            'push_session_id' => str_repeat('3', 32),
+        ], 'incorrect-secret');
+
+        $this->assertSame(403, $authentication_failure['http_code'], $authentication_failure['body']);
+        $this->assertSame('auth_failed', json_decode($authentication_failure['body'], true, 512, JSON_THROW_ON_ERROR)['reason']);
+        $this->assertNoCacheHeaders($authentication_failure['headers']);
     }
 
     public function testEndpointGuardsRejectWrongMethodContentTypeAndAuthentication(): void
@@ -500,10 +922,186 @@ final class PushEndpointsTest extends TestCase {
         $this->assertStringContainsString('multipart body ended before', $response['detail']);
     }
 
-    private function newClient(string $secret): MultipartPushStreamClient
+    /**
+     * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
+     */
+    private function sendChunkedUploadRequest(
+        string $base_url,
+        string $push_session_id,
+        string $boundary,
+        string $multipart_body,
+        string $trailing_bytes = ''
+    ): array {
+        $request_url = $base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $url = parse_url($request_url);
+        $this->assertIsArray($url);
+        $this->assertSame('http', $url['scheme'] ?? null);
+        $host = (string) ( $url['host'] ?? '' );
+        $port = (int) ( $url['port'] ?? 0 );
+        $request_target = (string) ( $url['path'] ?? '/' ) . '?' . (string) ( $url['query'] ?? '' );
+        $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $request_url);
+        $request_headers = '';
+        foreach ($authentication_headers as $name => $value) {
+            $request_headers .= $name . ': ' . $value . "\r\n";
+        }
+        $socket = stream_socket_client(
+            'tcp://' . $host . ':' . $port,
+            $connect_error,
+            $connect_error_message,
+            3
+        );
+        $this->assertIsResource($socket, $connect_error_message);
+        stream_set_timeout($socket, 5);
+        $request_head = 'POST ' . $request_target . " HTTP/1.1\r\n"
+            . 'Host: ' . $host . ':' . $port . "\r\n"
+            . "Transfer-Encoding: chunked\r\n"
+            . 'Content-Type: multipart/mixed; boundary=' . $boundary . "\r\n"
+            . "Connection: close\r\n"
+            . $request_headers
+            . "\r\n";
+        $chunked_body = dechex(strlen($multipart_body)) . "\r\n"
+            . $multipart_body . "\r\n";
+        if ($trailing_bytes !== '') {
+            $chunked_body .= dechex(strlen($trailing_bytes)) . "\r\n"
+                . $trailing_bytes . "\r\n";
+        }
+        $request = $request_head . $chunked_body . "0\r\n\r\n";
+        $request_bytes = strlen($request);
+        $written_bytes = 0;
+        while ($written_bytes < $request_bytes) {
+            $written = fwrite($socket, substr($request, $written_bytes));
+            $this->assertNotFalse($written);
+            $this->assertGreaterThan(0, $written);
+            $written_bytes += $written;
+        }
+        $raw_response = stream_get_contents($socket);
+        fclose($socket);
+        $this->assertIsString($raw_response);
+        $status_matches = [];
+        $this->assertSame(1, preg_match('/^HTTP\/1\.[01] ([0-9]{3}) /', $raw_response, $status_matches));
+        $body_offset = strrpos($raw_response, "\r\n\r\n");
+        $this->assertIsInt($body_offset);
+        $response = json_decode(
+            substr($raw_response, $body_offset + 4),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertIsArray($response);
+
+        return [
+            'http_code' => (int) $status_matches[1],
+            'response' => $response,
+        ];
+    }
+
+    /** @return resource */
+    private function startLockProcess(string $lock_path) {
+        $ready_path = $this->root . '/lock-ready-' . bin2hex(random_bytes(4));
+        $script = '$lock = fopen($argv[1], "c+b");'
+            . 'if ($lock === false || !flock($lock, LOCK_EX | LOCK_NB)) { exit(2); }'
+            . 'file_put_contents($argv[2], "ready");'
+            . 'sleep(30);';
+        $process = proc_open(
+            [PHP_BINARY, '-r', $script, $lock_path, $ready_path],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $deadline = microtime(true) + 10;
+        while (!is_file($ready_path) && microtime(true) < $deadline) {
+            usleep(1000);
+        }
+        $this->assertFileExists($ready_path);
+        unlink($ready_path);
+        return $process;
+    }
+
+    /** @param resource $process */
+    private function stopLockProcess($process): void
+    {
+        @proc_terminate($process, 9);
+        proc_close($process);
+    }
+
+    /** @return array{0:resource,1:array<int,resource>,2:string} */
+    private function startServer(int $post_max_bytes): array
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        fclose($listener);
+        $router = realpath(__DIR__ . '/fixtures/push-endpoint-router.php');
+        $this->assertNotFalse($router);
+        $environment = array_merge($_ENV, [
+            'REPRINT_PUSH_TEST_SECRET' => self::SECRET,
+            'REPRINT_PUSH_TEST_ABSPATH' => $this->wordpress_root,
+            'REPRINT_PUSH_TEST_DOCROOT_CONFIG' => $this->docroot_configuration_path,
+            'REPRINT_PUSH_TEST_DIRECTORY_CONFIG' => $this->reprint_configuration_path,
+            'REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG' => $this->excluded_paths_configuration_path,
+        ]);
+        $server_log_path = $this->root . '/server-' . $post_max_bytes . '-' . bin2hex(random_bytes(4)) . '.log';
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['file', $server_log_path, 'a'],
+            2 => ['file', $server_log_path, 'a'],
+        ];
+        // PHP enforces post_max_size before the router can disable display_errors,
+        // so disable it at startup to exercise the application-controlled JSON
+        // 413 path under the documented deployment configuration. PHP or a web
+        // server may otherwise reject a request before the endpoint can respond.
+        // Send process output to a file so repeated suppressed filesystem
+        // notices cannot fill a pipe and block the server response.
+        $process = proc_open(
+            [PHP_BINARY, '-d', 'display_errors=0', '-d', 'post_max_size=' . $post_max_bytes, '-S', $address, $router],
+            $descriptors,
+            $pipes,
+            dirname($router),
+            $environment
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        unset($pipes[0]);
+        $deadline = microtime(true) + 5;
+        do {
+            $connection = @stream_socket_client('tcp://' . $address, $connect_error, $connect_error_message, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                return [$process, $pipes, 'http://' . $address . '/?reprint-api=1'];
+            }
+            usleep(20000);
+        } while (microtime(true) < $deadline);
+        $server_log = file_get_contents($server_log_path);
+        $this->stopServer($process, $pipes);
+        $this->fail('Push endpoint test server did not start: ' . $server_log);
+    }
+
+    /**
+     * @param resource|null $process PHP built-in server process.
+     * @param array<int,resource> $pipes Open process pipes.
+     */
+    private function stopServer($process, array $pipes): void
+    {
+        if (!is_resource($process)) {
+            return;
+        }
+        proc_terminate($process);
+        foreach ($pipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+        proc_close($process);
+    }
+
+    private function newClient(string $secret, ?string $base_url = null): MultipartPushStreamClient
     {
         return new MultipartPushStreamClient([
-            'base_url' => $this->base_url,
+            'base_url' => $base_url ?? $this->base_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client($secret),
             'chunk_bytes' => 4,
@@ -511,6 +1109,93 @@ final class PushEndpointsTest extends TestCase {
             'stall_timeout' => 3,
             'response_timeout' => 5,
         ]);
+    }
+
+    /** @param array<string,mixed> $configuration Trusted router configuration. */
+    private function writeDocrootConfiguration(array $configuration): void
+    {
+        file_put_contents(
+            $this->docroot_configuration_path,
+            json_encode($configuration, JSON_THROW_ON_ERROR)
+        );
+    }
+
+    /** @param list<string> $excluded_paths Raw document-root-relative paths. */
+    private function writeExcludedPaths(array $excluded_paths): void
+    {
+        file_put_contents(
+            $this->excluded_paths_configuration_path,
+            json_encode(array_map('base64_encode', $excluded_paths), JSON_THROW_ON_ERROR)
+        );
+    }
+
+    /**
+     * @param list<array<string,mixed>> $parts Multipart parts sent in one request.
+     * @return array<string,mixed> Classified client result.
+     */
+    private function sendUploadRequest(MultipartPushStreamClient $client, string $push_session_id, array $parts): array
+    {
+        $this->assertTrue($client->start_upload_request($push_session_id));
+        foreach ($parts as $part) {
+            $client->send_part($part);
+        }
+        return $client->finish_request();
+    }
+
+    /**
+     * @param array<string,string> $parameters Signed query parameters.
+     * @return array{http_code:int,headers:array<string,list<string>>,body:string} Raw HTTP result.
+     */
+    private function sendControlRequestWithHeaders(string $method, string $endpoint, array $parameters, string $secret): array
+    {
+        $query = http_build_query(
+            array_merge(['endpoint' => $endpoint], $parameters),
+            '',
+            '&',
+            PHP_QUERY_RFC3986
+        );
+        $url = $this->base_url . '&' . $query;
+        $authentication_headers = ( new Site_Export_HMAC_Client($secret) )->get_envelope_auth_headers($method, $url);
+        $request_headers = [];
+        foreach ($authentication_headers as $name => $value) {
+            $request_headers[] = $name . ': ' . $value;
+        }
+        $response_headers = [];
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_HTTPHEADER => $request_headers,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADERFUNCTION => static function ($curl_handle, string $line) use (&$response_headers): int {
+                $separator = strpos($line, ':');
+                if ($separator !== false) {
+                    $name = strtolower(trim(substr($line, 0, $separator)));
+                    $response_headers[$name][] = trim(substr($line, $separator + 1));
+                }
+                return strlen($line);
+            },
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $http_code = (int) curl_getinfo($handle, CURLINFO_HTTP_CODE);
+        curl_close($handle);
+
+        return [
+            'http_code' => $http_code,
+            'headers' => $response_headers,
+            'body' => $body,
+        ];
+    }
+
+    /** @param array<string,list<string>> $headers Response headers by lowercase name. */
+    private function assertNoCacheHeaders(array $headers): void
+    {
+        $this->assertSame(
+            ['no-store, no-cache, must-revalidate, max-age=0'],
+            $headers['cache-control'] ?? []
+        );
+        $this->assertSame(['no-cache'], $headers['pragma'] ?? []);
+        $this->assertSame(['0'], $headers['expires'] ?? []);
     }
 
     private function removeTree(string $path): void

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -288,7 +288,7 @@ final class PushSessionTest extends TestCase {
                     ],
                     'body' => 'x',
                 ]]);
-                $this->fail('Unsafe path was work: ' . base64_encode($path));
+                $this->fail('A reserved or excluded path was accepted as work: ' . base64_encode($path));
             } catch (InvalidArgumentException $exception) {
                 $this->assertNotSame('', $exception->getMessage());
             }
@@ -866,6 +866,23 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testRepeatedCreateRejectsExcludedPathConfigurationDriftImmediately(): void {
+        $push_session = $this->push_session('45674567456745674567456745674568');
+
+        try {
+            Site_Export_Push_Session::create(
+                $this->reprint_directory,
+                $this->docroot,
+                ['wp-content/plugins/reprint', 'wp-config.php'],
+                $push_session->get_push_session_id()
+            );
+            $this->fail('Repeated create accepted different immutable excluded paths.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('corrupted_push_state', $exception->get_error_code());
+            $this->assertStringContainsString('does not match', $exception->getMessage());
+        }
+    }
+
     public function testCompletedTypeChangeDiscardsInFlightFileDataAtTheSamePath(): void {
         foreach (['directory', 'symlink'] as $index => $type) {
             $push_session = $this->push_session(sprintf('%032x', 500 + $index));
@@ -1374,11 +1391,11 @@ final class PushSessionTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_session->get_push_directory());
     }
 
-    public function testLifecycleLockContentionLeavesTheLivePushDirectoryUntouched(): void {
+    public function testCreateRemoveLockContentionLeavesTheLivePushDirectoryUntouched(): void {
         $push_session = $this->push_session('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd');
         $push_directory = $push_session->get_push_directory();
-        $lifecycle_lock_path = dirname($push_directory) . '/push-create.lock';
-        $lock_process = $this->start_lock_process($lifecycle_lock_path);
+        $create_remove_lock_path = dirname($push_directory) . '/push-create.lock';
+        $lock_process = $this->start_lock_process($create_remove_lock_path);
 
         $failure = null;
         try {
@@ -1395,7 +1412,7 @@ final class PushSessionTest extends TestCase {
         $this->assertFileDoesNotExist(dirname($push_directory) . '/.removing-' . $push_session->get_push_session_id());
     }
 
-    public function testRemovalTombstoneBlocksCreateAndConvergesUnderTheLifecycleLock(): void {
+    public function testRemovalTombstoneBlocksCreateAndConvergesUnderTheCreateRemoveLock(): void {
         $push_session_id = 'dededededededededededededededede';
         $push_session = $this->push_session($push_session_id);
         $parts = [];
@@ -1411,8 +1428,8 @@ final class PushSessionTest extends TestCase {
         $this->push_parts($push_session, $parts);
 
         $push_directory = $push_session->get_push_directory();
-        $push_parent_directory = dirname($push_directory);
-        $tombstone = $push_parent_directory . '/.removing-' . $push_session_id;
+        $push_sessions_directory = dirname($push_directory);
+        $tombstone = $push_sessions_directory . '/.removing-' . $push_session_id;
         $this->assertFalse($push_session->remove_push_directory());
         $this->assertDirectoryDoesNotExist($push_directory);
         $this->assertDirectoryExists($tombstone);
@@ -1425,7 +1442,7 @@ final class PushSessionTest extends TestCase {
         }
         $this->assertDirectoryDoesNotExist($push_directory);
 
-        $lock_process = $this->start_lock_process($push_parent_directory . '/push-create.lock');
+        $lock_process = $this->start_lock_process($push_sessions_directory . '/push-create.lock');
         $failure = null;
         try {
             $push_session->remove_push_directory();

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -295,6 +295,19 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testCommitTraversesAncestorsOfAnExcludedPathToInstallItsSibling(): void {
+        $excluded_directory = $this->docroot . '/wp-content/plugins/reprint';
+        mkdir($excluded_directory, 0700, true);
+        file_put_contents($excluded_directory . '/sentinel.php', 'preserved');
+        $push_session = $this->push_session('29292929292929292929292929292929');
+
+        $this->push_file($push_session, 'wp-content/plugins/other/file.php', 'installed');
+        $this->commit_all($push_session);
+
+        $this->assertSame('installed', file_get_contents($this->docroot . '/wp-content/plugins/other/file.php'));
+        $this->assertSame('preserved', file_get_contents($excluded_directory . '/sentinel.php'));
+    }
+
     public function testReprintDirectoryBelowDocumentRootIsExcludedAndRootCanBeReopened(): void {
         $reprint_directory = $this->docroot . '/private-work';
         $push_session = Site_Export_Push_Session::create($reprint_directory, $this->docroot, [], str_repeat('a', 32));
@@ -561,6 +574,90 @@ final class PushSessionTest extends TestCase {
         );
         $this->assertSame('receiving_work', $reopened->get_status()['phase']);
         $this->assertNotSame('complete', $reopened->get_status('truncated.bin')['path']['state']);
+    }
+
+    public function testMultipartCloseAtTheInputFragmentLimitReadsThroughEof(): void {
+        $push_session = $this->push_session('78787878787878787878787878787878');
+        [$boundary, $body] = $this->multipart_body_ending_at_input_fragment_limit();
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body);
+        rewind($input);
+
+        $push_session->accept_upload(
+            $input,
+            new Site_Export_Multipart_Processor($boundary),
+            PHP_INT_MAX,
+            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+        );
+        try {
+            $this->assertTrue($push_session->next_change());
+            $this->assertFalse($push_session->next_change());
+        } finally {
+            $push_session->finish_upload();
+            fclose($input);
+        }
+    }
+
+    public function testByteAfterMultipartCloseExceedsTheRequestLimit(): void {
+        $push_session = $this->push_session('79797979797979797979797979797979');
+        [$boundary, $body] = $this->multipart_body_ending_at_input_fragment_limit();
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body . 'x');
+        rewind($input);
+
+        $push_session->accept_upload(
+            $input,
+            new Site_Export_Multipart_Processor($boundary),
+            PHP_INT_MAX,
+            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+        );
+        try {
+            $this->assertTrue($push_session->next_change());
+            try {
+                $push_session->next_change();
+                $this->fail('A byte beyond the decoded request-body limit was ignored after the closing boundary.');
+            } catch (Site_Export_Push_Exception $exception) {
+                $this->assertSame('request_too_large', $exception->get_error_code());
+                $this->assertSame(
+                    ['observed_request_body_bytes' => Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1],
+                    $exception->get_context()
+                );
+                $this->assertStringContainsString(
+                    (string) ( Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1 ) . ' bytes',
+                    $exception->getMessage()
+                );
+            }
+        } finally {
+            $push_session->finish_upload();
+            fclose($input);
+        }
+    }
+
+    public function testByteAfterMultipartCloseIsInvalidWithinTheRequestLimit(): void {
+        $push_session = $this->push_session('7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a');
+        [$boundary, $body] = $this->multipart_body_ending_at_input_fragment_limit();
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body . 'x');
+        rewind($input);
+
+        $push_session->accept_upload(
+            $input,
+            new Site_Export_Multipart_Processor($boundary),
+            PHP_INT_MAX,
+            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1
+        );
+        try {
+            $this->assertTrue($push_session->next_change());
+            try {
+                $push_session->next_change();
+                $this->fail('A byte after the closing multipart boundary was accepted.');
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('after the closing boundary', $exception->getMessage());
+            }
+        } finally {
+            $push_session->finish_upload();
+            fclose($input);
+        }
     }
 
     public function testMalformedMultipartFieldsAreRejectedBeforeWork(): void {
@@ -1277,6 +1374,83 @@ final class PushSessionTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_session->get_push_directory());
     }
 
+    public function testLifecycleLockContentionLeavesTheLivePushDirectoryUntouched(): void {
+        $push_session = $this->push_session('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd');
+        $push_directory = $push_session->get_push_directory();
+        $lifecycle_lock_path = dirname($push_directory) . '/push-create.lock';
+        $lock_process = $this->start_lock_process($lifecycle_lock_path);
+
+        $failure = null;
+        try {
+            $push_session->remove_push_directory();
+        } catch (Site_Export_Push_Exception $exception) {
+            $failure = $exception;
+        } finally {
+            $this->stop_lock_process($lock_process);
+        }
+
+        $this->assertInstanceOf(Site_Export_Push_Exception::class, $failure);
+        $this->assertSame('lock_acquisition_failure', $failure->get_error_code());
+        $this->assertDirectoryExists($push_directory);
+        $this->assertFileDoesNotExist(dirname($push_directory) . '/.removing-' . $push_session->get_push_session_id());
+    }
+
+    public function testRemovalTombstoneBlocksCreateAndConvergesUnderTheLifecycleLock(): void {
+        $push_session_id = 'dededededededededededededededede';
+        $push_session = $this->push_session($push_session_id);
+        $parts = [];
+        for ($index = 0; $index < 300; ++$index) {
+            $parts[] = [
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('remove-entry-' . $index),
+                ],
+                'body' => '',
+            ];
+        }
+        $this->push_parts($push_session, $parts);
+
+        $push_directory = $push_session->get_push_directory();
+        $push_parent_directory = dirname($push_directory);
+        $tombstone = $push_parent_directory . '/.removing-' . $push_session_id;
+        $this->assertFalse($push_session->remove_push_directory());
+        $this->assertDirectoryDoesNotExist($push_directory);
+        $this->assertDirectoryExists($tombstone);
+
+        try {
+            $this->push_session($push_session_id);
+            $this->fail('A push session was recreated while its removal tombstone remained.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
+        }
+        $this->assertDirectoryDoesNotExist($push_directory);
+
+        $lock_process = $this->start_lock_process($push_parent_directory . '/push-create.lock');
+        $failure = null;
+        try {
+            $push_session->remove_push_directory();
+        } catch (Site_Export_Push_Exception $exception) {
+            $failure = $exception;
+        } finally {
+            $this->stop_lock_process($lock_process);
+        }
+        $this->assertInstanceOf(Site_Export_Push_Exception::class, $failure);
+        $this->assertSame('lock_acquisition_failure', $failure->get_error_code());
+        $this->assertDirectoryExists($tombstone);
+
+        $removal_calls = 0;
+        do {
+            $removed = $push_session->remove_push_directory();
+            ++$removal_calls;
+            $this->assertLessThan(10, $removal_calls, 'Bounded removal did not converge.');
+        } while (!$removed);
+        $this->assertTrue($push_session->remove_push_directory());
+        $this->assertDirectoryDoesNotExist($tombstone);
+
+        $recreated = $this->push_session($push_session_id);
+        $this->assertSame('receiving_work', $recreated->get_status()['phase']);
+    }
+
     /**
      * Runs an upload while one named filesystem call fails in production code.
      *
@@ -1388,6 +1562,61 @@ final class PushSessionTest extends TestCase {
             ['wp-content/plugins/reprint'],
             $id
         );
+    }
+
+    /** @return array{string,string} */
+    private function multipart_body_ending_at_input_fragment_limit(): array {
+        $boundary = 'fragment-limit-boundary';
+        $path = 'fragment-limit.bin';
+        $suffix = "\r\n--" . $boundary . "--\r\n";
+        $payload_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        do {
+            $previous_payload_bytes = $payload_bytes;
+            $prefix = '--' . $boundary . "\r\n"
+                . "X-Chunk-Type: file\r\n"
+                . 'X-File-Path: ' . base64_encode($path) . "\r\n"
+                . 'X-File-Size: ' . $payload_bytes . "\r\n"
+                . "X-Chunk-Offset: 0\r\n"
+                . 'Content-Length: ' . $payload_bytes . "\r\n\r\n";
+            $payload_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+                - strlen($prefix)
+                - strlen($suffix);
+        } while ($payload_bytes !== $previous_payload_bytes);
+
+        $body = $prefix . str_repeat('x', $payload_bytes) . $suffix;
+        $this->assertSame(Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES, strlen($body));
+        return [$boundary, $body];
+    }
+
+    /** @return resource */
+    private function start_lock_process(string $lock_path) {
+        $ready_path = $this->root . '/lock-ready-' . bin2hex(random_bytes(4));
+        $script = '$lock = fopen($argv[1], "c+b");'
+            . 'if ($lock === false || !flock($lock, LOCK_EX | LOCK_NB)) { exit(2); }'
+            . 'file_put_contents($argv[2], "ready");'
+            . 'sleep(30);';
+        $process = proc_open(
+            [PHP_BINARY, '-r', $script, $lock_path, $ready_path],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $deadline = microtime(true) + 10;
+        while (!is_file($ready_path) && microtime(true) < $deadline) {
+            usleep(1000);
+        }
+        $this->assertFileExists($ready_path);
+        unlink($ready_path);
+        return $process;
+    }
+
+    /** @param resource $process */
+    private function stop_lock_process($process): void {
+        @proc_terminate($process, 9);
+        proc_close($process);
     }
 
     private function push_file(Site_Export_Push_Session $push_session, string $path, string $contents): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,10 @@ if (!class_exists('Site_Export_Push_Exception', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-exception.php';
 }
 
+if (!class_exists('Site_Export_Push_Endpoints', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-endpoints.php';
+}
+
 if (!class_exists('Site_Export_Push_Session', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-session.php';
 }

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -5,10 +5,36 @@
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 
-define('ABSPATH', rtrim( (string) getenv('REPRINT_PUSH_TEST_DOCROOT'), '/\\') . '/');
+$reprint_push_test_docroot_configuration = json_decode(
+    (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_DOCROOT_CONFIG') ),
+    true
+);
+if (!is_array($reprint_push_test_docroot_configuration)) {
+    $reprint_push_test_docroot_configuration = [];
+}
+
+define('ABSPATH', rtrim( (string) getenv('REPRINT_PUSH_TEST_ABSPATH'), '/\\') . '/');
+if (is_string($reprint_push_test_docroot_configuration['document_root'] ?? null)) {
+    $_SERVER['DOCUMENT_ROOT'] = $reprint_push_test_docroot_configuration['document_root'];
+} else {
+    unset($_SERVER['DOCUMENT_ROOT']);
+}
+if (is_string($reprint_push_test_docroot_configuration['wp_plugin_dir'] ?? null)) {
+    define('WP_PLUGIN_DIR', $reprint_push_test_docroot_configuration['wp_plugin_dir']);
+}
 
 function plugin_dir_path(string $file): string {
     return $file === '' ? '' : dirname(__DIR__, 2) . '/reprint-exporter-wp/';
+}
+
+function plugin_basename(string $file): string {
+    global $reprint_push_test_docroot_configuration;
+
+    $registered_plugin_basename = $reprint_push_test_docroot_configuration['plugin_basename'] ?? null;
+    if (defined('SITE_EXPORT_PLUGIN_DIR') && $file === SITE_EXPORT_PLUGIN_DIR . 'index.php' && is_string($registered_plugin_basename)) {
+        return $registered_plugin_basename;
+    }
+    return basename($file);
 }
 
 function get_option(string $name, $fallback = false) {
@@ -20,14 +46,29 @@ function get_option(string $name, $fallback = false) {
 
 require_once dirname(__DIR__, 2) . '/reprint-exporter-wp/lib.php';
 
+$reprint_push_test_excluded_paths_b64 = json_decode(
+    (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG') ),
+    true
+);
 $reprint_push_test_options = [
-    'excluded_paths' => json_decode(
-        (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG') ),
-        true
-    ),
+    'excluded_paths' => is_array($reprint_push_test_excluded_paths_b64)
+        ? array_map(
+            static function ($encoded_path) {
+                return is_string($encoded_path) ? base64_decode($encoded_path, true) : $encoded_path;
+            },
+            $reprint_push_test_excluded_paths_b64
+        )
+        : $reprint_push_test_excluded_paths_b64,
     'maximum_part_bytes' => 4,
     'maximum_commit_entries' => 1,
 ];
+$reprint_push_test_docroot = $reprint_push_test_docroot_configuration['docroot'] ?? null;
+if (is_string($reprint_push_test_docroot)) {
+    $reprint_push_test_options['docroot'] = $reprint_push_test_docroot;
+}
+if (isset($reprint_push_test_docroot_configuration['maximum_part_bytes'])) {
+    $reprint_push_test_options['maximum_part_bytes'] = $reprint_push_test_docroot_configuration['maximum_part_bytes'];
+}
 $reprint_push_test_directory = trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_DIRECTORY_CONFIG') ) );
 if ($reprint_push_test_directory !== '') {
     $reprint_push_test_options['reprint_directory'] = $reprint_push_test_directory;

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -1,7 +1,8 @@
 <?php
 
-// This fixture supplies the WordPress values the production plugin router
-// reads; request authentication and endpoint dispatch remain production code.
+// This fixture supplies the WordPress functions and values the production
+// plugin entry point reads. API routing, authentication, and dispatch all run
+// through index.php and its site_export_api_options filter.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 
@@ -44,8 +45,6 @@ function get_option(string $name, $fallback = false) {
     return $fallback;
 }
 
-require_once dirname(__DIR__, 2) . '/reprint-exporter-wp/lib.php';
-
 $reprint_push_test_excluded_paths_b64 = json_decode(
     (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG') ),
     true
@@ -73,4 +72,14 @@ $reprint_push_test_directory = trim( (string) file_get_contents( (string) getenv
 if ($reprint_push_test_directory !== '') {
     $reprint_push_test_options['reprint_directory'] = $reprint_push_test_directory;
 }
-_site_export_handle_api_request($reprint_push_test_options);
+
+function apply_filters(string $hook_name, $value) {
+    global $reprint_push_test_options;
+
+    if ($hook_name === 'site_export_api_options') {
+        return $reprint_push_test_options;
+    }
+    return $value;
+}
+
+require_once dirname(__DIR__, 2) . '/reprint-exporter-wp/index.php';

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -1,0 +1,35 @@
+<?php
+
+// This fixture supplies the WordPress values the production plugin router
+// reads; request authentication and endpoint dispatch remain production code.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+
+define('ABSPATH', rtrim( (string) getenv('REPRINT_PUSH_TEST_DOCROOT'), '/\\') . '/');
+
+function plugin_dir_path(string $file): string {
+    return $file === '' ? '' : dirname(__DIR__, 2) . '/reprint-exporter-wp/';
+}
+
+function get_option(string $name, $fallback = false) {
+    if ($name === 'site_export_secret') {
+        return (string) getenv('REPRINT_PUSH_TEST_SECRET');
+    }
+    return $fallback;
+}
+
+require_once dirname(__DIR__, 2) . '/reprint-exporter-wp/lib.php';
+
+$reprint_push_test_options = [
+    'excluded_paths' => json_decode(
+        (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG') ),
+        true
+    ),
+    'maximum_part_bytes' => 4,
+    'maximum_commit_entries' => 1,
+];
+$reprint_push_test_directory = trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_DIRECTORY_CONFIG') ) );
+if ($reprint_push_test_directory !== '') {
+    $reprint_push_test_options['reprint_directory'] = $reprint_push_test_directory;
+}
+_site_export_handle_api_request($reprint_push_test_options);

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -31,6 +31,7 @@
             <file>FileIndexSkipDefaultsTest.php</file>
             <file>HmacServerTest.php</file>
             <file>MultipartProcessorTest.php</file>
+            <file>PushEndpointsTest.php</file>
             <file>SiteExportSecretTest.php</file>
             <file>PushSessionTest.php</file>
         </testsuite>


### PR DESCRIPTION
Authenticated push can write a site into the hosting platform's real document root without buffering uploads. `ABSPATH` may point at shared WordPress core, so it is not a safe default for the files the site actually serves.

The exporter adds authenticated create, upload, status, commit, and bounded remove operations. Upload passes `php://input` directly to the multipart processor and reads one bounded fragment at a time. Repeated create validates the existing session before returning success. Each HTTP endpoint now names every public success and failure field instead of forwarding session return arrays or exception context. The receiver preserves configured exclusions and uses `push-create.lock` to coordinate every create and bounded remove step; an unfinished removal tombstone continues to block recreation between steps.

The WordPress entry point accepts the complete trusted options array through the early `site_export_api_options` filter. A hosting platform can set `docroot`, private storage, exclusions, request budgets, and authentication there; a direct `lib.php` embedder passes the same array to `_site_export_handle_api_request()`. `DOCUMENT_ROOT` remains the push default, while `ABSPATH` remains the pull default. The multipart parser also reads through the closing boundary to EOF, rejects trailing data, and reports when that byte instead crosses the decoded request-body limit.

Push hosts must set `display_errors=Off` at PHP startup; PHP or the web server may otherwise emit a non-protocol response before exporter code runs. A bare HTTP 413 is still accepted by the sender and lowers its learned request ceiling. This receiver must not ship without the backend write-authorization gate in #364.

Verified with the focused 116-test push/HTTP suite, PHPStan, PHP 7.2+ compatibility checks for the changed production files, and `git diff --check`.
