### PR TITLE
[Docs] Expand array PHPDoc into WordPress hash notation

### DIFF
--- a/packages/reprint-exporter/src/class-hmac-server.php
+++ b/packages/reprint-exporter/src/class-hmac-server.php
@@ -97,7 +97,15 @@ final class Site_Export_HMAC_Server {
      * returned hash with the digest of a bounded control payload before acting
      * on that payload. Do not use this as a large-upload authentication scheme.
      *
-     * @return array{error:?string,content_hash:?string}
+     * @return array {
+     *     Signed content-hash verification result.
+     *
+     *     @type string|null $error        Verification error, or null when the
+     *                                     signed hash is valid.
+     *     @type string|null $content_hash Signed content hash, or null when
+     *                                     verification failed.
+     * }
+     * @phpstan-return array{error:?string,content_hash:?string}
      */
     public function verify_signed_content_hash(array $headers, ?float $now = null): array {
         $auth = $this->collect_auth_headers($headers);

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -429,9 +429,16 @@ final class Site_Export_Push_Session {
      * next_change() again clears the previous value before processing, and
      * finish_upload() clears it when the request closes.
      *
-     * @return array{state:string,type:string,accepted_bytes:int,path_b64?:string}|null
-     *     Accepted type, state, byte cursor, and path when applicable, or null
-     *     when no result is current.
+     * @return array|null {
+     *     Accepted part result, or null when no result is current.
+     *
+     *     @type string $state          Accepted work state.
+     *     @type string $type           Accepted work type.
+     *     @type int    $accepted_bytes Work-confirmed byte cursor.
+     *     @type string $path_b64       Optional. Base64-encoded path when the
+     *                                  accepted part belongs to a path.
+     * }
+     * @phpstan-return array{state:string,type:string,accepted_bytes:int,path_b64?:string}|null
      */
     public function get_current_change(): ?array {
         return $this->current_change;
@@ -462,13 +469,28 @@ final class Site_Export_Push_Session {
      * the push lock.
      *
      * @param string|null $path Raw document-root-relative path byte string to inspect.
-     * @return array{
+     * @return array {
+     *     Work-confirmed push-session and optional path progress.
+     *
+     *     @type string     $push_session_id       Push session ID.
+     *     @type string     $phase                 Current push-session phase.
+     *     @type int        $work_deletes_bytes    Confirmed delete-list byte
+     *                                             size.
+     *     @type bool       $work_deletes_complete Whether the delete list has
+     *                                             been explicitly closed.
+     *     @type array|null $path                  Optional path status when a
+     *                                             path was requested. Contains
+     *                                             `path_b64`, `state`,
+     *                                             `accepted_bytes`, and
+     *                                             optional `type`.
+     * }
+     * @phpstan-return array{
      *     push_session_id:string,
      *     phase:string,
      *     work_deletes_bytes:int,
      *     work_deletes_complete:bool,
      *     path:array{path_b64:string,state:string,accepted_bytes:int,type?:string}|null
-     * } Work-confirmed push-session and optional path progress.
+     * }
      *
      * @throws InvalidArgumentException If the requested path is unsafe.
      * @throws Site_Export_Push_Exception If the push session is busy,
@@ -531,9 +553,14 @@ final class Site_Export_Push_Session {
      * retry the same bounded step from the durable state.
      *
      * @param int $maximum_entries Maximum bounded commit entries to process in this call.
-     * @return array{phase:string,send_next_request:bool,entries_processed:int}
-     *     Current phase, whether another request is needed, and entries
-     *     processed by this call.
+     * @return array {
+     *     Current bounded commit result.
+     *
+     *     @type string $phase             Current commit phase.
+     *     @type bool   $send_next_request Whether another request is needed.
+     *     @type int    $entries_processed Entries processed by this call.
+     * }
+     * @phpstan-return array{phase:string,send_next_request:bool,entries_processed:int}
      */
     public function commit(int $maximum_entries = 1): array {
         if ($maximum_entries <= 0) {
@@ -757,7 +784,34 @@ final class Site_Export_Push_Session {
      * publish the completed value, or begin commit work. A missing record means
      * there is no unfinished value.
      *
-     * @return array{phase:'preparing'|'receiving'|'publishing',path_b64:string,type:'file',total_bytes:int}|array{phase:'preparing'|'publishing',path_b64:string,type:'directory'}|array{phase:'preparing'|'publishing',path_b64:string,type:'symlink',target_b64:string}|null In-flight work, or null when none exists.
+     * @return array|null {
+     *     In-flight work, or null when none exists.
+     *
+     *     @type string $phase       In-flight phase. Accepts 'preparing',
+     *                               'receiving', or 'publishing' for files;
+     *                               'preparing' or 'publishing' otherwise.
+     *     @type string $path_b64    Base64-encoded path.
+     *     @type string $type        Work type. Accepts 'file', 'directory', or
+     *                               'symlink'.
+     *     @type int    $total_bytes File size in bytes. Present for files.
+     *     @type string $target_b64  Base64-encoded symlink target. Present for
+     *                               symlinks.
+     * }
+     * @phpstan-return array{
+     *     phase:'preparing'|'receiving'|'publishing',
+     *     path_b64:string,
+     *     type:'file',
+     *     total_bytes:int
+     * }|array{
+     *     phase:'preparing'|'publishing',
+     *     path_b64:string,
+     *     type:'directory'
+     * }|array{
+     *     phase:'preparing'|'publishing',
+     *     path_b64:string,
+     *     type:'symlink',
+     *     target_b64:string
+     * }|null
      */
     private function read_inflight(): ?array {
         return $this->read_json($this->work_inflight_path);
@@ -832,8 +886,24 @@ final class Site_Export_Push_Session {
      * and promotes the file atomically inside the private reprint directory only when the
      * declared total size has been reached.
      *
-     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-file-path:string,x-file-size:string,x-chunk-offset:string} $headers
+     * @param array $headers {
      *     Normalized file part headers.
+     *
+     *     @type string $content-length  Declared Content-Length header.
+     *     @type string $content-type    Optional. Content-Type header.
+     *     @type string $x-chunk-type    Chunk type header.
+     *     @type string $x-file-path     Base64-encoded file path header.
+     *     @type string $x-file-size     Declared file size header.
+     *     @type string $x-chunk-offset  Declared chunk offset header.
+     * }
+     * @phpstan-param array{
+     *     content-length:string,
+     *     content-type?:string,
+     *     x-chunk-type:string,
+     *     x-file-path:string,
+     *     x-file-size:string,
+     *     x-chunk-offset:string
+     * } $headers
      * @param int $part_bytes Declared Content-Length for this file chunk.
      */
     private function receive_file_part(array $headers, int $part_bytes): void {
@@ -929,8 +999,15 @@ final class Site_Export_Push_Session {
      * descendants because a single staged path cannot be both a leaf value and a
      * structural parent.
      *
-     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-directory-path:string} $headers
+     * @param array $headers {
      *     Normalized directory part headers.
+     *
+     *     @type string $content-length   Declared Content-Length header.
+     *     @type string $content-type     Optional. Content-Type header.
+     *     @type string $x-chunk-type     Chunk type header.
+     *     @type string $x-directory-path Base64-encoded directory path header.
+     * }
+     * @phpstan-param array{content-length:string,content-type?:string,x-chunk-type:string,x-directory-path:string} $headers
      * @param int $part_bytes Declared Content-Length, which must be zero.
      */
     private function receive_directory_part(array $headers, int $part_bytes): void {
@@ -980,8 +1057,22 @@ final class Site_Export_Push_Session {
      * body. The staged value replaces any previous leaf at the same private path
      * and rejects directory conflicts that would orphan already staged children.
      *
-     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-symlink-path:string,x-symlink-target:string} $headers
+     * @param array $headers {
      *     Normalized symlink part headers.
+     *
+     *     @type string $content-length  Declared Content-Length header.
+     *     @type string $content-type    Optional. Content-Type header.
+     *     @type string $x-chunk-type    Chunk type header.
+     *     @type string $x-symlink-path  Base64-encoded symlink path header.
+     *     @type string $x-symlink-target Base64-encoded symlink target header.
+     * }
+     * @phpstan-param array{
+     *     content-length:string,
+     *     content-type?:string,
+     *     x-chunk-type:string,
+     *     x-symlink-path:string,
+     *     x-symlink-target:string
+     * } $headers
      * @param int $part_bytes Declared Content-Length, which must be zero.
      */
     private function receive_symlink_part(array $headers, int $part_bytes): void {
@@ -1036,8 +1127,23 @@ final class Site_Export_Push_Session {
      * exactly; new bytes are validated record-by-record before they are flushed.
      * A completion declaration records that no more delete bytes may be added.
      *
-     * @param array{content-length:string,content-type?:string,x-chunk-type:string,x-delete-offset:string,x-delete-complete?:string} $headers
+     * @param array $headers {
      *     Normalized delete-list part headers.
+     *
+     *     @type string $content-length    Declared Content-Length header.
+     *     @type string $content-type      Optional. Content-Type header.
+     *     @type string $x-chunk-type      Chunk type header.
+     *     @type string $x-delete-offset   Declared delete-list offset header.
+     *     @type string $x-delete-complete Optional. Delete-list completion
+     *                                    declaration header.
+     * }
+     * @phpstan-param array{
+     *     content-length:string,
+     *     content-type?:string,
+     *     x-chunk-type:string,
+     *     x-delete-offset:string,
+     *     x-delete-complete?:string
+     * } $headers
      * @param int $part_bytes Declared Content-Length for this delete segment.
      */
     private function receive_delete_list_part(array $headers, int $part_bytes): void {
@@ -1152,7 +1258,27 @@ final class Site_Export_Push_Session {
      * most one leaf or empty directory beneath that root and advances the byte
      * cursor only after the document-root path is confirmed absent.
      *
-     * @param array{
+     * @param array $commit_state {
+     *     Commit checkpoint, mutated in place.
+     *
+     *     @type string     $phase                         Current commit phase.
+     *     @type int        $work_deletes_byte_offset      Confirmed byte offset
+     *                                                     in the delete stream.
+     *     @type string|null $current_delete_path          Delete path currently
+     *                                                     being removed.
+     *     @type array|null $current_work_files_descendant Work-file descendant
+     *                                                     currently being
+     *                                                     installed.
+     *     @type array      $commit_cursor                 Commit cursor frames.
+     *     @type int        $deleted_files                 Number of deleted
+     *                                                     filesystem entries.
+     *     @type int        $installed_files               Number of installed
+     *                                                     filesystem entries.
+     *     @type array      $non_recoverable_commit_failure Optional. Stored
+     *                                                      permanent commit
+     *                                                      failure.
+     * }
+     * @phpstan-param array{
      *     phase:string,
      *     work_deletes_byte_offset:int,
      *     current_delete_path:?string,
@@ -1161,7 +1287,7 @@ final class Site_Export_Push_Session {
      *     deleted_files:int,
      *     installed_files:int,
      *     non_recoverable_commit_failure?:array{reason:string,detail:string,context:array<string,mixed>}
-     * } $commit_state Commit checkpoint, mutated in place.
+     * } $commit_state
      */
     private function advance_delete(array &$commit_state): void {
         if ($commit_state['current_delete_path'] === null) {
@@ -1285,7 +1411,27 @@ final class Site_Export_Push_Session {
      * installing one leaf value per step, and consuming empty structural work
      * directories after their descendants have been committed.
      *
-     * @param array{
+     * @param array $commit_state {
+     *     Commit checkpoint, mutated in place.
+     *
+     *     @type string     $phase                         Current commit phase.
+     *     @type int        $work_deletes_byte_offset      Confirmed byte offset
+     *                                                     in the delete stream.
+     *     @type string|null $current_delete_path          Delete path currently
+     *                                                     being removed.
+     *     @type array|null $current_work_files_descendant Work-file descendant
+     *                                                     currently being
+     *                                                     installed.
+     *     @type array      $commit_cursor                 Commit cursor frames.
+     *     @type int        $deleted_files                 Number of deleted
+     *                                                     filesystem entries.
+     *     @type int        $installed_files               Number of installed
+     *                                                     filesystem entries.
+     *     @type array      $non_recoverable_commit_failure Optional. Stored
+     *                                                      permanent commit
+     *                                                      failure.
+     * }
+     * @phpstan-param array{
      *     phase:string,
      *     work_deletes_byte_offset:int,
      *     current_delete_path:?string,
@@ -1294,7 +1440,7 @@ final class Site_Export_Push_Session {
      *     deleted_files:int,
      *     installed_files:int,
      *     non_recoverable_commit_failure?:array{reason:string,detail:string,context:array<string,mixed>}
-     * } $commit_state Commit checkpoint, mutated in place.
+     * } $commit_state
      */
     private function advance_installing_files(array &$commit_state): void {
         if ($commit_state['current_work_files_descendant'] !== null) {
@@ -1451,11 +1597,21 @@ final class Site_Export_Push_Session {
      * the document root already contains the committed value. Only same-filesystem
      * renames are allowed; copy fallback would break the direct-install model.
      *
-     * @param array{
+     * @param array $commit_state {
+     *     Commit checkpoint, mutated in place.
+     *
+     *     @type array|null $current_work_files_descendant Work-file descendant
+     *                                                     currently being
+     *                                                     installed.
+     *     @type array      $commit_cursor                 Commit cursor frames.
+     *     @type int        $installed_files               Number of installed
+     *                                                     filesystem entries.
+     * }
+     * @phpstan-param array{
      *     current_work_files_descendant:?array{path_b64:string,expected_type:string},
      *     commit_cursor:list<array{component_b64:string}>,
      *     installed_files:int
-     * } $commit_state Commit checkpoint, mutated in place.
+     * } $commit_state
      * @param string $path Document-root-relative value path.
      * @param string $expected_type Work type expected at $path.
      * @param bool $recovering Whether current_work_files_descendant is already durable.
@@ -1548,8 +1704,16 @@ final class Site_Export_Push_Session {
     /**
      * @param list<string> $expected_docroot_types Document-root identity types accepted at
      *                                          the conflicting path.
-     * @param array{type:string,dev:int,ino:int,size:int,ctime:int}|null $observed_identity
+     * @param array|null $observed_identity {
      *     Observed document-root filesystem identity, or null when absent.
+     *
+     *     @type string $type  Path type.
+     *     @type int    $dev   Device number.
+     *     @type int    $ino   Inode number.
+     *     @type int    $size  Size in bytes.
+     *     @type int    $ctime Change time.
+     * }
+     * @phpstan-param array{type:string,dev:int,ino:int,size:int,ctime:int}|null $observed_identity
      */
     private function throw_unexpected_docroot_mutation(
         string $operation,
@@ -1930,7 +2094,44 @@ final class Site_Export_Push_Session {
      * object must fit the same ceiling enforced by read_json().
      *
      * @param string $path Absolute metadata file path.
-     * @param array{
+     * @param array $value {
+     *     Push metadata, commit checkpoint, or in-flight work record to persist.
+     *
+     *     @type string $push_session_id                 Optional. Push session ID.
+     *     @type string $docroot_b64                     Optional. Base64-encoded
+     *                                                   document root.
+     *     @type array  $excluded_paths_b64              Optional. Base64-encoded
+     *                                                   excluded paths.
+     *     @type bool   $work_deletes_complete           Optional. Whether the
+     *                                                   delete list is closed.
+     *     @type string $phase                           Optional. Current phase.
+     *     @type int    $work_deletes_byte_offset        Optional. Confirmed byte
+     *                                                   offset in the delete
+     *                                                   stream.
+     *     @type string $current_delete_path             Optional. Delete path
+     *                                                   currently being removed.
+     *     @type array  $current_work_files_descendant   Optional. Work-file
+     *                                                   descendant currently
+     *                                                   being installed.
+     *     @type array  $commit_cursor                   Optional. Commit cursor
+     *                                                   frames.
+     *     @type int    $deleted_files                   Optional. Deleted entry
+     *                                                   count.
+     *     @type int    $installed_files                 Optional. Installed
+     *                                                   entry count.
+     *     @type array  $non_recoverable_commit_failure  Optional. Stored
+     *                                                   permanent commit
+     *                                                   failure.
+     *     @type string $path_b64                        Optional. Base64-encoded
+     *                                                   in-flight path.
+     *     @type string $type                            Optional. In-flight work
+     *                                                   type.
+     *     @type int    $total_bytes                     Optional. In-flight file
+     *                                                   size.
+     *     @type string $target_b64                      Optional. Base64-encoded
+     *                                                   symlink target.
+     * }
+     * @phpstan-param array{
      *     push_session_id?:string,
      *     docroot_b64?:string,
      *     excluded_paths_b64?:list<string>,
@@ -1947,7 +2148,7 @@ final class Site_Export_Push_Session {
      *     type?:string,
      *     total_bytes?:int,
      *     target_b64?:string
-     * } $value Push metadata, commit checkpoint, or in-flight work record to persist.
+     * } $value
      */
     private function write_json(string $path, array $value): void {
         $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
@@ -2025,7 +2226,29 @@ final class Site_Export_Push_Session {
      * work-file descendants is checked before use. This keeps a corrupt
      * checkpoint from being interpreted as document-root authority.
      *
-     * @param array{
+     * @param array $commit_state {
+     *     Decoded commit checkpoint.
+     *
+     *     @type mixed $phase                         Optional. Current commit
+     *                                               phase.
+     *     @type mixed $work_deletes_byte_offset      Optional. Confirmed byte
+     *                                               offset in the delete
+     *                                               stream.
+     *     @type mixed $deleted_files                 Optional. Deleted entry
+     *                                               count.
+     *     @type mixed $installed_files               Optional. Installed entry
+     *                                               count.
+     *     @type mixed $current_delete_path           Optional. Delete path
+     *                                               currently being removed.
+     *     @type mixed $current_work_files_descendant Optional. Work-file
+     *                                               descendant currently being
+     *                                               installed.
+     *     @type mixed $commit_cursor                 Optional. Commit cursor
+     *                                               frames.
+     *     @type mixed $non_recoverable_commit_failure Optional. Stored
+     *                                                permanent commit failure.
+     * }
+     * @phpstan-param array{
      *     phase?:mixed,
      *     work_deletes_byte_offset?:mixed,
      *     deleted_files?:mixed,
@@ -2034,7 +2257,7 @@ final class Site_Export_Push_Session {
      *     current_work_files_descendant?:mixed,
      *     commit_cursor?:mixed,
      *     non_recoverable_commit_failure?:mixed
-     * } $commit_state Decoded commit checkpoint.
+     * } $commit_state
      */
     private function require_valid_commit_state(array $commit_state): void {
         if (!in_array($commit_state['phase'] ?? null, ['deleting_files', 'installing_files', 'complete'], true)) {
@@ -2110,7 +2333,12 @@ final class Site_Export_Push_Session {
      * each component independently, rebuilds the slash-separated path, and then
      * applies the normal document-root-relative path rules to the result.
      *
-     * @param list<array{component_b64:string}> $stack Commit cursor frames.
+     * @param array $stack {
+     *     Commit cursor frames.
+     *
+     *     @type string $component_b64 Base64-encoded path component.
+     * }
+     * @phpstan-param list<array{component_b64:string}> $stack
      * @return string Document-root-relative path for the current commit cursor directory.
      */
     private function commit_cursor_path(array $stack): string {
@@ -2318,8 +2546,16 @@ final class Site_Export_Push_Session {
      * gives status, recovery, and drift reporting the same view of a path.
      *
      * @param string $path Absolute path to inspect.
-     * @return array{type:string,dev:int,ino:int,size:int,ctime:int}|null Type,
-     *     device, inode, size, and ctime, or null if absent.
+     * @return array|null {
+     *     Filesystem identity, or null if absent.
+     *
+     *     @type string $type  Path type.
+     *     @type int    $dev   Device number.
+     *     @type int    $ino   Inode number.
+     *     @type int    $size  Size in bytes.
+     *     @type int    $ctime Change time.
+     * }
+     * @phpstan-return array{type:string,dev:int,ino:int,size:int,ctime:int}|null
      */
     private function lstat_path(string $path): ?array {
         clearstatcache(true, $path);

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -120,7 +120,13 @@ $streaming_context = null;
  * @param bool $require_headers If true, throws when headers were already sent
  *                              (use for endpoints that can't degrade gracefully).
  * @param bool $gzip If true, emit Content-Encoding: gzip and compress the body.
- * @return array{gz: GzipOutputStream, boundary: string}
+ * @return array {
+ *     Multipart stream context.
+ *
+ *     @type GzipOutputStream $gz       Output stream used by the response.
+ *     @type string           $boundary MIME boundary for response parts.
+ * }
+ * @phpstan-return array{gz: GzipOutputStream, boundary: string}
  */
 function begin_multipart_stream(bool $require_headers = false, bool $gzip = true): array
 {
@@ -174,8 +180,24 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
  * Never reads from $config / HTTP parameters — credentials must come from
  * the server environment (PHP constants or environment variables).
  *
- * @return array{db_host: string, db_name: string, db_user: string, db_password: string,
- *               wp_config_path: ?string, table_prefix: ?string}
+ * @return array {
+ *     Database connection details resolved from the server environment.
+ *
+ *     @type string      $db_host        Database host.
+ *     @type string      $db_name        Database name.
+ *     @type string      $db_user        Database user.
+ *     @type string      $db_password    Database password.
+ *     @type string|null $wp_config_path WordPress config path, if known.
+ *     @type string|null $table_prefix   WordPress table prefix, if known.
+ * }
+ * @phpstan-return array{
+ *     db_host: string,
+ *     db_name: string,
+ *     db_user: string,
+ *     db_password: string,
+ *     wp_config_path: ?string,
+ *     table_prefix: ?string
+ * }
  * @throws InvalidArgumentException When required credentials are missing.
  */
 function resolve_db_credentials(): array
@@ -2644,9 +2666,15 @@ function find_parents_symlinks(string $absolute_path): array
  * find_parents_symlinks() catches those.
  *
  * @param string $path  Absolute path to the symlink.
- * @return array{target: string|null, intermediates: array} The resolved
- *               canonical target (null for file symlinks or unresolvable
- *               paths), and any intermediate symlink entries found.
+ * @return array {
+ *     Resolved symlink target details.
+ *
+ *     @type string|null $target        Resolved canonical target, or null for
+ *                                     file symlinks or unresolvable paths.
+ *     @type array       $intermediates Intermediate symlink entries found while
+ *                                     walking the raw target path.
+ * }
+ * @phpstan-return array{target: string|null, intermediates: array}
  */
 function resolve_symlink_target(string $path): array
 {
@@ -3683,7 +3711,14 @@ function path_is_default_skipped(string $path): bool
  * explicit `table` instead. Values are base64-encoded so raw bytes never travel
  * as SQL text.
  *
- * @return list<array{table: string, column: string, value: string}>
+ * @return array[] {
+ *     SQL row exclusion rules.
+ *
+ *     @type string $table  Table name.
+ *     @type string $column Column name.
+ *     @type string $value  Column value to exclude.
+ * }
+ * @phpstan-return list<array{table: string, column: string, value: string}>
  */
 function sql_exclude_rows_from_config(array $config, ?string $table_prefix): array
 {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4009,7 +4009,14 @@ class ImportClient
      * `hasCompletedOnce` is derived from Reprint-owned pull state so
      * callers do not need to persist a parallel flag that could drift.
      *
-     * @return array{hasCompletedOnce: bool, pullStage: mixed}
+     * @return array {
+     *     Import metadata for host integrations.
+     *
+     *     @type bool  $hasCompletedOnce Whether the pull pipeline has completed
+     *                                   at least once.
+     *     @type mixed $pullStage        Last completed pull stage.
+     * }
+     * @phpstan-return array{hasCompletedOnce: bool, pullStage: mixed}
      */
     private function build_import_metadata(): array
     {
@@ -6755,9 +6762,15 @@ class ImportClient
      *
      * @param string $list_file Path to the JSONL download list.
      * @param int    $offset    Byte offset into the download list file.
-     * @return array{file: string, offset: int, next_offset: int, entries: int}|null
-     *         The temp file path, byte offsets, and entry count, or null if
-     *         no paths remain.
+     * @return array|null {
+     *     Prepared fetch batch, or null if no paths remain.
+     *
+     *     @type string $file        Temporary batch file path.
+     *     @type int    $offset      Byte offset where the batch began.
+     *     @type int    $next_offset Byte offset for the next batch.
+     *     @type int    $entries     Number of entries in the batch.
+     * }
+     * @phpstan-return array{file: string, offset: int, next_offset: int, entries: int}|null
      */
     private function prepare_fetch_batch(string $list_file, int $offset): ?array
     {
@@ -12204,7 +12217,14 @@ if (
     /**
      * Parse CLI options using the declarative option definitions.
      *
-     * @return array{0: ?string, 1: ?string, 2: array} [$state_dir, $fs_root, $options]
+     * @return array {
+     *     Parsed CLI option tuple.
+     *
+     *     @type string|null $0 State directory path.
+     *     @type string|null $1 Filesystem root path.
+     *     @type array       $2 Parsed options.
+     * }
+     * @phpstan-return array{0: ?string, 1: ?string, 2: array}
      */
     function _cli_parse_options(array $argv, int $argc, int $start, array $option_defs): array
     {

--- a/packages/reprint-importer/src/lib/external-merge-sort.php
+++ b/packages/reprint-importer/src/lib/external-merge-sort.php
@@ -166,7 +166,13 @@ class ExternalMergeSort
      * Sort a chunk in memory and write it to a temp file.
      * Returns the path to the temp file.
      *
-     * @param array{key: string, line: string}[] $chunk
+     * @param array[] $chunk {
+     *     Sorted chunk entries.
+     *
+     *     @type string $key  Sort key.
+     *     @type string $line Original line.
+     * }
+     * @phpstan-param array{key: string, line: string}[] $chunk
      */
     private function flush_chunk(array $chunk): string
     {
@@ -274,7 +280,13 @@ class ExternalMergeSort
      *
      * @param resource $fh
      * @param callable(string): ?string $extract
-     * @return array{key: string, line: string}|null  Null when EOF.
+     * @return array|null {
+     *     Next keyed line, or null when EOF.
+     *
+     *     @type string $key  Sort key.
+     *     @type string $line Original line.
+     * }
+     * @phpstan-return array{key: string, line: string}|null
      */
     private function read_next($fh, callable $extract): ?array
     {

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -129,7 +129,13 @@ class PushJournal
      * line from each input file and the lists go straight to disk, so an
      * index with a million entries costs the same as one with ten.
      *
-     * @return array{changed: int, deleted: int} Entry counts, for the push summary.
+     * @return array {
+     *     Entry counts for the push summary.
+     *
+     *     @type int $changed Changed entry count.
+     *     @type int $deleted Deleted entry count.
+     * }
+     * @phpstan-return array{changed: int, deleted: int}
      */
     public function diff_local_files(string $current_index_file): array
     {

--- a/packages/reprint-importer/src/lib/target-runtime/functions.php
+++ b/packages/reprint-importer/src/lib/target-runtime/functions.php
@@ -125,7 +125,14 @@ function generate_runtime_php(RuntimeManifest $manifest, string $fs_root): strin
  * A mysqli_connect() stub is defined when the function doesn't exist,
  * because WordPress checks for it even when $wpdb is pre-set.
  *
- * @param array{plugin_dir: string, db_dir: string, db_file: string} $sqlite
+ * @param array $sqlite {
+ *     SQLite runtime paths.
+ *
+ *     @type string $plugin_dir SQLite plugin directory.
+ *     @type string $db_dir     SQLite database directory.
+ *     @type string $db_file    SQLite database file path.
+ * }
+ * @phpstan-param array{plugin_dir: string, db_dir: string, db_file: string} $sqlite
  *     'plugin_dir' is the absolute path to the copied plugin inside the
  *     output directory (set by the caller after copy_sqlite_plugin()).
  */

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -553,14 +553,27 @@ class MultipartPushStreamClient
      * - `parts_sent`: complete MIME parts supplied in this request.
      * - `body_bytes_sent`: MIME entity-body bytes accounted for this request.
      *
-     * @return array{
+     * @return array {
+     *     Classified request result and transmission counters.
+     *
+     *     @type string      $status          Request status.
+     *     @type string|null $reason          Machine-readable failure reason, or
+     *                                       null on success.
+     *     @type string|null $detail          Human-readable failure detail, or
+     *                                       null when none was supplied.
+     *     @type array|null  $response        Decoded target JSON, or null when
+     *                                       no usable JSON arrived.
+     *     @type int         $parts_sent      Complete MIME parts sent.
+     *     @type int         $body_bytes_sent MIME entity-body bytes sent.
+     * }
+     * @phpstan-return array{
      *     status:string,
      *     reason:?string,
      *     detail:?string,
      *     response:?array<string,mixed>,
      *     parts_sent:int,
      *     body_bytes_sent:int
-     * } Classified request result and transmission counters.
+     * }
      *
      * @throws RuntimeException If no upload request is open.
      */
@@ -669,14 +682,27 @@ class MultipartPushStreamClient
      * @param array<string,mixed> $parameters Endpoint-specific query parameters.
      *     Their keys are encoded and signed but are not interpreted here.
      * @param string[] $expected_statuses Successful protocol statuses for this endpoint.
-     * @return array{
+     * @return array {
+     *     Response classification. Keys have the meanings documented by
+     *     finish_request().
+     *
+     *     @type string      $status          Request status.
+     *     @type string|null $reason          Machine-readable failure reason, or
+     *                                       null on success.
+     *     @type string|null $detail          Human-readable failure detail, or
+     *                                       null when none was supplied.
+     *     @type array       $response        Decoded target JSON.
+     *     @type int         $parts_sent      Complete MIME parts sent.
+     *     @type int         $body_bytes_sent MIME entity-body bytes sent.
+     * }
+     * @phpstan-return array{
      *     status:string,
      *     reason:?string,
      *     detail:?string,
      *     response:array<string,mixed>,
      *     parts_sent:int,
      *     body_bytes_sent:int
-     * } Response classification. Keys have the meanings documented by finish_request().
+     * }
      *
      * @throws InvalidArgumentException If the method is unsupported.
      * @throws RuntimeException If transport, redirect, or JSON decoding fails.
@@ -746,11 +772,21 @@ class MultipartPushStreamClient
      * - `ceiling_bytes`: learned session ceiling, or null while unknown.
      * - `growth_holdoff_remaining`: accepted requests still required before growth.
      *
-     * @return array{
+     * @return array {
+     *     Serializable PushRequestSizer state.
+     *
+     *     @type int      $request_body_bytes       Current decoded entity-body
+     *                                             budget.
+     *     @type int|null $ceiling_bytes            Learned session ceiling, or
+     *                                             null while unknown.
+     *     @type int      $growth_holdoff_remaining Accepted requests still
+     *                                             required before growth.
+     * }
+     * @phpstan-return array{
      *     request_body_bytes:int,
      *     ceiling_bytes:?int,
      *     growth_holdoff_remaining:int
-     * } Serializable PushRequestSizer state.
+     * }
      */
     public function get_request_sizer_state(): array
     {
@@ -1020,14 +1056,26 @@ class MultipartPushStreamClient
      * @param array<string,mixed> $response Decoded target response containing
      *     the classification keys above.
      * @param string[] $expected_statuses Successful statuses for this request.
-     * @return array{
+     * @return array {
+     *     Stable result whose keys are documented by finish_request().
+     *
+     *     @type string      $status          Request status.
+     *     @type string|null $reason          Machine-readable failure reason, or
+     *                                       null on success.
+     *     @type string|null $detail          Human-readable failure detail, or
+     *                                       null when none was supplied.
+     *     @type array       $response        Decoded target JSON.
+     *     @type int         $parts_sent      Complete MIME parts sent.
+     *     @type int         $body_bytes_sent MIME entity-body bytes sent.
+     * }
+     * @phpstan-return array{
      *     status:string,
      *     reason:?string,
      *     detail:?string,
      *     response:array<string,mixed>,
      *     parts_sent:int,
      *     body_bytes_sent:int
-     * } Stable result whose keys are documented by finish_request().
+     * }
      */
     private function classify_response(array $response, array $expected_statuses): array
     {

--- a/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
+++ b/packages/reprint-importer/src/lib/upload/class-push-request-sizer.php
@@ -127,7 +127,13 @@ class PushRequestSizer
      * safety margin, becomes the ceiling.
      *
      * @param array $limit_bytes_list List of int|null limit candidates.
-     * @return array{action:string,request_body_bytes:int} Decision summary.
+     * @return array {
+     *     Decision summary.
+     *
+     *     @type string $action             Sizing action.
+     *     @type int    $request_body_bytes Current decoded entity-body budget.
+     * }
+     * @phpstan-return array{action:string,request_body_bytes:int}
      */
     public function apply_reported_limits(array $limit_bytes_list): array
     {
@@ -155,7 +161,13 @@ class PushRequestSizer
      * Record an accepted request; grows toward the ceiling unless a recent
      * failure is still being held off.
      *
-     * @return array{action:string,request_body_bytes:int} Decision summary.
+     * @return array {
+     *     Decision summary.
+     *
+     *     @type string $action             Sizing action.
+     *     @type int    $request_body_bytes Current decoded entity-body budget.
+     * }
+     * @phpstan-return array{action:string,request_body_bytes:int}
      */
     public function record_success(): array
     {
@@ -184,7 +196,13 @@ class PushRequestSizer
      * probing downward.
      *
      * @param int|null $reported_max_bytes Server-reported request limit, if any.
-     * @return array{action:string,request_body_bytes:int} Decision summary.
+     * @return array {
+     *     Decision summary.
+     *
+     *     @type string $action             Sizing action.
+     *     @type int    $request_body_bytes Current decoded entity-body budget.
+     * }
+     * @phpstan-return array{action:string,request_body_bytes:int}
      */
     public function record_too_large(?int $reported_max_bytes = null): array
     {
@@ -215,7 +233,13 @@ class PushRequestSizer
      * after the holdoff the size may grow back, so one transient failure does
      * not permanently clamp the session.
      *
-     * @return array{action:string,request_body_bytes:int} Decision summary.
+     * @return array {
+     *     Decision summary.
+     *
+     *     @type string $action             Sizing action.
+     *     @type int    $request_body_bytes Current decoded entity-body budget.
+     * }
+     * @phpstan-return array{action:string,request_body_bytes:int}
      */
     public function record_request_failure(): array
     {
@@ -230,7 +254,17 @@ class PushRequestSizer
     }
 
     /**
-     * @return array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
+     * @return array {
+     *     Serializable request-sizing state.
+     *
+     *     @type int      $request_body_bytes       Current decoded entity-body
+     *                                             budget.
+     *     @type int|null $ceiling_bytes            Learned session ceiling, or
+     *                                             null while unknown.
+     *     @type int      $growth_holdoff_remaining Accepted requests still
+     *                                             required before growth.
+     * }
+     * @phpstan-return array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
      */
     public function get_state(): array
     {
@@ -245,7 +279,13 @@ class PushRequestSizer
      * Lowers the learned per-session ceiling and shrinks the current size
      * when it no longer fits.
      *
-     * @return array{action:string,request_body_bytes:int}
+     * @return array {
+     *     Decision summary.
+     *
+     *     @type string $action             Sizing action.
+     *     @type int    $request_body_bytes Current decoded entity-body budget.
+     * }
+     * @phpstan-return array{action:string,request_body_bytes:int}
      */
     private function lower_ceiling(int $ceiling): array
     {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -70,7 +70,24 @@ class Base64ValueScanner
      * already located every FROM_BASE64() expression and captured its payload,
      * the scanner skips the lexer and still decodes values lazily.
      *
-     * @param list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
+     * @param array $entries {
+     *     FROM_BASE64() entries captured by the fast path.
+     *
+     *     @type int         $expr_start    Byte offset where the expression starts.
+     *     @type int         $quote_start   Byte offset where the quoted payload starts.
+     *     @type int         $quote_length  Quoted payload length in bytes.
+     *     @type string      $encoded_value Base64 payload.
+     *     @type string|null $value         Decoded value, when already decoded.
+     *     @type string|null $new_value     Rewritten value, when already set.
+     * }
+     * @phpstan-param list<array{
+     *     expr_start: int,
+     *     quote_start: int,
+     *     quote_length: int,
+     *     encoded_value: string,
+     *     value: ?string,
+     *     new_value: ?string
+     * }> $entries
      */
     public static function from_entries(string $sql, array $entries): self
     {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -34,7 +34,19 @@ class FastInsertScanner
     /**
      * Try to scan a producer-shape INSERT statement.
      *
-     * @return array{
+     * @return array|null {
+     *     Producer-shape INSERT scan result, or null when the SQL does not match
+     *     the recognised shape.
+     *
+     *     @type string $table          Table name.
+     *     @type array  $columns        Column names in statement order.
+     *     @type array  $column_map     Value ranges mapped to column names.
+     *     @type bool   $has_base64     Whether any FROM_BASE64() value was found.
+     *     @type array  $base64_entries FROM_BASE64() entries captured by the
+     *                                  fast path.
+     *     @type array  $value_entries  Value entries captured by the fast path.
+     * }
+     * @phpstan-return array{
      *   table: string,
      *   columns: list<string>,
      *   column_map: list<array{int, int, string}>,
@@ -42,7 +54,6 @@ class FastInsertScanner
      *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
      *   value_entries: list<array{kind: string, column: string, start?: int, end?: int, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>
      * }|null
-     *   Null when the SQL doesn't match the recognised shape.
      */
     public static function scan(string $sql, bool $include_column_map = true, bool $include_base64_entries = true): ?array
     {
@@ -216,8 +227,26 @@ class FastInsertScanner
     /**
      * Scan one value in producer's tuple shape, advancing $cursor past it.
      *
-     * @return null|array{kind: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}
-     *   null = unrecognized shape (caller bails)
+     * @return array|null {
+     *     Scanned value entry, or null for an unrecognized shape.
+     *
+     *     @type string $kind          Value kind.
+     *     @type string $raw           Optional. Raw SQL value.
+     *     @type int    $expr_start    Optional. Expression start byte offset.
+     *     @type int    $expr_length   Optional. Expression length in bytes.
+     *     @type int    $quote_start   Optional. Quoted payload start byte offset.
+     *     @type int    $quote_length  Optional. Quoted payload length in bytes.
+     *     @type string $encoded_value Optional. Base64 payload.
+     * }
+     * @phpstan-return null|array{
+     *     kind: string,
+     *     raw?: string,
+     *     expr_start?: int,
+     *     expr_length?: int,
+     *     quote_start?: int,
+     *     quote_length?: int,
+     *     encoded_value?: string
+     * }
      */
     private static function scan_value(string $sql, int $sql_len, int &$cursor, bool $include_base64_offsets = true)
     {
@@ -375,7 +404,16 @@ class FastInsertScanner
      * paren. Reads the quoted base64 string and the closing paren. Returns
      * the [expr_start, expr_length, quote_start, quote_length, encoded] tuple.
      *
-     * @return array{int,int,int,int,string}|null
+     * @return array|null {
+     *     FROM_BASE64() byte-offset tuple, or null when the call is malformed.
+     *
+     *     @type int    $0 Expression start byte offset.
+     *     @type int    $1 Expression length in bytes.
+     *     @type int    $2 Quoted payload start byte offset.
+     *     @type int    $3 Quoted payload length in bytes.
+     *     @type string $4 Base64 payload.
+     * }
+     * @phpstan-return array{int,int,int,int,string}|null
      */
     private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start)
     {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -164,7 +164,14 @@ class SqlStatementRewriter
      * statement shapes return null so callers can fall back to the normal
      * MySQL-on-SQLite execution path.
      *
-     * @return array{sql: string, params: list<mixed>, param_types: list<int>}|null
+     * @return array|null {
+     *     SQLite prepared statement, or null for an unsupported statement shape.
+     *
+     *     @type string $sql         SQL with placeholders.
+     *     @type array  $params      Decoded parameter values.
+     *     @type array  $param_types SQLite parameter types.
+     * }
+     * @phpstan-return array{sql: string, params: list<mixed>, param_types: list<int>}|null
      */
     public function build_sqlite_prepared_insert(string $sql): ?array
     {
@@ -203,7 +210,14 @@ class SqlStatementRewriter
      * Run the value-rewriting loop given an already-populated scanner and
      * the table/column-map context. Shared between the fast and lexer paths.
      *
-     * @param array{table: string, column_map: list<array{int, int, string}>}|null $value_to_column_map
+     * @param array|null $value_to_column_map {
+     *     Table and column ranges for the current statement, or null when the
+     *     statement shape is unknown.
+     *
+     *     @type string $table      Table name.
+     *     @type array  $column_map Value ranges mapped to column names.
+     * }
+     * @phpstan-param array{table: string, column_map: list<array{int, int, string}>}|null $value_to_column_map
      */
     private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
     {
@@ -279,7 +293,13 @@ class SqlStatementRewriter
      * contain `(`, `)`, `,` etc. arrive as a single token and never affect
      * depth.
      *
-     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     * @return array|null {
+     *     Table and column ranges, or null when the statement shape is unknown.
+     *
+     *     @type string $table      Table name.
+     *     @type array  $column_map Value ranges mapped to column names.
+     * }
+     * @phpstan-return array{table: string, column_map: list<array{int, int, string}>}|null
      */
     // Called via reflection in SqlStatementRewriterLexerWalkerTest.
     // @phpstan-ignore method.unused
@@ -293,7 +313,13 @@ class SqlStatementRewriter
      * statement avoid a second WP_MySQL_Lexer pass.
      *
      * @param WP_MySQL_Token[] $tokens
-     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     * @return array|null {
+     *     Table and column ranges, or null when the statement shape is unknown.
+     *
+     *     @type string $table      Table name.
+     *     @type array  $column_map Value ranges mapped to column names.
+     * }
+     * @phpstan-return array{table: string, column_map: list<array{int, int, string}>}|null
      */
     private function map_values_to_columns_from_tokens(array $tokens): ?array
     {
@@ -324,7 +350,13 @@ class SqlStatementRewriter
      * `$cursor` (which already points at the leading verb).
      *
      * @param WP_MySQL_Token[] $tokens
-     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     * @return array|null {
+     *     Table and column ranges, or null when the statement shape is unknown.
+     *
+     *     @type string $table      Table name.
+     *     @type array  $column_map Value ranges mapped to column names.
+     * }
+     * @phpstan-return array{table: string, column_map: list<array{int, int, string}>}|null
      */
     private static function walk_insert(array $tokens, int $token_count, int $cursor): ?array
     {
@@ -504,7 +536,13 @@ class SqlStatementRewriter
      * first occurrence of WHERE / ORDER / LIMIT / `;` / end of input.
      *
      * @param WP_MySQL_Token[] $tokens
-     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     * @return array|null {
+     *     Table and column ranges, or null when the statement shape is unknown.
+     *
+     *     @type string $table      Table name.
+     *     @type array  $column_map Value ranges mapped to column names.
+     * }
+     * @phpstan-return array{table: string, column_map: list<array{int, int, string}>}|null
      */
     private static function walk_update(array $tokens, int $token_count, int $cursor): ?array
     {
@@ -634,7 +672,14 @@ class SqlStatementRewriter
      * the linear cost was quadratic in row count and showed up as ~150 µs per
      * lookup under WASM PHP.
      *
-     * @param list<array{int, int, string}> $column_map [start, end, column_name] entries.
+     * @param array $column_map {
+     *     Column range entries.
+     *
+     *     @type int    $0 Start byte offset.
+     *     @type int    $1 End byte offset.
+     *     @type string $2 Column name.
+     * }
+     * @phpstan-param list<array{int, int, string}> $column_map
      * @param int $offset Byte offset of the CONVERT or FROM_BASE64 token.
      * @return string|null Column name, or null if the offset isn't in any range.
      */

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -31,7 +31,14 @@ class SQLitePreparedInsertBuilder
     /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
-     * @return array{sql: string, params: list<mixed>, param_types: list<int>}|null
+     * @return array|null {
+     *     SQLite prepared statement, or null for an unsupported statement shape.
+     *
+     *     @type string $sql         SQL with placeholders.
+     *     @type array  $params      Decoded parameter values.
+     *     @type array  $param_types SQLite parameter types.
+     * }
+     * @phpstan-return array{sql: string, params: list<mixed>, param_types: list<int>}|null
      */
     public static function build(string $sql, ?callable $rewrite_value = null): ?array
     {
@@ -45,7 +52,14 @@ class SQLitePreparedInsertBuilder
     /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
-     * @return array{sql: string, params: list<mixed>, param_types: list<int>}|null
+     * @return array|null {
+     *     SQLite prepared statement, or null for an unsupported statement shape.
+     *
+     *     @type string $sql         SQL with placeholders.
+     *     @type array  $params      Decoded parameter values.
+     *     @type array  $param_types SQLite parameter types.
+     * }
+     * @phpstan-return array{sql: string, params: list<mixed>, param_types: list<int>}|null
      */
     private static function build_with_fast_insert_scanner(string $sql, ?callable $rewrite_value): ?array
     {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -391,7 +391,13 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * @param false|array{raw_url: string, parsed_url: mixed} $value
+     * @param array|false $value {
+     *     Cached rewrite result, or false for an uncacheable value.
+     *
+     *     @type string $raw_url    Raw URL value.
+     *     @type mixed  $parsed_url Parsed URL value.
+     * }
+     * @phpstan-param false|array{raw_url: string, parsed_url: mixed} $value
      */
     private function set_cached_rewrite_result(string $cache_key, $value): void
     {

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -35,7 +35,12 @@ final class ExportLibraryLoadTest extends TestCase
     }
 
     /**
-     * @return array{output:string}
+     * @return array {
+     *     Export runner result.
+     *
+     *     @type string $output Captured output.
+     * }
+     * @phpstan-return array{output:string}
      */
     private function runExportWith(string $setup_script): array
     {

--- a/tests/FastQueryStreamTest.php
+++ b/tests/FastQueryStreamTest.php
@@ -11,7 +11,14 @@ class FastQueryStreamTest extends TestCase
      * Helper that drains every query out of the given parser and returns
      * the queries plus the final cumulative bytes_consumed value.
      *
-     * @return array{queries: list<string>, bytes_consumed: int, state: string}
+     * @return array {
+     *     Drained stream result.
+     *
+     *     @type array  $queries        Parsed queries.
+     *     @type int    $bytes_consumed Cumulative bytes consumed.
+     *     @type string $state          Final parser state.
+     * }
+     * @phpstan-return array{queries: list<string>, bytes_consumed: int, state: string}
      */
     private function drain($stream, string $sql): array
     {

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -59,7 +59,13 @@ final class FileIndexSkipDefaultsTest extends TestCase
     }
 
     /**
-     * @return list<array{0:string,1:bool}>
+     * @return array[] {
+     *     Default skip classifier cases.
+     *
+     *     @type string $0 Path to classify.
+     *     @type bool   $1 Expected skip result.
+     * }
+     * @phpstan-return list<array{0:string,1:bool}>
      */
     public static function skipCases(): array
     {
@@ -308,7 +314,13 @@ final class FileIndexSkipDefaultsTest extends TestCase
     }
 
     /**
-     * @return list<array{path: string, type: string}>
+     * @return array[] {
+     *     File-index entries.
+     *
+     *     @type string $path Indexed path.
+     *     @type string $type Indexed path type.
+     * }
+     * @phpstan-return list<array{path: string, type: string}>
      */
     private function runFileIndexEntries(string $siteDir, bool $includeCaches, int $batchSize = 5000, ?string $storagePath = null): array
     {

--- a/tests/NaiveQueryStreamTest.php
+++ b/tests/NaiveQueryStreamTest.php
@@ -16,7 +16,13 @@ class NaiveQueryStreamTest extends TestCase
      * @param int    $chunk_size How many bytes per fread() call.
      * @param int    $seek       Starting byte offset (simulates fseek on resume).
      * @param int    $limit      Stop after extracting this many queries (0 = all).
-     * @return array{queries: string[], bytes_consumed: int}
+     * @return array {
+     *     Streamed query result.
+     *
+     *     @type array $queries        Parsed queries.
+     *     @type int   $bytes_consumed Cumulative bytes consumed.
+     * }
+     * @phpstan-return array{queries: string[], bytes_consumed: int}
      */
     private function streamQueries(
         string $sql,

--- a/tests/UploadsProxy/PlaygroundUploadsProxyHandlerTest.php
+++ b/tests/UploadsProxy/PlaygroundUploadsProxyHandlerTest.php
@@ -69,7 +69,14 @@ class PlaygroundUploadsProxyHandlerTest extends TestCase
      * sidecar JSON-lines file (in invocation order), and streams the
      * body to stdout via curl's WRITEFUNCTION. We parse both.
      *
-     * @return array{0:?int,1:array<int,string>,2:string}
+     * @return array {
+     *     Proxy response tuple.
+     *
+     *     @type int|null $0 HTTP status code.
+     *     @type array    $1 Header lines.
+     *     @type string   $2 Response body.
+     * }
+     * @phpstan-return array{0:?int,1:array<int,string>,2:string}
      */
     private function runProxy(string $sourcePath): array
     {
@@ -108,7 +115,14 @@ class PlaygroundUploadsProxyHandlerTest extends TestCase
     }
 
     /**
-     * @return array{0:?int,1:array<int,string>,2:string}
+     * @return array {
+     *     Proxy response tuple.
+     *
+     *     @type int|null $0 HTTP status code.
+     *     @type array    $1 Header lines.
+     *     @type string   $2 Response body.
+     * }
+     * @phpstan-return array{0:?int,1:array<int,string>,2:string}
      */
     private function parseSidecar(string $sidecar, string $body): array
     {

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -21,7 +21,14 @@ class SQLitePreparedInsertBuilderTest extends TestCase
     }
 
     /**
-     * @param array{sql: string, params: list<mixed>, param_types: list<int>} $prepared
+     * @param array $prepared {
+     *     SQLite prepared statement.
+     *
+     *     @type string $sql         SQL with placeholders.
+     *     @type array  $params      Decoded parameter values.
+     *     @type array  $param_types SQLite parameter types.
+     * }
+     * @phpstan-param array{sql: string, params: list<mixed>, param_types: list<int>} $prepared
      */
     private function executePrepared(PDO $pdo, array $prepared): void
     {


### PR DESCRIPTION
Array PHPDoc now uses WordPress hash notation so the key contract is readable before the static-analysis shape.

The previous docblocks put structured params and returns in inline `array{...}` types. That preserved PHPStan detail, but made reviewers parse dense shapes to learn what a method accepted or returned. This changes those human-facing `@param` and `@return` docs to `array { ... @type ... }` blocks, including the test helpers. The exact shapes remain in `@phpstan-param` and `@phpstan-return` tags so static analysis still gets the same key-level types.

Checks run:

`git diff --check`

`git grep -n -E "@(param|return) [^\\n]*array\\{" -- '*.php'` produced no output.

`git diff --name-only -- '*.php' | xargs -n1 php -l`

`composer analyze -- --memory-limit=1G` ran after initializing submodules, but this worktree still reports existing missing `WordPress\\Filesystem\\wp_join_unix_paths` and Data Liberation symbols.

`vendor/bin/phpcs --standard=phpcs.xml.dist $(git diff --name-only -- '*.php')` reports existing per-file violations in the touched files.
