### PR TITLE
[Push] Resume local-file pushes from receiver-confirmed cursors

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/push-commit-language",
+            "version": "dev-adamziel/authenticated-push-endpoints",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "6a5cbcf2ac9d0b34789819f01ccb00033b67581a"
+                "reference": "2050e07227a82c058c6267c5e8b3e77d0cd4dbdc"
             },
             "require": {
                 "php": ">=7.2",
@@ -386,6 +386,7 @@
                     "src/class-http-server.php",
                     "src/class-multipart-processor.php",
                     "src/class-push-exception.php",
+                    "src/class-push-endpoints.php",
                     "src/class-push-session.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -102,6 +102,40 @@ durable delete queue.
 more cleanup remains and must be retried. A push with an unfinished commit is
 not removable; its next commit request resumes the durable cursor instead.
 
+## Push HTTP operations
+
+The production exporter router exposes five authenticated operations. Control
+and upload requests use the envelope signature described above, so
+`push_upload` passes `php://input` directly to the multipart processor instead
+of reading the complete request for authentication.
+
+- `POST push_create` creates or reopens the caller's 32-character lowercase
+  hexadecimal `push_session_id`. It returns
+  `{status:"created",push_session_id:string,max_part_bytes:int,post_max_bytes:int|null}`.
+  The two limits describe different dimensions: one part and the complete
+  decoded request body.
+- `POST push_upload` accepts `multipart/mixed`. It returns
+  `{status:"accepted",push_session_id:string,changes_accepted:int,last_change:change|null}`,
+  where `change` is exactly the `get_current_change()` file, directory,
+  symlink, or delete-list union. Only the latest change is retained for the
+  response; request memory does not grow with the number of parts.
+- `GET push_status` accepts an optional base64 `path_b64`. It returns
+  `status:"accepted"` together with the exact `get_status()` object: push
+  session phase, work-delete cursor and close bit, and the requested path's
+  missing, partial, or complete receiver-confirmed state.
+- `POST push_commit` performs a server-bounded call to `commit()`. It returns
+  `{status:"accepted",push_session_id:string,phase:"deleting_files"|"installing_files"|"complete",send_next_request:bool,entries_processed:int}`.
+  The sender repeats it while `send_next_request` is true.
+- `POST push_remove` performs one bounded remove step. It returns
+  `{status:"accepted",push_session_id:string,removed:bool}`. The sender repeats
+  it while `removed` is false.
+
+The WordPress plugin stores push work in a document-root-specific private
+directory beside `ABSPATH` unless its embedder supplies `reprint_directory`.
+It always excludes its own plugin directory from push. An embedding router
+must likewise choose its reprint directory and excluded paths as server
+configuration; request parameters cannot select either one.
+
 ## Where reprint stores its own data on the remote
 
 The remote is configured with one storage path for everything reprint keeps:

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -13,7 +13,7 @@ the end maps it to a PR stack.
 2. It shows a summary of local uploads and deletions. The user confirms that
    local should win for those paths and rows.
 3. It transfers everything into a private push directory on the remote — file bytes,
-   a deletion manifest, and (phase two) the database diff. The transfer is
+   the work-delete stream, and (phase two) the database diff. The transfer is
    resumable at byte granularity.
 4. It drives the commit step with repeated commands until done. The remote
    moves work files into place, executes deletions, and commits the database
@@ -136,6 +136,55 @@ It always excludes its own plugin directory from push. An embedding router
 must likewise choose its reprint directory and excluded paths as server
 configuration; request parameters cannot select either one.
 
+## Local files sender
+
+`PushFilesSender` drives those operations from one local `PushJournal`. An
+active push keeps these files under `<state-dir>/push/<site>/`:
+
+```text
+sender-index.jsonl          stable local index selected when the push began
+local-paths-to-push.jsonl   positive-work paths from that index
+local-paths-to-delete.jsonl deleted paths from that index
+work-deletes                raw NUL-delimited work-delete stream
+sender.json                 atomic sender checkpoint
+```
+
+The checkpoint names the push session, the next request phase, the selected
+positive-work path, the last source token confirmed by an upload response,
+receiver-confirmed file and work-delete cursors, bounded retry count, target
+part limit, and learned request-body
+sizing state. Before any positive-work request can become
+ambiguous, the durable phase tells a reopened sender to query `push_status` for
+that same path. Local counters never advance the checkpoint merely because
+bytes reached the network. A work-delete upload is likewise reconciled against
+`work_deletes_bytes`, and commit and remove requests are repeated until their
+durable target operation reports completion.
+
+The source token is its current type, size, and ctime. A changed token restarts
+the same in-flight work at offset zero, so new-version bytes are never appended
+behind an old-version prefix. A vanished selected path or a receiver work-delete
+cursor beyond the stable local stream abandons the upload-only push session by
+repeating bounded remove calls, then tells the caller to regenerate its local
+index. The caller must also regenerate that index before a later push. The
+stable `sender-index.jsonl` becomes the local baseline only after commit
+completes. A freshly generated later index selects any path whose size, ctime,
+or type now differs from that stable evidence.
+
+One upload request contains as many bounded chunks and work values as its
+decoded entity-body budget permits. The sender holds only one payload string,
+derives each part Content-Length from the bytes actually read, closes work
+deletes explicitly, and never selects another positive-work path until the
+current one is complete. Recoverable target contention, offset gaps, and
+ambiguous transport failures are retried at a fixed bounded count; exhaustion
+returns a terminal failure rather than a final retry.
+
+The token has one honest timestamp-resolution gap: a same-size edit that keeps
+the same ctime second is not detected by the token, and remains invisible when
+a freshly generated index contains the same size/ctime/type evidence. Other
+drift remains detectable by the next local-index diff. Push streaming requires
+PHP 8.1 or newer because older PHP cURL bindings can truncate a paused upload;
+pull remains PHP 7.4-compatible.
+
 ## Where reprint stores its own data on the remote
 
 The remote is configured with one storage path for everything reprint keeps:
@@ -238,14 +287,14 @@ Files first, database second, each PR small and stacked in this order:
 5. **Push journal and local diff** — per-site local baselines, capture and
    overwrite logic, local change and deletion detection.
 6. **Push stream endpoint** — the store's HTTP surface plus a sender that
-   streams framed chunks for many files through one authenticated request;
+   streams multipart chunks for many files through one authenticated request;
    deletion work received; `--force-http` with honest help text (the first
    push networking this flag can gate). Decisions this slice locked in:
    sending streams through libcurl's pause mechanism, which PHP's curl
    extension supports from 8.1 — so `reprint push` requires PHP 8.1+ (pull
    keeps 7.4+; the full story is
    https://github.com/WordPress/reprint/issues/327) — and paths
-   travel base64-encoded in frames, response cursors, and control-plane
+   travel base64-encoded in MIME headers, response cursors, and control-plane
    parameters, because file paths are arbitrary bytes and JSON strings must
    be UTF-8.
 7. **Package unification** — importer and exporter become one Reprint

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -73,10 +73,11 @@ development. There are no compatibility aliases or migration paths.
 The work-upload endpoint is `push_upload` and its push-session parameter is
 `push_session_id`. Endpoint names and endpoint prefixes begin with `push_`.
 JSON responses use `push_session_id`, `receiving_work`, and
-`work_deletes_bytes`. The stable classified failures are
+`work_deletes_bytes`. Push-session failures are
 `lock_acquisition_failure`, `offset_gap`, `push_not_found`, `filesystem_error`,
 `commit_required`, `unexpected_docroot_mutation`, `corrupted_push_state`, and
-`same_device`.
+`same_device`. Authentication and request-boundary failures are `auth_failed`,
+`not_configured`, `invalid_request`, and `request_too_large`.
 
 The document-root `.maintenance` file identifies its owner with the push
 session ID. `commit.json` stores no separate maintenance value.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -68,6 +68,31 @@ failure key is `non_recoverable_commit_failure`.
 These JSON records are unversioned while their schemas are still under
 development. There are no compatibility aliases or migration paths.
 
+## Local sender journal
+
+The sender's durable files are local machine state, not part of the push
+directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
+
+| Surface | Name |
+| --- | --- |
+| Active sender checkpoint | `sender.json`, `$sender_state_path` |
+| Stable index selected for the active push | `sender-index.jsonl`, `$sender_index_path` |
+| Positive-work path list | `local-paths-to-push.jsonl`, `$local_paths_to_push` |
+| Deleted-path list | `local-paths-to-delete.jsonl`, `$local_paths_to_delete` |
+| Raw local work-delete stream | `work-deletes`, `$work_deletes_path` |
+| Selected path-list cursor | `$paths_byte_offset` |
+| Selected positive-work path | `$current_path_b64` |
+| Receiver-confirmed file cursor | `$confirmed_bytes` |
+
+`sender.json` is version 1. Its phases are `creating`, `reconciling_work`,
+`uploading_work`, `reconciling_deletes`, `uploading_deletes`, `committing`,
+and `removing`. It also records the push session ID, selected path, last source
+token confirmed by an upload response, receiver-confirmed file and work-delete
+cursors, recoverable-failure count, target part limit, and request-sizing state.
+`push.json` remains the receiver-owned
+push identity and policy; it does not store local source evidence or transport
+progress.
+
 ## Protocol names
 
 The work-upload endpoint is `push_upload` and its push-session parameter is

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -24,6 +24,7 @@
             "src/class-http-server.php",
             "src/class-multipart-processor.php",
             "src/class-push-exception.php",
+            "src/class-push-endpoints.php",
             "src/class-push-session.php",
             "src/class-sqlite-driver-pdo.php",
             "src/class-wpdb-driver-pdo.php"

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -22,11 +22,20 @@ final class Site_Export_HTTP_Server {
     /** @var string|null */
     private $default_directory;
 
+    /** @var Site_Export_Push_Endpoints|null */
+    private $push_endpoints;
+
     /** @var string[] Endpoints dispatched without a resource budget. */
-    private $no_budget_endpoints = ['preflight'];
+    private $no_budget_endpoints = [
+        'preflight',
+        'push_create',
+        'push_upload',
+        'push_status',
+        'push_commit',
+        'push_remove',
+    ];
 
     public function __construct(array $options = []) {
-        $this->handlers = $options['handlers'] ?? $this->default_handlers();
         $this->budget_factory = $options['budget_factory'] ?? [$this, 'default_budget_factory'];
         $this->body_reader = $options['body_reader'] ?? static function (): string {
             $body = file_get_contents('php://input');
@@ -34,7 +43,17 @@ final class Site_Export_HTTP_Server {
         };
         $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
         $this->default_directory = $options['default_directory'] ?? null;
-
+        $this->push_endpoints = null;
+        if (array_key_exists('push', $options)) {
+            if (!is_array($options['push'])) {
+                throw new InvalidArgumentException('The push HTTP server option must be an array.');
+            }
+            if (!class_exists('Site_Export_Push_Endpoints', false)) {
+                require_once __DIR__ . '/class-push-endpoints.php';
+            }
+            $this->push_endpoints = new Site_Export_Push_Endpoints($options['push']);
+        }
+        $this->handlers = $options['handlers'] ?? $this->default_handlers();
     }
 
     public function handle_request(array $request = []): void {
@@ -286,13 +305,21 @@ final class Site_Export_HTTP_Server {
      * @return array<string, callable>
      */
     private function default_handlers(): array {
-        return [
+        $handlers = [
             'file_index' => 'endpoint_file_index',
             'file_fetch' => 'endpoint_file_fetch',
             'sql_chunk' => 'endpoint_sql_chunk',
             'db_index' => 'endpoint_db_index',
             'preflight' => 'endpoint_preflight',
         ];
+        if ($this->push_endpoints !== null) {
+            $handlers['push_create'] = [$this->push_endpoints, 'create'];
+            $handlers['push_upload'] = [$this->push_endpoints, 'upload'];
+            $handlers['push_status'] = [$this->push_endpoints, 'status'];
+            $handlers['push_commit'] = [$this->push_endpoints, 'commit'];
+            $handlers['push_remove'] = [$this->push_endpoints, 'remove'];
+        }
+        return $handlers;
     }
 
     private function is_json_content_type(array $server): bool {

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -1,0 +1,468 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped,WordPress.Security.EscapeOutput.OutputNotEscaped -- Authenticated protocol responses are JSON, never HTML output.
+// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- HTTP grammar and receiver validation require the exact request bytes.
+
+use function WordPress\Reprint\Exporter\parse_size;
+
+/**
+ * Exposes push-session operations through the exporter HTTP dispatcher.
+ *
+ * The endpoint configuration is supplied by the server, not by request
+ * parameters. It fixes the reprint directory, document root, excluded paths,
+ * maximum multipart part size, and bounded commit work for every request.
+ * Authentication happens in the embedding router before these methods run.
+ *
+ * Upload requests pass php://input directly to Site_Export_Push_Session. The
+ * endpoint retains only the latest accepted change while the receiver reads
+ * each multipart part in bounded fragments; it never buffers the request body
+ * or a list of all parts.
+ */
+final class Site_Export_Push_Endpoints {
+
+    private const DEFAULT_MAXIMUM_PART_BYTES = 4194304;
+    private const DEFAULT_MAXIMUM_COMMIT_ENTRIES = 256;
+
+    /** @var string */
+    private $reprint_directory;
+
+    /** @var string */
+    private $docroot;
+
+    /** @var list<string> */
+    private $excluded_paths;
+
+    /** @var int */
+    private $maximum_part_bytes;
+
+    /** @var int */
+    private $maximum_commit_entries;
+
+    /** @var int|null */
+    private $post_max_bytes;
+
+    /**
+     * Configures the server-owned push roots and request limits.
+     *
+     * Missing numeric options use bounded defaults. Present numeric options
+     * must be positive so a malformed server configuration cannot silently
+     * change the protocol limit.
+     *
+     * @param array<string,mixed> $options {
+     *     Trusted endpoint configuration.
+     *
+     *     @type string $reprint_directory Required private reprint directory.
+     *     @type string $docroot Required managed document-root directory.
+     *     @type list<string> $excluded_paths Required document-root-relative
+     *         paths which push must preserve.
+     *     @type int|float|string $maximum_part_bytes Maximum Content-Length
+     *         accepted for one multipart part. Default 4 MiB.
+     *     @type int|float|string $maximum_commit_entries Maximum entries one
+     *         commit request may process. Default 256.
+     *     @type int|float|string|null $post_max_bytes Decoded request-body
+     *         limit reported to senders. Defaults to PHP's post_max_size;
+     *         null means PHP reports no positive limit.
+     * }
+     *
+     * @throws InvalidArgumentException If required configuration is absent or
+     *     a present numeric limit is not positive.
+     */
+    public function __construct(array $options) {
+        $reprint_directory = $options['reprint_directory'] ?? null;
+        $docroot = $options['docroot'] ?? null;
+        $excluded_paths = $options['excluded_paths'] ?? null;
+        if (!is_string($reprint_directory) || $reprint_directory === '') {
+            throw new InvalidArgumentException('Push endpoints require a non-empty reprint_directory option.');
+        }
+        if (!is_string($docroot) || $docroot === '') {
+            throw new InvalidArgumentException('Push endpoints require a non-empty docroot option.');
+        }
+        if (!is_array($excluded_paths)) {
+            throw new InvalidArgumentException('Push endpoints require an excluded_paths array.');
+        }
+
+        $maximum_part_bytes = $options['maximum_part_bytes'] ?? self::DEFAULT_MAXIMUM_PART_BYTES;
+        $maximum_commit_entries = $options['maximum_commit_entries'] ?? self::DEFAULT_MAXIMUM_COMMIT_ENTRIES;
+        if (!is_numeric($maximum_part_bytes) || (int) $maximum_part_bytes <= 0) {
+            throw new InvalidArgumentException('maximum_part_bytes must be a positive integer.');
+        }
+        if (!is_numeric($maximum_commit_entries) || (int) $maximum_commit_entries <= 0) {
+            throw new InvalidArgumentException('maximum_commit_entries must be a positive integer.');
+        }
+
+        if (array_key_exists('post_max_bytes', $options)) {
+            $post_max_bytes = $options['post_max_bytes'];
+            if ($post_max_bytes !== null && ( !is_numeric($post_max_bytes) || (int) $post_max_bytes <= 0 )) {
+                throw new InvalidArgumentException('post_max_bytes must be null or a positive integer.');
+            }
+            $this->post_max_bytes = $post_max_bytes === null ? null : (int) $post_max_bytes;
+        } else {
+            $post_max_size = ini_get('post_max_size');
+            $parsed_post_max_bytes = is_string($post_max_size) && $post_max_size !== ''
+                ? parse_size($post_max_size)
+                : 0;
+            $this->post_max_bytes = $parsed_post_max_bytes > 0 ? $parsed_post_max_bytes : null;
+        }
+
+        $this->reprint_directory = $reprint_directory;
+        $this->docroot = $docroot;
+        $this->excluded_paths = $excluded_paths;
+        $this->maximum_part_bytes = (int) $maximum_part_bytes;
+        $this->maximum_commit_entries = (int) $maximum_commit_entries;
+    }
+
+    /**
+     * Creates or reopens the caller-named push session.
+     *
+     * This operation is idempotent for the same push session ID and immutable
+     * server configuration. A successful response reports the independent
+     * multipart-part and decoded request-body limits the sender must apply.
+     *
+     * Emits HTTP 200 with:
+     *
+     *     {status:"created", push_session_id:string,
+     *      max_part_bytes:int, post_max_bytes:int|null}
+     *
+     * @param array<string,mixed> $config Request parameters containing
+     *     `push_session_id`.
+     */
+    public function create(array $config): void {
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $push_session = Site_Export_Push_Session::create(
+                $this->reprint_directory,
+                $this->docroot,
+                $this->excluded_paths,
+                $push_session_id
+            );
+            // create() deliberately defers validation when the directory
+            // already exists. An endpoint success must not bless stale or
+            // incompatible durable state, so validate it under the push lock.
+            $push_session->get_status();
+            $this->respond(200, [
+                'status' => 'created',
+                'push_session_id' => $push_session_id,
+                'max_part_bytes' => $this->maximum_part_bytes,
+                'post_max_bytes' => $this->post_max_bytes,
+            ]);
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Streams one multipart request into an existing push session.
+     *
+     * The request must be POST multipart/mixed with one valid boundary. Each
+     * part is accepted before the next part is read. The response retains only
+     * the latest receiver-confirmed change, so response memory does not grow
+     * with the number of parts in the request.
+     *
+     * Emits HTTP 200 with one of these `last_change` branches, or null for an
+     * empty request:
+     *
+     *     {status:"accepted", push_session_id:string, changes_accepted:int,
+     *      last_change:
+     *        {path_b64:string,state:"partial"|"complete",type:"file",accepted_bytes:int}
+     *        | {path_b64:string,state:"complete",type:"directory"|"symlink",accepted_bytes:0}
+     *        | {state:"partial"|"complete",type:"delete-list",accepted_bytes:int}
+     *        | null}
+     *
+     * @param array<string,mixed> $config Request parameters containing
+     *     `push_session_id`.
+     */
+    public function upload(array $config): void {
+        $input = null;
+        $push_session = null;
+        $upload_open = false;
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $content_type = (string) ( $_SERVER['CONTENT_TYPE'] ?? '' );
+            $boundary = Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
+            $declared_request_bytes = $_SERVER['CONTENT_LENGTH'] ?? null;
+            if (
+                $this->post_max_bytes !== null
+                && is_numeric($declared_request_bytes)
+                && (int) $declared_request_bytes > $this->post_max_bytes
+            ) {
+                $this->respond(413, [
+                    'status' => 'rejected',
+                    'reason' => 'request_too_large',
+                    'detail' => 'The decoded request body exceeds the target post_max_size of ' . $this->post_max_bytes . ' bytes.',
+                    'post_max_bytes' => $this->post_max_bytes,
+                ]);
+                return;
+            }
+            $input = fopen('php://input', 'rb');
+            if ($input === false) {
+                throw new Site_Export_Push_Exception(
+                    Site_Export_Push_Session::ERROR_FILESYSTEM,
+                    'Could not open the multipart upload request body.'
+                );
+            }
+            $push_session = Site_Export_Push_Session::open(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $push_session->accept_upload(
+                $input,
+                new Site_Export_Multipart_Processor($boundary),
+                $this->maximum_part_bytes
+            );
+            $upload_open = true;
+            $changes_accepted = 0;
+            $last_change = null;
+            while ($push_session->next_change()) {
+                ++$changes_accepted;
+                $last_change = $push_session->get_current_change();
+            }
+            $push_session->finish_upload();
+            $upload_open = false;
+            fclose($input);
+            $input = null;
+            $this->respond(200, [
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'changes_accepted' => $changes_accepted,
+                'last_change' => $last_change,
+            ]);
+        } catch (Throwable $exception) {
+            if ($upload_open && $push_session instanceof Site_Export_Push_Session) {
+                $push_session->finish_upload();
+            }
+            if (is_resource($input)) {
+                fclose($input);
+            }
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Reports receiver-confirmed progress for a push session and optional path.
+     *
+     * `path_b64`, when supplied, is strict base64 for the raw document-root-
+     * relative path. The receiver reads actual work state under the push lock;
+     * it never echoes a sender-supplied cursor.
+     *
+     * Emits HTTP 200 with the exact Site_Export_Push_Session::get_status()
+     * object plus `status:"accepted"`:
+     *
+     *     {status:"accepted",push_session_id:string,
+     *      phase:"receiving_work"|"deleting_files"|"installing_files"|"complete",
+     *      work_deletes_bytes:int,work_deletes_complete:bool,
+     *      path:null
+     *        | {path_b64:string,state:"missing",accepted_bytes:0}
+     *        | {path_b64:string,state:"partial",type:"file",accepted_bytes:int}
+     *        | {path_b64:string,state:"partial",type:"directory"|"symlink",accepted_bytes:0}
+     *        | {path_b64:string,state:"complete",type:"file",accepted_bytes:int}
+     *        | {path_b64:string,state:"complete",type:"directory"|"symlink",accepted_bytes:0}}
+     *
+     * @param array<string,mixed> $config Request parameters containing
+     *     `push_session_id` and optional `path_b64`.
+     */
+    public function status(array $config): void {
+        try {
+            $this->require_method('GET');
+            $push_session_id = $this->require_push_session_id($config);
+            $path = null;
+            if (array_key_exists('path_b64', $config)) {
+                if (!is_string($config['path_b64'])) {
+                    throw new InvalidArgumentException('path_b64 must be base64 text.');
+                }
+                $path = base64_decode($config['path_b64'], true);
+                if ($path === false) {
+                    throw new InvalidArgumentException('path_b64 must be valid base64 text.');
+                }
+            }
+            $push_session = Site_Export_Push_Session::open(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $this->respond(200, array_merge(
+                ['status' => 'accepted'],
+                $push_session->get_status($path)
+            ));
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Advances bounded commit work for one push session.
+     *
+     * The server-owned entry limit controls each call. Senders repeat this
+     * operation while `send_next_request` is true; a repeated request after an
+     * indeterminate response resumes the receiver's durable commit checkpoint.
+     *
+     * Emits HTTP 200 with:
+     *
+     *     {status:"accepted",push_session_id:string,
+     *      phase:"deleting_files"|"installing_files"|"complete",
+     *      send_next_request:bool,entries_processed:int}
+     *
+     * @param array<string,mixed> $config Request parameters containing
+     *     `push_session_id`.
+     */
+    public function commit(array $config): void {
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $push_session = Site_Export_Push_Session::open(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $commit = $push_session->commit($this->maximum_commit_entries);
+            $this->respond(200, array_merge([
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+            ], $commit));
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Performs one bounded removal step for a push session.
+     *
+     * A false `removed` value means the sender must call this operation again.
+     * Repeating the operation after a lost response is safe: a missing push
+     * directory and completed removal tombstone report true.
+     *
+     * Emits HTTP 200 with:
+     *
+     *     {status:"accepted",push_session_id:string,removed:bool}
+     *
+     * @param array<string,mixed> $config Request parameters containing
+     *     `push_session_id`.
+     */
+    public function remove(array $config): void {
+        try {
+            $this->require_method('POST');
+            $push_session_id = $this->require_push_session_id($config);
+            $removed = Site_Export_Push_Session::remove(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                $this->excluded_paths
+            );
+            $this->respond(200, [
+                'status' => 'accepted',
+                'push_session_id' => $push_session_id,
+                'removed' => $removed,
+            ]);
+        } catch (Throwable $exception) {
+            $this->respond_to_failure($exception);
+        }
+    }
+
+    /**
+     * Requires the exact HTTP method assigned to an endpoint.
+     *
+     * @param string $expected_method Uppercase protocol method.
+     *
+     * @throws InvalidArgumentException If the current request uses another method.
+     */
+    private function require_method(string $expected_method): void {
+        $observed_method = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ));
+        if ($observed_method !== $expected_method) {
+            throw new InvalidArgumentException(
+                'Push endpoint requires ' . $expected_method . '; observed ' . ( $observed_method === '' ? 'no request method' : $observed_method ) . '.'
+            );
+        }
+    }
+
+    /**
+     * Reads the required push session identity from request parameters.
+     *
+     * Site_Export_Push_Session performs the canonical 32-character lowercase
+     * hexadecimal validation. This method only rejects missing or non-string
+     * values before a factory method is selected.
+     *
+     * @param array<string,mixed> $config Endpoint request parameters.
+     * @return string Caller-supplied push session ID.
+     *
+     * @throws InvalidArgumentException If `push_session_id` is not a string.
+     */
+    private function require_push_session_id(array $config): string {
+        $push_session_id = $config['push_session_id'] ?? null;
+        if (!is_string($push_session_id)) {
+            throw new InvalidArgumentException('push_session_id must be a string.');
+        }
+        return $push_session_id;
+    }
+
+    /**
+     * Maps a push exception onto its stable protocol reason and HTTP status.
+     *
+     * Classified context is copied without rewriting its keys. Invalid or
+     * malformed request data receives `invalid_request`; unexpected failures
+     * receive `filesystem_error` without exposing a PHP trace.
+     *
+     * @param Throwable $exception Failure raised while handling an endpoint.
+     */
+    private function respond_to_failure(Throwable $exception): void {
+        if ($exception instanceof Site_Export_Push_Exception) {
+            $reason = $exception->get_error_code();
+            $http_code = 409;
+            if ($reason === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND) {
+                $http_code = 404;
+            } elseif ($reason === Site_Export_Push_Session::ERROR_LOCK_ACQUISITION_FAILURE) {
+                $http_code = 423;
+            } elseif (
+                $reason === Site_Export_Push_Session::ERROR_FILESYSTEM
+                || $reason === Site_Export_Push_Session::ERROR_CORRUPTED_PUSH_STATE
+            ) {
+                $http_code = 500;
+            }
+            $this->respond($http_code, array_merge([
+                'status' => 'rejected',
+                'reason' => $reason,
+                'detail' => $exception->getMessage(),
+            ], $exception->get_context()));
+            return;
+        }
+        if (
+            $exception instanceof InvalidArgumentException
+            || $exception instanceof LogicException
+            || $exception instanceof RuntimeException
+        ) {
+            $this->respond(400, [
+                'status' => 'rejected',
+                'reason' => 'invalid_request',
+                'detail' => $exception->getMessage(),
+            ]);
+            return;
+        }
+        $this->respond(500, [
+            'status' => 'rejected',
+            'reason' => Site_Export_Push_Session::ERROR_FILESYSTEM,
+            'detail' => 'The push endpoint failed while processing the request.',
+        ]);
+    }
+
+    /**
+     * Emits one complete JSON protocol response.
+     *
+     * @param int $http_code HTTP status code.
+     * @param array<string,mixed> $body Exact endpoint-specific response object.
+     */
+    private function respond(int $http_code, array $body): void {
+        http_response_code($http_code);
+        header('Content-Type: application/json');
+        $json = json_encode($body);
+        if ($json === false) {
+            http_response_code(500);
+            echo '{"status":"rejected","reason":"filesystem_error","detail":"Could not encode the push response."}';
+            return;
+        }
+        echo $json;
+    }
+}

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -788,7 +788,11 @@ final class Site_Export_Push_Session {
             $data = $this->lstat_path($this->work_inflight_data_path);
             if ($data !== null) {
                 if ($data['type'] !== 'file' || $data['size'] !== $inflight['total_bytes']) {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Publishing in-flight data has an invalid size.');
+                    throw new Site_Export_Push_Exception(
+                        self::ERROR_CORRUPTED_PUSH_STATE,
+                        'Publishing in-flight file ' . $inflight['path_b64'] . ' requires data type file and size ' . $inflight['total_bytes']
+                        . '; observed type ' . $data['type'] . ' and size ' . $data['size'] . '.'
+                    );
                 }
                 $this->ensure_private_parent($work_path);
                 if ($work_identity !== null) {
@@ -798,24 +802,42 @@ final class Site_Export_Push_Session {
                     throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish in-flight file data.');
                 }
             } elseif ($work_identity === null || $work_identity['type'] !== 'file' || $work_identity['size'] !== $inflight['total_bytes']) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Published in-flight data has no completed file.');
+                $observed_type = $work_identity === null ? 'absent' : $work_identity['type'];
+                $observed_size = $work_identity === null ? 'absent' : (string) $work_identity['size'];
+                throw new Site_Export_Push_Exception(
+                    self::ERROR_CORRUPTED_PUSH_STATE,
+                    'Published in-flight file ' . $inflight['path_b64'] . ' requires completed type file and size ' . $inflight['total_bytes']
+                    . '; observed type ' . $observed_type . ' and size ' . $observed_size . '.'
+                );
             }
         } elseif ($inflight['type'] === 'directory') {
             if ($work_identity === null) {
                 $this->ensure_private_parent($work_path);
-                if (!@mkdir($work_path, 0700)) {
+                if (!@mkdir($work_path, 0777)) {
                     throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the in-flight directory.');
                 }
             } elseif ($work_identity['type'] !== 'directory') {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Published in-flight directory has an incompatible completed value.');
+                throw new Site_Export_Push_Exception(
+                    self::ERROR_CORRUPTED_PUSH_STATE,
+                    'Published in-flight directory ' . $inflight['path_b64'] . ' requires completed type directory; observed type ' . $work_identity['type'] . '.'
+                );
             }
         } elseif ($work_identity === null) {
             $this->ensure_private_parent($work_path);
             if (!@symlink(base64_decode($inflight['target_b64'], true), $work_path)) {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the in-flight symlink.');
             }
-        } elseif ($work_identity['type'] !== 'symlink' || @readlink($work_path) !== base64_decode($inflight['target_b64'], true)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Published in-flight symlink has an incompatible completed value.');
+        } else {
+            $expected_target = base64_decode($inflight['target_b64'], true);
+            $observed_target = $work_identity['type'] === 'symlink' ? @readlink($work_path) : false;
+            if ($work_identity['type'] !== 'symlink' || $observed_target !== $expected_target) {
+                throw new Site_Export_Push_Exception(
+                    self::ERROR_CORRUPTED_PUSH_STATE,
+                    'Published in-flight symlink ' . $inflight['path_b64'] . ' requires target ' . $inflight['target_b64']
+                    . '; observed type ' . $work_identity['type'] . ' and target '
+                    . ( is_string($observed_target) ? base64_encode($observed_target) : 'unavailable' ) . '.'
+                );
+            }
         }
         if (!@unlink($this->work_inflight_path)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear published in-flight metadata.');
@@ -902,10 +924,14 @@ final class Site_Export_Push_Session {
         }
         $accepted_bytes = $actual_bytes + $received;
         if ($accepted_bytes === $total_bytes) {
+            $existing = $this->lstat_path($complete_path);
+            if ($existing !== null && $existing['type'] === 'directory' && $this->first_directory_entry($complete_path) !== null) {
+                throw new InvalidArgumentException('Work file ' . base64_encode($path) . ' conflicts with completed work descendants.');
+            }
             $inflight['phase'] = 'publishing';
             $this->write_json($this->work_inflight_path, $inflight);
             $this->ensure_private_parent($complete_path);
-            if (($existing = $this->lstat_path($complete_path)) !== null) {
+            if ($existing !== null) {
                 $this->remove_work_path($complete_path);
             }
             if (!@rename($this->work_inflight_data_path, $complete_path)) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -58,6 +58,9 @@ require_once __DIR__ . '/lib/state/class-import-state.php';
 
 // Adaptive sizing for push request bodies
 require_once __DIR__ . '/lib/upload/class-push-request-sizer.php';
+require_once __DIR__ . '/lib/upload/class-multipart-push-stream-client.php';
+require_once __DIR__ . '/lib/push/class-push-journal.php';
+require_once __DIR__ . '/lib/push/class-push-files-sender.php';
 
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -116,8 +116,8 @@ final class PushFilesSender
         $this->current_index_file = $current_index_file;
         $this->journal = $journal;
         $this->client = new MultipartPushStreamClient($client_options);
-        if (is_array($state) && is_numeric($state['max_part_bytes'])) {
-            $this->client->set_max_part_bytes( (int) $state['max_part_bytes']);
+        if ($state !== null && $state['max_part_bytes'] !== null) {
+            $this->client->set_max_part_bytes($state['max_part_bytes']);
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -1,0 +1,1119 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Drives one resumable local-files push through real HTTP requests.
+ *
+ * Each send_next_request() call performs one create, status, upload, commit,
+ * or remove request and persists the receiver-reconcilable boundary before it
+ * returns. Upload requests contain as many bounded file chunks and work values
+ * as the learned request-body budget permits. Only one payload string is held
+ * at a time.
+ *
+ * The sender does not trust local byte counters after a restart or ambiguous
+ * response. It asks push_status for the current path or work-delete cursor,
+ * compares the source's type, size, and ctime with its persisted token, and
+ * resumes or restarts the same in-flight work. If a selected source disappears
+ * or the work-delete cursor cannot belong to the current list, it removes the
+ * upload-only push session and returns `restart` so the caller can regenerate
+ * the local index.
+ */
+final class PushFilesSender
+{
+    private const MAXIMUM_RECOVERABLE_FAILURES = 5;
+    private const RECOVERABLE_FAILURE_PAUSE_MICROSECONDS = 100000;
+
+    private string $docroot;
+    private string $current_index_file;
+    private PushJournal $journal;
+    private MultipartPushStreamClient $client;
+
+    /**
+     * Configures one sender and restores its learned request size when present.
+     *
+     * @param array<string,mixed> $options {
+     *     Sender, transport, and source configuration.
+     *
+     *     @type string $docroot Required local document-root directory.
+     *     @type string $current_index_file Current local file index required
+     *         when no sender checkpoint is active. An active sender resumes
+     *         from its stable journal copy instead.
+     *     @type PushJournal $journal Required per-target push journal.
+     *     @type string $base_url Required exporter API URL.
+     *     @type Site_Export_HMAC_Client $hmac_client Required envelope signer.
+     *     @type bool $allow_http Explicit plain-HTTP opt-in. Default false.
+     *     @type int|float|string $chunk_bytes Maximum one source read. Default
+     *         4 MiB.
+     *     @type int|float|string $connect_timeout Connect phase seconds.
+     *         Default 30.
+     *     @type int|float|string $stall_timeout No-upload-progress seconds.
+     *         Default 60.
+     *     @type int|float|string $response_timeout No-response-progress seconds.
+     *         Default 300.
+     *     @type array{
+     *         floor_bytes?:int|float|string,
+     *         start_bytes?:int|float|string,
+     *         max_bytes?:int|float|string,
+     *         limit_safety_ratio?:int|float|string,
+     *         growth_holdoff_successes?:int|float|string
+     *     } $request_sizer_config Optional PushRequestSizer bounds; persisted
+     *         sizing state still wins.
+     * }
+     *
+     * @throws InvalidArgumentException If source or transport options are invalid.
+     * @throws RuntimeException If the journal cannot be read or contains an
+     *     unsupported sender-state version.
+     */
+    public function __construct(array $options)
+    {
+        $docroot = $options['docroot'] ?? null;
+        $current_index_file = $options['current_index_file'] ?? null;
+        $journal = $options['journal'] ?? null;
+        if (!is_string($docroot) || !is_dir($docroot) || is_link($docroot)) {
+            throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
+        }
+        if (!is_string($current_index_file) || $current_index_file === '') {
+            throw new InvalidArgumentException('PushFilesSender requires a current_index_file path.');
+        }
+        if (!$journal instanceof PushJournal) {
+            throw new InvalidArgumentException('PushFilesSender requires a PushJournal.');
+        }
+        $state = $journal->read_sender_state();
+        if ($state === null && !is_file($current_index_file)) {
+            throw new InvalidArgumentException('PushFilesSender requires an existing current_index_file when no sender checkpoint is active.');
+        }
+        if (is_array($state) && ( $state['version'] ?? null ) !== 1) {
+            throw new RuntimeException(
+                'Sender state has an unsupported version: '
+                . json_encode($state['version'] ?? null, JSON_UNESCAPED_SLASHES)
+                . '.'
+            );
+        }
+        $request_sizer_config = $options['request_sizer_config'] ?? [];
+        if (!is_array($request_sizer_config)) {
+            throw new InvalidArgumentException('request_sizer_config must be an array.');
+        }
+        $request_sizer = new PushRequestSizer(
+            $request_sizer_config,
+            is_array($state) ? $state['request_sizer_state'] : []
+        );
+        $client_options = [
+            'base_url' => $options['base_url'] ?? null,
+            'hmac_client' => $options['hmac_client'] ?? null,
+            'allow_http' => $options['allow_http'] ?? false,
+            'request_sizer' => $request_sizer,
+        ];
+        foreach (['chunk_bytes', 'connect_timeout', 'stall_timeout', 'response_timeout'] as $option_name) {
+            if (array_key_exists($option_name, $options)) {
+                $client_options[$option_name] = $options[$option_name];
+            }
+        }
+
+        $this->docroot = rtrim($docroot, '/');
+        $this->current_index_file = $current_index_file;
+        $this->journal = $journal;
+        $this->client = new MultipartPushStreamClient($client_options);
+        if (is_array($state) && is_numeric($state['max_part_bytes'])) {
+            $this->client->set_max_part_bytes( (int) $state['max_part_bytes']);
+        }
+    }
+
+    /**
+     * Runs requests until the push completes, fails, or needs a new index.
+     *
+     * Recoverable results pause for 100 milliseconds before the next request,
+     * so the convenience loop does not spin on target lock contention.
+     *
+     * @return array{
+     *     status:'complete'|'restart'|'failed',
+     *     phase:'complete'|'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:?string,
+     *     reason:?string,
+     *     detail:?string
+     * } Terminal workflow result. `restart` means the abandoned upload-only
+     *     push session was removed and the caller must regenerate its index.
+     * @throws InvalidArgumentException If the stable index contains an unsafe
+     *     document-root-relative path.
+     * @throws RuntimeException If durable local sender state cannot be read or
+     *     written.
+     */
+    public function push(): array
+    {
+        do {
+            $result = $this->send_next_request();
+            if ($result['status'] === 'continue' && $result['reason'] !== null) {
+                usleep(self::RECOVERABLE_FAILURE_PAUSE_MICROSECONDS);
+            }
+        } while ($result['status'] === 'continue');
+        return $result;
+    }
+
+    /**
+     * Performs the next durable HTTP request in the local-files push.
+     *
+     * New work first produces journal path lists and a raw work-delete stream.
+     * Later calls create or reopen the push session, reconcile any current
+     * receiver cursor, fill one multipart request, close work deletes, repeat
+     * commit, or remove an abandoned upload-only push session.
+     *
+     * Returning `continue` means the checkpoint names the request to perform
+     * next. `complete` means receiver commit and local baseline capture both
+     * finished. `restart` means source selection changed incompatibly and the
+     * old push session is gone. `failed` is terminal for this checkpoint.
+     *
+     * @return array{
+     *     status:'continue'|'complete'|'restart'|'failed',
+     *     phase:'complete'|'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:?string,
+     *     reason:?string,
+     *     detail:?string
+     * } Result of one real request and its durable local transition.
+     * @throws InvalidArgumentException If the stable index contains an unsafe
+     *     document-root-relative path.
+     * @throws RuntimeException If durable local sender state cannot be read or
+     *     written.
+     */
+    public function send_next_request(): array
+    {
+        $state = $this->journal->read_sender_state();
+        if ($state === null) {
+            $this->journal->capture_sender_index($this->current_index_file);
+            $this->journal->diff_local_files($this->journal->sender_index_path);
+            $this->journal->prepare_work_deletes();
+            $state = [
+                'version' => 1,
+                'push_session_id' => bin2hex(random_bytes(16)),
+                'phase' => 'creating',
+                'paths_byte_offset' => 0,
+                'current_path_b64' => null,
+                'next_paths_byte_offset' => 0,
+                'source_token' => null,
+                'confirmed_bytes' => 0,
+                'work_deletes_byte_offset' => 0,
+                'recoverable_failures' => 0,
+                'max_part_bytes' => null,
+                'request_sizer_state' => $this->client->get_request_sizer_state(),
+            ];
+            $this->journal->write_sender_state($state);
+        }
+
+        if ($state['phase'] === 'creating') {
+            $request = $this->control_request('POST', 'push_create', [
+                'push_session_id' => $state['push_session_id'],
+            ], ['created']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_int($response['max_part_bytes'] ?? null)
+                || $response['max_part_bytes'] <= 0
+                || !array_key_exists('post_max_bytes', $response)
+                || ( $response['post_max_bytes'] !== null
+                    && ( !is_int($response['post_max_bytes']) || $response['post_max_bytes'] <= 0 ) )
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_create did not return the matching push session ID, a positive part limit, and a positive or unknown request-body limit.');
+            }
+            $this->client->set_max_part_bytes($response['max_part_bytes']);
+            $this->client->apply_reported_limits([$response['post_max_bytes'] ?? null]);
+            $state['max_part_bytes'] = $response['max_part_bytes'];
+            $state['recoverable_failures'] = 0;
+            $state['phase'] = 'reconciling_work';
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'reconciling_work') {
+            $parameters = ['push_session_id' => $state['push_session_id']];
+            if ($state['current_path_b64'] !== null) {
+                $parameters['path_b64'] = $state['current_path_b64'];
+            }
+            $request = $this->control_request('GET', 'push_status', $parameters, ['accepted']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || ( $response['phase'] ?? null ) !== 'receiving_work'
+                || !is_int($response['work_deletes_bytes'] ?? null)
+                || $response['work_deletes_bytes'] < 0
+                || !is_bool($response['work_deletes_complete'] ?? null)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_status did not return the matching push session and exact receiving_work state.');
+            }
+            $state['recoverable_failures'] = 0;
+            if ($state['current_path_b64'] === null) {
+                if (( $response['path'] ?? null ) !== null) {
+                    return $this->step_result('failed', $state, 'unexpected_response', 'push_status returned a path state when none was requested.');
+                }
+                $state['phase'] = 'uploading_work';
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, null, null);
+            }
+            $path = base64_decode($state['current_path_b64'], true);
+            if (!is_string($path) || $path === '') {
+                return $this->step_result('failed', $state, 'invalid_sender_state', 'The current sender path is not valid base64 text.');
+            }
+            $source_token = $this->source_token($path);
+            $path_status = $response['path'] ?? null;
+            if (!is_array($path_status) || ( $path_status['path_b64'] ?? null ) !== $state['current_path_b64']) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_status did not return the requested path state.');
+            }
+            $path_state = $path_status['state'] ?? null;
+            $path_type = $path_status['type'] ?? null;
+            $accepted_bytes = $path_status['accepted_bytes'] ?? null;
+            if (
+                !is_int($accepted_bytes)
+                || $accepted_bytes < 0
+                || !in_array($path_state, ['missing', 'partial', 'complete'], true)
+                || ( $path_state === 'missing'
+                    && ( $accepted_bytes !== 0 || array_key_exists('type', $path_status) ) )
+                || ( $path_state !== 'missing'
+                    && !in_array($path_type, ['file', 'directory', 'symlink'], true) )
+                || ( $path_state === 'partial' && $path_type !== 'file' )
+                || ( in_array($path_type, ['directory', 'symlink'], true) && $accepted_bytes !== 0 )
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_status returned an invalid receiver-confirmed path state.');
+            }
+            if ($source_token === null) {
+                $state['phase'] = 'removing';
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, 'source_changed', 'The selected source path disappeared; remove the upload-only push session before regenerating the index.');
+            }
+            if ($source_token !== $state['source_token']) {
+                $state['phase'] = 'uploading_work';
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, 'source_changed', 'The source token changed; restart the same in-flight work at offset zero.');
+            }
+            if (
+                $path_state === 'complete'
+                && $path_type === $source_token['type']
+                && ( $source_token['type'] !== 'file' || $accepted_bytes === $source_token['size'] )
+            ) {
+                $state['paths_byte_offset'] = $state['next_paths_byte_offset'];
+                $state['current_path_b64'] = null;
+                $state['source_token'] = null;
+                $state['confirmed_bytes'] = 0;
+                $state['phase'] = 'reconciling_work';
+            } else {
+                $state['confirmed_bytes'] = $path_state === 'partial' && $path_type === 'file'
+                    ? $accepted_bytes
+                    : 0;
+                if ($state['confirmed_bytes'] > $source_token['size']) {
+                    $state['confirmed_bytes'] = 0;
+                }
+                $state['phase'] = 'uploading_work';
+            }
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'uploading_work') {
+            $paths = fopen($this->journal->local_paths_to_push, 'r');
+            if ($paths === false) {
+                return $this->step_result('failed', $state, 'local_io_error', 'Could not open the journal paths selected for push.');
+            }
+            $path_list_offset = $state['paths_byte_offset'];
+            $current = null;
+            while ($current === null) {
+                if (fseek($paths, $path_list_offset) !== 0) {
+                    fclose($paths);
+                    return $this->step_result('failed', $state, 'invalid_sender_state', 'The sender path-list cursor is outside the selected path list.');
+                }
+                $path_line = fgets($paths);
+                if ($path_line === false) {
+                    if (!feof($paths)) {
+                        fclose($paths);
+                        return $this->step_result('failed', $state, 'local_io_error', 'Could not read the journal paths selected for push.');
+                    }
+                    fclose($paths);
+                    $state['phase'] = 'reconciling_deletes';
+                    $this->persist_state($state);
+                    return $this->reconcile_work_deletes($state);
+                }
+                $next_path_list_offset = ftell($paths);
+                if (!is_int($next_path_list_offset)) {
+                    fclose($paths);
+                    return $this->step_result('failed', $state, 'local_io_error', 'Could not read the next byte offset in the journal paths selected for push.');
+                }
+                $path_record = json_decode($path_line, true);
+                $path = is_array($path_record) && is_string($path_record['path'] ?? null)
+                    ? base64_decode($path_record['path'], true)
+                    : false;
+                if (!is_string($path) || $path === '') {
+                    fclose($paths);
+                    return $this->step_result('failed', $state, 'invalid_sender_state', 'The selected path list contains an invalid path record.');
+                }
+                $base64_path = base64_encode($path);
+                $is_current_path = $state['current_path_b64'] === $base64_path;
+                $source_token = $this->source_token($path);
+                if ($source_token === null) {
+                    fclose($paths);
+                    $state['current_path_b64'] = $base64_path;
+                    $state['next_paths_byte_offset'] = $next_path_list_offset;
+                    $state['phase'] = 'removing';
+                    $this->persist_state($state);
+                    return $this->step_result('continue', $state, 'source_changed', 'The selected source path disappeared; remove the upload-only push session before regenerating the index.');
+                }
+                if ($source_token['type'] === 'directory') {
+                    $directory_is_empty = $this->directory_is_empty($path);
+                    if ($directory_is_empty === null) {
+                        fclose($paths);
+                        return $this->step_result('failed', $state, 'local_io_error', 'Could not read the selected source directory: ' . base64_encode($path) . '.');
+                    }
+                    if ($this->source_token($path) !== $source_token) {
+                        continue;
+                    }
+                    if (!$directory_is_empty && !$is_current_path) {
+                        $path_list_offset = $next_path_list_offset;
+                        $state['paths_byte_offset'] = $path_list_offset;
+                        $state['next_paths_byte_offset'] = $path_list_offset;
+                        $state['current_path_b64'] = null;
+                        $state['source_token'] = null;
+                        $state['confirmed_bytes'] = 0;
+                        $this->persist_state($state);
+                        continue;
+                    }
+                }
+                $receiver_confirmed_source_token = $is_current_path ? $state['source_token'] : null;
+                $receiver_confirmed_bytes = $is_current_path ? $state['confirmed_bytes'] : 0;
+                $current = [
+                    'path' => $path,
+                    'path_b64' => $base64_path,
+                    'path_list_offset' => $path_list_offset,
+                    'next_path_list_offset' => $next_path_list_offset,
+                    'source_token' => $source_token,
+                    'confirmed_bytes' => $receiver_confirmed_source_token === $source_token
+                        ? $receiver_confirmed_bytes
+                        : 0,
+                ];
+                $state['current_path_b64'] = $current['path_b64'];
+                $state['next_paths_byte_offset'] = $next_path_list_offset;
+                $state['source_token'] = $receiver_confirmed_source_token;
+                $state['confirmed_bytes'] = $receiver_confirmed_bytes;
+                $reconciliation_state = $state;
+                $reconciliation_state['phase'] = 'reconciling_work';
+                $this->persist_state($reconciliation_state);
+            }
+
+            if (!$this->client->start_upload_request($state['push_session_id'])) {
+                fclose($paths);
+                $request = [
+                    'status' => 'retry',
+                    'reason' => 'request_failed',
+                    'detail' => $this->client->get_last_error(),
+                    'response' => null,
+                    'parts_sent' => 0,
+                    'body_bytes_sent' => 0,
+                ];
+                $failure = $this->handle_request_failure($request, $state);
+                return $failure ?? $this->step_result('failed', $state, 'unexpected_response', 'The work upload failed without a classified result.');
+            }
+
+            $last_sent = null;
+            $next_unsent_path_list_offset = null;
+            $local_failure_detail = null;
+            $request_size_failure_detail = null;
+            while ($current !== null) {
+                $path = $current['path'];
+                $source_token = $this->source_token($path);
+                if ($source_token === null) {
+                    $next_unsent_path_list_offset = $current['path_list_offset'];
+                    break;
+                }
+                if ($source_token !== $current['source_token']) {
+                    $this->record_source_restart($current, $source_token);
+                }
+
+                $part = null;
+                $logical_value_complete = false;
+                if ($source_token['type'] === 'file') {
+                    $offset = $current['confirmed_bytes'];
+                    if ($offset > $source_token['size']) {
+                        $offset = 0;
+                        $current['confirmed_bytes'] = 0;
+                    }
+                    $maximum = $this->client->next_file_body_bytes($path, $source_token['size'], $offset);
+                    if ($maximum === 0) {
+                        $next_unsent_path_list_offset = $current['path_list_offset'];
+                        if ($last_sent === null) {
+                            $request_size_failure_detail = 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($path) . '.';
+                        }
+                        break;
+                    }
+                    $payload = '';
+                    if ($source_token['size'] > 0) {
+                        $file = fopen($this->docroot . '/' . $path, 'rb');
+                        if ($file === false || fseek($file, $offset) !== 0) {
+                            if (is_resource($file)) {
+                                fclose($file);
+                            }
+                            $after_open_token = $this->source_token($path);
+                            if ($after_open_token !== $source_token) {
+                                $this->record_source_restart($current, $after_open_token);
+                                continue;
+                            }
+                            $next_unsent_path_list_offset = $current['path_list_offset'];
+                            $local_failure_detail = 'Could not open the selected source file at its receiver-confirmed cursor: ' . base64_encode($path) . '.';
+                            break;
+                        }
+                        $payload = fread($file, $maximum);
+                        fclose($file);
+                        $after_read_token = $this->source_token($path);
+                        if ($after_read_token !== $source_token) {
+                            $this->record_source_restart($current, $after_read_token);
+                            continue;
+                        }
+                        if (!is_string($payload) || ( $payload === '' && $offset < $source_token['size'] )) {
+                            $next_unsent_path_list_offset = $current['path_list_offset'];
+                            $local_failure_detail = 'Could not read the selected source file at its receiver-confirmed cursor: ' . base64_encode($path) . '.';
+                            break;
+                        }
+                    }
+                    $part = [
+                        'type' => 'file',
+                        'path' => $path,
+                        'total_bytes' => $source_token['size'],
+                        'offset' => $offset,
+                        'payload' => $payload,
+                    ];
+                    $logical_value_complete = $offset + strlen($payload) === $source_token['size'];
+                } elseif ($source_token['type'] === 'directory') {
+                    $part = ['type' => 'directory', 'path' => $path, 'payload' => ''];
+                    $logical_value_complete = true;
+                } else {
+                    $target = @readlink($this->docroot . '/' . $path);
+                    $after_read_token = $this->source_token($path);
+                    if ($after_read_token !== $source_token) {
+                        $this->record_source_restart($current, $after_read_token);
+                        continue;
+                    }
+                    if (!is_string($target) || $target === '') {
+                        $next_unsent_path_list_offset = $current['path_list_offset'];
+                        $local_failure_detail = 'Could not read the selected source symlink target: ' . base64_encode($path) . '.';
+                        break;
+                    }
+                    $part = ['type' => 'symlink', 'path' => $path, 'target' => $target, 'payload' => ''];
+                    $logical_value_complete = true;
+                }
+
+                if (!$this->client->send_part($part)) {
+                    $next_unsent_path_list_offset = $current['path_list_offset'];
+                    if ($last_sent === null) {
+                        $request_size_failure_detail = 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($path) . '.';
+                    }
+                    break;
+                }
+                $current['confirmed_bytes'] = $source_token['type'] === 'file'
+                    ? $part['offset'] + strlen($part['payload'])
+                    : 0;
+                $last_sent = $current;
+                $last_sent['complete'] = $logical_value_complete;
+                if (!$logical_value_complete) {
+                    if ($this->client->should_finish_request()) {
+                        break;
+                    }
+                    continue;
+                }
+                if ($this->client->should_finish_request()) {
+                    break;
+                }
+
+                $path_list_offset = $current['next_path_list_offset'];
+                $current = null;
+                while ($current === null) {
+                    if (fseek($paths, $path_list_offset) !== 0) {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        break 2;
+                    }
+                    $path_line = fgets($paths);
+                    if ($path_line === false) {
+                        if (!feof($paths)) {
+                            $next_unsent_path_list_offset = $path_list_offset;
+                            $local_failure_detail = 'Could not read the journal paths selected for push.';
+                        }
+                        break 2;
+                    }
+                    $next_path_list_offset = ftell($paths);
+                    if (!is_int($next_path_list_offset)) {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        $local_failure_detail = 'Could not read the next byte offset in the journal paths selected for push.';
+                        break 2;
+                    }
+                    $path_record = json_decode($path_line, true);
+                    $path = is_array($path_record) && is_string($path_record['path'] ?? null)
+                        ? base64_decode($path_record['path'], true)
+                        : false;
+                    if (!is_string($path) || $path === '') {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        break 2;
+                    }
+                    $base64_path = base64_encode($path);
+                    $is_current_path = $state['current_path_b64'] === $base64_path;
+                    $source_token = $this->source_token($path);
+                    if ($source_token === null) {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        break 2;
+                    }
+                    if ($source_token['type'] === 'directory') {
+                        $directory_is_empty = $this->directory_is_empty($path);
+                        if ($directory_is_empty === null) {
+                            $next_unsent_path_list_offset = $path_list_offset;
+                            $local_failure_detail = 'Could not read the selected source directory: ' . base64_encode($path) . '.';
+                            break 2;
+                        }
+                        if ($this->source_token($path) !== $source_token) {
+                            continue;
+                        }
+                        if (!$directory_is_empty && !$is_current_path) {
+                            $path_list_offset = $next_path_list_offset;
+                            continue;
+                        }
+                    }
+                    $current = [
+                        'path' => $path,
+                        'path_b64' => $base64_path,
+                        'path_list_offset' => $path_list_offset,
+                        'next_path_list_offset' => $next_path_list_offset,
+                        'source_token' => $source_token,
+                        'confirmed_bytes' => 0,
+                    ];
+                    $state['paths_byte_offset'] = $path_list_offset;
+                    $state['current_path_b64'] = $current['path_b64'];
+                    $state['next_paths_byte_offset'] = $next_path_list_offset;
+                    $state['source_token'] = null;
+                    $state['confirmed_bytes'] = 0;
+                    $reconciliation_state = $state;
+                    $reconciliation_state['phase'] = 'reconciling_work';
+                    $this->persist_state($reconciliation_state);
+                }
+            }
+            fclose($paths);
+            $request = $this->client->finish_request();
+            $state['phase'] = 'reconciling_work';
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $state['recoverable_failures'] = 0;
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_int($response['changes_accepted'] ?? null)
+                || $response['changes_accepted'] !== $request['parts_sent']
+                || !array_key_exists('last_change', $response)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not return the matching push session and exact accepted-part count.');
+            }
+            $last_change = $response['last_change'];
+            if ($last_sent === null) {
+                if ($last_change !== null) {
+                    return $this->step_result('failed', $state, 'unexpected_response', 'push_upload returned a positive-work change when no part was sent.');
+                }
+                $state['paths_byte_offset'] = $path_list_offset;
+                $state['current_path_b64'] = null;
+                $state['source_token'] = null;
+                $state['confirmed_bytes'] = 0;
+            } elseif (
+                !is_array($last_change)
+                || ( $last_change['path_b64'] ?? null ) !== $last_sent['path_b64']
+                || ( $last_change['type'] ?? null ) !== $last_sent['source_token']['type']
+                || ( $last_change['state'] ?? null ) !== ( $last_sent['complete'] ? 'complete' : 'partial' )
+                || !is_int($last_change['accepted_bytes'] ?? null)
+                || $last_change['accepted_bytes'] !== $last_sent['confirmed_bytes']
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not confirm the exact latest positive-work state.');
+            } elseif (( $last_change['state'] ?? null ) === 'complete') {
+                $state['paths_byte_offset'] = $next_unsent_path_list_offset ?? $last_sent['next_path_list_offset'];
+                $state['current_path_b64'] = null;
+                $state['source_token'] = null;
+                $state['confirmed_bytes'] = 0;
+            } else {
+                $state['paths_byte_offset'] = $last_sent['path_list_offset'];
+                $state['next_paths_byte_offset'] = $last_sent['next_path_list_offset'];
+                $state['current_path_b64'] = $last_sent['path_b64'];
+                $state['source_token'] = $last_sent['source_token'];
+                $state['confirmed_bytes'] = $last_change['accepted_bytes'];
+            }
+            $this->persist_state($state);
+            if ($local_failure_detail !== null) {
+                return $this->step_result('failed', $state, 'local_io_error', $local_failure_detail);
+            }
+            if ($request_size_failure_detail !== null) {
+                return $this->step_result('failed', $state, 'request_size_exhausted', $request_size_failure_detail);
+            }
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'reconciling_deletes') {
+            return $this->reconcile_work_deletes($state);
+        }
+
+        if ($state['phase'] === 'uploading_deletes') {
+            $deletes = fopen($this->journal->work_deletes_path, 'rb');
+            if ($deletes === false || fseek($deletes, $state['work_deletes_byte_offset']) !== 0) {
+                if (is_resource($deletes)) {
+                    fclose($deletes);
+                }
+                return $this->step_result('failed', $state, 'local_io_error', 'Could not open the raw work-delete stream at its receiver-confirmed cursor.');
+            }
+            $reconciliation_state = $state;
+            $reconciliation_state['phase'] = 'reconciling_deletes';
+            $this->persist_state($reconciliation_state);
+            if (!$this->client->start_upload_request($state['push_session_id'])) {
+                fclose($deletes);
+                $request = [
+                    'status' => 'retry',
+                    'reason' => 'request_failed',
+                    'detail' => $this->client->get_last_error(),
+                    'response' => null,
+                    'parts_sent' => 0,
+                    'body_bytes_sent' => 0,
+                ];
+                $failure = $this->handle_request_failure($request, $state);
+                return $failure ?? $this->step_result('failed', $state, 'unexpected_response', 'The work-delete upload failed without a classified result.');
+            }
+            $offset = $state['work_deletes_byte_offset'];
+            $sent_completion = false;
+            $delete_read_failed = false;
+            while (true) {
+                $maximum = $this->client->next_delete_body_bytes($offset);
+                if ($maximum === 0) {
+                    break;
+                }
+                $payload = fread($deletes, $maximum);
+                if (!is_string($payload)) {
+                    $delete_read_failed = true;
+                    break;
+                }
+                $complete = $payload === '' && feof($deletes);
+                if (!$this->client->send_part([
+                    'type' => 'delete-list',
+                    'offset' => $offset,
+                    'complete' => $complete,
+                    'payload' => $payload,
+                ])) {
+                    break;
+                }
+                $offset += strlen($payload);
+                if ($complete) {
+                    $sent_completion = true;
+                    break;
+                }
+                if ($this->client->should_finish_request()) {
+                    break;
+                }
+            }
+            fclose($deletes);
+            $request = $this->client->finish_request();
+            $state['phase'] = 'reconciling_deletes';
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            if ($delete_read_failed) {
+                return $this->step_result('failed', $state, 'local_io_error', 'Could not read the raw work-delete stream at its receiver-confirmed cursor.');
+            }
+            $response = $request['response'];
+            if ($request['parts_sent'] === 0) {
+                return $this->step_result('failed', $state, 'request_size_exhausted', 'The current request-body budget cannot fit one work-delete MIME part.');
+            }
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_int($response['changes_accepted'] ?? null)
+                || $response['changes_accepted'] !== $request['parts_sent']
+                || !is_array($response['last_change'] ?? null)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not return the matching push session and exact accepted work-delete part count.');
+            }
+            $last_change = $response['last_change'];
+            if (
+                ( $last_change['type'] ?? null ) !== 'delete-list'
+                || ( $last_change['state'] ?? null ) !== ( $sent_completion ? 'complete' : 'partial' )
+                || !is_int($last_change['accepted_bytes'] ?? null)
+                || $last_change['accepted_bytes'] !== $offset
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not confirm the exact work-delete cursor and completion state.');
+            }
+            $state['recoverable_failures'] = 0;
+            $state['work_deletes_byte_offset'] = $last_change['accepted_bytes'];
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'committing') {
+            $request = $this->control_request('POST', 'push_commit', [
+                'push_session_id' => $state['push_session_id'],
+            ], ['accepted']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !in_array($response['phase'] ?? null, ['deleting_files', 'installing_files', 'complete'], true)
+                || !is_bool($response['send_next_request'] ?? null)
+                || !is_int($response['entries_processed'] ?? null)
+                || $response['entries_processed'] < 0
+                || ( $response['send_next_request'] === ( $response['phase'] === 'complete' ) )
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_commit did not return the matching push session and exact bounded continuation state.');
+            }
+            $state['recoverable_failures'] = 0;
+            if ($response['send_next_request']) {
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, null, null);
+            }
+            $push_session_id = $state['push_session_id'];
+            $this->journal->capture_local_files_baseline($this->journal->sender_index_path);
+            $this->journal->clear_sender_state();
+            return [
+                'status' => 'complete',
+                'phase' => 'complete',
+                'push_session_id' => $push_session_id,
+                'reason' => null,
+                'detail' => null,
+            ];
+        }
+
+        if ($state['phase'] === 'removing') {
+            $request = $this->control_request('POST', 'push_remove', [
+                'push_session_id' => $state['push_session_id'],
+            ], ['accepted']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_bool($response['removed'] ?? null)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_remove did not return the matching push session and exact bounded completion state.');
+            }
+            $state['recoverable_failures'] = 0;
+            if (!$response['removed']) {
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, null, null);
+            }
+            $push_session_id = $state['push_session_id'];
+            $this->journal->clear_sender_state();
+            return [
+                'status' => 'restart',
+                'phase' => 'complete',
+                'push_session_id' => $push_session_id,
+                'reason' => 'source_changed',
+                'detail' => 'The abandoned upload-only push session was removed. Regenerate the local index before retrying.',
+            ];
+        }
+
+        return $this->step_result('failed', $state, 'invalid_sender_state', 'Sender state contains an unsupported phase.');
+    }
+
+    /**
+     * Reconciles the raw work-delete stream with the target cursor.
+     *
+     * This request runs both when positive work reaches its path-list end and
+     * after every work-delete upload. A cursor beyond the stable local stream
+     * cannot be resumed, so the upload-only push session is removed before the
+     * caller regenerates its local index.
+     *
+     * @param array<string,mixed> $state Complete sender checkpoint in the exact
+     *     PushJournal::write_sender_state() shape.
+     * @return array{
+     *     status:'continue'|'failed',
+     *     phase:'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:string,
+     *     reason:?string,
+     *     detail:?string
+     * } Result of the real push_status request and durable transition.
+     */
+    private function reconcile_work_deletes(array &$state): array
+    {
+        $request = $this->control_request('GET', 'push_status', [
+            'push_session_id' => $state['push_session_id'],
+        ], ['accepted']);
+        $failure = $this->handle_request_failure($request, $state);
+        if ($failure !== null) {
+            return $failure;
+        }
+        $response = $request['response'];
+        $work_deletes_bytes = is_array($response) ? ( $response['work_deletes_bytes'] ?? null ) : null;
+        $work_deletes_complete = is_array($response) ? ( $response['work_deletes_complete'] ?? null ) : null;
+        $local_work_deletes_bytes = @filesize($this->journal->work_deletes_path);
+        if (
+            !is_array($response)
+            || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+            || ( $response['phase'] ?? null ) !== 'receiving_work'
+            || ( $response['path'] ?? null ) !== null
+            || !is_int($work_deletes_bytes)
+            || $work_deletes_bytes < 0
+            || !is_bool($work_deletes_complete)
+        ) {
+            return $this->step_result('failed', $state, 'unexpected_response', 'push_status did not return the exact receiver-confirmed work-delete state.');
+        }
+        if (!is_int($local_work_deletes_bytes)) {
+            return $this->step_result('failed', $state, 'local_io_error', 'Could not read the stable local work-delete stream size.');
+        }
+        if ($work_deletes_bytes > $local_work_deletes_bytes) {
+            $state['phase'] = 'removing';
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, 'source_changed', 'The receiver work-delete cursor cannot belong to the current local deletion list.');
+        }
+        $state['recoverable_failures'] = 0;
+        $state['work_deletes_byte_offset'] = $work_deletes_bytes;
+        $state['phase'] = $work_deletes_complete ? 'committing' : 'uploading_deletes';
+        $this->persist_state($state);
+        return $this->step_result('continue', $state, null, null);
+    }
+
+    /**
+     * Records a changed source token for the open request.
+     *
+     * The durable checkpoint deliberately retains the previous source token
+     * until an upload response confirms a part from the new token. If the
+     * process dies before that response, the mismatch forces another
+     * offset-zero restart instead of accepting an old-version receiver cursor.
+     * A null token likewise leaves the previous evidence in place; if the path
+     * remains absent, status reconciliation removes the upload-only push
+     * session.
+     *
+     * @param array{
+     *     path:string,
+     *     path_b64:string,
+     *     path_list_offset:int,
+     *     next_path_list_offset:int,
+     *     source_token:array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null,
+     *     confirmed_bytes:int
+     * } $current Selected positive-work value for the open request.
+     * @param array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null $source_token
+     *     New source token, or null when the selected path disappeared.
+     */
+    private function record_source_restart(array &$current, ?array $source_token): void
+    {
+        $current['source_token'] = $source_token;
+        $current['confirmed_bytes'] = 0;
+    }
+
+    /**
+     * Sends a signed control request and classifies transport exceptions.
+     *
+     * Redirects are permanent because the HMAC covers the original target,
+     * and invalid JSON is a terminal protocol response. A missing response is
+     * recoverable within the sender's fixed retry bound; repeating create,
+     * status, commit, or remove is idempotent.
+     *
+     * @param string $method GET or POST.
+     * @param string $endpoint Push protocol endpoint.
+     * @param array<string,mixed> $parameters Request-target parameters.
+     * @param list<string> $expected_statuses Successful response statuses.
+     * @return array{
+     *     status:'complete'|'retry'|'failed',
+     *     reason:?string,
+     *     detail:?string,
+     *     response:?array<string,mixed>,
+     *     parts_sent:int,
+     *     body_bytes_sent:int
+     * } Classified control result.
+     */
+    private function control_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
+    {
+        try {
+            return $this->client->control_request($method, $endpoint, $parameters, $expected_statuses);
+        } catch (RuntimeException $exception) {
+            $message = $exception->getMessage();
+            if (strpos($message, 'The target redirected') === 0) {
+                $status = 'failed';
+                $reason = 'redirected';
+            } elseif (strpos($message, 'Push control request returned invalid JSON') === 0) {
+                $status = 'failed';
+                $reason = 'malformed_response';
+            } elseif (strpos($message, 'Push control request failed:') === 0) {
+                $status = 'retry';
+                $reason = 'request_failed';
+            } else {
+                $status = 'failed';
+                $reason = 'client_error';
+            }
+            return [
+                'status' => $status,
+                'reason' => $reason,
+                'detail' => $message,
+                'response' => null,
+                'parts_sent' => 0,
+                'body_bytes_sent' => 0,
+            ];
+        }
+    }
+
+    /**
+     * Indicates whether a selected source directory contains no child entry.
+     *
+     * The directory handle stops at the first name other than `.` or `..`, so
+     * checking a large non-empty directory never materializes its entry list.
+     *
+     * @param string $path Raw document-root-relative directory path.
+     * @return bool|null True for an empty directory, false for a non-empty
+     *     directory, or null when the directory cannot be opened.
+     */
+    private function directory_is_empty(string $path): ?bool
+    {
+        $directory = @opendir($this->docroot . '/' . $path);
+        if ($directory === false) {
+            return null;
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry !== '.' && $entry !== '..') {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            closedir($directory);
+        }
+    }
+
+    /**
+     * Returns the current source evidence used to decide resume versus restart.
+     *
+     * Paths are document-root-relative byte strings. Regular files,
+     * directories, and symlinks are the only sendable types. Size and ctime
+     * match PushJournal's diff evidence; a changed token restarts the same
+     * in-flight work at offset zero. A same-size edit within one ctime second
+     * remains the documented timestamp-resolution gap.
+     *
+     * @param string $path Raw document-root-relative path.
+     * @return array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null
+     *     Current source token, or null when the path is absent or unsupported.
+     */
+    private function source_token(string $path): ?array
+    {
+        if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('A selected push path is not a safe document-root-relative path: ' . base64_encode($path) . '.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException('A selected push path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
+            }
+        }
+        $identity = @lstat($this->docroot . '/' . $path);
+        if (!is_array($identity)) {
+            return null;
+        }
+        $kind = $identity['mode'] & 0170000;
+        if ($kind === 0100000) {
+            $type = 'file';
+        } elseif ($kind === 0040000) {
+            $type = 'directory';
+        } elseif ($kind === 0120000) {
+            $type = 'symlink';
+        } else {
+            return null;
+        }
+        return [
+            'type' => $type,
+            'size' => (int) $identity['size'],
+            'ctime' => (int) $identity['ctime'],
+        ];
+    }
+
+    /**
+     * Converts a failed request into a bounded workflow result.
+     *
+     * Complete results return null for phase-specific handling. Recoverable
+     * results increment the durable failure count and become terminal after
+     * five consecutive failures. Permanent protocol results fail immediately.
+     *
+     * @param array{
+     *     status:'complete'|'retry'|'failed',reason:?string,detail:?string,
+     *     response:?array<string,mixed>,parts_sent:int,body_bytes_sent:int
+     * } $request Classified client request result.
+     * @param array<string,mixed> $state Complete sender checkpoint, updated
+     *     and persisted when sizing or retry evidence changes.
+     * @return array{
+     *     status:'continue'|'failed',
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:string,
+     *     reason:?string,
+     *     detail:?string
+     * }|null Null when the request completed successfully.
+     */
+    private function handle_request_failure(array $request, array &$state): ?array
+    {
+        if ($request['status'] === 'complete') {
+            return null;
+        }
+        if ($request['status'] === 'retry') {
+            ++$state['recoverable_failures'];
+            $this->persist_state($state);
+            if ($state['recoverable_failures'] >= self::MAXIMUM_RECOVERABLE_FAILURES) {
+                return $this->step_result(
+                    'failed',
+                    $state,
+                    'retry_exhausted',
+                    'Push stopped after ' . self::MAXIMUM_RECOVERABLE_FAILURES . ' consecutive recoverable failures. Last failure: ' . ( $request['detail'] ?? $request['reason'] )
+                );
+            }
+            return $this->step_result('continue', $state, $request['reason'], $request['detail']);
+        }
+        $this->persist_state($state);
+        return $this->step_result('failed', $state, $request['reason'], $request['detail']);
+    }
+
+    /**
+     * Persists a complete checkpoint with current request-sizing evidence.
+     *
+     * @param array<string,mixed> $state Complete sender state in the exact
+     *     PushJournal::write_sender_state() shape.
+     */
+    private function persist_state(array $state): void
+    {
+        $state['request_sizer_state'] = $this->client->get_request_sizer_state();
+        $this->journal->write_sender_state($state);
+    }
+
+    /**
+     * Builds one exact workflow result without changing durable state.
+     *
+     * @param 'continue'|'failed' $status Step disposition.
+     * @param array<string,mixed> $state Complete sender checkpoint.
+     * @param string|null $reason Machine-readable classification.
+     * @param string|null $detail Human-readable condition.
+     * @return array{
+     *     status:'continue'|'failed',
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:string,
+     *     reason:?string,
+     *     detail:?string
+     * } Step result.
+     */
+    private function step_result(string $status, array $state, ?string $reason, ?string $detail): array
+    {
+        return [
+            'status' => $status,
+            'phase' => $state['phase'],
+            'push_session_id' => $state['push_session_id'],
+            'reason' => $reason,
+            'detail' => $detail,
+        ];
+    }
+}

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -1,4 +1,6 @@
 <?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 /**
  * Per-remote-site memory of the last completed push: the local baseline.
  *
@@ -26,6 +28,10 @@
  *                                  ctime, size, or type differs
  *     local-paths-to-delete.jsonl  paths in the baseline but gone from the
  *                                  current index
+ *     work-deletes                 the same deletions as raw NUL-delimited
+ *                                  path bytes for the receiver
+ *     sender-index.jsonl           stable index selected for the active push
+ *     sender.json                  the active sender's resumable request state
  *
  * The diff parses one JSON line at a time from each input. Ordering compares
  * decoded paths; two entries with the same path count as unchanged when their
@@ -39,10 +45,10 @@
  * With no baseline yet — the first push to a site — every current entry
  * counts as changed and no deletion can be detected.
  *
- * Producing the current index is the caller's job; this class only
- * compares and stores. The lists belong to the run that produced them:
- * a resumed push reruns the diff (one cheap local pass) rather than
- * trusting lists from an earlier run.
+ * Producing the current index is the caller's job; this class only compares
+ * and stores. A new push replaces the lists. An active sender keeps using the
+ * lists named by sender.json so its byte offsets continue to identify the
+ * same records after a process restart.
  */
 class PushJournal
 {
@@ -57,12 +63,24 @@ class PushJournal
     /** @var string JSONL file of local paths whose deletion should be pushed, written by diff_local_files(). */
     public string $local_paths_to_delete;
 
+    /** @var string Raw NUL-delimited work deletes prepared for the receiver. */
+    public string $work_deletes_path;
+
+    /** @var string Atomic checkpoint for the active high-level sender. */
+    public string $sender_state_path;
+
+    /** @var string Stable local index selected when the active push began. */
+    public string $sender_index_path;
+
     public function __construct(string $state_dir, string $site_url)
     {
         $this->site_dir = rtrim($state_dir, "/") . "/push/" . self::site_key($site_url);
         $this->local_files_baseline_path = $this->site_dir . "/last-sync-local-files.jsonl";
         $this->local_paths_to_push = $this->site_dir . "/local-paths-to-push.jsonl";
         $this->local_paths_to_delete = $this->site_dir . "/local-paths-to-delete.jsonl";
+        $this->work_deletes_path = $this->site_dir . "/work-deletes";
+        $this->sender_state_path = $this->site_dir . "/sender.json";
+        $this->sender_index_path = $this->site_dir . "/sender-index.jsonl";
     }
 
     /**
@@ -111,6 +129,21 @@ class PushJournal
     public function capture_local_files_baseline(string $index_file): void
     {
         $this->replace_file($this->local_files_baseline_path, $index_file);
+    }
+
+    /**
+     * Captures the stable index whose path lists and final baseline belong to
+     * the active push.
+     *
+     * Source tokens may still change after this copy; that restarts the value
+     * being sent and leaves the start-of-push index evidence as the baseline.
+     * A later index whose size, ctime, or type differs therefore selects the
+     * path again. Replacing the caller's index during a long push can never mark
+     * paths absent from the stable index as synchronized.
+     */
+    public function capture_sender_index(string $index_file): void
+    {
+        $this->replace_file($this->sender_index_path, $index_file);
     }
 
     /**
@@ -235,6 +268,142 @@ class PushJournal
     }
 
     /**
+     * Converts the deletion JSONL into the receiver's raw work-delete stream.
+     *
+     * Each input record is decoded and written immediately as `path + NUL`.
+     * A temporary file is renamed only after the complete list is consumed, so
+     * sender.json never refers to a torn work-delete record after interruption.
+     *
+     * @return int Complete raw work-delete byte count.
+     */
+    public function prepare_work_deletes(): int
+    {
+        if (!is_file($this->local_paths_to_delete)) {
+            throw new RuntimeException("Cannot prepare work deletes, the local deletion list is missing: {$this->local_paths_to_delete}");
+        }
+        $this->ensure_site_dir();
+        $input = fopen($this->local_paths_to_delete, "rb");
+        if (!$input) {
+            throw new RuntimeException("Failed to open local_paths_to_delete: {$this->local_paths_to_delete}");
+        }
+        $temporary = $this->work_deletes_path . ".tmp";
+        $output = fopen($temporary, "wb");
+        if (!$output) {
+            fclose($input);
+            throw new RuntimeException("Failed to open work deletes for writing: {$temporary}");
+        }
+        $bytes = 0;
+        try {
+            while (true) {
+                $this->read_line($input, $entry, $path, $base64_path);
+                if ($entry === null) {
+                    break;
+                }
+                $record = $path . "\0";
+                if (fwrite($output, $record) !== strlen($record)) {
+                    throw new RuntimeException("Short write on work deletes, is the disk full?");
+                }
+                $bytes += strlen($record);
+            }
+            if (!fclose($output)) {
+                $output = null;
+                throw new RuntimeException("Failed to close work deletes: {$temporary}");
+            }
+            $output = null;
+            if (!rename($temporary, $this->work_deletes_path)) {
+                throw new RuntimeException("Failed to move work deletes into place: {$this->work_deletes_path}");
+            }
+        } finally {
+            fclose($input);
+            if (is_resource($output)) {
+                fclose($output);
+            }
+        }
+        return $bytes;
+    }
+
+    /**
+     * Reads the active sender checkpoint written by write_sender_state().
+     *
+     * The journal owns this private file and atomically replaces it. A valid
+     * JSON object is therefore trusted as the sender's last durable boundary;
+     * the workflow interprets its phase and correlated fields. `source_token`
+     * and `confirmed_bytes` describe the last positive-work part confirmed by
+     * an upload response, not bytes merely handed to the network.
+     *
+     * @return array{
+     *     version:1,
+     *     push_session_id:string,
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     paths_byte_offset:int,
+     *     current_path_b64:?string,
+     *     next_paths_byte_offset:int,
+     *     source_token:array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null,
+     *     confirmed_bytes:int,
+     *     work_deletes_byte_offset:int,
+     *     recoverable_failures:int,
+     *     max_part_bytes:?int,
+     *     request_sizer_state:array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
+     * }|null Durable sender state, or null when no push is active.
+     */
+    public function read_sender_state(): ?array
+    {
+        if (!is_file($this->sender_state_path)) {
+            return null;
+        }
+        $json = file_get_contents($this->sender_state_path);
+        if (!is_string($json)) {
+            throw new RuntimeException("Failed to read sender state: {$this->sender_state_path}");
+        }
+        $state = json_decode($json, true);
+        if (!is_array($state)) {
+            throw new RuntimeException("Sender state does not contain a JSON object: {$this->sender_state_path}");
+        }
+        return $state;
+    }
+
+    /**
+     * Atomically records the sender's last receiver-reconcilable boundary.
+     *
+     * @param array{
+     *     version:1,
+     *     push_session_id:string,
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     paths_byte_offset:int,
+     *     current_path_b64:?string,
+     *     next_paths_byte_offset:int,
+     *     source_token:array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null,
+     *     confirmed_bytes:int,
+     *     work_deletes_byte_offset:int,
+     *     recoverable_failures:int,
+     *     max_part_bytes:?int,
+     *     request_sizer_state:array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
+     * } $state Complete sender checkpoint.
+     */
+    public function write_sender_state(array $state): void
+    {
+        $this->ensure_site_dir();
+        $json = json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $temporary = $this->sender_state_path . ".tmp";
+        if (file_put_contents($temporary, $json) !== strlen($json)) {
+            throw new RuntimeException("Failed to write sender state: {$temporary}");
+        }
+        if (!rename($temporary, $this->sender_state_path)) {
+            throw new RuntimeException("Failed to move sender state into place: {$this->sender_state_path}");
+        }
+    }
+
+    /**
+     * Removes the completed or deliberately abandoned sender checkpoint.
+     */
+    public function clear_sender_state(): void
+    {
+        if (is_file($this->sender_state_path) && !unlink($this->sender_state_path)) {
+            throw new RuntimeException("Failed to remove sender state: {$this->sender_state_path}");
+        }
+    }
+
+    /**
      * Read the next index line and parse its JSON object.
      *
      * All three out-parameters become null at end of file: $entry is the
@@ -275,21 +444,23 @@ class PushJournal
     }
 
     /**
-     * Copy an index file over a baseline: temp file in the same directory,
-     * then rename, so readers only ever see the old or the new baseline.
+     * Copies an index into a journal file by same-directory temp and rename.
+     *
+     * This supplies the atomic replacement used by both the completed local
+     * baseline and the stable index selected for an active sender.
      */
     private function replace_file(string $target, string $source_index_file): void
     {
         if (!is_file($source_index_file)) {
-            throw new RuntimeException("Cannot capture a baseline, the index file is missing: {$source_index_file}");
+            throw new RuntimeException("Cannot replace a journal file, the source index file is missing: {$source_index_file}");
         }
         $this->ensure_site_dir();
         $tmp = $target . ".tmp";
         if (!copy($source_index_file, $tmp)) {
-            throw new RuntimeException("Failed to copy the index into a baseline temp file: {$tmp}");
+            throw new RuntimeException("Failed to copy the source index into a temporary journal file: {$tmp}");
         }
         if (!rename($tmp, $target)) {
-            throw new RuntimeException("Failed to move the baseline into place: {$target}");
+            throw new RuntimeException("Failed to move the journal file into place: {$target}");
         }
     }
 

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -554,7 +554,7 @@ class MultipartPushStreamClient
      * - `body_bytes_sent`: MIME entity-body bytes accounted for this request.
      *
      * @return array{
-     *     status:string,
+     *     status:'complete'|'retry'|'failed',
      *     reason:?string,
      *     detail:?string,
      *     response:?array<string,mixed>,
@@ -670,7 +670,7 @@ class MultipartPushStreamClient
      *     Their keys are encoded and signed but are not interpreted here.
      * @param string[] $expected_statuses Successful protocol statuses for this endpoint.
      * @return array{
-     *     status:string,
+     *     status:'complete'|'retry'|'failed',
      *     reason:?string,
      *     detail:?string,
      *     response:array<string,mixed>,
@@ -1003,15 +1003,16 @@ class MultipartPushStreamClient
     /**
      * Classifies every decoded upload and control response by protocol reason.
      *
-     * `busy` and `offset_gap` are recoverable because a later request can use
-     * the receiver-confirmed cursor. Every other rejection fails the request; HTTP
-     * status alone never promotes an unknown reason into a retry.
+     * `lock_acquisition_failure` and `offset_gap` are recoverable because a
+     * later request can retry the locked operation or use the receiver-
+     * confirmed cursor. Every other rejection fails the request; HTTP status
+     * alone never promotes an unknown reason into a retry.
      *
      * Classification reads these response keys:
      *
      * - `status`: target protocol status compared with `$expected_statuses`.
-     * - `reason`: optional machine-readable rejection reason. Only `busy` and
-     *   `offset_gap` are recoverable.
+     * - `reason`: optional machine-readable rejection reason. Only
+     *   `lock_acquisition_failure` and `offset_gap` are recoverable.
      * - `detail`: optional human-readable rejection detail.
      * - `http_code`: observed HTTP status used when no detail was supplied.
      *
@@ -1021,7 +1022,7 @@ class MultipartPushStreamClient
      *     the classification keys above.
      * @param string[] $expected_statuses Successful statuses for this request.
      * @return array{
-     *     status:string,
+     *     status:'complete'|'retry'|'failed',
      *     reason:?string,
      *     detail:?string,
      *     response:array<string,mixed>,
@@ -1043,7 +1044,7 @@ class MultipartPushStreamClient
         }
         $reason = is_string($response['reason'] ?? null) ? $response['reason'] : 'unexpected_response';
         return [
-            'status' => in_array($reason, ['busy', 'offset_gap'], true) ? 'retry' : 'failed',
+            'status' => in_array($reason, ['lock_acquisition_failure', 'offset_gap'], true) ? 'retry' : 'failed',
             'reason' => $reason,
             'detail' => is_string($response['detail'] ?? null)
                 ? $response['detail']

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/push-commit-language",
+            "version": "dev-adamziel/authenticated-push-endpoints",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "6a5cbcf2ac9d0b34789819f01ccb00033b67581a"
+                "reference": "2050e07227a82c058c6267c5e8b3e77d0cd4dbdc"
             },
             "require": {
                 "php": ">=7.2",
@@ -386,6 +386,7 @@
                     "src/class-http-server.php",
                     "src/class-multipart-processor.php",
                     "src/class-push-exception.php",
+                    "src/class-push-endpoints.php",
                     "src/class-push-session.php",
                     "src/class-sqlite-driver-pdo.php",
                     "src/class-wpdb-driver-pdo.php"

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -38,6 +38,30 @@ function _site_export_error(int $code, string $message): void {
 }
 
 /**
+ * Sends one classified push-protocol failure and terminates the request.
+ *
+ * Authentication and configuration fail before the endpoint object is
+ * constructed, so they use the same response discriminator here instead of
+ * the legacy export error object.
+ *
+ * Emits `{status:"rejected",reason:string,detail:string}`.
+ *
+ * @param int $http_code HTTP status code.
+ * @param string $reason Machine-readable push failure reason.
+ * @param string $detail Human-readable violated condition.
+ */
+function _site_export_push_error(int $http_code, string $reason, string $detail): void {
+    http_response_code($http_code);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'status' => 'rejected',
+        'reason' => $reason,
+        'detail' => $detail,
+    ]);
+    exit;
+}
+
+/**
  * Resolve and load the exporter package runtime.
  *
  * Supports both plugin release bundles (with reprint-exporter-wp/vendor/) and
@@ -189,6 +213,15 @@ function _site_export_default_authenticate(): void {
  * @param array $options Optional overrides:
  *   - 'authenticate' (callable): Called to authenticate the request.
  *        Defaults to _site_export_default_authenticate().
+ *   - 'reprint_directory' (string): Private push storage path. Defaults to a
+ *        document-root-specific directory beside ABSPATH.
+ *   - 'excluded_paths' (string[]): Document-root-relative paths push must
+ *        preserve. The exporter plugin directory is always included when it
+ *        is below ABSPATH.
+ *   - 'maximum_part_bytes' (int): Maximum Content-Length for one push upload
+ *        part. Defaults to 4 MiB.
+ *   - 'maximum_commit_entries' (int): Maximum bounded entries processed by one
+ *        push_commit request. Defaults to 256.
  */
 function _site_export_handle_api_request(array $options = []): void {
     // Revert WordPress error display settings (wp_debug_mode may
@@ -250,17 +283,46 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    // push_upload authenticates inside its handler: the default handler
-    // here buffers the whole request body to hash it, which a chunk upload
-    // cannot afford. The upload route verifies the signed headers first and
-    // hashes the body as it streams. A custom authenticate callable still
-    // runs for every endpoint — its embedder owns that tradeoff.
+    // Push requests use envelope authentication: the signature covers the
+    // method and exact request target while TLS protects the streamed body.
+    // The legacy verifier hashes php://input and remains only for the existing
+    // pull endpoints with bounded command bodies. A custom authenticate
+    // callable still runs for every endpoint; its embedder owns that policy.
     // filter_input, not WP sanitizers: lib.php also runs without WordPress
     // bootstrapped (hosts that route the API from their own index.php).
     $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
+    } elseif (in_array($endpoint, ['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'], true)) {
+        if (_site_export_has_secret_file()) {
+            $secret = _site_export_get_file_secret();
+            if (empty($secret)) {
+                _site_export_push_error(503, 'not_configured', 'Invalid secret.php configuration. Remove it or replace it with a valid shared secret.');
+            }
+        } else {
+            $secret = _site_export_get_option_secret();
+        }
+        if (empty($secret) || !is_string($secret)) {
+            _site_export_push_error(503, 'not_configured', 'Configure the shared secret in WordPress admin under Tools > Reprint Exporter.');
+        }
+        if (!class_exists('Site_Export_HMAC_Server')) {
+            _site_export_load_exporter_runtime();
+        }
+        if (!class_exists('Site_Export_HMAC_Server')) {
+            _site_export_push_error(500, 'filesystem_error', 'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.');
+        }
+        // These exact request-line values are covered by the HMAC; WordPress
+        // slashing or sanitization would verify a different target.
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+        $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+        $request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
+        $hmac_server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
+        $auth_error = $hmac_server->verify_envelope($_SERVER, $request_method, $request_target);
+        if ($auth_error !== null) {
+            _site_export_push_error(403, 'auth_failed', $auth_error);
+        }
     } else {
         _site_export_default_authenticate();
     }
@@ -277,7 +339,38 @@ function _site_export_handle_api_request(array $options = []): void {
 
     // -- Dispatch --
     try {
-        Site_Export_HTTP_Server::serve(['default_directory' => ABSPATH]);
+        $docroot = rtrim(ABSPATH, '/\\');
+        $reprint_directory = $options['reprint_directory'] ?? (
+            dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
+        );
+        $excluded_paths = $options['excluded_paths'] ?? [];
+        if (!is_array($excluded_paths)) {
+            throw new InvalidArgumentException('excluded_paths must be an array.');
+        }
+        $plugin_directory = rtrim(SITE_EXPORT_PLUGIN_DIR, '/\\');
+        $docroot_prefix = $docroot . DIRECTORY_SEPARATOR;
+        if (strpos($plugin_directory . DIRECTORY_SEPARATOR, $docroot_prefix) === 0) {
+            $relative_plugin_directory = str_replace('\\', '/', substr($plugin_directory, strlen($docroot_prefix)));
+            if ($relative_plugin_directory !== '') {
+                $excluded_paths[] = $relative_plugin_directory;
+            }
+        }
+        $excluded_paths = array_values(array_unique($excluded_paths));
+        $push_options = [
+            'reprint_directory' => $reprint_directory,
+            'docroot' => $docroot,
+            'excluded_paths' => $excluded_paths,
+        ];
+        if (array_key_exists('maximum_part_bytes', $options)) {
+            $push_options['maximum_part_bytes'] = $options['maximum_part_bytes'];
+        }
+        if (array_key_exists('maximum_commit_entries', $options)) {
+            $push_options['maximum_commit_entries'] = $options['maximum_commit_entries'];
+        }
+        Site_Export_HTTP_Server::serve([
+            'default_directory' => ABSPATH,
+            'push' => $push_options,
+        ]);
     } catch (Exception $e) {
         if (!headers_sent()) {
             http_response_code(400);

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -68,6 +68,115 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertSame(2, $result['parts_sent']);
     }
 
+    /**
+     * Proves that two completed upload requests use one TCP connection.
+     *
+     * The child accepts exactly one socket and serves two complete chunked
+     * requests from it. Opening another connection therefore cannot satisfy
+     * the second request or make this test pass.
+     */
+    public function testBackToBackUploadRequestsReuseTheConnection(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Connection-reuse coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_blocking($connection, false);
+            $pending = '';
+            for ($request_number = 1; $request_number <= 2; ++$request_number) {
+                $deadline = microtime(true) + 8;
+                $header_end = false;
+                $closing_boundary = null;
+                while (true) {
+                    $piece = fread($connection, 64 * 1024);
+                    if (is_string($piece) && $piece !== '') {
+                        $pending .= $piece;
+                    } elseif (microtime(true) > $deadline) {
+                        fclose($connection);
+                        fclose($listener);
+                        exit(4);
+                    } else {
+                        usleep(1000);
+                    }
+                    if ($header_end === false) {
+                        $header_end = strpos($pending, "\r\n\r\n");
+                        if ($header_end !== false) {
+                            $headers = substr($pending, 0, $header_end + 4);
+                            if (
+                                strpos($headers, 'POST /?reprint-api=1&endpoint=push_upload&push_session_id=') === false
+                                || stripos($headers, "Transfer-Encoding: chunked\r\n") === false
+                                || preg_match('/boundary=(reprint-[a-f0-9]+)/', $headers, $matches) !== 1
+                            ) {
+                                fclose($connection);
+                                fclose($listener);
+                                exit(7);
+                            }
+                            $closing_boundary = '--' . $matches[1] . "--\r\n";
+                        }
+                    }
+                    if ($closing_boundary === null) {
+                        continue;
+                    }
+                    $closing_at = strpos($pending, $closing_boundary, $header_end + 4);
+                    if ($closing_at === false) {
+                        continue;
+                    }
+                    $request_end = strpos($pending, "\r\n0\r\n\r\n", $closing_at + strlen($closing_boundary));
+                    if ($request_end === false) {
+                        continue;
+                    }
+                    $pending = substr($pending, $request_end + 7);
+                    break;
+                }
+
+                $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+                $connection_header = $request_number === 1 ? 'keep-alive' : 'close';
+                fwrite(
+                    $connection,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response)
+                        . "\r\nConnection: " . $connection_header . "\r\n\r\n" . $response
+                );
+            }
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        foreach (['first.bin', 'second.bin'] as $request_number => $path) {
+            $this->assertTrue($client->start_upload_request(str_repeat( (string) ( $request_number + 4 ), 32)));
+            $this->assertTrue($client->send_part([
+                'type' => 'file',
+                'path' => $path,
+                'total_bytes' => 1,
+                'offset' => 0,
+                'payload' => 'x',
+            ]));
+            $result = $client->finish_request();
+            $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        }
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status), 'The child must receive both requests on its one accepted connection.');
+    }
+
     public function testTargetPartLimitBoundsTheNextSourceRead(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
@@ -185,6 +294,51 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertLessThan(32 * 1024 * 1024, $client->get_request_sizer_state()['request_body_bytes']);
     }
 
+    /**
+     * Shows that an accepted empty upload is not request-size evidence.
+     *
+     * The target has accepted only a MIME close, so the sender still knows
+     * nothing about whether a larger decoded entity body would pass its stack.
+     */
+    public function testAcceptedEmptyUploadDoesNotGrowTheRequestBudget(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $request_sizer = new PushRequestSizer([
+            'floor_bytes' => 512,
+            'start_bytes' => 512,
+            'max_bytes' => 2048,
+        ]);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'request_sizer' => $request_sizer,
+            'connect_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        $before = $client->get_request_sizer_state();
+        $this->assertTrue($client->start_upload_request(str_repeat('7', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+        fwrite(
+            $connection,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response)
+                . "\r\nConnection: close\r\n\r\n" . $response
+        );
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(0, $result['parts_sent']);
+        $this->assertSame($before, $client->get_request_sizer_state());
+    }
+
     public function testMalformedNonemptyUploadResponseIsTerminal(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
@@ -221,6 +375,98 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertSame('failed', $result['status']);
         $this->assertSame('malformed_response', $result['reason']);
         $this->assertStringContainsString('Invalid JSON response', $result['detail']);
+    }
+
+    /**
+     * Keeps redirects and unknown protocol failures terminal.
+     *
+     * Each case uses a real TCP response. Redirects must name the final target
+     * required for a new signature, while an unrecognized rejection reason is
+     * preserved for the caller instead of being guessed recoverable.
+     */
+    public function testControlRedirectAndUnknownReasonAreTerminal(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Raw control-response coverage requires PHP curl and pcntl.');
+        }
+        foreach (['redirect', 'unknown-reason'] as $case) {
+            $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+            $this->assertNotFalse($listener, (string) $error);
+            $address = stream_socket_get_name($listener, false);
+            $child = pcntl_fork();
+            $this->assertNotSame(-1, $child);
+            if ($child === 0) {
+                $connection = stream_socket_accept($listener, 3);
+                if ($connection === false) {
+                    exit(2);
+                }
+                stream_set_timeout($connection, 3);
+                $request = '';
+                while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                    $piece = fread($connection, 64 * 1024);
+                    if (!is_string($piece) || $piece === '') {
+                        break;
+                    }
+                    $request .= $piece;
+                }
+                if (strpos($request, 'POST /?reprint-api=1&endpoint=push_create&push_session_id=') === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(3);
+                }
+                if ($case === 'redirect') {
+                    fwrite(
+                        $connection,
+                        "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://example.test/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    );
+                } else {
+                    $body = (string) json_encode([
+                        'status' => 'rejected',
+                        'reason' => 'new_protocol_failure',
+                        'detail' => 'The target returned a reason this client does not classify.',
+                    ]);
+                    fwrite(
+                        $connection,
+                        "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: " . strlen($body)
+                            . "\r\nConnection: close\r\n\r\n" . $body
+                    );
+                }
+                fclose($connection);
+                fclose($listener);
+                exit(0);
+            }
+
+            $client = new MultipartPushStreamClient([
+                'base_url' => 'http://' . $address . '/?reprint-api=1',
+                'allow_http' => true,
+                'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+                'connect_timeout' => 2,
+                'response_timeout' => 2,
+            ]);
+            if ($case === 'redirect') {
+                try {
+                    $client->control_request('POST', 'push_create', [
+                        'push_session_id' => str_repeat('8', 32),
+                    ], ['created']);
+                    $this->fail('A redirected control request was accepted.');
+                } catch (\RuntimeException $exception) {
+                    $this->assertSame(
+                        'The target redirected to http://example.test/final. Use that address as the push base_url.',
+                        $exception->getMessage()
+                    );
+                }
+            } else {
+                $result = $client->control_request('POST', 'push_create', [
+                    'push_session_id' => str_repeat('9', 32),
+                ], ['created']);
+                $this->assertSame('failed', $result['status']);
+                $this->assertSame('new_protocol_failure', $result['reason']);
+                $this->assertSame('The target returned a reason this client does not classify.', $result['detail']);
+            }
+            pcntl_waitpid($child, $status);
+            fclose($listener);
+            $this->assertTrue(pcntl_wifexited($status));
+            $this->assertSame(0, pcntl_wexitstatus($status));
+        }
     }
 
     public function testZeroProgressUploadStallStopsWithoutATotalTransferTimeout(): void {

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -8,24 +8,27 @@ use PHPUnit\Framework\TestCase;
  * import.php requires the upload lib for every command, including pull on
  * PHP 7.4 — the push client's PHP 8.1 requirement is enforced at runtime in
  * its constructor, not at parse time. This scan fails when 8.x-only syntax
- * sneaks into the upload lib and would fatal 7.4 pull users at require time.
+ * sneaks into the upload or push lib and would fatal 7.4 pull users at require time.
  * The repo-wide lint:php:compat covers the same files but currently fails on
  * unrelated pre-existing findings, so this narrow scan is the enforced
  * regression check.
  */
 class PushClientPhpCompatibilityTest extends TestCase
 {
-    public function testUploadLibStaysParseableOnPhp74(): void
+    public function testPushLibsStayParseableOnPhp74(): void
     {
         $phpcs_path = realpath(__DIR__ . '/../../vendor/bin/phpcs');
         $upload_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/upload');
+        $push_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/push');
         $this->assertNotFalse($phpcs_path, 'vendor/bin/phpcs is missing; run composer install');
         $this->assertNotFalse($upload_lib_path);
+        $this->assertNotFalse($push_lib_path);
 
         exec(
             escapeshellarg($phpcs_path)
                 . ' --standard=PHPCompatibility --runtime-set testVersion 7.4- -q '
-                . escapeshellarg($upload_lib_path) . ' 2>&1',
+                . escapeshellarg($upload_lib_path) . ' '
+                . escapeshellarg($push_lib_path) . ' 2>&1',
             $scan_output,
             $scan_exit_code
         );

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -275,6 +275,74 @@ final class PushJournalTest extends TestCase
         $this->makeJournal()->diff_local_files($this->tempDir . '/no-such-index.jsonl');
     }
 
+    /**
+     * Keeps active path lists independent from later caller-index changes.
+     *
+     * The sender copy, positive-work list, and raw work-delete stream must all
+     * describe one index so their persisted byte offsets remain meaningful
+     * after the caller replaces or removes its original index file.
+     */
+    public function testActiveSenderIndexAndWorkDeletesStayStable(): void
+    {
+        $journal = $this->makeJournal();
+        $baseline = $this->writeIndex([
+            'delete-me.txt' => [100, 1, 'file'],
+            'keep.txt' => [100, 1, 'file'],
+        ]);
+        $journal->capture_local_files_baseline($baseline);
+        $current = $this->writeIndex([
+            'keep.txt' => [100, 1, 'file'],
+            'new.txt' => [200, 2, 'file'],
+        ]);
+
+        $journal->capture_sender_index($current);
+        $journal->diff_local_files($journal->sender_index_path);
+        $this->assertSame(strlen("delete-me.txt\0"), $journal->prepare_work_deletes());
+        $this->assertSame("delete-me.txt\0", file_get_contents($journal->work_deletes_path));
+
+        file_put_contents($current, $this->indexLine('later.txt', 300, 3, 'file') . "\n");
+        $this->assertSame(['new.txt'], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame(['delete-me.txt'], $this->listPaths($journal->local_paths_to_delete));
+        $this->assertStringContainsString(base64_encode('new.txt'), (string) file_get_contents($journal->sender_index_path));
+        $this->assertStringNotContainsString(base64_encode('later.txt'), (string) file_get_contents($journal->sender_index_path));
+    }
+
+    /**
+     * Round-trips and clears the complete sender checkpoint shape.
+     *
+     * The private JSON record is trusted as one atomically replaced unit, so
+     * every correlated cursor and source field must survive unchanged.
+     */
+    public function testSenderStateRoundTripsTheExactCheckpoint(): void
+    {
+        $journal = $this->makeJournal();
+        $state = [
+            'version' => 1,
+            'push_session_id' => str_repeat('a', 32),
+            'phase' => 'reconciling_work',
+            'paths_byte_offset' => 17,
+            'current_path_b64' => base64_encode('file.txt'),
+            'next_paths_byte_offset' => 41,
+            'source_token' => ['type' => 'file', 'size' => 9, 'ctime' => 123],
+            'confirmed_bytes' => 4,
+            'work_deletes_byte_offset' => 7,
+            'recoverable_failures' => 2,
+            'max_part_bytes' => 4194304,
+            'request_sizer_state' => [
+                'request_body_bytes' => 1048576,
+                'ceiling_bytes' => 2097152,
+                'growth_holdoff_remaining' => 1,
+            ],
+        ];
+
+        $this->assertNull($journal->read_sender_state());
+        $journal->write_sender_state($state);
+        $this->assertSame($state, $journal->read_sender_state());
+        $this->assertFileDoesNotExist($journal->sender_state_path . '.tmp');
+        $journal->clear_sender_state();
+        $this->assertNull($journal->read_sender_state());
+    }
+
     // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -46,13 +46,21 @@ final class PushCommitTest extends TestCase {
         $this->complete_work_deletes($push_session);
 
         $saw_deleted_before_install = false;
+        $reported_phases = [];
         do {
             $result = $push_session->commit(1);
+            $this->assertSame(['phase', 'send_next_request', 'entries_processed'], array_keys($result));
+            $this->assertContains($result['phase'], ['deleting_files', 'installing_files', 'complete']);
+            $this->assertIsBool($result['send_next_request']);
+            $this->assertIsInt($result['entries_processed']);
+            $this->assertSame($result['phase'], $push_session->get_status()['phase']);
+            $reported_phases[$result['phase']] = true;
             if (!file_exists($this->docroot . '/tree/old.txt') && !file_exists($this->docroot . '/tree/new.txt')) {
                 $saw_deleted_before_install = true;
             }
         } while ($result['send_next_request']);
 
+        $this->assertSame(['deleting_files', 'installing_files', 'complete'], array_keys($reported_phases));
         $this->assertTrue($saw_deleted_before_install);
         $this->assertSame('new', file_get_contents($this->docroot . '/tree/new.txt'));
         $this->assertSame([], $this->directory_entries($push_session->get_push_directory() . '/work/files'));

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -14,9 +14,6 @@ final class PushEndpointsTest extends TestCase {
     /** @var resource|null */
     private $server_process;
 
-    /** @var resource[] */
-    private array $server_pipes = [];
-
     private string $root;
     private string $docroot;
     private string $reprint_directory;
@@ -47,19 +44,15 @@ final class PushEndpointsTest extends TestCase {
             'REPRINT_PUSH_TEST_DOCROOT' => $this->docroot,
             'REPRINT_PUSH_TEST_DIRECTORY' => $this->reprint_directory,
         ]);
+        $server_log = $this->root . '/server.log';
         $descriptors = [
-            0 => ['pipe', 'r'],
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
+            0 => ['file', '/dev/null', 'r'],
+            1 => ['file', $server_log, 'a'],
+            2 => ['file', $server_log, 'a'],
         ];
         $process = proc_open([PHP_BINARY, '-d', 'post_max_size=1M', '-S', $address, $router], $descriptors, $pipes, dirname($router), $environment);
         $this->assertIsResource($process);
         $this->server_process = $process;
-        $this->server_pipes = $pipes;
-        fclose($this->server_pipes[0]);
-        unset($this->server_pipes[0]);
-        stream_set_blocking($this->server_pipes[1], false);
-        stream_set_blocking($this->server_pipes[2], false);
         $deadline = microtime(true) + 5;
         do {
             $connection = @stream_socket_client('tcp://' . $address, $connect_error, $connect_error_message, 0.1);
@@ -70,19 +63,13 @@ final class PushEndpointsTest extends TestCase {
             }
             usleep(20000);
         } while (microtime(true) < $deadline);
-        $stderr = stream_get_contents($this->server_pipes[2]);
-        $this->fail('Push endpoint test server did not start: ' . $stderr);
+        $this->fail('Push endpoint test server did not start: ' . file_get_contents($server_log));
     }
 
     protected function tearDown(): void
     {
         if (is_resource($this->server_process)) {
             proc_terminate($this->server_process);
-            foreach ($this->server_pipes as $pipe) {
-                if (is_resource($pipe)) {
-                    fclose($pipe);
-                }
-            }
             proc_close($this->server_process);
         }
         if (isset($this->root)) {

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-importer/src/import.php';
+require_once __DIR__ . '/../packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php';
+
+final class PushEndpointsTest extends TestCase {
+
+    private const SECRET = 'real-push-endpoint-test-secret';
+
+    /** @var resource|null */
+    private $server_process;
+
+    /** @var resource[] */
+    private array $server_pipes = [];
+
+    private string $root;
+    private string $docroot;
+    private string $reprint_directory;
+    private string $base_url;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Push endpoint E2E requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $this->root = sys_get_temp_dir() . '/push-endpoints-' . bin2hex(random_bytes(6));
+        $this->docroot = $this->root . '/docroot';
+        $this->reprint_directory = $this->root . '/reprint';
+        mkdir($this->docroot, 0700, true);
+        mkdir($this->reprint_directory, 0700, true);
+        file_put_contents($this->docroot . '/remove.txt', 'old');
+        mkdir($this->docroot . '/preserved');
+        file_put_contents($this->docroot . '/preserved/value.txt', 'keep');
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        fclose($listener);
+        $router = realpath(__DIR__ . '/fixtures/push-endpoint-router.php');
+        $this->assertNotFalse($router);
+        $environment = array_merge($_ENV, [
+            'REPRINT_PUSH_TEST_SECRET' => self::SECRET,
+            'REPRINT_PUSH_TEST_DOCROOT' => $this->docroot,
+            'REPRINT_PUSH_TEST_DIRECTORY' => $this->reprint_directory,
+        ]);
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open([PHP_BINARY, '-d', 'post_max_size=1M', '-S', $address, $router], $descriptors, $pipes, dirname($router), $environment);
+        $this->assertIsResource($process);
+        $this->server_process = $process;
+        $this->server_pipes = $pipes;
+        fclose($this->server_pipes[0]);
+        unset($this->server_pipes[0]);
+        stream_set_blocking($this->server_pipes[1], false);
+        stream_set_blocking($this->server_pipes[2], false);
+        $deadline = microtime(true) + 5;
+        do {
+            $connection = @stream_socket_client('tcp://' . $address, $connect_error, $connect_error_message, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                $this->base_url = 'http://' . $address . '/?reprint-api=1';
+                return;
+            }
+            usleep(20000);
+        } while (microtime(true) < $deadline);
+        $stderr = stream_get_contents($this->server_pipes[2]);
+        $this->fail('Push endpoint test server did not start: ' . $stderr);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            foreach ($this->server_pipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->server_process);
+        }
+        if (isset($this->root)) {
+            $this->removeTree($this->root);
+        }
+        parent::tearDown();
+    }
+
+    public function testSignedEndpointsReceiveManyChangesCommitAndRemove(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('a', 32);
+
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->assertSame([
+            'status' => 'created',
+            'push_session_id' => $push_session_id,
+            'max_part_bytes' => 4,
+            'post_max_bytes' => 1048576,
+            'http_code' => 200,
+        ], $create['response']);
+        $client->set_max_part_bytes($create['response']['max_part_bytes']);
+        $client->apply_reported_limits([$create['response']['post_max_bytes']]);
+
+        $this->assertTrue($client->start_upload_request($push_session_id));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'nested/file.bin',
+            'total_bytes' => 8,
+            'offset' => 0,
+            'payload' => "ab\0c",
+        ]));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'nested/file.bin',
+            'total_bytes' => 8,
+            'offset' => 4,
+            'payload' => 'defg',
+        ]));
+        $this->assertTrue($client->send_part([
+            'type' => 'directory',
+            'path' => 'empty-directory',
+            'payload' => '',
+        ]));
+        $this->assertTrue($client->send_part([
+            'type' => 'symlink',
+            'path' => 'file-link',
+            'target' => 'nested/file.bin',
+            'payload' => '',
+        ]));
+        $delete_payload = "remove.txt\0";
+        $delete_offset = 0;
+        foreach (str_split($delete_payload, 4) as $delete_piece) {
+            $this->assertTrue($client->send_part([
+                'type' => 'delete-list',
+                'offset' => $delete_offset,
+                'payload' => $delete_piece,
+            ]));
+            $delete_offset += strlen($delete_piece);
+        }
+        $this->assertTrue($client->send_part([
+            'type' => 'delete-list',
+            'offset' => $delete_offset,
+            'complete' => true,
+            'payload' => '',
+        ]));
+        $upload = $client->finish_request();
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+        $this->assertSame(8, $upload['response']['changes_accepted']);
+        $this->assertSame([
+            'state' => 'complete',
+            'type' => 'delete-list',
+            'accepted_bytes' => strlen($delete_payload),
+        ], $upload['response']['last_change']);
+
+        $status = $client->control_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+            'path_b64' => base64_encode('nested/file.bin'),
+        ], ['accepted']);
+        $this->assertSame('complete', $status['status'], (string) json_encode($status));
+        $this->assertSame('receiving_work', $status['response']['phase']);
+        $this->assertSame(strlen($delete_payload), $status['response']['work_deletes_bytes']);
+        $this->assertTrue($status['response']['work_deletes_complete']);
+        $this->assertSame([
+            'path_b64' => base64_encode('nested/file.bin'),
+            'state' => 'complete',
+            'type' => 'file',
+            'accepted_bytes' => 8,
+        ], $status['response']['path']);
+
+        $commit_requests = 0;
+        do {
+            $commit = $client->control_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+            ++$commit_requests;
+        } while ($commit['response']['send_next_request']);
+
+        $this->assertGreaterThan(1, $commit_requests, 'The one-entry endpoint budget must require repeated commit calls.');
+        $this->assertSame('complete', $commit['response']['phase']);
+        $this->assertFileDoesNotExist($this->docroot . '/remove.txt');
+        $this->assertSame("ab\0cdefg", file_get_contents($this->docroot . '/nested/file.bin'));
+        $this->assertDirectoryExists($this->docroot . '/empty-directory');
+        $this->assertSame([], array_values(array_diff(scandir($this->docroot . '/empty-directory') ?: [], ['.', '..'])));
+        $this->assertTrue(is_link($this->docroot . '/file-link'));
+        $this->assertSame('nested/file.bin', readlink($this->docroot . '/file-link'));
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+
+        do {
+            $remove = $client->control_request('POST', 'push_remove', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
+        } while (!$remove['response']['removed']);
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+    }
+
+    public function testEndpointGuardsRejectWrongMethodContentTypeAndAuthentication(): void
+    {
+        $push_session_id = str_repeat('b', 32);
+        $client = $this->newClient(self::SECRET);
+
+        $wrong_method = $client->control_request('GET', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('failed', $wrong_method['status']);
+        $this->assertSame('invalid_request', $wrong_method['reason']);
+        $this->assertSame('Push endpoint requires POST; observed GET.', $wrong_method['detail']);
+
+        $wrong_secret = $this->newClient('not-the-server-secret');
+        $authentication = $wrong_secret->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('failed', $authentication['status']);
+        $this->assertSame('auth_failed', $authentication['reason']);
+        $this->assertStringContainsString('HMAC signature verification failed', $authentication['detail']);
+
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status']);
+        $push_lock = fopen($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.lock', 'c+b');
+        $this->assertIsResource($push_lock);
+        $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
+        $lock_contention = $client->control_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('retry', $lock_contention['status']);
+        $this->assertSame('lock_acquisition_failure', $lock_contention['reason']);
+        flock($push_lock, LOCK_UN);
+        fclose($push_lock);
+
+        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $curl_headers = ['Content-Type: application/json'];
+        foreach ($headers as $name => $value) {
+            $curl_headers[] = $name . ': ' . $value;
+        }
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => '{}',
+            CURLOPT_HTTPHEADER => $curl_headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(400, curl_getinfo($handle, CURLINFO_HTTP_CODE));
+        curl_close($handle);
+        $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('invalid_request', $response['reason']);
+        $this->assertStringContainsString('multipart/mixed', $response['detail']);
+
+        $boundary = 'truncated-endpoint-test';
+        $truncated_body = '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: file\r\n"
+            . 'X-File-Path: ' . base64_encode('truncated.txt') . "\r\n"
+            . "X-File-Size: 1\r\n"
+            . "X-Chunk-Offset: 0\r\n"
+            . "Content-Length: 1\r\n\r\n"
+            . 'x';
+        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $curl_headers = ['Content-Type: multipart/mixed; boundary=' . $boundary];
+        foreach ($headers as $name => $value) {
+            $curl_headers[] = $name . ': ' . $value;
+        }
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $truncated_body,
+            CURLOPT_HTTPHEADER => $curl_headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(400, curl_getinfo($handle, CURLINFO_HTTP_CODE));
+        curl_close($handle);
+        $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('invalid_request', $response['reason']);
+        $this->assertStringContainsString('multipart body ended before', $response['detail']);
+    }
+
+    private function newClient(string $secret): MultipartPushStreamClient
+    {
+        return new MultipartPushStreamClient([
+            'base_url' => $this->base_url,
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client($secret),
+            'chunk_bytes' => 4,
+            'connect_timeout' => 3,
+            'stall_timeout' => 3,
+            'response_timeout' => 5,
+        ]);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -103,7 +103,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame([
             'status' => 'created',
             'push_session_id' => $push_session_id,
-            'max_part_bytes' => 4,
+            'max_part_bytes' => 64,
             'post_max_bytes' => 1048576,
             'http_code' => 200,
         ], $create['response']);
@@ -289,6 +289,604 @@ final class PushEndpointsTest extends TestCase {
         $this->assertStringContainsString('multipart body ended before', $response['detail']);
     }
 
+    /**
+     * Completes a mixed-value push while reconstructing the sender each step.
+     *
+     * The first upload request carries multiple work values and multiple
+     * bounded chunks. The large file then changes behind a partial receiver
+     * cursor, forcing an offset-zero restart before repeated commit installs
+     * the file, empty directory, symlink, replacement, and deletion.
+     */
+    public function testHighLevelSenderRestartsChangedSourceAndResumesAfterEveryRequest(): void
+    {
+        $local_docroot = $this->root . '/local-docroot';
+        mkdir($local_docroot . '/nested', 0700, true);
+        mkdir($local_docroot . '/empty-directory', 0700, true);
+        file_put_contents($local_docroot . '/nested/large.bin', str_repeat('A', 2000));
+        file_put_contents($local_docroot . '/same-size.txt', 'new!');
+        symlink('nested/large.bin', $local_docroot . '/file-link');
+        file_put_contents($this->docroot . '/same-size.txt', 'old!');
+
+        $large_identity = lstat($local_docroot . '/nested/large.bin');
+        $same_size_identity = lstat($local_docroot . '/same-size.txt');
+        $link_identity = lstat($local_docroot . '/file-link');
+        $nested_identity = lstat($local_docroot . '/nested');
+        $empty_identity = lstat($local_docroot . '/empty-directory');
+        $this->assertIsArray($large_identity);
+        $this->assertIsArray($same_size_identity);
+        $this->assertIsArray($link_identity);
+        $this->assertIsArray($nested_identity);
+        $this->assertIsArray($empty_identity);
+        $current_index = $this->root . '/current-index.jsonl';
+        $this->writeIndex($current_index, [
+            'empty-directory' => [ (int) $empty_identity['ctime'], (int) $empty_identity['size'], 'dir'],
+            'file-link' => [ (int) $link_identity['ctime'], (int) $link_identity['size'], 'link'],
+            'nested' => [ (int) $nested_identity['ctime'], (int) $nested_identity['size'], 'dir'],
+            'nested/large.bin' => [ (int) $large_identity['ctime'], (int) $large_identity['size'], 'file'],
+            'same-size.txt' => [ (int) $same_size_identity['ctime'], (int) $same_size_identity['size'], 'file'],
+        ]);
+
+        $journal = new PushJournal($this->root . '/sender-state', $this->base_url);
+        $baseline = $this->root . '/baseline-index.jsonl';
+        $this->writeIndex($baseline, [
+            'remove.txt' => [1, 3, 'file'],
+            'same-size.txt' => [1, 4, 'file'],
+        ]);
+        $journal->capture_local_files_baseline($baseline);
+
+        $source_changed = false;
+        $observed_many_chunks = false;
+        $observed_many_values = false;
+        $commit_requests = 0;
+        $removed_caller_index = false;
+        for ($step = 0; $step < 200; ++$step) {
+            // A new object on every step proves that sender.json, target
+            // status, the source token, the learned request size, and the
+            // target part limit are sufficient after process restart.
+            $state_before_request = $journal->read_sender_state();
+            $is_first_upload_request = is_array($state_before_request)
+                && $state_before_request['phase'] === 'uploading_work'
+                && $state_before_request['current_path_b64'] === null
+                && $state_before_request['paths_byte_offset'] === 0;
+            $sender = $this->newSender($local_docroot, $current_index, $journal);
+            $result = $sender->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (!$removed_caller_index && is_array($state)) {
+                unlink($current_index);
+                $removed_caller_index = true;
+            }
+            if (is_array($state) && $state['phase'] === 'committing') {
+                ++$commit_requests;
+            }
+            if ($is_first_upload_request) {
+                $this->assertIsArray($state);
+                $this->assertSame(base64_encode('nested/large.bin'), $state['current_path_b64']);
+                $this->assertGreaterThan(64, $state['confirmed_bytes']);
+                $this->assertLessThan(2000, $state['confirmed_bytes']);
+                $work_files = $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/work/files';
+                $this->assertDirectoryExists($work_files . '/empty-directory');
+                $this->assertTrue(is_link($work_files . '/file-link'));
+                $observed_many_chunks = true;
+                $observed_many_values = true;
+                sleep(1);
+                file_put_contents($local_docroot . '/nested/large.bin', str_repeat('B', 2000));
+                clearstatcache(true, $local_docroot . '/nested/large.bin');
+                $source_changed = true;
+            }
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+
+        $this->assertTrue($observed_many_chunks, 'One sender request must confirm more than one bounded file chunk.');
+        $this->assertTrue($observed_many_values, 'That same sender request must publish multiple positive-work values before the partial file.');
+        $this->assertTrue($removed_caller_index, 'The active sender must resume from its stable journal index after the caller index disappears.');
+        $this->assertTrue($source_changed, 'The test must edit the source while the receiver has a partial file.');
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertGreaterThan(1, $commit_requests, 'The one-entry endpoint budget must require repeated high-level commit calls.');
+        $this->assertSame(str_repeat('B', 2000), file_get_contents($this->docroot . '/nested/large.bin'));
+        $this->assertSame('new!', file_get_contents($this->docroot . '/same-size.txt'));
+        $this->assertDirectoryExists($this->docroot . '/empty-directory');
+        $this->assertTrue(is_link($this->docroot . '/file-link'));
+        $this->assertSame('nested/large.bin', readlink($this->docroot . '/file-link'));
+        $this->assertFileDoesNotExist($this->docroot . '/remove.txt');
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertNull($journal->read_sender_state());
+        $this->assertSame(
+            file_get_contents($journal->sender_index_path),
+            file_get_contents($journal->local_files_baseline_path),
+            'The stable start-of-push index becomes the baseline; a mid-push source edit is sent but remains detectable on the next diff.'
+        );
+    }
+
+    /**
+     * Restarts every source-drift class from an existing partial file.
+     *
+     * Growth, shrinkage past the receiver cursor, same-size replacement, and
+     * a file-to-directory change must all replace the old prefix rather than
+     * append bytes from a different source value.
+     */
+    public function testHighLevelSenderRestartsGrownShrunkSameSizeAndTypeChangedFiles(): void
+    {
+        $variants = [
+            'grew' => static function (string $path): void {
+                file_put_contents($path, str_repeat('G', 2500));
+            },
+            'shrank' => static function (string $path): void {
+                file_put_contents($path, str_repeat('S', 100));
+            },
+            'same-size' => static function (string $path): void {
+                file_put_contents($path, str_repeat('E', 2000));
+            },
+            'type-change' => static function (string $path): void {
+                unlink($path);
+                mkdir($path, 0700);
+                file_put_contents($path . '/appeared-after-index.txt', 'later');
+            },
+        ];
+
+        foreach ($variants as $name => $change_source) {
+            $local_docroot = $this->root . '/drift-' . $name;
+            mkdir($local_docroot, 0700, true);
+            $relative_path = 'value-' . $name;
+            $source_path = $local_docroot . '/' . $relative_path;
+            file_put_contents($source_path, str_repeat('O', 2000));
+            $identity = lstat($source_path);
+            $this->assertIsArray($identity);
+            $current_index = $this->root . '/drift-' . $name . '.jsonl';
+            $this->writeIndex($current_index, [
+                $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+            ]);
+            $journal = new PushJournal($this->root . '/drift-state-' . $name, $this->base_url);
+
+            for ($step = 0; $step < 100; ++$step) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
+                $state = $journal->read_sender_state();
+                if (
+                    is_array($state)
+                    && $state['current_path_b64'] === base64_encode($relative_path)
+                    && $state['confirmed_bytes'] > 64
+                    && $state['confirmed_bytes'] < 2000
+                ) {
+                    break;
+                }
+            }
+            $this->assertIsArray($state, $name);
+            $this->assertGreaterThan(64, $state['confirmed_bytes'], $name);
+            sleep(1);
+            $change_source($source_path);
+            clearstatcache(true, $source_path);
+
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertSame('continue', $result['status'], $name . ': ' . json_encode($result));
+            $this->assertSame('source_changed', $result['reason'], $name);
+            $restarted_state = $journal->read_sender_state();
+            $this->assertIsArray($restarted_state, $name);
+            $this->assertSame('uploading_work', $restarted_state['phase'], $name);
+            $this->assertSame($state['source_token'], $restarted_state['source_token'], $name);
+            $this->assertSame($state['confirmed_bytes'], $restarted_state['confirmed_bytes'], $name);
+            if ($name === 'shrank') {
+                $shrunken_identity = lstat($source_path);
+                $this->assertIsArray($shrunken_identity);
+                $this->assertGreaterThan(
+                    $shrunken_identity['size'],
+                    $state['confirmed_bytes'],
+                    'The target cursor must begin beyond the shrunken source EOF.'
+                );
+            }
+
+            for (++$step; $step < 200; ++$step) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
+                if ($result['status'] !== 'continue') {
+                    break;
+                }
+            }
+            $this->assertSame('complete', $result['status'], $name . ': ' . json_encode($result));
+            $target_path = $this->docroot . '/' . $relative_path;
+            if ($name === 'type-change') {
+                $this->assertFileExists($source_path . '/appeared-after-index.txt');
+                $this->assertDirectoryExists($target_path);
+                $this->assertSame([], array_values(array_diff(scandir($target_path) ?: [], ['.', '..'])));
+            } else {
+                $this->assertSame(file_get_contents($source_path), file_get_contents($target_path), $name);
+            }
+        }
+    }
+
+    /**
+     * Removes the upload-only push session when its selected source vanishes.
+     *
+     * The remove response is discarded to prove that a reconstructed sender
+     * repeats bounded removal before asking the caller for a fresh index.
+     */
+    public function testHighLevelSenderRemovesUploadOnlySessionWhenCurrentSourceDisappears(): void
+    {
+        $local_docroot = $this->root . '/deleted-source';
+        mkdir($local_docroot, 0700, true);
+        $relative_path = 'deleted-source.bin';
+        $source_path = $local_docroot . '/' . $relative_path;
+        file_put_contents($source_path, str_repeat('D', 2000));
+        $identity = lstat($source_path);
+        $this->assertIsArray($identity);
+        $current_index = $this->root . '/deleted-source.jsonl';
+        $this->writeIndex($current_index, [
+            $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/deleted-source-state', $this->base_url);
+
+        for ($step = 0; $step < 100; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (is_array($state) && $state['confirmed_bytes'] > 64 && $state['confirmed_bytes'] < 2000) {
+                break;
+            }
+        }
+        $this->assertIsArray($state);
+        $push_session_id = $state['push_session_id'];
+        unlink($source_path);
+        clearstatcache(true, $source_path);
+
+        $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $this->assertSame('continue', $result['status'], (string) json_encode($result));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('removing', $state['phase']);
+        $this->sendPostAndDiscardResponse(
+            $this->base_url . '&endpoint=push_remove&push_session_id=' . $push_session_id,
+            null,
+            ''
+        );
+
+        for (; $step < 200; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('restart', $result['status'], (string) json_encode($result));
+        $this->assertSame('source_changed', $result['reason']);
+        $this->assertNull($journal->read_sender_state());
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+        $this->assertFileDoesNotExist($this->docroot . '/' . $relative_path);
+    }
+
+    /**
+     * Verifies that recoverable target contention becomes a terminal result.
+     *
+     * The real push lock remains held while five reconstructed senders query
+     * status. Each one reads the durable failure count left by the previous
+     * process boundary; the fifth must stop instead of returning a final retry.
+     */
+    public function testHighLevelSenderStopsAfterBoundedRecoverableFailures(): void
+    {
+        $local_docroot = $this->root . '/retry-source';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'value');
+        $identity = lstat($local_docroot . '/value.txt');
+        $this->assertIsArray($identity);
+        $current_index = $this->root . '/retry-source.jsonl';
+        $this->writeIndex($current_index, [
+            'value.txt' => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/retry-state', $this->base_url);
+
+        $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $this->assertSame('continue', $result['status'], (string) json_encode($result));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('reconciling_work', $state['phase']);
+        $push_lock = fopen(
+            $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/push.lock',
+            'r+b'
+        );
+        $this->assertIsResource($push_lock);
+        $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
+        try {
+            for ($failure_number = 1; $failure_number <= 5; ++$failure_number) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertSame(
+                    $failure_number === 5 ? 'failed' : 'continue',
+                    $result['status'],
+                    (string) json_encode($result)
+                );
+            }
+        } finally {
+            flock($push_lock, LOCK_UN);
+            fclose($push_lock);
+        }
+
+        $this->assertSame('retry_exhausted', $result['reason']);
+        $this->assertStringContainsString('5 consecutive recoverable failures', $result['detail']);
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame(5, $state['recoverable_failures']);
+    }
+
+    /**
+     * Rejects a malformed control response without spending the retry budget.
+     *
+     * A real TCP peer accepts push_create and returns a non-JSON entity body.
+     * The response is complete and unambiguous, so repeating it cannot repair
+     * the protocol violation and must not be classified like a lost response.
+     */
+    public function testHighLevelSenderTreatsMalformedControlResponseAsTerminal(): void
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Malformed control-response coverage requires PHP curl and pcntl.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
+        $this->assertNotFalse($listener, $error_message);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_timeout($connection, 3);
+            $request = '';
+            while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    break;
+                }
+                $request .= $piece;
+            }
+            if (strpos($request, 'endpoint=push_create') === false) {
+                fclose($connection);
+                fclose($listener);
+                exit(3);
+            }
+            $body = '<html>not a push response</html>';
+            fwrite(
+                $connection,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: " . strlen($body)
+                    . "\r\nConnection: close\r\n\r\n" . $body
+            );
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $local_docroot = $this->root . '/malformed-response-source';
+        mkdir($local_docroot, 0700, true);
+        $current_index = $this->root . '/malformed-response-index.jsonl';
+        $this->writeIndex($current_index, []);
+        $journal = new PushJournal($this->root . '/malformed-response-state', 'http://' . $address . '/?reprint-api=1');
+        $sender = new PushFilesSender([
+            'docroot' => $local_docroot,
+            'current_index_file' => $current_index,
+            'journal' => $journal,
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        $result = $sender->send_next_request();
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertSame('failed', $result['status'], (string) json_encode($result));
+        $this->assertSame('malformed_response', $result['reason']);
+        $this->assertStringContainsString('invalid JSON', $result['detail']);
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame(0, $state['recoverable_failures']);
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+    }
+
+    /**
+     * Resumes from target-confirmed bytes after three interrupted requests.
+     *
+     * Raw chunked connections close before a part, within its declared body,
+     * and after a valid complete part without reading the response. The sender's
+     * durable checkpoint still names the same path with no optimistic cursor;
+     * status must recover zero until a complete MIME part was accepted, and
+     * the complete part's byte count afterward.
+     */
+    public function testHighLevelSenderReconcilesInterruptedUploadParts(): void
+    {
+        $interruptions = [
+            'before-part' => ['', 0],
+            'within-part' => [str_repeat('I', 32), 0],
+            'after-part' => [str_repeat('I', 64), 64],
+        ];
+        $base_url = parse_url($this->base_url);
+        $this->assertIsArray($base_url);
+        $this->assertIsString($base_url['host'] ?? null);
+        $this->assertIsInt($base_url['port'] ?? null);
+
+        foreach ($interruptions as $name => [$interrupted_payload, $expected_cursor]) {
+            $local_docroot = $this->root . '/interrupted-' . $name;
+            mkdir($local_docroot, 0700, true);
+            $relative_path = 'interrupted-' . $name . '.bin';
+            $source_path = $local_docroot . '/' . $relative_path;
+            file_put_contents($source_path, str_repeat('I', 2000));
+            $identity = lstat($source_path);
+            $this->assertIsArray($identity);
+            $current_index = $this->root . '/interrupted-' . $name . '.jsonl';
+            $this->writeIndex($current_index, [
+                $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+            ]);
+            $journal = new PushJournal($this->root . '/interrupted-state-' . $name, $this->base_url);
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertSame('continue', $result['status'], $name . ': ' . json_encode($result));
+            $state = $journal->read_sender_state();
+            $this->assertIsArray($state);
+
+            $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'];
+            $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+            $boundary = 'reprint-interrupted-' . str_replace('-', '', $name);
+            $mime_headers = '--' . $boundary . "\r\n"
+                . "X-Chunk-Type: file\r\n"
+                . 'X-File-Path: ' . base64_encode($relative_path) . "\r\n"
+                . "X-File-Size: 2000\r\n"
+                . "X-Chunk-Offset: 0\r\n"
+                . "Content-Length: 64\r\n\r\n";
+            $request_body = $interrupted_payload === '' ? '' : $mime_headers . $interrupted_payload;
+            if ($interrupted_payload !== '') {
+                $request_body .= "\r\n";
+            }
+            $complete_request = $name === 'after-part';
+            if ($complete_request) {
+                $request_body .= '--' . $boundary . "--\r\n";
+            }
+            $connection = stream_socket_client(
+                'tcp://' . $base_url['host'] . ':' . $base_url['port'],
+                $error_number,
+                $error_message,
+                3
+            );
+            $this->assertIsResource($connection, $error_message);
+            $request_target = (string) $base_url['path'] . '?' . $base_url['query']
+                . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'];
+            $request_headers = "POST " . $request_target . " HTTP/1.1\r\n"
+                . 'Host: ' . $base_url['host'] . ':' . $base_url['port'] . "\r\n"
+                . 'Content-Type: multipart/mixed; boundary=' . $boundary . "\r\n"
+                . "Transfer-Encoding: chunked\r\nConnection: close\r\n";
+            foreach ($authentication_headers as $header_name => $header_value) {
+                $request_headers .= $header_name . ': ' . $header_value . "\r\n";
+            }
+            $request_headers .= "\r\n";
+            if ($request_body !== '') {
+                $request_headers .= dechex(strlen($request_body)) . "\r\n" . $request_body . "\r\n";
+            }
+            if ($complete_request) {
+                $request_headers .= "0\r\n\r\n";
+            }
+            $this->assertSame(strlen($request_headers), fwrite($connection, $request_headers));
+            // The first two variants truncate the request. The third sends a
+            // complete body but discards the response immediately.
+            fclose($connection);
+
+            $state['phase'] = 'reconciling_work';
+            $state['current_path_b64'] = base64_encode($relative_path);
+            $state['next_paths_byte_offset'] = filesize($journal->local_paths_to_push);
+            $state['source_token'] = [
+                'type' => 'file',
+                'size' => (int) $identity['size'],
+                'ctime' => (int) $identity['ctime'],
+            ];
+            $state['confirmed_bytes'] = 0;
+            $journal->write_sender_state($state);
+
+            for ($attempt = 0; $attempt < 20; ++$attempt) {
+                $status = $this->newClient(self::SECRET)->control_request('GET', 'push_status', [
+                    'push_session_id' => $state['push_session_id'],
+                    'path_b64' => base64_encode($relative_path),
+                ], ['accepted']);
+                if ($status['status'] === 'complete') {
+                    break;
+                }
+                usleep(10000);
+            }
+            $this->assertSame('complete', $status['status'], $name . ': ' . json_encode($status));
+            $this->assertSame($expected_cursor, $status['response']['path']['accepted_bytes'], $name);
+
+            for ($step = 0; $step < 200; ++$step) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
+                if ($result['status'] !== 'continue') {
+                    break;
+                }
+            }
+            $this->assertSame('complete', $result['status'], $name . ': ' . json_encode($result));
+            $this->assertSame(str_repeat('I', 2000), file_get_contents($this->docroot . '/' . $relative_path));
+        }
+    }
+
+    /**
+     * Repeats work-delete close and commit after their responses are lost.
+     *
+     * Both requests reach the real endpoint, but the test closes its socket
+     * without reading the response. A reconstructed sender must recover the
+     * target's durable delete cursor and commit checkpoint, not its last local
+     * request result.
+     */
+    public function testHighLevelSenderRepeatsWorkDeleteAndCommitAfterLostResponses(): void
+    {
+        file_put_contents($this->docroot . '/delete-after-lost-response.txt', 'old');
+        $local_docroot = $this->root . '/lost-response-source';
+        mkdir($local_docroot, 0700, true);
+        $current_index = $this->root . '/lost-response-current.jsonl';
+        $this->writeIndex($current_index, []);
+        $baseline = $this->root . '/lost-response-baseline.jsonl';
+        $this->writeIndex($baseline, [
+            'delete-after-lost-response.txt' => [1, 3, 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/lost-response-state', $this->base_url);
+        $journal->capture_local_files_baseline($baseline);
+
+        for ($step = 0; $step < 20; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (is_array($state) && $state['phase'] === 'reconciling_deletes') {
+                break;
+            }
+        }
+        $this->assertIsArray($state);
+        $this->assertSame('reconciling_deletes', $state['phase']);
+        $work_deletes = (string) file_get_contents($journal->work_deletes_path);
+        $this->assertSame("delete-after-lost-response.txt\0", $work_deletes);
+        $boundary = 'reprint-lost-delete-response';
+        $delete_body = '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: delete-list\r\n"
+            . "X-Delete-Offset: 0\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . 'Content-Length: ' . strlen($work_deletes) . "\r\n\r\n"
+            . $work_deletes . "\r\n"
+            . '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: delete-list\r\n"
+            . 'X-Delete-Offset: ' . strlen($work_deletes) . "\r\n"
+            . "X-Delete-Complete: 1\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . "Content-Length: 0\r\n\r\n\r\n"
+            . '--' . $boundary . "--\r\n";
+        $this->sendPostAndDiscardResponse(
+            $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'],
+            'multipart/mixed; boundary=' . $boundary,
+            $delete_body
+        );
+
+        for (; $step < 60; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (is_array($state) && $state['phase'] === 'committing') {
+                break;
+            }
+        }
+        $this->assertIsArray($state);
+        $this->assertSame(strlen($work_deletes), $state['work_deletes_byte_offset']);
+        $this->assertSame('committing', $state['phase']);
+
+        $this->sendPostAndDiscardResponse(
+            $this->base_url . '&endpoint=push_commit&push_session_id=' . $state['push_session_id'],
+            null,
+            ''
+        );
+        for (; $step < 120; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertFileDoesNotExist($this->docroot . '/delete-after-lost-response.txt');
+        $this->assertNull($journal->read_sender_state());
+    }
+
     private function newClient(string $secret): MultipartPushStreamClient
     {
         return new MultipartPushStreamClient([
@@ -300,6 +898,79 @@ final class PushEndpointsTest extends TestCase {
             'stall_timeout' => 3,
             'response_timeout' => 5,
         ]);
+    }
+
+    /**
+     * Reconstructs the production sender at a process-restart boundary.
+     *
+     * @param string $local_docroot Local document root whose values are sent.
+     * @param string $current_index Path-sorted local file index for this push.
+     * @param PushJournal $journal Durable per-target sender journal.
+     * @return PushFilesSender Sender restored from the journal checkpoint.
+     */
+    private function newSender(string $local_docroot, string $current_index, PushJournal $journal): PushFilesSender
+    {
+        return new PushFilesSender([
+            'docroot' => $local_docroot,
+            'current_index_file' => $current_index,
+            'journal' => $journal,
+            'base_url' => $this->base_url,
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 64,
+            'request_sizer_config' => [
+                'floor_bytes' => 2048,
+                'start_bytes' => 2048,
+                'max_bytes' => 2048,
+            ],
+            'connect_timeout' => 3,
+            'stall_timeout' => 3,
+            'response_timeout' => 5,
+        ]);
+    }
+
+    /**
+     * Sends one complete signed POST request and discards its response.
+     *
+     * Closing the socket immediately after the terminating transfer chunk
+     * reproduces a sender that cannot know whether the target completed the
+     * operation. The caller must reconcile from target state afterward.
+     *
+     * @param string $url Exact push endpoint URL to authenticate and request.
+     * @param string|null $content_type Request Content-Type, or null when the
+     *     endpoint has no body format.
+     * @param string $body Decoded HTTP entity body.
+     */
+    private function sendPostAndDiscardResponse(string $url, ?string $content_type, string $body): void
+    {
+        $target = parse_url($url);
+        $this->assertIsArray($target);
+        $this->assertIsString($target['host'] ?? null);
+        $this->assertIsInt($target['port'] ?? null);
+        $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $connection = stream_socket_client(
+            'tcp://' . $target['host'] . ':' . $target['port'],
+            $error_number,
+            $error_message,
+            3
+        );
+        $this->assertIsResource($connection, $error_message);
+        $request = 'POST ' . $target['path'] . '?' . $target['query'] . " HTTP/1.1\r\n"
+            . 'Host: ' . $target['host'] . ':' . $target['port'] . "\r\n"
+            . "Transfer-Encoding: chunked\r\nConnection: close\r\n";
+        if ($content_type !== null) {
+            $request .= 'Content-Type: ' . $content_type . "\r\n";
+        }
+        foreach ($authentication_headers as $header_name => $header_value) {
+            $request .= $header_name . ': ' . $header_value . "\r\n";
+        }
+        $request .= "\r\n";
+        if ($body !== '') {
+            $request .= dechex(strlen($body)) . "\r\n" . $body . "\r\n";
+        }
+        $request .= "0\r\n\r\n";
+        $this->assertSame(strlen($request), fwrite($connection, $request));
+        fclose($connection);
     }
 
     private function removeTree(string $path): void
@@ -317,5 +988,28 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         @rmdir($path);
+    }
+
+    /**
+     * Writes a path-sorted local index in the production JSONL shape.
+     *
+     * @param array<string,array{0:int,1:int,2:'file'|'dir'|'link'}> $entries
+     *     Path to `[ctime, size, type]` records.
+     */
+    private function writeIndex(string $path, array $entries): void
+    {
+        uksort($entries, 'strcmp');
+        $handle = fopen($path, 'wb');
+        $this->assertIsResource($handle);
+        foreach ($entries as $entry_path => [$ctime, $size, $type]) {
+            $line = json_encode([
+                'path' => base64_encode($entry_path),
+                'ctime' => $ctime,
+                'size' => $size,
+                'type' => $type,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            $this->assertSame(strlen($line), fwrite($handle, $line));
+        }
+        fclose($handle);
     }
 }

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -1141,6 +1141,139 @@ final class PushSessionTest extends TestCase {
         $this->assertSame('new', file_get_contents($this->docroot . '/commit.txt'));
     }
 
+    /**
+     * Rejects a file which would replace completed work descendants.
+     *
+     * The complete file bytes remain in the receiving phase. Publication must
+     * not become durable until replacing the completed value is possible;
+     * otherwise every later operation would retry the same impossible cleanup.
+     */
+    public function testFilePublicationConflictRemainsReceiving(): void {
+        $push_session = $this->push_session('56565656565656565656565656565656');
+        $work_directory = $push_session->get_push_directory() . '/work';
+        $this->push_file($push_session, 'parent/child.txt', 'child');
+
+        try {
+            $this->push_file($push_session, 'parent', 'new');
+            $this->fail('A file replaced a completed work directory with descendants.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString(base64_encode('parent'), $exception->getMessage());
+            $this->assertStringContainsString('completed work descendants', $exception->getMessage());
+        }
+
+        $inflight = json_decode( (string) file_get_contents($work_directory . '/inflight.json'), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('receiving', $inflight['phase']);
+        $this->assertSame('new', file_get_contents($work_directory . '/inflight.data'));
+        $this->assertSame('child', file_get_contents($work_directory . '/files/parent/child.txt'));
+        $this->assertSame(
+            [
+                'path_b64' => base64_encode('parent'),
+                'state' => 'partial',
+                'type' => 'file',
+                'accepted_bytes' => 3,
+            ],
+            $push_session->get_status('parent')['path']
+        );
+    }
+
+    /**
+     * Gives recovered publication failures enough evidence to diagnose them.
+     *
+     * File data reports its expected and observed identity, directories report
+     * the incompatible completed type, and symlinks report both encoded targets.
+     */
+    public function testCorruptPublicationStateErrorsNameTheViolatedCondition(): void {
+        $file_session = $this->push_session('57575757575757575757575757575757');
+        $file_work_directory = $file_session->get_push_directory() . '/work';
+        file_put_contents($file_work_directory . '/inflight.json', json_encode([
+            'phase' => 'publishing',
+            'path_b64' => base64_encode('broken-file'),
+            'type' => 'file',
+            'total_bytes' => 2,
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        file_put_contents($file_work_directory . '/inflight.data', 'x');
+        try {
+            $file_session->get_status();
+            $this->fail('Publication accepted in-flight file data with the wrong size.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertStringContainsString(base64_encode('broken-file'), $exception->getMessage());
+            $this->assertStringContainsString('size 2', $exception->getMessage());
+            $this->assertStringContainsString('type file and size 1', $exception->getMessage());
+        }
+
+        $directory_session = $this->push_session('58585858585858585858585858585858');
+        $directory_work_directory = $directory_session->get_push_directory() . '/work';
+        file_put_contents($directory_work_directory . '/inflight.json', json_encode([
+            'phase' => 'publishing',
+            'path_b64' => base64_encode('broken-directory'),
+            'type' => 'directory',
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        file_put_contents($directory_work_directory . '/files/broken-directory', 'file');
+        try {
+            $directory_session->get_status();
+            $this->fail('Directory recovery accepted an incompatible completed file.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertStringContainsString(base64_encode('broken-directory'), $exception->getMessage());
+            $this->assertStringContainsString('observed type file', $exception->getMessage());
+        }
+
+        $symlink_session = $this->push_session('59595959595959595959595959595959');
+        $symlink_work_directory = $symlink_session->get_push_directory() . '/work';
+        file_put_contents($symlink_work_directory . '/inflight.json', json_encode([
+            'phase' => 'publishing',
+            'path_b64' => base64_encode('broken-symlink'),
+            'type' => 'symlink',
+            'target_b64' => base64_encode('../expected'),
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        symlink('../observed', $symlink_work_directory . '/files/broken-symlink');
+        try {
+            $symlink_session->get_status();
+            $this->fail('Symlink recovery accepted a different completed target.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertStringContainsString(base64_encode('broken-symlink'), $exception->getMessage());
+            $this->assertStringContainsString(base64_encode('../expected'), $exception->getMessage());
+            $this->assertStringContainsString(base64_encode('../observed'), $exception->getMessage());
+        }
+    }
+
+    /**
+     * Applies the normal directory mode when publication resumes after a crash.
+     *
+     * Both paths call mkdir() under the same process umask. Recovery must not
+     * replace the requested mode with a private-directory mode that can make the
+     * committed directory inaccessible to the web server.
+     */
+    public function testRecoveredDirectoryUsesNormalPublicationMode(): void {
+        $previous_umask = umask(0022);
+        try {
+            $normal_session = $this->push_session('60606060606060606060606060606060');
+            $this->push_parts($normal_session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('normal-directory'),
+                ],
+                'body' => '',
+            ]]);
+            $normal_mode = fileperms($normal_session->get_push_directory() . '/work/files/normal-directory') & 0777;
+
+            $recovered_session = $this->push_session('61616161616161616161616161616161');
+            $this->run_upload_with_filesystem_fault($recovered_session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('recovered-directory'),
+                ],
+                'body' => '',
+            ]], 'mkdir', '/work/files/recovered-directory');
+            $recovered_session->get_status('recovered-directory');
+            $recovered_mode = fileperms($recovered_session->get_push_directory() . '/work/files/recovered-directory') & 0777;
+
+            $this->assertSame(0755, $normal_mode);
+            $this->assertSame($normal_mode, $recovered_mode);
+        } finally {
+            umask($previous_umask);
+        }
+    }
+
     public function testDirectoryAndSymlinkPublicationRecoverBeforeAndAfterLeafCreation(): void {
         foreach (['directory', 'symlink'] as $type_index => $type) {
             foreach (['create', 'clear'] as $boundary_index => $boundary) {

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -29,7 +29,7 @@ final class PushSessionTest extends TestCase {
         $this->assertSame(['operation' => 'receive'], $exception->get_context());
     }
 
-    public function testNewPushSessionHasOneCompletedTreeAndNoPartialTree(): void {
+    public function testNewPushSessionHasOneCompletedTreeAndNoSecondPathShapedTree(): void {
         $push_session = $this->push_session('10101010101010101010101010101010');
         $work_directory = $push_session->get_push_directory() . '/work';
 
@@ -46,7 +46,7 @@ final class PushSessionTest extends TestCase {
         $this->assertArrayNotHasKey('version', $push_metadata);
     }
 
-    public function testPartialFileProgressComesFromTheFileAndOffsetZeroRestartsIt(): void {
+    public function testInFlightFileProgressComesFromTheDataFileAndOffsetZeroRestartsIt(): void {
         $push_session = $this->push_session('11111111111111111111111111111111');
         $this->push_parts($push_session, [[
             'headers' => [
@@ -66,6 +66,24 @@ final class PushSessionTest extends TestCase {
         );
         $this->assertArrayNotHasKey('version', $inflight);
 
+        foreach ([2, 4] as $offset) {
+            try {
+                $this->push_parts($push_session, [[
+                    'headers' => [
+                        'X-Chunk-Type' => 'file',
+                        'X-File-Path' => base64_encode('upload.bin'),
+                        'X-File-Size' => '6',
+                        'X-Chunk-Offset' => (string) $offset,
+                    ],
+                    'body' => 'x',
+                ]]);
+                $this->fail('An in-flight file accepted cursor ' . $offset . ' while its data file contained 3 bytes.');
+            } catch (Site_Export_Push_Exception $exception) {
+                $this->assertSame('offset_gap', $exception->get_error_code());
+            }
+            $this->assertSame('old', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
+        }
+
         $this->push_parts($push_session, [[
             'headers' => [
                 'X-Chunk-Type' => 'file',
@@ -81,6 +99,116 @@ final class PushSessionTest extends TestCase {
 
         $this->commit_all($push_session);
         $this->assertSame('new', file_get_contents($this->docroot . '/upload.bin'));
+    }
+
+    public function testCurrentChangeReturnsEveryDocumentedShapeAndResets(): void {
+        $push_session = $this->push_session('12121212121212121212121212121212');
+        $boundary = 'current-change-boundary';
+        $parts = [
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('file.txt'),
+                    'X-File-Size' => '2',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'a',
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('file.txt'),
+                    'X-File-Size' => '2',
+                    'X-Chunk-Offset' => '1',
+                ],
+                'body' => 'b',
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('empty'),
+                ],
+                'body' => '',
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'symlink',
+                    'X-Symlink-Path' => base64_encode('link'),
+                    'X-Symlink-Target' => base64_encode('file.txt'),
+                ],
+                'body' => '',
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '0',
+                ],
+                'body' => "gone\0",
+            ],
+            [
+                'headers' => [
+                    'X-Chunk-Type' => 'delete-list',
+                    'X-Delete-Offset' => '5',
+                    'X-Delete-Complete' => '1',
+                ],
+                'body' => '',
+            ],
+        ];
+        $body = '';
+        foreach ($parts as $part) {
+            $body .= '--' . $boundary . "\r\n";
+            foreach ($part['headers'] as $name => $value) {
+                $body .= $name . ': ' . $value . "\r\n";
+            }
+            $body .= 'Content-Length: ' . strlen($part['body']) . "\r\n\r\n" . $part['body'] . "\r\n";
+        }
+        $body .= '--' . $boundary . "--\r\n";
+        $input = fopen('php://temp', 'w+b');
+        fwrite($input, $body);
+        rewind($input);
+
+        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        try {
+            $this->assertNull($push_session->get_current_change());
+            $expected_changes = [
+                ['path_b64' => base64_encode('file.txt'), 'state' => 'partial', 'type' => 'file', 'accepted_bytes' => 1],
+                ['path_b64' => base64_encode('file.txt'), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => 2],
+                ['path_b64' => base64_encode('empty'), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0],
+                ['path_b64' => base64_encode('link'), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0],
+                ['state' => 'partial', 'type' => 'delete-list', 'accepted_bytes' => 5],
+                ['state' => 'complete', 'type' => 'delete-list', 'accepted_bytes' => 5],
+            ];
+            foreach ($expected_changes as $expected_change) {
+                $this->assertTrue($push_session->next_change());
+                $this->assertSame($expected_change, $push_session->get_current_change());
+            }
+            $this->assertFalse($push_session->next_change());
+            $this->assertNull($push_session->get_current_change());
+        } finally {
+            $push_session->finish_upload();
+            fclose($input);
+        }
+        $this->assertNull($push_session->get_current_change());
+
+        $input = fopen('php://temp', 'w+b');
+        fwrite(
+            $input,
+            '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: directory\r\n"
+            . 'X-Directory-Path: ' . base64_encode('empty') . "\r\n"
+            . "Content-Length: 0\r\n\r\n\r\n"
+            . '--' . $boundary . "--\r\n"
+        );
+        rewind($input);
+        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        try {
+            $this->assertTrue($push_session->next_change());
+            $this->assertNotNull($push_session->get_current_change());
+        } finally {
+            $push_session->finish_upload();
+            fclose($input);
+        }
+        $this->assertNull($push_session->get_current_change());
     }
 
     public function testInvalidPartStopsBeforeTheFollowingPartIsRead(): void {
@@ -105,6 +233,7 @@ final class PushSessionTest extends TestCase {
         } catch (Site_Export_Push_Exception $exception) {
             $this->assertSame('offset_gap', $exception->get_error_code());
             $this->assertStringContainsString('Start at offset 0', $exception->getMessage());
+            $this->assertNull($push_session->get_current_change());
         } finally {
             $push_session->finish_upload();
             fclose($input);
@@ -216,6 +345,51 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testCompletedEmptyDirectoryCanBecomeNonEmpty(): void {
+        foreach (['file', 'directory', 'symlink'] as $index => $type) {
+            $push_session = $this->push_session(sprintf('%032x', 700 + $index));
+            $this->push_parts($push_session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('parent'),
+                ],
+                'body' => '',
+            ]]);
+
+            if ($type === 'file') {
+                $headers = [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('parent/child'),
+                    'X-File-Size' => '1',
+                    'X-Chunk-Offset' => '0',
+                ];
+                $body = 'x';
+            } elseif ($type === 'directory') {
+                $headers = [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('parent/child'),
+                ];
+                $body = '';
+            } else {
+                $headers = [
+                    'X-Chunk-Type' => 'symlink',
+                    'X-Symlink-Path' => base64_encode('parent/child'),
+                    'X-Symlink-Target' => base64_encode('../elsewhere'),
+                ];
+                $body = '';
+            }
+
+            $this->push_parts($push_session, [['headers' => $headers, 'body' => $body]]);
+
+            $this->assertSame('complete', $push_session->get_status('parent')['path']['state']);
+            $this->assertSame('directory', $push_session->get_status('parent')['path']['type']);
+            $this->assertSame('complete', $push_session->get_status('parent/child')['path']['state']);
+            $this->assertSame($type, $push_session->get_status('parent/child')['path']['type']);
+            $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/inflight.json');
+            $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/inflight.data');
+        }
+    }
+
     public function testForeignMaintenanceStopsBeforeMutationAndOwnedMarkerRefreshes(): void {
         $push_session = $this->push_session('44444444444444444444444444444444');
         $this->push_file($push_session, 'pending.txt', 'new');
@@ -301,6 +475,59 @@ final class PushSessionTest extends TestCase {
         }
 
         $this->assertSame('receiving_work', $reopened->get_status()['phase']);
+    }
+
+    public function testPushSessionLockIsReleasedWhenTheUploadProcessDies(): void {
+        $push_session = $this->push_session('67676767676767676767676767676768');
+        $ready_path = $this->root . '/upload-lock-ready';
+        $configuration = base64_encode(json_encode([
+            'bootstrap_path' => __DIR__ . '/bootstrap.php',
+            'reprint_directory' => $this->reprint_directory,
+            'docroot' => $this->docroot,
+            'push_session_id' => $push_session->get_push_session_id(),
+            'ready_path' => $ready_path,
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $script = '$configuration = json_decode(base64_decode($argv[1], true), true, 512, JSON_THROW_ON_ERROR);'
+            . 'require $configuration["bootstrap_path"];'
+            . '$push_session = Site_Export_Push_Session::open($configuration["reprint_directory"], $configuration["docroot"], $configuration["push_session_id"], ["wp-content/plugins/reprint"]);'
+            . '$input = fopen("php://temp", "w+b");'
+            . '$push_session->accept_upload($input, new Site_Export_Multipart_Processor("dead-owner-boundary"));'
+            . 'file_put_contents($configuration["ready_path"], "ready");'
+            . 'sleep(30);';
+        $process = proc_open(
+            [PHP_BINARY, '-r', $script, $configuration],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $deadline = microtime(true) + 10;
+        while (!is_file($ready_path) && microtime(true) < $deadline) {
+            usleep(1000);
+        }
+        $this->assertFileExists($ready_path);
+
+        $process_closed = false;
+        try {
+            try {
+                $push_session->get_status();
+                $this->fail('Status acquired the push lock while another process held an upload open.');
+            } catch (Site_Export_Push_Exception $exception) {
+                $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
+            }
+
+            $this->assertTrue(proc_terminate($process, 9));
+            proc_close($process);
+            $process_closed = true;
+        } finally {
+            if (!$process_closed) {
+                @proc_terminate($process, 9);
+                proc_close($process);
+            }
+        }
+        $this->assertSame('receiving_work', $push_session->get_status()['phase']);
     }
 
     public function testTruncatedUploadDoesNotBecomeACompleteChangeAndReleasesCleanly(): void {
@@ -471,6 +698,49 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testMalformedInFlightFilesAreClassifiedAsCorruption(): void {
+        $malformed_session = $this->push_session('34563456345634563456345634563457');
+        file_put_contents($malformed_session->get_push_directory() . '/work/inflight.json', '{not-json');
+        try {
+            $malformed_session->get_status();
+            $this->fail('Malformed in-flight JSON was accepted.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('corrupted_push_state', $exception->get_error_code());
+            $this->assertStringContainsString('does not contain a JSON object', $exception->getMessage());
+        }
+
+        $oversized_session = $this->push_session('34563456345634563456345634563458');
+        file_put_contents($oversized_session->get_push_directory() . '/work/inflight.json', str_repeat('x', 1048577));
+        try {
+            $oversized_session->get_status();
+            $this->fail('Oversized in-flight JSON was accepted.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('corrupted_push_state', $exception->get_error_code());
+            $this->assertStringContainsString('not a bounded regular file', $exception->getMessage());
+        }
+
+        $wrong_type_session = $this->push_session('34563456345634563456345634563459');
+        mkdir($wrong_type_session->get_push_directory() . '/work/inflight.data');
+        try {
+            $wrong_type_session->get_status();
+            $this->fail('A directory was accepted as in-flight file data.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('corrupted_push_state', $exception->get_error_code());
+            $this->assertStringContainsString('unsupported type', $exception->getMessage());
+        }
+    }
+
+    public function testSourceKeepsOnePathShapedWorkTreeAndSharedInFlightHelpers(): void {
+        $source = file_get_contents(__DIR__ . '/../packages/reprint-exporter/src/class-push-session.php');
+        $this->assertIsString($source);
+        $this->assertStringNotContainsString('work/partial', $source);
+        $this->assertStringNotContainsString('work_partial', $source);
+        $this->assertStringNotContainsString('first_tree_entry', $source);
+        foreach (['read_inflight', 'finish_published_inflight'] as $method) {
+            $this->assertGreaterThanOrEqual(2, substr_count($source, '$this->' . $method . '('), $method . ' must remain shared by multiple callers.');
+        }
+    }
+
     public function testReopenRejectsDocumentRootAndExcludedPathConfigurationDrift(): void {
         $push_session = $this->push_session('45674567456745674567456745674567');
         $other_docroot = $this->root . '/other-docroot';
@@ -499,7 +769,7 @@ final class PushSessionTest extends TestCase {
         }
     }
 
-    public function testCompletedTypeChangeRemovesThePartialFileAtTheSamePath(): void {
+    public function testCompletedTypeChangeDiscardsInFlightFileDataAtTheSamePath(): void {
         foreach (['directory', 'symlink'] as $index => $type) {
             $push_session = $this->push_session(sprintf('%032x', 500 + $index));
             $this->push_parts($push_session, [[
@@ -529,7 +799,7 @@ final class PushSessionTest extends TestCase {
         }
     }
 
-    public function testStatusReportsMissingPartialAndEveryCompletedValueType(): void {
+    public function testStatusReportsMissingInFlightAndEveryCompletedValueType(): void {
         $push_session = $this->push_session('88888888888888888888888888888888');
         $raw_path = "line\nbreak.bin";
         $this->push_parts($push_session, [[
@@ -546,8 +816,10 @@ final class PushSessionTest extends TestCase {
             ['path_b64' => base64_encode('missing'), 'state' => 'missing', 'accepted_bytes' => 0],
             $push_session->get_status('missing')['path']
         );
-        $this->assertSame('partial', $push_session->get_status($raw_path)['path']['state']);
-        $this->assertSame(1, $push_session->get_status($raw_path)['path']['accepted_bytes']);
+        $this->assertSame(
+            ['path_b64' => base64_encode($raw_path), 'state' => 'partial', 'type' => 'file', 'accepted_bytes' => 1],
+            $push_session->get_status($raw_path)['path']
+        );
 
         $this->push_parts($push_session, [[
             'headers' => [
@@ -585,10 +857,29 @@ final class PushSessionTest extends TestCase {
             ],
         ]);
 
-        $this->assertSame('file', $push_session->get_status('empty.bin')['path']['type']);
-        $this->assertSame('directory', $push_session->get_status('empty-directory')['path']['type']);
-        $this->assertSame('symlink', $push_session->get_status('link')['path']['type']);
-        $this->assertNull($push_session->get_status()['path']);
+        $this->assertSame(
+            ['path_b64' => base64_encode($raw_path), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => 2],
+            $push_session->get_status($raw_path)['path']
+        );
+        $this->assertSame(
+            ['path_b64' => base64_encode('empty.bin'), 'state' => 'complete', 'type' => 'file', 'accepted_bytes' => 0],
+            $push_session->get_status('empty.bin')['path']
+        );
+        $this->assertSame(
+            ['path_b64' => base64_encode('empty-directory'), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0],
+            $push_session->get_status('empty-directory')['path']
+        );
+        $this->assertSame(
+            ['path_b64' => base64_encode('link'), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0],
+            $push_session->get_status('link')['path']
+        );
+        $this->assertSame([
+            'push_session_id' => '88888888888888888888888888888888',
+            'phase' => 'receiving_work',
+            'work_deletes_bytes' => 0,
+            'work_deletes_complete' => false,
+            'path' => null,
+        ], $push_session->get_status());
     }
 
     public function testCompletedFileReplayRequiresItsExactEmptyEndCursor(): void {
@@ -621,7 +912,7 @@ final class PushSessionTest extends TestCase {
         }
     }
 
-    public function testPartialFileCannotBecomeAParentOfCompletedValues(): void {
+    public function testInFlightFileCannotBecomeAParentOfCompletedValues(): void {
         foreach (['directory', 'symlink'] as $index => $type) {
             $push_session = $this->push_session(sprintf('%032x', 200 + $index));
             $this->push_parts($push_session, [[
@@ -646,7 +937,7 @@ final class PushSessionTest extends TestCase {
 
             try {
                 $this->push_parts($push_session, [['headers' => $headers, 'body' => '']]);
-                $this->fail('A partial file became the parent of a completed ' . $type . '.');
+                $this->fail('An in-flight file became the parent of a completed ' . $type . '.');
             } catch (Site_Export_Push_Exception $exception) {
                 $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
@@ -655,7 +946,7 @@ final class PushSessionTest extends TestCase {
         }
     }
 
-    public function testCompletedLeafCannotHidePartialDescendants(): void {
+    public function testCompletedLeafCannotHideInFlightDescendants(): void {
         foreach (['file', 'directory', 'symlink'] as $index => $type) {
             $push_session = $this->push_session(sprintf('%032x', 300 + $index));
             $this->push_parts($push_session, [[
@@ -692,7 +983,7 @@ final class PushSessionTest extends TestCase {
 
             try {
                 $this->push_parts($push_session, [['headers' => $headers, 'body' => $body]]);
-                $this->fail('A completed ' . $type . ' hid a partial descendant.');
+                $this->fail('A completed ' . $type . ' hid an in-flight descendant.');
             } catch (Site_Export_Push_Exception $exception) {
                 $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
@@ -702,23 +993,40 @@ final class PushSessionTest extends TestCase {
 
     public function testOnlyTheMatchingPathCanUseTheInFlightSlot(): void {
         $push_session = $this->push_session('77777777777777777777777777777777');
-        $this->push_parts($push_session, [[
-            'headers' => [
-                'X-Chunk-Type' => 'file',
-                'X-File-Path' => base64_encode('first.txt'),
-                'X-File-Size' => '2',
-                'X-Chunk-Offset' => '0',
-            ],
-            'body' => 'a',
-        ]]);
-
         try {
-            $this->push_file($push_session, 'second.txt', 'b');
-            $this->fail('A different path replaced unfinished work.');
+            $this->push_parts($push_session, [
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'file',
+                        'X-File-Path' => base64_encode('first.txt'),
+                        'X-File-Size' => '2',
+                        'X-Chunk-Offset' => '0',
+                    ],
+                    'body' => 'a',
+                ],
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'file',
+                        'X-File-Path' => base64_encode('second.txt'),
+                        'X-File-Size' => '1',
+                        'X-Chunk-Offset' => '0',
+                    ],
+                    'body' => 'b',
+                ],
+            ]);
+            $this->fail('A different path replaced in-flight work in the same request.');
         } catch (Site_Export_Push_Exception $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         }
 
+        $this->assertSame(
+            ['path_b64' => base64_encode('first.txt'), 'state' => 'partial', 'type' => 'file', 'accepted_bytes' => 1],
+            $push_session->get_status('first.txt')['path']
+        );
+        $this->assertSame(
+            ['path_b64' => base64_encode('second.txt'), 'state' => 'missing', 'accepted_bytes' => 0],
+            $push_session->get_status('second.txt')['path']
+        );
         $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
         $this->assertFileDoesNotExist($push_session->get_push_directory() . '/work/files/second.txt');
     }
@@ -754,102 +1062,177 @@ final class PushSessionTest extends TestCase {
         $this->assertSame('new', file_get_contents($push_session->get_push_directory() . '/work/files/same-size.txt'));
     }
 
-    public function testCommitRejectsUnfinishedWorkBeforeWritingACheckpoint(): void {
+    public function testCommitRejectsInFlightWorkBeforeWritingACheckpoint(): void {
         $push_session = $this->push_session('56565656565656565656565656565656');
         $this->push_parts($push_session, [[
             'headers' => [
                 'X-Chunk-Type' => 'file',
-                'X-File-Path' => base64_encode('unfinished.txt'),
+                'X-File-Path' => base64_encode('inflight.txt'),
                 'X-File-Size' => '2',
                 'X-Chunk-Offset' => '0',
             ],
             'body' => 'x',
         ]]);
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'delete-list',
+                'X-Delete-Offset' => '0',
+            ],
+            'body' => "gone.txt\0",
+        ]]);
         $this->complete_work_deletes($push_session);
+        $this->assertSame(9, $push_session->get_status()['work_deletes_bytes']);
+        $this->assertTrue($push_session->get_status()['work_deletes_complete']);
 
         try {
             $push_session->commit(1);
-            $this->fail('Commit accepted unfinished work.');
+            $this->fail('Commit accepted in-flight work.');
         } catch (InvalidArgumentException $exception) {
             $this->assertStringContainsString('unfinished', $exception->getMessage());
         }
 
         $this->assertFileDoesNotExist($push_session->get_push_directory() . '/commit.json');
-        $this->assertFileDoesNotExist($this->docroot . '/unfinished.txt');
+        $this->assertFileDoesNotExist($this->docroot . '/inflight.txt');
+        $this->assertFileDoesNotExist($this->docroot . '/.maintenance');
+        $this->assertFileDoesNotExist($this->reprint_directory . '/.reprint/push/commit-state');
     }
 
-    public function testStatusFinishesPublishedDirectoryAndSymlinkWork(): void {
-        foreach (['directory', 'symlink'] as $index => $type) {
-            $push_session = $this->push_session(sprintf('%032x', 60 + $index));
-            $work_directory = $push_session->get_push_directory() . '/work';
-            $inflight = [
-                'phase' => 'publishing',
-                'path_b64' => base64_encode($type . '-value'),
-                'type' => $type,
-            ];
-            if ($type === 'symlink') {
-                $inflight['target_b64'] = base64_encode('../target');
-            }
-            file_put_contents($work_directory . '/inflight.json', json_encode($inflight, JSON_THROW_ON_ERROR));
-
-            $status = $push_session->get_status($type . '-value')['path'];
-            $this->assertSame('complete', $status['state']);
-            $this->assertSame($type, $status['type']);
-            $this->assertFileDoesNotExist($work_directory . '/inflight.json');
-        }
-    }
-
-    public function testStatusFinishesPublishedFileDataWithoutAcceptingTheOldValue(): void {
+    public function testFilePublicationRecoversAtBothDurableBoundaries(): void {
         $push_session = $this->push_session('34343434343434343434343434343434');
         $work_directory = $push_session->get_push_directory() . '/work';
-        file_put_contents($work_directory . '/files/same-size.txt', 'old');
-        file_put_contents($work_directory . '/inflight.data', 'new');
-        file_put_contents($work_directory . '/inflight.json', json_encode([
-            'phase' => 'publishing',
-            'path_b64' => base64_encode('same-size.txt'),
-            'type' => 'file',
-            'total_bytes' => 3,
-        ], JSON_THROW_ON_ERROR));
+        $this->push_file($push_session, 'same-size.txt', 'old');
 
+        $this->run_upload_with_filesystem_fault($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('same-size.txt'),
+                'X-File-Size' => '3',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'new',
+        ]], 'unlink', '/work/files/same-size.txt');
+
+        $this->assertSame('old', file_get_contents($work_directory . '/files/same-size.txt'));
+        $this->assertSame('new', file_get_contents($work_directory . '/inflight.data'));
+        $this->assertFileExists($work_directory . '/inflight.json');
         $this->assertSame('complete', $push_session->get_status('same-size.txt')['path']['state']);
         $this->assertSame('new', file_get_contents($work_directory . '/files/same-size.txt'));
         $this->assertFileDoesNotExist($work_directory . '/inflight.json');
         $this->assertFileDoesNotExist($work_directory . '/inflight.data');
-    }
 
-    public function testStatusFinishesPublishedFileAfterItsDataWasRenamed(): void {
         $push_session = $this->push_session('45454545454545454545454545454545');
         $work_directory = $push_session->get_push_directory() . '/work';
-        file_put_contents($work_directory . '/files/renamed.txt', 'new');
-        file_put_contents($work_directory . '/inflight.json', json_encode([
-            'phase' => 'publishing',
-            'path_b64' => base64_encode('renamed.txt'),
-            'type' => 'file',
-            'total_bytes' => 3,
-        ], JSON_THROW_ON_ERROR));
+        $this->run_upload_with_filesystem_fault($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => base64_encode('commit.txt'),
+                'X-File-Size' => '3',
+                'X-Chunk-Offset' => '0',
+            ],
+            'body' => 'new',
+        ]], 'unlink', '/work/inflight.json');
 
-        $this->assertSame('complete', $push_session->get_status('renamed.txt')['path']['state']);
-        $this->assertSame('new', file_get_contents($work_directory . '/files/renamed.txt'));
+        $this->assertSame('new', file_get_contents($work_directory . '/files/commit.txt'));
+        $this->assertFileDoesNotExist($work_directory . '/inflight.data');
+        $this->assertFileExists($work_directory . '/inflight.json');
+        $this->complete_work_deletes($push_session);
+        $this->commit_all($push_session);
         $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+        $this->assertSame('new', file_get_contents($this->docroot . '/commit.txt'));
     }
 
-    public function testCommitFinishesPublishedFileBeforeWritingItsCheckpoint(): void {
-        $push_session = $this->push_session('46464646464646464646464646464646');
-        $work_directory = $push_session->get_push_directory() . '/work';
-        file_put_contents($work_directory . '/inflight.data', 'new');
-        file_put_contents($work_directory . '/inflight.json', json_encode([
-            'phase' => 'publishing',
-            'path_b64' => base64_encode('commit.txt'),
-            'type' => 'file',
-            'total_bytes' => 3,
-        ], JSON_THROW_ON_ERROR));
-        $this->complete_work_deletes($push_session);
+    public function testDirectoryAndSymlinkPublicationRecoverBeforeAndAfterLeafCreation(): void {
+        foreach (['directory', 'symlink'] as $type_index => $type) {
+            foreach (['create', 'clear'] as $boundary_index => $boundary) {
+                $push_session = $this->push_session(sprintf('%032x', 800 + ( $type_index * 10 ) + $boundary_index));
+                $work_directory = $push_session->get_push_directory() . '/work';
+                $path = 'nested/' . $type . '-' . $boundary;
+                if ($type === 'directory') {
+                    $headers = [
+                        'X-Chunk-Type' => 'directory',
+                        'X-Directory-Path' => base64_encode($path),
+                    ];
+                    $operation = 'mkdir';
+                } else {
+                    $headers = [
+                        'X-Chunk-Type' => 'symlink',
+                        'X-Symlink-Path' => base64_encode($path),
+                        'X-Symlink-Target' => base64_encode('../target'),
+                    ];
+                    $operation = 'symlink';
+                }
+                $fault_operation = $boundary === 'create' ? $operation : 'unlink';
+                $fault_path_suffix = $boundary === 'create' ? '/work/files/' . $path : '/work/inflight.json';
 
-        $push_session->commit(1);
+                $this->run_upload_with_filesystem_fault(
+                    $push_session,
+                    [['headers' => $headers, 'body' => '']],
+                    $fault_operation,
+                    $fault_path_suffix
+                );
 
-        $this->assertFileDoesNotExist($work_directory . '/inflight.json');
-        $this->assertSame('new', file_get_contents($work_directory . '/files/commit.txt'));
-        $this->assertFileExists($push_session->get_push_directory() . '/commit.json');
+                $this->assertFileExists($work_directory . '/inflight.json');
+                if ($boundary === 'create') {
+                    $this->assertFileDoesNotExist($work_directory . '/files/' . $path);
+                    $this->assertDirectoryExists($work_directory . '/files/nested');
+                } elseif ($type === 'directory') {
+                    $this->assertDirectoryExists($work_directory . '/files/' . $path);
+                } else {
+                    $this->assertTrue(is_link($work_directory . '/files/' . $path));
+                }
+
+                $this->assertSame(
+                    [
+                        'path_b64' => base64_encode($path),
+                        'state' => 'complete',
+                        'type' => $type,
+                        'accepted_bytes' => 0,
+                    ],
+                    $push_session->get_status($path)['path']
+                );
+                $this->assertFileDoesNotExist($work_directory . '/inflight.json');
+            }
+        }
+    }
+
+    public function testStatusReportsPreparingDirectoryAndSymlinkFromAProductionFailure(): void {
+        foreach (['directory', 'symlink'] as $index => $type) {
+            $push_session = $this->push_session(sprintf('%032x', 900 + $index));
+            $path = $type . '-replacement';
+            $this->push_parts($push_session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode($path),
+                    'X-File-Size' => '2',
+                    'X-Chunk-Offset' => '0',
+                ],
+                'body' => 'x',
+            ]]);
+            $headers = $type === 'directory'
+                ? [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode($path),
+                ]
+                : [
+                    'X-Chunk-Type' => 'symlink',
+                    'X-Symlink-Path' => base64_encode($path),
+                    'X-Symlink-Target' => base64_encode('../target'),
+                ];
+
+            $this->run_upload_with_filesystem_fault(
+                $push_session,
+                [['headers' => $headers, 'body' => '']],
+                'unlink',
+                '/work/inflight.data'
+            );
+
+            $this->assertSame(
+                ['path_b64' => base64_encode($path), 'state' => 'partial', 'type' => $type, 'accepted_bytes' => 0],
+                $push_session->get_status($path)['path']
+            );
+            $this->push_parts($push_session, [['headers' => $headers, 'body' => '']]);
+            $this->assertSame('complete', $push_session->get_status($path)['path']['state']);
+        }
     }
 
     public function testCheckpointMustContainEveryFieldReadByCommit(): void {
@@ -916,6 +1299,110 @@ final class PushSessionTest extends TestCase {
         } while (!$remove_complete);
         $this->assertFileExists($outside . '/sentinel');
         $this->assertDirectoryDoesNotExist($push_session->get_push_directory());
+    }
+
+    /**
+     * Runs an upload while one named filesystem call fails in production code.
+     *
+     * The upload runs in a separate PHP process with a small shared library
+     * interposed at the libc boundary. The library fails only the requested
+     * operation and path suffix. This leaves the same durable state that the
+     * production method wrote before the failed call, without rewriting private
+     * push-session files in the test.
+     *
+     * @param Site_Export_Push_Session $push_session Push session to reopen in the child process.
+     * @param array<int,array{headers:array<string,string>,body:string}> $parts Multipart parts to upload.
+     * @param string $operation One of unlink, mkdir, or symlink.
+     * @param string $path_suffix Absolute-path suffix whose operation must fail.
+     * @return array{class:string,reason:string|null,message:string} Classified child-process exception.
+     */
+    private function run_upload_with_filesystem_fault(
+        Site_Export_Push_Session $push_session,
+        array $parts,
+        string $operation,
+        string $path_suffix
+    ): array {
+        if (!in_array(PHP_OS_FAMILY, ['Linux', 'Darwin'], true)) {
+            $this->markTestSkipped('Filesystem publication fault tests require libc interposition on Linux or macOS.');
+        }
+
+        $source_path = __DIR__ . '/fixtures/push-session-filesystem-fault.c';
+        $library_extension = PHP_OS_FAMILY === 'Darwin' ? 'dylib' : 'so';
+        $library_path = sys_get_temp_dir() . '/reprint-push-session-fault-' . hash_file('sha256', $source_path) . '.' . $library_extension;
+        if (!is_file($library_path)) {
+            $compile_command = PHP_OS_FAMILY === 'Darwin'
+                ? ['cc', '-dynamiclib', '-O2', '-o', $library_path, $source_path]
+                : ['cc', '-shared', '-fPIC', '-O2', '-o', $library_path, $source_path, '-ldl'];
+            $compile_descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+            $compile_process = proc_open($compile_command, $compile_descriptors, $compile_pipes);
+            $this->assertIsResource($compile_process, 'Could not start the filesystem fault-library compiler.');
+            fclose($compile_pipes[0]);
+            $compile_stdout = stream_get_contents($compile_pipes[1]);
+            $compile_stderr = stream_get_contents($compile_pipes[2]);
+            fclose($compile_pipes[1]);
+            fclose($compile_pipes[2]);
+            $compile_exit_code = proc_close($compile_process);
+            $this->assertSame(0, $compile_exit_code, "Could not compile the filesystem fault library.\n" . $compile_stdout . $compile_stderr);
+        }
+
+        $boundary = 'filesystem-fault-boundary';
+        $body = '';
+        foreach ($parts as $part) {
+            $body .= '--' . $boundary . "\r\n";
+            foreach ($part['headers'] as $name => $value) {
+                $body .= $name . ': ' . $value . "\r\n";
+            }
+            $body .= 'Content-Length: ' . strlen($part['body']) . "\r\n\r\n" . $part['body'] . "\r\n";
+        }
+        $body .= '--' . $boundary . "--\r\n";
+        $configuration = base64_encode(json_encode([
+            'reprint_directory' => $this->reprint_directory,
+            'docroot' => $this->docroot,
+            'push_session_id' => $push_session->get_push_session_id(),
+            'excluded_paths' => ['wp-content/plugins/reprint'],
+            'boundary' => $boundary,
+            'body_b64' => base64_encode($body),
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $environment = getenv();
+        if (!is_array($environment)) {
+            $environment = [];
+        }
+        $environment['REPRINT_FAULT_OPERATION'] = $operation;
+        $environment['REPRINT_FAULT_PATH_SUFFIX'] = $path_suffix;
+        if (PHP_OS_FAMILY === 'Darwin') {
+            $environment['DYLD_INSERT_LIBRARIES'] = $library_path;
+            $environment['DYLD_FORCE_FLAT_NAMESPACE'] = '1';
+        } else {
+            $environment['LD_PRELOAD'] = $library_path;
+        }
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open(
+            [PHP_BINARY, __DIR__ . '/fixtures/run-push-session-upload.php', $configuration],
+            $descriptors,
+            $pipes,
+            null,
+            $environment
+        );
+        $this->assertIsResource($process, 'Could not start the faulted push-session upload process.');
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit_code = proc_close($process);
+        $this->assertSame(73, $exit_code, "The requested filesystem call did not fail.\nstdout: " . $stdout . "\nstderr: " . $stderr);
+        $failure = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(Site_Export_Push_Exception::class, $failure['class']);
+        $this->assertSame('filesystem_error', $failure['reason']);
+        return $failure;
     }
 
     private function push_session(string $id): Site_Export_Push_Session {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,10 @@ if (!class_exists('Site_Export_Push_Exception', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-exception.php';
 }
 
+if (!class_exists('Site_Export_Push_Endpoints', false)) {
+    require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-endpoints.php';
+}
+
 if (!class_exists('Site_Export_Push_Session', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-session.php';
 }

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -23,6 +23,6 @@ require_once dirname(__DIR__, 2) . '/reprint-exporter-wp/lib.php';
 _site_export_handle_api_request([
     'reprint_directory' => (string) getenv('REPRINT_PUSH_TEST_DIRECTORY'),
     'excluded_paths' => ['preserved'],
-    'maximum_part_bytes' => 4,
+    'maximum_part_bytes' => 64,
     'maximum_commit_entries' => 1,
 ]);

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -1,0 +1,28 @@
+<?php
+
+// This fixture supplies the WordPress values the production plugin router
+// reads; request authentication and endpoint dispatch remain production code.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+
+define('ABSPATH', rtrim( (string) getenv('REPRINT_PUSH_TEST_DOCROOT'), '/\\') . '/');
+
+function plugin_dir_path(string $file): string {
+    return $file === '' ? '' : dirname(__DIR__, 2) . '/reprint-exporter-wp/';
+}
+
+function get_option(string $name, $fallback = false) {
+    if ($name === 'site_export_secret') {
+        return (string) getenv('REPRINT_PUSH_TEST_SECRET');
+    }
+    return $fallback;
+}
+
+require_once dirname(__DIR__, 2) . '/reprint-exporter-wp/lib.php';
+
+_site_export_handle_api_request([
+    'reprint_directory' => (string) getenv('REPRINT_PUSH_TEST_DIRECTORY'),
+    'excluded_paths' => ['preserved'],
+    'maximum_part_bytes' => 4,
+    'maximum_commit_entries' => 1,
+]);

--- a/tests/fixtures/push-session-filesystem-fault.c
+++ b/tests/fixtures/push-session-filesystem-fault.c
@@ -1,0 +1,108 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/*
+ * Fail one selected filesystem call in the child upload process. Matching an
+ * operation and full path suffix keeps metadata writes and unrelated cleanup
+ * on the production path while stopping at the publication boundary under
+ * test.
+ */
+static int path_has_suffix(const char *path, const char *suffix) {
+    size_t path_length = strlen(path);
+    size_t suffix_length = strlen(suffix);
+    return path_length >= suffix_length && strcmp(path + path_length - suffix_length, suffix) == 0;
+}
+
+static int should_fail(const char *operation, const char *path) {
+    const char *requested_operation = getenv("REPRINT_FAULT_OPERATION");
+    const char *requested_path_suffix = getenv("REPRINT_FAULT_PATH_SUFFIX");
+    return requested_operation != NULL
+        && requested_path_suffix != NULL
+        && strcmp(operation, requested_operation) == 0
+        && path_has_suffix(path, requested_path_suffix);
+}
+
+#ifdef __APPLE__
+
+#define DYLD_INTERPOSE(replacement, replacee) \
+    __attribute__((used)) static struct { \
+        const void *replacement; \
+        const void *replacee; \
+    } interpose_##replacee __attribute__((section("__DATA,__interpose"))) = { \
+        (const void *)(uintptr_t)&replacement, \
+        (const void *)(uintptr_t)&replacee \
+    }
+
+static int fault_unlink(const char *path) {
+    if (should_fail("unlink", path)) {
+        errno = EIO;
+        return -1;
+    }
+    return unlink(path);
+}
+DYLD_INTERPOSE(fault_unlink, unlink);
+
+static int fault_mkdir(const char *path, mode_t mode) {
+    if (should_fail("mkdir", path)) {
+        errno = EIO;
+        return -1;
+    }
+    return mkdir(path, mode);
+}
+DYLD_INTERPOSE(fault_mkdir, mkdir);
+
+static int fault_symlink(const char *target, const char *path) {
+    if (should_fail("symlink", path)) {
+        errno = EIO;
+        return -1;
+    }
+    return symlink(target, path);
+}
+DYLD_INTERPOSE(fault_symlink, symlink);
+
+#else
+
+int unlink(const char *path) {
+    static int (*real_unlink)(const char *) = NULL;
+    if (should_fail("unlink", path)) {
+        errno = EIO;
+        return -1;
+    }
+    if (real_unlink == NULL) {
+        real_unlink = dlsym(RTLD_NEXT, "unlink");
+    }
+    return real_unlink(path);
+}
+
+int mkdir(const char *path, mode_t mode) {
+    static int (*real_mkdir)(const char *, mode_t) = NULL;
+    if (should_fail("mkdir", path)) {
+        errno = EIO;
+        return -1;
+    }
+    if (real_mkdir == NULL) {
+        real_mkdir = dlsym(RTLD_NEXT, "mkdir");
+    }
+    return real_mkdir(path, mode);
+}
+
+int symlink(const char *target, const char *path) {
+    static int (*real_symlink)(const char *, const char *) = NULL;
+    if (should_fail("symlink", path)) {
+        errno = EIO;
+        return -1;
+    }
+    if (real_symlink == NULL) {
+        real_symlink = dlsym(RTLD_NEXT, "symlink");
+    }
+    return real_symlink(target, path);
+}
+
+#endif

--- a/tests/fixtures/run-push-session-upload.php
+++ b/tests/fixtures/run-push-session-upload.php
@@ -1,0 +1,43 @@
+<?php
+
+// Run one upload through the production push-session API. The parent PHPUnit
+// process injects a filesystem failure and then examines the durable result.
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+$reprint_test_configuration = json_decode(base64_decode($argv[1], true), true, 512, JSON_THROW_ON_ERROR);
+$reprint_test_push_session = Site_Export_Push_Session::open(
+    $reprint_test_configuration['reprint_directory'],
+    $reprint_test_configuration['docroot'],
+    $reprint_test_configuration['push_session_id'],
+    $reprint_test_configuration['excluded_paths']
+);
+$reprint_test_input = fopen('php://temp', 'w+b');
+fwrite($reprint_test_input, base64_decode($reprint_test_configuration['body_b64'], true));
+rewind($reprint_test_input);
+$reprint_test_upload_open = false;
+
+try {
+    $reprint_test_push_session->accept_upload($reprint_test_input, new Site_Export_Multipart_Processor($reprint_test_configuration['boundary']));
+    $reprint_test_upload_open = true;
+    while (true) {
+        if (!$reprint_test_push_session->next_change()) {
+            break;
+        }
+    }
+    $reprint_test_push_session->finish_upload();
+    $reprint_test_upload_open = false;
+    fclose($reprint_test_input);
+    echo json_encode(['result' => 'accepted'], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    exit(0);
+} catch (Throwable $exception) {
+    if ($reprint_test_upload_open) {
+        $reprint_test_push_session->finish_upload();
+    }
+    fclose($reprint_test_input);
+    echo json_encode([
+        'class' => get_class($exception),
+        'reason' => $exception instanceof Site_Export_Push_Exception ? $exception->get_error_code() : null,
+        'message' => $exception->getMessage(),
+    ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    exit(73);
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -31,6 +31,7 @@
             <file>FileIndexSkipDefaultsTest.php</file>
             <file>HmacServerTest.php</file>
             <file>MultipartProcessorTest.php</file>
+            <file>PushEndpointsTest.php</file>
             <file>SiteExportSecretTest.php</file>
             <file>PushSessionTest.php</file>
         </testsuite>


### PR DESCRIPTION
Resumes local-file pushes from the receiver's durable cursor after an interrupted request or sender restart.

## Background

The receiver and authenticated endpoints can store and report one in-flight work value, but no caller owned local source selection, source tokens, request rotation, work-delete closure, repeated commit, or abandoned-session removal. A process could not drive that API end to end or safely decide whether a partial receiver cursor still belonged to the current source bytes.

## This change

`PushFilesSender` captures one stable local index and persists the selected path, the last source token confirmed by an upload response, receiver-confirmed cursors, and request-sizing state. Ambiguous uploads query `push_status` before continuing. A changed source restarts the same in-flight work at offset zero; until the receiver confirms that restart, another interruption forces offset zero again rather than appending new bytes behind an old prefix. A vanished selected source removes the upload-only push session before the caller generates another index.

One multipart request carries many bounded chunks and work values while retaining only one payload string. Work deletes close explicitly, commit and remove repeat from durable receiver state, recoverable failures stop at a fixed bound, and malformed protocol responses fail permanently.

## Testing

Start a push against the local production router, interrupt the large-file upload, and reconstruct the sender from its journal. Confirm it resumes the receiver cursor, restarts changed source bytes at zero, closes work deletes, repeats commit, and installs the expected file, empty directory, symlink, replacement, and deletion.
