### PR TITLE
[Push] Use the normal mode for recovered empty directories

### DIFF
--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -864,7 +864,7 @@ final class Site_Export_Push_Session {
         } elseif ($inflight['type'] === 'directory') {
             if ($work_identity === null) {
                 $this->ensure_private_parent($work_path);
-                if (!@mkdir($work_path, 0700)) {
+                if (!@mkdir($work_path, 0777)) {
                     throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the in-flight directory.');
                 }
             } elseif ($work_identity['type'] !== 'directory') {

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -864,6 +864,8 @@ final class Site_Export_Push_Session {
         } elseif ($inflight['type'] === 'directory') {
             if ($work_identity === null) {
                 $this->ensure_private_parent($work_path);
+                // The process umask filters 0777 to the document-root mode used by normal publication.
+                // Until commit, 0700 work ancestors deny group and other traversal.
                 if (!@mkdir($work_path, 0777)) {
                     throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not publish the in-flight directory.');
                 }

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -1142,14 +1142,14 @@ final class PushSessionTest extends TestCase {
     }
 
     /**
-     * Applies the normal directory mode when publication resumes after a failure.
+     * Applies the process umask when directory publication resumes after a failure.
      *
-     * Normal publication and recovery call mkdir() under the same process umask.
-     * Commit renames the work directory into the document root, preserving the
-     * mode chosen during publication.
+     * 0777 is the pre-umask ceiling, so a 0027 umask creates both normal and
+     * recovered directories as 0750. Commit preserves that mode when it renames
+     * the work directory into the document root.
      */
-    public function testRecoveredDirectoryUsesNormalPublicationMode(): void {
-        $previous_umask = umask(0022);
+    public function testRecoveredDirectoryUsesTheDocumentRootProcessUmask(): void {
+        $previous_umask = umask(0027);
         try {
             $normal_session = $this->push_session('60606060606060606060606060606060');
             $this->push_parts($normal_session, [[
@@ -1180,7 +1180,7 @@ final class PushSessionTest extends TestCase {
             $normal_mode = fileperms($this->docroot . '/normal-directory') & 0777;
             $recovered_mode = fileperms($this->docroot . '/recovered-directory') & 0777;
 
-            $this->assertSame(0755, $normal_mode);
+            $this->assertSame(0750, $normal_mode);
             $this->assertSame($normal_mode, $recovered_mode);
         } finally {
             umask($previous_umask);

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -1141,6 +1141,52 @@ final class PushSessionTest extends TestCase {
         $this->assertSame('new', file_get_contents($this->docroot . '/commit.txt'));
     }
 
+    /**
+     * Applies the normal directory mode when publication resumes after a failure.
+     *
+     * Normal publication and recovery call mkdir() under the same process umask.
+     * Commit renames the work directory into the document root, preserving the
+     * mode chosen during publication.
+     */
+    public function testRecoveredDirectoryUsesNormalPublicationMode(): void {
+        $previous_umask = umask(0022);
+        try {
+            $normal_session = $this->push_session('60606060606060606060606060606060');
+            $this->push_parts($normal_session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('normal-directory'),
+                ],
+                'body' => '',
+            ]]);
+
+            $recovered_session = $this->push_session('61616161616161616161616161616161');
+            $this->run_upload_with_filesystem_fault($recovered_session, [[
+                'headers' => [
+                    'X-Chunk-Type' => 'directory',
+                    'X-Directory-Path' => base64_encode('recovered-directory'),
+                ],
+                'body' => '',
+            ]], 'mkdir', '/work/files/recovered-directory');
+            $recovered_session->get_status('recovered-directory');
+
+            $this->complete_work_deletes($normal_session);
+            $this->commit_all($normal_session);
+            $this->complete_work_deletes($recovered_session);
+            $this->commit_all($recovered_session);
+
+            clearstatcache(true, $this->docroot . '/normal-directory');
+            clearstatcache(true, $this->docroot . '/recovered-directory');
+            $normal_mode = fileperms($this->docroot . '/normal-directory') & 0777;
+            $recovered_mode = fileperms($this->docroot . '/recovered-directory') & 0777;
+
+            $this->assertSame(0755, $normal_mode);
+            $this->assertSame($normal_mode, $recovered_mode);
+        } finally {
+            umask($previous_umask);
+        }
+    }
+
     public function testDirectoryAndSymlinkPublicationRecoverBeforeAndAfterLeafCreation(): void {
         foreach (['directory', 'symlink'] as $type_index => $type) {
             foreach (['create', 'clear'] as $boundary_index => $boundary) {


### PR DESCRIPTION
Recovered empty directories now use the same process-umask-derived document-root mode as normal publication, so a resumed push does not leave them owner-only.

`mkdir()` receives `0777` as a pre-umask ceiling, not as the final mode. For example, umask `0027` produces `0750`. Trunk instead requests `0700` during recovery, and commit renames that work directory into the document root without changing its mode.

The regression test interrupts directory publication at `mkdir()`, resumes it through status, commits normal and recovered directories under umask `0027`, and requires both document-root modes to be `0750`.
