### PR TITLE
[Push] Build the fresh local index inside PushPlan

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -380,6 +380,7 @@
                 },
                 "classmap": [
                     "src/class-mysql-dump-producer.php",
+                    "src/class-file-index-processor.php",
                     "src/class-file-tree-producer.php",
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -87,12 +87,13 @@ each successful commit:
     <state-dir>/push/<site>/local_index_at_previous_push.jsonl
     <state-dir>/push/<site>/previously_pushed_rows.jsonl   (phase two)
 
-`PushPlan` derives the local paths to push and delete by merging a path-sorted
-fresh local index with `local_index_at_previous_push.jsonl`. It never reopens
-the live tree. The indexer records physical emptiness while it observes each
-directory, so a completed index distinguishes empty directories from non-empty
-ones. Files and symlinks change when their `type`, `ctime`, or `size` changes;
-unrelated index values do not select a path for upload.
+`PushPlan` first builds a path-sorted fresh local index, then derives the local
+paths to push and delete by diffing it against
+`local_index_at_previous_push.jsonl`. The indexer marks physical emptiness while
+it observes each directory, so a completed index distinguishes empty
+directories from non-empty ones. Files and symlinks change when their `type`,
+`ctime`, or `size` changes; unrelated index values do not select a path for
+upload.
 
 The index reader trusts the indexer's entry values. It handles only failures to
 read a line, decode its JSON, or decode its base64 path. This keeps schema
@@ -101,42 +102,49 @@ the push plan.
 
 A push plan is an internal part of the sender lifecycle:
 
-1. `PushFilesSender::start()` copies the completed fresh local index into the
-   local push state directory through a `.swap` file, atomically renames the
-   completed copy, and then stores `sender.json`.
-2. `push_create` returns at most 100 target exclusions. The sender stores them
-   once in `excluded_paths.json` and calls `PushPlan::start()`. The plan reads
-   those exclusions and writes its initial cursor.
-3. Each `next_step()` merges one path. It returns true while another planning
-   step remains and false when both indexes reach EOF. It
+1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
+   100 target exclusions, which the sender stores once in
+   `excluded_paths.json`.
+2. The sender starts one internal `PushPlan`. The plan opens
+   `fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
+   step advances one traversal event, appends its JSONL entries when applicable,
+   flushes those bytes, and then stores the traversal cursor and committed byte
+   offset in `cursor.json`.
+3. Once traversal is complete, the plan enters `starting_diff`. The next step
+   starts the index diff and enters `diffing`.
+4. Each later `next_step()` compares at most one path represented by either
+   index. It returns true while another planning step remains and false when
+   both indexes reach EOF. It
    writes files, symlinks, and empty directories with their planned type, size,
    and ctime to
    `local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
    `local_paths_to_delete`.
-4. The sender closes the plan before consuming those two files.
-5. After the receiver commits successfully, the sender saves the retained fresh
+5. The sender closes the plan before consuming those two files.
+6. After the receiver commits successfully, the sender saves the retained fresh
    local index as `local_index_at_previous_push.jsonl` through the same swap-file
-   copy. It then asks the closed plan to remove its cursor.
+   copy. It then asks the closed plan to remove the fresh local index followed
+   by its cursor. A discarded plan removes them in the same order.
 
-The complete index copy is a deliberate exception to bounded sender steps. A
+The completed-index copy after commit is a deliberate exception to bounded
+sender steps. A
 representative index entry is about 150 bytes, so one million paths produce
 roughly 150 MB, which takes about 15 seconds even at 10 MiB/s. PHP `copy()`
 streams the index without loading it into memory, and only the final rename
 moves the completed copy into place. This accepts that a 1 MiB/s drive reaches
-30 seconds at roughly 200,000 paths. A stopped initial copy leaves no
-`sender.json`, so a later start repeats it. This stays
-simpler than two copy cursors, retained handles, and per-chunk state writes
-until measurements from materially larger installations justify that machinery.
+30 seconds at roughly 200,000 paths. A stopped copy is repeated by the next
+sender run. Keeping another cursor and retained handle for this post-commit copy
+is not justified until measurements from materially larger installations show
+that it matters.
 
-Each step flushes both path lists and the append-only deleted-directory stack
-before atomically storing the cursor with the two index offsets, two output
-byte offsets, path counts, and active stack byte offset. Each stack entry links
-to the preceding active directory, so resume reads only the top entry. A later
-process calls `PushPlan::resume()` with only
-the local push state directory. Resume uses the retained index and
-`excluded_paths.json`, discards
-bytes beyond the durable output offsets, and continues from the durable index
-offsets.
+During indexing, `cursor.json` contains the internal phase, the
+`FileIndexProcessor` cursor, and the committed fresh-index byte offset. During
+diffing, each step flushes only the path list or append-only deleted-directory
+stack changed by that step before atomically storing the two index offsets, two
+output byte offsets, and active stack byte offset. Each stack entry links to the
+preceding active directory, so continuation reads only the top entry. A later
+process calls `PushPlan::resume()` with the local push state directory and
+document root. The plan uses `excluded_paths.json`, discards bytes beyond its
+durable output offsets, and continues from the retained internal phase.
 
 The first push to a site has no local index from a previous push or previously
 pushed rows. Every current file, symlink, and empty directory is selected, and
@@ -272,8 +280,8 @@ acquires the same lock and reads the unfinished state once. The returned sender
 keeps that state in memory while `next_step()` performs bounded work. When the
 caller stops between steps, `cancel()` discards an open multipart request and
 returns to the preceding durable boundary. `close()` then releases the lock.
-Without cancellation, `close()` finishes the request and stores its confirmed
-local boundary. A second local process cannot start or resume the same sender
+`close()` never finishes a request or advances the workflow. A second local
+process cannot start or resume the same sender
 until the open sender is closed. `next_step()` returns true while another step
 may be performed and false after completion, restart, or failure; the caller
 reads that outcome from the sender. The caller may stop after any true return
@@ -281,33 +289,37 @@ and close the sender. If the process stops without closing, the next process
 uses the preceding sender boundary and receiver-confirmed cursors to account
 for later remote work.
 
-The open sender lazily opens `local_paths_to_push.jsonl`,
-`local_paths_to_delete`, and the current local file. It retains those handles
-across `next_step()` calls, lets each handle advance with the work, and seeks
-only when a newly opened or receiver-confirmed offset differs. It closes each
-handle when its phase or file ends and closes any remaining handles before
-`close()` releases the lifecycle lock.
+During PushPlan's internal `indexing` phase, the plan retains one
+`FileIndexProcessor` and the open fresh local index across steps. A
+newly opened plan truncates that file to the byte offset stored with the
+processor cursor before continuing. The sender lazily opens
+`local_paths_to_push.jsonl`, `local_paths_to_delete`, and the current local file.
+It retains those handles across `next_step()` calls, lets each handle advance
+with the work, and seeks only when a newly opened or receiver-confirmed offset
+differs. It closes each handle when its phase or file ends and closes any
+remaining handles before `close()` releases the lifecycle lock.
 
-`start()` copies the completed fresh local index into plan-owned state before
-storing `sender.json` or returning the sender. `push_create` then supplies the
-receiver exclusion policy, and each `planning` step merges one path. PushPlan
-owns the merge offsets, output lengths,
-deleted-directory ranges, and exclusions in `cursor.json`. No upload
-begins until both indexes have been consumed and the two path lists are stable.
+The sender creates the push session and stores its exclusion policy before it
+starts PushPlan. Each internal `indexing` step completes one traversal event,
+and `starting_diff` initializes the index diff. Each internal `diffing` step
+compares at most one path and updates the path lists. PushPlan owns the
+file-index cursor, index offsets, output lengths, deleted-directory ranges, and
+exclusions in `cursor.json`. No upload begins until both indexes have been
+consumed and the two path lists are stable.
 
 `sender.json` contains no second planning checkpoint and no copied receiver
 cursor. It stores the push session and phase, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
-sizing state.
-Its phases are `creating`, `starting_plan`, `planning`, `pushing_paths`,
-`pushing_deletes`, `committing`, `saving_local_index_at_previous_push`,
-`completing`, `removing`, and `discarding_plan`.
+sizing state. Its phases are `creating`, `starting_plan`, `planning`,
+`pushing_paths`, `pushing_deletes`, `committing`,
+`saving_local_index_at_previous_push`, `completing`, `removing`, and
+`discarding_plan`.
 The separate start, index-save, completion, removal, and discard phases ensure
 that a process stop between durable actions repeats only the current action.
-During `planning`, `cursor.json` alone owns the merge position and output
-lengths. A completed cursor remains until commit and the local index save
-finishes,
-or until `discarding_plan` follows confirmed target removal.
+During `planning`, `cursor.json` alone owns the plan's internal phase and
+continuation offsets. A completed cursor remains until commit and the local
+index save finishes, or until `discarding_plan` follows confirmed target
+removal.
 
 Each local path to push carries the type, size, and ctime from the index used to
 plan it. When the receiver position is unknown, the sender compares the live
@@ -331,8 +343,8 @@ the current push may delete it on the target and the next push will send it.
 A changed local path to push, a vanished path to push, or a directory to push
 that is no longer empty moves the sender to `removing`. Repeated bounded remove
 calls delete the upload-only push session; the sender enters `discarding_plan`,
-removes the PushPlan cursor, and changes its status to `restart` so the caller
-can produce a new fresh local index. Deletions deliberately retain the tree
+removes the PushPlan cursor, and changes its status to `restart` so a new sender
+can build a fresh local index. Deletions deliberately retain the tree
 captured by the completed fresh local index rather than attempting to describe
 the live tree at commit time.
 
@@ -346,8 +358,8 @@ Each local-path upload or deletion step sends at most one multipart part. A file
 part contains one bounded chunk, a deletion-list part contains one complete
 path, and a directory or symlink part contains one complete value. The sender
 retains one multipart request across successive steps until its body budget is
-spent or the caller explicitly cancels it. Without cancellation, close()
-finishes that request and stores the confirmed local boundary. The sender
+spent or the caller explicitly cancels it. `close()` only releases resources
+and the lifecycle lock. The sender
 derives Content-Length from the bytes actually read and never reads another
 local path to push until the current one is complete. Receiver
 contention, offset gaps, and transport failures end the current sender run. The

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -105,26 +105,28 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`cursor.json` owns planning offsets, output offsets, and the active byte offset
-in `deleted_directories_stack.jsonl`. The stack file is append-only;
-each entry links to the preceding active directory. `excluded_paths.json` stores
-the target exclusions once for the active push, with a maximum of 100 paths.
-`sender.json` does not repeat those values. Its phases are `creating`,
-`starting_plan`, `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
+`cursor.json` owns PushPlan's internal phase. During `indexing`, it stores the
+FileIndexProcessor cursor and the committed byte offset in
+`fresh_local_index.jsonl`. During `diffing`, it stores the index offsets,
+output offsets, and the active byte offset in
+`deleted_directories_stack.jsonl`. The stack file is append-only; each entry
+links to the preceding active directory. `excluded_paths.json` stores the target
+exclusions once for the active push, with a maximum of 100 paths. `sender.json`
+does not repeat those values. Its phases are `creating`, `starting_plan`,
+`planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index_at_previous_push`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
-path-list cursor, receiver part limit, and request-sizing state. Complete local
-indexes are copied through a `.swap` file and moved into place with `rename()`;
-their copy progress is not part of sender state. `start()` completes the fresh
-local index copy before storing `sender.json`, so later steps depend only on the
-plan-owned index.
+path-list cursor, receiver part limit, and request-sizing state. The index diff
+completes before local paths are sent. The index copy after a successful commit
+has no sender cursor and is repeated after interruption. The plan then removes
+the fresh local index and its cursor.
 
 A request failure ends the current sender run. The active state remains in
 place so a later push command can resume from the last durable boundary. Only
 an explicit `request_too_large` failure lowers future request sizes.
 
 When a local path to push changes, the sender reports `local_path_changed` and
-moves to `removing`. After removal it requests a new fresh local index. The
+moves to `removing`. After removal a new sender builds a fresh local index. The
 sender trusts the completed deletion plan without checking the live local tree;
 changes after planning belong to the next push.
 
@@ -186,6 +188,20 @@ Use these names verbatim inside `PushFilesSender`:
 | Local path stat result | `$path_stat` |
 | File type bits | `$file_type_bits` |
 | Delete active state | `delete_state()` |
+
+## PushPlan names
+
+Use these names verbatim inside `PushPlan`:
+
+| Meaning | Name |
+| --- | --- |
+| Local tree root | `$local_tree_root`, `set_local_tree_root()` |
+| Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
+| Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |
+| Fresh local index byte offset | `$fresh_local_index_byte_offset` |
+| Open fresh local index | `$fresh_local_index_handle` |
+| Index diff cursor | `IndexDiffCursor` |
+| Start index diff | `start_index_diff()` |
 
 ## Protocol names
 

--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -354,13 +354,13 @@ final class FileIndexProcessor {
             $type = "other";
         }
 
-        // Build the index entry from the one successful lstat() call. Only
-        // regular-file bytes contribute a size; directories and links carry
-        // their type-specific details separately.
+        // Build the index entry from the one successful lstat() call. File and
+        // link sizes participate in push change detection; directory size does
+        // not describe its descendants and is normalized to zero.
         $item = [
             "path" => $path,
             "ctime" => (int) ( isset($stat["ctime"]) ? $stat["ctime"] : 0 ),
-            "size" => $type === "file" ? (int) ( isset($stat["size"]) ? $stat["size"] : 0 ) : 0,
+            "size" => $type === "file" || $type === "link" ? (int) ( isset($stat["size"]) ? $stat["size"] : 0 ) : 0,
             "type" => $type,
         ];
         if ($link_target !== null) {

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -10,9 +10,10 @@
  * PushFilesSender owns the only caller-visible lifecycle. It holds the lock,
  * creates and removes the target push session, drives its internal PushPlan,
  * streams the selected paths, commits the push, and saves the completed fresh
- * local index as the local index at the previous push. The target owns the upload cursor for every path and for the
- * deletion list. Durable sender state retains the top-level phase, selected
- * path-list cursor, and learned request limits needed after a process restart.
+ * local index as the local index at the previous push. The target owns the
+ * upload cursor for every path and for the deletion list. Durable sender state
+ * retains the top-level phase, the selected path-list cursor, and learned
+ * request limits needed after a process restart.
  *
  * ## Usage
  *
@@ -48,24 +49,23 @@
  * process starts from the preceding durable boundary and reads
  * receiver-confirmed work before sending more data.
  *
- * Before start() returns, the sender copies the completed fresh local index
- * through a swap file into plan-owned state. A new push then calls `push_create`
- * to learn target-owned exclusions before starting PushPlan with that policy.
- * After planning completes, local files, symlinks, and empty
- * directories stream through multipart requests. The raw deletion list
- * follows, and repeated `push_commit` calls let the target install the work in
- * bounded steps. A confirmed commit enters another phase which saves the fresh
- * local index as the local index at the previous push through a swap file.
- * Starting and completing the plan, saving that index, and discarding a
- * removed plan have separate durable phases. A stopped process therefore
- * repeats only an idempotent boundary action rather than a group of unrelated
- * transitions.
+ * A new sender calls `push_create` to learn target-owned exclusions before
+ * starting PushPlan. The plan builds the fresh local index and merges it with
+ * the index at the previous push, one bounded step at a time. After planning
+ * completes, local files, symlinks, and empty directories stream through
+ * multipart requests. The raw deletion list follows, and repeated `push_commit`
+ * calls let the target install the work in bounded steps. A confirmed commit
+ * enters another phase which saves the fresh local index as the local index at
+ * the previous push through a swap file. Index completion, plan completion,
+ * local-index saving, and plan discard each have a separate durable phase. A
+ * stopped process therefore repeats only an idempotent boundary action rather
+ * than a group of unrelated transitions.
  *
  * sender.json owns the top-level phase. During `planning`, cursor.json owns the
- * exact merge position and output lengths; sender.json does not duplicate
+ * plan's internal phase and continuation offsets; sender.json does not duplicate
  * them. A completed plan cursor remains until the target commit and local index
- * save have both finished. A removed target session enters
- * `discarding_plan` before that cursor is deleted.
+ * save have both finished. A removed target session enters `discarding_plan`
+ * before that cursor is deleted.
  *
  * ## Resume after local changes
  *
@@ -82,8 +82,8 @@
  * tree again. A local path which reappears after planning may therefore be
  * deleted by this push; the next push will send it again. If a local path to
  * push changes, the sender removes the upload-only push session, discards the
- * plan, and changes the sender status to `restart` so the caller can produce a
- * new local index.
+ * plan, and changes the sender status to `restart` so the caller can start a
+ * new sender which builds a fresh local index.
  *
  * ## Streaming and durability
  *
@@ -95,7 +95,8 @@
  * the current path phase ends. An open sender retains that request, its
  * path-list handles, and its current local file handle between steps.
  *
- * Copying a complete local index is the deliberate exception to bounded steps.
+ * Saving a complete local index after commit is the deliberate exception to
+ * bounded steps.
  * A representative index entry is about 150 bytes, so one million paths produce
  * roughly 150 MB. Even a 10 MiB/s drive copies that in about 15 seconds. Keeping
  * two copy cursors, two retained handles, and per-chunk state writes for larger
@@ -209,8 +210,7 @@ final class PushFilesSender
     /**
      * Starts a new sender and acquires exclusive ownership of its push state.
      *
-     * The completed fresh local index is copied into plan-owned state before
-     * the initial `creating` state is written. An existing active state is
+     * The returned sender begins in `creating`. An existing active state is
      * rejected so unfinished work cannot be replaced. The returned sender
      * retains its lock until close().
      *
@@ -218,7 +218,6 @@ final class PushFilesSender
      *     Push, push stream client, and local-file options.
      *
      *     @type string                  $docroot                Required local document-root directory.
-     *     @type string                  $fresh_local_index_path Completed fresh local index required by start().
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $base_url                Required exporter API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
@@ -247,15 +246,6 @@ final class PushFilesSender
                     . $sender->state_path
                 );
             }
-            $fresh_local_index_path = $options['fresh_local_index_path'] ?? null;
-            if (!is_string($fresh_local_index_path) || $fresh_local_index_path === '') {
-                throw new InvalidArgumentException('PushFilesSender requires a fresh_local_index_path when starting a sender.');
-            }
-            $sender->copy_through_swap_file(
-                $fresh_local_index_path,
-                PushPlan::fresh_local_index_path($sender->push_state_directory)
-            );
-
             $sender->push_stream_client = $sender->create_push_stream_client(null);
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
@@ -279,8 +269,7 @@ final class PushFilesSender
      * works from that in-memory state, storing each later durable boundary
      * without reopening sender.json.
      *
-     * @param array<string,mixed> $options Options documented by start(). The
-     *     fresh_local_index_path option is not needed when resuming.
+     * @param array<string,mixed> $options Options documented by start().
      * @return self Open sender at its last durable state.
      */
     public static function resume(array $options): self
@@ -304,7 +293,7 @@ final class PushFilesSender
             $sender->state = $state;
             $sender->push_stream_client = $sender->create_push_stream_client($state);
             if ($state['phase'] === 'planning') {
-                $sender->plan = PushPlan::resume($sender->push_state_directory);
+                $sender->plan = PushPlan::resume($sender->push_state_directory, $sender->docroot);
             }
             return $sender;
         } catch (Throwable $throwable) {
@@ -346,7 +335,11 @@ final class PushFilesSender
             }
         }
 
-        $this->docroot = rtrim($docroot, '/');
+        $canonical_docroot = realpath($docroot);
+        if ($canonical_docroot === false) {
+            throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
+        }
+        $this->docroot = rtrim($canonical_docroot, '/');
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->lock_path = $this->push_state_directory . '/sender.lock';
@@ -360,12 +353,12 @@ final class PushFilesSender
      *
      * start() or resume() has already acquired the lifecycle lock and loaded the
      * durable state, so this method only dispatches its current phase. Every
-     * phase step is bounded except the deliberate complete-index copy described
+     * phase step is bounded except the deliberate completed-index copy described
      * in the class documentation. A caller stopping after this method returns
      * true calls cancel() before close(); close() does not finish an open
      * multipart request. A false return directs the caller to get_status(),
      * where `restart` means the old push session and local plan are gone and a
-     * new local index is required.
+     * new sender is required.
      *
      * @return bool Whether the sender can perform another step.
      */
@@ -553,14 +546,14 @@ final class PushFilesSender
     }
 
     /**
-     * Creates or reopens PushPlan after its fresh local index is complete.
+     * Creates or reopens PushPlan after the target exclusions are stored.
      */
     private function start_plan(): void
     {
         if (PushPlan::has_plan($this->push_state_directory)) {
-            $this->plan = PushPlan::resume($this->push_state_directory);
+            $this->plan = PushPlan::resume($this->push_state_directory, $this->docroot);
         } else {
-            $this->plan = PushPlan::start($this->push_state_directory);
+            $this->plan = PushPlan::start($this->push_state_directory, $this->docroot);
         }
         $this->state['phase'] = 'planning';
         $this->store_state($this->state);
@@ -571,7 +564,13 @@ final class PushFilesSender
      */
     private function next_plan_step(): void
     {
-        if (!$this->plan->next_step()) {
+        try {
+            $has_next_step = $this->plan->next_step();
+        } catch (RuntimeException $exception) {
+            $this->fail('local_io_error', $exception->getMessage());
+            return;
+        }
+        if (!$has_next_step) {
             $this->plan->close();
             $this->state['phase'] = 'pushing_paths';
             $this->store_state($this->state);
@@ -1245,7 +1244,7 @@ final class PushFilesSender
         $this->delete_state();
         $this->status = 'restart';
         $this->reason = 'local_path_changed';
-        $this->detail = 'The upload-only push session was removed. Generate a new local index before retrying.';
+        $this->detail = 'The upload-only push session was removed. Run the push command again to build a fresh local index.';
     }
 
     /**
@@ -1405,7 +1404,7 @@ final class PushFilesSender
         }
         return [
             'type' => $type,
-            'size' => (int) $path_stat['size'],
+            'size' => $type === 'directory' ? 0 : (int) $path_stat['size'],
             'ctime' => (int) $path_stat['ctime'],
         ];
     }

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -1,28 +1,29 @@
 <?php
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
+
 /**
  * Internal planner for one PushFilesSender lifecycle.
  *
- * PushPlan merges a path-sorted fresh local index with the local index at the
- * previous push. It writes durable lists of local paths to push and local paths
- * to delete without reading the local tree or accumulating either index in
+ * PushPlan builds a path-sorted fresh local index, then diffs it against the
+ * local index at the previous push. It writes durable lists of local paths to
+ * push and local paths to delete without accumulating an index or path list in
  * memory.
  *
  * PushFilesSender is the only caller-visible processor. It owns the lifecycle
  * lock, top-level phase, transport, result, commit, restart, and removal.
- * PushPlan only merges the two indexes, saves its planning cursor, and
- * produces the local paths to push and local paths to delete.
+ * PushPlan owns FileIndexProcessor, the fresh local index, the index diff, its
+ * planning cursor, and the two completed path lists.
  *
  * ## Durable boundary
  *
- * While sender.json says `planning`, cursor.json exists and the sender owns an
- * open PushPlan under sender.lock. A false next_step() result means both indexes
- * reached EOF; the sender closes the plan before changing its phase. The plan
- * cursor then remains in place until a confirmed commit saves the fresh local
- * index as the local index at the previous push, or removal discards the plan.
- * cursor.json owns planning progress;
- * sender.json never duplicates it.
+ * While sender.json says `planning`, cursor.json owns one of four internal
+ * phases: `indexing`, `starting_diff`, `diffing`, or `complete`. The sender
+ * owns an open PushPlan under sender.lock but does not duplicate any planning
+ * cursor. A false next_step() result means both indexes reached EOF; the sender
+ * closes the plan before changing its phase. The cursor remains until a
+ * confirmed commit saves the fresh local index as the local index at the
+ * previous push, or removal discards the plan.
  *
  * ## Change detection
  *
@@ -42,22 +43,34 @@
  *
  * ## Durability and memory
  *
- * The sender copies the fresh local index into plan-owned state before
- * `start()`. Each step merges one path, flushes the plan output changed by that
- * step, and atomically stores the next cursor.
- * `resume()` discards bytes written beyond the saved output offsets and
- * continues from the saved index offsets, so an interrupted step cannot leave
- * duplicate durable entries.
+ * Each indexing step advances one FileIndexProcessor traversal event and
+ * flushes any appended JSONL bytes before storing the traversal cursor and
+ * committed byte offset.
+ * A separate step starts the index diff. Each diff step compares at most one
+ * path represented by either index and flushes only the output changed by that
+ * step before storing its next cursor. `resume()` discards bytes beyond saved
+ * offsets, so an interrupted step cannot leave duplicate durable entries.
  *
  * PushPlan retains the next entry from each index and the top of an append-only
  * deleted-directory stack needed to suppress redundant descendant deletions. It
  * never loads an index, path list, or the stack in full.
  *
- * @phpstan-type PushPlanCursor array{byte_offset_in_fresh_index:int,byte_offset_in_previous_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null,complete:bool}
+ * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
+ * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
+ * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
+ * @phpstan-type CompleteCursor array{phase:'complete'}
+ * @phpstan-type PushPlanCursor IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
 {
+    /** @var string Canonical local tree root inspected while building the fresh local index. */
+    private string $local_tree_root;
+
+    /** @var string Local push state directory containing every plan file. */
+    private string $push_state_directory;
+
     /** @var string Paths and metadata from the last completed push. */
     private string $local_index_at_previous_push;
 
@@ -67,7 +80,7 @@ class PushPlan
     /** @var string Raw NUL-delimited local paths to delete. */
     private string $local_paths_to_delete;
 
-    /** @var string Plan-owned copy of the fresh local index. */
+    /** @var string Plan-owned fresh local index. */
     private string $fresh_local_index;
 
     /** @var string Path to the durable PushPlan cursor. */
@@ -88,8 +101,8 @@ class PushPlan
     /** @var bool Whether close() has closed this plan's file handles. */
     private bool $closed = false;
 
-    /** @var bool Whether both index handles reached EOF at a durable boundary. */
-    private bool $complete = false;
+    /** @var FileIndexProcessor Fresh local index traversal retained during indexing. */
+    private FileIndexProcessor $file_index_processor;
 
     /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
     private ?array $fresh_local_index_entry = null;
@@ -106,7 +119,7 @@ class PushPlan
     /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
     private ?array $deleted_directory_stack_entry = null;
 
-    /** @var resource|null */
+    /** @var resource|null Open fresh local index retained during indexing or the index diff. */
     private $fresh_local_index_handle = null;
     /** @var resource|null */
     private $local_index_at_previous_push_handle = null;
@@ -118,64 +131,64 @@ class PushPlan
     private $deleted_directories_stack_handle = null;
 
     /**
-     * Starts a push plan from a fresh local index.
+     * Starts a push plan by opening a fresh local index traversal.
      *
-     * The owning sender has already copied the fresh local index into this
-     * plan's directory. This method writes the initial cursor and opens the
-     * planning files. An existing cursor is rejected so unfinished work cannot
-     * be overwritten.
+     * The sender has already stored the target exclusions. An existing cursor
+     * is rejected so unfinished planning cannot be replaced.
      *
      * @param string $push_state_directory Local push state directory.
-     * @return self Open plan positioned at the initial cursor.
+     * @param string $local_tree_root      Canonical local tree root.
+     * @return self Open plan positioned at the initial indexing cursor.
      */
-    public static function start(string $push_state_directory): self
+    public static function start(string $push_state_directory, string $local_tree_root): self
     {
         $plan = new self($push_state_directory);
         if (is_file($plan->cursor_file)) {
             throw new LogicException("Cannot start a push plan while an unfinished plan exists: {$plan->cursor_file}");
         }
-        if (!is_file($plan->fresh_local_index)) {
-            throw new RuntimeException("Cannot plan local files, the fresh local index file is missing: {$plan->fresh_local_index}");
-        }
-
+        $plan->set_local_tree_root($local_tree_root);
         $plan->excluded_paths = $plan->load_excluded_paths();
-        if (file_put_contents($plan->deleted_directories_stack, '') !== 0) {
-            throw new RuntimeException("Failed to initialize the deleted-directory stack: {$plan->deleted_directories_stack}");
+        $plan->fresh_local_index_handle = fopen($plan->fresh_local_index, "w+b");
+        if (!is_resource($plan->fresh_local_index_handle)) {
+            throw new RuntimeException("Failed to open the fresh local index: {$plan->fresh_local_index}");
         }
+        $plan->file_index_processor = FileIndexProcessor::start(
+            [$plan->local_tree_root],
+            $plan->local_tree_root,
+            false,
+            false,
+            $plan->push_state_directory
+        );
         $plan->cursor = [
-            "byte_offset_in_fresh_index" => 0,
-            "byte_offset_in_previous_index" => 0,
-            "byte_offset_in_local_paths_to_push" => 0,
-            "byte_offset_in_local_paths_to_delete" => 0,
-            "deleted_directory_stack_top_byte_offset" => null,
-            "complete" => false,
+            "phase" => "indexing",
+            "file_index_cursor" => $plan->file_index_processor->get_cursor(),
+            "fresh_local_index_byte_offset" => 0,
         ];
         $plan->save_cursor($plan->cursor);
-        $plan->open_plan_files();
         return $plan;
     }
 
     /**
      * Resumes the unfinished push plan retained in local push state.
      *
-     * Reuses the plan-owned fresh local index, offsets, and deleted-directory
-     * ranges in the durable cursor. Excluded paths are the ones originally
-     * passed to start().
+     * Reopens only the processor and files required by the cursor's current
+     * internal phase.
      *
      * @param string $push_state_directory Local push state directory containing the unfinished plan.
+     * @param string $local_tree_root      Canonical local tree root.
      * @return self Open plan positioned at its last durable cursor.
      */
-    public static function resume(string $push_state_directory): self
+    public static function resume(string $push_state_directory, string $local_tree_root): self
     {
         $plan = self::load_retained($push_state_directory);
-        if (!is_file($plan->fresh_local_index)) {
-            throw new RuntimeException("Cannot resume the push plan, the retained fresh local index is missing: {$plan->fresh_local_index}");
-        }
-
+        $plan->set_local_tree_root($local_tree_root);
         $plan->excluded_paths = $plan->load_excluded_paths();
         $plan->closed = false;
-        $plan->complete = $plan->cursor["complete"];
-        $plan->open_plan_files();
+        if ($plan->cursor["phase"] === "indexing") {
+            $plan->open_fresh_local_index_for_continuation();
+        } elseif ($plan->cursor["phase"] === "diffing") {
+            $plan->open_plan_files();
+        }
         return $plan;
     }
 
@@ -265,6 +278,7 @@ class PushPlan
         if (!is_dir($push_state_directory) && !@mkdir($push_state_directory, 0755, true) && !is_dir($push_state_directory)) {
             throw new RuntimeException("Failed to create the push plan directory: {$push_state_directory}");
         }
+        $this->push_state_directory = $push_state_directory;
         $this->local_index_at_previous_push = self::local_index_at_previous_push_path($push_state_directory);
         $this->local_paths_to_push = self::local_paths_to_push_path($push_state_directory);
         $this->local_paths_to_delete = self::local_paths_to_delete_path($push_state_directory);
@@ -275,6 +289,50 @@ class PushPlan
     }
 
     /**
+     * Stores the canonical root of the local tree represented by this push.
+     *
+     * @param string $local_tree_root Local tree root selected by PushFilesSender.
+     */
+    private function set_local_tree_root(string $local_tree_root): void
+    {
+        clearstatcache(true, $local_tree_root);
+        $canonical_local_tree_root = realpath($local_tree_root);
+        if ($canonical_local_tree_root === false || !is_dir($canonical_local_tree_root) || is_link($local_tree_root)) {
+            throw new InvalidArgumentException("PushPlan requires the local tree root to be a real directory.");
+        }
+        $this->local_tree_root = rtrim($canonical_local_tree_root, "/");
+    }
+
+    /**
+     * Reopens the fresh local index at the byte offset stored with its traversal cursor.
+     *
+     * Any bytes appended after the last cursor replacement are discarded before
+     * FileIndexProcessor continues from that same durable step.
+     */
+    private function open_fresh_local_index_for_continuation(): void
+    {
+        /** @var IndexingCursor $cursor */
+        $cursor = $this->cursor;
+        $this->fresh_local_index_handle = fopen($this->fresh_local_index, "r+b");
+        if (!is_resource($this->fresh_local_index_handle)) {
+            throw new RuntimeException("Failed to reopen the fresh local index: {$this->fresh_local_index}");
+        }
+        if (!ftruncate($this->fresh_local_index_handle, $cursor["fresh_local_index_byte_offset"])) {
+            throw new RuntimeException("Failed to discard uncommitted fresh-local-index bytes.");
+        }
+        if (fseek($this->fresh_local_index_handle, $cursor["fresh_local_index_byte_offset"]) !== 0) {
+            throw new RuntimeException("Failed to seek to the fresh local index byte offset.");
+        }
+        $this->file_index_processor = FileIndexProcessor::resume(
+            [$this->local_tree_root],
+            json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+            false,
+            false,
+            $this->push_state_directory
+        );
+    }
+
+    /**
      * Opens and positions the files used by start() and resume().
      *
      * Indexes are positioned at their durable cursor offsets. Output bytes
@@ -282,6 +340,8 @@ class PushPlan
      */
     private function open_plan_files(): void
     {
+        /** @var IndexDiffCursor $cursor */
+        $cursor = $this->cursor;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
         $this->previous_local_index_entry = null;
@@ -289,11 +349,11 @@ class PushPlan
         $this->deleted_directory_stack_entry = null;
         $this->local_paths_to_push_handle = $this->open_and_truncate_and_seek(
             $this->local_paths_to_push,
-            $this->cursor["byte_offset_in_local_paths_to_push"]
+            $cursor["byte_offset_in_local_paths_to_push"]
         );
         $this->local_paths_to_delete_handle = $this->open_and_truncate_and_seek(
             $this->local_paths_to_delete,
-            $this->cursor["byte_offset_in_local_paths_to_delete"]
+            $cursor["byte_offset_in_local_paths_to_delete"]
         );
         $this->fresh_local_index_handle = fopen($this->fresh_local_index, "rb");
         if (!is_resource($this->fresh_local_index_handle)) {
@@ -308,13 +368,13 @@ class PushPlan
         }
         $this->seek_to_cursor(
             $this->fresh_local_index_handle,
-            $this->cursor["byte_offset_in_fresh_index"],
+            $cursor["byte_offset_in_fresh_index"],
             "fresh local index"
         );
         if ($this->local_index_at_previous_push_handle) {
             $this->seek_to_cursor(
                 $this->local_index_at_previous_push_handle,
-                $this->cursor["byte_offset_in_previous_index"],
+                $cursor["byte_offset_in_previous_index"],
                 "local index at the previous push"
             );
         }
@@ -323,71 +383,200 @@ class PushPlan
             throw new RuntimeException("Failed to open the deleted-directory stack: {$this->deleted_directories_stack}");
         }
         $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
-            $this->cursor["deleted_directory_stack_top_byte_offset"]
+            $cursor["deleted_directory_stack_top_byte_offset"]
         );
     }
 
     /**
-     * Removes the planning cursor after the sender finishes a successful push.
+     * Removes the completed plan after the sender finishes a successful push.
      *
-     * Only a closed, completed plan can remove its cursor. The sender owns
-     * commit and saves the fresh local index as the local index at the previous
-     * push before calling this method.
+     * The sender saves the fresh local index as the local index at the previous
+     * push before calling this method. The fresh index is removed before the
+     * cursor so interrupted cleanup can repeat safely.
      */
     public function after_successful_push(): void
     {
         if (!$this->closed) {
             throw new LogicException("Close the push plan before finishing a successful push.");
         }
-        if (!is_file($this->fresh_local_index)) {
-            throw new RuntimeException("Cannot finish a successful push, the fresh local index is missing: {$this->fresh_local_index}");
-        }
-        if (!$this->cursor["complete"]) {
+        if ($this->cursor["phase"] !== "complete") {
             throw new LogicException("Cannot finish a successful push before the plan is complete.");
         }
 
+        $this->remove_fresh_local_index();
         $this->remove_cursor();
     }
 
     /**
      * Discards a closed plan after its push session is removed.
      *
-     * Removing the cursor permits the next push to start from a new local
-     * index. The plan-owned index and output files may remain because start()
-     * replaces or truncates them before they can be used again.
+     * Removing the fresh index and cursor permits the next push to start from a
+     * new local index. Output files may remain because start() truncates them
+     * before they can be used again.
      */
     public function discard(): void
     {
         if (!$this->closed) {
             throw new LogicException("Close the push plan before discarding it.");
         }
+        $this->remove_fresh_local_index();
         $this->remove_cursor();
     }
 
     /**
-     * Merges one path and stores the resulting push plan cursor.
+     * Performs one step for the current internal phase.
      *
-     * A true return means another path may be merged. False means both indexes
-     * reached EOF and remains false on later calls. The owning sender closes the
-     * plan before using its output files.
-     *
-     * Exclusions suppress network changes, not entries in the retained fresh
-     * local index saved as the local index at the previous push after success.
+     * A false return means planning is complete and remains false on later
+     * calls. The owning sender closes the plan before using its path lists.
      *
      * @return bool Whether another planning step may be performed.
      */
     public function next_step(): bool
     {
-        if ($this->complete) {
+        if ($this->cursor["phase"] === "complete") {
             return false;
         }
         if ($this->closed) {
             throw new LogicException("Cannot take a push plan step after close().");
         }
 
-        $byte_offset_in_fresh_index = $this->cursor["byte_offset_in_fresh_index"];
-        $byte_offset_in_previous_index = $this->cursor["byte_offset_in_previous_index"];
-        $deleted_directory_stack_top_byte_offset = $this->cursor["deleted_directory_stack_top_byte_offset"];
+        switch ($this->cursor["phase"]) {
+            case "indexing":
+                $this->next_file_index_step();
+                return true;
+            case "starting_diff":
+                $this->start_index_diff();
+                return true;
+            case "diffing":
+                return $this->next_index_diff_step();
+        }
+    }
+
+    /**
+     * Performs one filesystem traversal step and stores its exact continuation point.
+     *
+     * Completed index entries are appended and flushed before the cursor moves
+     * past them. Steps which omit a path still store the changed traversal
+     * cursor. A directory failure leaves the durable cursor unchanged so the
+     * next plan run attempts that same directory again.
+     */
+    private function next_file_index_step(): void
+    {
+        if (!$this->file_index_processor->next_index_step()) {
+            $this->file_index_processor->close();
+            $this->close_fresh_local_index_handle();
+            $this->cursor = ["phase" => "starting_diff"];
+            $this->save_cursor($this->cursor);
+            return;
+        }
+
+        $fresh_local_index_changed = false;
+        switch ($this->file_index_processor->get_step_status()) {
+            case FileIndexProcessor::STATUS_INDEXED:
+                foreach ($this->file_index_processor->get_index_entries() as $index_entry) {
+                    $this->append_fresh_local_index_entry($index_entry);
+                    $fresh_local_index_changed = true;
+                }
+                break;
+
+            case FileIndexProcessor::STATUS_DIRECTORY_ERROR:
+                $directory_error = $this->file_index_processor->get_directory_error();
+                throw new RuntimeException(
+                    $directory_error["message"] . ": " . base64_encode($directory_error["path"]) . "."
+                );
+
+            case FileIndexProcessor::STATUS_SKIPPED:
+            case FileIndexProcessor::STATUS_PATH_UNAVAILABLE:
+            case FileIndexProcessor::STATUS_DIRECTORY_COMPLETE:
+                break;
+        }
+
+        if ($fresh_local_index_changed && !fflush($this->fresh_local_index_handle)) {
+            throw new RuntimeException("Failed to flush the fresh local index.");
+        }
+        $fresh_local_index_byte_offset = ftell($this->fresh_local_index_handle);
+        if (!is_int($fresh_local_index_byte_offset)) {
+            throw new RuntimeException("Failed to determine the fresh local index byte offset.");
+        }
+        $this->cursor = [
+            "phase" => "indexing",
+            "file_index_cursor" => $this->file_index_processor->get_cursor(),
+            "fresh_local_index_byte_offset" => $fresh_local_index_byte_offset,
+        ];
+        $this->save_cursor($this->cursor);
+    }
+
+    /**
+     * Starts the index diff and opens its plan files.
+     */
+    private function start_index_diff(): void
+    {
+        if (file_put_contents($this->deleted_directories_stack, "") !== 0) {
+            throw new RuntimeException("Failed to initialize the deleted-directory stack: {$this->deleted_directories_stack}");
+        }
+        $this->cursor = [
+            "phase" => "diffing",
+            "byte_offset_in_fresh_index" => 0,
+            "byte_offset_in_previous_index" => 0,
+            "byte_offset_in_local_paths_to_push" => 0,
+            "byte_offset_in_local_paths_to_delete" => 0,
+            "deleted_directory_stack_top_byte_offset" => null,
+        ];
+        $this->save_cursor($this->cursor);
+        $this->open_plan_files();
+    }
+
+    /**
+     * Appends one FileIndexProcessor entry in the JSONL format consumed by the
+     * index diff.
+     *
+     * @param array<string,mixed> $index_entry Filesystem path details from FileIndexProcessor.
+     */
+    private function append_fresh_local_index_entry(array $index_entry): void
+    {
+        if ($index_entry["type"] === "other") {
+            throw new RuntimeException(
+                "Cannot push the unsupported local path: " . base64_encode($index_entry["path"]) . "."
+            );
+        }
+        if ($index_entry["type"] === "dir" && !array_key_exists("empty", $index_entry)) {
+            throw new RuntimeException(
+                "Could not inspect the local directory: " . base64_encode($index_entry["path"]) . "."
+            );
+        }
+
+        $local_path = substr($index_entry["path"], strlen($this->local_tree_root) + 1);
+        $fresh_local_index_entry = [
+            "path" => base64_encode($local_path),
+            "ctime" => $index_entry["ctime"],
+            "size" => $index_entry["size"],
+            "type" => $index_entry["type"],
+        ];
+        if ($index_entry["type"] === "dir") {
+            $fresh_local_index_entry["empty"] = $index_entry["empty"];
+        }
+        $line = json_encode($fresh_local_index_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        if (fwrite($this->fresh_local_index_handle, $line) !== strlen($line)) {
+            throw new RuntimeException("Failed to write a fresh local index entry.");
+        }
+    }
+
+    /**
+     * Compares at most one path and stores the resulting push plan cursor.
+     *
+     * Exclusions suppress network changes, not entries in the retained fresh
+     * local index saved as the local index at the previous push after success.
+     *
+     * @return bool Whether another index diff step may be performed.
+     */
+    private function next_index_diff_step(): bool
+    {
+        /** @var IndexDiffCursor $cursor */
+        $cursor = $this->cursor;
+
+        $byte_offset_in_fresh_index = $cursor["byte_offset_in_fresh_index"];
+        $byte_offset_in_previous_index = $cursor["byte_offset_in_previous_index"];
+        $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
         $local_paths_to_push_changed = false;
         $local_paths_to_delete_changed = false;
         $deleted_directories_stack_changed = false;
@@ -546,17 +735,18 @@ class PushPlan
             $deleted_directory_stack_top_byte_offset = null;
             $this->deleted_directory_stack_entry = null;
         }
-        $cursor_after_step = [
-            "byte_offset_in_fresh_index" => $byte_offset_in_fresh_index,
-            "byte_offset_in_previous_index" => $byte_offset_in_previous_index,
-            "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
-            "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
-            "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
-            "complete" => $complete,
-        ];
+        $cursor_after_step = $complete
+            ? ["phase" => "complete"]
+            : [
+                "phase" => "diffing",
+                "byte_offset_in_fresh_index" => $byte_offset_in_fresh_index,
+                "byte_offset_in_previous_index" => $byte_offset_in_previous_index,
+                "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
+                "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
+                "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
+            ];
         $this->save_cursor($cursor_after_step);
         $this->cursor = $cursor_after_step;
-        $this->complete = $complete;
         return !$complete;
     }
 
@@ -569,9 +759,10 @@ class PushPlan
      */
     public function close(): void
     {
-        if (is_resource($this->fresh_local_index_handle)) {
-            fclose($this->fresh_local_index_handle);
+        if (isset($this->file_index_processor)) {
+            $this->file_index_processor->close();
         }
+        $this->close_fresh_local_index_handle();
         if (is_resource($this->local_index_at_previous_push_handle)) {
             fclose($this->local_index_at_previous_push_handle);
         }
@@ -584,7 +775,6 @@ class PushPlan
         if (is_resource($this->deleted_directories_stack_handle)) {
             fclose($this->deleted_directories_stack_handle);
         }
-        $this->fresh_local_index_handle = null;
         $this->local_index_at_previous_push_handle = null;
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
@@ -595,6 +785,17 @@ class PushPlan
         $this->previous_local_index_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
         $this->closed = true;
+    }
+
+    /**
+     * Closes the fresh local index retained while indexing or diffing the indexes.
+     */
+    private function close_fresh_local_index_handle(): void
+    {
+        if (is_resource($this->fresh_local_index_handle)) {
+            fclose($this->fresh_local_index_handle);
+        }
+        $this->fresh_local_index_handle = null;
     }
 
     /**
@@ -893,17 +1094,7 @@ class PushPlan
     /**
      * Loads the durable cursor for an unfinished push plan.
      *
-     * @return array|null {
-     *     Durable cursor, or null when no unfinished plan exists.
-     *
-     *     @type int      $byte_offset_in_fresh_index                Consumed bytes in the fresh local index.
-     *     @type int      $byte_offset_in_previous_index             Consumed bytes in the local index at the previous push.
-     *     @type int      $byte_offset_in_local_paths_to_push        Durable bytes in the local paths to push output.
-     *     @type int      $byte_offset_in_local_paths_to_delete      Durable bytes in the local paths to delete output.
-     *     @type int|null $deleted_directory_stack_top_byte_offset   Active stack entry, or null for an empty stack.
-     *     @type bool     $complete                                  Whether both indexes reached EOF.
-     * }
-     * @phpstan-return PushPlanCursor|null
+     * @phpstan-return PushPlanCursor|null Durable cursor, or null when no unfinished plan exists.
      */
     private function load_cursor(): ?array
     {
@@ -931,21 +1122,11 @@ class PushPlan
     }
 
     /**
-     * Persists the next durable push-plan boundary atomically.
+     * Stores the next durable push-plan boundary atomically.
      *
      * A temporary file and rename prevent readers from observing a partial cursor.
      *
-     * @param array $cursor {
-     *     Cursor to store as the durable plan boundary.
-     *
-     *     @type int      $byte_offset_in_fresh_index                Consumed bytes in the fresh local index.
-     *     @type int      $byte_offset_in_previous_index             Consumed bytes in the local index at the previous push.
-     *     @type int      $byte_offset_in_local_paths_to_push        Durable bytes in the local paths to push output.
-     *     @type int      $byte_offset_in_local_paths_to_delete      Durable bytes in the local paths to delete output.
-     *     @type int|null $deleted_directory_stack_top_byte_offset   Active stack entry, or null for an empty stack.
-     *     @type bool     $complete                                  Whether both indexes reached EOF.
-     * }
-     * @phpstan-param PushPlanCursor $cursor
+     * @phpstan-param PushPlanCursor $cursor Cursor to store as the durable plan boundary.
      */
     private function save_cursor(array $cursor): void
     {
@@ -960,7 +1141,17 @@ class PushPlan
     }
 
     /**
-     * Removes the cursor after the completed fresh local index is saved.
+     * Removes the fresh local index when its plan ends.
+     */
+    private function remove_fresh_local_index(): void
+    {
+        if (is_file($this->fresh_local_index) && !unlink($this->fresh_local_index)) {
+            throw new RuntimeException("Failed to remove the fresh local index: {$this->fresh_local_index}");
+        }
+    }
+
+    /**
+     * Removes the cursor when the plan ends.
      *
      * With no cursor, the local push state directory no longer contains an unfinished
      * push plan and start() may create the next one.

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -32,13 +32,22 @@ final class FileIndexProcessorTest extends TestCase {
         file_put_contents($docroot . '/a.txt', 'a');
         file_put_contents($docroot . '/nested/b.txt', 'b');
         file_put_contents($docroot . '/wp-content/cache/skipped.txt', 'skip');
+        symlink('a.txt', $docroot . '/a-link');
 
         $uninterrupted = $this->runProcessor($docroot, false);
         $resumed = $this->runProcessor($docroot, true);
 
         $this->assertSame($uninterrupted, $resumed);
         $this->assertContains('empty', $this->relativePaths($resumed['entries'], $docroot));
+        $this->assertContains('a-link', $this->relativePaths($resumed['entries'], $docroot));
         $this->assertContains('nested/b.txt', $this->relativePaths($resumed['entries'], $docroot));
+        $link_stat = lstat($docroot . '/a-link');
+        $this->assertIsArray($link_stat);
+        foreach ($resumed['entries'] as $index_entry) {
+            if ($index_entry['path'] === $docroot . '/a-link') {
+                $this->assertSame( (int) $link_stat['size'], $index_entry['size']);
+            }
+        }
         $this->assertNotContains(
             'wp-content/cache',
             $this->relativePaths($resumed['entries'], $docroot)

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -9,15 +9,18 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push
 /**
  * Coverage for PushPlan's per-target local index at the previous push and bounded steps.
  *
- * The plan merges the fresh local index, whose directory entries carry an `empty`
- * boolean from the indexer, with the local index at the previous push. The tests pin
- * the resulting local_paths_to_push JSONL, raw NUL-delimited local paths to delete,
- * cursor replay, and every transition among files, symlinks, empty
- * directories, and non-empty directories.
+ * The plan diffs the fresh local index, whose directory entries carry an
+ * `empty` boolean from the indexer, against the local index at the previous
+ * push. The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
+ * local paths to delete, cursor replay, and every transition among files,
+ * symlinks, empty directories, and non-empty directories.
  */
 final class PushPlanTest extends TestCase
 {
     private string $tempDir;
+
+    /** @var array<string,array<string,mixed>> Last tree shape created by materializeLocalTree(). */
+    private array $materializedIndexEntries = [];
 
     protected function setUp(): void
     {
@@ -45,29 +48,20 @@ final class PushPlanTest extends TestCase
         $localIndexAtPreviousPush = $this->tempDir . '/state/push/example.com/local_index_at_previous_push.jsonl';
         $this->assertFileDoesNotExist($localIndexAtPreviousPush);
 
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
         $this->assertFileExists($this->planPath('local_index_at_previous_push.jsonl'));
         $this->assertFileDoesNotExist($this->planPath('local_index_at_previous_push.jsonl') . '.tmp');
+        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
 
         // A second successful push replaces the first. Comparing that same index
         // again produces no paths to push or delete.
         $second = $this->writeIndex(['b.txt' => [200, 9, 'file']]);
-        $this->recordSuccessfulPush($second);
+        $this->saveSuccessfulPush($second);
         $plan = $this->startPlan($second);
         $this->planToCompletion($plan);
         $this->assertPathCounts(0, 0);
-    }
-
-    public function testAfterSuccessfulPushRequiresTheFreshLocalIndexToExist(): void
-    {
-        $plan = $this->startPlan();
-        $plan->close();
-        unlink($this->planPath('fresh_local_index.jsonl'));
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('fresh local index is missing');
-        $plan->after_successful_push();
     }
 
     public function testAfterSuccessfulPushRejectsAClosedIncompletePlan(): void
@@ -83,7 +77,7 @@ final class PushPlanTest extends TestCase
 
     public function testAfterSuccessfulPushRequiresThePreviousIndexToBeConsumed(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex($this->manyFileEntries(2)));
+        $this->saveSuccessfulPush($this->writeIndex($this->manyFileEntries(2)));
         $plan = $this->startPlan();
         $this->assertTrue($plan->next_step());
         $plan->close();
@@ -112,6 +106,7 @@ final class PushPlanTest extends TestCase
         $plan->discard();
 
         $this->assertFalse(PushPlan::has_plan($this->planDirectory()));
+        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
         $this->assertFileDoesNotExist($this->planPath('local_index_at_previous_push.jsonl'));
 
         $secondIndex = $this->writeIndex(['second.txt' => [200, 6, 'file']]);
@@ -154,15 +149,16 @@ final class PushPlanTest extends TestCase
         $pathsToPush = file_get_contents($this->planPath('local_paths_to_push.jsonl'));
         $this->assertIsString($pathsToPush);
         $firstLine = strtok($pathsToPush, "\n");
-        $this->assertSame(
-            '{"path":"' . base64_encode('index.php') . '","type":"file","size":5,"ctime":100}',
-            $firstLine
-        );
+        $firstPath = json_decode($firstLine, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(base64_encode('index.php'), $firstPath['path']);
+        $this->assertSame('file', $firstPath['type']);
+        $this->assertSame(5, $firstPath['size']);
+        $this->assertIsInt($firstPath['ctime']);
     }
 
     public function testPlanCopiesEveryFreshLocalIndexEntryAndExcludesOnlyPushAndDeletePaths(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
             'private' => [1, 0, 'dir', false],
             'private/gone.txt' => [1, 1, 'file'],
@@ -200,7 +196,7 @@ final class PushPlanTest extends TestCase
             'a.txt' => [100, 5, 'file'],
             'b/c.txt' => [200, 7, 'file'],
         ]);
-        $this->recordSuccessfulPush($index);
+        $this->saveSuccessfulPush($index);
 
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
@@ -212,12 +208,18 @@ final class PushPlanTest extends TestCase
 
     public function testCtimeSizeOrTypeChangeEachMarksThePathChanged(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'ctime-bump.txt' => [100, 5, 'file'],
             'size-bump.txt' => [100, 5, 'file'],
             'type-swap' => [100, 5, 'file'],
             'same.txt' => [100, 5, 'file'],
         ]));
+        $previousStat = lstat($this->localTreeRoot() . '/ctime-bump.txt');
+        $this->assertIsArray($previousStat);
+        $previousCtime = $previousStat['ctime'];
+        while (time() <= $previousCtime) {
+            usleep(10000);
+        }
         $current = $this->writeIndex([
             'ctime-bump.txt' => [101, 5, 'file'],
             'size-bump.txt' => [100, 6, 'file'],
@@ -233,37 +235,6 @@ final class PushPlanTest extends TestCase
             ['ctime-bump.txt', 'size-bump.txt', 'type-swap'],
             $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
         );
-    }
-
-    public function testUnrelatedIndexFieldsDoNotMarkFilesOrSymlinksChanged(): void
-    {
-        $previous = $this->tempDir . '/previous-with-extra-fields.jsonl';
-        $current = $this->tempDir . '/current-with-extra-fields.jsonl';
-        $previousEntries = [
-            ['path' => base64_encode('file.txt'), 'ctime' => 100, 'size' => 5, 'type' => 'file', 'future' => 'before'],
-            ['path' => base64_encode('link'), 'ctime' => 100, 'size' => 0, 'type' => 'link', 'future' => 'before'],
-        ];
-        $currentEntries = [
-            ['path' => base64_encode('file.txt'), 'ctime' => 100, 'size' => 5, 'type' => 'file', 'future' => 'after'],
-            ['path' => base64_encode('link'), 'ctime' => 100, 'size' => 0, 'type' => 'link', 'future' => 'after'],
-        ];
-        file_put_contents(
-            $previous,
-            json_encode($previousEntries[0], JSON_THROW_ON_ERROR) . "\n"
-            . json_encode($previousEntries[1], JSON_THROW_ON_ERROR) . "\n"
-        );
-        file_put_contents(
-            $current,
-            json_encode($currentEntries[0], JSON_THROW_ON_ERROR) . "\n"
-            . json_encode($currentEntries[1], JSON_THROW_ON_ERROR) . "\n"
-        );
-        $this->recordSuccessfulPush($previous);
-
-        $plan = $this->startPlan($current);
-        $this->planToCompletion($plan);
-
-        $this->assertPathCounts(0, 0);
-        $this->assertSame([], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
     }
 
     public function testEveryLogicalTypeTransitionEmitsOnlyTheRequiredPushAndDeletePaths(): void
@@ -297,7 +268,7 @@ final class PushPlanTest extends TestCase
 
         foreach ($matrix as $previousType => $transitions) {
             foreach ($transitions as $currentType => [$expectedPushes, $expectedDeletes]) {
-                $this->recordSuccessfulPush($this->writeLogicalIndex($previousType, 1));
+                $this->saveSuccessfulPush($this->writeLogicalIndex($previousType, 1));
                 $current = $this->writeLogicalIndex($currentType, 2);
 
                 $plan = $this->startPlan($current);
@@ -314,7 +285,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedSubtreeEmitsOnlyItsRootAsALocalPathToDelete(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'gone' => [1, 0, 'dir', false],
             'gone/child.txt' => [1, 1, 'file'],
             'gone/nested' => [1, 0, 'dir', false],
@@ -333,7 +304,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedDirectoryStackAppendsWithoutGrowingTheCursor(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
             'b.txt' => [1, 1, 'file'],
@@ -350,7 +321,7 @@ final class PushPlanTest extends TestCase
         $this->assertTrue($plan->next_step());
         $this->assertFalse($plan->next_step());
         $complete_cursor = $this->planCursor();
-        $this->assertNull($complete_cursor['deleted_directory_stack_top_byte_offset']);
+        $this->assertSame(['phase' => 'complete'], $complete_cursor);
         $this->assertSame($stack_bytes, filesize($this->planPath('deleted_directories_stack.jsonl')));
         $plan->close();
 
@@ -359,7 +330,7 @@ final class PushPlanTest extends TestCase
 
     public function testSeenDeletedDirectorySurvivesAnInterleavedSiblingCursor(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
@@ -383,7 +354,7 @@ final class PushPlanTest extends TestCase
 
     public function testReplacementRootSurvivesLexicallyInterleavedSiblingPaths(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
@@ -403,14 +374,14 @@ final class PushPlanTest extends TestCase
 
     public function testNewChangedDeletedAndUnchangedPathsArePlannedTogether(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'changed.txt' => [100, 5, 'file'],
             'deleted.txt' => [100, 5, 'file'],
             'unchanged.txt' => [100, 5, 'file'],
         ]));
         $current = $this->writeIndex([
             'added.txt' => [300, 3, 'file'],
-            'changed.txt' => [200, 5, 'file'],
+            'changed.txt' => [200, 6, 'file'],
             'unchanged.txt' => [100, 5, 'file'],
         ]);
 
@@ -436,6 +407,7 @@ final class PushPlanTest extends TestCase
             $this->planPath('local_index_at_previous_push.jsonl')
         );
         $plan->after_successful_push();
+        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
 
@@ -449,7 +421,7 @@ final class PushPlanTest extends TestCase
         // Newlines and non-ASCII bytes are why JSONL indexes encode paths.
         $newPath = "wp-content/uploads/line\nbreak.png";
         $deletedPath = 'wp-content/uploads/naïve-café.jpg';
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             $deletedPath => [100, 6, 'file'],
         ]));
         $current = $this->writeIndex([
@@ -464,38 +436,13 @@ final class PushPlanTest extends TestCase
         $this->assertSame($deletedPath . "\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testPlanParsesJsonWithoutDependingOnFieldOrderOrEscaping(): void
-    {
-        $path = 'wp-content/???';
-        $base64Path = base64_encode($path);
-        $localIndexAtPreviousPush = $this->tempDir . '/local_index_at_previous_push_shape.jsonl';
-        $current = $this->tempDir . '/current-shape.jsonl';
-
-        file_put_contents(
-            $localIndexAtPreviousPush,
-            json_encode(['path' => $base64Path, 'ctime' => 100, 'size' => 5, 'type' => 'file'], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
-        );
-        file_put_contents(
-            $current,
-            json_encode(['type' => 'file', 'size' => 5, 'ctime' => 100, 'path' => $base64Path], JSON_THROW_ON_ERROR) . "\n"
-        );
-        $this->recordSuccessfulPush($localIndexAtPreviousPush);
-
-        $plan = $this->startPlan($current);
-        $this->planToCompletion($plan);
-
-        $this->assertPathCounts(0, 0);
-        $this->assertSame([], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame('', file_get_contents($this->planPath('local_paths_to_delete')));
-    }
-
     // ------------------------------------------------------------------
     //  Bounded steps and restart
     // ------------------------------------------------------------------
 
-    public function testInitializationPinsTheIndexWithoutConsumingAndClearsOldOutput(): void
+    public function testIndexingFinishesBeforeDiffingAndClearsOldOutput(): void
     {
-        $this->recordSuccessfulPush($this->writeIndex([
+        $this->saveSuccessfulPush($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
         ]));
         $oldIndex = $this->writeIndex(['old.txt' => [1, 1, 'file']]);
@@ -508,30 +455,10 @@ final class PushPlanTest extends TestCase
 
         $current = $this->writeIndex($this->manyFileEntries(2));
         $plan = $this->startPlan($current);
-        $this->assertSame(file_get_contents($current), file_get_contents($this->planPath('fresh_local_index.jsonl')));
+        $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
+        $this->assertSame('diffing', $this->planCursor()['phase']);
         $this->assertFileExists(dirname($this->planPath('fresh_local_index.jsonl')) . '/cursor.json');
         $this->assertSame(0, filesize($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(0, filesize($this->planPath('local_paths_to_delete')));
-        $plan->close();
-    }
-
-    public function testPlanUsesItsCopyWhenTheStartingIndexIsReplacedBeforeTheFirstBatch(): void
-    {
-        $current = $this->tempDir . '/fresh-local-index.jsonl';
-        copy($this->writeIndex(['value.txt' => [1, 1, 'file']]), $current);
-        $plan = $this->startPlan($current);
-        // Replace the caller-owned index after the plan retained its copy.
-        $replacement = $this->writeIndex([
-            'another.txt' => [1, 1, 'file'],
-            'value.txt' => [1, 1, 'file'],
-        ]);
-        rename($replacement, $current);
-        clearstatcache(true, $current);
-
-        $this->assertFalse($plan->next_step());
-
-        $this->assertPathCounts(1, 0);
-        $this->assertSame(['value.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
         $this->assertSame(0, filesize($this->planPath('local_paths_to_delete')));
         $plan->close();
     }
@@ -603,12 +530,12 @@ final class PushPlanTest extends TestCase
         $cursor = json_decode($cursorContents, true, 512, JSON_THROW_ON_ERROR);
         $this->assertIsArray($cursor);
         $this->assertSame([
+            'phase',
             'byte_offset_in_fresh_index',
             'byte_offset_in_previous_index',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'deleted_directory_stack_top_byte_offset',
-            'complete',
         ], array_keys($cursor));
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
@@ -632,7 +559,7 @@ final class PushPlanTest extends TestCase
             $localIndexAtPreviousPushEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
         }
         $current = $this->writeIndex($currentEntries);
-        $this->recordSuccessfulPush($this->writeIndex($localIndexAtPreviousPushEntries));
+        $this->saveSuccessfulPush($this->writeIndex($localIndexAtPreviousPushEntries));
         $plan = $this->startPlan($current);
 
         $this->assertTrue($plan->next_step());
@@ -664,6 +591,8 @@ final class PushPlanTest extends TestCase
         $freshLocalIndex = $this->writeIndex(['value.txt' => [1, 5, 'file']]);
         $plan = $this->startPlan($freshLocalIndex);
         $this->planToCompletion($plan);
+        $completedFreshLocalIndex = file_get_contents($this->planPath('fresh_local_index.jsonl'));
+        $this->assertIsString($completedFreshLocalIndex);
 
         $loaded = PushPlan::load_retained($this->planDirectory());
         foreach ([
@@ -682,8 +611,9 @@ final class PushPlanTest extends TestCase
             $this->planPath('local_index_at_previous_push.jsonl')
         );
         $loaded->after_successful_push();
+        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
         $this->assertSame(
-            file_get_contents($freshLocalIndex),
+            $completedFreshLocalIndex,
             file_get_contents($this->planPath('local_index_at_previous_push.jsonl'))
         );
     }
@@ -712,25 +642,6 @@ final class PushPlanTest extends TestCase
         $this->assertSame($localPathsToDelete, file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testReplacingTheStartingIndexBetweenStepsDoesNotChangeThePlan(): void
-    {
-        $current = $this->tempDir . '/fresh-local-index.jsonl';
-        $index_to_copy = $this->writeIndex($this->manyFileEntries(2));
-        copy($index_to_copy, $current);
-        $plan = $this->startPlan($current);
-        $this->assertTrue($plan->next_step());
-
-        $replacement = $this->writeIndex($this->manyFileEntries(3));
-        rename($replacement, $current);
-        clearstatcache(true, $current);
-
-        $this->assertFalse($plan->next_step());
-
-        $this->assertPathCounts(2, 0);
-        $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $plan->close();
-    }
-
     public function testResumeUsesTheExcludedPathsSavedByStart(): void
     {
         $entries = $this->manyFileEntries(2);
@@ -752,54 +663,19 @@ final class PushPlanTest extends TestCase
     }
 
     // ------------------------------------------------------------------
-    //  Invalid indexes
-    // ------------------------------------------------------------------
-
-    public function testPlanReportsInvalidJson(): void
-    {
-        // A blank line is invalid JSON, so the plan stops instead of silently
-        // skipping an index line.
-        $garbage = $this->tempDir . '/garbage.jsonl';
-        file_put_contents(
-            $garbage,
-            $this->indexLine('a.txt', 100, 5, 'file') . "\n\nnot json at all\n"
-        );
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('not valid JSON');
-        $this->planToCompletion($this->startPlan($garbage));
-    }
-
-    public function testPlanReportsAPathThatIsNotBase64(): void
-    {
-        $bad = $this->tempDir . '/bad-path.jsonl';
-        file_put_contents($bad, '{"path":"%%%not-base64%%%","ctime":1,"size":1,"type":"file"}' . "\n");
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('index path is not valid base64');
-        $this->planToCompletion($this->startPlan($bad));
-    }
-
-    public function testPlanRequiresTheFreshLocalIndexToExist(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('fresh local index file is missing');
-        $this->startPlan($this->tempDir . '/no-such-index.jsonl');
-    }
-
-    // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------
 
     /** @param list<string> $excludedPaths */
-    private function startPlan(?string $freshLocalIndexPath = null, array $excludedPaths = []): PushPlan
+    private function startPlan(?string $treeDescriptionPath = null, array $excludedPaths = []): PushPlan
     {
-        if ($freshLocalIndexPath === null) {
-            $freshLocalIndexPath = $this->tempDir . '/empty-fresh-local-index.jsonl';
-            if (!is_file($freshLocalIndexPath)) {
-                file_put_contents($freshLocalIndexPath, '');
+        if ($treeDescriptionPath === null) {
+            $treeDescriptionPath = $this->tempDir . '/empty-tree.jsonl';
+            if (!is_file($treeDescriptionPath)) {
+                file_put_contents($treeDescriptionPath, '');
             }
         }
+        $this->materializeLocalTree($treeDescriptionPath);
         if (!is_dir($this->planDirectory())) {
             mkdir($this->planDirectory(), 0755, true);
         }
@@ -810,20 +686,24 @@ final class PushPlanTest extends TestCase
                 JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
             )
         );
-        if (is_file($freshLocalIndexPath)) {
-            copy($freshLocalIndexPath, $this->planPath('fresh_local_index.jsonl'));
+        $plan = PushPlan::start($this->planDirectory(), $this->localTreeRoot());
+        for ($step = 0; $step < 100; ++$step) {
+            if ($this->planCursor()['phase'] === 'diffing') {
+                return $plan;
+            }
+            $this->assertTrue($plan->next_step());
         }
-        return PushPlan::start($this->planDirectory());
+        $this->fail('Push plan did not finish indexing within 100 bounded steps.');
     }
 
     private function resumePlan(): PushPlan
     {
-        return PushPlan::resume($this->planDirectory());
+        return PushPlan::resume($this->planDirectory(), $this->localTreeRoot());
     }
 
-    private function recordSuccessfulPush(string $freshLocalIndex): void
+    private function saveSuccessfulPush(string $treeDescriptionPath): void
     {
-        $plan = $this->startPlan($freshLocalIndex);
+        $plan = $this->startPlan($treeDescriptionPath);
         $this->planToCompletion($plan);
         copy(
             $this->planPath('fresh_local_index.jsonl'),
@@ -882,6 +762,93 @@ final class PushPlanTest extends TestCase
         return $this->planDirectory() . '/' . $filename;
     }
 
+    private function localTreeRoot(): string
+    {
+        return $this->tempDir . '/local-tree-root';
+    }
+
+    /**
+     * Makes the local tree match one test description while preserving unchanged paths.
+     *
+     * @param string $treeDescriptionPath JSONL path descriptions created by writeIndex().
+     */
+    private function materializeLocalTree(string $treeDescriptionPath): void
+    {
+        $entries = $this->indexEntries($treeDescriptionPath);
+        if (!is_dir($this->localTreeRoot())) {
+            mkdir($this->localTreeRoot(), 0755, true);
+        }
+
+        $pathsToKeep = $this->pathsRequiredByIndexEntries($entries);
+        $previousPaths = $this->pathsRequiredByIndexEntries($this->materializedIndexEntries);
+        $pathsToRemove = array_keys(array_diff_key($previousPaths, $pathsToKeep));
+        usort($pathsToRemove, static fn(string $left, string $right): int => strlen($right) <=> strlen($left));
+        foreach ($pathsToRemove as $path) {
+            $this->recursiveDelete($this->localTreeRoot() . '/' . $path);
+        }
+
+        $implicitDirectories = array_keys(array_diff_key($pathsToKeep, $entries));
+        usort($implicitDirectories, static fn(string $left, string $right): int => strlen($left) <=> strlen($right));
+        foreach ($implicitDirectories as $path) {
+            $localPath = $this->localTreeRoot() . '/' . $path;
+            if (!is_dir($localPath) || is_link($localPath)) {
+                $this->recursiveDelete($localPath);
+                mkdir($localPath, 0755, true);
+            }
+        }
+
+        uksort($entries, static function (string $left, string $right): int {
+            $depthComparison = substr_count($left, '/') <=> substr_count($right, '/');
+            return $depthComparison !== 0 ? $depthComparison : strcmp($left, $right);
+        });
+        foreach ($entries as $path => $entry) {
+            $localPath = $this->localTreeRoot() . '/' . $path;
+            $parentDirectory = dirname($localPath);
+            if (!is_dir($parentDirectory)) {
+                mkdir($parentDirectory, 0755, true);
+            }
+            $previousEntry = $this->materializedIndexEntries[$path] ?? null;
+            if ($entry['type'] === 'dir') {
+                if (!is_dir($localPath) || is_link($localPath)) {
+                    $this->recursiveDelete($localPath);
+                    mkdir($localPath, 0755, true);
+                }
+                continue;
+            }
+            if ($previousEntry === $entry) {
+                continue;
+            }
+            $this->recursiveDelete($localPath);
+            if ($entry['type'] === 'link') {
+                symlink(str_repeat('x', max(1, (int) $entry['ctime'])), $localPath);
+                continue;
+            }
+            $byte = chr(97 + ( (int) $entry['ctime'] % 26 ));
+            file_put_contents($localPath, str_repeat($byte, (int) $entry['size']));
+        }
+        $this->materializedIndexEntries = $entries;
+    }
+
+    /**
+     * Returns every described path and the implicit parent directories it needs.
+     *
+     * @param array<string,array<string,mixed>> $entries Index entries keyed by local path.
+     * @return array<string,true>
+     */
+    private function pathsRequiredByIndexEntries(array $entries): array
+    {
+        $paths = [];
+        foreach (array_keys($entries) as $path) {
+            $paths[$path] = true;
+            $parent = dirname($path);
+            while ($parent !== '.' && $parent !== '') {
+                $paths[$parent] = true;
+                $parent = dirname($parent);
+            }
+        }
+        return $paths;
+    }
+
     private function writeLogicalIndex(string $logicalType, int $version): string
     {
         if ($logicalType === 'file') {
@@ -910,8 +877,7 @@ final class PushPlanTest extends TestCase
     }
 
     /**
-     * Write a sorted index. Entries map path to ctime, size, type, and the
-     * empty flag the indexer records on directory entries.
+     * Writes a sorted description of paths, versions, sizes, types, and directory emptiness.
      *
      * @param array<string,array{0:int,1:int,2:string,3?:bool}> $entries
      */
@@ -977,7 +943,7 @@ final class PushPlanTest extends TestCase
             return [];
         }
         $paths = explode("\0", $bytes);
-        $this->assertSame('', array_pop($paths), 'The local_paths_to_delete file must end at a NUL record boundary.');
+        $this->assertSame('', array_pop($paths), 'The local_paths_to_delete file must end after a NUL-terminated path.');
         return $paths;
     }
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1336,15 +1336,6 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/replace-directory/old.txt', 'old');
         file_put_contents($local_docroot . '/replace-directory', 'replacement');
 
-        $fresh_local_index_path = $this->root . '/fresh-local-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'empty-directory' => $this->indexEntry($local_docroot . '/empty-directory', 'dir', true),
-            'file-link' => $this->indexEntry($local_docroot . '/file-link', 'link'),
-            'nested' => $this->indexEntry($local_docroot . '/nested', 'dir', false),
-            'nested/large.bin' => $this->indexEntry($local_docroot . '/nested/large.bin', 'file'),
-            'replace-directory' => $this->indexEntry($local_docroot . '/replace-directory', 'file'),
-            'same-size.txt' => $this->indexEntry($local_docroot . '/same-size.txt', 'file'),
-        ]);
         $previous_local_index_path = $this->root . '/previous-local-index.jsonl';
         $this->writeIndex($previous_local_index_path, [
             'remove.txt' => [1, 3, 'file'],
@@ -1355,19 +1346,11 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/sender-state';
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
 
-        $removed_caller_index = false;
         $commit_advances = 0;
         for ($step = 0; $step < 200; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
-            if (
-                !$removed_caller_index
-                && is_array($state)
-            ) {
-                unlink($fresh_local_index_path);
-                $removed_caller_index = true;
-            }
             if (is_array($state) && $state['phase'] === 'committing') {
                 ++$commit_advances;
             }
@@ -1376,7 +1359,6 @@ final class PushEndpointsTest extends TestCase {
             }
         }
 
-        $this->assertTrue($removed_caller_index, 'PushFilesSender must own the fresh index before start() returns.');
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertGreaterThan(1, $commit_advances, 'The endpoint work budget must require repeated commit requests.');
         $this->assertSame(str_repeat('A', 2000), file_get_contents($this->docroot . '/nested/large.bin'));
@@ -1388,10 +1370,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertFileDoesNotExist($push_state_directory . '/cursor.json');
-        $this->assertSame(
-            file_get_contents($push_state_directory . '/fresh_local_index.jsonl'),
-            file_get_contents($push_state_directory . '/local_index_at_previous_push.jsonl')
-        );
+        $this->assertFileDoesNotExist($push_state_directory . '/fresh_local_index.jsonl');
+        $this->assertFileExists($push_state_directory . '/local_index_at_previous_push.jsonl');
     }
 
     /**
@@ -1402,13 +1382,9 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/retained-file-offset-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/large.bin', str_repeat('A', 6000));
-        $fresh_local_index_path = $this->root . '/retained-file-offset-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'large.bin' => $this->indexEntry($local_docroot . '/large.bin', 'file'),
-        ]);
         $push_state_directory = $this->root . '/retained-file-offset-state';
         $sender = PushFilesSender::start(
-            $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+            $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
@@ -1443,8 +1419,6 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/retained-deleted-paths-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/retained-deleted-paths-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
         $previous_local_index_path = $this->root . '/retained-deleted-paths-previous-index.jsonl';
         $previous_entries = [];
         for ($index = 0; $index < 60; ++$index) {
@@ -1454,7 +1428,7 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/retained-deleted-paths-state';
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
         $sender = PushFilesSender::start(
-            $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+            $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
@@ -1474,8 +1448,6 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/single-delete-part-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/single-delete-part-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
         $previous_local_index_path = $this->root . '/single-delete-part-previous-index.jsonl';
         $previous_entries = [];
         for ($index = 0; $index < 20; ++$index) {
@@ -1486,7 +1458,7 @@ final class PushEndpointsTest extends TestCase {
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
 
         for ($step = 0; $step < 30; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_deletes') {
@@ -1500,7 +1472,7 @@ final class PushEndpointsTest extends TestCase {
             'local_paths_to_delete_handle'
         );
         $sender = PushFilesSender::resume(
-            $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+            $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->assertTrue($sender->next_step());
@@ -1526,15 +1498,13 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/reappeared-delete-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($this->docroot . '/returned.txt', 'old');
-        $fresh_local_index_path = $this->root . '/reappeared-delete-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
         $previous_local_index_path = $this->root . '/reappeared-delete-previous-index.jsonl';
         $this->writeIndex($previous_local_index_path, [
             'returned.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/reappeared-delete-state';
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
 
         $sender = PushFilesSender::start($options);
         try {
@@ -1543,7 +1513,7 @@ final class PushEndpointsTest extends TestCase {
         } finally {
             $sender->close();
         }
-        $result = $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame('new', file_get_contents($local_docroot . '/returned.txt'));
@@ -1560,10 +1530,6 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/replace.txt', 'new');
         mkdir($this->docroot . '/replace.txt');
         file_put_contents($this->docroot . '/replace.txt/old.txt', 'old');
-        $fresh_local_index_path = $this->root . '/disappeared-replacement-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'replace.txt' => $this->indexEntry($local_docroot . '/replace.txt', 'file'),
-        ]);
         $previous_local_index_path = $this->root . '/disappeared-replacement-previous-index.jsonl';
         $this->writeIndex($previous_local_index_path, [
             'replace.txt' => [1, 0, 'dir', false],
@@ -1573,7 +1539,7 @@ final class PushEndpointsTest extends TestCase {
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
 
         for ($step = 0; $step < 30; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_deletes') {
@@ -1583,7 +1549,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertIsArray($state);
         unlink($local_docroot . '/replace.txt');
 
-        $result = $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame('new', file_get_contents($this->docroot . '/replace.txt'));
@@ -1596,12 +1562,9 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/retained-plan-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/retained-plan-index.jsonl';
-        $index_entries = [];
-        for ($index = 0; $index < 2500; ++$index) {
-            $index_entries[sprintf('file-%04d.txt', $index)] = [1, 1, 'file'];
+        for ($index = 0; $index < 3; ++$index) {
+            file_put_contents($local_docroot . sprintf('/file-%04d.txt', $index), 'x');
         }
-        $this->writeIndex($fresh_local_index_path, $index_entries);
         $push_state_directory = $this->root . '/retained-plan-state';
         $state_path = $push_state_directory . '/sender.json';
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
@@ -1612,7 +1575,7 @@ final class PushEndpointsTest extends TestCase {
         $fresh_local_index_handle = null;
 
         $sender = PushFilesSender::start(
-            $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+            $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'planning');
@@ -1650,51 +1613,145 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Copies a large fresh local index into plan-owned state before start() returns.
+     * Builds the fresh local index in bounded steps and continues after close().
      */
-    public function testHighLevelSenderCopiesALargeFreshLocalIndexThroughSwapFile(): void
+    public function testHighLevelSenderBuildsFreshLocalIndexInBoundedSteps(): void
     {
-        $local_docroot = $this->root . '/large-index-local-docroot';
+        $local_docroot = $this->root . '/bounded-index-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/large-index.jsonl';
-        $index_bytes = 4 * 1024 * 1024 + 37;
-        file_put_contents($fresh_local_index_path, str_repeat('x', $index_bytes));
-        $push_state_directory = $this->root . '/large-index-state';
-        $swap_index_path = $push_state_directory . '/fresh_local_index.jsonl.swap';
-        $retained_index_path = $push_state_directory . '/fresh_local_index.jsonl';
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        file_put_contents($local_docroot . '/a.txt', 'a');
+        file_put_contents($local_docroot . '/b.txt', 'bb');
+        $push_state_directory = $this->root . '/bounded-index-state';
+        $fresh_local_index_path = $push_state_directory . '/fresh_local_index.jsonl';
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
+        $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
+        $file_index_processor_property = new ReflectionProperty(PushPlan::class, 'file_index_processor');
+        $fresh_local_index_handle_property = new ReflectionProperty(
+            PushPlan::class,
+            'fresh_local_index_handle'
+        );
 
         $sender = PushFilesSender::start($options);
         try {
             $this->assertSame('creating', $sender->get_phase());
-            $this->assertFileDoesNotExist($swap_index_path);
-            $this->assertSame($index_bytes, filesize($retained_index_path));
-            $this->assertSame(hash_file('sha256', $fresh_local_index_path), hash_file('sha256', $retained_index_path));
+            $this->takeSenderStepsUntilPhase($sender, 'planning');
+            $this->assertFileExists($fresh_local_index_path);
+            $plan = $plan_property->getValue($sender);
+            $this->assertInstanceOf(PushPlan::class, $plan);
+            $file_index_processor = $file_index_processor_property->getValue($plan);
+            $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
+            $this->assertInstanceOf(FileIndexProcessor::class, $file_index_processor);
+            $this->assertIsResource($fresh_local_index_handle);
 
-            unlink($fresh_local_index_path);
-            $this->assertTrue($sender->next_step());
-            $this->assertSame('starting_plan', $sender->get_phase());
-            $state = $this->loadActiveState($push_state_directory);
-            $this->assertIsArray($state);
-            $this->assertArrayNotHasKey('fresh_local_index_path', $state);
-            $this->assertArrayNotHasKey('fresh_local_index_bytes', $state);
-            $this->assertArrayNotHasKey('fresh_local_index_ctime', $state);
-            $this->assertArrayNotHasKey('fresh_local_index_copy_byte_offset', $state);
-            $this->assertArrayNotHasKey('local_index_at_previous_push_copy_byte_offset', $state);
-        } finally {
-            $sender->close();
-        }
-
-        unset($options['fresh_local_index_path']);
-        $sender = PushFilesSender::resume($options);
-        try {
             $this->assertTrue($sender->next_step());
             $this->assertSame('planning', $sender->get_phase());
+            $this->assertSame($plan, $plan_property->getValue($sender));
+            $this->assertSame($file_index_processor, $file_index_processor_property->getValue($plan));
+            $this->assertSame($fresh_local_index_handle, $fresh_local_index_handle_property->getValue($plan));
+            $plan_cursor = json_decode(
+                (string) file_get_contents($push_state_directory . '/cursor.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+            $this->assertSame('indexing', $plan_cursor['phase']);
+            $this->assertSame(ftell($fresh_local_index_handle), $plan_cursor['fresh_local_index_byte_offset']);
+            $this->assertNotEmpty($plan_cursor['file_index_cursor']['stack']);
+            $state = $this->loadActiveState($push_state_directory);
+            $this->assertIsArray($state);
+            $this->assertArrayNotHasKey('file_index_cursor', $state);
+            $this->assertArrayNotHasKey('fresh_local_index_byte_offset', $state);
+        } finally {
+            $sender->close();
+        }
+        $this->assertFalse(is_resource($fresh_local_index_handle));
+
+        $sender = PushFilesSender::resume($options);
+        try {
+            $this->assertSame('planning', $sender->get_phase());
+            $resumed_plan = $plan_property->getValue($sender);
+            $this->assertIsResource($fresh_local_index_handle_property->getValue($resumed_plan));
+            $this->takeSenderStepsUntilPlanPhase($sender, $push_state_directory, 'starting_diff');
+            $this->assertFileExists($fresh_local_index_path);
+
+            $this->assertTrue($sender->next_step());
+            $this->assertSame('planning', $sender->get_phase());
+            $plan_cursor = json_decode(
+                (string) file_get_contents($push_state_directory . '/cursor.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+            $this->assertSame('diffing', $plan_cursor['phase']);
+            $this->assertFileExists($fresh_local_index_path);
+            $state = $this->loadActiveState($push_state_directory);
+            $this->assertIsArray($state);
+            $this->assertArrayNotHasKey('file_index_cursor', $state);
+            $this->assertArrayNotHasKey('fresh_local_index_byte_offset', $state);
         } finally {
             $sender->close();
         }
 
-        $this->assertFileDoesNotExist($swap_index_path);
+        $index_lines = file($fresh_local_index_path, FILE_IGNORE_NEW_LINES);
+        $this->assertIsArray($index_lines);
+        $this->assertCount(2, $index_lines);
+    }
+
+    /**
+     * Continues fresh local indexing after the process dies between steps.
+     */
+    public function testHighLevelSenderContinuesFreshLocalIndexAfterProcessDeath(): void
+    {
+        if (
+            !function_exists('pcntl_fork')
+            || !function_exists('posix_kill')
+            || !defined('SIGKILL')
+        ) {
+            $this->markTestSkipped('Fresh-local-index process-death coverage requires pcntl and posix.');
+        }
+        $local_docroot = $this->root . '/killed-index-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/a.txt', 'a');
+        file_put_contents($local_docroot . '/b.txt', 'b');
+        $push_state_directory = $this->root . '/killed-index-state';
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
+
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $sender = PushFilesSender::start($options);
+            $this->takeSenderStepsUntilPhase($sender, 'planning');
+            if (!$sender->next_step()) {
+                exit(2);
+            }
+            posix_kill(getmypid(), SIGKILL);
+            exit(3);
+        }
+
+        pcntl_waitpid($child, $child_status);
+        $this->assertTrue(pcntl_wifsignaled($child_status));
+        $this->assertSame(SIGKILL, pcntl_wtermsig($child_status));
+        $state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($state);
+        $this->assertSame('planning', $state['phase']);
+        $plan_cursor = json_decode(
+            (string) file_get_contents($push_state_directory . '/cursor.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('indexing', $plan_cursor['phase']);
+        $this->assertGreaterThan(0, $plan_cursor['fresh_local_index_byte_offset']);
+
+        $result = $this->runSender($local_docroot, $push_state_directory);
+
+        $this->assertSame('complete', $result['status']);
+        $index_lines = file(
+            $push_state_directory . '/local_index_at_previous_push.jsonl',
+            FILE_IGNORE_NEW_LINES
+        );
+        $this->assertIsArray($index_lines);
+        $this->assertCount(2, $index_lines);
     }
 
     /**
@@ -1705,10 +1762,6 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/retained-handles-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/file.bin', str_repeat('A', 130));
-        $fresh_local_index_path = $this->root . '/retained-handles-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'file.bin' => $this->indexEntry($local_docroot . '/file.bin', 'file'),
-        ]);
         $previous_local_index_path = $this->root . '/retained-handles-previous-index.jsonl';
         $previous_entries = [];
         for ($index = 0; $index < 20; ++$index) {
@@ -1729,7 +1782,7 @@ final class PushEndpointsTest extends TestCase {
         );
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
         $sender = PushFilesSender::start($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
@@ -1820,13 +1873,8 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/first.txt', 'a');
         file_put_contents($local_docroot . '/second.txt', 'b');
-        $fresh_local_index_path = $this->root . '/cancel-before-remove-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'first.txt' => $this->indexEntry($local_docroot . '/first.txt', 'file'),
-            'second.txt' => $this->indexEntry($local_docroot . '/second.txt', 'file'),
-        ]);
         $push_state_directory = $this->root . '/cancel-before-remove-state';
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
 
@@ -1867,12 +1915,8 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         $contents = str_repeat('a', 130);
         file_put_contents($local_docroot . '/file.bin', $contents);
-        $fresh_local_index_path = $this->root . '/cancel-and-continue-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'file.bin' => $this->indexEntry($local_docroot . '/file.bin', 'file'),
-        ]);
         $push_state_directory = $this->root . '/cancel-and-continue-state';
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
         $upload_request_stage_property = new ReflectionProperty(PushFilesSender::class, 'upload_request_stage');
 
         $sender = PushFilesSender::start($options);
@@ -1898,7 +1942,7 @@ final class PushEndpointsTest extends TestCase {
             $sender->close();
         }
 
-        $result = $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status']);
         $this->assertSame($contents, file_get_contents($this->docroot . '/file.bin'));
@@ -1920,13 +1964,9 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         $contents = str_repeat('k', 130);
         file_put_contents($local_docroot . '/file.bin', $contents);
-        $fresh_local_index_path = $this->root . '/killed-request-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'file.bin' => $this->indexEntry($local_docroot . '/file.bin', 'file'),
-        ]);
         $push_state_directory = $this->root . '/killed-request-state';
         $request_open_marker = $this->root . '/request-open';
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
 
         $child = pcntl_fork();
         $this->assertNotSame(-1, $child);
@@ -1966,7 +2006,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('pushing_paths', $state['phase']);
         $this->assertSame(0, $state['local_paths_to_push_byte_offset']);
 
-        $result = $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status']);
         $this->assertSame($contents, file_get_contents($this->docroot . '/file.bin'));
@@ -1980,14 +2020,10 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/deleted-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/large.bin', str_repeat('A', 2000));
-        $fresh_local_index_path = $this->root . '/deleted-local-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'large.bin' => $this->indexEntry($local_docroot . '/large.bin', 'file'),
-        ]);
         $push_state_directory = $this->root . '/deleted-local-state';
 
         for ($step = 0; $step < 30; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_paths' && $step >= 2) {
@@ -1999,7 +2035,7 @@ final class PushEndpointsTest extends TestCase {
         unlink($local_docroot . '/large.bin');
 
         for (; $step < 60; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -2020,14 +2056,10 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/changed-planned-file-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/large.bin', str_repeat('A', 2000));
-        $fresh_local_index_path = $this->root . '/changed-planned-file-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'large.bin' => $this->indexEntry($local_docroot . '/large.bin', 'file'),
-        ]);
         $push_state_directory = $this->root . '/changed-planned-file-state';
 
         for ($step = 0; $step < 30; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_paths' && $step >= 2) {
@@ -2041,14 +2073,14 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/large.bin', str_repeat('B', 2000));
         clearstatcache(true, $local_docroot . '/large.bin');
 
-        $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
         $this->assertSame('continue', $result['status']);
         $this->assertSame('removing', $result['phase']);
         $this->assertNull($result['reason']);
         $this->assertNull($result['detail']);
 
         for (; $step < 60; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -2068,18 +2100,12 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/changed-empty-directory-docroot';
         mkdir($local_docroot . '/empty', 0700, true);
-        $fresh_local_index_path = $this->root . '/changed-empty-directory-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'empty' => $this->indexEntry($local_docroot . '/empty', 'dir', true),
-        ]);
         $push_state_directory = $this->root . '/changed-empty-directory-state';
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
 
         $sender = PushFilesSender::start($options);
         try {
-            $this->takeSenderStepsUntilPhase($sender, 'planning');
-            $this->assertSame('planning', $sender->get_phase());
-            $this->assertTrue($sender->next_step());
+            $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $this->assertSame('pushing_paths', $sender->get_phase());
             file_put_contents($local_docroot . '/empty/child.txt', 'new');
 
@@ -2108,14 +2134,10 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/unsupported-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.bin', str_repeat('A', 2000));
-        $fresh_local_index_path = $this->root . '/unsupported-local-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'value.bin' => $this->indexEntry($local_docroot . '/value.bin', 'file'),
-        ]);
         $push_state_directory = $this->root . '/unsupported-local-state';
 
         for ($step = 0; $step < 30; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_paths' && $step >= 2) {
@@ -2127,7 +2149,7 @@ final class PushEndpointsTest extends TestCase {
         unlink($local_docroot . '/value.bin');
         $this->assertTrue(posix_mkfifo($local_docroot . '/value.bin', 0600));
 
-        $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
         $this->assertSame('continue', $result['status']);
         $this->assertSame('removing', $result['phase']);
         $this->assertNull($result['reason']);
@@ -2143,15 +2165,9 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot . '/preserved', 0700, true);
         file_put_contents($local_docroot . '/preserved/value.txt', 'local-change');
         file_put_contents($local_docroot . '/public.txt', 'public-change');
-        $fresh_local_index_path = $this->root . '/excluded-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'preserved' => $this->indexEntry($local_docroot . '/preserved', 'dir', false),
-            'preserved/value.txt' => $this->indexEntry($local_docroot . '/preserved/value.txt', 'file'),
-            'public.txt' => $this->indexEntry($local_docroot . '/public.txt', 'file'),
-        ]);
         $push_state_directory = $this->root . '/excluded-state';
 
-        $result = $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $stored_excluded_paths = json_decode(
@@ -2163,10 +2179,13 @@ final class PushEndpointsTest extends TestCase {
         $this->assertContains(base64_encode('preserved'), $stored_excluded_paths);
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertSame('public-change', file_get_contents($this->docroot . '/public.txt'));
-        $this->assertSame(
-            file_get_contents($push_state_directory . '/fresh_local_index.jsonl'),
-            file_get_contents($push_state_directory . '/local_index_at_previous_push.jsonl'),
-            'Exclusions suppress remote work but do not create a parallel retained-index representation.'
+        $this->assertFileDoesNotExist($push_state_directory . '/fresh_local_index.jsonl');
+        $saved_local_index = file_get_contents($push_state_directory . '/local_index_at_previous_push.jsonl');
+        $this->assertIsString($saved_local_index);
+        $this->assertStringContainsString(
+            '"path":"' . base64_encode('preserved/value.txt') . '"',
+            $saved_local_index,
+            'Exclusions suppress remote work but remain in the local index saved after the push.'
         );
     }
 
@@ -2179,15 +2198,13 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/locked-state';
         mkdir($local_docroot, 0700, true);
         mkdir($push_state_directory, 0700, true);
-        $fresh_local_index_path = $this->root . '/locked-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
         $lock = fopen($push_state_directory . '/sender.lock', 'c+');
         $this->assertIsResource($lock);
         $this->assertTrue(flock($lock, LOCK_EX | LOCK_NB));
         try {
             try {
                 PushFilesSender::start(
-                    $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+                    $this->senderOptions($local_docroot, $push_state_directory)
                 );
                 $this->fail('Starting a sender must fail while another process owns its lock.');
             } catch (RuntimeException $exception) {
@@ -2198,7 +2215,7 @@ final class PushEndpointsTest extends TestCase {
             fclose($lock);
         }
 
-        $options = $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory);
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
         $sender = PushFilesSender::start($options);
         try {
             $sender->next_step();
@@ -2246,7 +2263,7 @@ final class PushEndpointsTest extends TestCase {
 
         $this->assertSame(
             'complete',
-            $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory)['status']
+            $this->runSender($local_docroot, $push_state_directory)['status']
         );
     }
 
@@ -2258,12 +2275,10 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/missing-state-local-docroot';
         $push_state_directory = $this->root . '/missing-state';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/missing-state-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
 
         try {
             PushFilesSender::resume(
-                $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+                $this->senderOptions($local_docroot, $push_state_directory)
             );
             $this->fail('Resuming without active state must fail.');
         } catch (LogicException $exception) {
@@ -2281,14 +2296,10 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/retry-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'value');
-        $fresh_local_index_path = $this->root . '/retry-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'value.txt' => $this->indexEntry($local_docroot . '/value.txt', 'file'),
-        ]);
         $push_state_directory = $this->root . '/retry-state';
 
         for ($step = 0; $step < 20; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_paths') {
@@ -2303,7 +2314,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertIsResource($push_lock);
         $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
         try {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
         } finally {
             flock($push_lock, LOCK_UN);
             fclose($push_lock);
@@ -2314,7 +2325,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertIsArray($this->loadActiveState($push_state_directory));
         $this->assertSame(
             'complete',
-            $this->runSender($local_docroot, $fresh_local_index_path, $push_state_directory)['status']
+            $this->runSender($local_docroot, $push_state_directory)['status']
         );
     }
 
@@ -2327,14 +2338,9 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/first.txt', 'first');
         file_put_contents($local_docroot . '/second.txt', 'second');
-        $fresh_local_index_path = $this->root . '/failed-upload-state-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, [
-            'first.txt' => $this->indexEntry($local_docroot . '/first.txt', 'file'),
-            'second.txt' => $this->indexEntry($local_docroot . '/second.txt', 'file'),
-        ]);
         $push_state_directory = $this->root . '/failed-upload-state';
         $sender = PushFilesSender::start(
-            $this->senderOptions($local_docroot, $fresh_local_index_path, $push_state_directory)
+            $this->senderOptions($local_docroot, $push_state_directory)
         );
         $state_property = new ReflectionProperty(PushFilesSender::class, 'state');
 
@@ -2405,11 +2411,8 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/malformed-local-docroot';
         $push_state_directory = $this->root . '/malformed-state';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/malformed-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
         $sender = PushFilesSender::start([
             'docroot' => $local_docroot,
-            'fresh_local_index_path' => $fresh_local_index_path,
             'push_state_directory' => $push_state_directory,
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
@@ -2443,8 +2446,6 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/delete-after-lost-response.txt', 'old');
         $local_docroot = $this->root . '/lost-response-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $fresh_local_index_path = $this->root . '/lost-response-index.jsonl';
-        $this->writeIndex($fresh_local_index_path, []);
         $previous_local_index_path = $this->root . '/lost-response-previous-index.jsonl';
         $this->writeIndex($previous_local_index_path, [
             'delete-after-lost-response.txt' => [1, 3, 'file'],
@@ -2453,7 +2454,7 @@ final class PushEndpointsTest extends TestCase {
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
 
         for ($step = 0; $step < 30; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'pushing_deletes') {
@@ -2484,7 +2485,7 @@ final class PushEndpointsTest extends TestCase {
         );
 
         for (; $step < 70; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             $state = $this->loadActiveState($push_state_directory);
             if (is_array($state) && $state['phase'] === 'committing') {
@@ -2499,7 +2500,7 @@ final class PushEndpointsTest extends TestCase {
         );
 
         for (; $step < 140; ++$step) {
-            $result = $this->nextSenderDurableBoundary($local_docroot, $fresh_local_index_path, $push_state_directory);
+            $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
             if ($result['status'] !== 'continue') {
                 break;
@@ -2679,7 +2680,6 @@ final class PushEndpointsTest extends TestCase {
      */
     private function senderOptions(
         string $local_docroot,
-        string $fresh_local_index_path,
         string $push_state_directory
     ): array
     {
@@ -2689,7 +2689,6 @@ final class PushEndpointsTest extends TestCase {
         ]);
         return [
             'docroot' => $local_docroot,
-            'fresh_local_index_path' => $fresh_local_index_path,
             'push_state_directory' => $push_state_directory,
             'base_url' => $this->base_url,
             'allow_http' => true,
@@ -2716,12 +2715,10 @@ final class PushEndpointsTest extends TestCase {
      */
     private function nextSenderDurableBoundary(
         string $local_docroot,
-        string $fresh_local_index_path,
         string $push_state_directory
     ): array {
         $options = $this->senderOptions(
             $local_docroot,
-            $fresh_local_index_path,
             $push_state_directory
         );
         $sender = is_file($push_state_directory . '/sender.json')
@@ -2786,6 +2783,31 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
+     * Takes bounded sender steps until its open plan reaches one internal phase.
+     */
+    private function takeSenderStepsUntilPlanPhase(
+        PushFilesSender $sender,
+        string $push_state_directory,
+        string $phase
+    ): void {
+        for ($step = 0; $step < 300; ++$step) {
+            $cursor = json_decode(
+                (string) file_get_contents($push_state_directory . '/cursor.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+            if ($cursor['phase'] === $phase) {
+                return;
+            }
+            if (!$sender->next_step()) {
+                break;
+            }
+        }
+        $this->fail("The push plan did not reach its requested {$phase} phase.");
+    }
+
+    /**
      * Counts completed requests for one endpoint in the local server log.
      */
     private function countEndpointRequests(string $endpoint): int
@@ -2812,12 +2834,10 @@ final class PushEndpointsTest extends TestCase {
      */
     private function runSender(
         string $local_docroot,
-        string $fresh_local_index_path,
         string $push_state_directory
     ): array {
         $options = $this->senderOptions(
             $local_docroot,
-            $fresh_local_index_path,
             $push_state_directory
         );
         $sender = is_file($push_state_directory . '/sender.json')
@@ -2867,27 +2887,6 @@ final class PushEndpointsTest extends TestCase {
             mkdir($push_state_directory, 0700, true);
         }
         $this->assertTrue(copy($index_path, $push_state_directory . '/local_index_at_previous_push.jsonl'));
-    }
-
-    /**
-     * Builds one index record from a real local filesystem value.
-     *
-     * @param 'file'|'dir'|'link' $type Index entry type.
-     * @return array{0:int,1:int,2:'file'|'dir'|'link',3?:bool} Index test record.
-     */
-    private function indexEntry(
-        string $absolute_path,
-        string $type,
-        ?bool $directory_is_empty = null
-    ): array
-    {
-        $identity = lstat($absolute_path);
-        $this->assertIsArray($identity);
-        $entry = [ (int) $identity['ctime'], (int) $identity['size'], $type];
-        if ($directory_is_empty !== null) {
-            $entry[] = $directory_is_empty;
-        }
-        return $entry;
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@ require_once __DIR__ . '/../packages/reprint-exporter/src/class-mysql-dump-produ
 // Load the FileTreeProducer class
 require_once __DIR__ . '/../packages/reprint-exporter/src/class-file-tree-producer.php';
 
+require_once __DIR__ . '/../packages/reprint-exporter/src/class-file-index-processor.php';
+
 // Local path-package installs can be stale until composer reinstall.
 if (!function_exists('build_pdo_dsn')) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/utils.php';


### PR DESCRIPTION
`PushFilesSender` no longer needs a prebuilt local index: its internal `PushPlan` builds the index and derives the two path lists one bounded step at a time.

## This change

A new sender creates the push session and stores its exclusions before starting one plan. `PushPlan` owns `FileIndexProcessor`, the open fresh local index, and every indexing and diff offset in `cursor.json`. `sender.json` keeps only the caller-visible lifecycle phase and sending state.

Each indexing step advances one traversal event, flushes appended JSONL bytes, and stores the file-index cursor with the committed byte offset. A later process truncates an unfinished tail and continues from that boundary. After indexing, `starting_diff` begins the index diff; each `diffing` step compares at most one path represented by either index and updates the push/delete path lists.

The plan writes directly to `fresh_local_index.jsonl`; a second swap file adds nothing because the file is private to the active plan and its cursor already defines the committed length. After a successful commit, the sender atomically replaces `local_index_at_previous_push.jsonl`, then the plan removes the fresh local index and its cursor. A discarded plan removes them in the same order.

The shared indexer retains the symlink size returned by `lstat()` and keeps directory size at zero. The Composer classmap includes the processor so the importer PHAR can load it without bundling exporter application code.

## Testing

Start a push, stop it during local indexing, and run the push command again. Confirm that indexing continues and the push completes with files, empty directories, symlinks, and deletions applied.
