### PR TITLE
[Push] Keep connection tokens download-only until push is authorized

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -53,18 +53,25 @@ size. The secret travels in no URL and no body, so it never lands in an
 access log.
 
 Authentication does not grant write authority. Connection tokens are
-download-only by default, including tokens that predate push endpoints. After
-authentication, every `push_*` operation passes one authorization gate before
-the endpoint reads upload data, creates a push directory, or changes the
-document root. Missing authorization returns HTTP 403 with
-`reason: "push_disabled"`; custom authentication uses the same gate.
+download-only by default, including tokens that predate push endpoints. Except
+for the bounded recovery case below, every `push_*` operation requires current
+push authorization before upload data is read, a push directory is created, or
+the document root changes; custom authentication uses the same gate.
+
+Revocation does not abandon durable recovery state. An authenticated caller
+may keep calling `push_commit` only when that push session already has a durable
+commit checkpoint. Those requests converge the already-started document-root
+mutation; they cannot upload more work, inspect or remove private work, or
+start commit for another push session. Other push operations return HTTP 403
+with `reason: "push_disabled"`. This keeps token rotation or a managed policy
+change from stranding a partial commit and its maintenance marker.
 
 Personal consent stores only the current connection token's SHA-256
 fingerprint. Rotating the token therefore revokes push access. A hosting
 provider may override local consent by defining the boolean
 `SITE_EXPORT_PUSH_ENABLED` constant before active plugins load or by setting
 the environment variable of the same name. Managed `true` enables push and
-managed `false` hard-disables it.
+managed `false` hard-disables push without abandoning durable commit recovery.
 
 ## Change detection: local machine compared against itself
 

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -52,6 +52,20 @@ of buffering pain. Signing cost is constant per request regardless of payload
 size. The secret travels in no URL and no body, so it never lands in an
 access log.
 
+Authentication does not grant write authority. Connection tokens are
+download-only by default, including tokens that predate push endpoints. After
+authentication, every `push_*` operation passes one authorization gate before
+the endpoint reads upload data, creates a push directory, or changes the
+document root. Missing authorization returns HTTP 403 with
+`reason: "push_disabled"`; custom authentication uses the same gate.
+
+Personal consent stores only the current connection token's SHA-256
+fingerprint. Rotating the token therefore revokes push access. A hosting
+provider may override local consent by defining the boolean
+`SITE_EXPORT_PUSH_ENABLED` constant before active plugins load or by setting
+the environment variable of the same name. Managed `true` enables push and
+managed `false` hard-disables it.
+
 ## Change detection: local machine compared against itself
 
 ctime is machine-local, so push never compares a local timestamp to a remote

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -92,8 +92,9 @@ JSON responses use `push_session_id`, `receiving_work`, and
 `work_deletes_bytes`. Push-session failures are
 `lock_acquisition_failure`, `offset_gap`, `push_not_found`, `filesystem_error`,
 `commit_required`, `unexpected_docroot_mutation`, `corrupted_push_state`, and
-`same_device`. Authentication and request-boundary failures are `auth_failed`,
-`not_configured`, `invalid_request`, and `request_too_large`.
+`same_device`. Authentication, authorization, and request-boundary failures
+are `auth_failed`, `push_disabled`, `not_configured`, `invalid_request`, and
+`request_too_large`.
 
 The document-root `.maintenance` file identifies its owner with the push
 session ID. `commit.json` stores no separate maintenance value.

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -72,12 +72,21 @@ final class Site_Export_HTTP_Server {
         $server = $request['server'] ?? $_SERVER;
         $get = $request['get'] ?? $_GET;
         $post = $request['post'] ?? $_POST;
-        // push_upload validates Content-Type itself and streams php://input.
-        // Reading a mislabeled JSON body here would buffer the complete upload.
-        $is_push_upload = ( $get['endpoint'] ?? null ) === 'push_upload';
-        $body = array_key_exists('body', $request)
-            ? (string) $request['body']
-            : ( !$is_push_upload && $this->is_json_content_type($server) ? call_user_func($this->body_reader) : '' );
+        // Push parameters travel in the signed query string. push_upload streams
+        // php://input itself; reading JSON for any push endpoint would either
+        // buffer an upload or let a control request buffer an unused body.
+        $endpoint = $get['endpoint'] ?? null;
+        $uses_push_request_contract = is_string($endpoint) && strpos($endpoint, 'push_') === 0;
+        $body = '';
+        if ($uses_push_request_contract) {
+            // $_POST must not override the signed query endpoint after the
+            // router has applied push authorization to that query endpoint.
+            $post = [];
+        } else {
+            $body = array_key_exists('body', $request)
+                ? (string) $request['body']
+                : ( $this->is_json_content_type($server) ? call_user_func($this->body_reader) : '' );
+        }
         $config = $request['config'] ?? $this->parse_http_config(
             $get,
             $post,

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -42,6 +42,9 @@ final class Site_Export_Push_Endpoints {
     /** @var int */
     private $maximum_commit_entries;
 
+    /** @var string|null */
+    private $commit_start_denial_detail;
+
     /** @var int|null */
     private $post_max_bytes;
 
@@ -63,6 +66,9 @@ final class Site_Export_Push_Endpoints {
      *         accepted for one multipart part. Default 4 MiB.
      *     @type int|float|string $maximum_commit_entries Maximum entries one
      *         commit request may process. Default 256.
+     *     @type string $commit_start_denial_detail When present, starting commit
+     *         returns `push_disabled` with this detail. A commit with a durable
+     *         checkpoint remains recoverable.
      *     @type int|float|string|null $post_max_bytes Decoded request-body
      *         limit enforced and reported to senders. Defaults to PHP's
      *         post_max_size; null means PHP reports no positive limit.
@@ -73,11 +79,13 @@ final class Site_Export_Push_Endpoints {
      *     excluded_paths?:mixed,
      *     maximum_part_bytes?:mixed,
      *     maximum_commit_entries?:mixed,
+     *     commit_start_denial_detail?:mixed,
      *     post_max_bytes?:mixed
      * } $options
      *
-     * @throws InvalidArgumentException If required configuration is absent or
-     *     a present numeric limit is not positive.
+     * @throws InvalidArgumentException If required configuration is absent, a
+     *     present numeric limit is not positive, or a commit-start denial detail
+     *     is not a non-empty string.
      */
     public function __construct(array $options) {
         $reprint_directory = $options['reprint_directory'] ?? null;
@@ -154,6 +162,13 @@ final class Site_Export_Push_Endpoints {
         $this->excluded_paths = $excluded_paths;
         $this->maximum_part_bytes = (int) $maximum_part_bytes;
         $this->maximum_commit_entries = (int) $maximum_commit_entries;
+        $this->commit_start_denial_detail = null;
+        if (array_key_exists('commit_start_denial_detail', $options)) {
+            if (!is_string($options['commit_start_denial_detail']) || $options['commit_start_denial_detail'] === '') {
+                throw new InvalidArgumentException('commit_start_denial_detail must be a non-empty string.');
+            }
+            $this->commit_start_denial_detail = $options['commit_start_denial_detail'];
+        }
     }
 
     /**
@@ -409,7 +424,10 @@ final class Site_Export_Push_Endpoints {
                 $push_session_id,
                 $this->excluded_paths
             );
-            $commit = $push_session->commit($this->maximum_commit_entries);
+            $commit = $push_session->commit(
+                $this->maximum_commit_entries,
+                $this->commit_start_denial_detail
+            );
             $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
@@ -418,6 +436,18 @@ final class Site_Export_Push_Endpoints {
                 'entries_processed' => $commit['entries_processed'],
             ]);
         } catch (Throwable $exception) {
+            if (
+                $this->commit_start_denial_detail !== null
+                && $exception instanceof Site_Export_Push_Exception
+                && $exception->get_error_code() === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND
+            ) {
+                $this->respond(403, [
+                    'status' => 'rejected',
+                    'reason' => Site_Export_Push_Session::ERROR_PUSH_DISABLED,
+                    'detail' => $this->commit_start_denial_detail,
+                ]);
+                return;
+            }
             $this->respond_to_failure($exception);
         }
     }
@@ -516,6 +546,8 @@ final class Site_Export_Push_Endpoints {
             $http_code = 409;
             if ($reason === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND) {
                 $http_code = 404;
+            } elseif ($reason === Site_Export_Push_Session::ERROR_PUSH_DISABLED) {
+                $http_code = 403;
             } elseif ($reason === Site_Export_Push_Session::ERROR_LOCK_ACQUISITION_FAILURE) {
                 $http_code = 423;
             } elseif ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -60,6 +60,7 @@ final class Site_Export_Push_Session {
     public const ERROR_CORRUPTED_PUSH_STATE = 'corrupted_push_state';
     public const ERROR_SAME_DEVICE = 'same_device';
     public const ERROR_REQUEST_TOO_LARGE = 'request_too_large';
+    public const ERROR_PUSH_DISABLED = 'push_disabled';
 
     private const MAX_PATH_BYTES = 4096;
     private const MAX_METADATA_BYTES = 1048576;
@@ -596,6 +597,9 @@ final class Site_Export_Push_Session {
      * retry the same bounded step from the durable state.
      *
      * @param int $maximum_entries Maximum bounded commit entries to process in this call.
+     * @param string|null $commit_start_denial_detail When present, commit may
+     *     resume a durable checkpoint but may not create one. The string
+     *     describes why starting commit is denied.
      * @return array {
      *     Current bounded commit result.
      *
@@ -606,13 +610,25 @@ final class Site_Export_Push_Session {
      * }
      * @phpstan-return array{phase:'deleting_files'|'installing_files'|'complete',send_next_request:bool,entries_processed:int}
      */
-    public function commit(int $maximum_entries = 1): array {
+    public function commit(int $maximum_entries = 1, ?string $commit_start_denial_detail = null): array {
         if ($maximum_entries <= 0) {
             throw new InvalidArgumentException('The commit entry limit must be greater than zero.');
         }
-        return $this->with_push_lock(function () use ($maximum_entries): array {
+        if ($commit_start_denial_detail === '') {
+            throw new InvalidArgumentException('The commit start denial detail must be a non-empty string.');
+        }
+        return $this->with_push_lock(function () use ($maximum_entries, $commit_start_denial_detail): array {
             $commit_state = $this->read_json($this->commit_json_path);
             if ($commit_state === null) {
+                // The authorization decision and checkpoint creation share the
+                // push lock so a denied request cannot race another lifecycle
+                // operation into starting a new commit.
+                if ($commit_start_denial_detail !== null) {
+                    throw new Site_Export_Push_Exception(
+                        self::ERROR_PUSH_DISABLED,
+                        $commit_start_denial_detail
+                    );
+                }
                 if (!$this->work_deletes_are_complete()) {
                     throw new InvalidArgumentException('Commit requires an explicit completed delete upload declaration.');
                 }

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -56,7 +56,6 @@ The supported options are:
 - `maximum_commit_entries` — the maximum number of bounded entries processed
   by one `push_commit` request. It defaults to 256.
 
-
 ## Push access
 
 Connection tokens authorize downloads only by default. This also applies to
@@ -73,9 +72,13 @@ define('SITE_EXPORT_PUSH_ENABLED', true);
 
 The `SITE_EXPORT_PUSH_ENABLED` environment variable accepts the same boolean
 policy. The constant wins when both are present. `true` enables push without a
-local grant; `false` hard-disables it even when a local grant exists. Managed
-sites show the effective state as read-only in WordPress admin. Custom
-authentication does not bypass this authorization gate.
+local grant; `false` hard-disables push even when a local grant exists. The sole
+recovery exception lets an authenticated caller finish a commit which already
+has a durable checkpoint, so revocation cannot strand a partially changed
+document root. It cannot start commit or use any other push operation until
+push is authorized again. Managed sites show the effective state as read-only
+in WordPress admin. Custom authentication does not bypass this authorization
+gate.
 
 ## Using as a library
 
@@ -114,4 +117,5 @@ array argument and do not use the WordPress filter.
 - `SITE_EXPORT_PLUGIN_DIR` — absolute path to the plugin directory
 - `SITE_EXPORT_SECRET_FILE` — optional path to a PHP file that overrides the stored HMAC shared secret
 - `SITE_EXPORT_SECRET_OPTION` — WordPress site option name used for the stored HMAC shared secret
+- `SITE_EXPORT_PUSH_AUTHORIZATION_OPTION` — WordPress site option containing the token fingerprint granted personal push access
 - `SITE_EXPORT_TIMESTAMP_TOLERANCE` — max request age in seconds (default 300)

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -56,6 +56,27 @@ The supported options are:
 - `maximum_commit_entries` — the maximum number of bounded entries processed
   by one `push_commit` request. It defaults to 256.
 
+
+## Push access
+
+Connection tokens authorize downloads only by default. This also applies to
+tokens that already existed when the plugin was upgraded; no migration enables
+push access. A site administrator can grant push access from the plugin settings
+page. The grant stores a fingerprint of the current connection token, so rotating
+that token revokes the grant and requires fresh consent.
+
+Hosts can manage push access before active plugins load with an immutable boolean:
+
+```php
+define('SITE_EXPORT_PUSH_ENABLED', true);
+```
+
+The `SITE_EXPORT_PUSH_ENABLED` environment variable accepts the same boolean
+policy. The constant wins when both are present. `true` enables push without a
+local grant; `false` hard-disables it even when a local grant exists. Managed
+sites show the effective state as read-only in WordPress admin. Custom
+authentication does not bypass this authorization gate.
+
 ## Using as a library
 
 The export engine can be embedded in another PHP project without the WordPress plugin wrapper. Require `lib.php` instead of `index.php` — it defines constants and functions but does not handle any HTTP requests or check any URLs.

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -178,7 +178,7 @@ function _site_export_get_managed_push_enabled(): ?bool {
     }
 
     $environment_value = getenv('SITE_EXPORT_PUSH_ENABLED');
-    if ($environment_value === false || $environment_value === '') {
+    if ($environment_value === false) {
         return null;
     }
 
@@ -188,20 +188,28 @@ function _site_export_get_managed_push_enabled(): ?bool {
 
 /** Returns whether the current connection token is authorized for push. */
 function _site_export_is_push_authorized(): bool {
+    return _site_export_get_push_authorization_error() === null;
+}
+
+/** Returns the exact push authorization failure, or null when push may start new work. */
+function _site_export_get_push_authorization_error(): ?string {
     $managed_enabled = _site_export_get_managed_push_enabled();
     if ($managed_enabled !== null) {
-        return $managed_enabled;
+        return $managed_enabled
+            ? null
+            : 'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.';
     }
 
     $secret = _site_export_get_shared_secret();
     if ($secret === null || !function_exists('get_option')) {
-        return false;
+        return 'Push access is disabled for the current connection token.';
     }
 
     $authorized_fingerprint = get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '');
-    return is_string($authorized_fingerprint)
+    $authorized = is_string($authorized_fingerprint)
         && $authorized_fingerprint !== ''
         && hash_equals(hash('sha256', $secret), $authorized_fingerprint);
+    return $authorized ? null : 'Push access is disabled for the current connection token.';
 }
 
 /**
@@ -429,15 +437,23 @@ function _site_export_handle_api_request(array $options = []): void {
         _site_export_default_authenticate();
     }
 
-    // Authentication completes first. This separate gate prevents custom
-    // authentication or a future push_* operation from inheriting write
-    // access. It runs before endpoint setup can read php://input, create a
-    // push directory, or change the document root.
-    if (_site_export_is_push_endpoint($endpoint) && !_site_export_is_push_authorized()) {
+    // Authentication completes first. Every push operation requires current
+    // authorization except resuming commit from its durable checkpoint, which
+    // must remain available so revocation cannot strand document-root changes.
+    // Push endpoint parameters travel in the query string, so the dispatcher
+    // does not need to read php://input after this gate.
+    $push_authorization_error = null;
+    if (_site_export_is_push_endpoint($endpoint)) {
+        $push_authorization_error = _site_export_get_push_authorization_error();
+    }
+    if (
+        $push_authorization_error !== null
+        && $endpoint !== 'push_commit'
+    ) {
         _site_export_push_error(
             403,
             'push_disabled',
-            'Push access is disabled for the current connection token.'
+            $push_authorization_error
         );
     }
 
@@ -560,11 +576,14 @@ function _site_export_handle_api_request(array $options = []): void {
             if (array_key_exists('maximum_commit_entries', $options)) {
                 $push_options['maximum_commit_entries'] = $options['maximum_commit_entries'];
             }
+            if ($push_authorization_error !== null) {
+                $push_options['commit_start_denial_detail'] = $push_authorization_error;
+            }
             $server_options['push'] = $push_options;
         }
         Site_Export_HTTP_Server::serve($server_options);
     } catch (Exception $e) {
-        if (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
+        if (_site_export_is_push_endpoint($endpoint)) {
             if ($e instanceof Site_Export_Push_Configuration_Exception) {
                 _site_export_push_error(503, 'not_configured', $e->getMessage());
             }

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -22,6 +22,9 @@ if (!defined('SITE_EXPORT_SECRET_FILE')) {
 if (!defined('SITE_EXPORT_SECRET_OPTION')) {
     define('SITE_EXPORT_SECRET_OPTION', 'site_export_secret');
 }
+if (!defined('SITE_EXPORT_PUSH_AUTHORIZATION_OPTION')) {
+    define('SITE_EXPORT_PUSH_AUTHORIZATION_OPTION', 'site_export_push_authorized_token_fingerprint');
+}
 
 /**
  * Maximum age of a request timestamp in seconds.
@@ -62,6 +65,17 @@ function _site_export_push_error(int $http_code, string $reason, string $detail)
         'detail' => $detail,
     ]);
     exit;
+}
+
+/**
+ * Returns whether an endpoint uses the push authentication, authorization,
+ * and error contract.
+ *
+ * @param string $endpoint Exact endpoint query value.
+ * @return bool Whether this is in the push endpoint namespace.
+ */
+function _site_export_is_push_endpoint(string $endpoint): bool {
+    return strpos($endpoint, 'push_') === 0;
 }
 
 /**
@@ -150,6 +164,71 @@ function _site_export_update_shared_secret(string $secret): bool {
     }
 
     return (bool) update_option(SITE_EXPORT_SECRET_OPTION, $secret, false);
+}
+
+/**
+ * Returns the hosting provider's push policy, or null when the site controls it.
+ *
+ * An early boolean SITE_EXPORT_PUSH_ENABLED constant takes precedence over the
+ * environment variable of the same name. Any unrecognized value fails closed.
+ */
+function _site_export_get_managed_push_enabled(): ?bool {
+    if (defined('SITE_EXPORT_PUSH_ENABLED')) {
+        return SITE_EXPORT_PUSH_ENABLED === true;
+    }
+
+    $environment_value = getenv('SITE_EXPORT_PUSH_ENABLED');
+    if ($environment_value === false || $environment_value === '') {
+        return null;
+    }
+
+    $enabled = filter_var($environment_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    return $enabled === true;
+}
+
+/** Returns whether the current connection token is authorized for push. */
+function _site_export_is_push_authorized(): bool {
+    $managed_enabled = _site_export_get_managed_push_enabled();
+    if ($managed_enabled !== null) {
+        return $managed_enabled;
+    }
+
+    $secret = _site_export_get_shared_secret();
+    if ($secret === null || !function_exists('get_option')) {
+        return false;
+    }
+
+    $authorized_fingerprint = get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '');
+    return is_string($authorized_fingerprint)
+        && $authorized_fingerprint !== ''
+        && hash_equals(hash('sha256', $secret), $authorized_fingerprint);
+}
+
+/**
+ * Grants or revokes personal push authorization for the current token.
+ *
+ * The stored fingerprint is the only local authorization state. A different
+ * current token therefore cannot inherit the prior token's write authority.
+ */
+function _site_export_update_push_authorization(bool $enabled): bool {
+    if (!function_exists('update_option')) {
+        return false;
+    }
+
+    $secret = _site_export_get_shared_secret();
+    if ($enabled && $secret === null) {
+        return false;
+    }
+
+    $fingerprint = '';
+    if ($enabled) {
+        $fingerprint = hash('sha256', $secret);
+    }
+    if (function_exists('get_option') && get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint) {
+        return true;
+    }
+
+    return (bool) update_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, $fingerprint, false);
 }
 
 /**
@@ -317,7 +396,7 @@ function _site_export_handle_api_request(array $options = []): void {
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
-    } elseif (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
+    } elseif (_site_export_is_push_endpoint($endpoint)) {
         if (_site_export_has_secret_file()) {
             $secret = _site_export_get_file_secret();
             if (empty($secret)) {
@@ -348,6 +427,18 @@ function _site_export_handle_api_request(array $options = []): void {
         }
     } else {
         _site_export_default_authenticate();
+    }
+
+    // Authentication completes first. This separate gate prevents custom
+    // authentication or a future push_* operation from inheriting write
+    // access. It runs before endpoint setup can read php://input, create a
+    // push directory, or change the document root.
+    if (_site_export_is_push_endpoint($endpoint) && !_site_export_is_push_authorized()) {
+        _site_export_push_error(
+            403,
+            'push_disabled',
+            'Push access is disabled for the current connection token.'
+        );
     }
 
     // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server

--- a/reprint-exporter-wp/wordpress/site-export.php
+++ b/reprint-exporter-wp/wordpress/site-export.php
@@ -88,7 +88,9 @@ class Site_Export_Plugin {
      * Handle settings form submission.
      */
     public function handle_settings_save() {
-        if (!isset($_POST['site_export_save_settings'])) {
+        $saving_connection_token = isset($_POST['site_export_save_settings']);
+        $saving_push_access = isset($_POST['site_export_save_push_access']);
+        if (!$saving_connection_token && !$saving_push_access) {
             return;
         }
 
@@ -98,20 +100,48 @@ class Site_Export_Plugin {
 
         check_admin_referer('site_export_settings');
 
-        $secret = isset($_POST['site_export_secret']) ? sanitize_text_field($_POST['site_export_secret']) : '';
+        if ($saving_connection_token) {
+            $previous_effective_secret = _site_export_get_shared_secret();
+            $secret = isset($_POST['site_export_secret'])
+                ? sanitize_text_field(wp_unslash($_POST['site_export_secret']))
+                : '';
+            $updated = _site_export_update_shared_secret($secret);
+            $saved = $updated || _site_export_get_option_secret() === $secret;
 
-        $updated = _site_export_update_shared_secret($secret);
+            if (!$saved) {
+                add_settings_error('site_export', 'save_failed', 'Failed to save secret.', 'error');
+                return;
+            }
 
-        if (!$updated && _site_export_get_option_secret() !== $secret) {
-            add_settings_error('site_export', 'save_failed', 'Failed to save secret.', 'error');
-        } else {
+            if (_site_export_get_shared_secret() !== $previous_effective_secret) {
+                _site_export_update_push_authorization(false);
+            }
             add_settings_error(
                 'site_export',
                 'save_success',
                 'Settings saved successfully.',
                 'success'
             );
+            return;
         }
+
+        if (_site_export_get_managed_push_enabled() !== null) {
+            add_settings_error(
+                'site_export',
+                'push_access_managed',
+                'Push access is managed by your hosting provider.',
+                'info'
+            );
+            return;
+        }
+
+        $push_enabled = isset($_POST['site_export_push_enabled']);
+        if (!_site_export_update_push_authorization($push_enabled)) {
+            add_settings_error('site_export', 'push_access_save_failed', 'Failed to save push access.', 'error');
+            return;
+        }
+
+        add_settings_error('site_export', 'push_access_saved', 'Push access updated.', 'success');
     }
 
     /**
@@ -127,6 +157,8 @@ class Site_Export_Plugin {
         $api_url = home_url('?reprint-api');
         $is_configured = $effective_secret !== '';
         $has_file_override = _site_export_has_secret_file();
+        $managed_push_enabled = _site_export_get_managed_push_enabled();
+        $push_enabled = _site_export_is_push_authorized();
 
         ?>
         <style>
@@ -161,6 +193,27 @@ class Site_Export_Plugin {
             .site-export-card .card-desc {
                 color: #646970;
                 margin: 0 0 20px;
+            }
+            .site-export-push-access {
+                padding: 20px 24px;
+            }
+            .site-export-push-access label {
+                display: flex;
+                gap: 8px;
+                align-items: flex-start;
+                font-weight: 600;
+            }
+            .site-export-push-access input[type="checkbox"] {
+                margin-top: 1px;
+            }
+            .site-export-push-disclosure {
+                color: #646970;
+                font-size: 13px;
+                margin: 10px 0 16px 24px;
+            }
+            .site-export-managed-copy {
+                color: #646970;
+                margin: 12px 0 0 24px;
             }
             .site-export-secret-field {
                 display: flex;
@@ -266,7 +319,11 @@ class Site_Export_Plugin {
             <?php if ($is_configured): ?>
             <div class="site-export-status is-ready">
                 <span class="dashicons dashicons-yes-alt"></span>
-                <span><strong>Connected.</strong> The export API is ready to accept requests.</span>
+                <?php if ($push_enabled): ?>
+                <span><strong>Connected for downloads and push.</strong> The current connection token can change files on this site.</span>
+                <?php else: ?>
+                <span><strong>Connected for downloads.</strong> The connection token cannot change files on this site.</span>
+                <?php endif; ?>
             </div>
             <?php else: ?>
             <div class="site-export-status is-pending">
@@ -301,6 +358,35 @@ class Site_Export_Plugin {
                     </div>
                 </form>
             </div>
+
+            <?php if ($is_configured): ?>
+            <div class="site-export-card site-export-push-access">
+                <h2>Push access</h2>
+                <p class="card-desc">You do not need push access when moving this site to another host.</p>
+
+                <?php if ($managed_push_enabled !== null): ?>
+                <label>
+                    <input type="checkbox" name="site_export_push_enabled" value="1"<?php echo $push_enabled ? ' checked' : ''; ?> disabled />
+                    <span>Allow push to change files on this site</span>
+                </label>
+                <p class="site-export-push-disclosure">While enabled, anyone with the connection token can upload, replace, and delete files in this site's document root, except excluded paths.</p>
+                <p class="site-export-managed-copy">Push access is managed by your hosting provider.</p>
+                <?php else: ?>
+                <form method="post" action="">
+                    <?php wp_nonce_field('site_export_settings'); ?>
+                    <label>
+                        <input type="checkbox" name="site_export_push_enabled" value="1"<?php echo $push_enabled ? ' checked' : ''; ?> />
+                        <span>Allow push to change files on this site</span>
+                    </label>
+                    <p class="site-export-push-disclosure">While enabled, anyone with the connection token can upload, replace, and delete files in this site's document root, except excluded paths.</p>
+                    <input type="submit"
+                           name="site_export_save_push_access"
+                           class="button button-secondary"
+                           value="Save push access" />
+                </form>
+                <?php endif; ?>
+            </div>
+            <?php endif; ?>
 
             <?php if ($is_configured): ?>
             <div class="site-export-card">

--- a/reprint-exporter-wp/wordpress/site-export.php
+++ b/reprint-exporter-wp/wordpress/site-export.php
@@ -25,6 +25,18 @@ class Site_Export_Plugin {
 
     private function __construct() {
         add_action('init', [$this, 'register_settings']);
+        add_action(
+            'update_option_' . SITE_EXPORT_SECRET_OPTION,
+            [$this, 'revoke_push_authorization_after_connection_token_change'],
+            10,
+            2
+        );
+        add_action(
+            'add_option_' . SITE_EXPORT_SECRET_OPTION,
+            [$this, 'revoke_push_authorization_after_connection_token_added'],
+            10,
+            0
+        );
         add_action('admin_menu', [$this, 'add_admin_menu']);
         add_action('admin_init', [$this, 'handle_settings_save']);
         add_filter('plugin_action_links_' . plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'), [$this, 'add_settings_link']);
@@ -43,6 +55,40 @@ class Site_Export_Plugin {
                 'show_in_rest' => true,
             ]
         );
+    }
+
+    /**
+     * Revoke local push authorization when the effective connection token changes.
+     *
+     * The secret.php override keeps the option from becoming the effective token.
+     *
+     * @param mixed $old_value Previous option value.
+     * @param mixed $new_value New option value.
+     */
+    public function revoke_push_authorization_after_connection_token_change($old_value, $new_value) {
+        if (_site_export_has_secret_file()) {
+            return;
+        }
+
+        $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
+        $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
+        if ($old_connection_token !== $new_connection_token) {
+            _site_export_update_push_authorization(false);
+        }
+    }
+
+    /**
+     * Revoke stale local push authorization when the connection-token option is added.
+     *
+     * WordPress uses add_option() when update_option() receives a missing option,
+     * so that path does not emit the update hook above. A secret.php override
+     * still keeps the option from becoming the effective token.
+     *
+     */
+    public function revoke_push_authorization_after_connection_token_added() {
+        if (!_site_export_has_secret_file()) {
+            _site_export_update_push_authorization(false);
+        }
     }
 
     /**
@@ -101,7 +147,6 @@ class Site_Export_Plugin {
         check_admin_referer('site_export_settings');
 
         if ($saving_connection_token) {
-            $previous_effective_secret = _site_export_get_shared_secret();
             $secret = isset($_POST['site_export_secret'])
                 ? sanitize_text_field(wp_unslash($_POST['site_export_secret']))
                 : '';
@@ -113,9 +158,6 @@ class Site_Export_Plugin {
                 return;
             }
 
-            if (_site_export_get_shared_secret() !== $previous_effective_secret) {
-                _site_export_update_push_authorization(false);
-            }
             add_settings_error(
                 'site_export',
                 'save_success',

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -233,37 +233,74 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame([['endpoint' => 'preflight']], $calls);
     }
 
-    public function testPushUploadNeverReadsAJsonRequestBody(): void
+    public function testPushEndpointsNeverReadAJsonRequestBody(): void
     {
-        $body_reads = 0;
+        foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove', 'push_future_operation'] as $endpoint) {
+            $body_reads = 0;
+            $calls = [];
+            $server = new Site_Export_HTTP_Server([
+                'budget_factory' => static function (): stdClass {
+                    return new stdClass();
+                },
+                'body_reader' => static function () use (&$body_reads): string {
+                    ++$body_reads;
+                    return '{"body_parameter":"must-not-be-read"}';
+                },
+                'handlers' => [
+                    $endpoint => static function (array $config) use (&$calls): void {
+                        $calls[] = $config;
+                    },
+                ],
+            ]);
+
+            $server->handle_request([
+                'get' => [
+                    'endpoint' => $endpoint,
+                    'push_session_id' => str_repeat('a', 32),
+                ],
+                'post' => [],
+                'server' => [
+                    'REQUEST_METHOD' => 'POST',
+                    'CONTENT_TYPE' => 'application/json',
+                ],
+            ]);
+
+            $this->assertSame(0, $body_reads);
+            $this->assertSame([[
+                'endpoint' => $endpoint,
+                'push_session_id' => str_repeat('a', 32),
+            ]], $calls);
+        }
+    }
+
+    public function testPushQueryParametersCannotBeOverriddenByPostData(): void
+    {
         $calls = [];
         $server = new Site_Export_HTTP_Server([
-            'body_reader' => static function () use (&$body_reads): string {
-                ++$body_reads;
-                return '{"body_parameter":"must-not-be-read"}';
-            },
             'handlers' => [
-                'push_upload' => static function (array $config) use (&$calls): void {
+                'push_commit' => static function (array $config) use (&$calls): void {
                     $calls[] = $config;
+                },
+                'push_create' => static function (): void {
+                    throw new RuntimeException('POST data changed the dispatched push endpoint.');
                 },
             ],
         ]);
 
         $server->handle_request([
             'get' => [
-                'endpoint' => 'push_upload',
+                'endpoint' => 'push_commit',
                 'push_session_id' => str_repeat('a', 32),
             ],
-            'post' => [],
-            'server' => [
-                'REQUEST_METHOD' => 'POST',
-                'CONTENT_TYPE' => 'application/json',
+            'post' => [
+                'endpoint' => 'push_create',
+                'push_session_id' => str_repeat('b', 32),
             ],
+            'server' => ['REQUEST_METHOD' => 'POST'],
         ]);
 
-        $this->assertSame(0, $body_reads);
         $this->assertSame([[
-            'endpoint' => 'push_upload',
+            'endpoint' => 'push_commit',
             'push_session_id' => str_repeat('a', 32),
         ]], $calls);
     }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -74,7 +74,7 @@ final class PushEndpointsTest extends TestCase {
         parent::tearDown();
     }
 
-    public function testExistingTokenCannotUseAnyPushEndpointWithoutAuthorization(): void
+    public function testExistingTokenCannotUsePushEndpointsWithoutAuthorization(): void
     {
         file_put_contents($this->push_authorization_configuration_path, '');
         $push_session_id = str_repeat('0', 32);
@@ -117,9 +117,37 @@ final class PushEndpointsTest extends TestCase {
         );
         $this->assertSame(403, $future_endpoint['http_code']);
         $this->assertSame('push_disabled', $future_endpoint['response']['reason']);
+
+        $overridden_commit = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_commit',
+            $push_session_id,
+            'endpoint=push_create&push_session_id=' . str_repeat('1', 32),
+            'application/x-www-form-urlencoded'
+        );
+        $this->assertSame(403, $overridden_commit['http_code'], $overridden_commit['body']);
+        $this->assertSame('push_disabled', $overridden_commit['response']['reason']);
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push');
         $this->assertSame('old', file_get_contents($this->docroot . '/remove.txt'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+    }
+
+    public function testAuthorizedFuturePushEndpointUsesPushErrorContract(): void
+    {
+        $response = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_future_operation',
+            str_repeat('f', 32)
+        );
+
+        $this->assertSame(400, $response['http_code'], $response['body']);
+        $this->assertSame('rejected', $response['response']['status']);
+        $this->assertSame('invalid_request', $response['response']['reason']);
+        $this->assertStringContainsString('Invalid endpoint', $response['response']['detail']);
+        $this->assertArrayNotHasKey('error', $response['response']);
+        $this->assertArrayNotHasKey('trace', $response['response']);
     }
 
     public function testCustomAuthenticationCannotBypassPushAuthorization(): void
@@ -189,6 +217,108 @@ final class PushEndpointsTest extends TestCase {
         );
         $this->assertSame(403, $managed_disabled['http_code'], $managed_disabled['body']);
         $this->assertSame('push_disabled', $managed_disabled['response']['reason']);
+        $this->assertSame(
+            'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.',
+            $managed_disabled['response']['detail']
+        );
+    }
+
+    public function testRevokedAuthorizationCannotStartCommit(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('6', 32);
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $upload = $this->sendUploadRequest($client, $push_session_id, [
+            [
+                'type' => 'file',
+                'path' => 'must-not-install.txt',
+                'total_bytes' => 4,
+                'offset' => 0,
+                'payload' => 'deny',
+            ],
+            [
+                'type' => 'delete-list',
+                'offset' => 0,
+                'complete' => true,
+                'payload' => '',
+            ],
+        ]);
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+
+        file_put_contents($this->push_authorization_configuration_path, '');
+        $commit = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_commit',
+            $push_session_id
+        );
+
+        $this->assertSame(403, $commit['http_code'], $commit['body']);
+        $this->assertSame('push_disabled', $commit['response']['reason']);
+        $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
+        $this->assertFileDoesNotExist($push_directory . '/commit.json');
+        $this->assertFileDoesNotExist($this->reprint_directory . '/.reprint/push/commit-state');
+        $this->assertFileDoesNotExist($this->docroot . '/.maintenance');
+        $this->assertFileDoesNotExist($this->docroot . '/must-not-install.txt');
+        $this->assertSame('old', file_get_contents($this->docroot . '/remove.txt'));
+    }
+
+    public function testRevokedAuthorizationAllowsDurableCommitRecovery(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('7', 32);
+        $create = $client->control_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $upload = $this->sendUploadRequest($client, $push_session_id, [
+            [
+                'type' => 'file',
+                'path' => 'installed.txt',
+                'total_bytes' => 4,
+                'offset' => 0,
+                'payload' => 'new!',
+            ],
+            [
+                'type' => 'delete-list',
+                'offset' => 0,
+                'complete' => true,
+                'payload' => '',
+            ],
+        ]);
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+
+        $commit_before_revocation = null;
+        for ($request = 0; $request < 10; ++$request) {
+            $commit_before_revocation = $client->control_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit_before_revocation['status'], (string) json_encode($commit_before_revocation));
+            if (is_file($this->docroot . '/installed.txt')) {
+                break;
+            }
+        }
+        $this->assertIsArray($commit_before_revocation);
+        $this->assertTrue($commit_before_revocation['response']['send_next_request']);
+        $this->assertSame('new!', file_get_contents($this->docroot . '/installed.txt'));
+        $this->assertFileExists($this->docroot . '/.maintenance');
+
+        file_put_contents($this->push_authorization_configuration_path, '');
+        do {
+            $commit = $client->control_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        } while ($commit['response']['send_next_request']);
+
+        $this->assertSame('complete', $commit['response']['phase']);
+        $this->assertFileDoesNotExist($this->docroot . '/.maintenance');
+        $this->assertFileDoesNotExist($this->reprint_directory . '/.reprint/push/commit-state');
     }
 
     public function testPersonalOptInEnablesSignedEndpointsReceiveManyChangesCommitAndRemove(): void

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -22,6 +22,10 @@ final class PushEndpointsTest extends TestCase {
     private string $docroot;
     private string $wordpress_root;
     private string $reprint_directory;
+    private string $secret_configuration_path;
+    private string $push_authorization_configuration_path;
+    private string $managed_push_configuration_path;
+    private string $custom_auth_configuration_path;
     private string $reprint_configuration_path;
     private string $docroot_configuration_path;
     private string $excluded_paths_configuration_path;
@@ -37,11 +41,19 @@ final class PushEndpointsTest extends TestCase {
         $this->docroot = $this->root . '/site';
         $this->wordpress_root = $this->docroot . '/__wp__';
         $this->reprint_directory = $this->root . '/reprint';
+        $this->secret_configuration_path = $this->root . '/secret';
+        $this->push_authorization_configuration_path = $this->root . '/push-authorization';
+        $this->managed_push_configuration_path = $this->root . '/managed-push';
+        $this->custom_auth_configuration_path = $this->root . '/custom-auth';
         $this->reprint_configuration_path = $this->root . '/reprint-directory';
         $this->docroot_configuration_path = $this->root . '/docroot-configuration.json';
         $this->excluded_paths_configuration_path = $this->root . '/excluded-paths.json';
         mkdir($this->wordpress_root, 0700, true);
         mkdir($this->reprint_directory, 0700, true);
+        file_put_contents($this->secret_configuration_path, self::SECRET);
+        file_put_contents($this->push_authorization_configuration_path, hash('sha256', self::SECRET));
+        file_put_contents($this->managed_push_configuration_path, '');
+        file_put_contents($this->custom_auth_configuration_path, '');
         file_put_contents($this->reprint_configuration_path, $this->reprint_directory);
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
@@ -62,7 +74,124 @@ final class PushEndpointsTest extends TestCase {
         parent::tearDown();
     }
 
-    public function testSignedEndpointsReceiveManyChangesCommitAndRemove(): void
+    public function testExistingTokenCannotUseAnyPushEndpointWithoutAuthorization(): void
+    {
+        file_put_contents($this->push_authorization_configuration_path, '');
+        $push_session_id = str_repeat('0', 32);
+
+        $authentication = $this->requestPushEndpoint(
+            'not-the-server-secret',
+            'POST',
+            'push_create',
+            $push_session_id
+        );
+        $this->assertSame(403, $authentication['http_code']);
+        $this->assertSame('auth_failed', $authentication['response']['reason']);
+
+        $requests = [
+            ['POST', 'push_create', null, null],
+            ['POST', 'push_upload', 'not a multipart body', 'application/octet-stream'],
+            ['GET', 'push_status', null, null],
+            ['POST', 'push_commit', null, null],
+            ['POST', 'push_remove', null, null],
+        ];
+        foreach ($requests as [$method, $endpoint, $body, $content_type]) {
+            $response = $this->requestPushEndpoint(
+                self::SECRET,
+                $method,
+                $endpoint,
+                $push_session_id,
+                $body,
+                $content_type
+            );
+            $this->assertSame(403, $response['http_code'], $endpoint . ': ' . $response['body']);
+            $this->assertSame('rejected', $response['response']['status']);
+            $this->assertSame('push_disabled', $response['response']['reason']);
+        }
+
+        $future_endpoint = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_future_operation',
+            $push_session_id
+        );
+        $this->assertSame(403, $future_endpoint['http_code']);
+        $this->assertSame('push_disabled', $future_endpoint['response']['reason']);
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push');
+        $this->assertSame('old', file_get_contents($this->docroot . '/remove.txt'));
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+    }
+
+    public function testCustomAuthenticationCannotBypassPushAuthorization(): void
+    {
+        file_put_contents($this->push_authorization_configuration_path, '');
+        file_put_contents($this->custom_auth_configuration_path, 'enabled');
+
+        $response = $this->requestPushEndpoint(
+            null,
+            'POST',
+            'push_create',
+            str_repeat('1', 32)
+        );
+
+        $this->assertSame(403, $response['http_code'], $response['body']);
+        $this->assertSame('push_disabled', $response['response']['reason']);
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push');
+    }
+
+    public function testPersonalConsentDoesNotSurviveTokenRotation(): void
+    {
+        $first_push_session_id = str_repeat('2', 32);
+        $first = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_create',
+            $first_push_session_id
+        );
+        $this->assertSame(200, $first['http_code'], $first['body']);
+
+        $rotated_secret = 'rotated-push-endpoint-test-secret';
+        file_put_contents($this->secret_configuration_path, $rotated_secret);
+        $second_push_session_id = str_repeat('3', 32);
+        $second = $this->requestPushEndpoint(
+            $rotated_secret,
+            'POST',
+            'push_create',
+            $second_push_session_id
+        );
+
+        $this->assertSame(403, $second['http_code'], $second['body']);
+        $this->assertSame('push_disabled', $second['response']['reason']);
+        $this->assertDirectoryDoesNotExist(
+            $this->reprint_directory . '/.reprint/push/' . $second_push_session_id
+        );
+    }
+
+    public function testManagedStateOverridesPersonalConsent(): void
+    {
+        file_put_contents($this->push_authorization_configuration_path, '');
+        file_put_contents($this->managed_push_configuration_path, 'true');
+        $managed_enabled = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_create',
+            str_repeat('4', 32)
+        );
+        $this->assertSame(200, $managed_enabled['http_code'], $managed_enabled['body']);
+
+        file_put_contents($this->push_authorization_configuration_path, hash('sha256', self::SECRET));
+        file_put_contents($this->managed_push_configuration_path, 'false');
+        $managed_disabled = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_create',
+            str_repeat('5', 32)
+        );
+        $this->assertSame(403, $managed_disabled['http_code'], $managed_disabled['body']);
+        $this->assertSame('push_disabled', $managed_disabled['response']['reason']);
+    }
+
+    public function testPersonalOptInEnablesSignedEndpointsReceiveManyChangesCommitAndRemove(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('a', 32);
@@ -919,6 +1048,7 @@ final class PushEndpointsTest extends TestCase {
 
     public function testPreflightDoesNotConstructPushEndpoints(): void
     {
+        file_put_contents($this->push_authorization_configuration_path, '');
         file_put_contents($this->reprint_configuration_path, $this->docroot . '/invalid-push-directory');
         $url = $this->base_url . '&endpoint=preflight';
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_curl_headers();
@@ -1173,7 +1303,10 @@ final class PushEndpointsTest extends TestCase {
         $router = realpath(__DIR__ . '/fixtures/push-endpoint-router.php');
         $this->assertNotFalse($router);
         $environment = array_merge($_ENV, [
-            'REPRINT_PUSH_TEST_SECRET' => self::SECRET,
+            'REPRINT_PUSH_TEST_SECRET_CONFIG' => $this->secret_configuration_path,
+            'REPRINT_PUSH_TEST_AUTHORIZATION_CONFIG' => $this->push_authorization_configuration_path,
+            'REPRINT_PUSH_TEST_MANAGED_PUSH_CONFIG' => $this->managed_push_configuration_path,
+            'REPRINT_PUSH_TEST_CUSTOM_AUTH_CONFIG' => $this->custom_auth_configuration_path,
             'REPRINT_PUSH_TEST_ABSPATH' => $this->wordpress_root,
             'REPRINT_PUSH_TEST_DOCROOT_CONFIG' => $this->docroot_configuration_path,
             'REPRINT_PUSH_TEST_DIRECTORY_CONFIG' => $this->reprint_configuration_path,
@@ -1331,6 +1464,53 @@ final class PushEndpointsTest extends TestCase {
         );
         $this->assertSame(['no-cache'], $headers['pragma'] ?? []);
         $this->assertSame(['0'], $headers['expires'] ?? []);
+    }
+
+    /**
+     * @return array{http_code:int,body:string,response:array<string,mixed>}
+     */
+    private function requestPushEndpoint(
+        ?string $secret,
+        string $method,
+        string $endpoint,
+        string $push_session_id,
+        ?string $body = null,
+        ?string $content_type = null
+    ): array {
+        $url = $this->base_url
+            . '&endpoint=' . rawurlencode($endpoint)
+            . '&push_session_id=' . rawurlencode($push_session_id);
+        $curl_headers = [];
+        if ($content_type !== null) {
+            $curl_headers[] = 'Content-Type: ' . $content_type;
+        }
+        if ($secret !== null) {
+            $headers = ( new Site_Export_HMAC_Client($secret) )->get_envelope_auth_headers($method, $url);
+            foreach ($headers as $name => $value) {
+                $curl_headers[] = $name . ': ' . $value;
+            }
+        }
+
+        $handle = curl_init($url);
+        $options = [
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_HTTPHEADER => $curl_headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ];
+        if ($body !== null) {
+            $options[CURLOPT_POSTFIELDS] = $body;
+        }
+        curl_setopt_array($handle, $options);
+        $response_body = curl_exec($handle);
+        $this->assertIsString($response_body);
+        $http_code = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+        curl_close($handle);
+
+        return [
+            'http_code' => $http_code,
+            'body' => $response_body,
+            'response' => json_decode($response_body, true, 512, JSON_THROW_ON_ERROR),
+        ];
     }
 
     private function removeTree(string $path): void

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -19,6 +19,7 @@ if (!defined('SITE_EXPORT_SECRET_FILE')) {
 $GLOBALS['site_export_test_options'] = [];
 $GLOBALS['site_export_registered_settings'] = [];
 $GLOBALS['site_export_settings_errors'] = [];
+$GLOBALS['site_export_test_actions'] = [];
 
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(string $file): string {
@@ -36,7 +37,25 @@ if (!function_exists('get_option')) {
 
 if (!function_exists('update_option')) {
     function update_option(string $name, $value, $autoload = null): bool {
+        if (!array_key_exists($name, $GLOBALS['site_export_test_options'])) {
+            $GLOBALS['site_export_test_options'][$name] = $value;
+            foreach ($GLOBALS['site_export_test_actions']['add_option_' . $name] ?? [] as $action) {
+                $args = array_slice([$name, $value], 0, $action['accepted_args']);
+                call_user_func_array($action['callback'], $args);
+            }
+            return true;
+        }
+
+        $old_value = get_option($name);
         $GLOBALS['site_export_test_options'][$name] = $value;
+
+        if ($old_value !== $value) {
+            foreach ($GLOBALS['site_export_test_actions']['update_option_' . $name] ?? [] as $action) {
+                $args = array_slice([$old_value, $value, $name], 0, $action['accepted_args']);
+                call_user_func_array($action['callback'], $args);
+            }
+        }
+
         return true;
     }
 }
@@ -51,7 +70,12 @@ if (!function_exists('register_setting')) {
 }
 
 if (!function_exists('add_action')) {
-    function add_action(...$args): void {}
+    function add_action(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
+        $GLOBALS['site_export_test_actions'][$hook_name][] = [
+            'callback' => $callback,
+            'accepted_args' => $accepted_args,
+        ];
+    }
 }
 
 if (!function_exists('add_filter')) {
@@ -302,6 +326,21 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
+    public function testPresentEmptyManagedEnvironmentFailsClosed(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        putenv('SITE_EXPORT_PUSH_ENABLED=');
+
+        $this->assertFalse(_site_export_get_managed_push_enabled());
+        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertSame(
+            'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.',
+            _site_export_get_push_authorization_error()
+        );
+    }
+
     public function testSavingRotatedConnectionTokenRevokesPriorConsent(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
@@ -315,6 +354,49 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
         $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testRestSettingsTokenRotationPermanentlyRevokesPushAuthorization(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'token-a';
+        $this->assertTrue(_site_export_update_push_authorization(true));
+        Site_Export_Plugin::get_instance()->register_settings();
+
+        update_option(SITE_EXPORT_SECRET_OPTION, 'token-b');
+        update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
+
+        $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testAddingAFormerSecretFileTokenCannotRestorePushAuthorization(): void
+    {
+        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'token-a';\n");
+        $this->assertTrue(_site_export_update_push_authorization(true));
+        Site_Export_Plugin::get_instance()->register_settings();
+
+        unlink(SITE_EXPORT_SECRET_FILE);
+        $this->assertFalse(_site_export_is_push_authorized());
+        update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
+
+        $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testRestSettingsOptionChangePreservesAuthorizationForSecretFileToken(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token-a';
+        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
+        $this->assertTrue(_site_export_update_push_authorization(true));
+        Site_Export_Plugin::get_instance()->register_settings();
+
+        update_option(SITE_EXPORT_SECRET_OPTION, 'option-token-b');
+
+        $this->assertSame(
+            hash('sha256', 'file-token'),
+            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+        );
+        $this->assertTrue(_site_export_is_push_authorized());
     }
 
     public function testPushAccessFormAuthorizesTheCurrentConnectionToken(): void

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -18,6 +18,7 @@ if (!defined('SITE_EXPORT_SECRET_FILE')) {
 
 $GLOBALS['site_export_test_options'] = [];
 $GLOBALS['site_export_registered_settings'] = [];
+$GLOBALS['site_export_settings_errors'] = [];
 
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(string $file): string {
@@ -97,6 +98,69 @@ if (!function_exists('wp_safe_redirect')) {
     function wp_safe_redirect(...$args): void {}
 }
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WordPress test stubs.
+if (!function_exists('current_user_can')) {
+    function current_user_can(string $capability): bool {
+        return $capability === 'manage_options';
+    }
+}
+
+if (!function_exists('check_admin_referer')) {
+    function check_admin_referer(string $action): void {}
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value): string {
+        return trim( (string) $value );
+    }
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) {
+        return $value;
+    }
+}
+
+if (!function_exists('add_settings_error')) {
+    function add_settings_error(string $setting, string $code, string $message, string $type): void {
+        $GLOBALS['site_export_settings_errors'][] = [
+            'setting' => $setting,
+            'code' => $code,
+            'message' => $message,
+            'type' => $type,
+        ];
+    }
+}
+
+if (!function_exists('settings_errors')) {
+    function settings_errors(string $setting): void {}
+}
+
+if (!function_exists('home_url')) {
+    function home_url(string $path = ''): string {
+        return 'https://example.test/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('wp_nonce_field')) {
+    function wp_nonce_field(string $action): void {
+        echo '<input type="hidden" name="_wpnonce" value="' . esc_attr($action) . '" />';
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr(string $value): string {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html(string $value): string {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+
 require_once __DIR__ . '/../reprint-exporter-wp/lib.php';
 require_once __DIR__ . '/../reprint-exporter-wp/wordpress/site-export.php';
 
@@ -108,6 +172,12 @@ final class SiteExportSecretTest extends TestCase
     /** @var array<string, mixed> */
     private $original_files = [];
 
+    /** @var array<string, mixed> */
+    private $original_post = [];
+
+    /** @var string|false */
+    private $original_push_enabled_environment;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -118,11 +188,18 @@ final class SiteExportSecretTest extends TestCase
 
         $this->original_server = $_SERVER;
         $this->original_files = $_FILES;
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
+        $this->original_post = $_POST;
+        $this->original_push_enabled_environment = getenv('SITE_EXPORT_PUSH_ENABLED');
 
         $GLOBALS['site_export_test_options'] = [];
         $GLOBALS['site_export_registered_settings'] = [];
+        $GLOBALS['site_export_settings_errors'] = [];
         $_SERVER = [];
         $_FILES = [];
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
+        $_POST = [];
+        putenv('SITE_EXPORT_PUSH_ENABLED');
 
         if (file_exists(SITE_EXPORT_SECRET_FILE)) {
             unlink(SITE_EXPORT_SECRET_FILE);
@@ -141,6 +218,12 @@ final class SiteExportSecretTest extends TestCase
 
         $_SERVER = $this->original_server;
         $_FILES = $this->original_files;
+        $_POST = $this->original_post;
+        if ($this->original_push_enabled_environment === false) {
+            putenv('SITE_EXPORT_PUSH_ENABLED');
+        } else {
+            putenv('SITE_EXPORT_PUSH_ENABLED=' . $this->original_push_enabled_environment);
+        }
 
         parent::tearDown();
     }
@@ -193,5 +276,105 @@ final class SiteExportSecretTest extends TestCase
         $_SERVER['HTTP_X_AUTH_CONTENT_HASH'] = $content_hash;
 
         $this->assertNull(_site_export_verify_hmac($secret));
+    }
+
+    public function testPushAuthorizationMatchesOnlyTheCurrentConnectionToken(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertFalse(_site_export_is_push_authorized());
+
+        $this->assertTrue(_site_export_update_push_authorization(true));
+        $this->assertTrue(_site_export_is_push_authorized());
+
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'rotated-token';
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testManagedEnvironmentOverridesLocalPushAuthorization(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+
+        putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        $this->assertTrue(_site_export_is_push_authorized());
+
+        $this->assertTrue(_site_export_update_push_authorization(true));
+        putenv('SITE_EXPORT_PUSH_ENABLED=false');
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testSavingRotatedConnectionTokenRevokesPriorConsent(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        $_POST = [
+            'site_export_save_settings' => '1',
+            'site_export_secret' => 'rotated-token',
+        ];
+        Site_Export_Plugin::get_instance()->handle_settings_save();
+
+        $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testPushAccessFormAuthorizesTheCurrentConnectionToken(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $_POST = [
+            'site_export_save_push_access' => '1',
+            'site_export_push_enabled' => '1',
+        ];
+
+        Site_Export_Plugin::get_instance()->handle_settings_save();
+
+        $this->assertSame(
+            hash('sha256', 'current-token'),
+            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+        );
+        $this->assertTrue(_site_export_is_push_authorized());
+    }
+
+    public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('<strong>Connected for downloads.</strong>', $html);
+        $this->assertStringContainsString('The connection token cannot change files on this site.', $html);
+        $this->assertStringContainsString('You do not need push access when moving this site to another host.', $html);
+        $this->assertStringContainsString('Allow push to change files on this site', $html);
+        $this->assertStringContainsString('except excluded paths.', $html);
+        $this->assertStringNotContainsString('name="site_export_push_enabled" value="1" checked', $html);
+    }
+
+    public function testOptedInAdminCopyShowsCurrentTokenCanPush(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('<strong>Connected for downloads and push.</strong>', $html);
+        $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked', $html);
+    }
+
+    public function testManagedAdminCopyIsReadOnlyAndShowsEffectiveState(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        putenv('SITE_EXPORT_PUSH_ENABLED=true');
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('Push access is managed by your hosting provider.', $html);
+        $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked disabled', $html);
+        $this->assertStringNotContainsString('name="site_export_save_push_access"', $html);
+    }
+
+    private function renderAdminPage(): string
+    {
+        ob_start();
+        Site_Export_Plugin::get_instance()->render_admin_page();
+        return (string) ob_get_clean();
     }
 }

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -24,6 +24,11 @@ if (is_string($reprint_push_test_docroot_configuration['wp_plugin_dir'] ?? null)
     define('WP_PLUGIN_DIR', $reprint_push_test_docroot_configuration['wp_plugin_dir']);
 }
 
+$reprint_push_test_managed_state = trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_MANAGED_PUSH_CONFIG') ) );
+if ($reprint_push_test_managed_state !== '') {
+    define('SITE_EXPORT_PUSH_ENABLED', $reprint_push_test_managed_state === 'true');
+}
+
 function plugin_dir_path(string $file): string {
     return $file === '' ? '' : dirname(__DIR__, 2) . '/reprint-exporter-wp/';
 }
@@ -40,7 +45,10 @@ function plugin_basename(string $file): string {
 
 function get_option(string $name, $fallback = false) {
     if ($name === 'site_export_secret') {
-        return (string) getenv('REPRINT_PUSH_TEST_SECRET');
+        return trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_SECRET_CONFIG') ) );
+    }
+    if ($name === 'site_export_push_authorized_token_fingerprint') {
+        return trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_AUTHORIZATION_CONFIG') ) );
     }
     return $fallback;
 }
@@ -67,6 +75,10 @@ if (is_string($reprint_push_test_docroot)) {
 }
 if (isset($reprint_push_test_docroot_configuration['maximum_part_bytes'])) {
     $reprint_push_test_options['maximum_part_bytes'] = $reprint_push_test_docroot_configuration['maximum_part_bytes'];
+}
+if (trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_CUSTOM_AUTH_CONFIG') ) ) === 'enabled') {
+    $reprint_push_test_options['authenticate'] = function (): void {
+    };
 }
 $reprint_push_test_directory = trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_DIRECTORY_CONFIG') ) );
 if ($reprint_push_test_directory !== '') {


### PR DESCRIPTION
Connection tokens now authorize downloads only until a site owner or hosting platform explicitly enables push. Without push authorization, the router returns HTTP 403 with `reason: "push_disabled"` for the entire `push_*` namespace before it reads a request body or creates push state. The only exception is an authenticated `push_commit` for a session that already has a durable commit checkpoint. That request may finish the document-root mutation and remove its maintenance marker, but it cannot create a checkpoint or start new work.

Personal consent stores the current token's SHA-256 fingerprint. WordPress option updates and additions revoke that consent, so rotating a token from A to B and back to A does not restore the old grant. An early `SITE_EXPORT_PUSH_ENABLED` boolean constant or environment variable overrides local consent for managed platforms; a present empty environment value fails closed. Push control parameters remain query-only, so POST data cannot replace the authorized endpoint after the gate runs. Authorized future `push_*` names still use the push JSON error contract.

The settings screen says when a token is download-only, keeps push access in a separate low-emphasis form, and renders managed policy read-only.

### Screenshots

#### Download-only by default

![The Reprint Exporter screen showing Connected for downloads and an unchecked Push access checkbox](https://raw.githubusercontent.com/WordPress/reprint/91cd57a3b9ca0fa840b8a5bff79bc5fb4d1b0caa/download-only.png)

#### Personal push access enabled

![The Reprint Exporter screen showing Connected for downloads and push and a checked Push access checkbox](https://raw.githubusercontent.com/WordPress/reprint/91cd57a3b9ca0fa840b8a5bff79bc5fb4d1b0caa/opted-in.png)

#### Hosting-provider policy enabled

![The Reprint Exporter screen showing managed push access with a disabled checked checkbox](https://raw.githubusercontent.com/WordPress/reprint/91cd57a3b9ca0fa840b8a5bff79bc5fb4d1b0caa/managed.png)

### Testing

- `cd tests && ../vendor/bin/phpunit PushCommitTest.php PushSessionTest.php PushEndpointsTest.php SiteExportSecretTest.php ExportHttpServerTest.php`
- `composer analyze -- --memory-limit=1G`
- `vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps reprint-exporter-wp/lib.php reprint-exporter-wp/wordpress/site-export.php packages/reprint-exporter/src/class-http-server.php packages/reprint-exporter/src/class-push-endpoints.php packages/reprint-exporter/src/class-push-session.php tests/fixtures/push-endpoint-router.php`
- `git diff --check origin/trunk...HEAD`
