### PR TITLE
[Push] Separate file-index traversal from HTTP streaming

### DIFF
--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -18,6 +18,7 @@
         },
         "classmap": [
             "src/class-mysql-dump-producer.php",
+            "src/class-file-index-processor.php",
             "src/class-file-tree-producer.php",
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",

--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -97,6 +97,9 @@ final class FileIndexProcessor {
         bool $include_caches,
         string $storage_path
     ): self {
+        // Anchor traversal to a real directory. All later comparisons use
+        // canonical paths so configured roots and followed links share one
+        // path namespace.
         clearstatcache(true, $index_directory);
         $canonical_index_directory = realpath($index_directory);
         if ($canonical_index_directory === false || !is_dir($canonical_index_directory)) {
@@ -105,12 +108,18 @@ final class FileIndexProcessor {
             );
         }
 
+        // An ordinary traversal must begin inside a configured root. Following
+        // links deliberately relaxes that boundary because a link target may
+        // be outside every configured root and still belong in the index.
         if (!$follow_symlinks && !self::path_is_within_directories($canonical_index_directory, $directories)) {
             throw new InvalidArgumentException(
                 "list_dir is outside of allowed roots: {$canonical_index_directory}"
             );
         }
 
+        // Visit the requested directory first, followed by every other root in
+        // stable byte order. Stable ordering makes a cursor independent of the
+        // order in which configuration discovered the additional roots.
         $ordered_directories = [$canonical_index_directory];
         $extra_directories = [];
         foreach ($directories as $directory) {
@@ -131,6 +140,8 @@ final class FileIndexProcessor {
             }
         }
 
+        // The last stack element is visited next, so reverse the desired order
+        // while constructing the depth-first traversal stack.
         $directory_stack = [];
         for ($i = count($ordered_directories) - 1; $i >= 0; $i--) {
             $directory_stack[] = [
@@ -139,6 +150,9 @@ final class FileIndexProcessor {
             ];
         }
 
+        // Keep parent-link discovery as the first traversal event. This
+        // preserves the endpoint's established ordering: any link entries
+        // found here must precede ordinary directory entries.
         $initial_index_entries = [];
         if ($follow_symlinks) {
             foreach ($ordered_directories as $directory) {
@@ -177,6 +191,8 @@ final class FileIndexProcessor {
         bool $include_caches,
         string $storage_path
     ): self {
+        // A cursor is caller-held continuation state. Reject malformed JSON or
+        // a missing stack before any filesystem work begins.
         $cursor = json_decode($cursor_json, true);
         if (!is_array($cursor)) {
             throw new InvalidArgumentException("Invalid index cursor format");
@@ -185,6 +201,9 @@ final class FileIndexProcessor {
             throw new InvalidArgumentException("Index cursor missing stack");
         }
 
+        // Paths are base64 text because filesystem names are arbitrary bytes
+        // while JSON strings must be valid UTF-8. Decode each frame back into
+        // the in-memory stack used by traversal.
         $directory_stack = [];
         foreach ($cursor["stack"] as $frame) {
             if (!is_array($frame)) {
@@ -217,6 +236,9 @@ final class FileIndexProcessor {
             ];
         }
 
+        // During continuation, the active directory is the best description
+        // of what this request is indexing. A completed cursor has no active
+        // directory, so it falls back to the first configured root.
         $index_directory = !empty($directory_stack)
             ? $directory_stack[count($directory_stack) - 1]["dir"]
             : ( isset($directories[0]) ? $directories[0] : "/" );
@@ -239,14 +261,20 @@ final class FileIndexProcessor {
      */
     public function next_index_step(): bool
     {
+        // A closed processor has discarded its retained directory names and
+        // cannot safely take another step.
         if ($this->closed) {
             throw new LogicException("Cannot take a file-index step after close().");
         }
 
+        // Step accessors describe only the current call. Clear the preceding
+        // result before deciding which traversal event comes next.
         $this->step_status = null;
         $this->index_entries = [];
         $this->directory_error = null;
 
+        // Emit the parent links discovered during start() before descendants.
+        // They share one cursor boundary because traversal has not begun yet.
         if (!empty($this->initial_index_entries)) {
             $this->step_status = self::STATUS_INDEXED;
             $this->index_entries = $this->initial_index_entries;
@@ -254,12 +282,17 @@ final class FileIndexProcessor {
             return true;
         }
 
+        // Load the directory at the top of the stack only when no sorted name
+        // list is retained. A directory failure is itself a step; an empty
+        // stack means traversal has no further event.
         if ($this->current_directory_names === null) {
             if (!$this->open_current_directory()) {
                 return $this->step_status !== null;
             }
         }
 
+        // Finishing a directory is observable so callers may stop at this
+        // exact cursor before the processor returns to its parent directory.
         if ($this->current_directory_position >= count($this->current_directory_names)) {
             array_pop($this->directory_stack);
             $this->forget_current_directory_names();
@@ -267,6 +300,8 @@ final class FileIndexProcessor {
             return true;
         }
 
+        // Select exactly one name for this step. Move the cursor first so every
+        // later outcome, including omission or disappearance, settles the name.
         $frame_index = count($this->directory_stack) - 1;
         $entry_name = $this->current_directory_names[$this->current_directory_position];
         ++$this->current_directory_position;
@@ -276,6 +311,8 @@ final class FileIndexProcessor {
         $this->directory_stack[$frame_index]["after"] = $entry_name;
         $path = $this->current_directory . "/" . $entry_name;
 
+        // Apply omissions before lstat() and before a directory can enter the
+        // stack. Omitted subtrees therefore cost no extra filesystem calls.
         if (!$this->include_caches && self::path_is_default_skipped($path)) {
             $this->step_status = self::STATUS_SKIPPED;
             return true;
@@ -288,6 +325,8 @@ final class FileIndexProcessor {
             return true;
         }
 
+        // A name returned by scandir() may disappear before inspection. Its
+        // cursor is already settled, so continuation moves to the next name.
         clearstatcache(true, $path);
         $stat = @lstat($path);
         if ($stat === false) {
@@ -295,6 +334,9 @@ final class FileIndexProcessor {
             return true;
         }
 
+        // Translate platform mode bits into the four types understood by the
+        // file index. A directory link may also reveal intermediate links that
+        // canonicalization would otherwise hide.
         $mode = $stat["mode"] & self::STAT_TYPE_MASK;
         $type = "file";
         $link_target = null;
@@ -312,6 +354,9 @@ final class FileIndexProcessor {
             $type = "other";
         }
 
+        // Build the index entry from the one successful lstat() call. Only
+        // regular-file bytes contribute a size; directories and links carry
+        // their type-specific details separately.
         $item = [
             "path" => $path,
             "ctime" => (int) ( isset($stat["ctime"]) ? $stat["ctime"] : 0 ),
@@ -347,10 +392,15 @@ final class FileIndexProcessor {
             // deletions.
         }
 
+        // Intermediate links and the inspected path belong to the same step
+        // because the cursor cannot stop between them without losing one.
         $this->index_entries = $intermediate_symlinks;
         $this->index_entries[] = $item;
         $this->step_status = self::STATUS_INDEXED;
 
+        // Depth-first traversal enters a new directory before returning to the
+        // remaining names in its parent. Configured roots are scheduled
+        // independently and must not be entered again through an ancestor.
         if ($type === "dir") {
             $canonical_directory = realpath($path);
             if (
@@ -561,14 +611,19 @@ final class FileIndexProcessor {
      */
     private function open_current_directory(): bool
     {
+        // An empty stack is normal completion, not a directory failure.
         if (empty($this->directory_stack)) {
             return false;
         }
 
+        // The top frame names the next directory and the last name settled in
+        // it. Keep the directory available for any failure reported this step.
         $frame_index = count($this->directory_stack) - 1;
         $frame = $this->directory_stack[$frame_index];
         $this->current_directory = $frame["dir"];
 
+        // A directory may disappear while it waits on the stack. Remove that
+        // frame so a later call continues with its parent or the next root.
         clearstatcache(true, $this->current_directory);
         $canonical_directory = realpath($this->current_directory);
         if ($canonical_directory === false || !is_dir($canonical_directory)) {
@@ -582,6 +637,9 @@ final class FileIndexProcessor {
             return false;
         }
 
+        // When following links is disabled, every canonical directory must
+        // remain inside a configured root. Reject one that crosses that
+        // boundary, then continue with the remaining stack.
         if (
             !$this->follow_symlinks
             && !self::path_is_within_directories($canonical_directory, $this->directories)
@@ -601,6 +659,9 @@ final class FileIndexProcessor {
         $this->directory_stack[$frame_index]["dir"] = $canonical_directory;
         $this->current_directory = $canonical_directory;
 
+        // scandir() supplies the stable byte order on which cursor resumption
+        // depends. Failure settles this directory rather than retrying it on
+        // every subsequent request.
         clearstatcache(true, $canonical_directory);
         $directory_names = @scandir($canonical_directory, SCANDIR_SORT_ASCENDING);
         if ($directory_names === false) {
@@ -614,11 +675,15 @@ final class FileIndexProcessor {
             return false;
         }
 
+        // Tests may change the scanned names to exercise traversal boundaries.
+        // Production traversal has no hook and uses scandir() results directly.
         if (getenv("SITE_EXPORT_TEST_MODE") && function_exists("_e2e_call_hook")) {
             $hook_arguments = [$canonical_directory, &$directory_names];
             _e2e_call_hook("test_hook_during_dir_scan", $hook_arguments);
         }
 
+        // Remove the two navigation names, then seek past the last settled name.
+        // Binary search keeps continuation cheap for unusually wide directories.
         $this->current_directory_names = [];
         foreach ($directory_names as $directory_name) {
             if ($directory_name !== "." && $directory_name !== "..") {
@@ -752,6 +817,9 @@ final class FileIndexProcessor {
      */
     private static function resolve_symlink_target(string $path): array
     {
+        // Only links ending at a directory need a canonical target because only
+        // directories can add more traversal work. Broken, self-referential,
+        // and file links remain ordinary link entries without a target.
         clearstatcache(true, $path);
         $resolved_target = @realpath($path);
         if (
@@ -762,6 +830,8 @@ final class FileIndexProcessor {
             return ["target" => null, "intermediates" => []];
         }
 
+        // realpath() jumps directly to the final directory. Walk the unresolved
+        // target as well so links along that path are included in the index.
         $intermediates = [];
         $raw_target = @readlink($path);
         if ($raw_target !== false && $raw_target !== "") {
@@ -797,6 +867,9 @@ final class FileIndexProcessor {
         $entries = [];
         $parts = explode("/", $absolute_path);
         $current = "";
+
+        // Inspect each accumulated parent path. After a link, continue from its
+        // canonical location so later segments refer to the path PHP will use.
         foreach ($parts as $part) {
             if ($part === "") {
                 $current = "/";
@@ -807,6 +880,8 @@ final class FileIndexProcessor {
                 continue;
             }
 
+            // Preserve the link spelling returned by readlink(); pull needs it
+            // to reconstruct the same link rather than only its final directory.
             $target = @readlink($current);
             if ($target !== false && $target !== "") {
                 $stat = @lstat($current);
@@ -820,6 +895,8 @@ final class FileIndexProcessor {
                 ];
             }
 
+            // Resolve only the parent already inspected. This keeps the walk
+            // iterative and leaves any later link visible to the next segment.
             $canonical_current = @realpath($current);
             if ($canonical_current !== false) {
                 $current = $canonical_current;
@@ -841,6 +918,9 @@ final class FileIndexProcessor {
     {
         $parts = explode("/", $path);
         $normalized = [];
+
+        // Resolve only textual dot segments. Filesystem resolution here would
+        // skip the intermediate links this path is being prepared to inspect.
         foreach ($parts as $part) {
             if ($part === "" || $part === ".") {
                 if (empty($normalized)) {

--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -1,0 +1,861 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Exporter classes use unprefixed domain names.
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Traversal failures become API or CLI values, never HTML output.
+
+/**
+ * Walks filesystem paths for the file index one resumable step at a time.
+ *
+ * The processor owns directory traversal and path inspection. Callers own
+ * what happens to the resulting index entries: the HTTP endpoint batches and
+ * encodes them, while local push indexing will write them to its JSONL file.
+ *
+ * A cursor contains the active directory stack and the last settled name in
+ * each directory. Reopening from that cursor rescans only the active
+ * directories and continues after those names. Directory names remain sorted
+ * exactly as they were in endpoint_file_index() before this extraction.
+ *
+ * One step either produces one or more index entries for one filesystem path,
+ * skips one path, reports one directory failure, or finishes one directory.
+ * Following a symlink may produce additional intermediate-symlink entries in
+ * the same step because they share the path's cursor boundary.
+ *
+ * Directory names are still read with scandir(). This deliberately preserves
+ * the endpoint's established ordering and cursor behavior. It also means one
+ * unusually wide directory is held in memory; changing that requires a
+ * separate traversal design rather than hiding it inside this extraction.
+ */
+final class FileIndexProcessor {
+
+    const STATUS_INDEXED = "indexed";
+    const STATUS_SKIPPED = "skipped";
+    const STATUS_PATH_UNAVAILABLE = "path_unavailable";
+    const STATUS_DIRECTORY_COMPLETE = "directory_complete";
+    const STATUS_DIRECTORY_ERROR = "directory_error";
+
+    const STAT_TYPE_MASK = 0170000;
+    const STAT_TYPE_LINK = 0120000;
+    const STAT_TYPE_FILE = 0100000;
+    const STAT_TYPE_DIR = 0040000;
+
+    /** @var string[] Canonical directories allowed during traversal. */
+    private $directories;
+
+    /** @var bool Whether directory symlinks may lead outside the allowed directories. */
+    private $follow_symlinks;
+
+    /** @var bool Whether generated caches and development files are included. */
+    private $include_caches;
+
+    /** @var string Canonical Reprint storage path omitted from the index, or an empty string. */
+    private $storage_path;
+
+    /** @var array[] Active directory stack, from scheduled roots to the current directory. */
+    private $directory_stack;
+
+    /** @var string Directory reported as X-Index-Dir for this traversal. */
+    private $index_directory;
+
+    /** @var array[] Intermediate symlinks emitted before a new traversal begins. */
+    private $initial_index_entries;
+
+    /** @var string[]|null Sorted names in the current directory. */
+    private $current_directory_names = null;
+
+    /** @var int Position of the next name in $current_directory_names. */
+    private $current_directory_position = 0;
+
+    /** @var string|null Current directory used for endpoint exception reporting. */
+    private $current_directory = null;
+
+    /** @var string|null Result of the most recent step. */
+    private $step_status = null;
+
+    /** @var array[] Entries produced by the most recent indexed step. */
+    private $index_entries = [];
+
+    /** @var array|null Directory failure produced by the most recent step. */
+    private $directory_error = null;
+
+    /** @var bool Whether close() has been called. */
+    private $closed = false;
+
+    /**
+     * Starts a traversal at the requested directory and schedules the other roots.
+     *
+     * @param string[] $directories      Canonical directories allowed during traversal.
+     * @param string   $index_directory Directory where traversal begins.
+     * @param bool     $follow_symlinks  Whether directory symlinks may lead outside the allowed directories.
+     * @param bool     $include_caches   Whether generated caches and development files are included.
+     * @param string   $storage_path     Reprint storage path omitted from the index, or an empty string.
+     * @return self New file-index processor.
+     */
+    public static function start(
+        array $directories,
+        string $index_directory,
+        bool $follow_symlinks,
+        bool $include_caches,
+        string $storage_path
+    ): self {
+        clearstatcache(true, $index_directory);
+        $canonical_index_directory = realpath($index_directory);
+        if ($canonical_index_directory === false || !is_dir($canonical_index_directory)) {
+            throw new InvalidArgumentException(
+                "list_dir does not exist or is not accessible: {$index_directory}"
+            );
+        }
+
+        if (!$follow_symlinks && !self::path_is_within_directories($canonical_index_directory, $directories)) {
+            throw new InvalidArgumentException(
+                "list_dir is outside of allowed roots: {$canonical_index_directory}"
+            );
+        }
+
+        $ordered_directories = [$canonical_index_directory];
+        $extra_directories = [];
+        foreach ($directories as $directory) {
+            if ($directory !== $canonical_index_directory) {
+                $extra_directories[] = $directory;
+            }
+        }
+        sort($extra_directories, SORT_STRING);
+        foreach ($extra_directories as $directory) {
+            // Parent and child roots both remain scheduled. On wp.com Atomic,
+            // for example, the document root may be a parent of the primary
+            // WordPress root while also containing a separate wp-content.
+            // Dropping the parent would hide those plugins and themes. When
+            // traversal later reaches the scheduled child, the root check
+            // prevents entering it a second time.
+            if (!in_array($directory, $ordered_directories, true)) {
+                $ordered_directories[] = $directory;
+            }
+        }
+
+        $directory_stack = [];
+        for ($i = count($ordered_directories) - 1; $i >= 0; $i--) {
+            $directory_stack[] = [
+                "dir" => $ordered_directories[$i],
+                "after" => null,
+            ];
+        }
+
+        $initial_index_entries = [];
+        if ($follow_symlinks) {
+            foreach ($ordered_directories as $directory) {
+                $initial_index_entries = array_merge(
+                    $initial_index_entries,
+                    self::find_parent_symlinks($directory)
+                );
+            }
+        }
+
+        return new self(
+            $directories,
+            $follow_symlinks,
+            $include_caches,
+            $storage_path,
+            $directory_stack,
+            $canonical_index_directory,
+            $initial_index_entries
+        );
+    }
+
+    /**
+     * Resumes traversal from a cursor returned by get_cursor().
+     *
+     * @param string[] $directories     Canonical directories allowed during traversal.
+     * @param string   $cursor_json     JSON cursor returned by the preceding request.
+     * @param bool     $follow_symlinks Whether directory symlinks may lead outside the allowed directories.
+     * @param bool     $include_caches  Whether generated caches and development files are included.
+     * @param string   $storage_path    Reprint storage path omitted from the index, or an empty string.
+     * @return self Resumed file-index processor.
+     */
+    public static function resume(
+        array $directories,
+        string $cursor_json,
+        bool $follow_symlinks,
+        bool $include_caches,
+        string $storage_path
+    ): self {
+        $cursor = json_decode($cursor_json, true);
+        if (!is_array($cursor)) {
+            throw new InvalidArgumentException("Invalid index cursor format");
+        }
+        if (!isset($cursor["stack"]) || !is_array($cursor["stack"])) {
+            throw new InvalidArgumentException("Index cursor missing stack");
+        }
+
+        $directory_stack = [];
+        foreach ($cursor["stack"] as $frame) {
+            if (!is_array($frame)) {
+                throw new InvalidArgumentException("Invalid index cursor frame");
+            }
+            $encoded_directory = isset($frame["dir"]) ? $frame["dir"] : null;
+            if (!is_string($encoded_directory) || $encoded_directory === "") {
+                throw new InvalidArgumentException("Index cursor frame missing dir");
+            }
+            $directory = base64_decode($encoded_directory, true);
+            if ($directory === false || $directory === "") {
+                throw new InvalidArgumentException("Index cursor frame has invalid dir encoding");
+            }
+
+            $encoded_after = array_key_exists("after", $frame) ? $frame["after"] : null;
+            if ($encoded_after !== null && !is_string($encoded_after)) {
+                throw new InvalidArgumentException("Index cursor frame invalid after");
+            }
+            $after = null;
+            if ($encoded_after !== null) {
+                $after = base64_decode($encoded_after, true);
+                if ($after === false) {
+                    throw new InvalidArgumentException("Index cursor frame has invalid after encoding");
+                }
+            }
+
+            $directory_stack[] = [
+                "dir" => $directory,
+                "after" => $after,
+            ];
+        }
+
+        $index_directory = !empty($directory_stack)
+            ? $directory_stack[count($directory_stack) - 1]["dir"]
+            : ( isset($directories[0]) ? $directories[0] : "/" );
+
+        return new self(
+            $directories,
+            $follow_symlinks,
+            $include_caches,
+            $storage_path,
+            $directory_stack,
+            $index_directory,
+            []
+        );
+    }
+
+    /**
+     * Performs one traversal step.
+     *
+     * @return bool Whether a current step is available. False means traversal is complete.
+     */
+    public function next_index_step(): bool
+    {
+        if ($this->closed) {
+            throw new LogicException("Cannot take a file-index step after close().");
+        }
+
+        $this->step_status = null;
+        $this->index_entries = [];
+        $this->directory_error = null;
+
+        if (!empty($this->initial_index_entries)) {
+            $this->step_status = self::STATUS_INDEXED;
+            $this->index_entries = $this->initial_index_entries;
+            $this->initial_index_entries = [];
+            return true;
+        }
+
+        if ($this->current_directory_names === null) {
+            if (!$this->open_current_directory()) {
+                return $this->step_status !== null;
+            }
+        }
+
+        if ($this->current_directory_position >= count($this->current_directory_names)) {
+            array_pop($this->directory_stack);
+            $this->forget_current_directory_names();
+            $this->step_status = self::STATUS_DIRECTORY_COMPLETE;
+            return true;
+        }
+
+        $frame_index = count($this->directory_stack) - 1;
+        $entry_name = $this->current_directory_names[$this->current_directory_position];
+        ++$this->current_directory_position;
+        // Set "after" before any skip or stat call. The cursor must move past
+        // a cache path or a path that disappears between scandir() and lstat(),
+        // or every resumed request would inspect that same name again.
+        $this->directory_stack[$frame_index]["after"] = $entry_name;
+        $path = $this->current_directory . "/" . $entry_name;
+
+        if (!$this->include_caches && self::path_is_default_skipped($path)) {
+            $this->step_status = self::STATUS_SKIPPED;
+            return true;
+        }
+        if (
+            $this->storage_path !== ""
+            && \WordPress\Reprint\Exporter\path_is_within_root($path, $this->storage_path)
+        ) {
+            $this->step_status = self::STATUS_SKIPPED;
+            return true;
+        }
+
+        clearstatcache(true, $path);
+        $stat = @lstat($path);
+        if ($stat === false) {
+            $this->step_status = self::STATUS_PATH_UNAVAILABLE;
+            return true;
+        }
+
+        $mode = $stat["mode"] & self::STAT_TYPE_MASK;
+        $type = "file";
+        $link_target = null;
+        $intermediate_symlinks = [];
+        if ($mode === self::STAT_TYPE_LINK) {
+            $type = "link";
+            $resolved_symlink = self::resolve_symlink_target($path);
+            $link_target = $resolved_symlink["target"];
+            if ($this->follow_symlinks) {
+                $intermediate_symlinks = $resolved_symlink["intermediates"];
+            }
+        } elseif ($mode === self::STAT_TYPE_DIR) {
+            $type = "dir";
+        } elseif ($mode !== self::STAT_TYPE_FILE) {
+            $type = "other";
+        }
+
+        $item = [
+            "path" => $path,
+            "ctime" => (int) ( isset($stat["ctime"]) ? $stat["ctime"] : 0 ),
+            "size" => $type === "file" ? (int) ( isset($stat["size"]) ? $stat["size"] : 0 ) : 0,
+            "type" => $type,
+        ];
+        if ($link_target !== null) {
+            $item["target"] = $link_target;
+        }
+        if ($type === "dir") {
+            // The index describes physical emptiness, not emptiness after
+            // exclusions. A cache or Reprint-storage child still makes its
+            // parent non-empty; calling that parent empty could turn an
+            // intentionally omitted descendant into destructive push work.
+            $directory_handle = @opendir($path);
+            if ($directory_handle !== false) {
+                $item["empty"] = true;
+                while (true) {
+                    $directory_entry = readdir($directory_handle);
+                    if ($directory_entry === false) {
+                        break;
+                    }
+                    if ($directory_entry !== "." && $directory_entry !== "..") {
+                        $item["empty"] = false;
+                        break;
+                    }
+                }
+                closedir($directory_handle);
+            }
+            // When the directory cannot be inspected, leave "empty" absent.
+            // Pull reports the later directory-open failure. A push index
+            // builder can stop instead of treating unknown descendants as
+            // deletions.
+        }
+
+        $this->index_entries = $intermediate_symlinks;
+        $this->index_entries[] = $item;
+        $this->step_status = self::STATUS_INDEXED;
+
+        if ($type === "dir") {
+            $canonical_directory = realpath($path);
+            if (
+                $canonical_directory === false
+                || !self::should_skip_index_root($canonical_directory, $this->directories)
+            ) {
+                $this->directory_stack[] = [
+                    "dir" => $path,
+                    "after" => null,
+                ];
+                $this->forget_current_directory_names();
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns what the most recent step did.
+     *
+     * @return string|null One STATUS_* value, or null before the first step and after completion.
+     */
+    public function get_step_status()
+    {
+        return $this->step_status;
+    }
+
+    /**
+     * Returns entries produced by the most recent indexed step.
+     *
+     * @return array[] File-index entries, normally containing exactly one entry.
+     */
+    public function get_index_entries(): array
+    {
+        return $this->index_entries;
+    }
+
+    /**
+     * Returns the directory failure produced by the most recent step.
+     *
+     * @return array|null {
+     *     Directory failure, or null when the current step did not report one.
+     *
+     *     @type string $error_type Protocol error type.
+     *     @type string $path       Filesystem path that could not be traversed.
+     *     @type string $message    Human-readable explanation.
+     * }
+     */
+    public function get_directory_error()
+    {
+        return $this->directory_error;
+    }
+
+    /**
+     * Returns a JSON-safe cursor for the next traversal step.
+     *
+     * @return array {
+     *     File-index cursor.
+     *
+     *     @type array[] $stack Active directories with base64-encoded path names.
+     * }
+     */
+    public function get_cursor(): array
+    {
+        $encoded_stack = [];
+        foreach ($this->directory_stack as $frame) {
+            $encoded_stack[] = [
+                "dir" => base64_encode($frame["dir"]),
+                "after" => $frame["after"] !== null ? base64_encode($frame["after"]) : null,
+            ];
+        }
+        return ["stack" => $encoded_stack];
+    }
+
+    /**
+     * Returns the directory reported by the endpoint as X-Index-Dir.
+     *
+     * @return string Index directory for this traversal.
+     */
+    public function get_index_directory(): string
+    {
+        return $this->index_directory;
+    }
+
+    /**
+     * Returns the directory active during the most recent step.
+     *
+     * @return string|null Current directory, or null before traversal begins.
+     */
+    public function get_current_directory()
+    {
+        return $this->current_directory;
+    }
+
+    /**
+     * Releases in-memory directory data without performing another step.
+     */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        $this->closed = true;
+        $this->initial_index_entries = [];
+        $this->forget_current_directory_names();
+    }
+
+    /**
+     * Reports whether a path belongs to the established default skip set.
+     *
+     * @param string $path Filesystem path to classify.
+     * @return bool Whether the path should be omitted unless caches are included.
+     */
+    public static function path_is_default_skipped(string $path): bool
+    {
+        // Sentinel slashes make component matches independent of whether the
+        // component appears at the beginning, middle, or end of the path.
+        $path_with_boundaries = "/" . trim($path, "/") . "/";
+
+        // These generated directories are limited to wp-content. A directory
+        // named cache elsewhere may contain user files and remains included.
+        // wpcomsh-cache is wp.com Atomic's filesystem cache shadow; wflogs is
+        // Wordfence request and scan data which can grow to gigabytes.
+        static $cache_directories = [
+            "/wp-content/cache/",
+            "/wp-content/upgrade/",
+            "/wp-content/wpcomsh-cache/",
+            "/wp-content/wflogs/",
+        ];
+        foreach ($cache_directories as $directory) {
+            if (strpos($path_with_boundaries, $directory) !== false) {
+                return true;
+            }
+        }
+
+        // Version-control metadata and local development dependencies match
+        // complete path components. Similar names such as cache-control or
+        // node_modules-backup remain included.
+        static $skipped_components = [
+            ".git", ".svn", ".hg", ".bzr",
+            "node_modules",
+            ".idea", ".vscode",
+            ".cache", ".npm", ".yarn", ".pnpm-store",
+        ];
+        foreach ($skipped_components as $component) {
+            if (strpos($path_with_boundaries, "/" . $component . "/") !== false) {
+                return true;
+            }
+        }
+
+        // Operating-system metadata matches only the basename.
+        $basename = basename($path);
+        static $skipped_basenames = [
+            ".DS_Store", "._.DS_Store",
+            "Thumbs.db", "desktop.ini", "ehthumbs.db",
+        ];
+        if (in_array($basename, $skipped_basenames, true)) {
+            return true;
+        }
+        // Editor and merge scratch files: Emacs locks and autosaves, trailing
+        // tildes, Vim swaps, backups, and conflict leftovers.
+        if ($basename !== "" && $basename[0] === "." && isset($basename[1]) && $basename[1] === "#") {
+            return true;
+        }
+        if (strlen($basename) >= 3 && $basename[0] === "#" && substr($basename, -1) === "#") {
+            return true;
+        }
+        if (preg_match("/(?:~|\\.(?:swp|swo|swn|bak|orig|rej))$/", $basename) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Initializes common traversal state.
+     *
+     * @param string[] $directories          Canonical directories allowed during traversal.
+     * @param bool     $follow_symlinks      Whether directory symlinks may leave the allowed directories.
+     * @param bool     $include_caches       Whether generated caches and development files are included.
+     * @param string   $storage_path         Reprint storage path omitted from the index, or an empty string.
+     * @param array[]  $directory_stack      Active directory stack.
+     * @param string   $index_directory      Directory reported by the endpoint.
+     * @param array[]  $initial_index_entries Intermediate symlinks emitted before traversal.
+     */
+    private function __construct(
+        array $directories,
+        bool $follow_symlinks,
+        bool $include_caches,
+        string $storage_path,
+        array $directory_stack,
+        string $index_directory,
+        array $initial_index_entries
+    ) {
+        $this->directories = $directories;
+        $this->follow_symlinks = $follow_symlinks;
+        $this->include_caches = $include_caches;
+        $this->storage_path = self::canonical_storage_path($storage_path);
+        $this->directory_stack = $directory_stack;
+        $this->index_directory = $index_directory;
+        $this->initial_index_entries = $initial_index_entries;
+    }
+
+    /**
+     * Opens and positions the directory at the top of the traversal stack.
+     *
+     * @return bool Whether directory entries are ready for the current step.
+     */
+    private function open_current_directory(): bool
+    {
+        if (empty($this->directory_stack)) {
+            return false;
+        }
+
+        $frame_index = count($this->directory_stack) - 1;
+        $frame = $this->directory_stack[$frame_index];
+        $this->current_directory = $frame["dir"];
+
+        clearstatcache(true, $this->current_directory);
+        $canonical_directory = realpath($this->current_directory);
+        if ($canonical_directory === false || !is_dir($canonical_directory)) {
+            array_pop($this->directory_stack);
+            $this->directory_error = [
+                "error_type" => "dir_open",
+                "path" => $this->current_directory,
+                "message" => "Directory does not exist or is not accessible",
+            ];
+            $this->step_status = self::STATUS_DIRECTORY_ERROR;
+            return false;
+        }
+
+        if (
+            !$this->follow_symlinks
+            && !self::path_is_within_directories($canonical_directory, $this->directories)
+        ) {
+            array_pop($this->directory_stack);
+            $this->directory_error = [
+                "error_type" => "dir_outside_root",
+                "path" => $canonical_directory,
+                "message" => "Directory is outside allowed roots",
+            ];
+            $this->step_status = self::STATUS_DIRECTORY_ERROR;
+            return false;
+        }
+
+        // Canonical paths keep split roots and followed symlinks in one
+        // namespace, matching the endpoint's previous traversal.
+        $this->directory_stack[$frame_index]["dir"] = $canonical_directory;
+        $this->current_directory = $canonical_directory;
+
+        clearstatcache(true, $canonical_directory);
+        $directory_names = @scandir($canonical_directory, SCANDIR_SORT_ASCENDING);
+        if ($directory_names === false) {
+            array_pop($this->directory_stack);
+            $this->directory_error = [
+                "error_type" => "dir_open",
+                "path" => $canonical_directory,
+                "message" => "Failed to open directory",
+            ];
+            $this->step_status = self::STATUS_DIRECTORY_ERROR;
+            return false;
+        }
+
+        if (getenv("SITE_EXPORT_TEST_MODE") && function_exists("_e2e_call_hook")) {
+            $hook_arguments = [$canonical_directory, &$directory_names];
+            _e2e_call_hook("test_hook_during_dir_scan", $hook_arguments);
+        }
+
+        $this->current_directory_names = [];
+        foreach ($directory_names as $directory_name) {
+            if ($directory_name !== "." && $directory_name !== "..") {
+                $this->current_directory_names[] = $directory_name;
+            }
+        }
+        $this->current_directory_position = 0;
+        $after = isset($frame["after"]) ? $frame["after"] : null;
+        if ($after !== null && $after !== "") {
+            $this->current_directory_position = self::position_after_name(
+                $this->current_directory_names,
+                $after
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Drops the cached names for the current directory.
+     */
+    private function forget_current_directory_names(): void
+    {
+        $this->current_directory_names = null;
+        $this->current_directory_position = 0;
+    }
+
+    /**
+     * Returns a canonical storage path when the configured path exists.
+     *
+     * @param string $storage_path Configured Reprint storage path.
+     * @return string Canonical or normalized storage path, or an empty string.
+     */
+    private static function canonical_storage_path(string $storage_path): string
+    {
+        // Reprint storage may live inside the document root on hosts that can
+        // write nowhere else. It must never enter an index or a push could
+        // copy or delete its own work while using it. Traversal canonicalizes
+        // directories with realpath(), so the comparison uses the same form.
+        // rtrim() also prevents a trailing slash from missing an exact match.
+        $storage_path = rtrim($storage_path, "/");
+        if ($storage_path === "") {
+            return "";
+        }
+        $canonical_storage_path = realpath($storage_path);
+        return $canonical_storage_path !== false ? $canonical_storage_path : $storage_path;
+    }
+
+    /**
+     * Reports whether a path is inside one of the allowed directories.
+     *
+     * @param string   $path        Canonical filesystem path.
+     * @param string[] $directories Canonical allowed directories.
+     * @return bool Whether the path belongs to an allowed directory.
+     */
+    private static function path_is_within_directories(string $path, array $directories): bool
+    {
+        foreach ($directories as $directory) {
+            if ($path === $directory || strpos($path, $directory . "/") === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Reports whether traversing a directory would duplicate a scheduled root.
+     *
+     * An exact root is already scheduled. A parent of a scheduled root would
+     * expose paths outside the requested tree before entering that root again.
+     *
+     * @param string   $candidate Canonical directory considered for traversal.
+     * @param string[] $roots     Canonical scheduled roots.
+     * @return bool Whether traversal should omit this directory.
+     */
+    private static function should_skip_index_root(string $candidate, array $roots): bool
+    {
+        foreach ($roots as $root) {
+            if ($candidate === $root) {
+                return true;
+            }
+            if ($candidate === "/" || strpos($root . "/", $candidate . "/") === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Finds the first sorted directory name after a cursor name.
+     *
+     * @param string[] $directory_names Sorted directory names.
+     * @param string   $after_name      Last settled directory name.
+     * @return int Position of the next directory name.
+     */
+    private static function position_after_name(array $directory_names, string $after_name): int
+    {
+        $low = 0;
+        $high = count($directory_names);
+        while ($low < $high) {
+            $middle = (int) ( ( $low + $high ) / 2 );
+            if (strcmp($directory_names[$middle], $after_name) <= 0) {
+                $low = $middle + 1;
+            } else {
+                $high = $middle;
+            }
+        }
+        return $low;
+    }
+
+    /**
+     * Resolves a directory symlink and finds symlinks in its unresolved path.
+     *
+     * Managed WordPress hosts often chain symlinks: /srv may point to /,
+     * /srv/wordpress may point to /wordpress, and readlink() may return a
+     * relative path containing more symlinks. realpath() gives the final
+     * canonical directory used for further indexing. File symlinks do not get
+     * a canonical target because the pull client does not traverse them.
+     *
+     * realpath() skips the intermediate links, so the unresolved readlink()
+     * path is also walked. Those intermediate entries let pull recreate the
+     * complete path rather than only its final target.
+     *
+     * @param string $path Absolute path to the symlink.
+     * @return array {
+     *     Symlink details for file indexing.
+     *
+     *     @type string|null $target        Canonical directory target, or null.
+     *     @type array[]     $intermediates Symlinks encountered before that target.
+     * }
+     */
+    private static function resolve_symlink_target(string $path): array
+    {
+        clearstatcache(true, $path);
+        $resolved_target = @realpath($path);
+        if (
+            $resolved_target === false
+            || $resolved_target === $path
+            || !is_dir($resolved_target)
+        ) {
+            return ["target" => null, "intermediates" => []];
+        }
+
+        $intermediates = [];
+        $raw_target = @readlink($path);
+        if ($raw_target !== false && $raw_target !== "") {
+            if ($raw_target[0] !== "/") {
+                $raw_target = dirname($path) . "/" . $raw_target;
+            }
+            $absolute_raw_target = self::normalize_dot_segments($raw_target);
+            if (
+                $absolute_raw_target !== ""
+                && $absolute_raw_target[0] === "/"
+                && $absolute_raw_target !== $resolved_target
+            ) {
+                $intermediates = self::find_parent_symlinks($absolute_raw_target);
+            }
+        }
+
+        return ["target" => $resolved_target, "intermediates" => $intermediates];
+    }
+
+    /**
+     * Returns symlinks found while walking the parents of an absolute path.
+     *
+     * For `/srv/wordpress/wp-content/plugins`, this inspects `/srv`, then
+     * `/srv/wordpress`, and so on. After finding a link, traversal continues
+     * from its canonical path. The walk is intentionally not recursive into
+     * the final target; pull decides whether another directory needs indexing.
+     *
+     * @param string $absolute_path Absolute filesystem path.
+     * @return array[] Intermediate symlink index entries.
+     */
+    private static function find_parent_symlinks(string $absolute_path): array
+    {
+        $entries = [];
+        $parts = explode("/", $absolute_path);
+        $current = "";
+        foreach ($parts as $part) {
+            if ($part === "") {
+                $current = "/";
+                continue;
+            }
+            $current = rtrim($current, "/") . "/" . $part;
+            if (!@is_link($current)) {
+                continue;
+            }
+
+            $target = @readlink($current);
+            if ($target !== false && $target !== "") {
+                $stat = @lstat($current);
+                $entries[] = [
+                    "path" => $current,
+                    "ctime" => (int) ( is_array($stat) && isset($stat["ctime"]) ? $stat["ctime"] : 0 ),
+                    "size" => 0,
+                    "type" => "link",
+                    "target" => $target,
+                    "intermediate" => true,
+                ];
+            }
+
+            $canonical_current = @realpath($current);
+            if ($canonical_current !== false) {
+                $current = $canonical_current;
+            }
+        }
+        return $entries;
+    }
+
+    /**
+     * Removes dot segments without following symlinks.
+     *
+     * realpath() cannot be used here because it would skip the intermediate
+     * symlinks that find_parent_symlinks() needs to inspect.
+     *
+     * @param string $path Absolute path containing optional dot segments.
+     * @return string Path with dot segments removed.
+     */
+    private static function normalize_dot_segments(string $path): string
+    {
+        $parts = explode("/", $path);
+        $normalized = [];
+        foreach ($parts as $part) {
+            if ($part === "" || $part === ".") {
+                if (empty($normalized)) {
+                    $normalized[] = "";
+                }
+                continue;
+            }
+            if ($part === "..") {
+                if (count($normalized) > 1) {
+                    array_pop($normalized);
+                }
+                continue;
+            }
+            $normalized[] = $part;
+        }
+        return implode("/", $normalized);
+    }
+}

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -9,6 +9,8 @@ use function WordPress\Reprint\Exporter\json_encode_or_throw;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
 
+require_once __DIR__ . '/class-file-index-processor.php';
+
 // Capture any accidental output before headers are set so we can discard it
 // when switching to streaming mode later.
 if (!ob_get_level()) {
@@ -1204,29 +1206,6 @@ function resolve_directories(array $config): array
     }
 
     return $directories;
-}
-
-/**
- * Returns true when traversing $candidate would only duplicate or re-enter
- * one of the already-scheduled roots.
- *
- * Examples:
- * - candidate == root: duplicate root
- * - candidate is a parent of root: would expose outside-tree paths and then
- *   re-enter the scheduled root again
- */
-function should_skip_index_root(string $candidate, array $roots): bool
-{
-    foreach ($roots as $root) {
-        if ($candidate === $root) {
-            return true;
-        }
-        if ($candidate === "/" || str_starts_with($root . "/", $candidate . "/")) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 /**
@@ -2513,201 +2492,6 @@ function stream_file_producer(
 }
 
 /**
- * Encodes a file_index stack for JSON serialization.
- *
- * Paths may contain non-UTF8 bytes, so dir and after are base64-encoded.
- */
-function encode_index_stack(array $stack): array
-{
-    $encoded = [];
-    foreach ($stack as $frame) {
-        $encoded[] = [
-            "dir" => base64_encode($frame["dir"]),
-            "after" => $frame["after"] !== null ? base64_encode($frame["after"]) : null,
-        ];
-    }
-    return $encoded;
-}
-
-/**
- * Resolve "." and ".." segments in a path without resolving symlinks.
- *
- * Unlike realpath(), this only performs textual normalization — it collapses
- * "." and ".." but leaves symlink components intact.  This is useful when
- * you need a clean absolute path to inspect which components are symlinks.
- *
- * @param string $path An absolute path that may contain "." or ".." segments.
- * @return string The normalized absolute path.
- */
-function normalize_dot_segments(string $path): string
-{
-    $parts = explode("/", $path);
-    $normalized = [];
-    foreach ($parts as $p) {
-        if ($p === "" || $p === ".") {
-            if (empty($normalized)) {
-                $normalized[] = "";
-            }
-            continue;
-        }
-        if ($p === "..") {
-            if (count($normalized) > 1) {
-                array_pop($normalized);
-            }
-            continue;
-        }
-        $normalized[] = $p;
-    }
-    return implode("/", $normalized);
-}
-
-/**
- * Given a path, such as `/srv/wordpress/wp-content/plugins/akismet/assets`, returns
- * a list of all the parent paths that are symlinks. It will check `/srv`,
- * `/srv/wordpress`, `/srv/wordpress/wp-content`, etc.
- *
- * For example, given the following filesystem layout:
- *
- *     /srv/wordpress/wp-content -> /htdocs/wp-content
- *     /srv/wordpress/wp-content/plugins/akismet -> /wordpress/plugins/akismet/latest
- *     /wordpress/plugins/akismet/latest -> /wordpress/plugins/akismet/5.0.5
- *
- * Calling
- *
- *     find_parents_symlinks("/srv/wordpress/wp-content/plugins/akismet/assets")
- *
- * will return the following symlinks:
- *
- * ['path' => '/srv/wordpress/wp-content', 'target' => '/htdocs/wp-content']
- * ['path' => '/htdocs/wp-content/plugins/akismet', 'target' => '/wordpress/plugins/akismet/latest']
- *
- * Note:
- *
- * * Every found `path` is a resolved realpath(), which means that all the parents are
- *   regular directories, not symlinks.
- * * It is intentionally not recursive. That last `akismet/latest` -> `akismet/5.0.5`
- *   symlink was not returned. The client is free to recursively request the files from
- *   any additional directories outside of the initial content root based on the parent
- *   symlinks resolved by this function.
- *
- * @param string $absolute_path An absolute path to a file or directory.
- * @return array An array of symlinks found in the path.
- * Each array element is an associative array with the following keys:
- * - "path": The path to the symlink.
- * - "ctime": The creation time of the symlink.
- * - "size": The size of the symlink.
- * - "type": The type of the symlink.
- * - "target": The target of the symlink.
- * - "intermediate": Whether the symlink is an intermediate symlink.
- */
-function find_parents_symlinks(string $absolute_path): array
-{
-    $entries = [];
-    $parts = explode('/', $absolute_path);
-    $current = "";
-    // Walk through /srv, /srv/wordpress, /srv/wordpress/wp-content, etc.
-    foreach ($parts as $part) {
-        if ($part === "") {
-            $current = "/";
-            continue;
-        }
-        $current = rtrim($current, "/") . "/" . $part;
-        // If the path up to this point is not a symlink, we can just
-        // expand to the next path segment.
-        if (!@is_link($current)) {
-            continue;
-        }
-
-        // If we're looking at a valid symlink, record it.
-        $target = @readlink($current);
-        if ($target !== false && $target !== "") {
-            $stat = @lstat($current);
-            $entries[] = [
-                "path" => $current,
-                "ctime" => (int) ($stat["ctime"] ?? 0),
-                "size" => 0,
-                "type" => "link",
-                "target" => $target,
-                "intermediate" => true,
-            ];
-        }
-        // Swap the current path for the resolved realpath().
-        // e.g. if $current is a symlink at /srv/wordpress/wp-content pointing
-        // to /htdocs/wp-content, then from now on we'll use /htdocs/wp-content
-        // as our $current and append the next path segments to it.
-        $real = @realpath($current);
-        if ($real !== false) {
-            $current = $real;
-        }
-    }
-    return $entries;
-}
-
-/**
- * Resolves a symlink's target to a canonical path for the file index.
- *
- * On many WordPress hosts (wp.com, SiteGround, etc.), the filesystem
- * contains chains of symlinks.  For example, /srv might point to /,
- * /srv/wordpress might point to /wordpress, and readlink() returns
- * relative paths like "../wordpress/core/latest" that still contain
- * intermediate symlinks.  realpath() cuts through all of this and
- * returns the final canonical path — e.g. /htdocs instead of /srv/htdocs.
- *
- * The client uses symlink targets to discover additional directories to
- * index, so only directory symlinks get a resolved target.  File symlink
- * targets are ignored because the client doesn't need to recurse into them.
- *
- * Also walks the raw readlink() path to find intermediate symlinks that
- * realpath() skips.  For example, if readlink() returns a relative path
- * like "../../../wordpress/plugins/akismet/latest", the absolute form
- * might be /srv/wordpress/plugins/akismet/latest — and /srv/wordpress is
- * itself a symlink to /wordpress.  realpath() jumps straight to
- * /wordpress/..., so we'd never record the /srv/wordpress intermediate.
- * find_parents_symlinks() catches those.
- *
- * @param string $path  Absolute path to the symlink.
- * @return array {
- *     Resolved symlink target details.
- *
- *     @type string|null $target        Resolved canonical target, or null for
- *                                     file symlinks or unresolvable paths.
- *     @type array       $intermediates Intermediate symlink entries found while
- *                                     walking the raw target path.
- * }
- * @phpstan-return array{target: string|null, intermediates: array}
- */
-function resolve_symlink_target(string $path): array
-{
-    clearstatcache(true, $path);
-    $resolved_target = @realpath($path);
-
-    // Only directory symlinks matter — the client uses targets to discover
-    // additional directories to index.  Also skip unresolvable symlinks
-    // and self-referencing paths.
-    if (
-        $resolved_target === false ||
-        $resolved_target === $path ||
-        !is_dir($resolved_target)
-    ) {
-        return ['target' => null, 'intermediates' => []];
-    }
-
-    $intermediates = [];
-    $raw_target = @readlink($path);
-    if ($raw_target !== false && $raw_target !== "") {
-        if ($raw_target[0] !== "/") {
-            $raw_target = dirname($path) . "/" . $raw_target;
-        }
-        $abs_raw = normalize_dot_segments($raw_target);
-        if ($abs_raw !== "" && $abs_raw[0] === "/" && $abs_raw !== $resolved_target) {
-            $intermediates = find_parents_symlinks($abs_raw);
-        }
-    }
-
-    return ['target' => $resolved_target, 'intermediates' => $intermediates];
-}
-
-/**
  * Encodes batch items for JSON serialization, base64-encoding paths
  * to handle non-UTF8 filesystem bytes.
  */
@@ -2739,9 +2523,8 @@ function encode_index_batch(array $batch_items): array
  * Streams a directory index as gzipped JSON batches of {path, ctime, size,
  * type}, plus an `empty` boolean on every inspected directory.
  *
- * The client supplies list_dir and drives traversal depth-first by
- * enqueuing directories as they are discovered. Resumption is supported
- * via cursor containing the directory stack and last-seen entry.
+ * FileIndexProcessor owns the resumable filesystem traversal. This endpoint
+ * owns HTTP framing, batching, request budgets, and error chunks.
  */
 function endpoint_file_index(
     array $config,
@@ -2753,169 +2536,50 @@ function endpoint_file_index(
     clearstatcache(true);
 
     $directories = resolve_directories($config);
-    $batch_size = $config["batch_size"] ?? 5000;
     $batch_size = require_int_range(
         "batch_size",
-        (int) $batch_size,
+        (int) ($config["batch_size"] ?? 5000),
         100,
         100000
     );
-
-    $list_dir = $config["list_dir"] ?? null;
-    $list_dir_real = null;
-    $stack = [];
-    $ordered = [];
     $follow_symlinks = !empty($config["follow_symlinks"]);
-    $cursor_provided = isset($config["cursor"]);
-    // Default-skip generated caches, VCS metadata, OS junk, and editor
-    // scratch files unless the client explicitly opts in. See
-    // path_is_default_skipped() for the full deny-list and rationale.
     $include_caches = !empty($config["include_caches"]);
-    // Reprint's own storage (the push work area and commit bookkeeping)
-    // must never appear in an index: it can sit inside the document root on
-    // hosts that allow writing nowhere else, and indexing it would sync or
-    // delete reprint's own records mid-transfer. storage_path is the
-    // server's own setting, so it is known here for every request — a
-    // pulling peer's request does not need to mention it.
     $storage_path = isset($config["storage_path"]) && is_string($config["storage_path"])
-        ? rtrim($config["storage_path"], "/")
+        ? $config["storage_path"]
         : "";
-    if ($storage_path !== "") {
-        // The traversal canonicalizes every path with realpath() (see the
-        // wp.com note further down), so the setting must be compared in the
-        // same form. path_is_within_root() compares plain strings, and a
-        // trailing slash on the setting would make it miss — hence the
-        // rtrim above. When the directory does not exist yet there is
-        // nothing to exclude and the trimmed value stays as a harmless
-        // fallback.
-        $storage_real = realpath($storage_path);
-        if ($storage_real !== false) {
-            $storage_path = $storage_real;
-        }
-    }
 
-    // Find the starting point – either by parsing the cursor, or by
-    // sourcing it from the filesystem.
-
-    // -- Restore or initialize the directory traversal stack --
-    // On resumption, the cursor encodes the stack of directories and the
-    // last-processed entry in each. On first request, build the stack from
-    // the list_dir and any extra allowed roots.
-    if ($cursor_provided) {
-        $cursor_data = json_decode($config["cursor"], true);
-        if (!is_array($cursor_data)) {
-            throw new InvalidArgumentException("Invalid index cursor format");
-        }
-        if (!isset($cursor_data["stack"]) || !is_array($cursor_data["stack"])) {
-            throw new InvalidArgumentException("Index cursor missing stack");
-        }
-        foreach ($cursor_data["stack"] as $frame) {
-            if (!is_array($frame)) {
-                throw new InvalidArgumentException("Invalid index cursor frame");
-            }
-            $dir_encoded = $frame["dir"] ?? null;
-            if (!is_string($dir_encoded) || $dir_encoded === "") {
-                throw new InvalidArgumentException("Index cursor frame missing dir");
-            }
-            $dir = base64_decode($dir_encoded, true);
-            if ($dir === false || $dir === "") {
-                throw new InvalidArgumentException("Index cursor frame has invalid dir encoding");
-            }
-            $after_encoded = $frame["after"] ?? null;
-            if ($after_encoded !== null && !is_string($after_encoded)) {
-                throw new InvalidArgumentException("Index cursor frame invalid after");
-            }
-            $after = null;
-            if ($after_encoded !== null) {
-                $after = base64_decode($after_encoded, true);
-                if ($after === false) {
-                    throw new InvalidArgumentException("Index cursor frame has invalid after encoding");
-                }
-            }
-            $stack[] = [
-                "dir" => $dir,
-                "after" => $after,
-            ];
-        }
+    if (isset($config["cursor"])) {
+        $file_index = FileIndexProcessor::resume(
+            $directories,
+            $config["cursor"],
+            $follow_symlinks,
+            $include_caches,
+            $storage_path
+        );
     } else {
-        if (!$list_dir) {
+        $list_directory = $config["list_dir"] ?? null;
+        if (!is_string($list_directory) || $list_directory === "") {
             throw new InvalidArgumentException("list_dir is required for file_index");
         }
-
-        clearstatcache(true, $list_dir);
-        $list_dir_real = realpath($list_dir);
-        if ($list_dir_real === false || !is_dir($list_dir_real)) {
-            throw new InvalidArgumentException(
-                "list_dir does not exist or is not accessible: {$list_dir}"
-            );
-        }
-
-        $allowed = false;
-        foreach ($directories as $root) {
-            if (
-                $list_dir_real === $root ||
-                str_starts_with($list_dir_real, $root . "/")
-            ) {
-                $allowed = true;
-                break;
-            }
-        }
-        // When follow_symlinks is enabled, allow any directory that the
-        // authenticated client requests.  The client is already authenticated
-        // via HMAC, so there is no untrusted-input risk.
-        if (!$allowed && !$follow_symlinks) {
-            throw new InvalidArgumentException(
-                "list_dir is outside of allowed roots: {$list_dir_real}"
-            );
-        }
-
-        $ordered = [$list_dir_real];
-        $extra_roots = [];
-        foreach ($directories as $root) {
-            if ($root === $list_dir_real) {
-                continue;
-            }
-            $extra_roots[] = $root;
-        }
-        if (!empty($extra_roots)) {
-            sort($extra_roots, SORT_STRING);
-            foreach ($extra_roots as $root) {
-                // Skip exact duplicates of already-ordered roots.
-                // Do NOT skip parent roots — on hosts like wp.com Atomic
-                // the document root (/srv/htdocs) is a parent of the
-                // primary root (/srv/htdocs/__wp__) but contains a separate
-                // wp-content with the site's actual plugins and themes.
-                // The during-traversal dedup in the main loop already
-                // prevents re-entering child roots (i.e. when traversing
-                // /srv/htdocs we won't descend back into __wp__/).
-                if (in_array($root, $ordered, true)) {
-                    continue;
-                }
-                $ordered[] = $root;
-            }
-        }
-
-        for ($i = count($ordered) - 1; $i >= 0; $i--) {
-            $stack[] = [
-                "dir" => $ordered[$i],
-                "after" => null,
-            ];
-        }
+        $file_index = FileIndexProcessor::start(
+            $directories,
+            $list_directory,
+            $follow_symlinks,
+            $include_caches,
+            $storage_path
+        );
     }
 
-    if ($list_dir_real === null) {
-        if (!empty($stack)) {
-            $list_dir_real = $stack[count($stack) - 1]["dir"];
-        } else {
-            $list_dir_real = $directories[0] ?? "/";
-        }
+    if (getenv('SITE_EXPORT_TEST_MODE')) {
+        _e2e_load_test_hooks_if_needed($config);
     }
+
+    $list_directory = $file_index->get_index_directory();
+    $filesystem_root = $directories[0] ?? "/";
 
     prepare_streaming_response();
-
     ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream();
 
-    $filesystem_root = $directories[0] ?? "/";
     $batches_emitted = 0;
     $total_entries = 0;
     $batch_items = [];
@@ -2923,425 +2587,116 @@ function endpoint_file_index(
     $aborted = false;
     $abort_payload = null;
 
-    // -- Pre-scan: discover intermediate symlinks --
-    // When following symlinks, discover intermediate symlinks along each
-    // directory path being traversed.  For example, if list_dir is
-    // /srv/wordpress/plugins/akismet/latest and /srv/wordpress is itself
-    // a symlink to /wordpress, emit that intermediate symlink so the
-    // client can recreate the full chain locally.
-    if (!$cursor_provided && $follow_symlinks) {
-        foreach ($ordered as $dir) {
-            $path_symlinks = find_parents_symlinks($dir);
-            foreach ($path_symlinks as $entry) {
-                $batch_items[] = $entry;
-            }
-        }
-    }
-
-    // -- Depth-first directory traversal --
-    // Walk the directory tree using the stack. Each directory's entries are
-    // read with scandir (sorted ascending), yielding files, symlinks, and
-    // subdirectories. Subdirectories push new frames onto the stack. Entries
-    // are batched into JSON index_batch chunks and streamed to the client.
-
-    $current_dir = $list_dir_real;
-
     try {
         $metadata = [
             "filesystem_root" => base64_encode($filesystem_root),
-            "list_dir" => base64_encode($list_dir_real),
+            "list_dir" => base64_encode($list_directory),
         ];
         $metadata_json = json_encode_or_throw($metadata);
-
         $gz->write(
             "--{$boundary}\r\n" .
             "Content-Type: application/json\r\n" .
             "Content-Length: " . strlen($metadata_json) . "\r\n" .
             "X-Chunk-Type: metadata\r\n" .
-            "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
-            "X-Index-Dir: " . base64_encode($list_dir_real ?? "") . "\r\n" .
+            "X-Filesystem-Root: " . base64_encode($filesystem_root) . "\r\n" .
+            "X-Index-Dir: " . base64_encode($list_directory) . "\r\n" .
             "\r\n" .
             $metadata_json . "\r\n"
         );
         $gz->sync();
-        $stop = false;
 
+        $stop = false;
         while (!$stop) {
-            if (empty($stack)) {
+            if (!$file_index->next_index_step()) {
                 $status = "complete";
                 break;
             }
 
-            $frame_index = count($stack) - 1;
-            $frame = $stack[$frame_index];
-            $current_dir = $frame["dir"];
-            $current_after = $frame["after"] ?? null;
-
-            clearstatcache(true, $current_dir);
-            $current_real = realpath($current_dir);
-            if ($current_real === false || !is_dir($current_real)) {
-                $abort_payload = [
-                    "error_type" => "dir_open",
-                    "path" => base64_encode($current_dir),
-                    "message" => "Directory does not exist or is not accessible",
-                ];
-                array_pop($stack);
-                $json = json_encode_or_throw($abort_payload);
-                $cursor_json = json_encode_or_throw(
-                    ["stack" => encode_index_stack($stack)],
-                    JSON_UNESCAPED_SLASHES
-                );
-                $cursor_b64 = base64_encode($cursor_json);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . $cursor_b64 . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n"
-                );
-                $gz->sync();
-                $abort_payload = null;
-                continue;
-            }
-
-            $allowed = $follow_symlinks;
-            if (!$allowed) {
-                foreach ($directories as $root) {
-                    if (
-                        $current_real === $root ||
-                        str_starts_with($current_real, $root . "/")
-                    ) {
-                        $allowed = true;
-                        break;
+            switch ($file_index->get_step_status()) {
+                case FileIndexProcessor::STATUS_INDEXED:
+                    foreach ($file_index->get_index_entries() as $index_entry) {
+                        $batch_items[] = $index_entry;
                     }
-                }
-            }
-            if (!$allowed) {
-                $abort_payload = [
-                    "error_type" => "dir_outside_root",
-                    "path" => base64_encode($current_real),
-                    "message" => "Directory is outside allowed roots",
-                ];
-                array_pop($stack);
-                $json = json_encode_or_throw($abort_payload);
-                $cursor_json = json_encode_or_throw(
-                    ["stack" => encode_index_stack($stack)],
-                    JSON_UNESCAPED_SLASHES
-                );
-                $cursor_b64 = base64_encode($cursor_json);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . $cursor_b64 . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n"
-                );
-                $gz->sync();
-                $abort_payload = null;
-                continue;
-            }
-
-            // Use realpath() consistently for all paths. On hosts like wp.com,
-            // /srv is a symlink to / and /srv/wordpress is a symlink to
-            // /wordpress, so realpath() canonicalizes everything into one
-            // namespace: /srv/htdocs → /htdocs, /srv/wordpress/... → /wordpress/...
-            // This keeps root dirs and symlink-followed dirs consistent.
-            $stack[$frame_index]["dir"] = $current_real;
-            $current_dir = $current_real;
-
-
-
-            clearstatcache(true, $current_real);
-            $entries = @scandir($current_real, SCANDIR_SORT_ASCENDING);
-            if ($entries === false) {
-                $abort_payload = [
-                    "error_type" => "dir_open",
-                    "path" => base64_encode($current_real),
-                    "message" => "Failed to open directory",
-                ];
-                $json = json_encode_or_throw($abort_payload);
-                $cursor_json = json_encode_or_throw(
-                    ["stack" => encode_index_stack($stack)],
-                    JSON_UNESCAPED_SLASHES
-                );
-                $cursor_b64 = base64_encode($cursor_json);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . $cursor_b64 . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n"
-                );
-                $gz->sync();
-                $abort_payload = null;
-                array_pop($stack);
-                continue;
-            }
-
-            // E2E test hook: during directory scanning
-            if (getenv('SITE_EXPORT_TEST_MODE')) {
-                _e2e_load_test_hooks_if_needed($config);
-                $hook_args = [$current_real, &$entries];
-                _e2e_call_hook('test_hook_during_dir_scan', $hook_args);
-            }
-
-            $filtered = [];
-            foreach ($entries as $entry) {
-                if ($entry === "." || $entry === "..") {
-                    continue;
-                }
-                $filtered[] = $entry;
-            }
-
-            $position = 0;
-            if ($current_after !== null && $current_after !== "") {
-                $position = position_after_entry($filtered, $current_after);
-            }
-
-            while (true) {
-                if ($position >= count($filtered)) {
-                    array_pop($stack);
-                    break;
-                }
-                $entry = $filtered[$position];
-                $position++;
-
-                $stack[$frame_index]["after"] = $entry;
-                $path = $current_dir . "/" . $entry;
-                // Default deny-list. Applied before stat() to save a syscall
-                // per skipped entry, and before the traversal push so we
-                // don't recurse into skipped directories. The "after" cursor
-                // is updated above this check, so resume correctly skips
-                // past the filtered entry on the next request.
-                if (!$include_caches && path_is_default_skipped($path)) {
-                    continue;
-                }
-                // The "" guard matters: path_is_within_root() with an empty
-                // root would match every absolute path.
-                if ($storage_path !== "" && path_is_within_root($path, $storage_path)) {
-                    continue;
-                }
-                clearstatcache(true, $path);
-                $stat = @lstat($path);
-                if ($stat === false) {
-                    if (
-                        !$budget->has_remaining()
-                    ) {
-                        $status = "partial";
+                    if (count($batch_items) >= $batch_size) {
+                        emit_file_index_batch(
+                            $gz,
+                            $boundary,
+                            $batch_items,
+                            $file_index
+                        );
+                        $batches_emitted++;
+                        $total_entries += count($batch_items);
+                        $batch_items = [];
+                    }
+                    if (!$budget->has_remaining()) {
                         $stop = true;
-                        break;
                     }
-                    continue;
-                }
-
-                $mode = $stat["mode"] & STAT_TYPE_MASK;
-                $type = "file";
-                $link_target = null;
-                if ($mode === STAT_TYPE_LINK) {
-                    $type = "link";
-                    $resolved = resolve_symlink_target($path);
-                    $link_target = $resolved['target'];
-                    if ($follow_symlinks && !empty($resolved['intermediates'])) {
-                        $batch_items = array_merge($batch_items, $resolved['intermediates']);
-                    }
-                } elseif ($mode === STAT_TYPE_DIR) {
-                    $type = "dir";
-                } elseif ($mode !== STAT_TYPE_FILE) {
-                    $type = "other";
-                }
-
-                $ctime = (int) ($stat["ctime"] ?? 0);
-                $size = $type === "file" ? (int) ($stat["size"] ?? 0) : 0;
-
-                $item = [
-                    "path" => $path,
-                    "ctime" => $ctime,
-                    "size" => $size,
-                    "type" => $type,
-                ];
-                if ($link_target !== null) {
-                    $item["target"] = $link_target;
-                }
-                if ($type === "dir") {
-                    // Record physical emptiness in the source index so later
-                    // push planning compares two index files without reopening
-                    // the live source tree. Skipped or storage-owned children
-                    // still make the directory non-empty: calling it empty
-                    // could turn their omission into destructive root work.
-                    $directory_handle = @opendir($path);
-                    if ($directory_handle !== false) {
-                        $item["empty"] = true;
-                        while (true) {
-                            $directory_entry = readdir($directory_handle);
-                            if ($directory_entry === false) {
-                                break;
-                            }
-                            if ($directory_entry !== "." && $directory_entry !== "..") {
-                                $item["empty"] = false;
-                                break;
-                            }
-                        }
-                        closedir($directory_handle);
-                    }
-                    // When the directory cannot be inspected, leave `empty`
-                    // absent. Pull keeps its existing dir_open reporting, while
-                    // push planning fails closed instead of treating missing
-                    // descendants as deletions.
-                }
-                $batch_items[] = $item;
-
-                if (count($batch_items) >= $batch_size) {
-                    // E2E test hook: before index batch is emitted
-                    if (getenv('SITE_EXPORT_TEST_MODE')) {
-                        _e2e_load_test_hooks_if_needed($config);
-                        $hook_args = [&$batch_items, $stack];
-                        _e2e_call_hook('test_hook_before_index_batch', $hook_args);
-                    }
-
-                    $cursor_json = json_encode_or_throw(
-                        ["stack" => encode_index_stack($stack)],
-                        JSON_UNESCAPED_SLASHES
-                    );
-                    $cursor_b64 = base64_encode($cursor_json);
-                    $json = json_encode_or_throw(
-                        encode_index_batch($batch_items),
-                        JSON_UNESCAPED_SLASHES
-                    );
-
-                    $gz->write(
-                        "--{$boundary}\r\n" .
-                        "Content-Type: application/json\r\n" .
-                        "Content-Length: " . strlen($json) . "\r\n" .
-                        "X-Chunk-Type: index_batch\r\n" .
-                        "X-Cursor: " . $cursor_b64 . "\r\n" .
-                        "X-Batch-Size: " . count($batch_items) . "\r\n" .
-                        "\r\n"
-                    );
-                    $gz->write($json);
-                    $gz->write("\r\n");
-                    $gz->sync();
-
-                    $batches_emitted++;
-                    $total_entries += count($batch_items);
-                    $batch_items = [];
-                }
-
-                if ($type === "dir") {
-                    // Skip traversing directories whose realpath is already
-                    // covered by the configured roots (duplicate root), or is a
-                    // parent of one of them (would expose outside-tree files and
-                    // re-enter a scheduled root). O(k) where k = number of roots.
-                    $dir_real = realpath($path);
-                    if ($dir_real !== false && should_skip_index_root($dir_real, $directories)) {
-                        // Don't push — emit the entry but skip traversal
-                        continue;
-                    }
-                    $stack[] = [
-                        "dir" => $path,
-                        "after" => null,
-                    ];
                     break;
-                }
 
-                if (
-                    !$budget->has_remaining()
-                ) {
-                    $status = "partial";
-                    $stop = true;
+                case FileIndexProcessor::STATUS_PATH_UNAVAILABLE:
+                case FileIndexProcessor::STATUS_DIRECTORY_COMPLETE:
+                    if (!$budget->has_remaining()) {
+                        $stop = true;
+                    }
                     break;
-                }
-            }
 
-            if ($stop) {
-                break;
-            }
+                case FileIndexProcessor::STATUS_DIRECTORY_ERROR:
+                    $directory_error = $file_index->get_directory_error();
+                    emit_file_index_error(
+                        $gz,
+                        $boundary,
+                        $directory_error,
+                        $file_index->get_cursor()
+                    );
+                    break;
 
-            if (
-                !$budget->has_remaining()
-            ) {
-                $status = "partial";
-                break;
+                case FileIndexProcessor::STATUS_SKIPPED:
+                    // Cache, development, and Reprint-storage paths never
+                    // entered the previous endpoint's budget checks either.
+                    break;
             }
         }
     } catch (Throwable $e) {
         $aborted = true;
+        $current_directory = $file_index->get_current_directory();
         $abort_payload = [
             "error_type" => "exception",
-            "path" => base64_encode($current_dir),
+            "path" => base64_encode($current_directory ?? $list_directory),
             "message" => $e->getMessage(),
         ];
     }
 
-    // -- Flush remaining items and write completion chunk --
     if (!empty($batch_items)) {
-        $cursor_json = json_encode_or_throw(
-            ["stack" => encode_index_stack($stack)],
-            JSON_UNESCAPED_SLASHES
-        );
-        $cursor_b64 = base64_encode($cursor_json);
-        $json = json_encode_or_throw(
-            encode_index_batch($batch_items),
-            JSON_UNESCAPED_SLASHES
-        );
-
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/json\r\n" .
-            "Content-Length: " . strlen($json) . "\r\n" .
-            "X-Chunk-Type: index_batch\r\n" .
-            "X-Cursor: " . $cursor_b64 . "\r\n" .
-            "X-Batch-Size: " . count($batch_items) . "\r\n" .
-            "\r\n"
-        );
-        $gz->write($json);
-        $gz->write("\r\n");
-        $gz->sync();
-
+        emit_file_index_batch($gz, $boundary, $batch_items, $file_index);
         $batches_emitted++;
         $total_entries += count($batch_items);
     }
 
     try {
         if ($abort_payload !== null) {
-            $json = json_encode_or_throw($abort_payload);
-            $cursor_json = json_encode_or_throw(
-                ["stack" => encode_index_stack($stack)],
-                JSON_UNESCAPED_SLASHES
+            emit_file_index_error(
+                $gz,
+                $boundary,
+                $abort_payload,
+                $file_index->get_cursor(),
+                true
             );
-            $cursor_b64 = base64_encode($cursor_json);
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/json\r\n" .
-                "Content-Length: " . strlen($json) . "\r\n" .
-                "X-Chunk-Type: error\r\n" .
-                "X-Cursor: " . $cursor_b64 . "\r\n" .
-                "\r\n" .
-                $json . "\r\n"
-            );
-            $gz->sync();
             $status = "partial";
         }
 
         $cursor_json = json_encode_or_throw(
-            ["stack" => encode_index_stack($stack)],
+            $file_index->get_cursor(),
             JSON_UNESCAPED_SLASHES
         );
-        $cursor_b64 = base64_encode($cursor_json);
-
+        $cursor_base64 = base64_encode($cursor_json);
         $gz->write(
             "--{$boundary}\r\n" .
             "Content-Type: application/octet-stream\r\n" .
             "Content-Length: 0\r\n" .
             "X-Chunk-Type: completion\r\n" .
             "X-Status: " . ($aborted ? "partial" : $status) . "\r\n" .
-            "X-Cursor: " . $cursor_b64 . "\r\n" .
-            "X-Index-Dir: " . base64_encode($list_dir_real) . "\r\n" .
+            "X-Cursor: {$cursor_base64}\r\n" .
+            "X-Index-Dir: " . base64_encode($list_directory) . "\r\n" .
             "X-Batches-Emitted: {$batches_emitted}\r\n" .
             "X-Total-Entries: {$total_entries}\r\n" .
             "X-Memory-Used: " . memory_get_peak_usage(true) . "\r\n" .
@@ -3352,8 +2707,10 @@ function endpoint_file_index(
             "--{$boundary}--\r\n"
         );
         $gz->finish();
-    } catch (\Throwable $e) {
+    } catch (Throwable $e) {
         error_log("Export: failed to write completion chunk: " . $e->getMessage());
+    } finally {
+        $file_index->close();
     }
 
     return [
@@ -3365,6 +2722,101 @@ function endpoint_file_index(
             "time_elapsed" => microtime(true) - $budget->start_time,
         ],
     ];
+}
+
+/**
+ * Writes one file-index batch with the processor's current cursor.
+ *
+ * @param object             $gzip_stream Gzip stream returned by begin_multipart_stream().
+ * @param string             $boundary    Multipart boundary.
+ * @param array[]            $batch_items File-index entries in this batch.
+ * @param FileIndexProcessor $file_index  Active file-index processor.
+ */
+function emit_file_index_batch(
+    $gzip_stream,
+    string $boundary,
+    array &$batch_items,
+    FileIndexProcessor $file_index
+): void {
+    if (getenv('SITE_EXPORT_TEST_MODE')) {
+        $directory_stack = [];
+        foreach ($file_index->get_cursor()["stack"] as $encoded_frame) {
+            $directory_stack[] = [
+                "dir" => base64_decode($encoded_frame["dir"]),
+                "after" => $encoded_frame["after"] !== null
+                    ? base64_decode($encoded_frame["after"])
+                    : null,
+            ];
+        }
+        $hook_args = [&$batch_items, $directory_stack];
+        _e2e_call_hook('test_hook_before_index_batch', $hook_args);
+    }
+
+    $cursor_json = json_encode_or_throw(
+        $file_index->get_cursor(),
+        JSON_UNESCAPED_SLASHES
+    );
+    $cursor_base64 = base64_encode($cursor_json);
+    $json = json_encode_or_throw(
+        encode_index_batch($batch_items),
+        JSON_UNESCAPED_SLASHES
+    );
+    $gzip_stream->write(
+        "--{$boundary}\r\n" .
+        "Content-Type: application/json\r\n" .
+        "Content-Length: " . strlen($json) . "\r\n" .
+        "X-Chunk-Type: index_batch\r\n" .
+        "X-Cursor: {$cursor_base64}\r\n" .
+        "X-Batch-Size: " . count($batch_items) . "\r\n" .
+        "\r\n"
+    );
+    $gzip_stream->write($json);
+    $gzip_stream->write("\r\n");
+    $gzip_stream->sync();
+}
+
+/**
+ * Writes one file-index error with the cursor after that failure.
+ *
+ * @param object $gzip_stream    Gzip stream returned by begin_multipart_stream().
+ * @param string $boundary       Multipart boundary.
+ * @param array  $error          {
+ *     File-index error.
+ *
+ *     @type string $error_type Protocol error type.
+ *     @type string $path       Filesystem path.
+ *     @type string $message    Human-readable explanation.
+ * }
+ * @param array  $cursor         {
+ *     File-index cursor after the failure.
+ *
+ *     @type array[] $stack Active directories with base64-encoded path names.
+ * }
+ * @param bool   $path_is_base64 Whether the error path is already base64 text.
+ */
+function emit_file_index_error(
+    $gzip_stream,
+    string $boundary,
+    array $error,
+    array $cursor,
+    bool $path_is_base64 = false
+): void {
+    if (!$path_is_base64) {
+        $error["path"] = base64_encode($error["path"]);
+    }
+    $json = json_encode_or_throw($error);
+    $cursor_json = json_encode_or_throw($cursor, JSON_UNESCAPED_SLASHES);
+    $cursor_base64 = base64_encode($cursor_json);
+    $gzip_stream->write(
+        "--{$boundary}\r\n" .
+        "Content-Type: application/json\r\n" .
+        "Content-Length: " . strlen($json) . "\r\n" .
+        "X-Chunk-Type: error\r\n" .
+        "X-Cursor: {$cursor_base64}\r\n" .
+        "\r\n" .
+        $json . "\r\n"
+    );
+    $gzip_stream->sync();
 }
 
 /**
@@ -3630,101 +3082,14 @@ function path_head_looks_like_text(string $path): bool
 }
 
 /**
- * Returns true if $path is a generated cache file, version-control or
- * dev-tooling artifact, or OS-level junk that is not worth shipping in
- * a typical site migration.
+ * Reports whether a path belongs to the established default file-index skip set.
  *
- * Matching rules:
- *
- *   - Path-component-aware: a segment that *contains* a skipped name as a
- *     substring (e.g. "cache-control" or "node_modules-backup") does NOT
- *     trigger a skip. Only whole-segment matches do. This is done by
- *     wrapping `/` around both the haystack and needle and doing a
- *     substring check.
- *
- *   - Cache/upgrade dirs are matched only under `wp-content/` so a user
- *     directory literally called `cache` in some other tree doesn't
- *     silently disappear.
- *
- *   - Dotfiles that ship in real WordPress sites — `.htaccess`,
- *     `.user.ini`, `.well-known/` — are preserved. Editor/VCS dotfiles
- *     and macOS metadata are not.
- *
- * The default deny-list is conservative: false-negatives (something we
- * could have skipped but didn't) are mere wire-byte waste; false-positives
- * (something the user actually wanted) are silent data loss. Callers
- * opting in to a more aggressive filter can pass extra patterns; callers
- * who want everything can set include_caches=1 on the request.
+ * @param string $path Filesystem path to classify.
+ * @return bool Whether the path is omitted unless caches are included.
  */
 function path_is_default_skipped(string $path): bool
 {
-    // Sentinel slashes on each side make "starts-with" / "ends-with" /
-    // "anywhere-in-middle" the same str_contains() check.
-    $needle_haystack = '/' . trim($path, '/') . '/';
-
-    // Generated content under wp-content/. WordPress regenerates these
-    // on demand (cache via the page lifecycle, upgrade via wp-admin
-    // updates), so transferring them is pure waste.
-    //
-    // Notable specific entries:
-    //   - wp-content/wpcomsh-cache: wp.com Atomic's Memcached-backed
-    //     filesystem cache shadow.
-    //   - wp-content/wflogs: Wordfence's per-request scan logs; can
-    //     reach gigabytes on long-running sites.
-    static $cache_dirs = [
-        '/wp-content/cache/',
-        '/wp-content/upgrade/',
-        '/wp-content/wpcomsh-cache/',
-        '/wp-content/wflogs/',
-    ];
-    foreach ($cache_dirs as $needle) {
-        if (strpos($needle_haystack, $needle) !== false) {
-            return true;
-        }
-    }
-
-    // VCS metadata + local dev tooling. Match any path component exactly.
-    static $junk_components = [
-        '.git', '.svn', '.hg', '.bzr',
-        'node_modules',
-        '.idea', '.vscode',
-        '.cache', '.npm', '.yarn', '.pnpm-store',
-    ];
-    foreach ($junk_components as $needle) {
-        if (strpos($needle_haystack, '/' . $needle . '/') !== false) {
-            return true;
-        }
-    }
-
-    // OS junk + filesystem metadata files (basename match).
-    $basename = basename($path);
-    static $junk_basenames = [
-        '.DS_Store', '._.DS_Store',
-        'Thumbs.db', 'desktop.ini', 'ehthumbs.db',
-    ];
-    if (in_array($basename, $junk_basenames, true)) {
-        return true;
-    }
-
-    // Editor / merge scratch files (basename pattern):
-    //   `.#name`      Emacs lock
-    //   `#name#`      Emacs autosave
-    //   `name~`       Editor backup
-    //   `name.swp`    Vim swap (also .swo, .swn)
-    //   `name.bak`    generic backup
-    //   `name.orig`   merge conflict leftover
-    //   `name.rej`    merge conflict leftover
-    if ($basename !== '' && $basename[0] === '.' && isset($basename[1]) && $basename[1] === '#') {
-        return true;
-    }
-    if (strlen($basename) >= 3 && $basename[0] === '#' && substr($basename, -1) === '#') {
-        return true;
-    }
-    if (preg_match('/(?:~|\.(?:swp|swo|swn|bak|orig|rej))$/', $basename) === 1) {
-        return true;
-    }
-
-    return false;
+    return FileIndexProcessor::path_is_default_skipped($path);
 }
 
 /**
@@ -3851,25 +3216,6 @@ function require_float_range(
         );
     }
     return $value;
-}
-
-/**
- * Returns the index of the first entry lexicographically after $after (binary search).
- */
-function position_after_entry(array $entries, string $after): int
-{
-    $low = 0;
-    $high = count($entries);
-    while ($low < $high) {
-        $mid = (int) (($low + $high) / 2);
-        $entry = $entries[$mid];
-        if (strcmp($entry, $after) <= 0) {
-            $low = $mid + 1;
-        } else {
-            $high = $mid;
-        }
-    }
-    return $low;
 }
 
 /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,17 +26,7 @@ parameters:
 			path: packages/reprint-exporter/src/export.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: packages/reprint-exporter/src/export.php
-
-		-
 			message: "#^Variable \\$directories in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: packages/reprint-exporter/src/export.php
-
-		-
-			message: "#^Variable \\$filesystem_root on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: packages/reprint-exporter/src/export.php
 

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__) . '/packages/reprint-exporter/src/class-file-index-processor.php';
+
+final class FileIndexProcessorTest extends TestCase {
+
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/file-index-processor-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testResumeAfterEveryStepMatchesOneOpenProcessor(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        mkdir($docroot . '/empty', 0755, true);
+        mkdir($docroot . '/nested', 0755, true);
+        mkdir($docroot . '/wp-content/cache', 0755, true);
+        file_put_contents($docroot . '/a.txt', 'a');
+        file_put_contents($docroot . '/nested/b.txt', 'b');
+        file_put_contents($docroot . '/wp-content/cache/skipped.txt', 'skip');
+
+        $uninterrupted = $this->runProcessor($docroot, false);
+        $resumed = $this->runProcessor($docroot, true);
+
+        $this->assertSame($uninterrupted, $resumed);
+        $this->assertContains('empty', $this->relativePaths($resumed['entries'], $docroot));
+        $this->assertContains('nested/b.txt', $this->relativePaths($resumed['entries'], $docroot));
+        $this->assertNotContains(
+            'wp-content/cache',
+            $this->relativePaths($resumed['entries'], $docroot)
+        );
+        $this->assertContains(FileIndexProcessor::STATUS_SKIPPED, $resumed['statuses']);
+        $this->assertContains(FileIndexProcessor::STATUS_DIRECTORY_COMPLETE, $resumed['statuses']);
+        $this->assertTrue($resumed['empty_directory_was_empty']);
+    }
+
+    public function testPathThatDisappearsAfterDirectoryScanGetsItsOwnStep(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        mkdir($docroot, 0755, true);
+        file_put_contents($docroot . '/a.txt', 'a');
+        file_put_contents($docroot . '/b.txt', 'b');
+
+        $processor = FileIndexProcessor::start(
+            [realpath($docroot)],
+            $docroot,
+            false,
+            true,
+            ''
+        );
+        $this->assertTrue($processor->next_index_step());
+        $this->assertSame(FileIndexProcessor::STATUS_INDEXED, $processor->get_step_status());
+
+        unlink($docroot . '/b.txt');
+
+        $this->assertTrue($processor->next_index_step());
+        $this->assertSame(
+            FileIndexProcessor::STATUS_PATH_UNAVAILABLE,
+            $processor->get_step_status()
+        );
+        $this->assertSame([], $processor->get_index_entries());
+        $processor->close();
+    }
+
+    public function testMissingScheduledDirectoryReportsTheDirectoryAndContinues(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        $vanishingDirectory = $docroot . '/a-directory';
+        mkdir($vanishingDirectory, 0755, true);
+        file_put_contents($docroot . '/z.txt', 'z');
+        $docroot = (string) realpath($docroot);
+        $vanishingDirectory = (string) realpath($vanishingDirectory);
+
+        $processor = FileIndexProcessor::start(
+            [realpath($docroot)],
+            $docroot,
+            false,
+            true,
+            ''
+        );
+        $this->assertTrue($processor->next_index_step());
+        $this->assertSame(FileIndexProcessor::STATUS_INDEXED, $processor->get_step_status());
+        $this->assertSame($vanishingDirectory, $processor->get_index_entries()[0]['path']);
+
+        rmdir($vanishingDirectory);
+
+        $this->assertTrue($processor->next_index_step());
+        $this->assertSame(
+            FileIndexProcessor::STATUS_DIRECTORY_ERROR,
+            $processor->get_step_status()
+        );
+        $this->assertSame(
+            [
+                'error_type' => 'dir_open',
+                'path' => $vanishingDirectory,
+                'message' => 'Directory does not exist or is not accessible',
+            ],
+            $processor->get_directory_error()
+        );
+
+        $this->assertTrue($processor->next_index_step());
+        $this->assertSame(FileIndexProcessor::STATUS_INDEXED, $processor->get_step_status());
+        $this->assertSame($docroot . '/z.txt', $processor->get_index_entries()[0]['path']);
+        $processor->close();
+    }
+
+    public function testResumeWithACompletedCursorRemainsComplete(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        mkdir($docroot, 0755, true);
+
+        $processor = FileIndexProcessor::start(
+            [realpath($docroot)],
+            $docroot,
+            false,
+            true,
+            ''
+        );
+        $this->assertTrue($processor->next_index_step());
+        $this->assertSame(
+            FileIndexProcessor::STATUS_DIRECTORY_COMPLETE,
+            $processor->get_step_status()
+        );
+        $this->assertFalse($processor->next_index_step());
+        $this->assertFalse($processor->next_index_step());
+        $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
+        $processor->close();
+        $processor->close();
+
+        $resumed = FileIndexProcessor::resume(
+            [realpath($docroot)],
+            $cursor,
+            false,
+            true,
+            ''
+        );
+        $this->assertFalse($resumed->next_index_step());
+        $resumed->close();
+    }
+
+    public function testStepAfterCloseIsRejected(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        mkdir($docroot, 0755, true);
+        $processor = FileIndexProcessor::start(
+            [realpath($docroot)],
+            $docroot,
+            false,
+            true,
+            ''
+        );
+        $processor->close();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot take a file-index step after close().');
+        $processor->next_index_step();
+    }
+
+    /**
+     * @return array {
+     *     Completed traversal.
+     *
+     *     @type array[]  $entries                    File-index entries.
+     *     @type string[] $statuses                   Status returned by every step.
+     *     @type bool     $empty_directory_was_empty Whether the empty directory was classified correctly.
+     * }
+     */
+    private function runProcessor(string $docroot, bool $resumeAfterEveryStep): array
+    {
+        $canonicalDocroot = realpath($docroot);
+        $processor = FileIndexProcessor::start(
+            [$canonicalDocroot],
+            $canonicalDocroot,
+            false,
+            false,
+            ''
+        );
+        $entries = [];
+        $statuses = [];
+        while ($processor->next_index_step()) {
+            $statuses[] = $processor->get_step_status();
+            foreach ($processor->get_index_entries() as $entry) {
+                $entries[] = $entry;
+            }
+
+            if ($resumeAfterEveryStep) {
+                $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
+                $processor->close();
+                $processor = FileIndexProcessor::resume(
+                    [$canonicalDocroot],
+                    $cursor,
+                    false,
+                    false,
+                    ''
+                );
+            }
+        }
+        $processor->close();
+
+        $emptyDirectoryWasEmpty = false;
+        foreach ($entries as $entry) {
+            if ($entry['path'] === $canonicalDocroot . '/empty') {
+                $emptyDirectoryWasEmpty = ( $entry['empty'] ?? null ) === true;
+            }
+        }
+
+        return [
+            'entries' => $entries,
+            'statuses' => $statuses,
+            'empty_directory_was_empty' => $emptyDirectoryWasEmpty,
+        ];
+    }
+
+    /**
+     * @param array[] $entries File-index entries.
+     * @return string[] Document-root-relative paths.
+     */
+    private function relativePaths(array $entries, string $docroot): array
+    {
+        $prefix = rtrim( (string) realpath($docroot), '/') . '/';
+        $paths = [];
+        foreach ($entries as $entry) {
+            if (strpos($entry['path'], $prefix) === 0) {
+                $paths[] = substr($entry['path'], strlen($prefix));
+            }
+        }
+        return $paths;
+    }
+
+    private function deleteTree(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        foreach (scandir($directory) as $name) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $name;
+            if (is_dir($path) && !is_link($path)) {
+                $this->deleteTree($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}


### PR DESCRIPTION
Extracts filesystem traversal from `endpoint_file_index()` into `FileIndexProcessor`.

The processor owns directory ordering, one-path steps, path inspection, exclusions, symlink handling, and the resumable cursor. The endpoint remains responsible for request limits, batching, gzip, multipart framing, and protocol errors. The goal is to use the same processor for local push indexing in a follow-up PR.

A discovered directory is added to the traversal stack before its index entry is returned. If that entry completes an HTTP batch, the batch cursor therefore contains the directory that must be traversed next.

`FileIndexProcessor` remains PHP 7.2-compatible and retains the established `scandir()` ordering and one-wide-directory memory bound.

Part of #276.

## Testing

There's no useful manual test for this extraction. Review `FileIndexProcessorTest` and rely on CI.
