### PR TITLE
[Push] Resume local-file pushes from receiver-confirmed cursors

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -85,9 +85,9 @@ after each successful commit:
     <state-dir>/push/<site>/last-sync-local-files.jsonl
     <state-dir>/push/<site>/last-sync-local-rows.jsonl   (phase two)
 
-Each file baseline is a copy of a local file index in the `.import-index.jsonl`
-format the pull path already reads and writes — one JSON object per line,
-sorted by path.
+Each file baseline uses the local `.import-index.jsonl` fields, sorted by path,
+and adds an `empty` boolean to directory entries. This records whether each
+directory was empty or non-empty for the next planning pass.
 
 The first push to a site has no baselines: every current local file counts as
 changed, and no local deletion can be detected yet.
@@ -199,35 +199,46 @@ configuration; request parameters cannot select any of them.
 active push keeps these files under `<state-dir>/push/<site>/`:
 
 ```text
-sender-index.jsonl          stable local index selected when the push began
+sender-index.jsonl          enriched current index built during planning
 local-paths-to-push.jsonl   positive-work paths from that index
-local-paths-to-delete.jsonl deleted paths from that index
-work-deletes                raw NUL-delimited work-delete stream
-sender.json                 atomic sender checkpoint
+work-deletes                raw NUL-delimited work-delete roots
+sender.json                 atomic sender and planning checkpoint
 ```
 
-The checkpoint names the push session, the next request phase, the selected
-positive-work path, the last source token confirmed by an upload response,
-receiver-confirmed file and work-delete cursors, bounded retry count, target
-part limit, receiver exclusion policy, and learned request-body sizing state.
-Before any positive-work request can become
-ambiguous, the durable phase tells a reopened sender to query `push_status` for
-that same path. Local counters never advance the checkpoint merely because
-bytes reached the network. A work-delete upload is likewise reconciled against
-`work_deletes_bytes`, and commit and remove requests are repeated until their
-durable target operation reports completion.
+`PushFilesSender::advance()` performs at most one real HTTP request and at most
+one bounded local planning step. `push_create` first supplies the receiver
+exclusion policy and that same advance pins the current-index identity without
+consuming a record. The sender then enters `planning`; each advance merges at
+most one bounded batch from the current index and prior baseline while writing
+all three planning outputs. It persists the two next-unconsumed input offsets,
+three committed output lengths, counts, active work-delete roots, and
+current-index identity in `sender.json`. The next process truncates any bytes
+beyond those lengths before resuming. No upload begins until planning is
+complete and those outputs are immutable.
+
+The same checkpoint names the push session, selected positive-work path, last
+source token confirmed by an upload response, receiver-confirmed file and
+work-delete cursors, bounded retry count, target part limit, receiver exclusion
+policy, and learned request-body sizing state. Before any positive-work request
+can become ambiguous, the durable phase tells a reopened sender to query
+`push_status` for that same path. Local counters never advance the checkpoint
+merely because bytes reached the network. A work-delete upload is likewise
+reconciled against `work_deletes_bytes`, and commit and remove requests are
+repeated until their durable target operation reports completion.
 
 The source token is its current type, size, and ctime. A changed token restarts
 the same in-flight work at offset zero, so new-version bytes are never appended
-behind an old-version prefix. A vanished selected path or a receiver work-delete
-cursor beyond the stable local stream abandons the upload-only push session by
-repeating bounded remove calls, then tells the caller to regenerate its local
-index. The caller must also regenerate that index before a later push. The
-stable `sender-index.jsonl` updates the local baseline only after commit
-completes. Current evidence under excluded paths is omitted because those bytes
-were not sent; any prior synchronized evidence there is retained. If the target
-later removes an exclusion, the next diff therefore selects local changes and
-deletions made while that path was protected.
+behind an old-version prefix. A changed planning index, changed indexed
+directory, vanished selected path, or receiver work-delete cursor beyond the
+stable local stream abandons the upload-only push session by repeating bounded
+remove calls, then tells the caller to regenerate its local index. The caller
+must also regenerate that index before a later push. The completed
+`sender-index.jsonl` updates the local baseline only after commit completes.
+Every current entry appears in that enriched index, but baseline publication
+omits current evidence under excluded paths because those bytes were not sent;
+any prior synchronized evidence there is retained. If the target later removes
+an exclusion, the next diff therefore selects local changes and deletions made
+while that path was protected.
 
 One upload request contains as many bounded chunks and work values as its
 decoded entity-body budget permits. The sender holds only one payload string,
@@ -237,10 +248,10 @@ current one is complete. Recoverable target contention, offset gaps, and
 ambiguous transport failures are retried at a fixed bounded count; exhaustion
 returns a terminal failure rather than a final retry.
 
-A nonblocking per-site sender lock covers each journal read, HTTP request, and
-following checkpoint write. A second local process returns `sender_busy` and
-resumes after the in-flight request releases that lock instead of advancing the
-same fixed-name journal files concurrently.
+A nonblocking per-site sender lock covers each journal read, bounded planning
+step or HTTP request, and following checkpoint write. A second local process
+returns `sender_busy` and resumes after the in-flight advance releases that lock
+instead of changing the same fixed-name journal files concurrently.
 
 The token has one honest timestamp-resolution gap: a same-size edit that keeps
 the same ctime second is not detected by the token, and remains invisible when

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -209,8 +209,8 @@ sender.json                 atomic sender checkpoint
 The checkpoint names the push session, the next request phase, the selected
 positive-work path, the last source token confirmed by an upload response,
 receiver-confirmed file and work-delete cursors, bounded retry count, target
-part limit, and learned request-body
-sizing state. Before any positive-work request can become
+part limit, receiver exclusion policy, and learned request-body sizing state.
+Before any positive-work request can become
 ambiguous, the durable phase tells a reopened sender to query `push_status` for
 that same path. Local counters never advance the checkpoint merely because
 bytes reached the network. A work-delete upload is likewise reconciled against
@@ -223,9 +223,11 @@ behind an old-version prefix. A vanished selected path or a receiver work-delete
 cursor beyond the stable local stream abandons the upload-only push session by
 repeating bounded remove calls, then tells the caller to regenerate its local
 index. The caller must also regenerate that index before a later push. The
-stable `sender-index.jsonl` becomes the local baseline only after commit
-completes. A freshly generated later index selects any path whose size, ctime,
-or type now differs from that stable evidence.
+stable `sender-index.jsonl` updates the local baseline only after commit
+completes. Current evidence under excluded paths is omitted because those bytes
+were not sent; any prior synchronized evidence there is retained. If the target
+later removes an exclusion, the next diff therefore selects local changes and
+deletions made while that path was protected.
 
 One upload request contains as many bounded chunks and work values as its
 decoded entity-body budget permits. The sender holds only one payload string,
@@ -234,6 +236,11 @@ deletes explicitly, and never selects another positive-work path until the
 current one is complete. Recoverable target contention, offset gaps, and
 ambiguous transport failures are retried at a fixed bounded count; exhaustion
 returns a terminal failure rather than a final retry.
+
+A nonblocking per-site sender lock covers each journal read, HTTP request, and
+following checkpoint write. A second local process returns `sender_busy` and
+resumes after the in-flight request releases that lock instead of advancing the
+same fixed-name journal files concurrently.
 
 The token has one honest timestamp-resolution gap: a same-size edit that keeps
 the same ctime second is not detected by the token, and remains invisible when

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -13,7 +13,7 @@ the end maps it to a PR stack.
 2. It shows a summary of local uploads and deletions. The user confirms that
    local should win for those paths and rows.
 3. It transfers everything into a private push directory on the remote — file bytes,
-   a deletion manifest, and (phase two) the database diff. The transfer is
+   the work-delete stream, and (phase two) the database diff. The transfer is
    resumable at byte granularity.
 4. It drives the commit step with repeated commands until done. The remote
    moves work files into place, executes deletions, and commits the database
@@ -193,6 +193,55 @@ physical target outside the document root. A platform hook or embedding router
 must choose its document root, reprint directory, and excluded paths as server
 configuration; request parameters cannot select any of them.
 
+## Local files sender
+
+`PushFilesSender` drives those operations from one local `PushJournal`. An
+active push keeps these files under `<state-dir>/push/<site>/`:
+
+```text
+sender-index.jsonl          stable local index selected when the push began
+local-paths-to-push.jsonl   positive-work paths from that index
+local-paths-to-delete.jsonl deleted paths from that index
+work-deletes                raw NUL-delimited work-delete stream
+sender.json                 atomic sender checkpoint
+```
+
+The checkpoint names the push session, the next request phase, the selected
+positive-work path, the last source token confirmed by an upload response,
+receiver-confirmed file and work-delete cursors, bounded retry count, target
+part limit, and learned request-body
+sizing state. Before any positive-work request can become
+ambiguous, the durable phase tells a reopened sender to query `push_status` for
+that same path. Local counters never advance the checkpoint merely because
+bytes reached the network. A work-delete upload is likewise reconciled against
+`work_deletes_bytes`, and commit and remove requests are repeated until their
+durable target operation reports completion.
+
+The source token is its current type, size, and ctime. A changed token restarts
+the same in-flight work at offset zero, so new-version bytes are never appended
+behind an old-version prefix. A vanished selected path or a receiver work-delete
+cursor beyond the stable local stream abandons the upload-only push session by
+repeating bounded remove calls, then tells the caller to regenerate its local
+index. The caller must also regenerate that index before a later push. The
+stable `sender-index.jsonl` becomes the local baseline only after commit
+completes. A freshly generated later index selects any path whose size, ctime,
+or type now differs from that stable evidence.
+
+One upload request contains as many bounded chunks and work values as its
+decoded entity-body budget permits. The sender holds only one payload string,
+derives each part Content-Length from the bytes actually read, closes work
+deletes explicitly, and never selects another positive-work path until the
+current one is complete. Recoverable target contention, offset gaps, and
+ambiguous transport failures are retried at a fixed bounded count; exhaustion
+returns a terminal failure rather than a final retry.
+
+The token has one honest timestamp-resolution gap: a same-size edit that keeps
+the same ctime second is not detected by the token, and remains invisible when
+a freshly generated index contains the same size/ctime/type evidence. Other
+drift remains detectable by the next local-index diff. Push streaming requires
+PHP 8.1 or newer because older PHP cURL bindings can truncate a paused upload;
+pull remains PHP 7.4-compatible.
+
 ## Where reprint stores its own data on the remote
 
 The remote is configured with one storage path for everything reprint keeps:
@@ -289,14 +338,14 @@ Files first, database second, each PR small and stacked in this order:
 5. **Push journal and local diff** — per-site local baselines, capture and
    overwrite logic, local change and deletion detection.
 6. **Push stream endpoint** — the store's HTTP surface plus a sender that
-   streams framed chunks for many files through one authenticated request;
+   streams multipart chunks for many files through one authenticated request;
    deletion work received; `--force-http` with honest help text (the first
    push networking this flag can gate). Decisions this slice locked in:
    sending streams through libcurl's pause mechanism, which PHP's curl
    extension supports from 8.1 — so `reprint push` requires PHP 8.1+ (pull
    keeps 7.4+; the full story is
    https://github.com/WordPress/reprint/issues/327) — and paths
-   travel base64-encoded in frames, response cursors, and control-plane
+   travel base64-encoded in MIME headers, response cursors, and control-plane
    parameters, because file paths are arbitrary bytes and JSON strings must
    be UTF-8.
 7. **Package unification** — importer and exporter become one Reprint

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -84,6 +84,31 @@ failure key is `non_recoverable_commit_failure`.
 These JSON records are unversioned while their schemas are still under
 development. There are no compatibility aliases or migration paths.
 
+## Local sender journal
+
+The sender's durable files are local machine state, not part of the push
+directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
+
+| Surface | Name |
+| --- | --- |
+| Active sender checkpoint | `sender.json`, `$sender_state_path` |
+| Stable index selected for the active push | `sender-index.jsonl`, `$sender_index_path` |
+| Positive-work path list | `local-paths-to-push.jsonl`, `$local_paths_to_push` |
+| Deleted-path list | `local-paths-to-delete.jsonl`, `$local_paths_to_delete` |
+| Raw local work-delete stream | `work-deletes`, `$work_deletes_path` |
+| Selected path-list cursor | `$paths_byte_offset` |
+| Selected positive-work path | `$current_path_b64` |
+| Receiver-confirmed file cursor | `$confirmed_bytes` |
+
+`sender.json` is version 1. Its phases are `creating`, `reconciling_work`,
+`uploading_work`, `reconciling_deletes`, `uploading_deletes`, `committing`,
+and `removing`. It also records the push session ID, selected path, last source
+token confirmed by an upload response, receiver-confirmed file and work-delete
+cursors, recoverable-failure count, target part limit, and request-sizing state.
+`push.json` remains the receiver-owned
+push identity and policy; it does not store local source evidence or transport
+progress.
+
 ## Protocol names
 
 The work-upload endpoint is `push_upload` and its push-session parameter is

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -92,21 +92,24 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 | Surface | Name |
 | --- | --- |
 | Active sender checkpoint | `sender.json`, `$sender_state_path` |
-| Stable index selected for the active push | `sender-index.jsonl`, `$sender_index_path` |
+| Enriched index selected for the active push | `sender-index.jsonl`, `$sender_index_path` |
 | Positive-work path list | `local-paths-to-push.jsonl`, `$local_paths_to_push` |
-| Deleted-path list | `local-paths-to-delete.jsonl`, `$local_paths_to_delete` |
 | Raw local work-delete stream | `work-deletes`, `$work_deletes_path` |
 | Local sender transition lock | `sender.lock` |
+| Local planning checkpoint key | `planning_checkpoint` |
 | Selected path-list cursor | `$paths_byte_offset` |
 | Selected positive-work path | `$current_path_b64` |
 | Receiver-confirmed file cursor | `$confirmed_bytes` |
 
 `sender.json` is unversioned development state. Its phases are `creating`,
-`reconciling_work`, `uploading_work`, `reconciling_deletes`,
+`planning`, `reconciling_work`, `uploading_work`, `reconciling_deletes`,
 `uploading_deletes`, `committing`, and `removing`. It also records the push
-session ID, selected path, last source token confirmed by an upload response,
-receiver-confirmed file and work-delete cursors, recoverable-failure count,
-target part limit, receiver exclusion policy, and request-sizing state.
+session ID, local planning input offsets and committed output lengths, selected
+path, last source token confirmed by an upload response, receiver-confirmed
+file and work-delete cursors, recoverable-failure count, target part limit,
+receiver exclusion policy, and request-sizing state.
+`planning_checkpoint` is local sender resume metadata. It is unrelated to the
+receiver commit checkpoint in `commit.json`, named `$commit_state` in PHP.
 `push.json` remains the receiver-owned
 push identity and policy; it does not store local source evidence or transport
 progress.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -96,15 +96,17 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 | Positive-work path list | `local-paths-to-push.jsonl`, `$local_paths_to_push` |
 | Deleted-path list | `local-paths-to-delete.jsonl`, `$local_paths_to_delete` |
 | Raw local work-delete stream | `work-deletes`, `$work_deletes_path` |
+| Local sender transition lock | `sender.lock` |
 | Selected path-list cursor | `$paths_byte_offset` |
 | Selected positive-work path | `$current_path_b64` |
 | Receiver-confirmed file cursor | `$confirmed_bytes` |
 
-`sender.json` is version 1. Its phases are `creating`, `reconciling_work`,
-`uploading_work`, `reconciling_deletes`, `uploading_deletes`, `committing`,
-and `removing`. It also records the push session ID, selected path, last source
-token confirmed by an upload response, receiver-confirmed file and work-delete
-cursors, recoverable-failure count, target part limit, and request-sizing state.
+`sender.json` is unversioned development state. Its phases are `creating`,
+`reconciling_work`, `uploading_work`, `reconciling_deletes`,
+`uploading_deletes`, `committing`, and `removing`. It also records the push
+session ID, selected path, last source token confirmed by an upload response,
+receiver-confirmed file and work-delete cursors, recoverable-failure count,
+target part limit, receiver exclusion policy, and request-sizing state.
 `push.json` remains the receiver-owned
 push identity and policy; it does not store local source evidence or transport
 progress.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -58,6 +58,9 @@ require_once __DIR__ . '/lib/state/class-import-state.php';
 
 // Adaptive sizing for push request bodies
 require_once __DIR__ . '/lib/upload/class-push-request-sizer.php';
+require_once __DIR__ . '/lib/upload/class-multipart-push-stream-client.php';
+require_once __DIR__ . '/lib/push/class-push-journal.php';
+require_once __DIR__ . '/lib/push/class-push-files-sender.php';
 
 // High-level pull commands — orchestrate lower-level commands into pipelines
 require_once __DIR__ . '/lib/pull/class-pull.php';

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -30,6 +30,10 @@ final class PushFilesSender
     private string $current_index_file;
     private PushJournal $journal;
     private MultipartPushStreamClient $client;
+    private array $request_sizer_config;
+    private array $client_options;
+    private bool $client_has_authoritative_state = false;
+    private ?string $client_state_fingerprint = null;
 
     /**
      * Configures one sender and restores its learned request size when present.
@@ -64,8 +68,7 @@ final class PushFilesSender
      * }
      *
      * @throws InvalidArgumentException If source or transport options are invalid.
-     * @throws RuntimeException If the journal cannot be read or contains an
-     *     unsupported sender-state version.
+     * @throws RuntimeException If the journal cannot be read.
      */
     public function __construct(array $options)
     {
@@ -81,30 +84,14 @@ final class PushFilesSender
         if (!$journal instanceof PushJournal) {
             throw new InvalidArgumentException('PushFilesSender requires a PushJournal.');
         }
-        $state = $journal->read_sender_state();
-        if ($state === null && !is_file($current_index_file)) {
-            throw new InvalidArgumentException('PushFilesSender requires an existing current_index_file when no sender checkpoint is active.');
-        }
-        if (is_array($state) && ( $state['version'] ?? null ) !== 1) {
-            throw new RuntimeException(
-                'Sender state has an unsupported version: '
-                . json_encode($state['version'] ?? null, JSON_UNESCAPED_SLASHES)
-                . '.'
-            );
-        }
         $request_sizer_config = $options['request_sizer_config'] ?? [];
         if (!is_array($request_sizer_config)) {
             throw new InvalidArgumentException('request_sizer_config must be an array.');
         }
-        $request_sizer = new PushRequestSizer(
-            $request_sizer_config,
-            is_array($state) ? $state['request_sizer_state'] : []
-        );
         $client_options = [
             'base_url' => $options['base_url'] ?? null,
             'hmac_client' => $options['hmac_client'] ?? null,
             'allow_http' => $options['allow_http'] ?? false,
-            'request_sizer' => $request_sizer,
         ];
         foreach (['chunk_bytes', 'connect_timeout', 'stall_timeout', 'response_timeout'] as $option_name) {
             if (array_key_exists($option_name, $options)) {
@@ -115,10 +102,9 @@ final class PushFilesSender
         $this->docroot = rtrim($docroot, '/');
         $this->current_index_file = $current_index_file;
         $this->journal = $journal;
-        $this->client = new MultipartPushStreamClient($client_options);
-        if ($state !== null && $state['max_part_bytes'] !== null) {
-            $this->client->set_max_part_bytes($state['max_part_bytes']);
-        }
+        $this->request_sizer_config = $request_sizer_config;
+        $this->client_options = $client_options;
+        $this->client = $this->create_client(null);
     }
 
     /**
@@ -178,13 +164,46 @@ final class PushFilesSender
      */
     public function send_next_request(): array
     {
+        $sender_lock = $this->journal->acquire_sender_lock();
+        if ($sender_lock === null) {
+            return [
+                'status' => 'continue',
+                'phase' => 'creating',
+                'push_session_id' => null,
+                'reason' => 'sender_busy',
+                'detail' => 'Another process is advancing this target site\'s local push sender. Retry after that request finishes.',
+            ];
+        }
+        try {
+            return $this->send_next_request_under_lock();
+        } finally {
+            $this->journal->release_sender_lock($sender_lock);
+        }
+    }
+
+    /**
+     * Performs one sender transition while the site journal lock is held.
+     *
+     * @return array<string,mixed> Result in send_next_request()'s documented shape.
+     */
+    private function send_next_request_under_lock(): array
+    {
         $state = $this->journal->read_sender_state();
+        clearstatcache(true, $this->current_index_file);
+        if ($state === null && !is_file($this->current_index_file)) {
+            throw new InvalidArgumentException('PushFilesSender requires an existing current_index_file when no sender checkpoint is active.');
+        }
+        $state_fingerprint = $state === null
+            ? null
+            : json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        if (!$this->client_has_authoritative_state || $this->client_state_fingerprint !== $state_fingerprint) {
+            $this->client = $this->create_client($state);
+            $this->client_has_authoritative_state = true;
+            $this->client_state_fingerprint = $state_fingerprint;
+        }
         if ($state === null) {
             $this->journal->capture_sender_index($this->current_index_file);
-            $this->journal->diff_local_files($this->journal->sender_index_path);
-            $this->journal->prepare_work_deletes();
             $state = [
-                'version' => 1,
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
                 'paths_byte_offset' => 0,
@@ -195,9 +214,11 @@ final class PushFilesSender
                 'work_deletes_byte_offset' => 0,
                 'recoverable_failures' => 0,
                 'max_part_bytes' => null,
+                'excluded_paths_b64' => null,
                 'request_sizer_state' => $this->client->get_request_sizer_state(),
             ];
             $this->journal->write_sender_state($state);
+            $this->client_state_fingerprint = json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
         }
 
         if ($state['phase'] === 'creating') {
@@ -209,6 +230,9 @@ final class PushFilesSender
                 return $failure;
             }
             $response = $request['response'];
+            $excluded_paths = is_array($response)
+                ? $this->decode_excluded_paths_b64($response['excluded_paths_b64'] ?? null)
+                : null;
             if (
                 !is_array($response)
                 || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
@@ -217,12 +241,16 @@ final class PushFilesSender
                 || !array_key_exists('post_max_bytes', $response)
                 || ( $response['post_max_bytes'] !== null
                     && ( !is_int($response['post_max_bytes']) || $response['post_max_bytes'] <= 0 ) )
+                || $excluded_paths === null
             ) {
-                return $this->step_result('failed', $state, 'unexpected_response', 'push_create did not return the matching push session ID, a positive part limit, and a positive or unknown request-body limit.');
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_create did not return the matching push session ID, a positive part limit, a positive or unknown request-body limit, and a canonical excluded-path list.');
             }
+            $this->journal->diff_local_files($this->journal->sender_index_path, $excluded_paths);
+            $this->journal->prepare_work_deletes();
             $this->client->set_max_part_bytes($response['max_part_bytes']);
             $this->client->apply_reported_limits([$response['post_max_bytes'] ?? null]);
             $state['max_part_bytes'] = $response['max_part_bytes'];
+            $state['excluded_paths_b64'] = $response['excluded_paths_b64'];
             $state['recoverable_failures'] = 0;
             $state['phase'] = 'reconciling_work';
             $this->persist_state($state);
@@ -778,8 +806,13 @@ final class PushFilesSender
                 return $this->step_result('continue', $state, null, null);
             }
             $push_session_id = $state['push_session_id'];
-            $this->journal->capture_local_files_baseline($this->journal->sender_index_path);
+            $excluded_paths = $this->decode_excluded_paths_b64($state['excluded_paths_b64'] ?? null);
+            if ($excluded_paths === null) {
+                return $this->step_result('failed', $state, 'invalid_sender_state', 'Sender state does not contain the receiver exclusion policy for this push session.');
+            }
+            $this->journal->capture_local_files_baseline($this->journal->sender_index_path, $excluded_paths);
             $this->journal->clear_sender_state();
+            $this->client_state_fingerprint = null;
             return [
                 'status' => 'complete',
                 'phase' => 'complete',
@@ -812,6 +845,7 @@ final class PushFilesSender
             }
             $push_session_id = $state['push_session_id'];
             $this->journal->clear_sender_state();
+            $this->client_state_fingerprint = null;
             return [
                 'status' => 'restart',
                 'phase' => 'complete',
@@ -822,6 +856,75 @@ final class PushFilesSender
         }
 
         return $this->step_result('failed', $state, 'invalid_sender_state', 'Sender state contains an unsupported phase.');
+    }
+
+    /**
+     * Restores transport limits from the checkpoint read under the sender lock.
+     *
+     * @param array<string,mixed>|null $state Authoritative sender checkpoint.
+     */
+    private function create_client(?array $state): MultipartPushStreamClient
+    {
+        $request_sizer = new PushRequestSizer(
+            $this->request_sizer_config,
+            $state === null ? [] : $state['request_sizer_state']
+        );
+        $client_options = $this->client_options;
+        $client_options['request_sizer'] = $request_sizer;
+        $client = new MultipartPushStreamClient($client_options);
+        if ($state !== null && $state['max_part_bytes'] !== null) {
+            $client->set_max_part_bytes($state['max_part_bytes']);
+        }
+        return $client;
+    }
+
+    /**
+     * Decodes the receiver's normalized excluded-path policy.
+     *
+     * @param mixed $encoded_paths Candidate list from push_create or sender state.
+     * @return list<string>|null Raw paths, or null when the policy is not the
+     *     canonical sorted, deduplicated server shape.
+     */
+    private function decode_excluded_paths_b64($encoded_paths): ?array
+    {
+        if (!is_array($encoded_paths) || array_values($encoded_paths) !== $encoded_paths) {
+            return null;
+        }
+        $decoded_paths = [];
+        foreach ($encoded_paths as $encoded_path) {
+            if (!is_string($encoded_path)) {
+                return null;
+            }
+            $path = base64_decode($encoded_path, true);
+            if (
+                !is_string($path)
+                || base64_encode($path) !== $encoded_path
+                || !$this->is_safe_document_root_relative_path($path)
+            ) {
+                return null;
+            }
+            $decoded_paths[] = $path;
+        }
+        $normalized_paths = $decoded_paths;
+        sort($normalized_paths, SORT_STRING);
+        $normalized_paths = array_values(array_unique($normalized_paths));
+        return $normalized_paths === $decoded_paths ? $decoded_paths : null;
+    }
+
+    /**
+     * Reports whether raw path bytes name one safe document-root-relative path.
+     */
+    private function is_safe_document_root_relative_path(string $path): bool
+    {
+        if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            return false;
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -1007,15 +1110,12 @@ final class PushFilesSender
      */
     private function source_token(string $path): ?array
     {
-        if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+        if (!$this->is_safe_document_root_relative_path($path)) {
             throw new InvalidArgumentException('A selected push path is not a safe document-root-relative path: ' . base64_encode($path) . '.');
         }
-        foreach (explode('/', $path) as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..') {
-                throw new InvalidArgumentException('A selected push path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
-            }
-        }
-        $identity = @lstat($this->docroot . '/' . $path);
+        $absolute_path = $this->docroot . '/' . $path;
+        clearstatcache(true, $absolute_path);
+        $identity = @lstat($absolute_path);
         if (!is_array($identity)) {
             return null;
         }
@@ -1089,6 +1189,8 @@ final class PushFilesSender
     {
         $state['request_sizer_state'] = $this->client->get_request_sizer_state();
         $this->journal->write_sender_state($state);
+        $this->client_has_authoritative_state = true;
+        $this->client_state_fingerprint = json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -7,11 +7,11 @@
 /**
  * Drives one resumable local-files push through real HTTP requests.
  *
- * Each send_next_request() call performs one create, status, upload, commit,
- * or remove request and persists the receiver-reconcilable boundary before it
- * returns. Upload requests contain as many bounded file chunks and work values
- * as the learned request-body budget permits. Only one payload string is held
- * at a time.
+ * Each advance() call performs at most one create, status, upload, commit, or
+ * remove request and at most one bounded local planning step, then persists the
+ * durable boundary before it returns. Upload requests contain as many bounded
+ * file chunks and work values as the learned request-body budget permits. Only
+ * one payload string is held at a time.
  *
  * The sender does not trust local byte counters after a restart or ambiguous
  * response. It asks push_status for the current path or work-delete cursor,
@@ -43,8 +43,8 @@ final class PushFilesSender
      *
      *     @type string $docroot Required local document-root directory.
      *     @type string $current_index_file Current local file index required
-     *         when no sender checkpoint is active. An active sender resumes
-     *         from its stable journal copy instead.
+     *         until bounded planning finishes. Later sender phases resume from
+     *         the completed journal outputs instead.
      *     @type PushJournal $journal Required per-target push journal.
      *     @type string $base_url Required exporter API URL.
      *     @type Site_Export_HMAC_Client $hmac_client Required envelope signer.
@@ -108,14 +108,15 @@ final class PushFilesSender
     }
 
     /**
-     * Runs requests until the push completes, fails, or needs a new index.
+     * Runs sender advances until the push completes, fails, or needs a new
+     * index.
      *
-     * Recoverable results pause for 100 milliseconds before the next request,
+     * Recoverable results pause for 100 milliseconds before the next advance,
      * so the convenience loop does not spin on target lock contention.
      *
      * @return array{
      *     status:'complete'|'restart'|'failed',
-     *     phase:'complete'|'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     phase:'complete'|'creating'|'planning'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
      *     push_session_id:?string,
      *     reason:?string,
      *     detail:?string
@@ -129,7 +130,7 @@ final class PushFilesSender
     public function push(): array
     {
         do {
-            $result = $this->send_next_request();
+            $result = $this->advance();
             if ($result['status'] === 'continue' && $result['reason'] !== null) {
                 usleep(self::RECOVERABLE_FAILURE_PAUSE_MICROSECONDS);
             }
@@ -138,31 +139,32 @@ final class PushFilesSender
     }
 
     /**
-     * Performs the next durable HTTP request in the local-files push.
+     * Performs the next durable step in the local-files push.
      *
-     * New work first produces journal path lists and a raw work-delete stream.
-     * Later calls create or reopen the push session, reconcile any current
-     * receiver cursor, fill one multipart request, close work deletes, repeat
-     * commit, or remove an abandoned upload-only push session.
+     * New work first creates the push session to learn its excluded paths, then
+     * produces journal path lists and a raw work-delete stream in bounded local
+     * planning calls. Later calls reconcile any current receiver cursor, fill
+     * one multipart request, close work deletes, repeat commit, or remove an
+     * abandoned upload-only push session.
      *
-     * Returning `continue` means the checkpoint names the request to perform
-     * next. `complete` means receiver commit and local baseline capture both
+     * Returning `continue` means the checkpoint names the next local step or
+     * request. `complete` means receiver commit and local baseline capture both
      * finished. `restart` means source selection changed incompatibly and the
      * old push session is gone. `failed` is terminal for this checkpoint.
      *
      * @return array{
      *     status:'continue'|'complete'|'restart'|'failed',
-     *     phase:'complete'|'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     phase:'complete'|'creating'|'planning'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
      *     push_session_id:?string,
      *     reason:?string,
      *     detail:?string
-     * } Result of one real request and its durable local transition.
+     * } Result of one bounded sender advance and its durable local transition.
      * @throws InvalidArgumentException If the stable index contains an unsafe
      *     document-root-relative path.
      * @throws RuntimeException If durable local sender state cannot be read or
      *     written.
      */
-    public function send_next_request(): array
+    public function advance(): array
     {
         $sender_lock = $this->journal->acquire_sender_lock();
         if ($sender_lock === null) {
@@ -171,11 +173,11 @@ final class PushFilesSender
                 'phase' => 'creating',
                 'push_session_id' => null,
                 'reason' => 'sender_busy',
-                'detail' => 'Another process is advancing this target site\'s local push sender. Retry after that request finishes.',
+                'detail' => 'Another process is advancing this target site\'s local push sender. Retry after that advance finishes.',
             ];
         }
         try {
-            return $this->send_next_request_under_lock();
+            return $this->advance_under_lock();
         } finally {
             $this->journal->release_sender_lock($sender_lock);
         }
@@ -184,9 +186,9 @@ final class PushFilesSender
     /**
      * Performs one sender transition while the site journal lock is held.
      *
-     * @return array<string,mixed> Result in send_next_request()'s documented shape.
+     * @return array<string,mixed> Result in advance()'s documented shape.
      */
-    private function send_next_request_under_lock(): array
+    private function advance_under_lock(): array
     {
         $state = $this->journal->read_sender_state();
         clearstatcache(true, $this->current_index_file);
@@ -202,10 +204,10 @@ final class PushFilesSender
             $this->client_state_fingerprint = $state_fingerprint;
         }
         if ($state === null) {
-            $this->journal->capture_sender_index($this->current_index_file);
             $state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
+                'planning_checkpoint' => null,
                 'paths_byte_offset' => 0,
                 'current_path_b64' => null,
                 'next_paths_byte_offset' => 0,
@@ -245,14 +247,71 @@ final class PushFilesSender
             ) {
                 return $this->step_result('failed', $state, 'unexpected_response', 'push_create did not return the matching push session ID, a positive part limit, a positive or unknown request-body limit, and a canonical excluded-path list.');
             }
-            $this->journal->diff_local_files($this->journal->sender_index_path, $excluded_paths);
-            $this->journal->prepare_work_deletes();
             $this->client->set_max_part_bytes($response['max_part_bytes']);
             $this->client->apply_reported_limits([$response['post_max_bytes'] ?? null]);
             $state['max_part_bytes'] = $response['max_part_bytes'];
             $state['excluded_paths_b64'] = $response['excluded_paths_b64'];
             $state['recoverable_failures'] = 0;
-            $state['phase'] = 'reconciling_work';
+            try {
+                $planning = $this->journal->diff_local_files(
+                    $this->current_index_file,
+                    $this->docroot,
+                    $excluded_paths,
+                    null
+                );
+            } catch (RuntimeException $exception) {
+                clearstatcache(true, $this->current_index_file);
+                if (is_file($this->current_index_file)) {
+                    throw $exception;
+                }
+                $state['phase'] = 'removing';
+                $this->persist_state($state);
+                return $this->step_result(
+                    'continue',
+                    $state,
+                    'source_changed',
+                    'The current index disappeared before local planning began; remove the upload-only push session before regenerating the index.'
+                );
+            }
+            $state['planning_checkpoint'] = $planning['checkpoint'];
+            if ($planning['status'] === 'source_changed') {
+                $state['phase'] = 'removing';
+                $this->persist_state($state);
+                return $this->step_result(
+                    'continue',
+                    $state,
+                    'source_changed',
+                    'The current index changed while local planning began; remove the upload-only push session before regenerating the index.'
+                );
+            }
+            $state['phase'] = $planning['status'] === 'complete' ? 'reconciling_work' : 'planning';
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'planning') {
+            $excluded_paths = $this->decode_excluded_paths_b64($state['excluded_paths_b64']);
+            if ($excluded_paths === null) {
+                return $this->step_result('failed', $state, 'invalid_sender_state', 'Sender state does not contain the receiver exclusion policy for local planning.');
+            }
+            $planning = $this->journal->diff_local_files(
+                $this->current_index_file,
+                $this->docroot,
+                $excluded_paths,
+                $state['planning_checkpoint']
+            );
+            $state['planning_checkpoint'] = $planning['checkpoint'];
+            if ($planning['status'] === 'source_changed') {
+                $state['phase'] = 'removing';
+                $this->persist_state($state);
+                return $this->step_result(
+                    'continue',
+                    $state,
+                    'source_changed',
+                    'The current index or an indexed directory changed during local planning; remove the upload-only push session before regenerating the index.'
+                );
+            }
+            $state['phase'] = $planning['status'] === 'complete' ? 'reconciling_work' : 'planning';
             $this->persist_state($state);
             return $this->step_result('continue', $state, null, null);
         }
@@ -1151,7 +1210,7 @@ final class PushFilesSender
      *     and persisted when sizing or retry evidence changes.
      * @return array{
      *     status:'continue'|'failed',
-     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     phase:'creating'|'planning'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
      *     push_session_id:string,
      *     reason:?string,
      *     detail:?string
@@ -1202,7 +1261,7 @@ final class PushFilesSender
      * @param string|null $detail Human-readable condition.
      * @return array{
      *     status:'continue'|'failed',
-     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     phase:'creating'|'planning'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
      *     push_session_id:string,
      *     reason:?string,
      *     detail:?string

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -116,8 +116,8 @@ final class PushFilesSender
         $this->current_index_file = $current_index_file;
         $this->journal = $journal;
         $this->client = new MultipartPushStreamClient($client_options);
-        if (is_array($state) && is_numeric($state['max_part_bytes'])) {
-            $this->client->set_max_part_bytes( (int) $state['max_part_bytes']);
+        if ($state !== null && $state['max_part_bytes'] !== null) {
+            $this->client->set_max_part_bytes($state['max_part_bytes']);
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -1,0 +1,1119 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Drives one resumable local-files push through real HTTP requests.
+ *
+ * Each send_next_request() call performs one create, status, upload, commit,
+ * or remove request and persists the receiver-reconcilable boundary before it
+ * returns. Upload requests contain as many bounded file chunks and work values
+ * as the learned request-body budget permits. Only one payload string is held
+ * at a time.
+ *
+ * The sender does not trust local byte counters after a restart or ambiguous
+ * response. It asks push_status for the current path or work-delete cursor,
+ * compares the source's type, size, and ctime with its persisted token, and
+ * resumes or restarts the same in-flight work. If a selected source disappears
+ * or the work-delete cursor cannot belong to the current list, it removes the
+ * upload-only push session and returns `restart` so the caller can regenerate
+ * the local index.
+ */
+final class PushFilesSender
+{
+    private const MAXIMUM_RECOVERABLE_FAILURES = 5;
+    private const RECOVERABLE_FAILURE_PAUSE_MICROSECONDS = 100000;
+
+    private string $docroot;
+    private string $current_index_file;
+    private PushJournal $journal;
+    private MultipartPushStreamClient $client;
+
+    /**
+     * Configures one sender and restores its learned request size when present.
+     *
+     * @param array<string,mixed> $options {
+     *     Sender, transport, and source configuration.
+     *
+     *     @type string $docroot Required local document-root directory.
+     *     @type string $current_index_file Current local file index required
+     *         when no sender checkpoint is active. An active sender resumes
+     *         from its stable journal copy instead.
+     *     @type PushJournal $journal Required per-target push journal.
+     *     @type string $base_url Required exporter API URL.
+     *     @type Site_Export_HMAC_Client $hmac_client Required envelope signer.
+     *     @type bool $allow_http Explicit plain-HTTP opt-in. Default false.
+     *     @type int|float|string $chunk_bytes Maximum one source read. Default
+     *         4 MiB.
+     *     @type int|float|string $connect_timeout Connect phase seconds.
+     *         Default 30.
+     *     @type int|float|string $stall_timeout No-upload-progress seconds.
+     *         Default 60.
+     *     @type int|float|string $response_timeout No-response-progress seconds.
+     *         Default 300.
+     *     @type array{
+     *         floor_bytes?:int|float|string,
+     *         start_bytes?:int|float|string,
+     *         max_bytes?:int|float|string,
+     *         limit_safety_ratio?:int|float|string,
+     *         growth_holdoff_successes?:int|float|string
+     *     } $request_sizer_config Optional PushRequestSizer bounds; persisted
+     *         sizing state still wins.
+     * }
+     *
+     * @throws InvalidArgumentException If source or transport options are invalid.
+     * @throws RuntimeException If the journal cannot be read or contains an
+     *     unsupported sender-state version.
+     */
+    public function __construct(array $options)
+    {
+        $docroot = $options['docroot'] ?? null;
+        $current_index_file = $options['current_index_file'] ?? null;
+        $journal = $options['journal'] ?? null;
+        if (!is_string($docroot) || !is_dir($docroot) || is_link($docroot)) {
+            throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
+        }
+        if (!is_string($current_index_file) || $current_index_file === '') {
+            throw new InvalidArgumentException('PushFilesSender requires a current_index_file path.');
+        }
+        if (!$journal instanceof PushJournal) {
+            throw new InvalidArgumentException('PushFilesSender requires a PushJournal.');
+        }
+        $state = $journal->read_sender_state();
+        if ($state === null && !is_file($current_index_file)) {
+            throw new InvalidArgumentException('PushFilesSender requires an existing current_index_file when no sender checkpoint is active.');
+        }
+        if (is_array($state) && ( $state['version'] ?? null ) !== 1) {
+            throw new RuntimeException(
+                'Sender state has an unsupported version: '
+                . json_encode($state['version'] ?? null, JSON_UNESCAPED_SLASHES)
+                . '.'
+            );
+        }
+        $request_sizer_config = $options['request_sizer_config'] ?? [];
+        if (!is_array($request_sizer_config)) {
+            throw new InvalidArgumentException('request_sizer_config must be an array.');
+        }
+        $request_sizer = new PushRequestSizer(
+            $request_sizer_config,
+            is_array($state) ? $state['request_sizer_state'] : []
+        );
+        $client_options = [
+            'base_url' => $options['base_url'] ?? null,
+            'hmac_client' => $options['hmac_client'] ?? null,
+            'allow_http' => $options['allow_http'] ?? false,
+            'request_sizer' => $request_sizer,
+        ];
+        foreach (['chunk_bytes', 'connect_timeout', 'stall_timeout', 'response_timeout'] as $option_name) {
+            if (array_key_exists($option_name, $options)) {
+                $client_options[$option_name] = $options[$option_name];
+            }
+        }
+
+        $this->docroot = rtrim($docroot, '/');
+        $this->current_index_file = $current_index_file;
+        $this->journal = $journal;
+        $this->client = new MultipartPushStreamClient($client_options);
+        if (is_array($state) && is_numeric($state['max_part_bytes'])) {
+            $this->client->set_max_part_bytes( (int) $state['max_part_bytes']);
+        }
+    }
+
+    /**
+     * Runs requests until the push completes, fails, or needs a new index.
+     *
+     * Recoverable results pause for 100 milliseconds before the next request,
+     * so the convenience loop does not spin on target lock contention.
+     *
+     * @return array{
+     *     status:'complete'|'restart'|'failed',
+     *     phase:'complete'|'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:?string,
+     *     reason:?string,
+     *     detail:?string
+     * } Terminal workflow result. `restart` means the abandoned upload-only
+     *     push session was removed and the caller must regenerate its index.
+     * @throws InvalidArgumentException If the stable index contains an unsafe
+     *     document-root-relative path.
+     * @throws RuntimeException If durable local sender state cannot be read or
+     *     written.
+     */
+    public function push(): array
+    {
+        do {
+            $result = $this->send_next_request();
+            if ($result['status'] === 'continue' && $result['reason'] !== null) {
+                usleep(self::RECOVERABLE_FAILURE_PAUSE_MICROSECONDS);
+            }
+        } while ($result['status'] === 'continue');
+        return $result;
+    }
+
+    /**
+     * Performs the next durable HTTP request in the local-files push.
+     *
+     * New work first produces journal path lists and a raw work-delete stream.
+     * Later calls create or reopen the push session, reconcile any current
+     * receiver cursor, fill one multipart request, close work deletes, repeat
+     * commit, or remove an abandoned upload-only push session.
+     *
+     * Returning `continue` means the checkpoint names the request to perform
+     * next. `complete` means receiver commit and local baseline capture both
+     * finished. `restart` means source selection changed incompatibly and the
+     * old push session is gone. `failed` is terminal for this checkpoint.
+     *
+     * @return array{
+     *     status:'continue'|'complete'|'restart'|'failed',
+     *     phase:'complete'|'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:?string,
+     *     reason:?string,
+     *     detail:?string
+     * } Result of one real request and its durable local transition.
+     * @throws InvalidArgumentException If the stable index contains an unsafe
+     *     document-root-relative path.
+     * @throws RuntimeException If durable local sender state cannot be read or
+     *     written.
+     */
+    public function send_next_request(): array
+    {
+        $state = $this->journal->read_sender_state();
+        if ($state === null) {
+            $this->journal->capture_sender_index($this->current_index_file);
+            $this->journal->diff_local_files($this->journal->sender_index_path);
+            $this->journal->prepare_work_deletes();
+            $state = [
+                'version' => 1,
+                'push_session_id' => bin2hex(random_bytes(16)),
+                'phase' => 'creating',
+                'paths_byte_offset' => 0,
+                'current_path_b64' => null,
+                'next_paths_byte_offset' => 0,
+                'source_token' => null,
+                'confirmed_bytes' => 0,
+                'work_deletes_byte_offset' => 0,
+                'recoverable_failures' => 0,
+                'max_part_bytes' => null,
+                'request_sizer_state' => $this->client->get_request_sizer_state(),
+            ];
+            $this->journal->write_sender_state($state);
+        }
+
+        if ($state['phase'] === 'creating') {
+            $request = $this->control_request('POST', 'push_create', [
+                'push_session_id' => $state['push_session_id'],
+            ], ['created']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_int($response['max_part_bytes'] ?? null)
+                || $response['max_part_bytes'] <= 0
+                || !array_key_exists('post_max_bytes', $response)
+                || ( $response['post_max_bytes'] !== null
+                    && ( !is_int($response['post_max_bytes']) || $response['post_max_bytes'] <= 0 ) )
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_create did not return the matching push session ID, a positive part limit, and a positive or unknown request-body limit.');
+            }
+            $this->client->set_max_part_bytes($response['max_part_bytes']);
+            $this->client->apply_reported_limits([$response['post_max_bytes'] ?? null]);
+            $state['max_part_bytes'] = $response['max_part_bytes'];
+            $state['recoverable_failures'] = 0;
+            $state['phase'] = 'reconciling_work';
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'reconciling_work') {
+            $parameters = ['push_session_id' => $state['push_session_id']];
+            if ($state['current_path_b64'] !== null) {
+                $parameters['path_b64'] = $state['current_path_b64'];
+            }
+            $request = $this->control_request('GET', 'push_status', $parameters, ['accepted']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || ( $response['phase'] ?? null ) !== 'receiving_work'
+                || !is_int($response['work_deletes_bytes'] ?? null)
+                || $response['work_deletes_bytes'] < 0
+                || !is_bool($response['work_deletes_complete'] ?? null)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_status did not return the matching push session and exact receiving_work state.');
+            }
+            $state['recoverable_failures'] = 0;
+            if ($state['current_path_b64'] === null) {
+                if (( $response['path'] ?? null ) !== null) {
+                    return $this->step_result('failed', $state, 'unexpected_response', 'push_status returned a path state when none was requested.');
+                }
+                $state['phase'] = 'uploading_work';
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, null, null);
+            }
+            $path = base64_decode($state['current_path_b64'], true);
+            if (!is_string($path) || $path === '') {
+                return $this->step_result('failed', $state, 'invalid_sender_state', 'The current sender path is not valid base64 text.');
+            }
+            $source_token = $this->source_token($path);
+            $path_status = $response['path'] ?? null;
+            if (!is_array($path_status) || ( $path_status['path_b64'] ?? null ) !== $state['current_path_b64']) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_status did not return the requested path state.');
+            }
+            $path_state = $path_status['state'] ?? null;
+            $path_type = $path_status['type'] ?? null;
+            $accepted_bytes = $path_status['accepted_bytes'] ?? null;
+            if (
+                !is_int($accepted_bytes)
+                || $accepted_bytes < 0
+                || !in_array($path_state, ['missing', 'partial', 'complete'], true)
+                || ( $path_state === 'missing'
+                    && ( $accepted_bytes !== 0 || array_key_exists('type', $path_status) ) )
+                || ( $path_state !== 'missing'
+                    && !in_array($path_type, ['file', 'directory', 'symlink'], true) )
+                || ( $path_state === 'partial' && $path_type !== 'file' )
+                || ( in_array($path_type, ['directory', 'symlink'], true) && $accepted_bytes !== 0 )
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_status returned an invalid receiver-confirmed path state.');
+            }
+            if ($source_token === null) {
+                $state['phase'] = 'removing';
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, 'source_changed', 'The selected source path disappeared; remove the upload-only push session before regenerating the index.');
+            }
+            if ($source_token !== $state['source_token']) {
+                $state['phase'] = 'uploading_work';
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, 'source_changed', 'The source token changed; restart the same in-flight work at offset zero.');
+            }
+            if (
+                $path_state === 'complete'
+                && $path_type === $source_token['type']
+                && ( $source_token['type'] !== 'file' || $accepted_bytes === $source_token['size'] )
+            ) {
+                $state['paths_byte_offset'] = $state['next_paths_byte_offset'];
+                $state['current_path_b64'] = null;
+                $state['source_token'] = null;
+                $state['confirmed_bytes'] = 0;
+                $state['phase'] = 'reconciling_work';
+            } else {
+                $state['confirmed_bytes'] = $path_state === 'partial' && $path_type === 'file'
+                    ? $accepted_bytes
+                    : 0;
+                if ($state['confirmed_bytes'] > $source_token['size']) {
+                    $state['confirmed_bytes'] = 0;
+                }
+                $state['phase'] = 'uploading_work';
+            }
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'uploading_work') {
+            $paths = fopen($this->journal->local_paths_to_push, 'r');
+            if ($paths === false) {
+                return $this->step_result('failed', $state, 'local_io_error', 'Could not open the journal paths selected for push.');
+            }
+            $path_list_offset = $state['paths_byte_offset'];
+            $current = null;
+            while ($current === null) {
+                if (fseek($paths, $path_list_offset) !== 0) {
+                    fclose($paths);
+                    return $this->step_result('failed', $state, 'invalid_sender_state', 'The sender path-list cursor is outside the selected path list.');
+                }
+                $path_line = fgets($paths);
+                if ($path_line === false) {
+                    if (!feof($paths)) {
+                        fclose($paths);
+                        return $this->step_result('failed', $state, 'local_io_error', 'Could not read the journal paths selected for push.');
+                    }
+                    fclose($paths);
+                    $state['phase'] = 'reconciling_deletes';
+                    $this->persist_state($state);
+                    return $this->reconcile_work_deletes($state);
+                }
+                $next_path_list_offset = ftell($paths);
+                if (!is_int($next_path_list_offset)) {
+                    fclose($paths);
+                    return $this->step_result('failed', $state, 'local_io_error', 'Could not read the next byte offset in the journal paths selected for push.');
+                }
+                $path_record = json_decode($path_line, true);
+                $path = is_array($path_record) && is_string($path_record['path'] ?? null)
+                    ? base64_decode($path_record['path'], true)
+                    : false;
+                if (!is_string($path) || $path === '') {
+                    fclose($paths);
+                    return $this->step_result('failed', $state, 'invalid_sender_state', 'The selected path list contains an invalid path record.');
+                }
+                $base64_path = base64_encode($path);
+                $is_current_path = $state['current_path_b64'] === $base64_path;
+                $source_token = $this->source_token($path);
+                if ($source_token === null) {
+                    fclose($paths);
+                    $state['current_path_b64'] = $base64_path;
+                    $state['next_paths_byte_offset'] = $next_path_list_offset;
+                    $state['phase'] = 'removing';
+                    $this->persist_state($state);
+                    return $this->step_result('continue', $state, 'source_changed', 'The selected source path disappeared; remove the upload-only push session before regenerating the index.');
+                }
+                if ($source_token['type'] === 'directory') {
+                    $directory_is_empty = $this->directory_is_empty($path);
+                    if ($directory_is_empty === null) {
+                        fclose($paths);
+                        return $this->step_result('failed', $state, 'local_io_error', 'Could not read the selected source directory: ' . base64_encode($path) . '.');
+                    }
+                    if ($this->source_token($path) !== $source_token) {
+                        continue;
+                    }
+                    if (!$directory_is_empty && !$is_current_path) {
+                        $path_list_offset = $next_path_list_offset;
+                        $state['paths_byte_offset'] = $path_list_offset;
+                        $state['next_paths_byte_offset'] = $path_list_offset;
+                        $state['current_path_b64'] = null;
+                        $state['source_token'] = null;
+                        $state['confirmed_bytes'] = 0;
+                        $this->persist_state($state);
+                        continue;
+                    }
+                }
+                $receiver_confirmed_source_token = $is_current_path ? $state['source_token'] : null;
+                $receiver_confirmed_bytes = $is_current_path ? $state['confirmed_bytes'] : 0;
+                $current = [
+                    'path' => $path,
+                    'path_b64' => $base64_path,
+                    'path_list_offset' => $path_list_offset,
+                    'next_path_list_offset' => $next_path_list_offset,
+                    'source_token' => $source_token,
+                    'confirmed_bytes' => $receiver_confirmed_source_token === $source_token
+                        ? $receiver_confirmed_bytes
+                        : 0,
+                ];
+                $state['current_path_b64'] = $current['path_b64'];
+                $state['next_paths_byte_offset'] = $next_path_list_offset;
+                $state['source_token'] = $receiver_confirmed_source_token;
+                $state['confirmed_bytes'] = $receiver_confirmed_bytes;
+                $reconciliation_state = $state;
+                $reconciliation_state['phase'] = 'reconciling_work';
+                $this->persist_state($reconciliation_state);
+            }
+
+            if (!$this->client->start_upload_request($state['push_session_id'])) {
+                fclose($paths);
+                $request = [
+                    'status' => 'retry',
+                    'reason' => 'request_failed',
+                    'detail' => $this->client->get_last_error(),
+                    'response' => null,
+                    'parts_sent' => 0,
+                    'body_bytes_sent' => 0,
+                ];
+                $failure = $this->handle_request_failure($request, $state);
+                return $failure ?? $this->step_result('failed', $state, 'unexpected_response', 'The work upload failed without a classified result.');
+            }
+
+            $last_sent = null;
+            $next_unsent_path_list_offset = null;
+            $local_failure_detail = null;
+            $request_size_failure_detail = null;
+            while ($current !== null) {
+                $path = $current['path'];
+                $source_token = $this->source_token($path);
+                if ($source_token === null) {
+                    $next_unsent_path_list_offset = $current['path_list_offset'];
+                    break;
+                }
+                if ($source_token !== $current['source_token']) {
+                    $this->record_source_restart($current, $source_token);
+                }
+
+                $part = null;
+                $logical_value_complete = false;
+                if ($source_token['type'] === 'file') {
+                    $offset = $current['confirmed_bytes'];
+                    if ($offset > $source_token['size']) {
+                        $offset = 0;
+                        $current['confirmed_bytes'] = 0;
+                    }
+                    $maximum = $this->client->next_file_body_bytes($path, $source_token['size'], $offset);
+                    if ($maximum === 0) {
+                        $next_unsent_path_list_offset = $current['path_list_offset'];
+                        if ($last_sent === null) {
+                            $request_size_failure_detail = 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($path) . '.';
+                        }
+                        break;
+                    }
+                    $payload = '';
+                    if ($source_token['size'] > 0) {
+                        $file = fopen($this->docroot . '/' . $path, 'rb');
+                        if ($file === false || fseek($file, $offset) !== 0) {
+                            if (is_resource($file)) {
+                                fclose($file);
+                            }
+                            $after_open_token = $this->source_token($path);
+                            if ($after_open_token !== $source_token) {
+                                $this->record_source_restart($current, $after_open_token);
+                                continue;
+                            }
+                            $next_unsent_path_list_offset = $current['path_list_offset'];
+                            $local_failure_detail = 'Could not open the selected source file at its receiver-confirmed cursor: ' . base64_encode($path) . '.';
+                            break;
+                        }
+                        $payload = fread($file, $maximum);
+                        fclose($file);
+                        $after_read_token = $this->source_token($path);
+                        if ($after_read_token !== $source_token) {
+                            $this->record_source_restart($current, $after_read_token);
+                            continue;
+                        }
+                        if (!is_string($payload) || ( $payload === '' && $offset < $source_token['size'] )) {
+                            $next_unsent_path_list_offset = $current['path_list_offset'];
+                            $local_failure_detail = 'Could not read the selected source file at its receiver-confirmed cursor: ' . base64_encode($path) . '.';
+                            break;
+                        }
+                    }
+                    $part = [
+                        'type' => 'file',
+                        'path' => $path,
+                        'total_bytes' => $source_token['size'],
+                        'offset' => $offset,
+                        'payload' => $payload,
+                    ];
+                    $logical_value_complete = $offset + strlen($payload) === $source_token['size'];
+                } elseif ($source_token['type'] === 'directory') {
+                    $part = ['type' => 'directory', 'path' => $path, 'payload' => ''];
+                    $logical_value_complete = true;
+                } else {
+                    $target = @readlink($this->docroot . '/' . $path);
+                    $after_read_token = $this->source_token($path);
+                    if ($after_read_token !== $source_token) {
+                        $this->record_source_restart($current, $after_read_token);
+                        continue;
+                    }
+                    if (!is_string($target) || $target === '') {
+                        $next_unsent_path_list_offset = $current['path_list_offset'];
+                        $local_failure_detail = 'Could not read the selected source symlink target: ' . base64_encode($path) . '.';
+                        break;
+                    }
+                    $part = ['type' => 'symlink', 'path' => $path, 'target' => $target, 'payload' => ''];
+                    $logical_value_complete = true;
+                }
+
+                if (!$this->client->send_part($part)) {
+                    $next_unsent_path_list_offset = $current['path_list_offset'];
+                    if ($last_sent === null) {
+                        $request_size_failure_detail = 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($path) . '.';
+                    }
+                    break;
+                }
+                $current['confirmed_bytes'] = $source_token['type'] === 'file'
+                    ? $part['offset'] + strlen($part['payload'])
+                    : 0;
+                $last_sent = $current;
+                $last_sent['complete'] = $logical_value_complete;
+                if (!$logical_value_complete) {
+                    if ($this->client->should_finish_request()) {
+                        break;
+                    }
+                    continue;
+                }
+                if ($this->client->should_finish_request()) {
+                    break;
+                }
+
+                $path_list_offset = $current['next_path_list_offset'];
+                $current = null;
+                while ($current === null) {
+                    if (fseek($paths, $path_list_offset) !== 0) {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        break 2;
+                    }
+                    $path_line = fgets($paths);
+                    if ($path_line === false) {
+                        if (!feof($paths)) {
+                            $next_unsent_path_list_offset = $path_list_offset;
+                            $local_failure_detail = 'Could not read the journal paths selected for push.';
+                        }
+                        break 2;
+                    }
+                    $next_path_list_offset = ftell($paths);
+                    if (!is_int($next_path_list_offset)) {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        $local_failure_detail = 'Could not read the next byte offset in the journal paths selected for push.';
+                        break 2;
+                    }
+                    $path_record = json_decode($path_line, true);
+                    $path = is_array($path_record) && is_string($path_record['path'] ?? null)
+                        ? base64_decode($path_record['path'], true)
+                        : false;
+                    if (!is_string($path) || $path === '') {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        break 2;
+                    }
+                    $base64_path = base64_encode($path);
+                    $is_current_path = $state['current_path_b64'] === $base64_path;
+                    $source_token = $this->source_token($path);
+                    if ($source_token === null) {
+                        $next_unsent_path_list_offset = $path_list_offset;
+                        break 2;
+                    }
+                    if ($source_token['type'] === 'directory') {
+                        $directory_is_empty = $this->directory_is_empty($path);
+                        if ($directory_is_empty === null) {
+                            $next_unsent_path_list_offset = $path_list_offset;
+                            $local_failure_detail = 'Could not read the selected source directory: ' . base64_encode($path) . '.';
+                            break 2;
+                        }
+                        if ($this->source_token($path) !== $source_token) {
+                            continue;
+                        }
+                        if (!$directory_is_empty && !$is_current_path) {
+                            $path_list_offset = $next_path_list_offset;
+                            continue;
+                        }
+                    }
+                    $current = [
+                        'path' => $path,
+                        'path_b64' => $base64_path,
+                        'path_list_offset' => $path_list_offset,
+                        'next_path_list_offset' => $next_path_list_offset,
+                        'source_token' => $source_token,
+                        'confirmed_bytes' => 0,
+                    ];
+                    $state['paths_byte_offset'] = $path_list_offset;
+                    $state['current_path_b64'] = $current['path_b64'];
+                    $state['next_paths_byte_offset'] = $next_path_list_offset;
+                    $state['source_token'] = null;
+                    $state['confirmed_bytes'] = 0;
+                    $reconciliation_state = $state;
+                    $reconciliation_state['phase'] = 'reconciling_work';
+                    $this->persist_state($reconciliation_state);
+                }
+            }
+            fclose($paths);
+            $request = $this->client->finish_request();
+            $state['phase'] = 'reconciling_work';
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $state['recoverable_failures'] = 0;
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_int($response['changes_accepted'] ?? null)
+                || $response['changes_accepted'] !== $request['parts_sent']
+                || !array_key_exists('last_change', $response)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not return the matching push session and exact accepted-part count.');
+            }
+            $last_change = $response['last_change'];
+            if ($last_sent === null) {
+                if ($last_change !== null) {
+                    return $this->step_result('failed', $state, 'unexpected_response', 'push_upload returned a positive-work change when no part was sent.');
+                }
+                $state['paths_byte_offset'] = $path_list_offset;
+                $state['current_path_b64'] = null;
+                $state['source_token'] = null;
+                $state['confirmed_bytes'] = 0;
+            } elseif (
+                !is_array($last_change)
+                || ( $last_change['path_b64'] ?? null ) !== $last_sent['path_b64']
+                || ( $last_change['type'] ?? null ) !== $last_sent['source_token']['type']
+                || ( $last_change['state'] ?? null ) !== ( $last_sent['complete'] ? 'complete' : 'partial' )
+                || !is_int($last_change['accepted_bytes'] ?? null)
+                || $last_change['accepted_bytes'] !== $last_sent['confirmed_bytes']
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not confirm the exact latest positive-work state.');
+            } elseif (( $last_change['state'] ?? null ) === 'complete') {
+                $state['paths_byte_offset'] = $next_unsent_path_list_offset ?? $last_sent['next_path_list_offset'];
+                $state['current_path_b64'] = null;
+                $state['source_token'] = null;
+                $state['confirmed_bytes'] = 0;
+            } else {
+                $state['paths_byte_offset'] = $last_sent['path_list_offset'];
+                $state['next_paths_byte_offset'] = $last_sent['next_path_list_offset'];
+                $state['current_path_b64'] = $last_sent['path_b64'];
+                $state['source_token'] = $last_sent['source_token'];
+                $state['confirmed_bytes'] = $last_change['accepted_bytes'];
+            }
+            $this->persist_state($state);
+            if ($local_failure_detail !== null) {
+                return $this->step_result('failed', $state, 'local_io_error', $local_failure_detail);
+            }
+            if ($request_size_failure_detail !== null) {
+                return $this->step_result('failed', $state, 'request_size_exhausted', $request_size_failure_detail);
+            }
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'reconciling_deletes') {
+            return $this->reconcile_work_deletes($state);
+        }
+
+        if ($state['phase'] === 'uploading_deletes') {
+            $deletes = fopen($this->journal->work_deletes_path, 'rb');
+            if ($deletes === false || fseek($deletes, $state['work_deletes_byte_offset']) !== 0) {
+                if (is_resource($deletes)) {
+                    fclose($deletes);
+                }
+                return $this->step_result('failed', $state, 'local_io_error', 'Could not open the raw work-delete stream at its receiver-confirmed cursor.');
+            }
+            $reconciliation_state = $state;
+            $reconciliation_state['phase'] = 'reconciling_deletes';
+            $this->persist_state($reconciliation_state);
+            if (!$this->client->start_upload_request($state['push_session_id'])) {
+                fclose($deletes);
+                $request = [
+                    'status' => 'retry',
+                    'reason' => 'request_failed',
+                    'detail' => $this->client->get_last_error(),
+                    'response' => null,
+                    'parts_sent' => 0,
+                    'body_bytes_sent' => 0,
+                ];
+                $failure = $this->handle_request_failure($request, $state);
+                return $failure ?? $this->step_result('failed', $state, 'unexpected_response', 'The work-delete upload failed without a classified result.');
+            }
+            $offset = $state['work_deletes_byte_offset'];
+            $sent_completion = false;
+            $delete_read_failed = false;
+            while (true) {
+                $maximum = $this->client->next_delete_body_bytes($offset);
+                if ($maximum === 0) {
+                    break;
+                }
+                $payload = fread($deletes, $maximum);
+                if (!is_string($payload)) {
+                    $delete_read_failed = true;
+                    break;
+                }
+                $complete = $payload === '' && feof($deletes);
+                if (!$this->client->send_part([
+                    'type' => 'delete-list',
+                    'offset' => $offset,
+                    'complete' => $complete,
+                    'payload' => $payload,
+                ])) {
+                    break;
+                }
+                $offset += strlen($payload);
+                if ($complete) {
+                    $sent_completion = true;
+                    break;
+                }
+                if ($this->client->should_finish_request()) {
+                    break;
+                }
+            }
+            fclose($deletes);
+            $request = $this->client->finish_request();
+            $state['phase'] = 'reconciling_deletes';
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            if ($delete_read_failed) {
+                return $this->step_result('failed', $state, 'local_io_error', 'Could not read the raw work-delete stream at its receiver-confirmed cursor.');
+            }
+            $response = $request['response'];
+            if ($request['parts_sent'] === 0) {
+                return $this->step_result('failed', $state, 'request_size_exhausted', 'The current request-body budget cannot fit one work-delete MIME part.');
+            }
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_int($response['changes_accepted'] ?? null)
+                || $response['changes_accepted'] !== $request['parts_sent']
+                || !is_array($response['last_change'] ?? null)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not return the matching push session and exact accepted work-delete part count.');
+            }
+            $last_change = $response['last_change'];
+            if (
+                ( $last_change['type'] ?? null ) !== 'delete-list'
+                || ( $last_change['state'] ?? null ) !== ( $sent_completion ? 'complete' : 'partial' )
+                || !is_int($last_change['accepted_bytes'] ?? null)
+                || $last_change['accepted_bytes'] !== $offset
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_upload did not confirm the exact work-delete cursor and completion state.');
+            }
+            $state['recoverable_failures'] = 0;
+            $state['work_deletes_byte_offset'] = $last_change['accepted_bytes'];
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, null, null);
+        }
+
+        if ($state['phase'] === 'committing') {
+            $request = $this->control_request('POST', 'push_commit', [
+                'push_session_id' => $state['push_session_id'],
+            ], ['accepted']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !in_array($response['phase'] ?? null, ['deleting_files', 'installing_files', 'complete'], true)
+                || !is_bool($response['send_next_request'] ?? null)
+                || !is_int($response['entries_processed'] ?? null)
+                || $response['entries_processed'] < 0
+                || ( $response['send_next_request'] === ( $response['phase'] === 'complete' ) )
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_commit did not return the matching push session and exact bounded continuation state.');
+            }
+            $state['recoverable_failures'] = 0;
+            if ($response['send_next_request']) {
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, null, null);
+            }
+            $push_session_id = $state['push_session_id'];
+            $this->journal->capture_local_files_baseline($this->journal->sender_index_path);
+            $this->journal->clear_sender_state();
+            return [
+                'status' => 'complete',
+                'phase' => 'complete',
+                'push_session_id' => $push_session_id,
+                'reason' => null,
+                'detail' => null,
+            ];
+        }
+
+        if ($state['phase'] === 'removing') {
+            $request = $this->control_request('POST', 'push_remove', [
+                'push_session_id' => $state['push_session_id'],
+            ], ['accepted']);
+            $failure = $this->handle_request_failure($request, $state);
+            if ($failure !== null) {
+                return $failure;
+            }
+            $response = $request['response'];
+            if (
+                !is_array($response)
+                || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+                || !is_bool($response['removed'] ?? null)
+            ) {
+                return $this->step_result('failed', $state, 'unexpected_response', 'push_remove did not return the matching push session and exact bounded completion state.');
+            }
+            $state['recoverable_failures'] = 0;
+            if (!$response['removed']) {
+                $this->persist_state($state);
+                return $this->step_result('continue', $state, null, null);
+            }
+            $push_session_id = $state['push_session_id'];
+            $this->journal->clear_sender_state();
+            return [
+                'status' => 'restart',
+                'phase' => 'complete',
+                'push_session_id' => $push_session_id,
+                'reason' => 'source_changed',
+                'detail' => 'The abandoned upload-only push session was removed. Regenerate the local index before retrying.',
+            ];
+        }
+
+        return $this->step_result('failed', $state, 'invalid_sender_state', 'Sender state contains an unsupported phase.');
+    }
+
+    /**
+     * Reconciles the raw work-delete stream with the target cursor.
+     *
+     * This request runs both when positive work reaches its path-list end and
+     * after every work-delete upload. A cursor beyond the stable local stream
+     * cannot be resumed, so the upload-only push session is removed before the
+     * caller regenerates its local index.
+     *
+     * @param array<string,mixed> $state Complete sender checkpoint in the exact
+     *     PushJournal::write_sender_state() shape.
+     * @return array{
+     *     status:'continue'|'failed',
+     *     phase:'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:string,
+     *     reason:?string,
+     *     detail:?string
+     * } Result of the real push_status request and durable transition.
+     */
+    private function reconcile_work_deletes(array &$state): array
+    {
+        $request = $this->control_request('GET', 'push_status', [
+            'push_session_id' => $state['push_session_id'],
+        ], ['accepted']);
+        $failure = $this->handle_request_failure($request, $state);
+        if ($failure !== null) {
+            return $failure;
+        }
+        $response = $request['response'];
+        $work_deletes_bytes = is_array($response) ? ( $response['work_deletes_bytes'] ?? null ) : null;
+        $work_deletes_complete = is_array($response) ? ( $response['work_deletes_complete'] ?? null ) : null;
+        $local_work_deletes_bytes = @filesize($this->journal->work_deletes_path);
+        if (
+            !is_array($response)
+            || ( $response['push_session_id'] ?? null ) !== $state['push_session_id']
+            || ( $response['phase'] ?? null ) !== 'receiving_work'
+            || ( $response['path'] ?? null ) !== null
+            || !is_int($work_deletes_bytes)
+            || $work_deletes_bytes < 0
+            || !is_bool($work_deletes_complete)
+        ) {
+            return $this->step_result('failed', $state, 'unexpected_response', 'push_status did not return the exact receiver-confirmed work-delete state.');
+        }
+        if (!is_int($local_work_deletes_bytes)) {
+            return $this->step_result('failed', $state, 'local_io_error', 'Could not read the stable local work-delete stream size.');
+        }
+        if ($work_deletes_bytes > $local_work_deletes_bytes) {
+            $state['phase'] = 'removing';
+            $this->persist_state($state);
+            return $this->step_result('continue', $state, 'source_changed', 'The receiver work-delete cursor cannot belong to the current local deletion list.');
+        }
+        $state['recoverable_failures'] = 0;
+        $state['work_deletes_byte_offset'] = $work_deletes_bytes;
+        $state['phase'] = $work_deletes_complete ? 'committing' : 'uploading_deletes';
+        $this->persist_state($state);
+        return $this->step_result('continue', $state, null, null);
+    }
+
+    /**
+     * Records a changed source token for the open request.
+     *
+     * The durable checkpoint deliberately retains the previous source token
+     * until an upload response confirms a part from the new token. If the
+     * process dies before that response, the mismatch forces another
+     * offset-zero restart instead of accepting an old-version receiver cursor.
+     * A null token likewise leaves the previous evidence in place; if the path
+     * remains absent, status reconciliation removes the upload-only push
+     * session.
+     *
+     * @param array{
+     *     path:string,
+     *     path_b64:string,
+     *     path_list_offset:int,
+     *     next_path_list_offset:int,
+     *     source_token:array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null,
+     *     confirmed_bytes:int
+     * } $current Selected positive-work value for the open request.
+     * @param array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null $source_token
+     *     New source token, or null when the selected path disappeared.
+     */
+    private function record_source_restart(array &$current, ?array $source_token): void
+    {
+        $current['source_token'] = $source_token;
+        $current['confirmed_bytes'] = 0;
+    }
+
+    /**
+     * Sends a signed control request and classifies transport exceptions.
+     *
+     * Redirects are permanent because the HMAC covers the original target,
+     * and invalid JSON is a terminal protocol response. A missing response is
+     * recoverable within the sender's fixed retry bound; repeating create,
+     * status, commit, or remove is idempotent.
+     *
+     * @param string $method GET or POST.
+     * @param string $endpoint Push protocol endpoint.
+     * @param array<string,mixed> $parameters Request-target parameters.
+     * @param list<string> $expected_statuses Successful response statuses.
+     * @return array{
+     *     status:'complete'|'retry'|'failed',
+     *     reason:?string,
+     *     detail:?string,
+     *     response:?array<string,mixed>,
+     *     parts_sent:int,
+     *     body_bytes_sent:int
+     * } Classified control result.
+     */
+    private function control_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
+    {
+        try {
+            return $this->client->control_request($method, $endpoint, $parameters, $expected_statuses);
+        } catch (RuntimeException $exception) {
+            $message = $exception->getMessage();
+            if (strpos($message, 'The target redirected') === 0) {
+                $status = 'failed';
+                $reason = 'redirected';
+            } elseif (strpos($message, 'Push control request returned invalid JSON') === 0) {
+                $status = 'failed';
+                $reason = 'malformed_response';
+            } elseif (strpos($message, 'Push control request failed:') === 0) {
+                $status = 'retry';
+                $reason = 'request_failed';
+            } else {
+                $status = 'failed';
+                $reason = 'client_error';
+            }
+            return [
+                'status' => $status,
+                'reason' => $reason,
+                'detail' => $message,
+                'response' => null,
+                'parts_sent' => 0,
+                'body_bytes_sent' => 0,
+            ];
+        }
+    }
+
+    /**
+     * Indicates whether a selected source directory contains no child entry.
+     *
+     * The directory handle stops at the first name other than `.` or `..`, so
+     * checking a large non-empty directory never materializes its entry list.
+     *
+     * @param string $path Raw document-root-relative directory path.
+     * @return bool|null True for an empty directory, false for a non-empty
+     *     directory, or null when the directory cannot be opened.
+     */
+    private function directory_is_empty(string $path): ?bool
+    {
+        $directory = @opendir($this->docroot . '/' . $path);
+        if ($directory === false) {
+            return null;
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory);
+                if ($entry === false) {
+                    break;
+                }
+                if ($entry !== '.' && $entry !== '..') {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            closedir($directory);
+        }
+    }
+
+    /**
+     * Returns the current source evidence used to decide resume versus restart.
+     *
+     * Paths are document-root-relative byte strings. Regular files,
+     * directories, and symlinks are the only sendable types. Size and ctime
+     * match PushJournal's diff evidence; a changed token restarts the same
+     * in-flight work at offset zero. A same-size edit within one ctime second
+     * remains the documented timestamp-resolution gap.
+     *
+     * @param string $path Raw document-root-relative path.
+     * @return array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null
+     *     Current source token, or null when the path is absent or unsupported.
+     */
+    private function source_token(string $path): ?array
+    {
+        if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false || strpos($path, '\\') !== false) {
+            throw new InvalidArgumentException('A selected push path is not a safe document-root-relative path: ' . base64_encode($path) . '.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException('A selected push path contains an empty, dot, or parent segment: ' . base64_encode($path) . '.');
+            }
+        }
+        $identity = @lstat($this->docroot . '/' . $path);
+        if (!is_array($identity)) {
+            return null;
+        }
+        $kind = $identity['mode'] & 0170000;
+        if ($kind === 0100000) {
+            $type = 'file';
+        } elseif ($kind === 0040000) {
+            $type = 'directory';
+        } elseif ($kind === 0120000) {
+            $type = 'symlink';
+        } else {
+            return null;
+        }
+        return [
+            'type' => $type,
+            'size' => (int) $identity['size'],
+            'ctime' => (int) $identity['ctime'],
+        ];
+    }
+
+    /**
+     * Converts a failed request into a bounded workflow result.
+     *
+     * Complete results return null for phase-specific handling. Recoverable
+     * results increment the durable failure count and become terminal after
+     * five consecutive failures. Permanent protocol results fail immediately.
+     *
+     * @param array{
+     *     status:'complete'|'retry'|'failed',reason:?string,detail:?string,
+     *     response:?array<string,mixed>,parts_sent:int,body_bytes_sent:int
+     * } $request Classified client request result.
+     * @param array<string,mixed> $state Complete sender checkpoint, updated
+     *     and persisted when sizing or retry evidence changes.
+     * @return array{
+     *     status:'continue'|'failed',
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:string,
+     *     reason:?string,
+     *     detail:?string
+     * }|null Null when the request completed successfully.
+     */
+    private function handle_request_failure(array $request, array &$state): ?array
+    {
+        if ($request['status'] === 'complete') {
+            return null;
+        }
+        if ($request['status'] === 'retry') {
+            ++$state['recoverable_failures'];
+            $this->persist_state($state);
+            if ($state['recoverable_failures'] >= self::MAXIMUM_RECOVERABLE_FAILURES) {
+                return $this->step_result(
+                    'failed',
+                    $state,
+                    'retry_exhausted',
+                    'Push stopped after ' . self::MAXIMUM_RECOVERABLE_FAILURES . ' consecutive recoverable failures. Last failure: ' . ( $request['detail'] ?? $request['reason'] )
+                );
+            }
+            return $this->step_result('continue', $state, $request['reason'], $request['detail']);
+        }
+        $this->persist_state($state);
+        return $this->step_result('failed', $state, $request['reason'], $request['detail']);
+    }
+
+    /**
+     * Persists a complete checkpoint with current request-sizing evidence.
+     *
+     * @param array<string,mixed> $state Complete sender state in the exact
+     *     PushJournal::write_sender_state() shape.
+     */
+    private function persist_state(array $state): void
+    {
+        $state['request_sizer_state'] = $this->client->get_request_sizer_state();
+        $this->journal->write_sender_state($state);
+    }
+
+    /**
+     * Builds one exact workflow result without changing durable state.
+     *
+     * @param 'continue'|'failed' $status Step disposition.
+     * @param array<string,mixed> $state Complete sender checkpoint.
+     * @param string|null $reason Machine-readable classification.
+     * @param string|null $detail Human-readable condition.
+     * @return array{
+     *     status:'continue'|'failed',
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     push_session_id:string,
+     *     reason:?string,
+     *     detail:?string
+     * } Step result.
+     */
+    private function step_result(string $status, array $state, ?string $reason, ?string $detail): array
+    {
+        return [
+            'status' => $status,
+            'phase' => $state['phase'],
+            'push_session_id' => $state['push_session_id'],
+            'reason' => $reason,
+            'detail' => $detail,
+        ];
+    }
+}

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -640,7 +640,8 @@ class PushJournal
      *
      * @return array{
      *     push_session_id:string,
-     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     phase:'creating'|'planning'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     planning_checkpoint:PlanningCheckpoint|null,
      *     paths_byte_offset:int,
      *     current_path_b64:?string,
      *     next_paths_byte_offset:int,
@@ -671,11 +672,12 @@ class PushJournal
     }
 
     /**
-     * Atomically records the sender's last receiver-reconcilable boundary.
+     * Atomically records the sender's last durable workflow boundary.
      *
      * @param array{
      *     push_session_id:string,
-     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     phase:'creating'|'planning'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     planning_checkpoint:PlanningCheckpoint|null,
      *     paths_byte_offset:int,
      *     current_path_b64:?string,
      *     next_paths_byte_offset:int,
@@ -715,9 +717,9 @@ class PushJournal
     /**
      * Acquires exclusive ownership of one target site's sender transition.
      *
-     * The lock stays held across the HTTP request and the following checkpoint
-     * write so two legitimate push processes cannot both advance fixed-name
-     * journal files from different snapshots.
+     * The lock stays held across the local planning step or HTTP request and
+     * the following checkpoint write so two legitimate push processes cannot
+     * both advance fixed-name journal files from different snapshots.
      *
      * @return resource|null Lock handle, or null while another process owns it.
      */

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -59,6 +59,9 @@ class PushJournal
     /** @var string Raw NUL-delimited work deletes. */
     public string $work_deletes_path;
 
+    /** @var string Atomic checkpoint for the active high-level sender. */
+    public string $sender_state_path;
+
     /** @var string Enriched current index selected for the active push. */
     public string $sender_index_path;
 
@@ -68,6 +71,7 @@ class PushJournal
         $this->local_files_baseline_path = $this->site_dir . "/last-sync-local-files.jsonl";
         $this->local_paths_to_push = $this->site_dir . "/local-paths-to-push.jsonl";
         $this->work_deletes_path = $this->site_dir . "/work-deletes";
+        $this->sender_state_path = $this->site_dir . "/sender.json";
         $this->sender_index_path = $this->site_dir . "/sender-index.jsonl";
     }
 
@@ -499,6 +503,87 @@ class PushJournal
                     fclose($handle);
                 }
             }
+        }
+    }
+
+    /**
+     * Reads the active sender checkpoint written by write_sender_state().
+     *
+     * The journal owns this private file and atomically replaces it. A valid
+     * JSON object is therefore trusted as the sender's last durable boundary;
+     * the workflow interprets its phase and correlated fields. `source_token`
+     * and `confirmed_bytes` describe the last positive-work part confirmed by
+     * an upload response, not bytes merely handed to the network.
+     *
+     * @return array{
+     *     version:1,
+     *     push_session_id:string,
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     paths_byte_offset:int,
+     *     current_path_b64:?string,
+     *     next_paths_byte_offset:int,
+     *     source_token:array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null,
+     *     confirmed_bytes:int,
+     *     work_deletes_byte_offset:int,
+     *     recoverable_failures:int,
+     *     max_part_bytes:?int,
+     *     request_sizer_state:array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
+     * }|null Durable sender state, or null when no push is active.
+     */
+    public function read_sender_state(): ?array
+    {
+        if (!is_file($this->sender_state_path)) {
+            return null;
+        }
+        $json = file_get_contents($this->sender_state_path);
+        if (!is_string($json)) {
+            throw new RuntimeException("Failed to read sender state: {$this->sender_state_path}");
+        }
+        $state = json_decode($json, true);
+        if (!is_array($state)) {
+            throw new RuntimeException("Sender state does not contain a JSON object: {$this->sender_state_path}");
+        }
+        return $state;
+    }
+
+    /**
+     * Atomically records the sender's last receiver-reconcilable boundary.
+     *
+     * @param array{
+     *     version:1,
+     *     push_session_id:string,
+     *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
+     *     paths_byte_offset:int,
+     *     current_path_b64:?string,
+     *     next_paths_byte_offset:int,
+     *     source_token:array{type:'file'|'directory'|'symlink',size:int,ctime:int}|null,
+     *     confirmed_bytes:int,
+     *     work_deletes_byte_offset:int,
+     *     recoverable_failures:int,
+     *     max_part_bytes:?int,
+     *     request_sizer_state:array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
+     * } $state Complete sender checkpoint.
+     */
+    public function write_sender_state(array $state): void
+    {
+        $this->ensure_site_dir();
+        $json = json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $temporary = $this->sender_state_path . ".tmp";
+        if (file_put_contents($temporary, $json) !== strlen($json)) {
+            throw new RuntimeException("Failed to write sender state: {$temporary}");
+        }
+        if (!rename($temporary, $this->sender_state_path)) {
+            throw new RuntimeException("Failed to move sender state into place: {$this->sender_state_path}");
+        }
+    }
+
+    /**
+     * Removes the completed or deliberately abandoned sender checkpoint.
+     */
+    public function clear_sender_state(): void
+    {
+        if (is_file($this->sender_state_path) && !unlink($this->sender_state_path)) {
+            throw new RuntimeException("Failed to remove sender state: {$this->sender_state_path}");
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-journal.php
+++ b/packages/reprint-importer/src/lib/push/class-push-journal.php
@@ -12,10 +12,11 @@
  *     <state-dir>/push/<site>/last-sync-local-files.jsonl
  *
  * The baseline is the sender index from the last completed push. It uses the
- * .import-index.jsonl fields and adds an `empty` boolean to directory entries.
- * That fact distinguishes an empty directory from a non-empty directory after
- * the source may have changed. The push driver captures the sender index only
- * after the receiver commits successfully.
+ * .import-index.jsonl fields and adds an `empty` boolean to directory entries,
+ * which distinguishes an empty directory from a non-empty directory after the
+ * source may have changed. After the receiver commits, the baseline takes
+ * current evidence for paths the receiver allowed this push to change and
+ * retains prior evidence under excluded paths.
  *
  * diff_local_files() performs one bounded planning step. It merges the
  * path-sorted current index and baseline while writing three durable files:
@@ -112,17 +113,139 @@ class PushJournal
     }
 
     /**
-     * Store an enriched sender index as the new local baseline.
+     * Stores receiver-confirmed local index evidence as the new baseline.
      *
      * The push driver calls this at the end of a successful push; from then
      * on "changed locally" means "different from this index". The copy is
      * atomic (temp file + rename) and the source file is left untouched. A
      * killed process therefore leaves the previous complete baseline in
      * effect rather than publishing a truncated replacement.
+     *
+     * @param string $index_file Enriched current index selected for the push.
+     * @param string[] $excluded_paths Receiver-owned paths. Their prior
+     *     baseline evidence is retained because this push did not change them.
+     * @phpstan-param list<string> $excluded_paths
      */
-    public function capture_local_files_baseline(string $index_file): void
+    public function capture_local_files_baseline(string $index_file, array $excluded_paths = []): void
     {
-        $this->replace_file($this->local_files_baseline_path, $index_file);
+        if ($excluded_paths === []) {
+            $this->replace_file($this->local_files_baseline_path, $index_file);
+            return;
+        }
+        if (!is_file($index_file)) {
+            throw new RuntimeException("Cannot replace a journal file, the source index file is missing: {$index_file}");
+        }
+        $this->ensure_site_dir();
+
+        $current_handle = fopen($index_file, "rb");
+        if (!$current_handle) {
+            throw new RuntimeException("Failed to open the current index: {$index_file}");
+        }
+        $baseline_handle = null;
+        if (is_file($this->local_files_baseline_path)) {
+            $baseline_handle = fopen($this->local_files_baseline_path, "rb");
+            if (!$baseline_handle) {
+                fclose($current_handle);
+                throw new RuntimeException("Failed to open the local baseline: {$this->local_files_baseline_path}");
+            }
+        }
+        $temporary = $this->local_files_baseline_path . ".tmp";
+        $output = fopen($temporary, "wb");
+        if (!$output) {
+            fclose($current_handle);
+            if ($baseline_handle) {
+                fclose($baseline_handle);
+            }
+            throw new RuntimeException("Failed to open the local baseline for writing: {$temporary}");
+        }
+
+        try {
+            $this->read_line(
+                $current_handle,
+                $current_entry,
+                $current_path,
+                $current_base64_path,
+                $next_current_index_byte_offset
+            );
+            $this->read_line(
+                $baseline_handle,
+                $baseline_entry,
+                $baseline_path,
+                $baseline_base64_path,
+                $next_baseline_byte_offset
+            );
+            while ($current_entry !== null || $baseline_entry !== null) {
+                while (
+                    $current_entry !== null
+                    && $this->path_conflicts_with_excluded_paths($current_path, $excluded_paths)
+                ) {
+                    $this->read_line(
+                        $current_handle,
+                        $current_entry,
+                        $current_path,
+                        $current_base64_path,
+                        $next_current_index_byte_offset
+                    );
+                }
+                while (
+                    $baseline_entry !== null
+                    && !$this->path_conflicts_with_excluded_paths($baseline_path, $excluded_paths)
+                ) {
+                    $this->read_line(
+                        $baseline_handle,
+                        $baseline_entry,
+                        $baseline_path,
+                        $baseline_base64_path,
+                        $next_baseline_byte_offset
+                    );
+                }
+                if ($current_entry === null && $baseline_entry === null) {
+                    break;
+                }
+                if (
+                    $baseline_entry === null
+                    || ( $current_entry !== null && strcmp($current_path, $baseline_path) < 0 )
+                ) {
+                    $entry = $current_entry;
+                    $this->read_line(
+                        $current_handle,
+                        $current_entry,
+                        $current_path,
+                        $current_base64_path,
+                        $next_current_index_byte_offset
+                    );
+                } else {
+                    $entry = $baseline_entry;
+                    $this->read_line(
+                        $baseline_handle,
+                        $baseline_entry,
+                        $baseline_path,
+                        $baseline_base64_path,
+                        $next_baseline_byte_offset
+                    );
+                }
+                $line = json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                if (fwrite($output, $line) !== strlen($line)) {
+                    throw new RuntimeException("Short write on the local baseline, is the disk full?");
+                }
+            }
+            if (!fclose($output)) {
+                $output = null;
+                throw new RuntimeException("Failed to close the local baseline: {$temporary}");
+            }
+            $output = null;
+            if (!rename($temporary, $this->local_files_baseline_path)) {
+                throw new RuntimeException("Failed to move the local baseline into place: {$this->local_files_baseline_path}");
+            }
+        } finally {
+            fclose($current_handle);
+            if ($baseline_handle) {
+                fclose($baseline_handle);
+            }
+            if (is_resource($output)) {
+                fclose($output);
+            }
+        }
     }
 
     /**
@@ -516,7 +639,6 @@ class PushJournal
      * an upload response, not bytes merely handed to the network.
      *
      * @return array{
-     *     version:1,
      *     push_session_id:string,
      *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
      *     paths_byte_offset:int,
@@ -527,11 +649,13 @@ class PushJournal
      *     work_deletes_byte_offset:int,
      *     recoverable_failures:int,
      *     max_part_bytes:?int,
+     *     excluded_paths_b64:?list<string>,
      *     request_sizer_state:array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
      * }|null Durable sender state, or null when no push is active.
      */
     public function read_sender_state(): ?array
     {
+        clearstatcache(true, $this->sender_state_path);
         if (!is_file($this->sender_state_path)) {
             return null;
         }
@@ -550,7 +674,6 @@ class PushJournal
      * Atomically records the sender's last receiver-reconcilable boundary.
      *
      * @param array{
-     *     version:1,
      *     push_session_id:string,
      *     phase:'creating'|'reconciling_work'|'uploading_work'|'reconciling_deletes'|'uploading_deletes'|'committing'|'removing',
      *     paths_byte_offset:int,
@@ -561,6 +684,7 @@ class PushJournal
      *     work_deletes_byte_offset:int,
      *     recoverable_failures:int,
      *     max_part_bytes:?int,
+     *     excluded_paths_b64:?list<string>,
      *     request_sizer_state:array{request_body_bytes:int,ceiling_bytes:?int,growth_holdoff_remaining:int}
      * } $state Complete sender checkpoint.
      */
@@ -582,9 +706,41 @@ class PushJournal
      */
     public function clear_sender_state(): void
     {
+        clearstatcache(true, $this->sender_state_path);
         if (is_file($this->sender_state_path) && !unlink($this->sender_state_path)) {
             throw new RuntimeException("Failed to remove sender state: {$this->sender_state_path}");
         }
+    }
+
+    /**
+     * Acquires exclusive ownership of one target site's sender transition.
+     *
+     * The lock stays held across the HTTP request and the following checkpoint
+     * write so two legitimate push processes cannot both advance fixed-name
+     * journal files from different snapshots.
+     *
+     * @return resource|null Lock handle, or null while another process owns it.
+     */
+    public function acquire_sender_lock()
+    {
+        $this->ensure_site_dir();
+        $lock_path = $this->site_dir . "/sender.lock";
+        $lock = fopen($lock_path, "c+b");
+        if (!$lock) {
+            throw new RuntimeException("Failed to open the sender lock: {$lock_path}");
+        }
+        if (!flock($lock, LOCK_EX | LOCK_NB)) {
+            fclose($lock);
+            return null;
+        }
+        return $lock;
+    }
+
+    /** @param resource $lock Lock returned by acquire_sender_lock(). */
+    public function release_sender_lock($lock): void
+    {
+        flock($lock, LOCK_UN);
+        fclose($lock);
     }
 
     /**

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -68,6 +68,115 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertSame(2, $result['parts_sent']);
     }
 
+    /**
+     * Proves that two completed upload requests use one TCP connection.
+     *
+     * The child accepts exactly one socket and serves two complete chunked
+     * requests from it. Opening another connection therefore cannot satisfy
+     * the second request or make this test pass.
+     */
+    public function testBackToBackUploadRequestsReuseTheConnection(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Connection-reuse coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_blocking($connection, false);
+            $pending = '';
+            for ($request_number = 1; $request_number <= 2; ++$request_number) {
+                $deadline = microtime(true) + 8;
+                $header_end = false;
+                $closing_boundary = null;
+                while (true) {
+                    $piece = fread($connection, 64 * 1024);
+                    if (is_string($piece) && $piece !== '') {
+                        $pending .= $piece;
+                    } elseif (microtime(true) > $deadline) {
+                        fclose($connection);
+                        fclose($listener);
+                        exit(4);
+                    } else {
+                        usleep(1000);
+                    }
+                    if ($header_end === false) {
+                        $header_end = strpos($pending, "\r\n\r\n");
+                        if ($header_end !== false) {
+                            $headers = substr($pending, 0, $header_end + 4);
+                            if (
+                                strpos($headers, 'POST /?reprint-api=1&endpoint=push_upload&push_session_id=') === false
+                                || stripos($headers, "Transfer-Encoding: chunked\r\n") === false
+                                || preg_match('/boundary=(reprint-[a-f0-9]+)/', $headers, $matches) !== 1
+                            ) {
+                                fclose($connection);
+                                fclose($listener);
+                                exit(7);
+                            }
+                            $closing_boundary = '--' . $matches[1] . "--\r\n";
+                        }
+                    }
+                    if ($closing_boundary === null) {
+                        continue;
+                    }
+                    $closing_at = strpos($pending, $closing_boundary, $header_end + 4);
+                    if ($closing_at === false) {
+                        continue;
+                    }
+                    $request_end = strpos($pending, "\r\n0\r\n\r\n", $closing_at + strlen($closing_boundary));
+                    if ($request_end === false) {
+                        continue;
+                    }
+                    $pending = substr($pending, $request_end + 7);
+                    break;
+                }
+
+                $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+                $connection_header = $request_number === 1 ? 'keep-alive' : 'close';
+                fwrite(
+                    $connection,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response)
+                        . "\r\nConnection: " . $connection_header . "\r\n\r\n" . $response
+                );
+            }
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        foreach (['first.bin', 'second.bin'] as $request_number => $path) {
+            $this->assertTrue($client->start_upload_request(str_repeat( (string) ( $request_number + 4 ), 32)));
+            $this->assertTrue($client->send_part([
+                'type' => 'file',
+                'path' => $path,
+                'total_bytes' => 1,
+                'offset' => 0,
+                'payload' => 'x',
+            ]));
+            $result = $client->finish_request();
+            $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        }
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status), 'The child must receive both requests on its one accepted connection.');
+    }
+
     public function testTargetPartLimitBoundsTheNextSourceRead(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
@@ -185,6 +294,51 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertLessThan(32 * 1024 * 1024, $client->get_request_sizer_state()['request_body_bytes']);
     }
 
+    /**
+     * Shows that an accepted empty upload is not request-size evidence.
+     *
+     * The target has accepted only a MIME close, so the sender still knows
+     * nothing about whether a larger decoded entity body would pass its stack.
+     */
+    public function testAcceptedEmptyUploadDoesNotGrowTheRequestBudget(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $request_sizer = new PushRequestSizer([
+            'floor_bytes' => 512,
+            'start_bytes' => 512,
+            'max_bytes' => 2048,
+        ]);
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'request_sizer' => $request_sizer,
+            'connect_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        $before = $client->get_request_sizer_state();
+        $this->assertTrue($client->start_upload_request(str_repeat('7', 32)));
+        $connection = stream_socket_accept($listener, 3);
+        $this->assertNotFalse($connection);
+        $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
+        fwrite(
+            $connection,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response)
+                . "\r\nConnection: close\r\n\r\n" . $response
+        );
+        fclose($connection);
+        fclose($listener);
+
+        $result = $client->finish_request();
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame(0, $result['parts_sent']);
+        $this->assertSame($before, $client->get_request_sizer_state());
+    }
+
     public function testStructured413AppliesPostMaxBytesAndPreservesDetail(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
@@ -266,6 +420,98 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertSame('failed', $result['status']);
         $this->assertSame('malformed_response', $result['reason']);
         $this->assertStringContainsString('Invalid JSON response', $result['detail']);
+    }
+
+    /**
+     * Keeps redirects and unknown protocol failures terminal.
+     *
+     * Each case uses a real TCP response. Redirects must name the final target
+     * required for a new signature, while an unrecognized rejection reason is
+     * preserved for the caller instead of being guessed recoverable.
+     */
+    public function testControlRedirectAndUnknownReasonAreTerminal(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Raw control-response coverage requires PHP curl and pcntl.');
+        }
+        foreach (['redirect', 'unknown-reason'] as $case) {
+            $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+            $this->assertNotFalse($listener, (string) $error);
+            $address = stream_socket_get_name($listener, false);
+            $child = pcntl_fork();
+            $this->assertNotSame(-1, $child);
+            if ($child === 0) {
+                $connection = stream_socket_accept($listener, 3);
+                if ($connection === false) {
+                    exit(2);
+                }
+                stream_set_timeout($connection, 3);
+                $request = '';
+                while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                    $piece = fread($connection, 64 * 1024);
+                    if (!is_string($piece) || $piece === '') {
+                        break;
+                    }
+                    $request .= $piece;
+                }
+                if (strpos($request, 'POST /?reprint-api=1&endpoint=push_create&push_session_id=') === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(3);
+                }
+                if ($case === 'redirect') {
+                    fwrite(
+                        $connection,
+                        "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://example.test/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    );
+                } else {
+                    $body = (string) json_encode([
+                        'status' => 'rejected',
+                        'reason' => 'new_protocol_failure',
+                        'detail' => 'The target returned a reason this client does not classify.',
+                    ]);
+                    fwrite(
+                        $connection,
+                        "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: " . strlen($body)
+                            . "\r\nConnection: close\r\n\r\n" . $body
+                    );
+                }
+                fclose($connection);
+                fclose($listener);
+                exit(0);
+            }
+
+            $client = new MultipartPushStreamClient([
+                'base_url' => 'http://' . $address . '/?reprint-api=1',
+                'allow_http' => true,
+                'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+                'connect_timeout' => 2,
+                'response_timeout' => 2,
+            ]);
+            if ($case === 'redirect') {
+                try {
+                    $client->control_request('POST', 'push_create', [
+                        'push_session_id' => str_repeat('8', 32),
+                    ], ['created']);
+                    $this->fail('A redirected control request was accepted.');
+                } catch (\RuntimeException $exception) {
+                    $this->assertSame(
+                        'The target redirected to http://example.test/final. Use that address as the push base_url.',
+                        $exception->getMessage()
+                    );
+                }
+            } else {
+                $result = $client->control_request('POST', 'push_create', [
+                    'push_session_id' => str_repeat('9', 32),
+                ], ['created']);
+                $this->assertSame('failed', $result['status']);
+                $this->assertSame('new_protocol_failure', $result['reason']);
+                $this->assertSame('The target returned a reason this client does not classify.', $result['detail']);
+            }
+            pcntl_waitpid($child, $status);
+            fclose($listener);
+            $this->assertTrue(pcntl_wifexited($status));
+            $this->assertSame(0, pcntl_wexitstatus($status));
+        }
     }
 
     public function testZeroProgressUploadStallStopsWithoutATotalTransferTimeout(): void {

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -9,9 +9,8 @@ use PHPUnit\Framework\TestCase;
  * PHP 7.4 — the push client's PHP 8.1 requirement is enforced at runtime in
  * its constructor, not at parse time. This scan fails when 8.x-only syntax
  * sneaks into the upload or push lib and would fatal 7.4 pull users at require time.
- * The repo-wide lint:php:compat covers the same files but currently fails on
- * unrelated pre-existing findings, so this narrow scan is the enforced
- * regression check.
+ * The repo-wide lint:php:compat covers the same files; this narrow scan keeps
+ * PHP 7.4 parseability tied directly to the push regression suite.
  */
 class PushClientPhpCompatibilityTest extends TestCase
 {

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -8,24 +8,27 @@ use PHPUnit\Framework\TestCase;
  * import.php requires the upload lib for every command, including pull on
  * PHP 7.4 — the push client's PHP 8.1 requirement is enforced at runtime in
  * its constructor, not at parse time. This scan fails when 8.x-only syntax
- * sneaks into the upload lib and would fatal 7.4 pull users at require time.
+ * sneaks into the upload or push lib and would fatal 7.4 pull users at require time.
  * The repo-wide lint:php:compat covers the same files but currently fails on
  * unrelated pre-existing findings, so this narrow scan is the enforced
  * regression check.
  */
 class PushClientPhpCompatibilityTest extends TestCase
 {
-    public function testUploadLibStaysParseableOnPhp74(): void
+    public function testPushLibsStayParseableOnPhp74(): void
     {
         $phpcs_path = realpath(__DIR__ . '/../../vendor/bin/phpcs');
         $upload_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/upload');
+        $push_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/push');
         $this->assertNotFalse($phpcs_path, 'vendor/bin/phpcs is missing; run composer install');
         $this->assertNotFalse($upload_lib_path);
+        $this->assertNotFalse($push_lib_path);
 
         exec(
             escapeshellarg($phpcs_path)
                 . ' --standard=PHPCompatibility --runtime-set testVersion 7.4- -q '
-                . escapeshellarg($upload_lib_path) . ' 2>&1',
+                . escapeshellarg($upload_lib_path) . ' '
+                . escapeshellarg($push_lib_path) . ' 2>&1',
             $scan_output,
             $scan_exit_code
         );

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -677,6 +677,53 @@ final class PushJournalTest extends TestCase
     }
 
     /**
+     * Filters every path that conflicts with receiver-owned exclusions.
+     *
+     * The next baseline combines the current non-excluded evidence with the
+     * last synchronized evidence under excluded roots. This keeps skipped
+     * bytes honest and makes later policy removal detect both changes and
+     * deletions. Paths remain raw bytes throughout.
+     */
+    public function testExcludedPathsFilterWorkAndPreservePriorBaselineEvidence(): void
+    {
+        $arbitrary_bytes_root = "private-\xff";
+        $journal = $this->makeJournal();
+        $journal->capture_local_files_baseline($this->writeIndex([
+            'ordinary-deleted.txt' => [1, 1, 'file'],
+            'private/owned' => [1, 1, 'dir'],
+            'private/owned/deleted.txt' => [1, 1, 'file'],
+            'private/owned/value.txt' => [1, 3, 'file'],
+            $arbitrary_bytes_root . '/value.txt' => [1, 3, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'private' => [2, 2, 'dir'],
+            'private/owned' => [2, 2, 'dir'],
+            'private/owned/value.txt' => [2, 7, 'file'],
+            'private/sibling.txt' => [2, 7, 'file'],
+            $arbitrary_bytes_root . '/value.txt' => [2, 7, 'file'],
+        ]);
+        $excluded_paths = ['private/owned', $arbitrary_bytes_root];
+
+        $this->assertSame(
+            ['changed' => 1, 'deleted' => 1],
+            $journal->diff_local_files($current, $excluded_paths)
+        );
+        $this->assertSame(['private/sibling.txt'], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame(['ordinary-deleted.txt'], $this->listPaths($journal->local_paths_to_delete));
+
+        $journal->capture_local_files_baseline($current, $excluded_paths);
+        $expected_baseline_paths = [
+            'private/owned',
+            'private/owned/deleted.txt',
+            'private/owned/value.txt',
+            'private/sibling.txt',
+            $arbitrary_bytes_root . '/value.txt',
+        ];
+        usort($expected_baseline_paths, 'strcmp');
+        $this->assertSame($expected_baseline_paths, $this->listPaths($journal->local_files_baseline_path));
+    }
+
+    /**
      * Keeps active path lists independent from later caller-index changes.
      *
      * The sender copy, positive-work list, and raw work-delete stream must all
@@ -718,7 +765,6 @@ final class PushJournalTest extends TestCase
     {
         $journal = $this->makeJournal();
         $state = [
-            'version' => 1,
             'push_session_id' => str_repeat('a', 32),
             'phase' => 'reconciling_work',
             'paths_byte_offset' => 17,
@@ -729,6 +775,7 @@ final class PushJournalTest extends TestCase
             'work_deletes_byte_offset' => 7,
             'recoverable_failures' => 2,
             'max_part_bytes' => 4194304,
+            'excluded_paths_b64' => [base64_encode('private')],
             'request_sizer_state' => [
                 'request_body_bytes' => 1048576,
                 'ceiling_bytes' => 2097152,

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -687,31 +687,34 @@ final class PushJournalTest extends TestCase
     public function testExcludedPathsFilterWorkAndPreservePriorBaselineEvidence(): void
     {
         $arbitrary_bytes_root = "private-\xff";
+        mkdir($this->docroot . '/private/owned', 0755, true);
+        file_put_contents($this->docroot . '/private/owned/value.txt', 'changed');
+        file_put_contents($this->docroot . '/private/sibling.txt', 'changed');
+
         $journal = $this->makeJournal();
         $journal->capture_local_files_baseline($this->writeIndex([
             'ordinary-deleted.txt' => [1, 1, 'file'],
-            'private/owned' => [1, 1, 'dir'],
+            'private/owned' => [1, 1, 'dir', false],
             'private/owned/deleted.txt' => [1, 1, 'file'],
             'private/owned/value.txt' => [1, 3, 'file'],
             $arbitrary_bytes_root . '/value.txt' => [1, 3, 'file'],
         ]));
         $current = $this->writeIndex([
-            'private' => [2, 2, 'dir'],
-            'private/owned' => [2, 2, 'dir'],
+            'private' => [$this->pathCtime('private'), 0, 'dir'],
+            'private/owned' => [$this->pathCtime('private/owned'), 0, 'dir'],
             'private/owned/value.txt' => [2, 7, 'file'],
             'private/sibling.txt' => [2, 7, 'file'],
             $arbitrary_bytes_root . '/value.txt' => [2, 7, 'file'],
         ]);
         $excluded_paths = ['private/owned', $arbitrary_bytes_root];
 
-        $this->assertSame(
-            ['changed' => 1, 'deleted' => 1],
-            $journal->diff_local_files($current, $excluded_paths)
-        );
-        $this->assertSame(['private/sibling.txt'], $this->listPaths($journal->local_paths_to_push));
-        $this->assertSame(['ordinary-deleted.txt'], $this->listPaths($journal->local_paths_to_delete));
+        $result = $this->planToCompletion($journal, $current, $excluded_paths);
 
-        $journal->capture_local_files_baseline($current, $excluded_paths);
+        $this->assertPlanningCounts(1, 1, $result);
+        $this->assertSame(['private/sibling.txt'], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame(['ordinary-deleted.txt'], $this->workDeletePaths($journal->work_deletes_path));
+
+        $journal->capture_local_files_baseline($journal->sender_index_path, $excluded_paths);
         $expected_baseline_paths = [
             'private/owned',
             'private/owned/deleted.txt',
@@ -721,38 +724,6 @@ final class PushJournalTest extends TestCase
         ];
         usort($expected_baseline_paths, 'strcmp');
         $this->assertSame($expected_baseline_paths, $this->listPaths($journal->local_files_baseline_path));
-    }
-
-    /**
-     * Keeps active path lists independent from later caller-index changes.
-     *
-     * The sender copy, positive-work list, and raw work-delete stream must all
-     * describe one index so their persisted byte offsets remain meaningful
-     * after the caller replaces or removes its original index file.
-     */
-    public function testActiveSenderIndexAndWorkDeletesStayStable(): void
-    {
-        $journal = $this->makeJournal();
-        $baseline = $this->writeIndex([
-            'delete-me.txt' => [100, 1, 'file'],
-            'keep.txt' => [100, 1, 'file'],
-        ]);
-        $journal->capture_local_files_baseline($baseline);
-        $current = $this->writeIndex([
-            'keep.txt' => [100, 1, 'file'],
-            'new.txt' => [200, 2, 'file'],
-        ]);
-
-        $journal->capture_sender_index($current);
-        $journal->diff_local_files($journal->sender_index_path);
-        $this->assertSame(strlen("delete-me.txt\0"), $journal->prepare_work_deletes());
-        $this->assertSame("delete-me.txt\0", file_get_contents($journal->work_deletes_path));
-
-        file_put_contents($current, $this->indexLine('later.txt', 300, 3, 'file') . "\n");
-        $this->assertSame(['new.txt'], $this->listPaths($journal->local_paths_to_push));
-        $this->assertSame(['delete-me.txt'], $this->listPaths($journal->local_paths_to_delete));
-        $this->assertStringContainsString(base64_encode('new.txt'), (string) file_get_contents($journal->sender_index_path));
-        $this->assertStringNotContainsString(base64_encode('later.txt'), (string) file_get_contents($journal->sender_index_path));
     }
 
     /**
@@ -767,6 +738,23 @@ final class PushJournalTest extends TestCase
         $state = [
             'push_session_id' => str_repeat('a', 32),
             'phase' => 'reconciling_work',
+            'planning_checkpoint' => [
+                'current_index_byte_offset' => 101,
+                'baseline_byte_offset' => 83,
+                'sender_index_bytes' => 111,
+                'local_paths_to_push_bytes' => 37,
+                'work_deletes_bytes' => 12,
+                'changed' => 3,
+                'deleted' => 1,
+                'active_work_delete_roots_b64' => [],
+                'current_index_identity' => [
+                    'device' => 1,
+                    'inode' => 2,
+                    'size' => 101,
+                    'ctime' => 123,
+                    'mtime' => 123,
+                ],
+            ],
             'paths_byte_offset' => 17,
             'current_path_b64' => base64_encode('file.txt'),
             'next_paths_byte_offset' => 41,

--- a/tests/Import/PushJournalTest.php
+++ b/tests/Import/PushJournalTest.php
@@ -676,6 +676,74 @@ final class PushJournalTest extends TestCase
         $this->makeJournal()->diff_local_files($this->tempDir . '/no-such-index.jsonl', $this->docroot);
     }
 
+    /**
+     * Keeps active path lists independent from later caller-index changes.
+     *
+     * The sender copy, positive-work list, and raw work-delete stream must all
+     * describe one index so their persisted byte offsets remain meaningful
+     * after the caller replaces or removes its original index file.
+     */
+    public function testActiveSenderIndexAndWorkDeletesStayStable(): void
+    {
+        $journal = $this->makeJournal();
+        $baseline = $this->writeIndex([
+            'delete-me.txt' => [100, 1, 'file'],
+            'keep.txt' => [100, 1, 'file'],
+        ]);
+        $journal->capture_local_files_baseline($baseline);
+        $current = $this->writeIndex([
+            'keep.txt' => [100, 1, 'file'],
+            'new.txt' => [200, 2, 'file'],
+        ]);
+
+        $journal->capture_sender_index($current);
+        $journal->diff_local_files($journal->sender_index_path);
+        $this->assertSame(strlen("delete-me.txt\0"), $journal->prepare_work_deletes());
+        $this->assertSame("delete-me.txt\0", file_get_contents($journal->work_deletes_path));
+
+        file_put_contents($current, $this->indexLine('later.txt', 300, 3, 'file') . "\n");
+        $this->assertSame(['new.txt'], $this->listPaths($journal->local_paths_to_push));
+        $this->assertSame(['delete-me.txt'], $this->listPaths($journal->local_paths_to_delete));
+        $this->assertStringContainsString(base64_encode('new.txt'), (string) file_get_contents($journal->sender_index_path));
+        $this->assertStringNotContainsString(base64_encode('later.txt'), (string) file_get_contents($journal->sender_index_path));
+    }
+
+    /**
+     * Round-trips and clears the complete sender checkpoint shape.
+     *
+     * The private JSON record is trusted as one atomically replaced unit, so
+     * every correlated cursor and source field must survive unchanged.
+     */
+    public function testSenderStateRoundTripsTheExactCheckpoint(): void
+    {
+        $journal = $this->makeJournal();
+        $state = [
+            'version' => 1,
+            'push_session_id' => str_repeat('a', 32),
+            'phase' => 'reconciling_work',
+            'paths_byte_offset' => 17,
+            'current_path_b64' => base64_encode('file.txt'),
+            'next_paths_byte_offset' => 41,
+            'source_token' => ['type' => 'file', 'size' => 9, 'ctime' => 123],
+            'confirmed_bytes' => 4,
+            'work_deletes_byte_offset' => 7,
+            'recoverable_failures' => 2,
+            'max_part_bytes' => 4194304,
+            'request_sizer_state' => [
+                'request_body_bytes' => 1048576,
+                'ceiling_bytes' => 2097152,
+                'growth_holdoff_remaining' => 1,
+            ],
+        ];
+
+        $this->assertNull($journal->read_sender_state());
+        $journal->write_sender_state($state);
+        $this->assertSame($state, $journal->read_sender_state());
+        $this->assertFileDoesNotExist($journal->sender_state_path . '.tmp');
+        $journal->clear_sender_state();
+        $this->assertNull($journal->read_sender_state());
+    }
+
     // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1326,7 +1326,7 @@ final class PushEndpointsTest extends TestCase {
      * cursor, forcing an offset-zero restart before repeated commit installs
      * the file, empty directory, symlink, replacement, and deletion.
      */
-    public function testHighLevelSenderRestartsChangedSourceAndResumesAfterEveryRequest(): void
+    public function testHighLevelSenderRestartsChangedSourceAndResumesAfterEveryAdvance(): void
     {
         $local_docroot = $this->root . '/local-docroot';
         mkdir($local_docroot . '/nested', 0700, true);
@@ -1368,20 +1368,25 @@ final class PushEndpointsTest extends TestCase {
         $observed_many_values = false;
         $commit_requests = 0;
         $removed_caller_index = false;
+        $observed_planning_checkpoint = false;
         for ($step = 0; $step < 200; ++$step) {
-            // A new object on every step proves that sender.json, target
-            // status, the source token, the learned request size, and the
-            // target part limit are sufficient after process restart.
+            // A new object on every advance proves that sender.json, local
+            // planning outputs, target status, source tokens, and learned
+            // transport limits are sufficient after process restart.
             $state_before_request = $journal->read_sender_state();
             $is_first_upload_request = is_array($state_before_request)
                 && $state_before_request['phase'] === 'uploading_work'
                 && $state_before_request['current_path_b64'] === null
                 && $state_before_request['paths_byte_offset'] === 0;
             $sender = $this->newSender($local_docroot, $current_index, $journal);
-            $result = $sender->send_next_request();
+            $result = $sender->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $journal->read_sender_state();
-            if (!$removed_caller_index && is_array($state)) {
+            if (is_array($state) && $state['phase'] === 'planning') {
+                $this->assertIsArray($state['planning_checkpoint']);
+                $observed_planning_checkpoint = true;
+            }
+            if (!$removed_caller_index && is_array($state) && $state['phase'] !== 'planning') {
                 unlink($current_index);
                 $removed_caller_index = true;
             }
@@ -1410,7 +1415,8 @@ final class PushEndpointsTest extends TestCase {
 
         $this->assertTrue($observed_many_chunks, 'One sender request must confirm more than one bounded file chunk.');
         $this->assertTrue($observed_many_values, 'That same sender request must publish multiple positive-work values before the partial file.');
-        $this->assertTrue($removed_caller_index, 'The active sender must resume from its stable journal index after the caller index disappears.');
+        $this->assertTrue($observed_planning_checkpoint, 'The reconstructed sender must resume the persisted local planning checkpoint.');
+        $this->assertTrue($removed_caller_index, 'After planning, the active sender must resume from immutable journal outputs when the caller index disappears.');
         $this->assertTrue($source_changed, 'The test must edit the source while the receiver has a partial file.');
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertGreaterThan(1, $commit_requests, 'The one-entry endpoint budget must require repeated high-level commit calls.');
@@ -1425,8 +1431,218 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(
             file_get_contents($journal->sender_index_path),
             file_get_contents($journal->local_files_baseline_path),
-            'The stable start-of-push index becomes the baseline; a mid-push source edit is sent but remains detectable on the next diff.'
+            'The completed enriched sender index becomes the baseline; a mid-push source edit is sent but remains detectable on the next diff.'
         );
+    }
+
+    /**
+     * Removes the real upload-only session when the current index changes.
+     *
+     * One reconstructed sender persists a full bounded batch. The index is
+     * then atomically replaced with the same bytes before the next process
+     * consumes its final record, so planning must keep the committed
+     * checkpoint, enter removal, and ask the caller for a newly generated
+     * index only after the target session is gone.
+     */
+    public function testHighLevelSenderRemovesSessionWhenCurrentIndexChangesDuringPlanning(): void
+    {
+        $local_docroot = $this->root . '/planning-drift-source';
+        mkdir($local_docroot, 0700, true);
+        $entries = [];
+        for ($index = 0; $index < 1000; ++$index) {
+            $relative_path = sprintf('file-%04d.txt', $index);
+            file_put_contents($local_docroot . '/' . $relative_path, 'x');
+            $identity = lstat($local_docroot . '/' . $relative_path);
+            $this->assertIsArray($identity);
+            $entries[$relative_path] = [ (int) $identity['ctime'], 1, 'file'];
+        }
+        $directory_path = 'z-planning-directory';
+        mkdir($local_docroot . '/' . $directory_path, 0700);
+        $directory_identity = lstat($local_docroot . '/' . $directory_path);
+        $this->assertIsArray($directory_identity);
+        $entries[$directory_path] = [
+            (int) $directory_identity['ctime'],
+            (int) $directory_identity['size'],
+            'dir',
+        ];
+        $current_index = $this->root . '/planning-drift-index.jsonl';
+        $this->writeIndex($current_index, $entries);
+        $journal = new PushJournal($this->root . '/planning-drift-state', $this->base_url);
+
+        $created = $this->newSender($local_docroot, $current_index, $journal)->advance();
+        $this->assertSame('continue', $created['status'], (string) json_encode($created));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('planning', $state['phase']);
+        $this->assertSame(0, $state['planning_checkpoint']['current_index_byte_offset']);
+
+        // A real client pointed at a closed port proves that a planning
+        // advance performs no HTTP request.
+        $offline_sender = new PushFilesSender([
+            'docroot' => $local_docroot,
+            'current_index_file' => $current_index,
+            'journal' => $journal,
+            'base_url' => 'http://127.0.0.1:1/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 1,
+            'stall_timeout' => 1,
+            'response_timeout' => 1,
+        ]);
+        $planned = $offline_sender->advance();
+        $this->assertSame('continue', $planned['status'], (string) json_encode($planned));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('planning', $state['phase']);
+        $this->assertSame(1000, $state['planning_checkpoint']['changed']);
+        $this->assertGreaterThan(0, $state['planning_checkpoint']['current_index_byte_offset']);
+        $push_session_id = $state['push_session_id'];
+        $this->assertFileDoesNotExist(
+            $this->reprint_directory . '/.reprint/push/' . $push_session_id . '/work/files/file-0000.txt'
+        );
+
+        $replacement_index = $current_index . '.replacement';
+        $index_bytes = file_get_contents($current_index);
+        $this->assertIsString($index_bytes);
+        $this->assertSame(strlen($index_bytes), file_put_contents($replacement_index, $index_bytes));
+        $index_mtime = filemtime($current_index);
+        $this->assertIsInt($index_mtime);
+        $this->assertTrue(touch($replacement_index, $index_mtime + 1));
+        $this->assertTrue(rename($replacement_index, $current_index));
+        clearstatcache(true, $current_index);
+
+        $changed = $this->newSender($local_docroot, $current_index, $journal)->advance();
+        $this->assertSame('continue', $changed['status'], (string) json_encode($changed));
+        $this->assertSame('source_changed', $changed['reason']);
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('removing', $state['phase']);
+        $this->assertSame(1000, $state['planning_checkpoint']['changed']);
+        $this->assertSame(
+            $state['planning_checkpoint']['sender_index_bytes'],
+            filesize($journal->sender_index_path)
+        );
+        $this->assertSame(
+            $state['planning_checkpoint']['local_paths_to_push_bytes'],
+            filesize($journal->local_paths_to_push)
+        );
+        $this->assertSame(
+            $state['planning_checkpoint']['work_deletes_bytes'],
+            filesize($journal->work_deletes_path)
+        );
+
+        for ($step = 0; $step < 20; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('restart', $result['status'], (string) json_encode($result));
+        $this->assertSame('source_changed', $result['reason']);
+        $this->assertNull($journal->read_sender_state());
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+    }
+
+    /**
+     * Removes a session created after the current index disappeared.
+     *
+     * Target create-lock contention leaves the production sender in `creating`.
+     * The source index is removed before the reconstructed process successfully
+     * creates the session, so beginning local planning must enter the same
+     * bounded remove-and-restart lifecycle instead of leaking that session.
+     */
+    public function testHighLevelSenderRemovesCreatedSessionWhenIndexDisappearsBeforePlanning(): void
+    {
+        $local_docroot = $this->root . '/missing-planning-index-source';
+        mkdir($local_docroot, 0700, true);
+        $current_index = $this->root . '/missing-planning-index.jsonl';
+        $this->writeIndex($current_index, []);
+        $journal = new PushJournal($this->root . '/missing-planning-index-state', $this->base_url);
+        $push_sessions_directory = $this->reprint_directory . '/.reprint/push';
+        mkdir($push_sessions_directory, 0700, true);
+        $create_lock_process = $this->startLockProcess($push_sessions_directory . '/push-create.lock');
+
+        try {
+            $contended = $this->newSender($local_docroot, $current_index, $journal)->advance();
+            $this->assertSame('continue', $contended['status'], (string) json_encode($contended));
+            $this->assertSame('lock_acquisition_failure', $contended['reason']);
+            $state = $journal->read_sender_state();
+            $this->assertIsArray($state);
+            $this->assertSame('creating', $state['phase']);
+            $push_session_id = $state['push_session_id'];
+        } finally {
+            $this->stopLockProcess($create_lock_process);
+        }
+
+        unlink($current_index);
+        $changed = $this->newSender($local_docroot, $current_index, $journal)->advance();
+        $this->assertSame('continue', $changed['status'], (string) json_encode($changed));
+        $this->assertSame('source_changed', $changed['reason']);
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('removing', $state['phase']);
+        $this->assertDirectoryExists($push_sessions_directory . '/' . $push_session_id);
+
+        for ($step = 0; $step < 20; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('restart', $result['status'], (string) json_encode($result));
+        $this->assertSame('source_changed', $result['reason']);
+        $this->assertNull($journal->read_sender_state());
+        $this->assertDirectoryDoesNotExist($push_sessions_directory . '/' . $push_session_id);
+    }
+
+    /**
+     * Replaces a target directory with a file through the real endpoint.
+     *
+     * The completed baseline says the old value was a non-empty directory.
+     * Planning must emit the directory root as work delete before upload and
+     * commit can install the file at that same path.
+     */
+    public function testHighLevelSenderReplacesDirectoryWithFile(): void
+    {
+        $relative_path = 'replace-directory';
+        mkdir($this->docroot . '/' . $relative_path, 0700);
+        file_put_contents($this->docroot . '/' . $relative_path . '/old.txt', 'old');
+
+        $local_docroot = $this->root . '/directory-replacement-source';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/' . $relative_path, 'replacement file');
+        $source_identity = lstat($local_docroot . '/' . $relative_path);
+        $this->assertIsArray($source_identity);
+        $current_index = $this->root . '/directory-replacement-index.jsonl';
+        $this->writeIndex($current_index, [
+            $relative_path => [
+                (int) $source_identity['ctime'],
+                (int) $source_identity['size'],
+                'file',
+            ],
+        ]);
+        $baseline = $this->root . '/directory-replacement-baseline.jsonl';
+        $this->writeIndex($baseline, [
+            $relative_path => [1, 0, 'dir', false],
+            $relative_path . '/old.txt' => [1, 3, 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/directory-replacement-state', $this->base_url);
+        $journal->capture_local_files_baseline($baseline);
+
+        for ($step = 0; $step < 100; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertFileExists($this->docroot . '/' . $relative_path);
+        $this->assertSame('replacement file', file_get_contents($this->docroot . '/' . $relative_path));
+        $this->assertNull($journal->read_sender_state());
     }
 
     /**
@@ -1449,7 +1665,7 @@ final class PushEndpointsTest extends TestCase {
 
         try {
             $sender = $this->newSender($local_docroot, $current_index, $journal);
-            $blocked = $sender->send_next_request();
+            $blocked = $sender->advance();
             $this->assertSame('continue', $blocked['status'], (string) json_encode($blocked));
             $this->assertSame('sender_busy', $blocked['reason'], (string) json_encode($blocked));
             $this->assertNull($blocked['push_session_id']);
@@ -1458,12 +1674,13 @@ final class PushEndpointsTest extends TestCase {
             $this->stopLockProcess($sender_lock_process);
         }
 
-        $resumed = $sender->send_next_request();
+        $resumed = $sender->advance();
         $this->assertSame('continue', $resumed['status'], (string) json_encode($resumed));
         $this->assertNull($resumed['reason'], (string) json_encode($resumed));
         $state = $journal->read_sender_state();
         $this->assertIsArray($state);
-        $this->assertSame('reconciling_work', $state['phase']);
+        $this->assertSame('planning', $state['phase']);
+        $this->assertIsArray($state['planning_checkpoint']);
     }
 
     /**
@@ -1499,12 +1716,18 @@ final class PushEndpointsTest extends TestCase {
             'response_timeout' => 5,
         ]);
 
-        $created = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $created = $this->newSender($local_docroot, $current_index, $journal)->advance();
         $this->assertSame('continue', $created['status'], (string) json_encode($created));
-        $reconciled = $stale_sender->send_next_request();
-        $this->assertSame('continue', $reconciled['status'], (string) json_encode($reconciled));
-        $uploaded = $stale_sender->send_next_request();
-        $this->assertSame('continue', $uploaded['status'], (string) json_encode($uploaded));
+        for ($step = 0; $step < 20; ++$step) {
+            $advanced = $stale_sender->advance();
+            $this->assertSame('continue', $advanced['status'], (string) json_encode($advanced));
+            $state = $journal->read_sender_state();
+            $this->assertIsArray($state);
+            $work_file = $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/work/files/value.bin';
+            if (is_file($work_file) && filesize($work_file) === 256) {
+                break;
+            }
+        }
         $state = $journal->read_sender_state();
         $this->assertIsArray($state);
         $this->assertSame(64, $state['max_part_bytes']);
@@ -1546,7 +1769,7 @@ final class PushEndpointsTest extends TestCase {
 
         $baseline = $this->root . '/excluded-baseline.jsonl';
         $this->writeIndex($baseline, [
-            'preserved' => [1, 1, 'dir'],
+            'preserved' => [1, 1, 'dir', false],
             'preserved/deleted-locally.txt' => [1, 11, 'file'],
             'preserved/value.txt' => [1, 4, 'file'],
         ]);
@@ -1554,7 +1777,7 @@ final class PushEndpointsTest extends TestCase {
         $journal->capture_local_files_baseline($baseline);
 
         for ($step = 0; $step < 100; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -1578,7 +1801,7 @@ final class PushEndpointsTest extends TestCase {
 
         $this->writeExcludedPaths([]);
         for ($step = 0; $step < 100; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -1630,7 +1853,7 @@ final class PushEndpointsTest extends TestCase {
             $journal = new PushJournal($this->root . '/drift-state-' . $name, $this->base_url);
 
             for ($step = 0; $step < 100; ++$step) {
-                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
                 $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
                 $state = $journal->read_sender_state();
                 if (
@@ -1648,7 +1871,7 @@ final class PushEndpointsTest extends TestCase {
             $change_source($source_path);
             clearstatcache(true, $source_path);
 
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertSame('continue', $result['status'], $name . ': ' . json_encode($result));
             $this->assertSame('source_changed', $result['reason'], $name);
             $restarted_state = $journal->read_sender_state();
@@ -1667,7 +1890,7 @@ final class PushEndpointsTest extends TestCase {
             }
 
             for (++$step; $step < 200; ++$step) {
-                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
                 $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
                 if ($result['status'] !== 'continue') {
                     break;
@@ -1709,7 +1932,7 @@ final class PushEndpointsTest extends TestCase {
         $journal = new PushJournal($this->root . '/deleted-source-state', $this->base_url);
 
         for ($step = 0; $step < 100; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $journal->read_sender_state();
             if (is_array($state) && $state['confirmed_bytes'] > 64 && $state['confirmed_bytes'] < 2000) {
@@ -1729,7 +1952,7 @@ final class PushEndpointsTest extends TestCase {
         }
         $this->assertSame(0, proc_close($delete_process));
 
-        $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
         $this->assertSame('continue', $result['status'], (string) json_encode($result));
         $state = $journal->read_sender_state();
         $this->assertIsArray($state);
@@ -1741,7 +1964,7 @@ final class PushEndpointsTest extends TestCase {
         );
 
         for (; $step < 200; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -1809,10 +2032,15 @@ final class PushEndpointsTest extends TestCase {
         ]);
         $journal = new PushJournal($this->root . '/retry-state', $this->base_url);
 
-        $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
-        $this->assertSame('continue', $result['status'], (string) json_encode($result));
-        $state = $journal->read_sender_state();
-        $this->assertIsArray($state);
+        for ($step = 0; $step < 10; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
+            $this->assertSame('continue', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            $this->assertIsArray($state);
+            if ($state['phase'] === 'reconciling_work') {
+                break;
+            }
+        }
         $this->assertSame('reconciling_work', $state['phase']);
         $push_lock = fopen(
             $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/push.lock',
@@ -1822,7 +2050,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
         try {
             for ($failure_number = 1; $failure_number <= 5; ++$failure_number) {
-                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
                 $this->assertSame(
                     $failure_number === 5 ? 'failed' : 'continue',
                     $result['status'],
@@ -1904,7 +2132,7 @@ final class PushEndpointsTest extends TestCase {
             'connect_timeout' => 2,
             'response_timeout' => 2,
         ]);
-        $result = $sender->send_next_request();
+        $result = $sender->advance();
         pcntl_waitpid($child, $status);
         fclose($listener);
 
@@ -1998,7 +2226,7 @@ final class PushEndpointsTest extends TestCase {
                 'connect_timeout' => 2,
                 'response_timeout' => 2,
             ]);
-            $result = $sender->send_next_request();
+            $result = $sender->advance();
             pcntl_waitpid($child, $status);
             fclose($listener);
 
@@ -2035,7 +2263,7 @@ final class PushEndpointsTest extends TestCase {
         $journal->capture_local_files_baseline($baseline);
 
         for ($step = 0; $step < 20; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $journal->read_sender_state();
             if (is_array($state) && $state['phase'] === 'reconciling_deletes') {
@@ -2067,7 +2295,7 @@ final class PushEndpointsTest extends TestCase {
         );
 
         for (; $step < 60; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $journal->read_sender_state();
             if (is_array($state) && $state['phase'] === 'committing') {
@@ -2084,7 +2312,7 @@ final class PushEndpointsTest extends TestCase {
             ''
         );
         for (; $step < 120; ++$step) {
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $result = $this->newSender($local_docroot, $current_index, $journal)->advance();
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -2510,23 +2738,28 @@ final class PushEndpointsTest extends TestCase {
         @rmdir($path);
     }
     /**
-     * Writes a path-sorted local index in the production JSONL shape.
+     * Writes a path-sorted current index or enriched baseline JSONL.
      *
-     * @param array<string,array{0:int,1:int,2:'file'|'dir'|'link'}> $entries
-     *     Path to `[ctime, size, type]` records.
+     * @param array<string,array{0:int,1:int,2:'file'|'dir'|'link',3?:bool}> $entries
+     *     Path to `[ctime, size, type, optional directory emptiness]` records.
      */
     private function writeIndex(string $path, array $entries): void
     {
         uksort($entries, 'strcmp');
         $handle = fopen($path, 'wb');
         $this->assertIsResource($handle);
-        foreach ($entries as $entry_path => [$ctime, $size, $type]) {
-            $line = json_encode([
+        foreach ($entries as $entry_path => $index_entry) {
+            [$ctime, $size, $type] = $index_entry;
+            $record = [
                 'path' => base64_encode($entry_path),
                 'ctime' => $ctime,
                 'size' => $size,
                 'type' => $type,
-            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            ];
+            if (array_key_exists(3, $index_entry)) {
+                $record['empty'] = $index_entry[3];
+            }
+            $line = json_encode($record, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
             $this->assertSame(strlen($line), fwrite($handle, $line));
         }
         fclose($handle);

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -57,6 +57,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->reprint_configuration_path, $this->reprint_directory);
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
+            'maximum_part_bytes' => 64,
         ]);
         $this->writeExcludedPaths(['preserved']);
         file_put_contents($this->docroot . '/remove.txt', 'old');
@@ -332,7 +333,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $this->assertSame('created', $create['response']['status']);
         $this->assertSame($push_session_id, $create['response']['push_session_id']);
-        $this->assertSame(4, $create['response']['max_part_bytes']);
+        $this->assertSame(64, $create['response']['max_part_bytes']);
         $this->assertSame(self::POST_MAX_BYTES, $create['response']['post_max_bytes']);
         $this->assertSame(200, $create['response']['http_code']);
         $client->set_max_part_bytes($create['response']['max_part_bytes']);
@@ -628,7 +629,7 @@ final class PushEndpointsTest extends TestCase {
         $expected_response = [
             'status' => 'created',
             'push_session_id' => $push_session_id,
-            'max_part_bytes' => 4,
+            'max_part_bytes' => 64,
             'post_max_bytes' => self::POST_MAX_BYTES,
             'excluded_paths_b64' => $expected_excluded_paths_b64,
             'http_code' => 200,
@@ -1318,9 +1319,6 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
-     */
-    /**
      * Completes a mixed-value push while reconstructing the sender each step.
      *
      * The first upload request carries multiple work values and multiple
@@ -1432,6 +1430,166 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
+     * Defers a sender step while another process owns the same site journal.
+     *
+     * The second call resumes after the lock is released. It must not create a
+     * competing push session or replace any of the first process's fixed-name
+     * journal files while the lock is held.
+     */
+    public function testHighLevelSenderWaitsForLocalJournalLockAndResumes(): void
+    {
+        $local_docroot = $this->root . '/local-lock-source';
+        mkdir($local_docroot, 0700, true);
+        $current_index = $this->root . '/local-lock-index.jsonl';
+        $this->writeIndex($current_index, []);
+        $journal = new PushJournal($this->root . '/local-lock-state', $this->base_url);
+        $site_directory = dirname($journal->sender_state_path);
+        mkdir($site_directory, 0700, true);
+        $sender_lock_process = $this->startLockProcess($site_directory . '/sender.lock');
+
+        try {
+            $sender = $this->newSender($local_docroot, $current_index, $journal);
+            $blocked = $sender->send_next_request();
+            $this->assertSame('continue', $blocked['status'], (string) json_encode($blocked));
+            $this->assertSame('sender_busy', $blocked['reason'], (string) json_encode($blocked));
+            $this->assertNull($blocked['push_session_id']);
+            $this->assertNull($journal->read_sender_state());
+        } finally {
+            $this->stopLockProcess($sender_lock_process);
+        }
+
+        $resumed = $sender->send_next_request();
+        $this->assertSame('continue', $resumed['status'], (string) json_encode($resumed));
+        $this->assertNull($resumed['reason'], (string) json_encode($resumed));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('reconciling_work', $state['phase']);
+    }
+
+    /**
+     * Reloads target limits when another process advanced the sender journal.
+     */
+    public function testHighLevelSenderReloadsStateReadBeforeAnotherProcessAdvancedIt(): void
+    {
+        $local_docroot = $this->root . '/stale-sender-source';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.bin', str_repeat('S', 256));
+        $identity = lstat($local_docroot . '/value.bin');
+        $this->assertIsArray($identity);
+        $current_index = $this->root . '/stale-sender-index.jsonl';
+        $this->writeIndex($current_index, [
+            'value.bin' => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/stale-sender-state', $this->base_url);
+        $stale_sender = new PushFilesSender([
+            'docroot' => $local_docroot,
+            'current_index_file' => $current_index,
+            'journal' => $journal,
+            'base_url' => $this->base_url,
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 128,
+            'request_sizer_config' => [
+                'floor_bytes' => 2048,
+                'start_bytes' => 2048,
+                'max_bytes' => 2048,
+            ],
+            'connect_timeout' => 3,
+            'stall_timeout' => 3,
+            'response_timeout' => 5,
+        ]);
+
+        $created = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $this->assertSame('continue', $created['status'], (string) json_encode($created));
+        $reconciled = $stale_sender->send_next_request();
+        $this->assertSame('continue', $reconciled['status'], (string) json_encode($reconciled));
+        $uploaded = $stale_sender->send_next_request();
+        $this->assertSame('continue', $uploaded['status'], (string) json_encode($uploaded));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame(64, $state['max_part_bytes']);
+        $this->assertSame(
+            str_repeat('S', 256),
+            file_get_contents(
+                $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/work/files/value.bin'
+            )
+        );
+    }
+
+    /**
+     * Applies the receiver's exclusion policy without claiming skipped values.
+     *
+     * The first push preserves an excluded subtree and its prior baseline
+     * evidence. Removing the policy must then select the unchanged local value
+     * and the local deletion that were deliberately skipped before.
+     */
+    public function testHighLevelSenderPreservesExcludedPathsAndReselectsThemAfterPolicyRemoval(): void
+    {
+        file_put_contents($this->docroot . '/preserved/deleted-locally.txt', 'remote-only');
+        $local_docroot = $this->root . '/excluded-source';
+        mkdir($local_docroot . '/preserved', 0700, true);
+        file_put_contents($local_docroot . '/preserved/value.txt', 'local replacement');
+        file_put_contents($local_docroot . '/ordinary.txt', 'ordinary value');
+
+        $preserved_directory_identity = lstat($local_docroot . '/preserved');
+        $preserved_value_identity = lstat($local_docroot . '/preserved/value.txt');
+        $ordinary_identity = lstat($local_docroot . '/ordinary.txt');
+        $this->assertIsArray($preserved_directory_identity);
+        $this->assertIsArray($preserved_value_identity);
+        $this->assertIsArray($ordinary_identity);
+        $current_index = $this->root . '/excluded-current.jsonl';
+        $this->writeIndex($current_index, [
+            'ordinary.txt' => [ (int) $ordinary_identity['ctime'], (int) $ordinary_identity['size'], 'file'],
+            'preserved' => [ (int) $preserved_directory_identity['ctime'], (int) $preserved_directory_identity['size'], 'dir'],
+            'preserved/value.txt' => [ (int) $preserved_value_identity['ctime'], (int) $preserved_value_identity['size'], 'file'],
+        ]);
+
+        $baseline = $this->root . '/excluded-baseline.jsonl';
+        $this->writeIndex($baseline, [
+            'preserved' => [1, 1, 'dir'],
+            'preserved/deleted-locally.txt' => [1, 11, 'file'],
+            'preserved/value.txt' => [1, 4, 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/excluded-state', $this->base_url);
+        $journal->capture_local_files_baseline($baseline);
+
+        for ($step = 0; $step < 100; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('ordinary value', file_get_contents($this->docroot . '/ordinary.txt'));
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertSame('remote-only', file_get_contents($this->docroot . '/preserved/deleted-locally.txt'));
+        $baseline_paths = [];
+        foreach (file($journal->local_files_baseline_path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $record = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $baseline_paths[] = base64_decode($record['path'], true);
+        }
+        $this->assertSame([
+            'ordinary.txt',
+            'preserved',
+            'preserved/deleted-locally.txt',
+            'preserved/value.txt',
+        ], $baseline_paths);
+
+        $this->writeExcludedPaths([]);
+        for ($step = 0; $step < 100; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('local replacement', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertFileDoesNotExist($this->docroot . '/preserved/deleted-locally.txt');
+    }
+
+    /**
      * Restarts every source-drift class from an existing partial file.
      *
      * Growth, shrinkage past the receiver cursor, same-size replacement, and
@@ -1530,8 +1688,10 @@ final class PushEndpointsTest extends TestCase {
     /**
      * Removes the upload-only push session when its selected source vanishes.
      *
-     * The remove response is discarded to prove that a reconstructed sender
-     * repeats bounded removal before asking the caller for a fresh index.
+     * A separate process removes the source without clearing this process's
+     * stat cache. The remove response is then discarded to prove that a
+     * reconstructed sender repeats bounded removal before asking the caller
+     * for a fresh index.
      */
     public function testHighLevelSenderRemovesUploadOnlySessionWhenCurrentSourceDisappears(): void
     {
@@ -1558,8 +1718,16 @@ final class PushEndpointsTest extends TestCase {
         }
         $this->assertIsArray($state);
         $push_session_id = $state['push_session_id'];
-        unlink($source_path);
-        clearstatcache(true, $source_path);
+        $delete_process = proc_open(
+            [PHP_BINARY, '-r', 'unlink($argv[1]);', $source_path],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $delete_pipes
+        );
+        $this->assertIsResource($delete_process);
+        foreach ($delete_pipes as $delete_pipe) {
+            fclose($delete_pipe);
+        }
+        $this->assertSame(0, proc_close($delete_process));
 
         $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
         $this->assertSame('continue', $result['status'], (string) json_encode($result));
@@ -1584,6 +1752,41 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($journal->read_sender_state());
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
         $this->assertFileDoesNotExist($this->docroot . '/' . $relative_path);
+    }
+
+    /**
+     * Observes an external source deletion instead of reusing cached identity.
+     */
+    public function testHighLevelSenderSourceTokenSeesExternalDeletion(): void
+    {
+        $local_docroot = $this->root . '/source-token-cache';
+        mkdir($local_docroot, 0700, true);
+        $relative_path = 'cached.txt';
+        $source_path = $local_docroot . '/' . $relative_path;
+        file_put_contents($source_path, 'cached');
+        $identity = lstat($source_path);
+        $this->assertIsArray($identity);
+        $current_index = $this->root . '/source-token-cache.jsonl';
+        $this->writeIndex($current_index, [
+            $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/source-token-cache-state', $this->base_url);
+        $sender = $this->newSender($local_docroot, $current_index, $journal);
+        $source_token = new ReflectionMethod(PushFilesSender::class, 'source_token');
+        $this->assertIsArray($source_token->invoke($sender, $relative_path));
+
+        $delete_process = proc_open(
+            [PHP_BINARY, '-r', 'unlink($argv[1]);', $source_path],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $delete_pipes
+        );
+        $this->assertIsResource($delete_process);
+        foreach ($delete_pipes as $delete_pipe) {
+            fclose($delete_pipe);
+        }
+        $this->assertSame(0, proc_close($delete_process));
+
+        $this->assertNull($source_token->invoke($sender, $relative_path));
     }
 
     /**
@@ -1716,122 +1919,96 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Resumes from target-confirmed bytes after three interrupted requests.
-     *
-     * Raw chunked connections close before a part, within its declared body,
-     * and after a valid complete part without reading the response. The sender's
-     * durable checkpoint still names the same path with no optimistic cursor;
-     * status must recover zero until a complete MIME part was accepted, and
-     * the complete part's byte count afterward.
+     * Rejects malformed receiver exclusion policies before any upload begins.
      */
-    public function testHighLevelSenderReconcilesInterruptedUploadParts(): void
+    public function testHighLevelSenderRequiresCanonicalExcludedPathsFromCreate(): void
     {
-        $interruptions = [
-            'before-part' => ['', 0],
-            'within-part' => [str_repeat('I', 32), 0],
-            'after-part' => [str_repeat('I', 64), 64],
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Malformed create-response coverage requires PHP curl and pcntl.');
+        }
+        $invalid_policies = [
+            'missing' => null,
+            'not-a-list' => ['path' => base64_encode('private')],
+            'non-string' => [123],
+            'bad-base64' => ['***'],
+            'unsafe' => [base64_encode('../private')],
+            'unsorted' => [base64_encode('z-private'), base64_encode('a-private')],
+            'duplicate' => [base64_encode('private'), base64_encode('private')],
         ];
-        $base_url = parse_url($this->base_url);
-        $this->assertIsArray($base_url);
-        $this->assertIsString($base_url['host'] ?? null);
-        $this->assertIsInt($base_url['port'] ?? null);
 
-        foreach ($interruptions as $name => [$interrupted_payload, $expected_cursor]) {
-            $local_docroot = $this->root . '/interrupted-' . $name;
+        foreach ($invalid_policies as $name => $invalid_policy) {
+            $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
+            $this->assertNotFalse($listener, $name . ': ' . $error_message);
+            $address = stream_socket_get_name($listener, false);
+            $this->assertIsString($address);
+            $child = pcntl_fork();
+            $this->assertNotSame(-1, $child);
+            if ($child === 0) {
+                $connection = stream_socket_accept($listener, 3);
+                if ($connection === false) {
+                    exit(2);
+                }
+                stream_set_timeout($connection, 3);
+                $request = '';
+                while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                    $piece = fread($connection, 64 * 1024);
+                    if (!is_string($piece) || $piece === '') {
+                        break;
+                    }
+                    $request .= $piece;
+                }
+                if (!preg_match('/[?&]push_session_id=([a-f0-9]{32})/', $request, $matches)) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(3);
+                }
+                $response = [
+                    'status' => 'created',
+                    'push_session_id' => $matches[1],
+                    'max_part_bytes' => 64,
+                    'post_max_bytes' => self::POST_MAX_BYTES,
+                ];
+                if ($invalid_policy !== null) {
+                    $response['excluded_paths_b64'] = $invalid_policy;
+                }
+                $body = json_encode($response, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+                fwrite(
+                    $connection,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($body)
+                        . "\r\nConnection: close\r\n\r\n" . $body
+                );
+                fclose($connection);
+                fclose($listener);
+                exit(0);
+            }
+
+            $local_docroot = $this->root . '/invalid-exclusions-' . $name;
             mkdir($local_docroot, 0700, true);
-            $relative_path = 'interrupted-' . $name . '.bin';
-            $source_path = $local_docroot . '/' . $relative_path;
-            file_put_contents($source_path, str_repeat('I', 2000));
-            $identity = lstat($source_path);
-            $this->assertIsArray($identity);
-            $current_index = $this->root . '/interrupted-' . $name . '.jsonl';
-            $this->writeIndex($current_index, [
-                $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+            $current_index = $this->root . '/invalid-exclusions-' . $name . '.jsonl';
+            $this->writeIndex($current_index, []);
+            $base_url = 'http://' . $address . '/?reprint-api=1';
+            $journal = new PushJournal($this->root . '/invalid-exclusions-state-' . $name, $base_url);
+            $sender = new PushFilesSender([
+                'docroot' => $local_docroot,
+                'current_index_file' => $current_index,
+                'journal' => $journal,
+                'base_url' => $base_url,
+                'allow_http' => true,
+                'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+                'connect_timeout' => 2,
+                'response_timeout' => 2,
             ]);
-            $journal = new PushJournal($this->root . '/interrupted-state-' . $name, $this->base_url);
-            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
-            $this->assertSame('continue', $result['status'], $name . ': ' . json_encode($result));
+            $result = $sender->send_next_request();
+            pcntl_waitpid($child, $status);
+            fclose($listener);
+
+            $this->assertSame('failed', $result['status'], $name . ': ' . json_encode($result));
+            $this->assertSame('unexpected_response', $result['reason'], $name . ': ' . json_encode($result));
             $state = $journal->read_sender_state();
-            $this->assertIsArray($state);
-
-            $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'];
-            $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
-            $boundary = 'reprint-interrupted-' . str_replace('-', '', $name);
-            $mime_headers = '--' . $boundary . "\r\n"
-                . "X-Chunk-Type: file\r\n"
-                . 'X-File-Path: ' . base64_encode($relative_path) . "\r\n"
-                . "X-File-Size: 2000\r\n"
-                . "X-Chunk-Offset: 0\r\n"
-                . "Content-Length: 64\r\n\r\n";
-            $request_body = $interrupted_payload === '' ? '' : $mime_headers . $interrupted_payload;
-            if ($interrupted_payload !== '') {
-                $request_body .= "\r\n";
-            }
-            $complete_request = $name === 'after-part';
-            if ($complete_request) {
-                $request_body .= '--' . $boundary . "--\r\n";
-            }
-            $connection = stream_socket_client(
-                'tcp://' . $base_url['host'] . ':' . $base_url['port'],
-                $error_number,
-                $error_message,
-                3
-            );
-            $this->assertIsResource($connection, $error_message);
-            $request_target = (string) $base_url['path'] . '?' . $base_url['query']
-                . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'];
-            $request_headers = "POST " . $request_target . " HTTP/1.1\r\n"
-                . 'Host: ' . $base_url['host'] . ':' . $base_url['port'] . "\r\n"
-                . 'Content-Type: multipart/mixed; boundary=' . $boundary . "\r\n"
-                . "Transfer-Encoding: chunked\r\nConnection: close\r\n";
-            foreach ($authentication_headers as $header_name => $header_value) {
-                $request_headers .= $header_name . ': ' . $header_value . "\r\n";
-            }
-            $request_headers .= "\r\n";
-            if ($request_body !== '') {
-                $request_headers .= dechex(strlen($request_body)) . "\r\n" . $request_body . "\r\n";
-            }
-            if ($complete_request) {
-                $request_headers .= "0\r\n\r\n";
-            }
-            $this->assertSame(strlen($request_headers), fwrite($connection, $request_headers));
-            // The first two variants truncate the request. The third sends a
-            // complete body but discards the response immediately.
-            fclose($connection);
-
-            $state['phase'] = 'reconciling_work';
-            $state['current_path_b64'] = base64_encode($relative_path);
-            $state['next_paths_byte_offset'] = filesize($journal->local_paths_to_push);
-            $state['source_token'] = [
-                'type' => 'file',
-                'size' => (int) $identity['size'],
-                'ctime' => (int) $identity['ctime'],
-            ];
-            $state['confirmed_bytes'] = 0;
-            $journal->write_sender_state($state);
-
-            for ($attempt = 0; $attempt < 20; ++$attempt) {
-                $status = $this->newClient(self::SECRET)->control_request('GET', 'push_status', [
-                    'push_session_id' => $state['push_session_id'],
-                    'path_b64' => base64_encode($relative_path),
-                ], ['accepted']);
-                if ($status['status'] === 'complete') {
-                    break;
-                }
-                usleep(10000);
-            }
-            $this->assertSame('complete', $status['status'], $name . ': ' . json_encode($status));
-            $this->assertSame($expected_cursor, $status['response']['path']['accepted_bytes'], $name);
-
-            for ($step = 0; $step < 200; ++$step) {
-                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
-                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
-                if ($result['status'] !== 'continue') {
-                    break;
-                }
-            }
-            $this->assertSame('complete', $result['status'], $name . ': ' . json_encode($result));
-            $this->assertSame(str_repeat('I', 2000), file_get_contents($this->docroot . '/' . $relative_path));
+            $this->assertIsArray($state, $name);
+            $this->assertSame('creating', $state['phase'], $name);
+            $this->assertTrue(pcntl_wifexited($status), $name);
+            $this->assertSame(0, pcntl_wexitstatus($status), $name);
         }
     }
 
@@ -1917,8 +2094,9 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileDoesNotExist($this->docroot . '/delete-after-lost-response.txt');
         $this->assertNull($journal->read_sender_state());
     }
-
-
+    /**
+     * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
+     */
     private function sendChunkedUploadRequest(
         string $base_url,
         string $push_session_id,
@@ -2105,18 +2283,6 @@ final class PushEndpointsTest extends TestCase {
             'response_timeout' => 5,
         ]);
     }
-
-    /**
-     * Sends one complete signed POST request and discards its response.
-     *
-     * Closing the socket immediately after the terminating transfer chunk
-     * reproduces a sender that cannot know whether the target completed the
-     * operation. The caller must reconcile from target state afterward.
-     *
-     * @param string $url Exact push endpoint URL to authenticate and request.
-     * @param string|null $content_type Request Content-Type, or null when the
-     *     endpoint has no body format.
-     * @param string $body Decoded HTTP entity body.
 
     /**
      * @param resource|null $process PHP built-in server process.

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1320,6 +1320,605 @@ final class PushEndpointsTest extends TestCase {
     /**
      * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
      */
+    /**
+     * Completes a mixed-value push while reconstructing the sender each step.
+     *
+     * The first upload request carries multiple work values and multiple
+     * bounded chunks. The large file then changes behind a partial receiver
+     * cursor, forcing an offset-zero restart before repeated commit installs
+     * the file, empty directory, symlink, replacement, and deletion.
+     */
+    public function testHighLevelSenderRestartsChangedSourceAndResumesAfterEveryRequest(): void
+    {
+        $local_docroot = $this->root . '/local-docroot';
+        mkdir($local_docroot . '/nested', 0700, true);
+        mkdir($local_docroot . '/empty-directory', 0700, true);
+        file_put_contents($local_docroot . '/nested/large.bin', str_repeat('A', 2000));
+        file_put_contents($local_docroot . '/same-size.txt', 'new!');
+        symlink('nested/large.bin', $local_docroot . '/file-link');
+        file_put_contents($this->docroot . '/same-size.txt', 'old!');
+
+        $large_identity = lstat($local_docroot . '/nested/large.bin');
+        $same_size_identity = lstat($local_docroot . '/same-size.txt');
+        $link_identity = lstat($local_docroot . '/file-link');
+        $nested_identity = lstat($local_docroot . '/nested');
+        $empty_identity = lstat($local_docroot . '/empty-directory');
+        $this->assertIsArray($large_identity);
+        $this->assertIsArray($same_size_identity);
+        $this->assertIsArray($link_identity);
+        $this->assertIsArray($nested_identity);
+        $this->assertIsArray($empty_identity);
+        $current_index = $this->root . '/current-index.jsonl';
+        $this->writeIndex($current_index, [
+            'empty-directory' => [ (int) $empty_identity['ctime'], (int) $empty_identity['size'], 'dir'],
+            'file-link' => [ (int) $link_identity['ctime'], (int) $link_identity['size'], 'link'],
+            'nested' => [ (int) $nested_identity['ctime'], (int) $nested_identity['size'], 'dir'],
+            'nested/large.bin' => [ (int) $large_identity['ctime'], (int) $large_identity['size'], 'file'],
+            'same-size.txt' => [ (int) $same_size_identity['ctime'], (int) $same_size_identity['size'], 'file'],
+        ]);
+
+        $journal = new PushJournal($this->root . '/sender-state', $this->base_url);
+        $baseline = $this->root . '/baseline-index.jsonl';
+        $this->writeIndex($baseline, [
+            'remove.txt' => [1, 3, 'file'],
+            'same-size.txt' => [1, 4, 'file'],
+        ]);
+        $journal->capture_local_files_baseline($baseline);
+
+        $source_changed = false;
+        $observed_many_chunks = false;
+        $observed_many_values = false;
+        $commit_requests = 0;
+        $removed_caller_index = false;
+        for ($step = 0; $step < 200; ++$step) {
+            // A new object on every step proves that sender.json, target
+            // status, the source token, the learned request size, and the
+            // target part limit are sufficient after process restart.
+            $state_before_request = $journal->read_sender_state();
+            $is_first_upload_request = is_array($state_before_request)
+                && $state_before_request['phase'] === 'uploading_work'
+                && $state_before_request['current_path_b64'] === null
+                && $state_before_request['paths_byte_offset'] === 0;
+            $sender = $this->newSender($local_docroot, $current_index, $journal);
+            $result = $sender->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (!$removed_caller_index && is_array($state)) {
+                unlink($current_index);
+                $removed_caller_index = true;
+            }
+            if (is_array($state) && $state['phase'] === 'committing') {
+                ++$commit_requests;
+            }
+            if ($is_first_upload_request) {
+                $this->assertIsArray($state);
+                $this->assertSame(base64_encode('nested/large.bin'), $state['current_path_b64']);
+                $this->assertGreaterThan(64, $state['confirmed_bytes']);
+                $this->assertLessThan(2000, $state['confirmed_bytes']);
+                $work_files = $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/work/files';
+                $this->assertDirectoryExists($work_files . '/empty-directory');
+                $this->assertTrue(is_link($work_files . '/file-link'));
+                $observed_many_chunks = true;
+                $observed_many_values = true;
+                sleep(1);
+                file_put_contents($local_docroot . '/nested/large.bin', str_repeat('B', 2000));
+                clearstatcache(true, $local_docroot . '/nested/large.bin');
+                $source_changed = true;
+            }
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+
+        $this->assertTrue($observed_many_chunks, 'One sender request must confirm more than one bounded file chunk.');
+        $this->assertTrue($observed_many_values, 'That same sender request must publish multiple positive-work values before the partial file.');
+        $this->assertTrue($removed_caller_index, 'The active sender must resume from its stable journal index after the caller index disappears.');
+        $this->assertTrue($source_changed, 'The test must edit the source while the receiver has a partial file.');
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertGreaterThan(1, $commit_requests, 'The one-entry endpoint budget must require repeated high-level commit calls.');
+        $this->assertSame(str_repeat('B', 2000), file_get_contents($this->docroot . '/nested/large.bin'));
+        $this->assertSame('new!', file_get_contents($this->docroot . '/same-size.txt'));
+        $this->assertDirectoryExists($this->docroot . '/empty-directory');
+        $this->assertTrue(is_link($this->docroot . '/file-link'));
+        $this->assertSame('nested/large.bin', readlink($this->docroot . '/file-link'));
+        $this->assertFileDoesNotExist($this->docroot . '/remove.txt');
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertNull($journal->read_sender_state());
+        $this->assertSame(
+            file_get_contents($journal->sender_index_path),
+            file_get_contents($journal->local_files_baseline_path),
+            'The stable start-of-push index becomes the baseline; a mid-push source edit is sent but remains detectable on the next diff.'
+        );
+    }
+
+    /**
+     * Restarts every source-drift class from an existing partial file.
+     *
+     * Growth, shrinkage past the receiver cursor, same-size replacement, and
+     * a file-to-directory change must all replace the old prefix rather than
+     * append bytes from a different source value.
+     */
+    public function testHighLevelSenderRestartsGrownShrunkSameSizeAndTypeChangedFiles(): void
+    {
+        $variants = [
+            'grew' => static function (string $path): void {
+                file_put_contents($path, str_repeat('G', 2500));
+            },
+            'shrank' => static function (string $path): void {
+                file_put_contents($path, str_repeat('S', 100));
+            },
+            'same-size' => static function (string $path): void {
+                file_put_contents($path, str_repeat('E', 2000));
+            },
+            'type-change' => static function (string $path): void {
+                unlink($path);
+                mkdir($path, 0700);
+                file_put_contents($path . '/appeared-after-index.txt', 'later');
+            },
+        ];
+
+        foreach ($variants as $name => $change_source) {
+            $local_docroot = $this->root . '/drift-' . $name;
+            mkdir($local_docroot, 0700, true);
+            $relative_path = 'value-' . $name;
+            $source_path = $local_docroot . '/' . $relative_path;
+            file_put_contents($source_path, str_repeat('O', 2000));
+            $identity = lstat($source_path);
+            $this->assertIsArray($identity);
+            $current_index = $this->root . '/drift-' . $name . '.jsonl';
+            $this->writeIndex($current_index, [
+                $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+            ]);
+            $journal = new PushJournal($this->root . '/drift-state-' . $name, $this->base_url);
+
+            for ($step = 0; $step < 100; ++$step) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
+                $state = $journal->read_sender_state();
+                if (
+                    is_array($state)
+                    && $state['current_path_b64'] === base64_encode($relative_path)
+                    && $state['confirmed_bytes'] > 64
+                    && $state['confirmed_bytes'] < 2000
+                ) {
+                    break;
+                }
+            }
+            $this->assertIsArray($state, $name);
+            $this->assertGreaterThan(64, $state['confirmed_bytes'], $name);
+            sleep(1);
+            $change_source($source_path);
+            clearstatcache(true, $source_path);
+
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertSame('continue', $result['status'], $name . ': ' . json_encode($result));
+            $this->assertSame('source_changed', $result['reason'], $name);
+            $restarted_state = $journal->read_sender_state();
+            $this->assertIsArray($restarted_state, $name);
+            $this->assertSame('uploading_work', $restarted_state['phase'], $name);
+            $this->assertSame($state['source_token'], $restarted_state['source_token'], $name);
+            $this->assertSame($state['confirmed_bytes'], $restarted_state['confirmed_bytes'], $name);
+            if ($name === 'shrank') {
+                $shrunken_identity = lstat($source_path);
+                $this->assertIsArray($shrunken_identity);
+                $this->assertGreaterThan(
+                    $shrunken_identity['size'],
+                    $state['confirmed_bytes'],
+                    'The target cursor must begin beyond the shrunken source EOF.'
+                );
+            }
+
+            for (++$step; $step < 200; ++$step) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
+                if ($result['status'] !== 'continue') {
+                    break;
+                }
+            }
+            $this->assertSame('complete', $result['status'], $name . ': ' . json_encode($result));
+            $target_path = $this->docroot . '/' . $relative_path;
+            if ($name === 'type-change') {
+                $this->assertFileExists($source_path . '/appeared-after-index.txt');
+                $this->assertDirectoryExists($target_path);
+                $this->assertSame([], array_values(array_diff(scandir($target_path) ?: [], ['.', '..'])));
+            } else {
+                $this->assertSame(file_get_contents($source_path), file_get_contents($target_path), $name);
+            }
+        }
+    }
+
+    /**
+     * Removes the upload-only push session when its selected source vanishes.
+     *
+     * The remove response is discarded to prove that a reconstructed sender
+     * repeats bounded removal before asking the caller for a fresh index.
+     */
+    public function testHighLevelSenderRemovesUploadOnlySessionWhenCurrentSourceDisappears(): void
+    {
+        $local_docroot = $this->root . '/deleted-source';
+        mkdir($local_docroot, 0700, true);
+        $relative_path = 'deleted-source.bin';
+        $source_path = $local_docroot . '/' . $relative_path;
+        file_put_contents($source_path, str_repeat('D', 2000));
+        $identity = lstat($source_path);
+        $this->assertIsArray($identity);
+        $current_index = $this->root . '/deleted-source.jsonl';
+        $this->writeIndex($current_index, [
+            $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/deleted-source-state', $this->base_url);
+
+        for ($step = 0; $step < 100; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (is_array($state) && $state['confirmed_bytes'] > 64 && $state['confirmed_bytes'] < 2000) {
+                break;
+            }
+        }
+        $this->assertIsArray($state);
+        $push_session_id = $state['push_session_id'];
+        unlink($source_path);
+        clearstatcache(true, $source_path);
+
+        $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $this->assertSame('continue', $result['status'], (string) json_encode($result));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('removing', $state['phase']);
+        $this->sendPostAndDiscardResponse(
+            $this->base_url . '&endpoint=push_remove&push_session_id=' . $push_session_id,
+            null,
+            ''
+        );
+
+        for (; $step < 200; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('restart', $result['status'], (string) json_encode($result));
+        $this->assertSame('source_changed', $result['reason']);
+        $this->assertNull($journal->read_sender_state());
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
+        $this->assertFileDoesNotExist($this->docroot . '/' . $relative_path);
+    }
+
+    /**
+     * Verifies that recoverable target contention becomes a terminal result.
+     *
+     * The real push lock remains held while five reconstructed senders query
+     * status. Each one reads the durable failure count left by the previous
+     * process boundary; the fifth must stop instead of returning a final retry.
+     */
+    public function testHighLevelSenderStopsAfterBoundedRecoverableFailures(): void
+    {
+        $local_docroot = $this->root . '/retry-source';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'value');
+        $identity = lstat($local_docroot . '/value.txt');
+        $this->assertIsArray($identity);
+        $current_index = $this->root . '/retry-source.jsonl';
+        $this->writeIndex($current_index, [
+            'value.txt' => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/retry-state', $this->base_url);
+
+        $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+        $this->assertSame('continue', $result['status'], (string) json_encode($result));
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame('reconciling_work', $state['phase']);
+        $push_lock = fopen(
+            $this->reprint_directory . '/.reprint/push/' . $state['push_session_id'] . '/push.lock',
+            'r+b'
+        );
+        $this->assertIsResource($push_lock);
+        $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
+        try {
+            for ($failure_number = 1; $failure_number <= 5; ++$failure_number) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertSame(
+                    $failure_number === 5 ? 'failed' : 'continue',
+                    $result['status'],
+                    (string) json_encode($result)
+                );
+            }
+        } finally {
+            flock($push_lock, LOCK_UN);
+            fclose($push_lock);
+        }
+
+        $this->assertSame('retry_exhausted', $result['reason']);
+        $this->assertStringContainsString('5 consecutive recoverable failures', $result['detail']);
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame(5, $state['recoverable_failures']);
+    }
+
+    /**
+     * Rejects a malformed control response without spending the retry budget.
+     *
+     * A real TCP peer accepts push_create and returns a non-JSON entity body.
+     * The response is complete and unambiguous, so repeating it cannot repair
+     * the protocol violation and must not be classified like a lost response.
+     */
+    public function testHighLevelSenderTreatsMalformedControlResponseAsTerminal(): void
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Malformed control-response coverage requires PHP curl and pcntl.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
+        $this->assertNotFalse($listener, $error_message);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_timeout($connection, 3);
+            $request = '';
+            while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    break;
+                }
+                $request .= $piece;
+            }
+            if (strpos($request, 'endpoint=push_create') === false) {
+                fclose($connection);
+                fclose($listener);
+                exit(3);
+            }
+            $body = '<html>not a push response</html>';
+            fwrite(
+                $connection,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: " . strlen($body)
+                    . "\r\nConnection: close\r\n\r\n" . $body
+            );
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $local_docroot = $this->root . '/malformed-response-source';
+        mkdir($local_docroot, 0700, true);
+        $current_index = $this->root . '/malformed-response-index.jsonl';
+        $this->writeIndex($current_index, []);
+        $journal = new PushJournal($this->root . '/malformed-response-state', 'http://' . $address . '/?reprint-api=1');
+        $sender = new PushFilesSender([
+            'docroot' => $local_docroot,
+            'current_index_file' => $current_index,
+            'journal' => $journal,
+            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        $result = $sender->send_next_request();
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertSame('failed', $result['status'], (string) json_encode($result));
+        $this->assertSame('malformed_response', $result['reason']);
+        $this->assertStringContainsString('invalid JSON', $result['detail']);
+        $state = $journal->read_sender_state();
+        $this->assertIsArray($state);
+        $this->assertSame(0, $state['recoverable_failures']);
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+    }
+
+    /**
+     * Resumes from target-confirmed bytes after three interrupted requests.
+     *
+     * Raw chunked connections close before a part, within its declared body,
+     * and after a valid complete part without reading the response. The sender's
+     * durable checkpoint still names the same path with no optimistic cursor;
+     * status must recover zero until a complete MIME part was accepted, and
+     * the complete part's byte count afterward.
+     */
+    public function testHighLevelSenderReconcilesInterruptedUploadParts(): void
+    {
+        $interruptions = [
+            'before-part' => ['', 0],
+            'within-part' => [str_repeat('I', 32), 0],
+            'after-part' => [str_repeat('I', 64), 64],
+        ];
+        $base_url = parse_url($this->base_url);
+        $this->assertIsArray($base_url);
+        $this->assertIsString($base_url['host'] ?? null);
+        $this->assertIsInt($base_url['port'] ?? null);
+
+        foreach ($interruptions as $name => [$interrupted_payload, $expected_cursor]) {
+            $local_docroot = $this->root . '/interrupted-' . $name;
+            mkdir($local_docroot, 0700, true);
+            $relative_path = 'interrupted-' . $name . '.bin';
+            $source_path = $local_docroot . '/' . $relative_path;
+            file_put_contents($source_path, str_repeat('I', 2000));
+            $identity = lstat($source_path);
+            $this->assertIsArray($identity);
+            $current_index = $this->root . '/interrupted-' . $name . '.jsonl';
+            $this->writeIndex($current_index, [
+                $relative_path => [ (int) $identity['ctime'], (int) $identity['size'], 'file'],
+            ]);
+            $journal = new PushJournal($this->root . '/interrupted-state-' . $name, $this->base_url);
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertSame('continue', $result['status'], $name . ': ' . json_encode($result));
+            $state = $journal->read_sender_state();
+            $this->assertIsArray($state);
+
+            $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'];
+            $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+            $boundary = 'reprint-interrupted-' . str_replace('-', '', $name);
+            $mime_headers = '--' . $boundary . "\r\n"
+                . "X-Chunk-Type: file\r\n"
+                . 'X-File-Path: ' . base64_encode($relative_path) . "\r\n"
+                . "X-File-Size: 2000\r\n"
+                . "X-Chunk-Offset: 0\r\n"
+                . "Content-Length: 64\r\n\r\n";
+            $request_body = $interrupted_payload === '' ? '' : $mime_headers . $interrupted_payload;
+            if ($interrupted_payload !== '') {
+                $request_body .= "\r\n";
+            }
+            $complete_request = $name === 'after-part';
+            if ($complete_request) {
+                $request_body .= '--' . $boundary . "--\r\n";
+            }
+            $connection = stream_socket_client(
+                'tcp://' . $base_url['host'] . ':' . $base_url['port'],
+                $error_number,
+                $error_message,
+                3
+            );
+            $this->assertIsResource($connection, $error_message);
+            $request_target = (string) $base_url['path'] . '?' . $base_url['query']
+                . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'];
+            $request_headers = "POST " . $request_target . " HTTP/1.1\r\n"
+                . 'Host: ' . $base_url['host'] . ':' . $base_url['port'] . "\r\n"
+                . 'Content-Type: multipart/mixed; boundary=' . $boundary . "\r\n"
+                . "Transfer-Encoding: chunked\r\nConnection: close\r\n";
+            foreach ($authentication_headers as $header_name => $header_value) {
+                $request_headers .= $header_name . ': ' . $header_value . "\r\n";
+            }
+            $request_headers .= "\r\n";
+            if ($request_body !== '') {
+                $request_headers .= dechex(strlen($request_body)) . "\r\n" . $request_body . "\r\n";
+            }
+            if ($complete_request) {
+                $request_headers .= "0\r\n\r\n";
+            }
+            $this->assertSame(strlen($request_headers), fwrite($connection, $request_headers));
+            // The first two variants truncate the request. The third sends a
+            // complete body but discards the response immediately.
+            fclose($connection);
+
+            $state['phase'] = 'reconciling_work';
+            $state['current_path_b64'] = base64_encode($relative_path);
+            $state['next_paths_byte_offset'] = filesize($journal->local_paths_to_push);
+            $state['source_token'] = [
+                'type' => 'file',
+                'size' => (int) $identity['size'],
+                'ctime' => (int) $identity['ctime'],
+            ];
+            $state['confirmed_bytes'] = 0;
+            $journal->write_sender_state($state);
+
+            for ($attempt = 0; $attempt < 20; ++$attempt) {
+                $status = $this->newClient(self::SECRET)->control_request('GET', 'push_status', [
+                    'push_session_id' => $state['push_session_id'],
+                    'path_b64' => base64_encode($relative_path),
+                ], ['accepted']);
+                if ($status['status'] === 'complete') {
+                    break;
+                }
+                usleep(10000);
+            }
+            $this->assertSame('complete', $status['status'], $name . ': ' . json_encode($status));
+            $this->assertSame($expected_cursor, $status['response']['path']['accepted_bytes'], $name);
+
+            for ($step = 0; $step < 200; ++$step) {
+                $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+                $this->assertNotSame('failed', $result['status'], $name . ': ' . json_encode($result));
+                if ($result['status'] !== 'continue') {
+                    break;
+                }
+            }
+            $this->assertSame('complete', $result['status'], $name . ': ' . json_encode($result));
+            $this->assertSame(str_repeat('I', 2000), file_get_contents($this->docroot . '/' . $relative_path));
+        }
+    }
+
+    /**
+     * Repeats work-delete close and commit after their responses are lost.
+     *
+     * Both requests reach the real endpoint, but the test closes its socket
+     * without reading the response. A reconstructed sender must recover the
+     * target's durable delete cursor and commit checkpoint, not its last local
+     * request result.
+     */
+    public function testHighLevelSenderRepeatsWorkDeleteAndCommitAfterLostResponses(): void
+    {
+        file_put_contents($this->docroot . '/delete-after-lost-response.txt', 'old');
+        $local_docroot = $this->root . '/lost-response-source';
+        mkdir($local_docroot, 0700, true);
+        $current_index = $this->root . '/lost-response-current.jsonl';
+        $this->writeIndex($current_index, []);
+        $baseline = $this->root . '/lost-response-baseline.jsonl';
+        $this->writeIndex($baseline, [
+            'delete-after-lost-response.txt' => [1, 3, 'file'],
+        ]);
+        $journal = new PushJournal($this->root . '/lost-response-state', $this->base_url);
+        $journal->capture_local_files_baseline($baseline);
+
+        for ($step = 0; $step < 20; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (is_array($state) && $state['phase'] === 'reconciling_deletes') {
+                break;
+            }
+        }
+        $this->assertIsArray($state);
+        $this->assertSame('reconciling_deletes', $state['phase']);
+        $work_deletes = (string) file_get_contents($journal->work_deletes_path);
+        $this->assertSame("delete-after-lost-response.txt\0", $work_deletes);
+        $boundary = 'reprint-lost-delete-response';
+        $delete_body = '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: delete-list\r\n"
+            . "X-Delete-Offset: 0\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . 'Content-Length: ' . strlen($work_deletes) . "\r\n\r\n"
+            . $work_deletes . "\r\n"
+            . '--' . $boundary . "\r\n"
+            . "X-Chunk-Type: delete-list\r\n"
+            . 'X-Delete-Offset: ' . strlen($work_deletes) . "\r\n"
+            . "X-Delete-Complete: 1\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . "Content-Length: 0\r\n\r\n\r\n"
+            . '--' . $boundary . "--\r\n";
+        $this->sendPostAndDiscardResponse(
+            $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'],
+            'multipart/mixed; boundary=' . $boundary,
+            $delete_body
+        );
+
+        for (; $step < 60; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            $state = $journal->read_sender_state();
+            if (is_array($state) && $state['phase'] === 'committing') {
+                break;
+            }
+        }
+        $this->assertIsArray($state);
+        $this->assertSame(strlen($work_deletes), $state['work_deletes_byte_offset']);
+        $this->assertSame('committing', $state['phase']);
+
+        $this->sendPostAndDiscardResponse(
+            $this->base_url . '&endpoint=push_commit&push_session_id=' . $state['push_session_id'],
+            null,
+            ''
+        );
+        for (; $step < 120; ++$step) {
+            $result = $this->newSender($local_docroot, $current_index, $journal)->send_next_request();
+            $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
+            if ($result['status'] !== 'continue') {
+                break;
+            }
+        }
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertFileDoesNotExist($this->docroot . '/delete-after-lost-response.txt');
+        $this->assertNull($journal->read_sender_state());
+    }
+
+
     private function sendChunkedUploadRequest(
         string $base_url,
         string $push_session_id,
@@ -1477,6 +2076,47 @@ final class PushEndpointsTest extends TestCase {
         $this->stopServer($process, $pipes);
         $this->fail('Push endpoint test server did not start: ' . $server_log);
     }
+
+    /**
+     * Reconstructs the production sender at a process-restart boundary.
+     *
+     * @param string $local_docroot Local document root whose values are sent.
+     * @param string $current_index Path-sorted local file index for this push.
+     * @param PushJournal $journal Durable per-target sender journal.
+     * @return PushFilesSender Sender restored from the journal checkpoint.
+     */
+    private function newSender(string $local_docroot, string $current_index, PushJournal $journal): PushFilesSender
+    {
+        return new PushFilesSender([
+            'docroot' => $local_docroot,
+            'current_index_file' => $current_index,
+            'journal' => $journal,
+            'base_url' => $this->base_url,
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 64,
+            'request_sizer_config' => [
+                'floor_bytes' => 2048,
+                'start_bytes' => 2048,
+                'max_bytes' => 2048,
+            ],
+            'connect_timeout' => 3,
+            'stall_timeout' => 3,
+            'response_timeout' => 5,
+        ]);
+    }
+
+    /**
+     * Sends one complete signed POST request and discards its response.
+     *
+     * Closing the socket immediately after the terminating transfer chunk
+     * reproduces a sender that cannot know whether the target completed the
+     * operation. The caller must reconcile from target state afterward.
+     *
+     * @param string $url Exact push endpoint URL to authenticate and request.
+     * @param string|null $content_type Request Content-Type, or null when the
+     *     endpoint has no body format.
+     * @param string $body Decoded HTTP entity body.
 
     /**
      * @param resource|null $process PHP built-in server process.
@@ -1643,6 +2283,50 @@ final class PushEndpointsTest extends TestCase {
         ];
     }
 
+    /**
+     * Sends one complete signed POST request and discards its response.
+     *
+     * Closing the socket immediately after the terminating transfer chunk
+     * reproduces a sender that cannot know whether the target completed the
+     * operation. The caller must reconcile from target state afterward.
+     *
+     * @param string $url Exact push endpoint URL to authenticate and request.
+     * @param string|null $content_type Request Content-Type, or null when the
+     *     endpoint has no body format.
+     * @param string $body Decoded HTTP entity body.
+     */
+    private function sendPostAndDiscardResponse(string $url, ?string $content_type, string $body): void
+    {
+        $target = parse_url($url);
+        $this->assertIsArray($target);
+        $this->assertIsString($target['host'] ?? null);
+        $this->assertIsInt($target['port'] ?? null);
+        $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $connection = stream_socket_client(
+            'tcp://' . $target['host'] . ':' . $target['port'],
+            $error_number,
+            $error_message,
+            3
+        );
+        $this->assertIsResource($connection, $error_message);
+        $request = 'POST ' . $target['path'] . '?' . $target['query'] . " HTTP/1.1\r\n"
+            . 'Host: ' . $target['host'] . ':' . $target['port'] . "\r\n"
+            . "Transfer-Encoding: chunked\r\nConnection: close\r\n";
+        if ($content_type !== null) {
+            $request .= 'Content-Type: ' . $content_type . "\r\n";
+        }
+        foreach ($authentication_headers as $header_name => $header_value) {
+            $request .= $header_name . ': ' . $header_value . "\r\n";
+        }
+        $request .= "\r\n";
+        if ($body !== '') {
+            $request .= dechex(strlen($body)) . "\r\n" . $body . "\r\n";
+        }
+        $request .= "0\r\n\r\n";
+        $this->assertSame(strlen($request), fwrite($connection, $request));
+        fclose($connection);
+    }
+
     private function removeTree(string $path): void
     {
         if (is_link($path) || is_file($path)) {
@@ -1658,5 +2342,27 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         @rmdir($path);
+    }
+    /**
+     * Writes a path-sorted local index in the production JSONL shape.
+     *
+     * @param array<string,array{0:int,1:int,2:'file'|'dir'|'link'}> $entries
+     *     Path to `[ctime, size, type]` records.
+     */
+    private function writeIndex(string $path, array $entries): void
+    {
+        uksort($entries, 'strcmp');
+        $handle = fopen($path, 'wb');
+        $this->assertIsResource($handle);
+        foreach ($entries as $entry_path => [$ctime, $size, $type]) {
+            $line = json_encode([
+                'path' => base64_encode($entry_path),
+                'ctime' => $ctime,
+                'size' => $size,
+                'type' => $type,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            $this->assertSame(strlen($line), fwrite($handle, $line));
+        }
+        fclose($handle);
     }
 }


### PR DESCRIPTION
Local-file pushes now resume both bounded local planning and receiver-confirmed uploads after a request or process stops.

`PushFilesSender::advance()` first creates the target push session to obtain its excluded paths and saves an empty planning boundary. Each later planning advance processes one bounded batch and atomically saves the resulting state in `sender.json`. During `planning`, that state includes the two input offsets, the committed lengths of `sender-index.jsonl`, `local-paths-to-push.jsonl`, and `work-deletes`, the accumulated counts and active delete roots, and the current-index identity. A restarted process truncates uncommitted output tails and resumes at the saved offsets. No upload begins until planning is complete.

The sender then reconciles work with `push_status`, streams multiple bounded file chunks and work values per request, resumes from receiver-confirmed cursors, repeats bounded commit, and removes abandoned upload-only sessions before requesting a new index. A changed planning index or indexed directory enters that remove-and-restart path. Baseline publication keeps prior evidence under excluded paths instead of claiming that unsent local values were synchronized.

This is the sender core only: importer startup loads the class, while the CLI and connection/token UI remain separate work. The push runtime requires PHP 8.1+; these libraries remain PHP 7.4-parseable so existing pull commands can still load `import.php`.

The real-endpoint tests reconstruct the sender after every advance and cover persisted planning progress, index replacement during planning, directory replacement, lost responses, source drift, exclusion-policy transitions, target limits, and journal contention.

## Testing

```text
cd tests && ../vendor/bin/phpunit Import/MultipartPushStreamClientTest.php Import/PushClientPhpCompatibilityTest.php Import/PushJournalTest.php Import/PushRequestSizerTest.php PushCommitTest.php PushEndpointsTest.php PushSessionTest.php
composer analyze -- --memory-limit=1G
composer lint:php:compat
git diff --check
```

Depends on #366.
