### PR TITLE
[Push] Remove schema versions from durable JSON

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -89,7 +89,7 @@ later request can resume from durable evidence instead of repeating a delete.
 `<reprint-directory>/.reprint/push/<push-session-id>/`. `push.json` is the
 push identity and policy plus whether the work-delete stream is complete.
 `commit.json` holds the bounded commit cursor. Both are atomically replaced
-and their versions are rejected when they do not match the current schema.
+and validated against the current schema.
 
 Multipart file bytes are received directly into `work/partial/` and promoted
 to `work/files/` only after their declared byte count is complete. A file

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -54,19 +54,19 @@ maintenance copy. The shared `.reprint/push/` directory contains
 `push-create.lock`, `commit-state`, `commit-state.lock`, and bounded removal
 tombstones named `.removing-<push-session-id>/`.
 
-`push.json` is version 3. Its keys are
+`push.json` has the keys
 `push_session_id`, `docroot_b64`, `excluded_paths_b64`,
 and `work_deletes_complete`.
 
-`commit.json` is version 3. Its phases are `deleting_files`,
+`commit.json` has the phases `deleting_files`,
 `installing_files`, and `complete`. Its cursor keys are
 `work_deletes_byte_offset`, `current_delete_path`,
 `current_work_files_descendant`, and `commit_cursor`. Path values remain
 base64 text even where a key does not include a suffix. Its non-recoverable
 failure key is `non_recoverable_commit_failure`.
 
-Prior versions are rejected. There are no compatibility aliases or migration
-paths.
+These JSON records are unversioned while their schemas are still under
+development. There are no compatibility aliases or migration paths.
 
 ## Protocol names
 

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -189,7 +189,6 @@ final class Site_Export_Push_Session {
                 throw $exception;
             }
             $push_session->write_json($push_session->push_json_path, [
-                'version' => 3,
                 'push_session_id' => $push_session_id,
                 'docroot_b64' => base64_encode($docroot),
                 'excluded_paths_b64' => array_map('base64_encode', $push_session->excluded_paths),
@@ -566,7 +565,6 @@ final class Site_Export_Push_Session {
                     throw new InvalidArgumentException('Commit cannot begin while an unfinished work value remains.');
                 }
                 $commit_state = [
-                    'version' => 3,
                     'phase' => 'deleting_files',
                     'work_deletes_byte_offset' => 0,
                     'current_delete_path' => null,
@@ -759,7 +757,7 @@ final class Site_Export_Push_Session {
      * publish the completed value, or begin commit work. A missing record means
      * there is no unfinished value.
      *
-     * @return array{version:1,phase:'preparing'|'receiving'|'publishing',path_b64:string,type:'file',total_bytes:int}|array{version:1,phase:'preparing'|'publishing',path_b64:string,type:'directory'}|array{version:1,phase:'preparing'|'publishing',path_b64:string,type:'symlink',target_b64:string}|null In-flight work, or null when none exists.
+     * @return array{phase:'preparing'|'receiving'|'publishing',path_b64:string,type:'file',total_bytes:int}|array{phase:'preparing'|'publishing',path_b64:string,type:'directory'}|array{phase:'preparing'|'publishing',path_b64:string,type:'symlink',target_b64:string}|null In-flight work, or null when none exists.
      */
     private function read_inflight(): ?array {
         return $this->read_json($this->work_inflight_path);
@@ -867,7 +865,7 @@ final class Site_Export_Push_Session {
             if ($inflight !== null && $this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard in-flight file data for restart.');
             }
-            $inflight = ['version' => 1, 'phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'file', 'total_bytes' => $total_bytes];
+            $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'file', 'total_bytes' => $total_bytes];
             $this->write_json($this->work_inflight_path, $inflight);
             $handle = @fopen($this->work_inflight_data_path, 'wb');
             if ($handle === false) {
@@ -955,7 +953,7 @@ final class Site_Export_Push_Session {
             $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0];
             return;
         }
-        $inflight = ['version' => 1, 'phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'directory'];
+        $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'directory'];
         $this->write_json($this->work_inflight_path, $inflight);
         if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
@@ -1010,7 +1008,7 @@ final class Site_Export_Push_Session {
             $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0];
             return;
         }
-        $inflight = ['version' => 1, 'phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'symlink', 'target_b64' => base64_encode($target_value)];
+        $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'symlink', 'target_b64' => base64_encode($target_value)];
         $this->write_json($this->work_inflight_path, $inflight);
         if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
@@ -1872,9 +1870,9 @@ final class Site_Export_Push_Session {
      */
     private function assert_push_configuration(): void {
         $push_metadata = $this->read_json($this->push_json_path);
-        if (!is_array($push_metadata) || ( $push_metadata['version'] ?? null ) !== 3 || ( $push_metadata['push_session_id'] ?? null ) !== $this->push_session_id
+        if (!is_array($push_metadata) || ( $push_metadata['push_session_id'] ?? null ) !== $this->push_session_id
             || !is_bool($push_metadata['work_deletes_complete'] ?? null)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has an unsupported version or push session ID.');
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has an invalid push session ID or work-deletes completion state.');
         }
         if (!is_string($push_metadata['docroot_b64'] ?? null) || !is_array($push_metadata['excluded_paths_b64'] ?? null)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain the configured document root and excluded paths.');
@@ -1933,7 +1931,6 @@ final class Site_Export_Push_Session {
      *
      * @param string $path Absolute metadata file path.
      * @param array{
-     *     version?:int,
      *     push_session_id?:string,
      *     docroot_b64?:string,
      *     excluded_paths_b64?:list<string>,
@@ -2029,7 +2026,6 @@ final class Site_Export_Push_Session {
      * checkpoint from being interpreted as document-root authority.
      *
      * @param array{
-     *     version?:mixed,
      *     phase?:mixed,
      *     work_deletes_byte_offset?:mixed,
      *     deleted_files?:mixed,
@@ -2041,9 +2037,6 @@ final class Site_Export_Push_Session {
      * } $commit_state Decoded commit checkpoint.
      */
     private function require_valid_commit_state(array $commit_state): void {
-        if (( $commit_state['version'] ?? null ) !== 3) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit checkpoint has an unsupported version.');
-        }
         if (!in_array($commit_state['phase'] ?? null, ['deleting_files', 'installing_files', 'complete'], true)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit checkpoint has an invalid phase.');
         }

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -437,7 +437,6 @@ final class PushCommitTest extends TestCase {
             'deleted_files',
             'installed_files',
             'phase',
-            'version',
             'work_deletes_byte_offset',
         ], $commit_state_keys);
         $this->assertStringNotContainsString("line\nbreak", (string) file_get_contents($push_session->get_push_directory() . '/commit.json'));

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -37,6 +37,13 @@ final class PushSessionTest extends TestCase {
         $this->assertFileDoesNotExist($work_directory . '/partial');
         $this->assertFileDoesNotExist($work_directory . '/inflight.json');
         $this->assertFileDoesNotExist($work_directory . '/inflight.data');
+        $push_metadata = json_decode(
+            (string) file_get_contents($push_session->get_push_directory() . '/push.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertArrayNotHasKey('version', $push_metadata);
     }
 
     public function testPartialFileProgressComesFromTheFileAndOffsetZeroRestartsIt(): void {
@@ -51,6 +58,13 @@ final class PushSessionTest extends TestCase {
             'body' => 'old',
         ]]);
         $this->assertSame(3, $push_session->get_status('upload.bin')['path']['accepted_bytes']);
+        $inflight = json_decode(
+            (string) file_get_contents($push_session->get_push_directory() . '/work/inflight.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertArrayNotHasKey('version', $inflight);
 
         $this->push_parts($push_session, [[
             'headers' => [
@@ -769,7 +783,6 @@ final class PushSessionTest extends TestCase {
             $push_session = $this->push_session(sprintf('%032x', 60 + $index));
             $work_directory = $push_session->get_push_directory() . '/work';
             $inflight = [
-                'version' => 1,
                 'phase' => 'publishing',
                 'path_b64' => base64_encode($type . '-value'),
                 'type' => $type,
@@ -792,7 +805,6 @@ final class PushSessionTest extends TestCase {
         file_put_contents($work_directory . '/files/same-size.txt', 'old');
         file_put_contents($work_directory . '/inflight.data', 'new');
         file_put_contents($work_directory . '/inflight.json', json_encode([
-            'version' => 1,
             'phase' => 'publishing',
             'path_b64' => base64_encode('same-size.txt'),
             'type' => 'file',
@@ -810,7 +822,6 @@ final class PushSessionTest extends TestCase {
         $work_directory = $push_session->get_push_directory() . '/work';
         file_put_contents($work_directory . '/files/renamed.txt', 'new');
         file_put_contents($work_directory . '/inflight.json', json_encode([
-            'version' => 1,
             'phase' => 'publishing',
             'path_b64' => base64_encode('renamed.txt'),
             'type' => 'file',
@@ -827,7 +838,6 @@ final class PushSessionTest extends TestCase {
         $work_directory = $push_session->get_push_directory() . '/work';
         file_put_contents($work_directory . '/inflight.data', 'new');
         file_put_contents($work_directory . '/inflight.json', json_encode([
-            'version' => 1,
             'phase' => 'publishing',
             'path_b64' => base64_encode('commit.txt'),
             'type' => 'file',


### PR DESCRIPTION
This keeps durable push JSON unversioned while its schema is still under development.

`push.json`, `commit.json`, and `work/inflight.json` no longer write version fields. Push metadata and commit checkpoints still validate every field they use, but they no longer carry or reject schema version numbers. The push terminology and delivery plan now describe the records as unversioned.

Tested with `cd tests && ../vendor/bin/phpunit PushSessionTest.php PushCommitTest.php` and `composer analyze -- --memory-limit=1G`.
