### PR TITLE
[Push] Keep sender outcomes at target-confirmed boundaries

### DIFF
--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -645,9 +645,7 @@ final class PushFilesSender
         if ($local_path_type_size_and_ctime === null) {
             $this->close_local_file_handle();
             $this->close_local_paths_to_push_handle();
-            $this->start_removing_push_session_after_local_change(
-                'A local path to push disappeared; remove the upload-only push session before generating another index.'
-            );
+            $this->start_removing_push_session_after_local_change();
             return;
         }
 
@@ -655,9 +653,7 @@ final class PushFilesSender
         if ($local_path_type_size_and_ctime['type'] === 'unsupported') {
             $this->close_local_file_handle();
             $this->close_local_paths_to_push_handle();
-            $this->start_removing_push_session_after_local_change(
-                'A local path to push changed to a file type that cannot be pushed; remove the upload-only push session before generating another index.'
-            );
+            $this->start_removing_push_session_after_local_change();
             return;
         }
 
@@ -665,9 +661,7 @@ final class PushFilesSender
         if ($local_path_type_size_and_ctime !== $planned_local_path_type_size_and_ctime) {
             $this->close_local_file_handle();
             $this->close_local_paths_to_push_handle();
-            $this->start_removing_push_session_after_local_change(
-                'A local path to push changed after planning; remove the upload-only push session before generating another index.'
-            );
+            $this->start_removing_push_session_after_local_change();
             return;
         }
 
@@ -724,23 +718,17 @@ final class PushFilesSender
             $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
-                $this->start_removing_push_session_after_local_change(
-                    'A local path to push disappeared; remove the upload-only push session before generating another index.'
-                );
+                $this->start_removing_push_session_after_local_change();
                 return;
             }
             if ($local_path_type_size_and_ctime_after_read !== $planned_local_path_type_size_and_ctime) {
                 $this->close_local_paths_to_push_handle();
-                $this->start_removing_push_session_after_local_change(
-                    'The local path to push changed while its directory was being read; remove the upload-only push session before generating another index.'
-                );
+                $this->start_removing_push_session_after_local_change();
                 return;
             }
             if (!$directory_is_empty) {
                 $this->close_local_paths_to_push_handle();
-                $this->start_removing_push_session_after_local_change(
-                    'A directory selected as empty now contains a local path; remove the upload-only push session before generating another index.'
-                );
+                $this->start_removing_push_session_after_local_change();
                 return;
             }
             $upload_part = [
@@ -754,16 +742,12 @@ final class PushFilesSender
             $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
-                $this->start_removing_push_session_after_local_change(
-                    'A local path to push disappeared; remove the upload-only push session before generating another index.'
-                );
+                $this->start_removing_push_session_after_local_change();
                 return;
             }
             if ($local_path_type_size_and_ctime_after_read !== $planned_local_path_type_size_and_ctime) {
                 $this->close_local_paths_to_push_handle();
-                $this->start_removing_push_session_after_local_change(
-                    'The local path to push changed while its symlink was being read; remove the upload-only push session before generating another index.'
-                );
+                $this->start_removing_push_session_after_local_change();
                 return;
             }
             if ($symlink_target === false) {
@@ -828,17 +812,13 @@ final class PushFilesSender
                 if ($local_path_type_size_and_ctime_after_read === null) {
                     $this->close_local_file_handle();
                     $this->close_local_paths_to_push_handle();
-                    $this->start_removing_push_session_after_local_change(
-                        'A local path to push disappeared; remove the upload-only push session before generating another index.'
-                    );
+                    $this->start_removing_push_session_after_local_change();
                     return;
                 }
                 if ($local_path_type_size_and_ctime_after_read !== $planned_local_path_type_size_and_ctime) {
                     $this->close_local_file_handle();
                     $this->close_local_paths_to_push_handle();
-                    $this->start_removing_push_session_after_local_change(
-                        'The local path to push changed while its file chunk was being read; remove the upload-only push session before generating another index.'
-                    );
+                    $this->start_removing_push_session_after_local_change();
                     return;
                 }
                 if ($local_io_failure_detail !== null) {
@@ -1060,6 +1040,10 @@ final class PushFilesSender
         $request_had_parts = $request_result['parts_sent'] > 0;
         $request_failed = $this->handle_request_failure($request_result);
         if ($request_failed) {
+            /** @var State $state_before_upload_request */
+            $state_before_upload_request = $this->state_before_upload_request;
+            $this->state = $state_before_upload_request;
+            $this->state['request_sizer_state'] = $this->push_stream_client->get_request_sizer_state();
             $this->receiver_confirmed_file_byte_offset = null;
             $this->receiver_confirmed_deleted_paths_byte_offset = null;
             $this->receiver_confirmed_deleted_paths_complete = null;
@@ -1084,16 +1068,12 @@ final class PushFilesSender
 
     /**
      * Moves a changed local tree to push-session removal.
-     *
-     * @param string $detail Human-readable description of the local change.
      */
-    private function start_removing_push_session_after_local_change(string $detail): void
+    private function start_removing_push_session_after_local_change(): void
     {
         $this->cancel();
         $this->state['phase'] = 'removing';
         $this->store_state($this->state);
-        $this->reason = 'local_path_changed';
-        $this->detail = $detail;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -122,7 +122,7 @@ final class PushFilesSender
     /** @var string Local push state directory shared with PushPlan. */
     private string $push_state_directory;
 
-    /** @var string Atomic checkpoint for the active push workflow. */
+    /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
 
     /** @var string Advisory lock file for one open lifecycle. */
@@ -203,7 +203,7 @@ final class PushFilesSender
     /** @var array<string,mixed> Options used to construct the PushRequestSizer. */
     private array $request_sizer_options;
 
-    /** @var array<string,mixed> Transport options used by start() or resume(). */
+    /** @var array<string,mixed> Push stream client options used by start() or resume(). */
     private array $push_stream_client_options;
 
     /**
@@ -215,7 +215,7 @@ final class PushFilesSender
      * retains its lock until close().
      *
      * @param array $options {
-     *     Push, transport, and local-file options.
+     *     Push, push stream client, and local-file options.
      *
      *     @type string                  $docroot                Required local document-root directory.
      *     @type string                  $fresh_local_index_path Completed fresh local index required by start().
@@ -314,11 +314,11 @@ final class PushFilesSender
     }
 
     /**
-     * Configures the paths and transport options shared by start() and resume().
+     * Configures the paths and push stream client options shared by start() and resume().
      *
      * @param array<string,mixed> $options Options documented by start().
      *
-     * @throws InvalidArgumentException If local path or transport options are invalid.
+     * @throws InvalidArgumentException If local path or push stream client options are invalid.
      */
     private function __construct(array $options)
     {
@@ -493,7 +493,7 @@ final class PushFilesSender
      *
      * The caller uses cancel() first when stopping with an open multipart
      * request. Durable state remains available to resume unless next_step()
-     * already completed or discarded the workflow.
+     * already completed or discarded the lifecycle.
      */
     public function close(): void
     {
@@ -667,7 +667,9 @@ final class PushFilesSender
 
         // Continue at the tentative byte offset in an open request, then at the
         // target-confirmed offset cached during this run. Ask the target only
-        // when neither byte offset is available.
+        // when neither byte offset is available. The same call sends one part
+        // because target-confirmed offsets are not stored in sender state and
+        // even a caller which performs one step per process must make progress.
         if ($this->upload_request_stage !== 'closed') {
             $file_byte_offset = $this->next_file_byte_offset ?? 0;
         } elseif ($this->receiver_confirmed_file_byte_offset !== null) {
@@ -892,15 +894,19 @@ final class PushFilesSender
      */
     private function upload_next_chunk_of_deleted_paths(): void
     {
+        // Confirm a request after the deletion list ends or its remaining budget is spent.
         if ($this->upload_request_stage === 'finishing') {
             $this->finish_upload_request();
             return;
         }
 
+        // Select one complete path at the tentative or target-confirmed list position.
         if ($this->local_path_to_delete === null && !$this->local_delete_list_complete) {
             if ($this->upload_request_stage !== 'closed') {
                 $delete_list_byte_offset = $this->next_delete_list_byte_offset ?? 0;
             } else {
+                // Without a cached position, ask how much of the list the target accepted.
+                // The same call then sends one part so even a one-step process makes progress.
                 if ($this->receiver_confirmed_deleted_paths_byte_offset === null) {
                     $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                         'push_session_id' => $this->state['push_session_id'],
@@ -925,6 +931,7 @@ final class PushFilesSender
                 $this->next_delete_list_byte_offset = $delete_list_byte_offset;
             }
 
+            // Finish a request which cannot fit another complete deleted path.
             $maximum_delete_list_payload_bytes = $this->push_stream_client->next_delete_body_bytes(
                 $delete_list_byte_offset
             );
@@ -937,6 +944,7 @@ final class PushFilesSender
                 return;
             }
 
+            // Keep the completed deletion plan open while successive calls consume it.
             if (!is_resource($this->local_paths_to_delete_handle)) {
                 $local_paths_to_delete_path = PushPlan::local_paths_to_delete_path($this->push_state_directory);
                 $this->local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
@@ -974,6 +982,7 @@ final class PushFilesSender
             }
         }
 
+        // EOF becomes the empty part which marks the deletion list complete.
         if ($this->local_path_to_delete === null) {
             $delete_list_byte_offset = $this->next_delete_list_byte_offset ?? 0;
             $payload = '';
@@ -993,6 +1002,7 @@ final class PushFilesSender
             }
         }
 
+        // Open a request only after the next complete part is ready.
         if ($this->upload_request_stage === 'closed') {
             $this->state_before_upload_request = $this->state;
             if (!$this->push_stream_client->start_upload_request($this->state['push_session_id'])) {
@@ -1009,6 +1019,9 @@ final class PushFilesSender
             'complete' => $this->local_delete_list_complete,
             'payload' => $payload,
         ]);
+
+        // Confirm an existing request before retrying this path in a new one.
+        // An empty request which cannot fit the part cannot make progress.
         if (!$part_sent) {
             if ($this->push_stream_client->has_sent_parts()) {
                 $this->local_path_to_delete = null;
@@ -1023,6 +1036,7 @@ final class PushFilesSender
             return;
         }
 
+        // Keep the next list position tentative until the target confirms the request.
         $this->next_delete_list_byte_offset = $delete_list_byte_offset + strlen($payload);
         $this->local_path_to_delete = null;
         if ($this->local_delete_list_complete || $this->push_stream_client->should_finish_request()) {
@@ -1183,7 +1197,7 @@ final class PushFilesSender
     }
 
     /**
-     * Removes local planning state after saving the committed index.
+     * Completes the sender after removing the completed planning cursor.
      */
     private function complete_push(): void
     {
@@ -1218,7 +1232,7 @@ final class PushFilesSender
     }
 
     /**
-     * Discards local planning state after the target push session is removed.
+     * Restarts the sender after removing the discarded planning cursor.
      */
     private function discard_plan(): void
     {
@@ -1235,7 +1249,7 @@ final class PushFilesSender
     }
 
     /**
-     * Builds a streaming client from the sizing state in the durable checkpoint.
+     * Builds a streaming client from the sizing state in active sender state.
      *
      * @param State|null $state Current state, or null before a push starts.
      */

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1844,12 +1844,15 @@ final class PushEndpointsTest extends TestCase {
             $sender->next_step();
 
             $this->assertSame('removing', $sender->get_phase());
-            $this->assertSame('local_path_changed', $sender->get_reason());
+            $this->assertSame('continue', $sender->get_status());
+            $this->assertNull($sender->get_reason());
+            $this->assertNull($sender->get_detail());
             $this->assertNull($curl_handle_property->getValue($push_stream_client));
             $this->assertTrue($sender->next_step());
             $this->assertSame('discarding_plan', $sender->get_phase());
             $this->assertFalse($sender->next_step());
             $this->assertSame('restart', $sender->get_status());
+            $this->assertSame('local_path_changed', $sender->get_reason());
         } finally {
             $sender->close();
         }
@@ -2041,7 +2044,8 @@ final class PushEndpointsTest extends TestCase {
         $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
         $this->assertSame('continue', $result['status']);
         $this->assertSame('removing', $result['phase']);
-        $this->assertSame('local_path_changed', $result['reason']);
+        $this->assertNull($result['reason']);
+        $this->assertNull($result['detail']);
 
         for (; $step < 60; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
@@ -2051,6 +2055,7 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         $this->assertSame('restart', $result['status']);
+        $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertFileDoesNotExist($push_state_directory . '/cursor.json');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
@@ -2087,13 +2092,14 @@ final class PushEndpointsTest extends TestCase {
 
         $this->assertSame('continue', $result['status']);
         $this->assertSame('removing', $result['phase']);
-        $this->assertSame('local_path_changed', $result['reason']);
+        $this->assertNull($result['reason']);
+        $this->assertNull($result['detail']);
     }
 
     /**
-     * Distinguishes an unpushable local file type from a path that disappeared.
+     * Removes a push session when a local path changes to an unsupported type.
      */
-    public function testHighLevelSenderReportsWhenLocalPathChangesToUnsupportedType(): void
+    public function testHighLevelSenderRemovesSessionWhenLocalPathChangesToUnsupportedType(): void
     {
         if (!function_exists('posix_mkfifo')) {
             $this->markTestSkipped('posix_mkfifo() is unavailable.');
@@ -2124,8 +2130,8 @@ final class PushEndpointsTest extends TestCase {
         $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
         $this->assertSame('continue', $result['status']);
         $this->assertSame('removing', $result['phase']);
-        $this->assertSame('local_path_changed', $result['reason']);
-        $this->assertStringContainsString('file type that cannot be pushed', $result['detail']);
+        $this->assertNull($result['reason']);
+        $this->assertNull($result['detail']);
     }
 
     /**
@@ -2310,6 +2316,56 @@ final class PushEndpointsTest extends TestCase {
             'complete',
             $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory)['status']
         );
+    }
+
+    /**
+     * Returns in-memory sender state to its durable boundary after an upload request fails.
+     */
+    public function testHighLevelSenderReturnsToDurableStateAfterUploadRequestFailure(): void
+    {
+        $local_docroot = $this->root . '/failed-upload-state-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/first.txt', 'first');
+        file_put_contents($local_docroot . '/second.txt', 'second');
+        $fresh_local_index_path = $this->root . '/failed-upload-state-index.jsonl';
+        $this->writeIndex($fresh_local_index_path, [
+            'first.txt' => $this->indexEntry($local_docroot . '/first.txt', 'file'),
+            'second.txt' => $this->indexEntry($local_docroot . '/second.txt', 'file'),
+        ]);
+        $push_state_directory = $this->root . '/failed-upload-state';
+        $sender = PushFilesSender::start(
+            $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+        );
+        $state_property = new ReflectionProperty(PushFilesSender::class, 'state');
+
+        try {
+            $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
+            $this->assertTrue($sender->next_step());
+            $this->assertTrue($sender->next_step());
+
+            $durable_state = $this->loadActiveState($push_state_directory);
+            $this->assertIsArray($durable_state);
+            $this->assertNotSame($durable_state, $state_property->getValue($sender));
+
+            $push_lock = fopen(
+                $this->reprint_directory . '/.reprint/push/' . $durable_state['push_session_id'] . '/push.lock',
+                'r+b'
+            );
+            $this->assertIsResource($push_lock);
+            $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
+            try {
+                $this->assertFalse($sender->next_step());
+            } finally {
+                flock($push_lock, LOCK_UN);
+                fclose($push_lock);
+            }
+
+            $this->assertSame('failed', $sender->get_status());
+            $this->assertSame('lock_acquisition_failure', $sender->get_reason());
+            $this->assertSame($durable_state, $state_property->getValue($sender));
+        } finally {
+            $sender->close();
+        }
     }
 
     /**


### PR DESCRIPTION
`PushFilesSender` no longer reports upload progress that the target has not confirmed.

## Background

`sender.json` is saved only at durable boundaries. While a multipart request is open, the sender can advance its in-memory path-list position before the target accepts the request. If that request fails, the current process must return to the last saved boundary instead of presenting the tentative position as real progress.

Local path drift has the same boundary problem. Starting removal of the upload-only push session is progress, not the final restart result. The restart reason belongs to the discard step, after the push session and planning cursor are gone.

## This change

A failed upload request restores the sender snapshot taken before that request and keeps only the learned request-size ceiling. Local path changes now move the lifecycle to `removing` with status `continue`; `discard_plan()` is the single place that returns `restart` with `local_path_changed`.

The deletion-step comments now describe the actual request boundaries: confirmed offsets are target state, open-request offsets are tentative, EOF is sent as the final empty part, and one-step callers still send a part after asking `push_status` where to resume.

## Testing

No useful browser test. Review CI for the sender tests covering failed upload requests and changed local paths.
