### PR TITLE
[Push] Let PushFilesSender store the PushPlan cursor and own its directory

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -104,12 +104,14 @@ A push plan is an internal part of the sender lifecycle:
 
 1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
    100 target exclusions, which the sender stores once in
-   `plan/excluded_paths.json` after creating the active `plan/` directory.
-2. The sender starts one internal `PushPlan`. The plan opens
+   `excluded_paths.json` after creating the active `plan/` directory.
+2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
+   `plan/excluded_paths.json`, then opens
    `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
    step advances one traversal event, appends its JSONL entries when applicable,
-   flushes those bytes, and then stores the traversal cursor and committed byte
-   offset in `plan/cursor.json`.
+   flushes those bytes, and then updates its traversal cursor and committed byte
+   offset. The sender stores that cursor in `sender.json` before returning
+   from its step.
 3. Once traversal is complete, the plan enters `starting_diff`. The next step
    starts the index diff and enters `diffing`.
 4. Each later `next_step()` compares at most one path represented by either
@@ -122,9 +124,15 @@ A push plan is an internal part of the sender lifecycle:
 5. The sender closes the plan before consuming those two files.
 6. After the receiver commits successfully, the sender saves the retained fresh
    local index as `local_index_at_previous_push.jsonl` through the same swap-file
-   copy. It then removes the complete `plan/` directory. After the target
+   copy. It then removes the complete `plan/` directory and the sender-owned
+   exclusions file. After the target
    confirms removal of a discarded push session, the sender removes the same
-   directory without changing the local index at the previous push.
+   files without changing the local index at the previous push.
+
+Until the sender stores the initial PushPlan cursor, `starting_plan` remains
+the durable phase. An interrupted start is repeated and overwrites its initial
+plan files. After each later plan step, changed files are flushed before the
+sender atomically stores the returned cursor in `sender.json`.
 
 The completed-index copy after commit is a deliberate exception to bounded
 sender steps. A
@@ -137,16 +145,16 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-During indexing, `plan/cursor.json` contains the internal phase, the
-`FileIndexProcessor` cursor, and the committed fresh-index byte offset. During
-diffing, each step flushes only the path list or append-only deleted-directory
-stack changed by that step before atomically storing the two index offsets, two
-output byte offsets, and active stack byte offset. Each stack entry links to the
-preceding active directory, so continuation reads only the top entry. A later
-process calls `PushPlan::resume()` with the plan directory, local tree root,
-and local index at the previous push. The plan uses
-`plan/excluded_paths.json`, discards bytes beyond its durable output offsets,
-and continues from the retained internal phase.
+The cursor contains the plan directory, local tree root, local index at
+the previous push, and current planning position. During indexing, that
+position contains the `FileIndexProcessor` cursor and committed fresh-index byte
+offset. During diffing, each step flushes only the path list or append-only
+deleted-directory stack changed by that step before updating the two index
+offsets, two output byte offsets, and active stack byte offset. Each stack entry
+links to the preceding active directory, so continuation reads only the top
+entry. A later process passes the stored cursor to `PushPlan::resume()`. The
+plan uses its private exclusions copy, discards bytes beyond the stored output
+offsets, and continues from the retained internal phase.
 
 The first push to a site has no local index from a previous push or previously
 pushed rows. Every current file, symlink, and empty directory is selected, and
@@ -265,11 +273,11 @@ An active push keeps these files under `<state-dir>/push/<site>/`:
 
 ```text
 local_index_at_previous_push.jsonl  index saved after the previous commit
+excluded_paths.json                 sender-owned target exclusions
 sender.json                         active push state
 sender.lock                         lifecycle lock
 plan/
   excluded_paths.json               target exclusions for the active push
-  cursor.json                       PushPlan cursor
   fresh_local_index.jsonl           plan-owned fresh local index
   local_paths_to_push.jsonl         local paths to push
   local_paths_to_delete             raw NUL-delimited local paths to delete
@@ -306,12 +314,13 @@ The sender creates the push session and stores its exclusion policy before it
 starts PushPlan. Each internal `indexing` step completes one traversal event,
 and `starting_diff` initializes the index diff. Each internal `diffing` step
 compares at most one path and updates the path lists. PushPlan owns the
-file-index cursor, index offsets, output lengths, deleted-directory ranges, and
-exclusions in `plan/cursor.json`. No upload begins until both indexes have been
-consumed and the two path lists are stable.
+meaning of its file-index cursor, index offsets, output lengths, and
+deleted-directory ranges. `sender.json` stores the complete cursor. No
+upload begins until both indexes have been consumed and the two path lists are
+stable.
 
-`sender.json` contains no second planning checkpoint and no copied receiver
-cursor. It stores the push session and phase, the next byte offset in
+`sender.json` contains no copied receiver cursor. It stores the push session
+and phase, the PushPlan cursor, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
 sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
@@ -319,10 +328,11 @@ sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `discarding_plan`.
 The separate start, index-save, completion, removal, and discard phases ensure
 that a process stop between durable actions repeats only the current action.
-During `planning`, `plan/cursor.json` alone owns the plan's internal phase and
-continuation offsets. A completed cursor remains until commit and the local
-index save finishes, or until `discarding_plan` follows confirmed target
-removal.
+During `planning`, the PushPlan cursor in `sender.json` contains the
+plan's internal phase and continuation offsets. A completed cursor remains until
+the local index is saved, or until the target confirms removal. The sender then
+clears the cursor, enters `completing` or `discarding_plan`, and removes the
+active plan files without reopening PushPlan.
 
 Each local path to push carries the type, size, and ctime from the index used to
 plan it. When the receiver position is unknown, the sender compares the live

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -104,12 +104,12 @@ A push plan is an internal part of the sender lifecycle:
 
 1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
    100 target exclusions, which the sender stores once in
-   `excluded_paths.json`.
+   `plan/excluded_paths.json` after creating the active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan opens
-   `fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
+   `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
    step advances one traversal event, appends its JSONL entries when applicable,
    flushes those bytes, and then stores the traversal cursor and committed byte
-   offset in `cursor.json`.
+   offset in `plan/cursor.json`.
 3. Once traversal is complete, the plan enters `starting_diff`. The next step
    starts the index diff and enters `diffing`.
 4. Each later `next_step()` compares at most one path represented by either
@@ -117,13 +117,14 @@ A push plan is an internal part of the sender lifecycle:
    both indexes reach EOF. It
    writes files, symlinks, and empty directories with their planned type, size,
    and ctime to
-   `local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
-   `local_paths_to_delete`.
+   `plan/local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
+   `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
 6. After the receiver commits successfully, the sender saves the retained fresh
    local index as `local_index_at_previous_push.jsonl` through the same swap-file
-   copy. It then asks the closed plan to remove the fresh local index followed
-   by its cursor. A discarded plan removes them in the same order.
+   copy. It then removes the complete `plan/` directory. After the target
+   confirms removal of a discarded push session, the sender removes the same
+   directory without changing the local index at the previous push.
 
 The completed-index copy after commit is a deliberate exception to bounded
 sender steps. A
@@ -136,15 +137,16 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-During indexing, `cursor.json` contains the internal phase, the
+During indexing, `plan/cursor.json` contains the internal phase, the
 `FileIndexProcessor` cursor, and the committed fresh-index byte offset. During
 diffing, each step flushes only the path list or append-only deleted-directory
 stack changed by that step before atomically storing the two index offsets, two
 output byte offsets, and active stack byte offset. Each stack entry links to the
 preceding active directory, so continuation reads only the top entry. A later
-process calls `PushPlan::resume()` with the local push state directory and
-document root. The plan uses `excluded_paths.json`, discards bytes beyond its
-durable output offsets, and continues from the retained internal phase.
+process calls `PushPlan::resume()` with the plan directory, local tree root,
+and local index at the previous push. The plan uses
+`plan/excluded_paths.json`, discards bytes beyond its durable output offsets,
+and continues from the retained internal phase.
 
 The first push to a site has no local index from a previous push or previously
 pushed rows. Every current file, symlink, and empty directory is selected, and
@@ -262,15 +264,16 @@ configuration; request parameters cannot select any of them.
 An active push keeps these files under `<state-dir>/push/<site>/`:
 
 ```text
-fresh_local_index.jsonl             plan-owned fresh local index
-excluded_paths.json                 target exclusions for the active push
-deleted_directories_stack.jsonl     append-only planning stack
 local_index_at_previous_push.jsonl  index saved after the previous commit
-local_paths_to_push.jsonl           local paths to push
-local_paths_to_delete               raw NUL-delimited local paths to delete
-cursor.json                         PushPlan cursor
 sender.json                         active push state
 sender.lock                         lifecycle lock
+plan/
+  excluded_paths.json               target exclusions for the active push
+  cursor.json                       PushPlan cursor
+  fresh_local_index.jsonl           plan-owned fresh local index
+  local_paths_to_push.jsonl         local paths to push
+  local_paths_to_delete             raw NUL-delimited local paths to delete
+  deleted_directories_stack.jsonl   append-only planning stack
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.
@@ -304,7 +307,7 @@ starts PushPlan. Each internal `indexing` step completes one traversal event,
 and `starting_diff` initializes the index diff. Each internal `diffing` step
 compares at most one path and updates the path lists. PushPlan owns the
 file-index cursor, index offsets, output lengths, deleted-directory ranges, and
-exclusions in `cursor.json`. No upload begins until both indexes have been
+exclusions in `plan/cursor.json`. No upload begins until both indexes have been
 consumed and the two path lists are stable.
 
 `sender.json` contains no second planning checkpoint and no copied receiver
@@ -316,7 +319,7 @@ sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `discarding_plan`.
 The separate start, index-save, completion, removal, and discard phases ensure
 that a process stop between durable actions repeats only the current action.
-During `planning`, `cursor.json` alone owns the plan's internal phase and
+During `planning`, `plan/cursor.json` alone owns the plan's internal phase and
 continuation offsets. A completed cursor remains until commit and the local
 index save finishes, or until `discarding_plan` follows confirmed target
 removal.
@@ -343,8 +346,8 @@ the current push may delete it on the target and the next push will send it.
 A changed local path to push, a vanished path to push, or a directory to push
 that is no longer empty moves the sender to `removing`. Repeated bounded remove
 calls delete the upload-only push session; the sender enters `discarding_plan`,
-removes the PushPlan cursor, and changes its status to `restart` so a new sender
-can build a fresh local index. Deletions deliberately retain the tree
+removes the entire plan directory, and changes its status to `restart` so a new
+sender can build a fresh local index. Deletions deliberately retain the tree
 captured by the completed fresh local index rather than attempting to describe
 the live tree at commit time.
 
@@ -352,7 +355,8 @@ Repeated `push_commit` calls drive the receiver to `complete`. Only then does
 the sender enter `saving_local_index_at_previous_push` and copy the plan-owned
 fresh local index to `local_index_at_previous_push.jsonl`. Excluded entries
 remain in that complete index; exclusions suppress remote work rather than
-creating a second retained index representation.
+creating a second retained index representation. The sender then removes the
+entire plan directory before deleting active sender state.
 
 Each local-path upload or deletion step sends at most one multipart part. A file
 part contains one bounded chunk, a deletion-list part contains one complete

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -91,6 +91,7 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 
 | Surface | Name |
 | --- | --- |
+| Active plan directory | `plan`, `$plan_directory` |
 | Plan-owned fresh local index | `fresh_local_index.jsonl`, `$fresh_local_index` |
 | Local index at the previous push | `local_index_at_previous_push.jsonl`, `$local_index_at_previous_push` |
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
@@ -105,6 +106,12 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
+`sender.json`, `sender.lock`, and `local_index_at_previous_push.jsonl` live
+directly under the local push state directory. The sender creates `plan/` for
+one active plan. `excluded_paths.json`, `cursor.json`,
+`fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
+`local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
+
 `cursor.json` owns PushPlan's internal phase. During `indexing`, it stores the
 FileIndexProcessor cursor and the committed byte offset in
 `fresh_local_index.jsonl`. During `diffing`, it stores the index offsets,
@@ -118,8 +125,10 @@ does not repeat those values. Its phases are `creating`, `starting_plan`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
 completes before local paths are sent. The index copy after a successful commit
-has no sender cursor and is repeated after interruption. The plan then removes
-the fresh local index and its cursor.
+has no sender cursor and is repeated after interruption. The sender then
+removes the entire plan directory. It also removes that directory after the
+target confirms removal of a discarded push session. PushPlan only closes its
+open handles; it does not manage terminal cleanup.
 
 A request failure ends the current sender run. The active state remains in
 place so a later push command can resume from the last durable boundary. Only
@@ -195,6 +204,7 @@ Use these names verbatim inside `PushPlan`:
 
 | Meaning | Name |
 | --- | --- |
+| Active plan directory | `$plan_directory` |
 | Local tree root | `$local_tree_root`, `set_local_tree_root()` |
 | Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
 | Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -97,8 +97,8 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
 | Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
-| PushPlan cursor | `cursor.json`, `$cursor_file` |
-| Excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
+| PushPlan cursor | `push_plan_cursor`, `$push_plan_cursor`, `get_cursor()` |
+| Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
 | Active state | `sender.json`, `$state_path` |
 | Lifecycle lock file | `sender.lock`, `$lock_path` |
@@ -106,29 +106,32 @@ directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`sender.json`, `sender.lock`, and `local_index_at_previous_push.jsonl` live
-directly under the local push state directory. The sender creates `plan/` for
-one active plan. `excluded_paths.json`, `cursor.json`,
+`sender.json`, `sender.lock`, `excluded_paths.json`, and
+`local_index_at_previous_push.jsonl` live directly under the local push state
+directory. The sender creates `plan/` for one active plan. PushPlan copies the
+sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
-`cursor.json` owns PushPlan's internal phase. During `indexing`, it stores the
+The PushPlan cursor is stored in `sender.json`. It contains the plan
+directory, local tree root, local index at the previous push, and current
+planning position. During `indexing`, that position contains the
 FileIndexProcessor cursor and the committed byte offset in
-`fresh_local_index.jsonl`. During `diffing`, it stores the index offsets,
+`fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
 output offsets, and the active byte offset in
 `deleted_directories_stack.jsonl`. The stack file is append-only; each entry
-links to the preceding active directory. `excluded_paths.json` stores the target
-exclusions once for the active push, with a maximum of 100 paths. `sender.json`
-does not repeat those values. Its phases are `creating`, `starting_plan`,
+links to the preceding active directory. The exclusions have a maximum of 100
+paths. `sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index_at_previous_push`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
 completes before local paths are sent. The index copy after a successful commit
-has no sender cursor and is repeated after interruption. The sender then
-removes the entire plan directory. It also removes that directory after the
-target confirms removal of a discarded push session. PushPlan only closes its
-open handles; it does not manage terminal cleanup.
+has no separate copy cursor and is repeated after interruption. After the index
+is saved or the target confirms removal, the sender clears the PushPlan
+cursor, then removes the entire plan directory and its exclusions file. It
+does not ask PushPlan to manage terminal cleanup; PushPlan only closes its open
+handles.
 
 A request failure ends the current sender run. The active state remains in
 place so a later push command can resume from the last durable boundary. Only
@@ -206,6 +209,8 @@ Use these names verbatim inside `PushPlan`:
 | --- | --- |
 | Active plan directory | `$plan_directory` |
 | Local tree root | `$local_tree_root`, `set_local_tree_root()` |
+| Cursor | `$cursor`, `get_cursor()` |
+| Plan-owned excluded paths | `$excluded_paths_file` |
 | Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
 | Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -13,7 +13,7 @@
  * local index as the local index at the previous push. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
- * request limits needed after a process restart.
+ * request limits and the PushPlan cursor needed after a process restart.
  *
  * ## Usage
  *
@@ -61,11 +61,14 @@
  * stopped process therefore repeats only an idempotent boundary action rather
  * than a group of unrelated transitions.
  *
- * sender.json owns the top-level phase. During `planning`, plan/cursor.json owns
- * the plan's internal phase and continuation offsets; sender.json does not
- * duplicate them. The sender creates the active plan directory before planning
- * and removes the whole directory only after success or target-session removal.
- * The local index at the previous push remains beside sender.json.
+ * sender.json owns the top-level phase and the cursor returned by
+ * PushPlan. PushFilesSender stores that cursor after every completed planning
+ * step but never interprets its internal phase or offsets. The sender creates
+ * the active plan directory before planning and removes the whole directory
+ * only after success or target-session removal. The local index at the previous
+ * push remains beside sender.json. Once the plan result is saved or discarded,
+ * the sender clears its cursor before removing the directory without reopening
+ * PushPlan.
  *
  * ## Resume after local changes
  *
@@ -113,7 +116,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index_at_previous_push'|'completing'|'removing'|'discarding_plan',local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index_at_previous_push'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -256,6 +259,7 @@ final class PushFilesSender
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
+                'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'max_part_bytes' => null,
                 'request_sizer_state' => $sender->push_stream_client->get_request_sizer_state(),
@@ -298,12 +302,8 @@ final class PushFilesSender
             }
             $sender->state = $state;
             $sender->push_stream_client = $sender->create_push_stream_client($state);
-            if ($state['phase'] === 'planning') {
-                $sender->plan = PushPlan::resume(
-                    $sender->plan_directory,
-                    $sender->docroot,
-                    $sender->local_index_at_previous_push
-                );
+            if ($state['push_plan_cursor'] !== null) {
+                $sender->plan = PushPlan::resume($state['push_plan_cursor']);
             }
             return $sender;
         } catch (Throwable $throwable) {
@@ -355,7 +355,7 @@ final class PushFilesSender
         $this->local_index_at_previous_push = $this->push_state_directory . '/local_index_at_previous_push.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->lock_path = $this->push_state_directory . '/sender.lock';
-        $this->excluded_paths_path = $this->plan_directory . '/excluded_paths.json';
+        $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
     }
@@ -572,29 +572,25 @@ final class PushFilesSender
     }
 
     /**
-     * Creates or reopens PushPlan after the target exclusions are stored.
+     * Creates PushPlan and stores its initial cursor with the planning phase.
      */
     private function start_plan(): void
     {
-        if (PushPlan::has_plan($this->plan_directory)) {
-            $this->plan = PushPlan::resume(
-                $this->plan_directory,
-                $this->docroot,
-                $this->local_index_at_previous_push
-            );
-        } else {
-            $this->plan = PushPlan::start(
-                $this->plan_directory,
-                $this->docroot,
-                $this->local_index_at_previous_push
-            );
-        }
+        $this->plan = PushPlan::start(
+            $this->plan_directory,
+            $this->docroot,
+            $this->local_index_at_previous_push,
+            $this->excluded_paths_path
+        );
+        $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         $this->state['phase'] = 'planning';
         $this->store_state($this->state);
     }
 
     /**
-     * Performs one PushPlan step and moves to local paths to push at plan completion.
+     * Performs one PushPlan step and stores its cursor before returning.
+     *
+     * A completed cursor is stored with the transition to local paths to push.
      */
     private function next_plan_step(): void
     {
@@ -604,11 +600,12 @@ final class PushFilesSender
             $this->fail('local_io_error', $exception->getMessage());
             return;
         }
+        $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         if (!$has_next_step) {
             $this->plan->close();
             $this->state['phase'] = 'pushing_paths';
-            $this->store_state($this->state);
         }
+        $this->store_state($this->state);
     }
 
     /**
@@ -628,7 +625,7 @@ final class PushFilesSender
 
         // Keep the planned-path list open across calls while this phase is active.
         if (!is_resource($this->local_paths_to_push_handle)) {
-            $local_paths_to_push_path = PushPlan::local_paths_to_push_path($this->plan_directory);
+            $local_paths_to_push_path = $this->plan->get_local_paths_to_push_path();
             $this->local_paths_to_push_handle = fopen($local_paths_to_push_path, 'rb');
             if (!is_resource($this->local_paths_to_push_handle)) {
                 $this->fail('local_io_error', 'Could not open the local paths to push.');
@@ -979,7 +976,7 @@ final class PushFilesSender
 
             // Keep the completed deletion plan open while successive calls consume it.
             if (!is_resource($this->local_paths_to_delete_handle)) {
-                $local_paths_to_delete_path = PushPlan::local_paths_to_delete_path($this->plan_directory);
+                $local_paths_to_delete_path = $this->plan->get_local_paths_to_delete_path();
                 $this->local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
                 if (!is_resource($this->local_paths_to_delete_handle)) {
                     $this->fail('local_io_error', 'Could not open the local paths to delete.');
@@ -1191,7 +1188,7 @@ final class PushFilesSender
      */
     private function save_local_index_at_previous_push(): void
     {
-        $fresh_local_index = PushPlan::fresh_local_index_path($this->plan_directory);
+        $fresh_local_index = $this->plan->get_fresh_local_index_path();
         try {
             $this->copy_through_swap_file(
                 $fresh_local_index,
@@ -1201,6 +1198,7 @@ final class PushFilesSender
             $this->fail('local_io_error', $exception->getMessage());
             return;
         }
+        $this->state['push_plan_cursor'] = null;
         $this->state['phase'] = 'completing';
         $this->store_state($this->state);
     }
@@ -1232,6 +1230,7 @@ final class PushFilesSender
     private function complete_push(): void
     {
         $this->remove_plan_directory();
+        $this->remove_excluded_paths_file();
         $this->delete_state();
         $this->status = 'complete';
     }
@@ -1252,6 +1251,7 @@ final class PushFilesSender
         if (!$response['removed']) {
             return;
         }
+        $this->state['push_plan_cursor'] = null;
         $this->state['phase'] = 'discarding_plan';
         $this->store_state($this->state);
     }
@@ -1262,6 +1262,7 @@ final class PushFilesSender
     private function discard_plan(): void
     {
         $this->remove_plan_directory();
+        $this->remove_excluded_paths_file();
         $this->delete_state();
         $this->status = 'restart';
         $this->reason = 'local_path_changed';
@@ -1295,6 +1296,16 @@ final class PushFilesSender
         }
         if (!rmdir($this->plan_directory)) {
             throw new RuntimeException('Failed to remove the push plan directory: ' . $this->plan_directory);
+        }
+    }
+
+    /**
+     * Removes the sender-owned exclusions after its active plan ends.
+     */
+    private function remove_excluded_paths_file(): void
+    {
+        if (is_file($this->excluded_paths_path) && !unlink($this->excluded_paths_path)) {
+            throw new RuntimeException('Failed to remove excluded paths: ' . $this->excluded_paths_path);
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -50,7 +50,7 @@
  * receiver-confirmed work before sending more data.
  *
  * A new sender calls `push_create` to learn target-owned exclusions before
- * starting PushPlan. The plan builds the fresh local index and merges it with
+ * starting PushPlan. The plan builds the fresh local index and diffs it against
  * the index at the previous push, one bounded step at a time. After planning
  * completes, local files, symlinks, and empty directories stream through
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
@@ -61,11 +61,11 @@
  * stopped process therefore repeats only an idempotent boundary action rather
  * than a group of unrelated transitions.
  *
- * sender.json owns the top-level phase. During `planning`, cursor.json owns the
- * plan's internal phase and continuation offsets; sender.json does not duplicate
- * them. A completed plan cursor remains until the target commit and local index
- * save have both finished. A removed target session enters `discarding_plan`
- * before that cursor is deleted.
+ * sender.json owns the top-level phase. During `planning`, plan/cursor.json owns
+ * the plan's internal phase and continuation offsets; sender.json does not
+ * duplicate them. The sender creates the active plan directory before planning
+ * and removes the whole directory only after success or target-session removal.
+ * The local index at the previous push remains beside sender.json.
  *
  * ## Resume after local changes
  *
@@ -120,8 +120,14 @@ final class PushFilesSender
     /** @var string Local document root whose local paths to push are sent. */
     private string $docroot;
 
-    /** @var string Local push state directory shared with PushPlan. */
+    /** @var string Local push state directory owned by this sender. */
     private string $push_state_directory;
+
+    /** @var string Sender-owned active plan directory. */
+    private string $plan_directory;
+
+    /** @var string Index saved after the previous successful push. */
+    private string $local_index_at_previous_push;
 
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
@@ -293,7 +299,11 @@ final class PushFilesSender
             $sender->state = $state;
             $sender->push_stream_client = $sender->create_push_stream_client($state);
             if ($state['phase'] === 'planning') {
-                $sender->plan = PushPlan::resume($sender->push_state_directory, $sender->docroot);
+                $sender->plan = PushPlan::resume(
+                    $sender->plan_directory,
+                    $sender->docroot,
+                    $sender->local_index_at_previous_push
+                );
             }
             return $sender;
         } catch (Throwable $throwable) {
@@ -341,9 +351,11 @@ final class PushFilesSender
         }
         $this->docroot = rtrim($canonical_docroot, '/');
         $this->push_state_directory = rtrim($push_state_directory, '/');
+        $this->plan_directory = $this->push_state_directory . '/plan';
+        $this->local_index_at_previous_push = $this->push_state_directory . '/local_index_at_previous_push.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->lock_path = $this->push_state_directory . '/sender.lock';
-        $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
+        $this->excluded_paths_path = $this->plan_directory . '/excluded_paths.json';
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
     }
@@ -535,6 +547,7 @@ final class PushFilesSender
                 return;
             }
         }
+        $this->create_plan_directory();
         $this->store_excluded_paths($response['excluded_paths_b64']);
 
         $this->push_stream_client->set_max_part_bytes($response['max_part_bytes']);
@@ -546,14 +559,35 @@ final class PushFilesSender
     }
 
     /**
+     * Creates the active plan directory before storing its first file.
+     *
+     * A repeated `creating` step may find the directory left by an interrupted
+     * earlier step.
+     */
+    private function create_plan_directory(): void
+    {
+        if (!is_dir($this->plan_directory) && !@mkdir($this->plan_directory, 0755) && !is_dir($this->plan_directory)) {
+            throw new RuntimeException('Failed to create the push plan directory: ' . $this->plan_directory);
+        }
+    }
+
+    /**
      * Creates or reopens PushPlan after the target exclusions are stored.
      */
     private function start_plan(): void
     {
-        if (PushPlan::has_plan($this->push_state_directory)) {
-            $this->plan = PushPlan::resume($this->push_state_directory, $this->docroot);
+        if (PushPlan::has_plan($this->plan_directory)) {
+            $this->plan = PushPlan::resume(
+                $this->plan_directory,
+                $this->docroot,
+                $this->local_index_at_previous_push
+            );
         } else {
-            $this->plan = PushPlan::start($this->push_state_directory, $this->docroot);
+            $this->plan = PushPlan::start(
+                $this->plan_directory,
+                $this->docroot,
+                $this->local_index_at_previous_push
+            );
         }
         $this->state['phase'] = 'planning';
         $this->store_state($this->state);
@@ -594,7 +628,7 @@ final class PushFilesSender
 
         // Keep the planned-path list open across calls while this phase is active.
         if (!is_resource($this->local_paths_to_push_handle)) {
-            $local_paths_to_push_path = PushPlan::local_paths_to_push_path($this->push_state_directory);
+            $local_paths_to_push_path = PushPlan::local_paths_to_push_path($this->plan_directory);
             $this->local_paths_to_push_handle = fopen($local_paths_to_push_path, 'rb');
             if (!is_resource($this->local_paths_to_push_handle)) {
                 $this->fail('local_io_error', 'Could not open the local paths to push.');
@@ -945,7 +979,7 @@ final class PushFilesSender
 
             // Keep the completed deletion plan open while successive calls consume it.
             if (!is_resource($this->local_paths_to_delete_handle)) {
-                $local_paths_to_delete_path = PushPlan::local_paths_to_delete_path($this->push_state_directory);
+                $local_paths_to_delete_path = PushPlan::local_paths_to_delete_path($this->plan_directory);
                 $this->local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
                 if (!is_resource($this->local_paths_to_delete_handle)) {
                     $this->fail('local_io_error', 'Could not open the local paths to delete.');
@@ -1151,20 +1185,17 @@ final class PushFilesSender
     /**
      * Saves the committed fresh local index as the local index at the previous push.
      *
-     * This uses the same deliberate whole-index copy as the pre-plan snapshot.
-     * If the process stops before the next phase is stored, repeating the copy
-     * is safe and leaves readers on either the old or complete new index.
+     * If the process stops before the next phase is stored, repeating the
+     * deliberate whole-index copy is safe and leaves readers on either the old
+     * or complete new index.
      */
     private function save_local_index_at_previous_push(): void
     {
-        $fresh_local_index = PushPlan::fresh_local_index_path($this->push_state_directory);
-        $local_index_at_previous_push = PushPlan::local_index_at_previous_push_path(
-            $this->push_state_directory
-        );
+        $fresh_local_index = PushPlan::fresh_local_index_path($this->plan_directory);
         try {
             $this->copy_through_swap_file(
                 $fresh_local_index,
-                $local_index_at_previous_push
+                $this->local_index_at_previous_push
             );
         } catch (RuntimeException $exception) {
             $this->fail('local_io_error', $exception->getMessage());
@@ -1196,16 +1227,11 @@ final class PushFilesSender
     }
 
     /**
-     * Completes the sender after removing the completed planning cursor.
+     * Completes the sender after removing its active plan directory.
      */
     private function complete_push(): void
     {
-        if (PushPlan::has_plan($this->push_state_directory)) {
-            if (!isset($this->plan)) {
-                $this->plan = PushPlan::load_retained($this->push_state_directory);
-            }
-            $this->plan->after_successful_push();
-        }
+        $this->remove_plan_directory();
         $this->delete_state();
         $this->status = 'complete';
     }
@@ -1231,20 +1257,45 @@ final class PushFilesSender
     }
 
     /**
-     * Restarts the sender after removing the discarded planning cursor.
+     * Restarts the sender after removing the discarded plan directory.
      */
     private function discard_plan(): void
     {
-        if (PushPlan::has_plan($this->push_state_directory)) {
-            if (!isset($this->plan)) {
-                $this->plan = PushPlan::load_retained($this->push_state_directory);
-            }
-            $this->plan->discard();
-        }
+        $this->remove_plan_directory();
         $this->delete_state();
         $this->status = 'restart';
         $this->reason = 'local_path_changed';
         $this->detail = 'The upload-only push session was removed. Run the push command again to build a fresh local index.';
+    }
+
+    /**
+     * Removes the active plan directory and its files.
+     *
+     * PushPlan creates only a fixed handful of files directly in this
+     * directory. If the process stops during cleanup, the same sender phase
+     * removes the remaining files on the next run.
+     */
+    private function remove_plan_directory(): void
+    {
+        if (!is_dir($this->plan_directory)) {
+            return;
+        }
+        $plan_files = scandir($this->plan_directory);
+        if ($plan_files === false) {
+            throw new RuntimeException('Failed to read the push plan directory: ' . $this->plan_directory);
+        }
+        foreach ($plan_files as $plan_file) {
+            if ($plan_file === '.' || $plan_file === '..') {
+                continue;
+            }
+            $plan_file_path = $this->plan_directory . '/' . $plan_file;
+            if (!unlink($plan_file_path)) {
+                throw new RuntimeException('Failed to remove a push plan file: ' . $plan_file_path);
+            }
+        }
+        if (!rmdir($this->plan_directory)) {
+            throw new RuntimeException('Failed to remove the push plan directory: ' . $this->plan_directory);
+        }
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -17,13 +17,12 @@
  *
  * ## Durable boundary
  *
- * While sender.json says `planning`, cursor.json owns one of four internal
+ * While sender.json says `planning`, plan/cursor.json owns one of four internal
  * phases: `indexing`, `starting_diff`, `diffing`, or `complete`. The sender
  * owns an open PushPlan under sender.lock but does not duplicate any planning
  * cursor. A false next_step() result means both indexes reached EOF; the sender
- * closes the plan before changing its phase. The cursor remains until a
- * confirmed commit saves the fresh local index as the local index at the
- * previous push, or removal discards the plan.
+ * closes the plan before changing its phase. The completed files remain in the
+ * sender-owned plan directory until the sender finishes or discards the push.
  *
  * ## Change detection
  *
@@ -68,8 +67,8 @@ class PushPlan
     /** @var string Canonical local tree root inspected while building the fresh local index. */
     private string $local_tree_root;
 
-    /** @var string Local push state directory containing every plan file. */
-    private string $push_state_directory;
+    /** @var string Sender-owned active plan directory. */
+    private string $plan_directory;
 
     /** @var string Paths and metadata from the last completed push. */
     private string $local_index_at_previous_push;
@@ -86,7 +85,7 @@ class PushPlan
     /** @var string Path to the durable PushPlan cursor. */
     private string $cursor_file;
 
-    /** @var string Sender-owned excluded paths retained for the active push. */
+    /** @var string Plan path containing receiver-owned exclusions for the active push. */
     private string $excluded_paths_file;
 
     /** @var string Append-only deleted-directory stack for the active plan. */
@@ -136,13 +135,17 @@ class PushPlan
      * The sender has already stored the target exclusions. An existing cursor
      * is rejected so unfinished planning cannot be replaced.
      *
-     * @param string $push_state_directory Local push state directory.
-     * @param string $local_tree_root      Canonical local tree root.
+     * @param string $plan_directory              Sender-owned active plan directory.
+     * @param string $local_tree_root              Canonical local tree root.
+     * @param string $local_index_at_previous_push Index saved after the previous successful push.
      * @return self Open plan positioned at the initial indexing cursor.
      */
-    public static function start(string $push_state_directory, string $local_tree_root): self
-    {
-        $plan = new self($push_state_directory);
+    public static function start(
+        string $plan_directory,
+        string $local_tree_root,
+        string $local_index_at_previous_push
+    ): self {
+        $plan = new self($plan_directory, $local_index_at_previous_push);
         if (is_file($plan->cursor_file)) {
             throw new LogicException("Cannot start a push plan while an unfinished plan exists: {$plan->cursor_file}");
         }
@@ -157,7 +160,7 @@ class PushPlan
             $plan->local_tree_root,
             false,
             false,
-            $plan->push_state_directory
+            $plan->plan_directory
         );
         $plan->cursor = [
             "phase" => "indexing",
@@ -174,16 +177,24 @@ class PushPlan
      * Reopens only the processor and files required by the cursor's current
      * internal phase.
      *
-     * @param string $push_state_directory Local push state directory containing the unfinished plan.
-     * @param string $local_tree_root      Canonical local tree root.
+     * @param string $plan_directory              Sender-owned active plan directory.
+     * @param string $local_tree_root              Canonical local tree root.
+     * @param string $local_index_at_previous_push Index saved after the previous successful push.
      * @return self Open plan positioned at its last durable cursor.
      */
-    public static function resume(string $push_state_directory, string $local_tree_root): self
-    {
-        $plan = self::load_retained($push_state_directory);
+    public static function resume(
+        string $plan_directory,
+        string $local_tree_root,
+        string $local_index_at_previous_push
+    ): self {
+        $plan = new self($plan_directory, $local_index_at_previous_push);
+        $cursor = $plan->load_cursor();
+        if ($cursor === null) {
+            throw new LogicException("Cannot resume a push plan without a retained plan: {$plan->cursor_file}");
+        }
+        $plan->cursor = $cursor;
         $plan->set_local_tree_root($local_tree_root);
         $plan->excluded_paths = $plan->load_excluded_paths();
-        $plan->closed = false;
         if ($plan->cursor["phase"] === "indexing") {
             $plan->open_fresh_local_index_for_continuation();
         } elseif ($plan->cursor["phase"] === "diffing") {
@@ -193,99 +204,65 @@ class PushPlan
     }
 
     /**
-     * Loads a retained plan without opening files used only while planning.
+     * Reports whether a plan directory contains a retained planning cursor.
      *
-     * The returned plan is closed. It can remove its cursor after a successful
-     * push or be discarded without opening and immediately closing all planning
-     * handles.
-     *
-     * @param string $push_state_directory Local push state directory containing the retained plan.
-     * @return self Closed plan loaded from its durable cursor.
+     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function load_retained(string $push_state_directory): self
+    public static function has_plan(string $plan_directory): bool
     {
-        $plan = new self($push_state_directory);
-        $cursor = $plan->load_cursor();
-        if ($cursor === null) {
-            throw new LogicException("Cannot load a push plan without a retained plan: {$plan->cursor_file}");
-        }
-        $plan->cursor = $cursor;
-        $plan->closed = true;
-        return $plan;
-    }
-
-    /**
-     * Reports whether local push state contains a retained planning cursor.
-     *
-     * @param string $push_state_directory Local push state directory.
-     */
-    public static function has_plan(string $push_state_directory): bool
-    {
-        return is_file(rtrim($push_state_directory, "/") . "/cursor.json");
+        return is_file(rtrim($plan_directory, "/") . "/cursor.json");
     }
 
     /**
      * Returns the JSONL local paths to push list.
      *
-     * @param string $push_state_directory Local push state directory.
+     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function local_paths_to_push_path(string $push_state_directory): string
+    public static function local_paths_to_push_path(string $plan_directory): string
     {
-        return rtrim($push_state_directory, "/") . "/local_paths_to_push.jsonl";
+        return rtrim($plan_directory, "/") . "/local_paths_to_push.jsonl";
     }
 
     /**
      * Returns the raw NUL-delimited path list produced for local deletions.
      *
-     * @param string $push_state_directory Local push state directory.
+     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function local_paths_to_delete_path(string $push_state_directory): string
+    public static function local_paths_to_delete_path(string $plan_directory): string
     {
-        return rtrim($push_state_directory, "/") . "/local_paths_to_delete";
+        return rtrim($plan_directory, "/") . "/local_paths_to_delete";
     }
 
     /**
      * Returns the plan-owned fresh local index path.
      *
-     * @param string $push_state_directory Local push state directory.
+     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function fresh_local_index_path(string $push_state_directory): string
+    public static function fresh_local_index_path(string $plan_directory): string
     {
-        return rtrim($push_state_directory, "/") . "/fresh_local_index.jsonl";
+        return rtrim($plan_directory, "/") . "/fresh_local_index.jsonl";
     }
 
     /**
-     * Returns the local index saved after the previous successful push.
+     * Initializes paths in the sender-owned active plan directory.
      *
-     * @param string $push_state_directory Local push state directory.
+     * @param string $plan_directory              Sender-owned active plan directory.
+     * @param string $local_index_at_previous_push Index saved after the previous successful push.
      */
-    public static function local_index_at_previous_push_path(string $push_state_directory): string
+    private function __construct(string $plan_directory, string $local_index_at_previous_push)
     {
-        return rtrim($push_state_directory, "/") . "/local_index_at_previous_push.jsonl";
-    }
-
-    /**
-     * Initializes the files in one local push state directory.
-     *
-     * Creates the directory when it does not already exist. Plan
-     * files are opened only after start() or resume() establishes a cursor.
-     *
-     * @param string $push_state_directory Local push state directory.
-     */
-    private function __construct(string $push_state_directory)
-    {
-        $push_state_directory = rtrim($push_state_directory, "/");
-        if (!is_dir($push_state_directory) && !@mkdir($push_state_directory, 0755, true) && !is_dir($push_state_directory)) {
-            throw new RuntimeException("Failed to create the push plan directory: {$push_state_directory}");
+        $plan_directory = rtrim($plan_directory, "/");
+        if (!is_dir($plan_directory)) {
+            throw new LogicException("Cannot open a push plan without its directory: {$plan_directory}");
         }
-        $this->push_state_directory = $push_state_directory;
-        $this->local_index_at_previous_push = self::local_index_at_previous_push_path($push_state_directory);
-        $this->local_paths_to_push = self::local_paths_to_push_path($push_state_directory);
-        $this->local_paths_to_delete = self::local_paths_to_delete_path($push_state_directory);
-        $this->fresh_local_index = self::fresh_local_index_path($push_state_directory);
-        $this->cursor_file = $push_state_directory . "/cursor.json";
-        $this->excluded_paths_file = $push_state_directory . "/excluded_paths.json";
-        $this->deleted_directories_stack = $push_state_directory . "/deleted_directories_stack.jsonl";
+        $this->plan_directory = $plan_directory;
+        $this->local_index_at_previous_push = $local_index_at_previous_push;
+        $this->local_paths_to_push = self::local_paths_to_push_path($plan_directory);
+        $this->local_paths_to_delete = self::local_paths_to_delete_path($plan_directory);
+        $this->fresh_local_index = self::fresh_local_index_path($plan_directory);
+        $this->cursor_file = $plan_directory . "/cursor.json";
+        $this->excluded_paths_file = $plan_directory . "/excluded_paths.json";
+        $this->deleted_directories_stack = $plan_directory . "/deleted_directories_stack.jsonl";
     }
 
     /**
@@ -328,7 +305,7 @@ class PushPlan
             json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
             false,
             false,
-            $this->push_state_directory
+            $this->plan_directory
         );
     }
 
@@ -385,42 +362,6 @@ class PushPlan
         $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
             $cursor["deleted_directory_stack_top_byte_offset"]
         );
-    }
-
-    /**
-     * Removes the completed plan after the sender finishes a successful push.
-     *
-     * The sender saves the fresh local index as the local index at the previous
-     * push before calling this method. The fresh index is removed before the
-     * cursor so interrupted cleanup can repeat safely.
-     */
-    public function after_successful_push(): void
-    {
-        if (!$this->closed) {
-            throw new LogicException("Close the push plan before finishing a successful push.");
-        }
-        if ($this->cursor["phase"] !== "complete") {
-            throw new LogicException("Cannot finish a successful push before the plan is complete.");
-        }
-
-        $this->remove_fresh_local_index();
-        $this->remove_cursor();
-    }
-
-    /**
-     * Discards a closed plan after its push session is removed.
-     *
-     * Removing the fresh index and cursor permits the next push to start from a
-     * new local index. Output files may remain because start() truncates them
-     * before they can be used again.
-     */
-    public function discard(): void
-    {
-        if (!$this->closed) {
-            throw new LogicException("Close the push plan before discarding it.");
-        }
-        $this->remove_fresh_local_index();
-        $this->remove_cursor();
     }
 
     /**
@@ -1137,29 +1078,6 @@ class PushPlan
         }
         if (!rename($temporary_cursor, $this->cursor_file)) {
             throw new RuntimeException("Failed to move the cursor into place: {$this->cursor_file}");
-        }
-    }
-
-    /**
-     * Removes the fresh local index when its plan ends.
-     */
-    private function remove_fresh_local_index(): void
-    {
-        if (is_file($this->fresh_local_index) && !unlink($this->fresh_local_index)) {
-            throw new RuntimeException("Failed to remove the fresh local index: {$this->fresh_local_index}");
-        }
-    }
-
-    /**
-     * Removes the cursor when the plan ends.
-     *
-     * With no cursor, the local push state directory no longer contains an unfinished
-     * push plan and start() may create the next one.
-     */
-    private function remove_cursor(): void
-    {
-        if (is_file($this->cursor_file) && !unlink($this->cursor_file)) {
-            throw new RuntimeException("Failed to remove the cursor: {$this->cursor_file}");
         }
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -12,17 +12,18 @@
  *
  * PushFilesSender is the only caller-visible processor. It owns the lifecycle
  * lock, top-level phase, transport, result, commit, restart, and removal.
- * PushPlan owns FileIndexProcessor, the fresh local index, the index diff, its
- * planning cursor, and the two completed path lists.
+ * PushPlan owns FileIndexProcessor, the fresh local index, the index diff, the
+ * meaning of its cursor, and the two completed path lists. PushFilesSender
+ * stores the cursor returned by get_cursor().
  *
  * ## Durable boundary
  *
- * While sender.json says `planning`, plan/cursor.json owns one of four internal
- * phases: `indexing`, `starting_diff`, `diffing`, or `complete`. The sender
- * owns an open PushPlan under sender.lock but does not duplicate any planning
- * cursor. A false next_step() result means both indexes reached EOF; the sender
- * closes the plan before changing its phase. The completed files remain in the
- * sender-owned plan directory until the sender finishes or discards the push.
+ * While sender.json says `planning`, its PushPlan cursor contains one of
+ * four internal phases: `indexing`, `starting_diff`, `diffing`, or `complete`.
+ * A false next_step() result means both indexes reached EOF; the sender stores
+ * the returned cursor and closes the plan before changing its phase. The
+ * completed files remain in the sender-owned plan directory until the sender
+ * finishes or discards the push.
  *
  * ## Change detection
  *
@@ -43,12 +44,13 @@
  * ## Durability and memory
  *
  * Each indexing step advances one FileIndexProcessor traversal event and
- * flushes any appended JSONL bytes before storing the traversal cursor and
- * committed byte offset.
+ * flushes any appended JSONL bytes before updating the traversal cursor and
+ * committed byte offset returned to the sender.
  * A separate step starts the index diff. Each diff step compares at most one
  * path represented by either index and flushes only the output changed by that
- * step before storing its next cursor. `resume()` discards bytes beyond saved
- * offsets, so an interrupted step cannot leave duplicate durable entries.
+ * step before updating its next cursor. The sender stores that cursor before
+ * returning from its own step. `resume()` discards bytes beyond saved offsets,
+ * so an interrupted step cannot leave duplicate durable entries.
  *
  * PushPlan retains the next entry from each index and the top of an append-only
  * deleted-directory stack needed to suppress redundant descendant deletions. It
@@ -59,7 +61,8 @@
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
  * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
- * @phpstan-type PushPlanCursor IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
+ * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
+ * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,local_index_at_previous_push:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
@@ -82,9 +85,6 @@ class PushPlan
     /** @var string Plan-owned fresh local index. */
     private string $fresh_local_index;
 
-    /** @var string Path to the durable PushPlan cursor. */
-    private string $cursor_file;
-
     /** @var string Plan path containing receiver-owned exclusions for the active push. */
     private string $excluded_paths_file;
 
@@ -94,7 +94,7 @@ class PushPlan
     /** @var list<string> Receiver-owned paths that the plan must not push or delete. */
     private array $excluded_paths = [];
 
-    /** @var PushPlanCursor Last durable push plan boundary. */
+    /** @var PushPlanCursor Current cursor returned to PushFilesSender. */
     private array $cursor;
 
     /** @var bool Whether close() has closed this plan's file handles. */
@@ -132,24 +132,26 @@ class PushPlan
     /**
      * Starts a push plan by opening a fresh local index traversal.
      *
-     * The sender has already stored the target exclusions. An existing cursor
-     * is rejected so unfinished planning cannot be replaced.
+     * Copies the target exclusions into the plan directory before opening the
+     * fresh local index traversal. Until the caller stores the returned cursor,
+     * an interrupted start is repeated and overwrites these initial plan files.
      *
      * @param string $plan_directory              Sender-owned active plan directory.
      * @param string $local_tree_root              Canonical local tree root.
      * @param string $local_index_at_previous_push Index saved after the previous successful push.
+     * @param string $excluded_paths_path          Sender-owned target exclusions file.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $local_tree_root,
-        string $local_index_at_previous_push
+        string $local_index_at_previous_push,
+        string $excluded_paths_path
     ): self {
-        $plan = new self($plan_directory, $local_index_at_previous_push);
-        if (is_file($plan->cursor_file)) {
-            throw new LogicException("Cannot start a push plan while an unfinished plan exists: {$plan->cursor_file}");
+        $plan = new self($plan_directory, $local_tree_root, $local_index_at_previous_push);
+        if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
+            throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
-        $plan->set_local_tree_root($local_tree_root);
         $plan->excluded_paths = $plan->load_excluded_paths();
         $plan->fresh_local_index_handle = fopen($plan->fresh_local_index, "w+b");
         if (!is_resource($plan->fresh_local_index_handle)) {
@@ -163,11 +165,15 @@ class PushPlan
             $plan->plan_directory
         );
         $plan->cursor = [
-            "phase" => "indexing",
-            "file_index_cursor" => $plan->file_index_processor->get_cursor(),
-            "fresh_local_index_byte_offset" => 0,
+            "plan_directory" => $plan->plan_directory,
+            "local_tree_root" => $plan->local_tree_root,
+            "local_index_at_previous_push" => $plan->local_index_at_previous_push,
+            "position" => [
+                "phase" => "indexing",
+                "file_index_cursor" => $plan->file_index_processor->get_cursor(),
+                "fresh_local_index_byte_offset" => 0,
+            ],
         ];
-        $plan->save_cursor($plan->cursor);
         return $plan;
     }
 
@@ -177,90 +183,85 @@ class PushPlan
      * Reopens only the processor and files required by the cursor's current
      * internal phase.
      *
-     * @param string $plan_directory              Sender-owned active plan directory.
-     * @param string $local_tree_root              Canonical local tree root.
-     * @param string $local_index_at_previous_push Index saved after the previous successful push.
+     * @phpstan-param PushPlanCursor $cursor Cursor previously returned by get_cursor().
      * @return self Open plan positioned at its last durable cursor.
      */
-    public static function resume(
-        string $plan_directory,
-        string $local_tree_root,
-        string $local_index_at_previous_push
-    ): self {
-        $plan = new self($plan_directory, $local_index_at_previous_push);
-        $cursor = $plan->load_cursor();
-        if ($cursor === null) {
-            throw new LogicException("Cannot resume a push plan without a retained plan: {$plan->cursor_file}");
-        }
+    public static function resume(array $cursor): self
+    {
+        $plan = new self(
+            $cursor["plan_directory"],
+            $cursor["local_tree_root"],
+            $cursor["local_index_at_previous_push"]
+        );
         $plan->cursor = $cursor;
-        $plan->set_local_tree_root($local_tree_root);
-        $plan->excluded_paths = $plan->load_excluded_paths();
-        if ($plan->cursor["phase"] === "indexing") {
+        $position = $plan->cursor["position"];
+        if ($position["phase"] !== "complete") {
+            $plan->excluded_paths = $plan->load_excluded_paths();
+        }
+        if ($position["phase"] === "indexing") {
             $plan->open_fresh_local_index_for_continuation();
-        } elseif ($plan->cursor["phase"] === "diffing") {
+        } elseif ($position["phase"] === "diffing") {
             $plan->open_plan_files();
         }
         return $plan;
     }
 
     /**
-     * Reports whether a plan directory contains a retained planning cursor.
+     * Returns the cursor required to resume this plan.
      *
-     * @param string $plan_directory Sender-owned active plan directory.
+     * @phpstan-return PushPlanCursor Current cursor after the latest completed step.
      */
-    public static function has_plan(string $plan_directory): bool
+    public function get_cursor(): array
     {
-        return is_file(rtrim($plan_directory, "/") . "/cursor.json");
+        return $this->cursor;
     }
 
     /**
      * Returns the JSONL local paths to push list.
-     *
-     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function local_paths_to_push_path(string $plan_directory): string
+    public function get_local_paths_to_push_path(): string
     {
-        return rtrim($plan_directory, "/") . "/local_paths_to_push.jsonl";
+        return $this->local_paths_to_push;
     }
 
     /**
      * Returns the raw NUL-delimited path list produced for local deletions.
-     *
-     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function local_paths_to_delete_path(string $plan_directory): string
+    public function get_local_paths_to_delete_path(): string
     {
-        return rtrim($plan_directory, "/") . "/local_paths_to_delete";
+        return $this->local_paths_to_delete;
     }
 
     /**
      * Returns the plan-owned fresh local index path.
-     *
-     * @param string $plan_directory Sender-owned active plan directory.
      */
-    public static function fresh_local_index_path(string $plan_directory): string
+    public function get_fresh_local_index_path(): string
     {
-        return rtrim($plan_directory, "/") . "/fresh_local_index.jsonl";
+        return $this->fresh_local_index;
     }
 
     /**
      * Initializes paths in the sender-owned active plan directory.
      *
      * @param string $plan_directory              Sender-owned active plan directory.
+     * @param string $local_tree_root              Canonical local tree root.
      * @param string $local_index_at_previous_push Index saved after the previous successful push.
      */
-    private function __construct(string $plan_directory, string $local_index_at_previous_push)
-    {
+    private function __construct(
+        string $plan_directory,
+        string $local_tree_root,
+        string $local_index_at_previous_push
+    ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
             throw new LogicException("Cannot open a push plan without its directory: {$plan_directory}");
         }
         $this->plan_directory = $plan_directory;
+        $this->set_local_tree_root($local_tree_root);
         $this->local_index_at_previous_push = $local_index_at_previous_push;
-        $this->local_paths_to_push = self::local_paths_to_push_path($plan_directory);
-        $this->local_paths_to_delete = self::local_paths_to_delete_path($plan_directory);
-        $this->fresh_local_index = self::fresh_local_index_path($plan_directory);
-        $this->cursor_file = $plan_directory . "/cursor.json";
+        $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
+        $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
+        $this->fresh_local_index = $plan_directory . "/fresh_local_index.jsonl";
         $this->excluded_paths_file = $plan_directory . "/excluded_paths.json";
         $this->deleted_directories_stack = $plan_directory . "/deleted_directories_stack.jsonl";
     }
@@ -283,13 +284,13 @@ class PushPlan
     /**
      * Reopens the fresh local index at the byte offset stored with its traversal cursor.
      *
-     * Any bytes appended after the last cursor replacement are discarded before
-     * FileIndexProcessor continues from that same durable step.
+     * Any bytes appended after the cursor last stored by the sender are
+     * discarded before FileIndexProcessor continues from that same step.
      */
     private function open_fresh_local_index_for_continuation(): void
     {
         /** @var IndexingCursor $cursor */
-        $cursor = $this->cursor;
+        $cursor = $this->cursor["position"];
         $this->fresh_local_index_handle = fopen($this->fresh_local_index, "r+b");
         if (!is_resource($this->fresh_local_index_handle)) {
             throw new RuntimeException("Failed to reopen the fresh local index: {$this->fresh_local_index}");
@@ -318,7 +319,7 @@ class PushPlan
     private function open_plan_files(): void
     {
         /** @var IndexDiffCursor $cursor */
-        $cursor = $this->cursor;
+        $cursor = $this->cursor["position"];
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
         $this->previous_local_index_entry = null;
@@ -374,14 +375,15 @@ class PushPlan
      */
     public function next_step(): bool
     {
-        if ($this->cursor["phase"] === "complete") {
+        $position = $this->cursor["position"];
+        if ($position["phase"] === "complete") {
             return false;
         }
         if ($this->closed) {
             throw new LogicException("Cannot take a push plan step after close().");
         }
 
-        switch ($this->cursor["phase"]) {
+        switch ($position["phase"]) {
             case "indexing":
                 $this->next_file_index_step();
                 return true;
@@ -394,20 +396,19 @@ class PushPlan
     }
 
     /**
-     * Performs one filesystem traversal step and stores its exact continuation point.
+     * Performs one filesystem traversal step and updates its exact continuation point.
      *
      * Completed index entries are appended and flushed before the cursor moves
-     * past them. Steps which omit a path still store the changed traversal
-     * cursor. A directory failure leaves the durable cursor unchanged so the
-     * next plan run attempts that same directory again.
+     * past them. Steps which omit a path still update the changed traversal
+     * cursor. A directory failure leaves the caller's stored cursor unchanged,
+     * so the next plan run attempts that same directory again.
      */
     private function next_file_index_step(): void
     {
         if (!$this->file_index_processor->next_index_step()) {
             $this->file_index_processor->close();
             $this->close_fresh_local_index_handle();
-            $this->cursor = ["phase" => "starting_diff"];
-            $this->save_cursor($this->cursor);
+            $this->cursor["position"] = ["phase" => "starting_diff"];
             return;
         }
 
@@ -439,12 +440,11 @@ class PushPlan
         if (!is_int($fresh_local_index_byte_offset)) {
             throw new RuntimeException("Failed to determine the fresh local index byte offset.");
         }
-        $this->cursor = [
+        $this->cursor["position"] = [
             "phase" => "indexing",
             "file_index_cursor" => $this->file_index_processor->get_cursor(),
             "fresh_local_index_byte_offset" => $fresh_local_index_byte_offset,
         ];
-        $this->save_cursor($this->cursor);
     }
 
     /**
@@ -455,7 +455,7 @@ class PushPlan
         if (file_put_contents($this->deleted_directories_stack, "") !== 0) {
             throw new RuntimeException("Failed to initialize the deleted-directory stack: {$this->deleted_directories_stack}");
         }
-        $this->cursor = [
+        $this->cursor["position"] = [
             "phase" => "diffing",
             "byte_offset_in_fresh_index" => 0,
             "byte_offset_in_previous_index" => 0,
@@ -463,7 +463,6 @@ class PushPlan
             "byte_offset_in_local_paths_to_delete" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
         ];
-        $this->save_cursor($this->cursor);
         $this->open_plan_files();
     }
 
@@ -503,7 +502,7 @@ class PushPlan
     }
 
     /**
-     * Compares at most one path and stores the resulting push plan cursor.
+     * Compares at most one path and updates the resulting push plan cursor.
      *
      * Exclusions suppress network changes, not entries in the retained fresh
      * local index saved as the local index at the previous push after success.
@@ -513,7 +512,7 @@ class PushPlan
     private function next_index_diff_step(): bool
     {
         /** @var IndexDiffCursor $cursor */
-        $cursor = $this->cursor;
+        $cursor = $this->cursor["position"];
 
         $byte_offset_in_fresh_index = $cursor["byte_offset_in_fresh_index"];
         $byte_offset_in_previous_index = $cursor["byte_offset_in_previous_index"];
@@ -686,17 +685,16 @@ class PushPlan
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
             ];
-        $this->save_cursor($cursor_after_step);
-        $this->cursor = $cursor_after_step;
+        $this->cursor["position"] = $cursor_after_step;
         return !$complete;
     }
 
     /**
      * Closes every plan file handle and prevents further plan steps.
      *
-     * The durable cursor and plan-owned files remain available to resume the
-     * plan or to let the sender save the completed fresh local index after a
-     * successful push.
+     * The cursor returned to the sender and the plan-owned files remain
+     * available to resume the plan or save the completed fresh local index
+     * after a successful push.
      */
     public function close(): void
     {
@@ -1030,55 +1028,6 @@ class PushPlan
         }
         $entry["path"] = $path;
         return $entry;
-    }
-
-    /**
-     * Loads the durable cursor for an unfinished push plan.
-     *
-     * @phpstan-return PushPlanCursor|null Durable cursor, or null when no unfinished plan exists.
-     */
-    private function load_cursor(): ?array
-    {
-        if (!is_file($this->cursor_file)) {
-            return null;
-        }
-        $contents = file_get_contents($this->cursor_file);
-        if (!is_string($contents)) {
-            throw new RuntimeException("Failed to read the cursor: {$this->cursor_file}");
-        }
-        try {
-            $cursor = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $error) {
-            throw new RuntimeException(
-                "The cursor is not valid JSON: {$this->cursor_file}",
-                0,
-                $error
-            );
-        }
-        if (!is_array($cursor)) {
-            throw new RuntimeException("The cursor must be a JSON object: {$this->cursor_file}");
-        }
-        /** @var PushPlanCursor $cursor */
-        return $cursor;
-    }
-
-    /**
-     * Stores the next durable push-plan boundary atomically.
-     *
-     * A temporary file and rename prevent readers from observing a partial cursor.
-     *
-     * @phpstan-param PushPlanCursor $cursor Cursor to store as the durable plan boundary.
-     */
-    private function save_cursor(array $cursor): void
-    {
-        $contents = json_encode($cursor, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-        $temporary_cursor = $this->cursor_file . ".tmp";
-        if (file_put_contents($temporary_cursor, $contents) !== strlen($contents)) {
-            throw new RuntimeException("Failed to write the cursor: {$temporary_cursor}");
-        }
-        if (!rename($temporary_cursor, $this->cursor_file)) {
-            throw new RuntimeException("Failed to move the cursor into place: {$this->cursor_file}");
-        }
     }
 
 }

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -43,17 +43,16 @@ final class PushPlanTest extends TestCase
     //  Successful push
     // ------------------------------------------------------------------
 
-    public function testCompletedPlanCanRemoveItsCursorAfterTheSenderSavesTheIndex(): void
+    public function testSavedIndexCanBeUsedByTheNextPlan(): void
     {
-        $localIndexAtPreviousPush = $this->tempDir . '/state/push/example.com/local_index_at_previous_push.jsonl';
-        $this->assertFileDoesNotExist($localIndexAtPreviousPush);
+        $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath());
 
         $this->saveSuccessfulPush($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
-        $this->assertFileExists($this->planPath('local_index_at_previous_push.jsonl'));
-        $this->assertFileDoesNotExist($this->planPath('local_index_at_previous_push.jsonl') . '.tmp');
-        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
+        $this->assertFileExists($this->localIndexAtPreviousPushPath());
+        $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath() . '.tmp');
+        $this->assertDirectoryDoesNotExist($this->planDirectory());
 
         // A second successful push replaces the first. Comparing that same index
         // again produces no paths to push or delete.
@@ -62,29 +61,6 @@ final class PushPlanTest extends TestCase
         $plan = $this->startPlan($second);
         $this->planToCompletion($plan);
         $this->assertPathCounts(0, 0);
-    }
-
-    public function testAfterSuccessfulPushRejectsAClosedIncompletePlan(): void
-    {
-        $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));
-        $this->assertTrue($plan->next_step());
-        $plan->close();
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('before the plan is complete');
-        $plan->after_successful_push();
-    }
-
-    public function testAfterSuccessfulPushRequiresThePreviousIndexToBeConsumed(): void
-    {
-        $this->saveSuccessfulPush($this->writeIndex($this->manyFileEntries(2)));
-        $plan = $this->startPlan();
-        $this->assertTrue($plan->next_step());
-        $plan->close();
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('before the plan is complete');
-        $plan->after_successful_push();
     }
 
     public function testStartRejectsAnUnfinishedPlanInsteadOfResumingIt(): void
@@ -97,17 +73,28 @@ final class PushPlanTest extends TestCase
         $this->startPlan();
     }
 
-    public function testDiscardAllowsANewPlanWithoutSavingTheOldIndex(): void
+    public function testStartRequiresTheSenderToCreateThePlanDirectory(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('without its directory');
+        PushPlan::start(
+            $this->planDirectory(),
+            $this->localTreeRoot(),
+            $this->localIndexAtPreviousPushPath()
+        );
+    }
+
+    public function testRemovingThePlanDirectoryAllowsANewPlanWithoutSavingTheOldIndex(): void
     {
         $firstIndex = $this->writeIndex(['first.txt' => [100, 5, 'file']]);
         $plan = $this->startPlan($firstIndex);
         $this->assertTrue(PushPlan::has_plan($this->planDirectory()));
         $plan->close();
-        $plan->discard();
+        $this->removePlanDirectory();
 
         $this->assertFalse(PushPlan::has_plan($this->planDirectory()));
-        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
-        $this->assertFileDoesNotExist($this->planPath('local_index_at_previous_push.jsonl'));
+        $this->assertDirectoryDoesNotExist($this->planDirectory());
+        $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath());
 
         $secondIndex = $this->writeIndex(['second.txt' => [200, 6, 'file']]);
         $secondPlan = $this->startPlan($secondIndex);
@@ -278,7 +265,7 @@ final class PushPlanTest extends TestCase
                 $this->assertSame($expectedPushes, $this->listPaths($this->planPath('local_paths_to_push.jsonl')), $message);
                 $this->assertSame($expectedDeletes, $this->localPathsToDelete($this->planPath('local_paths_to_delete')), $message);
                 $this->assertPathCounts(count($expectedPushes), count($expectedDeletes), $message);
-                $plan->after_successful_push();
+                $this->removePlanDirectory();
             }
         }
     }
@@ -402,12 +389,9 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
         $this->assertSame(['a.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
 
-        copy(
-            $this->planPath('fresh_local_index.jsonl'),
-            $this->planPath('local_index_at_previous_push.jsonl')
-        );
-        $plan->after_successful_push();
-        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
+        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexAtPreviousPushPath());
+        $this->removePlanDirectory();
+        $this->assertDirectoryDoesNotExist($this->planDirectory());
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
 
@@ -451,7 +435,7 @@ final class PushPlanTest extends TestCase
         $this->assertGreaterThan(0, filesize($this->planPath('fresh_local_index.jsonl')));
         $this->assertGreaterThan(0, filesize($this->planPath('local_paths_to_push.jsonl')));
         $this->assertGreaterThan(0, filesize($this->planPath('local_paths_to_delete')));
-        $plan->after_successful_push();
+        $this->removePlanDirectory();
 
         $current = $this->writeIndex($this->manyFileEntries(2));
         $plan = $this->startPlan($current);
@@ -586,38 +570,6 @@ final class PushPlanTest extends TestCase
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
-    public function testLoadRetainedLeavesPlanningFilesClosed(): void
-    {
-        $freshLocalIndex = $this->writeIndex(['value.txt' => [1, 5, 'file']]);
-        $plan = $this->startPlan($freshLocalIndex);
-        $this->planToCompletion($plan);
-        $completedFreshLocalIndex = file_get_contents($this->planPath('fresh_local_index.jsonl'));
-        $this->assertIsString($completedFreshLocalIndex);
-
-        $loaded = PushPlan::load_retained($this->planDirectory());
-        foreach ([
-            'fresh_local_index_handle',
-            'local_index_at_previous_push_handle',
-            'local_paths_to_push_handle',
-            'local_paths_to_delete_handle',
-            'deleted_directories_stack_handle',
-        ] as $property_name) {
-            $property = new ReflectionProperty(PushPlan::class, $property_name);
-            $this->assertNull($property->getValue($loaded));
-        }
-
-        copy(
-            $this->planPath('fresh_local_index.jsonl'),
-            $this->planPath('local_index_at_previous_push.jsonl')
-        );
-        $loaded->after_successful_push();
-        $this->assertFileDoesNotExist($this->planPath('fresh_local_index.jsonl'));
-        $this->assertSame(
-            $completedFreshLocalIndex,
-            file_get_contents($this->planPath('local_index_at_previous_push.jsonl'))
-        );
-    }
-
     public function testSavedOffsetsAndCompletedEofAreIdempotentAfterRestart(): void
     {
         $current = $this->writeIndex($this->manyFileEntries(2));
@@ -686,7 +638,11 @@ final class PushPlanTest extends TestCase
                 JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
             )
         );
-        $plan = PushPlan::start($this->planDirectory(), $this->localTreeRoot());
+        $plan = PushPlan::start(
+            $this->planDirectory(),
+            $this->localTreeRoot(),
+            $this->localIndexAtPreviousPushPath()
+        );
         for ($step = 0; $step < 100; ++$step) {
             if ($this->planCursor()['phase'] === 'diffing') {
                 return $plan;
@@ -698,18 +654,19 @@ final class PushPlanTest extends TestCase
 
     private function resumePlan(): PushPlan
     {
-        return PushPlan::resume($this->planDirectory(), $this->localTreeRoot());
+        return PushPlan::resume(
+            $this->planDirectory(),
+            $this->localTreeRoot(),
+            $this->localIndexAtPreviousPushPath()
+        );
     }
 
     private function saveSuccessfulPush(string $treeDescriptionPath): void
     {
         $plan = $this->startPlan($treeDescriptionPath);
         $this->planToCompletion($plan);
-        copy(
-            $this->planPath('fresh_local_index.jsonl'),
-            $this->planPath('local_index_at_previous_push.jsonl')
-        );
-        $plan->after_successful_push();
+        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexAtPreviousPushPath());
+        $this->removePlanDirectory();
     }
 
     /**
@@ -754,12 +711,27 @@ final class PushPlanTest extends TestCase
 
     private function planDirectory(): string
     {
-        return $this->tempDir . '/state/push/example.com';
+        return $this->pushStateDirectory() . '/plan';
     }
 
     private function planPath(string $filename): string
     {
         return $this->planDirectory() . '/' . $filename;
+    }
+
+    private function pushStateDirectory(): string
+    {
+        return $this->tempDir . '/state/push/example.com';
+    }
+
+    private function localIndexAtPreviousPushPath(): string
+    {
+        return $this->pushStateDirectory() . '/local_index_at_previous_push.jsonl';
+    }
+
+    private function removePlanDirectory(): void
+    {
+        $this->recursiveDelete($this->planDirectory());
     }
 
     private function localTreeRoot(): string

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -19,6 +19,9 @@ final class PushPlanTest extends TestCase
 {
     private string $tempDir;
 
+    /** @var array<string,mixed> Cursor stored by the test caller after each plan step. */
+    private array $cursor;
+
     /** @var array<string,array<string,mixed>> Last tree shape created by materializeLocalTree(). */
     private array $materializedIndexEntries = [];
 
@@ -63,16 +66,6 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(0, 0);
     }
 
-    public function testStartRejectsAnUnfinishedPlanInsteadOfResumingIt(): void
-    {
-        $plan = $this->startPlan();
-        $plan->close();
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('unfinished plan exists');
-        $this->startPlan();
-    }
-
     public function testStartRequiresTheSenderToCreateThePlanDirectory(): void
     {
         $this->expectException(LogicException::class);
@@ -80,7 +73,8 @@ final class PushPlanTest extends TestCase
         PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
-            $this->localIndexAtPreviousPushPath()
+            $this->localIndexAtPreviousPushPath(),
+            $this->excludedPathsPath()
         );
     }
 
@@ -88,11 +82,9 @@ final class PushPlanTest extends TestCase
     {
         $firstIndex = $this->writeIndex(['first.txt' => [100, 5, 'file']]);
         $plan = $this->startPlan($firstIndex);
-        $this->assertTrue(PushPlan::has_plan($this->planDirectory()));
         $plan->close();
         $this->removePlanDirectory();
 
-        $this->assertFalse(PushPlan::has_plan($this->planDirectory()));
         $this->assertDirectoryDoesNotExist($this->planDirectory());
         $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath());
 
@@ -102,11 +94,11 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(1, 0);
         $this->assertSame(
             ['second.txt'],
-            $this->listPaths(PushPlan::local_paths_to_push_path($this->planDirectory()))
+            $this->listPaths($secondPlan->get_local_paths_to_push_path())
         );
         $this->assertSame(
             [],
-            $this->localPathsToDelete(PushPlan::local_paths_to_delete_path($this->planDirectory()))
+            $this->localPathsToDelete($secondPlan->get_local_paths_to_delete_path())
         );
     }
 
@@ -298,15 +290,15 @@ final class PushPlanTest extends TestCase
         ]));
         $plan = $this->startPlan();
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $stack_bytes = filesize($this->planPath('deleted_directories_stack.jsonl'));
         $this->assertIsInt($stack_bytes);
         $this->assertGreaterThan(0, $stack_bytes);
         $first_cursor = $this->planCursor();
         $this->assertSame(0, $first_cursor['deleted_directory_stack_top_byte_offset']);
 
-        $this->assertTrue($plan->next_step());
-        $this->assertFalse($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
+        $this->assertFalse($this->nextPlanStep($plan));
         $complete_cursor = $this->planCursor();
         $this->assertSame(['phase' => 'complete'], $complete_cursor);
         $this->assertSame($stack_bytes, filesize($this->planPath('deleted_directories_stack.jsonl')));
@@ -329,7 +321,7 @@ final class PushPlanTest extends TestCase
         $current = $this->writeIndex($entries);
         $plan = $this->startPlan($current);
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $plan->close();
         $resumedPlan = $this->resumePlan();
         $this->planToCompletion($resumedPlan);
@@ -441,7 +433,7 @@ final class PushPlanTest extends TestCase
         $plan = $this->startPlan($current);
         $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
         $this->assertSame('diffing', $this->planCursor()['phase']);
-        $this->assertFileExists(dirname($this->planPath('fresh_local_index.jsonl')) . '/cursor.json');
+        $this->assertFileDoesNotExist($this->planPath('cursor.json'));
         $this->assertSame(0, filesize($this->planPath('local_paths_to_push.jsonl')));
         $this->assertSame(0, filesize($this->planPath('local_paths_to_delete')));
         $plan->close();
@@ -453,7 +445,7 @@ final class PushPlanTest extends TestCase
         $current = $this->writeIndex($entries);
         $plan = $this->startPlan($current);
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
 
         $this->assertPathCounts(1, 0);
         $this->assertCount(1, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
@@ -468,13 +460,34 @@ final class PushPlanTest extends TestCase
         $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
+    public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
+    {
+        $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));
+        $stored_cursor = $this->cursor;
+
+        // Simulate the process stopping after PushPlan returns but before its caller stores the new cursor.
+        $this->assertTrue($plan->next_step());
+        $this->assertPathCounts(1, 0);
+        $plan->close();
+
+        $this->cursor = $stored_cursor;
+        $resumed_plan = $this->resumePlan();
+        $this->planToCompletion($resumed_plan);
+
+        $this->assertPathCounts(2, 0);
+        $this->assertSame(
+            ['file-0000.txt', 'file-0001.txt'],
+            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+        );
+    }
+
     public function testStepRetainsTheNextIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
         $fresh_index_handle_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_handle');
         $fresh_index_entry_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_entry');
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $first_cursor = $this->planCursor();
         $fresh_index_handle = $fresh_index_handle_property->getValue($plan);
         $this->assertIsResource($fresh_index_handle);
@@ -486,7 +499,7 @@ final class PushPlanTest extends TestCase
         $this->assertIsArray($retained_entry);
         $this->assertSame('file-0001.txt', $retained_entry['path']);
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $second_cursor = $this->planCursor();
         $this->assertGreaterThan(
             $second_cursor['byte_offset_in_fresh_index'],
@@ -497,22 +510,28 @@ final class PushPlanTest extends TestCase
         $plan->close();
         $plan->close();
         $resumed_plan = $this->resumePlan();
-        $this->assertFalse($resumed_plan->next_step());
-        $this->assertFalse($resumed_plan->next_step());
+        $this->assertFalse($this->nextPlanStep($resumed_plan));
+        $this->assertFalse($this->nextPlanStep($resumed_plan));
         $resumed_plan->close();
         $resumed_plan->close();
-        $this->assertFalse($resumed_plan->next_step());
+        $this->assertFalse($this->nextPlanStep($resumed_plan));
     }
 
-    public function testCursorContainsOnlyDurableOffsetsAndCompletionState(): void
+    public function testCursorContainsResumePathsOffsetsAndCompletionState(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
 
-        $cursorContents = file_get_contents($this->planPath('cursor.json'));
-        $this->assertIsString($cursorContents);
-        $cursor = json_decode($cursorContents, true, 512, JSON_THROW_ON_ERROR);
-        $this->assertIsArray($cursor);
+        $cursor = $plan->get_cursor();
+        $this->assertSame([
+            'plan_directory',
+            'local_tree_root',
+            'local_index_at_previous_push',
+            'position',
+        ], array_keys($cursor));
+        $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
+        $this->assertSame(realpath($this->localTreeRoot()), $cursor['local_tree_root']);
+        $this->assertSame($this->localIndexAtPreviousPushPath(), $cursor['local_index_at_previous_push']);
         $this->assertSame([
             'phase',
             'byte_offset_in_fresh_index',
@@ -520,15 +539,16 @@ final class PushPlanTest extends TestCase
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'deleted_directory_stack_top_byte_offset',
-        ], array_keys($cursor));
+        ], array_keys($cursor['position']));
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
-            $cursor['byte_offset_in_local_paths_to_push']
+            $cursor['position']['byte_offset_in_local_paths_to_push']
         );
         $this->assertSame(
             filesize($this->planPath('local_paths_to_delete')),
-            $cursor['byte_offset_in_local_paths_to_delete']
+            $cursor['position']['byte_offset_in_local_paths_to_delete']
         );
+        $this->assertFileDoesNotExist($this->planPath('cursor.json'));
         $plan->close();
     }
 
@@ -546,13 +566,13 @@ final class PushPlanTest extends TestCase
         $this->saveSuccessfulPush($this->writeIndex($localIndexAtPreviousPushEntries));
         $plan = $this->startPlan($current);
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $firstPushBytes = filesize($this->planPath('local_paths_to_push.jsonl'));
         $firstDeleteBytes = filesize($this->planPath('local_paths_to_delete'));
         $plan->close();
 
         $reopened = $this->resumePlan();
-        $this->assertTrue($reopened->next_step());
+        $this->assertTrue($this->nextPlanStep($reopened));
         $this->assertSame(
             $firstPushBytes,
             filesize($this->planPath('local_paths_to_push.jsonl'))
@@ -574,18 +594,18 @@ final class PushPlanTest extends TestCase
     {
         $current = $this->writeIndex($this->manyFileEntries(2));
         $plan = $this->startPlan($current);
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $plan->close();
 
         $reopened = $this->resumePlan();
-        $this->assertFalse($reopened->next_step());
+        $this->assertFalse($this->nextPlanStep($reopened));
         $freshLocalIndex = file_get_contents($this->planPath('fresh_local_index.jsonl'));
         $pathsToPush = file_get_contents($this->planPath('local_paths_to_push.jsonl'));
         $localPathsToDelete = file_get_contents($this->planPath('local_paths_to_delete'));
         $reopened->close();
 
         $replayedPlan = $this->resumePlan();
-        $replayedEof = $replayedPlan->next_step();
+        $replayedEof = $this->nextPlanStep($replayedPlan);
         $replayedPlan->close();
 
         $this->assertFalse($replayedEof);
@@ -600,8 +620,13 @@ final class PushPlanTest extends TestCase
         $entries['private/value.txt'] = [2000, 1, 'file'];
         $current = $this->writeIndex($entries);
         $plan = $this->startPlan($current, ['private']);
+        $this->assertSame(
+            file_get_contents($this->excludedPathsPath()),
+            file_get_contents($this->planPath('excluded_paths.json'))
+        );
+        unlink($this->excludedPathsPath());
 
-        $this->assertTrue($plan->next_step());
+        $this->assertTrue($this->nextPlanStep($plan));
         $plan->close();
 
         $resumedPlan = $this->resumePlan();
@@ -632,7 +657,7 @@ final class PushPlanTest extends TestCase
             mkdir($this->planDirectory(), 0755, true);
         }
         file_put_contents(
-            $this->planPath('excluded_paths.json'),
+            $this->excludedPathsPath(),
             json_encode(
                 array_map('base64_encode', $excludedPaths),
                 JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
@@ -641,24 +666,22 @@ final class PushPlanTest extends TestCase
         $plan = PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
-            $this->localIndexAtPreviousPushPath()
+            $this->localIndexAtPreviousPushPath(),
+            $this->excludedPathsPath()
         );
+        $this->cursor = $plan->get_cursor();
         for ($step = 0; $step < 100; ++$step) {
             if ($this->planCursor()['phase'] === 'diffing') {
                 return $plan;
             }
-            $this->assertTrue($plan->next_step());
+            $this->assertTrue($this->nextPlanStep($plan));
         }
         $this->fail('Push plan did not finish indexing within 100 bounded steps.');
     }
 
     private function resumePlan(): PushPlan
     {
-        return PushPlan::resume(
-            $this->planDirectory(),
-            $this->localTreeRoot(),
-            $this->localIndexAtPreviousPushPath()
-        );
+        return PushPlan::resume($this->cursor);
     }
 
     private function saveSuccessfulPush(string $treeDescriptionPath): void
@@ -676,7 +699,7 @@ final class PushPlanTest extends TestCase
     private function planToCompletion(PushPlan $plan): void
     {
         for ($step = 0; $step < 100; ++$step) {
-            if (!$plan->next_step()) {
+            if (!$this->nextPlanStep($plan)) {
                 $plan->close();
                 return;
             }
@@ -684,14 +707,20 @@ final class PushPlanTest extends TestCase
         $this->fail('Push plan did not complete within 100 bounded steps.');
     }
 
+    /**
+     * Performs one plan step and stores its cursor as the caller would.
+     */
+    private function nextPlanStep(PushPlan $plan): bool
+    {
+        $has_next_step = $plan->next_step();
+        $this->cursor = $plan->get_cursor();
+        return $has_next_step;
+    }
+
     /** @return array<string,mixed> */
     private function planCursor(): array
     {
-        $contents = file_get_contents($this->planPath('cursor.json'));
-        $this->assertIsString($contents);
-        $cursor = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        $this->assertIsArray($cursor);
-        return $cursor;
+        return $this->cursor['position'];
     }
 
     private function assertPathCounts(
@@ -727,6 +756,11 @@ final class PushPlanTest extends TestCase
     private function localIndexAtPreviousPushPath(): string
     {
         return $this->pushStateDirectory() . '/local_index_at_previous_push.jsonl';
+    }
+
+    private function excludedPathsPath(): string
+    {
+        return $this->pushStateDirectory() . '/excluded_paths.json';
     }
 
     private function removePlanDirectory(): void

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1347,6 +1347,7 @@ final class PushEndpointsTest extends TestCase {
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
 
         $commit_advances = 0;
+        $saw_completing = false;
         for ($step = 0; $step < 200; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
             $this->assertNotSame('failed', $result['status'], (string) json_encode($result));
@@ -1354,12 +1355,18 @@ final class PushEndpointsTest extends TestCase {
             if (is_array($state) && $state['phase'] === 'committing') {
                 ++$commit_advances;
             }
+            if (is_array($state) && $state['phase'] === 'completing') {
+                $this->assertNull($state['push_plan_cursor']);
+                $this->assertDirectoryExists($push_state_directory . '/plan');
+                $saw_completing = true;
+            }
             if ($result['status'] !== 'continue') {
                 break;
             }
         }
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertTrue($saw_completing);
         $this->assertGreaterThan(1, $commit_advances, 'The endpoint work budget must require repeated commit requests.');
         $this->assertSame(str_repeat('A', 2000), file_get_contents($this->docroot . '/nested/large.bin'));
         $this->assertSame('new!', file_get_contents($this->docroot . '/same-size.txt'));
@@ -1370,6 +1377,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
+        $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
         $this->assertFileExists($push_state_directory . '/local_index_at_previous_push.jsonl');
     }
 
@@ -1555,7 +1563,7 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Retains one open PushPlan and leaves sender state untouched while planning continues.
+     * Retains one open PushPlan while storing its cursor after each planning step.
      */
     public function testHighLevelSenderRetainsPushPlanAcrossPlanningSteps(): void
     {
@@ -1565,7 +1573,6 @@ final class PushEndpointsTest extends TestCase {
             file_put_contents($local_docroot . sprintf('/file-%04d.txt', $index), 'x');
         }
         $push_state_directory = $this->root . '/retained-plan-state';
-        $state_path = $push_state_directory . '/sender.json';
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
         $fresh_local_index_handle_property = new ReflectionProperty(
             PushPlan::class,
@@ -1585,25 +1592,25 @@ final class PushEndpointsTest extends TestCase {
             $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
             $this->assertIsResource($fresh_local_index_handle);
 
-            clearstatcache(true, $state_path);
-            $state_inode = fileinode($state_path);
-            $this->assertIsInt($state_inode);
+            $cursor_before_step = $this->loadPlanPosition($push_state_directory);
 
             $sender->next_step();
 
             $first_plan_result = $this->senderResult($sender);
             $this->assertSame('planning', $first_plan_result['phase']);
             $this->assertSame($plan, $plan_property->getValue($sender));
-            clearstatcache(true, $state_path);
-            $this->assertSame($state_inode, fileinode($state_path));
+            $cursor_after_first_step = $this->loadPlanPosition($push_state_directory);
+            $this->assertNotSame($cursor_before_step, $cursor_after_first_step);
 
             $sender->next_step();
 
             $second_plan_result = $this->senderResult($sender);
             $this->assertSame('planning', $second_plan_result['phase']);
             $this->assertSame($plan, $plan_property->getValue($sender));
-            clearstatcache(true, $state_path);
-            $this->assertSame($state_inode, fileinode($state_path));
+            $this->assertNotSame(
+                $cursor_after_first_step,
+                $this->loadPlanPosition($push_state_directory)
+            );
         } finally {
             $sender->close();
         }
@@ -1636,6 +1643,11 @@ final class PushEndpointsTest extends TestCase {
             $this->takeSenderStepsUntilPhase($sender, 'planning');
             $this->assertFileExists($fresh_local_index_path);
             $this->assertFileExists($push_state_directory . '/plan/excluded_paths.json');
+            $this->assertFileDoesNotExist($push_state_directory . '/plan/cursor.json');
+            $this->assertSame(
+                file_get_contents($push_state_directory . '/excluded_paths.json'),
+                file_get_contents($push_state_directory . '/plan/excluded_paths.json')
+            );
             $plan = $plan_property->getValue($sender);
             $this->assertInstanceOf(PushPlan::class, $plan);
             $file_index_processor = $file_index_processor_property->getValue($plan);
@@ -1648,12 +1660,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($plan, $plan_property->getValue($sender));
             $this->assertSame($file_index_processor, $file_index_processor_property->getValue($plan));
             $this->assertSame($fresh_local_index_handle, $fresh_local_index_handle_property->getValue($plan));
-            $plan_cursor = json_decode(
-                (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
-                true,
-                512,
-                JSON_THROW_ON_ERROR
-            );
+            $plan_cursor = $this->loadPlanPosition($push_state_directory);
             $this->assertSame('indexing', $plan_cursor['phase']);
             $this->assertSame(ftell($fresh_local_index_handle), $plan_cursor['fresh_local_index_byte_offset']);
             $this->assertNotEmpty($plan_cursor['file_index_cursor']['stack']);
@@ -1676,12 +1683,7 @@ final class PushEndpointsTest extends TestCase {
 
             $this->assertTrue($sender->next_step());
             $this->assertSame('planning', $sender->get_phase());
-            $plan_cursor = json_decode(
-                (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
-                true,
-                512,
-                JSON_THROW_ON_ERROR
-            );
+            $plan_cursor = $this->loadPlanPosition($push_state_directory);
             $this->assertSame('diffing', $plan_cursor['phase']);
             $this->assertFileExists($fresh_local_index_path);
             $state = $this->loadActiveState($push_state_directory);
@@ -1734,12 +1736,7 @@ final class PushEndpointsTest extends TestCase {
         $state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state);
         $this->assertSame('planning', $state['phase']);
-        $plan_cursor = json_decode(
-            (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
+        $plan_cursor = $this->loadPlanPosition($push_state_directory);
         $this->assertSame('indexing', $plan_cursor['phase']);
         $this->assertGreaterThan(0, $plan_cursor['fresh_local_index_byte_offset']);
 
@@ -1898,6 +1895,10 @@ final class PushEndpointsTest extends TestCase {
             $this->assertNull($curl_handle_property->getValue($push_stream_client));
             $this->assertTrue($sender->next_step());
             $this->assertSame('discarding_plan', $sender->get_phase());
+            $state = $this->loadActiveState($push_state_directory);
+            $this->assertIsArray($state);
+            $this->assertNull($state['push_plan_cursor']);
+            $this->assertDirectoryExists($push_state_directory . '/plan');
             $this->assertFalse($sender->next_step());
             $this->assertSame('restart', $sender->get_status());
             $this->assertSame('local_path_changed', $sender->get_reason());
@@ -2045,6 +2046,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
+        $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
@@ -2090,6 +2092,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
+        $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
@@ -2784,12 +2787,7 @@ final class PushEndpointsTest extends TestCase {
         string $phase
     ): void {
         for ($step = 0; $step < 300; ++$step) {
-            $cursor = json_decode(
-                (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
-                true,
-                512,
-                JSON_THROW_ON_ERROR
-            );
+            $cursor = $this->loadPlanPosition($push_state_directory);
             if ($cursor['phase'] === $phase) {
                 return;
             }
@@ -2798,6 +2796,18 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         $this->fail("The push plan did not reach its requested {$phase} phase.");
+    }
+
+    /** @return array<string,mixed> */
+    private function loadPlanPosition(string $push_state_directory): array
+    {
+        $state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($state);
+        $cursor = $state['push_plan_cursor'];
+        $this->assertIsArray($cursor);
+        $position = $cursor['position'];
+        $this->assertIsArray($position);
+        return $position;
     }
 
     /**

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1369,8 +1369,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileDoesNotExist($this->docroot . '/remove.txt');
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertNull($this->loadActiveState($push_state_directory));
-        $this->assertFileDoesNotExist($push_state_directory . '/cursor.json');
-        $this->assertFileDoesNotExist($push_state_directory . '/fresh_local_index.jsonl');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileExists($push_state_directory . '/local_index_at_previous_push.jsonl');
     }
 
@@ -1622,7 +1621,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/a.txt', 'a');
         file_put_contents($local_docroot . '/b.txt', 'bb');
         $push_state_directory = $this->root . '/bounded-index-state';
-        $fresh_local_index_path = $push_state_directory . '/fresh_local_index.jsonl';
+        $fresh_local_index_path = $push_state_directory . '/plan/fresh_local_index.jsonl';
         $options = $this->senderOptions($local_docroot, $push_state_directory);
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
         $file_index_processor_property = new ReflectionProperty(PushPlan::class, 'file_index_processor');
@@ -1636,6 +1635,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('creating', $sender->get_phase());
             $this->takeSenderStepsUntilPhase($sender, 'planning');
             $this->assertFileExists($fresh_local_index_path);
+            $this->assertFileExists($push_state_directory . '/plan/excluded_paths.json');
             $plan = $plan_property->getValue($sender);
             $this->assertInstanceOf(PushPlan::class, $plan);
             $file_index_processor = $file_index_processor_property->getValue($plan);
@@ -1649,7 +1649,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($file_index_processor, $file_index_processor_property->getValue($plan));
             $this->assertSame($fresh_local_index_handle, $fresh_local_index_handle_property->getValue($plan));
             $plan_cursor = json_decode(
-                (string) file_get_contents($push_state_directory . '/cursor.json'),
+                (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
                 true,
                 512,
                 JSON_THROW_ON_ERROR
@@ -1677,7 +1677,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertTrue($sender->next_step());
             $this->assertSame('planning', $sender->get_phase());
             $plan_cursor = json_decode(
-                (string) file_get_contents($push_state_directory . '/cursor.json'),
+                (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
                 true,
                 512,
                 JSON_THROW_ON_ERROR
@@ -1735,7 +1735,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertIsArray($state);
         $this->assertSame('planning', $state['phase']);
         $plan_cursor = json_decode(
-            (string) file_get_contents($push_state_directory . '/cursor.json'),
+            (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
             true,
             512,
             JSON_THROW_ON_ERROR
@@ -2044,7 +2044,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('restart', $result['status'], (string) json_encode($result));
         $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
-        $this->assertFileDoesNotExist($push_state_directory . '/cursor.json');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
@@ -2089,7 +2089,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('restart', $result['status']);
         $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
-        $this->assertFileDoesNotExist($push_state_directory . '/cursor.json');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
@@ -2170,16 +2170,9 @@ final class PushEndpointsTest extends TestCase {
         $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
-        $stored_excluded_paths = json_decode(
-            (string) file_get_contents($push_state_directory . '/excluded_paths.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
-        $this->assertContains(base64_encode('preserved'), $stored_excluded_paths);
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertSame('public-change', file_get_contents($this->docroot . '/public.txt'));
-        $this->assertFileDoesNotExist($push_state_directory . '/fresh_local_index.jsonl');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $saved_local_index = file_get_contents($push_state_directory . '/local_index_at_previous_push.jsonl');
         $this->assertIsString($saved_local_index);
         $this->assertStringContainsString(
@@ -2462,7 +2455,7 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         $this->assertIsArray($state);
-        $deletions = (string) file_get_contents($push_state_directory . '/local_paths_to_delete');
+        $deletions = (string) file_get_contents($push_state_directory . '/plan/local_paths_to_delete');
         $this->assertSame("delete-after-lost-response.txt\0", $deletions);
         $boundary = 'reprint-lost-delete-response';
         $delete_body = '--' . $boundary . "\r\n"
@@ -2792,7 +2785,7 @@ final class PushEndpointsTest extends TestCase {
     ): void {
         for ($step = 0; $step < 300; ++$step) {
             $cursor = json_decode(
-                (string) file_get_contents($push_state_directory . '/cursor.json'),
+                (string) file_get_contents($push_state_directory . '/plan/cursor.json'),
                 true,
                 512,
                 JSON_THROW_ON_ERROR


### PR DESCRIPTION
Moves active planning files into a sender-owned `plan/` directory and stores the PushPlan cursor in `sender.json`, so PushPlan no longer manages durable JSON or terminal cleanup.

## Background

`PushPlan` previously received the full local push state directory. It shared that directory with `sender.json`, `sender.lock`, and the index from the previous push, wrote its own `cursor.json`, and removed selected files after success or discard. That split durable lifecycle work between the plan and its owning sender.

## This change

`PushFilesSender` creates `plan/` after `push_create` returns the target exclusions. PushPlan copies those exclusions into its directory and owns the active index traversal, diff, fresh index, path lists, deleted-directory stack, and the meaning of its cursor.

Each completed planning step flushes changed plan files before returning an updated cursor. The sender atomically stores that cursor in `sender.json`; a later process resumes PushPlan from the cursor alone. If a process stops after a plan step but before the sender stores its new cursor, continuation uses the preceding offsets and discards the uncommitted tail.

After commit, the sender obtains the fresh index path from PushPlan, copies it to `local_index_at_previous_push.jsonl`, clears the cursor, and removes the complete plan directory. Confirmed target-session removal follows the same cleanup without changing the previous index. A new push therefore starts with an empty plan directory.

## Testing

The plan and endpoint suites cover caller-owned cursor storage, continuation after process death, interruption before cursor storage, the private exclusions copy, successful cleanup, discard cleanup, and preservation of the previous index.
