### PR TITLE
[Push] Add resumable files-push CLI command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,6 +120,34 @@ jobs:
           STATE_DIR="/tmp/e2e-smoke-state"
           FS_ROOT="/tmp/e2e-smoke-fs"
 
+          if [ "$IMPORTER_PHP" = "php7.4" ] || [ "$IMPORTER_PHP" = "php8.0" ]; then
+            echo "=== Importer files-push PHP version gate ==="
+            PUSH_STATE_DIR="/tmp/e2e-files-push-version-state"
+            PUSH_FS_ROOT="/tmp/e2e-files-push-version-files"
+            PUSH_PROBE="files-push-version-${{ matrix.importer_php }}"
+            rm -rf "$PUSH_STATE_DIR" "$PUSH_FS_ROOT"
+            mkdir -p "$PUSH_FS_ROOT"
+            set +e
+            files_push_version_output="$("$IMPORTER_PHP" "$IMPORTER_PATH" files-push "${BASE}&directory=${DIR}&version_gate_probe=${PUSH_PROBE}" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" --force-http 2>&1)"
+            files_push_version_status=$?
+            set -e
+            if [ "$files_push_version_status" -ne 1 ]; then
+              echo "$files_push_version_output"
+              echo "Expected files-push to exit 1 on ${IMPORTER_PHP}; got ${files_push_version_status}"
+              exit 1
+            fi
+            echo "$files_push_version_output" | grep -F 'reprint push requires PHP 8.1 or newer'
+            echo "$files_push_version_output" | sed 's#\\/#/#g' | grep -F 'https://github.com/WordPress/reprint/issues/327'
+            if find "$PUSH_STATE_DIR" -name sender.json -print -quit | grep -q .; then
+              echo "files-push created sender.json below PHP 8.1"
+              exit 1
+            fi
+            if sudo grep -F "version_gate_probe=${PUSH_PROBE}" /var/log/nginx/access.log >/dev/null 2>&1; then
+              echo "files-push contacted the target below PHP 8.1"
+              exit 1
+            fi
+          fi
+
           echo "=== Importer preflight ==="
           preflight_output="$(timeout 30 "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" || {
             status=$?

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -81,11 +81,11 @@ one. It only answers "what changed locally since my last successful push to
 this remote" by comparing the current local paths and rows against the local
 index at the previous push and the previously pushed rows.
 
-The local machine keeps these files **per remote site**, overwritten after
-each successful commit:
+The local machine keeps these files **per target URL and canonical local
+tree**, overwritten after each successful commit:
 
-    <state-dir>/push/<site>/local_index_at_previous_push.jsonl
-    <state-dir>/push/<site>/previously_pushed_rows.jsonl   (phase two)
+    <state-dir>/push/<pair-key>/local_index_at_previous_push.jsonl
+    <state-dir>/push/<pair-key>/previously_pushed_rows.jsonl   (phase two)
 
 `PushPlan` first builds a path-sorted fresh local index, then derives the local
 paths to push and delete by diffing it against
@@ -269,7 +269,7 @@ configuration; request parameters cannot select any of them.
 ## Local files sender
 
 `PushFilesSender` joins the durable `PushPlan` to the receiver's push session.
-An active push keeps these files under `<state-dir>/push/<site>/`:
+An active push keeps these files under `<state-dir>/push/<pair-key>/`:
 
 ```text
 local_index_at_previous_push.jsonl  index saved after the previous commit
@@ -392,6 +392,51 @@ and type values. Other drift remains detectable by the next local-index diff.
 Push streaming requires PHP 8.1 or newer because older PHP cURL bindings can
 truncate a paused upload; pull remains PHP 7.4-compatible.
 
+## Low-level files-push command
+
+`reprint files-push <target-url>` is the production CLI caller for one
+`PushFilesSender`. It sends only the canonical local tree named by `--fs-root`.
+It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
+the operator passes `--force-http`. It does not run pull preflight, read or
+write `.import-state.json`, show a plan, ask for confirmation, transfer a
+database, retry a failed request, or start a replacement sender after a
+`restart` outcome.
+
+The command derives one pair key without general URL normalization:
+
+```text
+sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
+```
+
+Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
+query or canonical local tree therefore selects a different retained local
+index. Fragments, URL user-info, and `SECRET_KEY` target parameters are
+rejected. The pair state directory must be outside the local tree so planning
+cannot index its own changing files.
+
+One process starts or resumes exactly one sender. Before every `next_step()` it
+checks whether another step may begin. The wall-clock admission deadline is 80
+percent of PHP's finite `max_execution_time`; zero is unlimited. With a finite
+`memory_limit`, another step begins only when current allocated PHP memory plus
+the same 4 MiB file chunk passed to the sender remains below 80 percent of the
+limit. These checks happen between steps. An active network step that keeps
+moving bytes, and the completed-index copy, may run past the deadline.
+
+A planned pause or first handled SIGINT or SIGTERM calls `cancel()` while the
+sender still reports `continue`, then calls `close()`. A first handled signal
+only asks the outer loop to stop after the active step; a terminal sender
+outcome takes precedence. A second signal may terminate immediately. Without
+PCNTL, ordinary process termination can bypass cleanup, and the next process
+continues through the same hard-death contract used after SIGKILL.
+
+The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
+`restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
+same command again. After `restart`, that next run builds a fresh plan. The
+shared audit log records opening mode, phase changes, planned pauses, handled
+interruptions, and terminal outcomes with the pair key. The flat status file
+records only the command, pair, outcome, phase, reason, detail, and timestamp;
+neither file copies receiver cursors or tentative upload positions.
+
 ## Where reprint stores its own data on the remote
 
 The remote is configured with one storage path for everything reprint keeps:
@@ -508,9 +553,12 @@ Files first, database second, each PR small and stacked in this order:
 9. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
 10. **Row index and database diff** — the local row index, previously pushed
     rows, diff generation and URL rewrite, the commit batch.
-11. **`reprint push`** — the one command that orchestrates plan, confirm,
-    transfer, commit, resume.
-12. **Budgets and resumable limits** — push requests stay bounded by two
+11. **`reprint files-push`** — the low-level, files-only caller that retains
+    one sender per process, applies caller time and memory admission budgets,
+    and reports completion, continuation, restart, or failure without retrying.
+12. **`reprint push`** — the high-level command that adds a change summary,
+    confirmation boundary, database work, transfer, commit, and resume.
+13. **Budgets and resumable limits** — push requests stay bounded by two
     budgets of different dimensions: the fixed chunk (the sender's in-memory
     unit of one read) and the host-learned request body budget that
     PushRequestSizer sizes from reported php.ini limits and 413s, plus a

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -87,7 +87,7 @@ development. There are no compatibility aliases or migration paths.
 ## Local push state
 
 The local machine keeps planning and active state outside the receiver push
-directory. Under `<state-dir>/push/<site>/`, use these names verbatim:
+directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
 
 | Surface | Name |
 | --- | --- |
@@ -159,6 +159,36 @@ never finishes an open request. In `pushing_paths` or
 `pushing_deletes`, one step sends at most one multipart part. `next_step()`
 returns true while another step may be performed and false when `get_status()`
 reports `complete`, `restart`, or `failed`.
+
+## Files-push CLI names
+
+The low-level, files-only command is `files-push`. Its `target URL` is the
+exporter API URL, and its `local tree` is the canonical directory supplied by
+`--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
+plain-HTTP opt-in.
+
+The `pair key` identifies exactly one target URL and canonical local tree:
+
+```text
+sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
+```
+
+The `pair state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
+chooses `start` or `resume` only from whether `sender.json` exists there. The
+receiver-confirmed upload positions remain receiver-owned; they are not a
+files-push cursor and are not copied into `.import-state.json` or
+`.import-status.json`.
+
+Files-push lifecycle lines use these command-first names verbatim: `START
+files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,
+`INTERRUPTED files-push`, `COMPLETE files-push`, `RESTART files-push`, `FAILED
+files-push`, and `ERROR files-push`. Every line contains `pair=<pair-key>`.
+Planned stop causes are `time_limit` and `memory_limit`.
+
+The CLI outcome names are `complete`, `partial`, `interrupted`, `restart`,
+`failed`, and `error`. `complete` exits 0; `partial`, `interrupted`, and
+`restart` exit 2; `failed` and `error` exit 1. A `restart` ends the current
+process, and the next invocation starts a fresh plan.
 
 ## PushFilesSender names
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1087,6 +1087,9 @@ class ImportClient
     /** @var bool Set to true by SIGTERM/SIGINT handler to finish the current chunk and exit cleanly. */
     private $shutdown_requested = false;
 
+    /** @var int|null First signal asking files-push to stop after its active sender step. */
+    private $files_push_stop_signal = null;
+
     /**
      * @var bool When true, tell the server to follow symlinks that point outside
      * the document root (expanding them into real files). Enabled by default,
@@ -1244,8 +1247,28 @@ class ImportClient
      */
     public $exit_code = 0;
 
-    public function __construct(string $remote_url, string $state_dir, string $fs_root)
+    public function __construct(
+        string $remote_url,
+        string $state_dir,
+        string $fs_root,
+        ?string $signal_handling_command = null
+    )
     {
+        // Register the command's signal behavior before constructor work can
+        // create state or receive a signal under another command's policy.
+        if (function_exists("pcntl_signal")) {
+            // Enable async signals (PHP 7.1+) so signals work during blocking operations
+            if (function_exists("pcntl_async_signals")) {
+                pcntl_async_signals(true);
+            }
+            if ($signal_handling_command === 'files-push') {
+                $this->enable_files_push_signal_handling();
+            } else {
+                pcntl_signal(SIGINT, [$this, "handle_shutdown"]);
+                pcntl_signal(SIGTERM, [$this, "handle_shutdown"]);
+            }
+        }
+
         $this->remote_url = rtrim($remote_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
         $this->fs_root = rtrim($fs_root, "/");
@@ -1269,16 +1292,6 @@ class ImportClient
         $this->progress_fd = STDOUT;
         $this->progress = new TerminalProgress($this->is_tty, $this->progress_fd);
         $this->pull = new Pull($this, $this->progress);
-
-        // Register signal handlers for graceful shutdown
-        if (function_exists("pcntl_signal")) {
-            // Enable async signals (PHP 7.1+) so signals work during blocking operations
-            if (function_exists("pcntl_async_signals")) {
-                pcntl_async_signals(true);
-            }
-            pcntl_signal(SIGINT, [$this, "handle_shutdown"]);
-            pcntl_signal(SIGTERM, [$this, "handle_shutdown"]);
-        }
 
         // Create directories
         if (!is_dir($this->state_dir)) {
@@ -1443,15 +1456,28 @@ class ImportClient
      * Log the executed command and full argv to the audit log.
      * Called from the CLI entry point before run() so the invocation
      * is captured even if run() throws early.
+     *
+     * @param string       $command Canonical CLI command name.
+     * @param list<string> $argv    Raw command arguments.
+     * @param string|null  $pair    Files-push pair key, when available.
      */
-    public function audit_log_argv(string $command, array $argv): void
+    public function audit_log_argv(string $command, array $argv, ?string $pair = null): void
     {
         // Mask the remote URL (argv[2]) to avoid logging secrets embedded in query strings.
         $masked = $argv;
         if (isset($masked[2]) && $command !== 'apply-runtime') {
             $masked[2] = preg_replace('/SECRET_KEY=[^&\s]+/', 'SECRET_KEY=***', $masked[2]);
+            if ($command === 'files-push') {
+                $masked[2] = self::mask_files_push_url_user_info($masked[2]);
+            }
         }
-        $this->audit_log("COMMAND | {$command} | argv=" . implode(' ', $masked), false);
+        foreach ($masked as $argument_index => $argument) {
+            if (is_string($argument) && strpos($argument, '--secret=') === 0) {
+                $masked[$argument_index] = '--secret=***';
+            }
+        }
+        $pair_field = $pair === null ? '' : " | pair={$pair}";
+        $this->audit_log("COMMAND | {$command}{$pair_field} | argv=" . implode(' ', $masked), false);
     }
 
     /**
@@ -1614,6 +1640,7 @@ class ImportClient
             "pull-files",
             "pull-db",
             "files-pull",
+            "files-push",
             "files-index",
             "files-stats",
             "db-pull",
@@ -1637,6 +1664,13 @@ class ImportClient
             throw new InvalidArgumentException(
                 "Invalid command: {$command}. Valid commands: " . implode(", ", $valid_commands),
             );
+        }
+
+        // files-push owns separate pair state and must not load or write the
+        // pull command's .import-state.json file.
+        if ($command === "files-push") {
+            $this->run_files_push($options);
+            return;
         }
 
         // High-level pulls persist resume state before they enter the stage
@@ -1970,6 +2004,414 @@ class ImportClient
             $this->write_status_file($e->getMessage());
             throw $e;
         }
+    }
+
+    /**
+     * Runs one caller-bounded files-push lifecycle.
+     *
+     * One open sender performs at most one step per loop turn. A planned stop
+     * cancels any open multipart request before close() releases the lifecycle
+     * lock. Terminal sender outcomes are reported without retrying or opening
+     * a replacement; this process never opens a second sender.
+     *
+     * @param array $options {
+     *     Parsed files-push options and context.
+     *
+     *     @type string $secret             HMAC shared secret.
+     *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
+     *     @type array  $files_push_context Optional context already validated by the CLI entry point.
+     * }
+     * @phpstan-param array<string,mixed> $options
+     */
+    private function run_files_push(array $options): void
+    {
+        $started_at = hrtime(true) / 1000000000;
+        $context = $options['files_push_context'] ?? self::prepare_files_push_context(
+            $this->remote_url,
+            $this->state_dir,
+            $this->fs_root,
+            $options
+        );
+        if (!is_array($context)) {
+            throw new InvalidArgumentException('files-push requires its validated command context.');
+        }
+
+        $this->enable_files_push_signal_handling();
+
+        if (!class_exists('Site_Export_HMAC_Client')) {
+            throw new RuntimeException(
+                'Streaming exporter runtime not found. Run composer install before using --secret.'
+            );
+        }
+
+        $chunk_bytes = 4 * 1024 * 1024;
+        $max_execution_seconds = (int) ini_get('max_execution_time');
+        $memory_limit_value = trim( (string) ini_get('memory_limit') );
+        $memory_limit_bytes = $memory_limit_value === '' || $memory_limit_value === '-1'
+            ? -1
+            : parse_size($memory_limit_value);
+        $sender_options = [
+            'docroot' => $context['local_tree'],
+            'push_state_directory' => $context['push_state_directory'],
+            'base_url' => $context['target_url'],
+            'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
+            'allow_http' => $options['force_http'] ?? false,
+            'chunk_bytes' => $chunk_bytes,
+        ];
+
+        $resuming = is_file($context['push_state_directory'] . '/sender.json');
+        $sender = $resuming
+            ? PushFilesSender::resume($sender_options)
+            : PushFilesSender::start($sender_options);
+        $status = null;
+        $reason = null;
+        $detail = null;
+        $phase = $sender->get_phase();
+        $previous_phase = $phase;
+
+        try {
+            $this->audit_log(
+                ( $resuming ? 'RESUME' : 'START' )
+                    . " files-push | pair={$context['pair']} | phase={$phase}",
+                false
+            );
+
+            while ($sender->get_status() === 'continue') {
+                if ($this->files_push_stop_signal !== null) {
+                    $status = 'interrupted';
+                    $reason = 'signal';
+                    $detail = 'Received signal ' . $this->files_push_stop_signal . '.';
+                    break;
+                }
+
+                $stop_cause = self::files_push_stop_cause(
+                    hrtime(true) / 1000000000 - $started_at,
+                    memory_get_usage(true),
+                    $max_execution_seconds,
+                    $memory_limit_bytes,
+                    $chunk_bytes
+                );
+                if ($stop_cause !== null) {
+                    $status = 'partial';
+                    $reason = $stop_cause;
+                    break;
+                }
+
+                $has_next_sender_step = $sender->next_step();
+                $phase = $sender->get_phase();
+                if ($phase !== $previous_phase) {
+                    $this->audit_log(
+                        "PHASE files-push | pair={$context['pair']} | from={$previous_phase} | to={$phase}",
+                        false
+                    );
+                    $previous_phase = $phase;
+                }
+                if (!$has_next_sender_step) {
+                    break;
+                }
+            }
+
+            if ($sender->get_status() !== 'continue') {
+                $status = $sender->get_status();
+                $reason = $sender->get_reason();
+                $detail = $sender->get_detail();
+            }
+        } catch (\Throwable $throwable) {
+            $status = 'error';
+            $reason = 'unexpected_error';
+            $detail = $throwable->getMessage();
+        } finally {
+            if ($sender->get_status() === 'continue') {
+                try {
+                    $sender->cancel();
+                } catch (\Throwable $throwable) {
+                    $status = 'error';
+                    $reason = 'unexpected_error';
+                    $detail = ( $detail === null ? '' : $detail . ' ' )
+                        . 'Could not cancel the active sender request: '
+                        . $throwable->getMessage();
+                }
+            }
+            $phase = $sender->get_phase();
+            try {
+                $sender->close();
+            } catch (\Throwable $throwable) {
+                $status = 'error';
+                $reason = 'unexpected_error';
+                $detail = ( $detail === null ? '' : $detail . ' ' )
+                    . 'Could not close the sender lifecycle: '
+                    . $throwable->getMessage();
+            }
+        }
+
+        if ($status === null) {
+            $status = 'error';
+            $reason = 'unexpected_error';
+            $detail = 'The files-push sender stopped without an outcome.';
+        }
+
+        switch ($status) {
+            case 'complete':
+                $audit_line = "COMPLETE files-push | pair={$context['pair']} | phase={$phase}";
+                $message = 'Files push complete.';
+                $this->exit_code = 0;
+                break;
+            case 'partial':
+                $audit_line = "PARTIAL files-push | pair={$context['pair']} | phase={$phase} | cause={$reason}";
+                $message = 'Files push paused at a durable boundary; run the same command again to continue.';
+                $this->exit_code = 2;
+                break;
+            case 'interrupted':
+                $audit_line = "INTERRUPTED files-push | pair={$context['pair']} | phase={$phase} | signal={$this->files_push_stop_signal}";
+                $message = 'Files push was interrupted at a durable boundary; run the same command again to continue.';
+                $this->exit_code = 2;
+                break;
+            case 'restart':
+                $audit_line = "RESTART files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $message = 'Files push must restart; the next run will build a fresh plan.';
+                $this->exit_code = 2;
+                break;
+            case 'failed':
+                $audit_line = "FAILED files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $message = $detail === null ? 'Files push failed.' : 'Files push failed: ' . $detail;
+                $this->exit_code = 1;
+                break;
+            case 'error':
+            default:
+                $audit_line = "ERROR files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $message = $detail === null ? 'Files push stopped with an error.' : 'Files push stopped with an error: ' . $detail;
+                $this->exit_code = 1;
+                break;
+        }
+
+        $this->audit_log($audit_line, false);
+        $result = [
+            'command' => 'files-push',
+            'pair' => $context['pair'],
+            'status' => $status,
+            'phase' => $phase,
+            'message' => $message,
+        ];
+        if ($reason !== null) {
+            $result['reason'] = $reason;
+        }
+        if ($detail !== null) {
+            $result['detail'] = $detail;
+        }
+        // Write the flat run status without consulting import state.
+        $status_payload = [
+            'command' => 'files-push',
+            'pair' => $context['pair'],
+            'status' => $status,
+            'phase' => $phase,
+            'reason' => $reason,
+            'detail' => $detail,
+            'ts' => microtime(true),
+        ];
+        $status_json = json_encode(
+            $status_payload,
+            JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+        if ($status_json !== false) {
+            $temporary_status_path = $this->status_file . '.tmp';
+            if (file_put_contents($temporary_status_path, $status_json) !== false) {
+                rename($temporary_status_path, $this->status_file);
+            }
+        }
+
+        // Emit the sole final JSON line for non-interactive callers.
+        if ($this->is_tty && !$this->verbose_mode) {
+            $this->progress->show_lifecycle_line($result['message'] . "\n");
+            return;
+        }
+        $result_json = json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE);
+        if ($result_json === false) {
+            $result_json = '{"command":"files-push","status":"error","message":"Could not encode the files-push result."}';
+        }
+        @fwrite($this->progress_fd, $result_json . "\n");
+        @flush();
+    }
+
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions are CLI text, not HTML.
+    /**
+     * Validates files-push inputs and derives its per-pair state path.
+     *
+     * @param array $options {
+     *     Parsed files-push options.
+     *
+     *     @type string $secret     HMAC shared secret.
+     *     @type bool   $force_http Whether the operator allowed a plain-HTTP target.
+     * }
+     * @phpstan-param array<string,mixed> $options
+     * @return array {
+     *     Validated files-push command context.
+     *
+     *     @type string $target_url           Target exporter API URL.
+     *     @type string $local_tree           Canonical local tree being sent.
+     *     @type string $pair                 Target/local-tree pair key.
+     *     @type string $push_state_directory Sender state directory for the pair.
+     * }
+     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
+     */
+    public static function prepare_files_push_context(
+        string $target_url,
+        string $state_directory,
+        string $local_tree,
+        array $options
+    ): array {
+        $secret = $options['secret'] ?? null;
+        if (!is_string($secret) || $secret === '') {
+            throw new InvalidArgumentException('files-push requires --secret=TOKEN.');
+        }
+        if (preg_match('/(?:\?|&)SECRET_KEY(?:=|&|$)/', $target_url) === 1) {
+            throw new InvalidArgumentException(
+                'files-push does not accept SECRET_KEY in the target URL; pass --secret=TOKEN.'
+            );
+        }
+
+        $masked_target_url = self::mask_files_push_url_user_info($target_url);
+        if (strpos($target_url, '#') !== false) {
+            throw new InvalidArgumentException(
+                'The files-push target URL must not contain a fragment: ' . $masked_target_url . '.'
+            );
+        }
+        $target_url_user = parse_url($target_url, PHP_URL_USER);
+        $target_url_password = parse_url($target_url, PHP_URL_PASS);
+        if (is_string($target_url_user) || is_string($target_url_password)) {
+            throw new InvalidArgumentException(
+                'The files-push target URL must not contain URL user-info: ' . $masked_target_url . '.'
+            );
+        }
+        if (is_link($local_tree)) {
+            throw new InvalidArgumentException('The local tree must not be a symlink: ' . $local_tree . '.');
+        }
+        if (!is_dir($local_tree)) {
+            throw new InvalidArgumentException(
+                'The local tree does not exist or is not a directory: ' . $local_tree . '.'
+            );
+        }
+
+        $force_http = $options['force_http'] ?? false;
+        $scheme = strtolower( (string) parse_url($target_url, PHP_URL_SCHEME) );
+        if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
+            throw new InvalidArgumentException(
+                'The files-push target must use HTTPS: ' . $masked_target_url
+                . '. Pass --force-http only for a target you trust.'
+            );
+        }
+
+        $canonical_local_tree = realpath($local_tree);
+        if ($canonical_local_tree === false) {
+            throw new InvalidArgumentException(
+                'The local tree does not exist or is not a directory: ' . $local_tree . '.'
+            );
+        }
+        $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
+        $target_url = rtrim($target_url, '?&');
+        $pair = hash('sha256', $target_url . "\0" . $canonical_local_tree);
+        // Resolve an absolute physical path even when its final components do not exist.
+        $push_state_directory = $state_directory . '/push/' . $pair;
+        if (strpos($push_state_directory, '/') !== 0) {
+            $working_directory = getcwd();
+            if ($working_directory === false) {
+                throw new RuntimeException('Could not resolve the current working directory.');
+            }
+            $push_state_directory = $working_directory . '/' . $push_state_directory;
+        }
+        $push_state_directory = normalize_path($push_state_directory);
+        $existing_state_path = $push_state_directory;
+        $missing_state_components = [];
+        while (
+            !file_exists($existing_state_path)
+            && !is_link($existing_state_path)
+            && $existing_state_path !== '/'
+        ) {
+            array_unshift($missing_state_components, basename($existing_state_path));
+            $existing_state_path = dirname($existing_state_path);
+        }
+        $canonical_existing_state_path = realpath($existing_state_path);
+        if ($canonical_existing_state_path !== false) {
+            $push_state_directory = normalize_path(
+                $canonical_existing_state_path
+                    . ( $missing_state_components === []
+                        ? ''
+                        : '/' . implode('/', $missing_state_components) )
+            );
+        }
+        if (
+            $canonical_local_tree === '/'
+            || path_is_within_root($push_state_directory, $canonical_local_tree)
+        ) {
+            throw new InvalidArgumentException(
+                'The push state directory ' . $push_state_directory
+                . ' must be outside the local tree ' . $canonical_local_tree . '.'
+            );
+        }
+
+        return [
+            'target_url' => $target_url,
+            'local_tree' => $canonical_local_tree,
+            'pair' => $pair,
+            'push_state_directory' => $push_state_directory,
+        ];
+    }
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+    /**
+     * Returns why another sender step must not begin, or null when admitted.
+     */
+    public static function files_push_stop_cause(
+        float $elapsed_seconds,
+        int $allocated_bytes,
+        int $max_execution_seconds,
+        int $memory_limit_bytes,
+        int $chunk_bytes
+    ): ?string {
+        if ($max_execution_seconds > 0 && $elapsed_seconds >= $max_execution_seconds * 0.8) {
+            return 'time_limit';
+        }
+        if (
+            $memory_limit_bytes !== -1
+            && $allocated_bytes + $chunk_bytes >= $memory_limit_bytes * 0.8
+        ) {
+            return 'memory_limit';
+        }
+        return null;
+    }
+
+    /**
+     * Handles a first files-push signal without interrupting its active step.
+     */
+    public function handle_files_push_shutdown(int $signal): void
+    {
+        if ($this->files_push_stop_signal === null) {
+            $this->files_push_stop_signal = $signal;
+            return;
+        }
+        if (function_exists('posix_kill') && function_exists('posix_getpid')) {
+            posix_kill(posix_getpid(), SIGKILL);
+        }
+        die("\nForced exit.\n");
+    }
+
+    /** Installs the files-push first-signal stop behavior when PCNTL exists. */
+    public function enable_files_push_signal_handling(): void
+    {
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGINT, [$this, 'handle_files_push_shutdown']);
+            pcntl_signal(SIGTERM, [$this, 'handle_files_push_shutdown']);
+        }
+    }
+
+    /** Masks URL authority credentials without changing the pair-key input. */
+    private static function mask_files_push_url_user_info(string $url): string
+    {
+        $masked = preg_replace(
+            '~^([a-z][a-z0-9+.-]*://)[^/?#]*@~i',
+            '$1***@',
+            $url
+        );
+        return is_string($masked) ? $masked : $url;
     }
 
     /**
@@ -11831,7 +12273,7 @@ if (
             'type' => 'value',
             'target' => 'fs_root',
             'placeholder' => 'DIR',
-            'help' => 'Directory where downloaded site files are written',
+            'help' => 'Local directory read from or written to for site files',
             'help_section' => 'required',
             'commands' => ['apply-runtime'],
             'aliases' => ['docroot'],
@@ -11845,7 +12287,14 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+        ],
+        [
+            'name' => 'force-http',
+            'type' => 'flag',
+            'target' => 'force_http',
+            'help' => 'Allow a trusted plain-HTTP target; anyone able to observe or alter the connection can read or modify transferred content',
+            'commands' => ['files-push'],
         ],
         [
             'name' => 'abort',
@@ -11862,7 +12311,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -12396,7 +12845,7 @@ if (
             echo "  " . str_pad($name, $max_len + 2) . $info["short"] . "\n";
         }
         echo "\n";
-        echo "Low-level commands (used by pull internally):\n";
+        echo "Low-level commands:\n";
         foreach ($low as $name => $info) {
             echo "  " . str_pad($name, $max_len + 2) . $info["short"] . "\n";
         }
@@ -12411,7 +12860,7 @@ if (
             echo "\n";
         }
 
-        echo "Global options:\n";
+        echo "Shared options (see command help for availability):\n";
         $global = array_filter($option_defs, fn($d) => ($d['help_section'] ?? null) === 'global');
         // --version/-V is handled before option parsing, so inject it manually.
         _cli_render_option_list($global, ['--version, -V' => 'Print version and exit']);
@@ -12422,9 +12871,8 @@ if (
         echo "  2  Partial progress — run the same command again to continue\n";
         echo "  1  Error\n";
         echo "\n";
-        echo "State is stored in --state-dir/.import-state.json. Interrupted\n";
-        echo "commands automatically resume. Use --abort to abort the current\n";
-        echo "sync and exit — downloaded files are preserved.\n";
+        echo "Resumable commands keep their command-specific work under --state-dir.\n";
+        echo "Run command-specific help for continuation and cancellation behavior.\n";
     }
 
     /**
@@ -12608,8 +13056,8 @@ if (
     // The Options: section itself is generated from $option_defs so that
     // every declared option for a command is guaranteed to appear.
     // High-level commands are the ones most users will use. Low-level
-    // commands are the building blocks that pull composes internally —
-    // useful for scripting and hosting platform integrations.
+    // commands expose focused workflows useful for scripting and hosting
+    // platform integrations; pull composes the relevant pull-side commands.
     $command_info = [
         "pull" => [
             "level" => "high",
@@ -12776,6 +13224,26 @@ if (
                 "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
                 "  .import-state.json                      Resumable state\n" .
                 "  .import-audit.log                       Audit log\n",
+        ],
+        "files-push" => [
+            "level" => "low",
+            "short" => "Push one local file tree without database work",
+            "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
+            "description" =>
+                "Sends the existing local tree at --fs-root to the target exporter API.\n" .
+                "This is a low-level, files-only command: it performs no database work,\n" .
+                "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
+                "It does not require pull preflight.\n" .
+                "\n" .
+                "Each process runs one sender until it completes, reaches a caller time or\n" .
+                "memory boundary, or receives a signal handled by this PHP runtime.\n" .
+                "Re-run the same command after exit 2.\n" .
+                "After a restart result, the next run starts a fresh plan.\n",
+            "extra" =>
+                "Exit outcomes:\n" .
+                "  0  File push complete\n" .
+                "  2  Partial, interrupted, or restart; run the command again\n" .
+                "  1  Failed request or command error\n",
         ],
         "files-index" => [
             "level" => "low",
@@ -13009,6 +13477,28 @@ if (
     );
     $options["command"] = $command;
 
+    $reprint_files_push_command_arguments = array_slice($argv, $option_start_index);
+    if ($command === 'files-push') {
+        foreach ($reprint_files_push_command_arguments as $reprint_files_push_command_argument) {
+            $reprint_files_push_option_allowed = in_array(
+                $reprint_files_push_command_argument,
+                ['--force-http', '--verbose', '-v'],
+                true
+            )
+                || strpos($reprint_files_push_command_argument, '--state-dir=') === 0
+                || strpos($reprint_files_push_command_argument, '--fs-root=') === 0
+                || strpos($reprint_files_push_command_argument, '--secret=') === 0;
+            if (!$reprint_files_push_option_allowed) {
+                $reprint_files_push_option_name = explode('=', $reprint_files_push_command_argument, 2)[0];
+                fwrite(STDERR, "Error: files-push does not accept {$reprint_files_push_option_name}.\n");
+                exit(1);
+            }
+        }
+    } elseif (!empty($options['force_http'])) {
+        fwrite(STDERR, "Error: --force-http is accepted only by files-push.\n");
+        exit(1);
+    }
+
     if (!$state_dir) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
@@ -13037,9 +13527,23 @@ if (
     }
 
     try {
-        $client = new ImportClient($remote_url, $state_dir, $fs_root);
-        $client->audit_log_argv($command, $argv);
-        $client->run($options ?? []);
+        $reprint_files_push_context = null;
+        if ($command === 'files-push') {
+            $reprint_files_push_context = ImportClient::prepare_files_push_context(
+                $remote_url,
+                $state_dir,
+                $fs_root,
+                $options
+            );
+        }
+        $client = new ImportClient($remote_url, $state_dir, $fs_root, $command);
+        $reprint_files_push_pair = $reprint_files_push_context['pair'] ?? null;
+        $client->audit_log_argv($command, $argv, $reprint_files_push_pair);
+        $client->run(
+            $reprint_files_push_context === null
+                ? $options
+                : $options + ['files_push_context' => $reprint_files_push_context]
+        );
         // EXIT_AFTER_IMPORT controls whether we hand control back to
         // the caller after pull returns. Default true: standard CLI
         // invocations (reprint pull, the phar bin, e2e tests) get the

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -34,4 +34,34 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--target-engine=ENGINE', $output);
         $this->assertStringContainsString('--new-site-url=URL', $output);
     }
+
+    public function testFilesPushHelpShowsOnlyItsCommandOptions(): void
+    {
+        $output = $this->runHelp('files-push');
+
+        $this->assertStringContainsString('Usage: reprint files-push <target-url>', $output);
+        $this->assertStringContainsString('--state-dir=DIR', $output);
+        $this->assertStringContainsString('--fs-root=DIR', $output);
+        $this->assertStringContainsString('--secret=TOKEN', $output);
+        $this->assertStringContainsString('--force-http', $output);
+        $this->assertStringContainsString('--verbose, -v', $output);
+        $this->assertStringContainsString('low-level, files-only command', $output);
+        $this->assertStringContainsString('existing local tree at --fs-root', $output);
+        $this->assertStringContainsString('read or modify', $output);
+        $this->assertStringNotContainsString('--abort', $output);
+        $this->assertStringNotContainsString('--filter', $output);
+        $this->assertStringNotContainsString('--remap', $output);
+        $this->assertStringNotContainsString('--only', $output);
+    }
+
+    public function testMainHelpDescribesFilesPushWithoutApplyingPullOnlyContractsGlobally(): void
+    {
+        $output = $this->runHelp('--help');
+
+        $this->assertStringContainsString('files-push', $output);
+        $this->assertStringContainsString('Low-level commands:', $output);
+        $this->assertStringNotContainsString('Low-level commands (used by pull internally):', $output);
+        $this->assertStringNotContainsString('State is stored in --state-dir/.import-state.json', $output);
+        $this->assertStringNotContainsString('Use --abort to abort the current', $output);
+    }
 }

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -1,0 +1,391 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use ImportClient;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+final class FilesPushCommandTest extends TestCase
+{
+    private string $root;
+    private string $localTree;
+    private string $stateDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/files-push-command-' . bin2hex(random_bytes(6));
+        $this->localTree = $this->root . '/local-tree';
+        $this->stateDirectory = $this->root . '/state';
+        mkdir($this->localTree, 0700, true);
+        mkdir($this->stateDirectory, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testCallerBudgetDecisionUsesFiniteAndUnlimitedLimits(): void
+    {
+        $chunkBytes = 20;
+
+        $this->assertNull(ImportClient::files_push_stop_cause(7.99, 59, 10, 100, $chunkBytes));
+        $this->assertSame('time_limit', ImportClient::files_push_stop_cause(8.0, 0, 10, -1, $chunkBytes));
+        $this->assertNull(ImportClient::files_push_stop_cause(1000.0, 59, 0, 100, $chunkBytes));
+        $this->assertSame('memory_limit', ImportClient::files_push_stop_cause(0.0, 60, 0, 100, $chunkBytes));
+        $this->assertNull(ImportClient::files_push_stop_cause(1000.0, PHP_INT_MAX, 0, -1, $chunkBytes));
+    }
+
+    public function testPairContextUsesTheTrimmedTargetAndCanonicalLocalTree(): void
+    {
+        $targetUrl = 'https://example.test/?reprint-api=1&&';
+        $context = ImportClient::prepare_files_push_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            ['secret' => 'token', 'force_http' => false]
+        );
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
+        $trimmedTargetUrl = rtrim($targetUrl, '?&');
+        $expectedPair = hash('sha256', $trimmedTargetUrl . "\0" . $canonicalLocalTree);
+
+        $this->assertSame($trimmedTargetUrl, $context['target_url']);
+        $this->assertSame($canonicalLocalTree, $context['local_tree']);
+        $this->assertSame($expectedPair, $context['pair']);
+        $this->assertSame(
+            realpath($this->stateDirectory) . '/push/' . $expectedPair,
+            $context['push_state_directory']
+        );
+
+        $differentQuery = ImportClient::prepare_files_push_context(
+            'https://example.test/?reprint-api=1&directory=other',
+            $this->stateDirectory,
+            $this->localTree,
+            ['secret' => 'token', 'force_http' => false]
+        );
+        $otherTree = $this->root . '/other-tree';
+        mkdir($otherTree);
+        $differentTree = ImportClient::prepare_files_push_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $otherTree,
+            ['secret' => 'token', 'force_http' => false]
+        );
+
+        $this->assertNotSame($context['pair'], $differentQuery['pair']);
+        $this->assertNotSame($context['pair'], $differentTree['pair']);
+    }
+
+    public function testFilesPushRejectsOptionsOutsideItsExactAllowlist(): void
+    {
+        foreach (['--abort', '--filter=none', '--docroot=' . $this->localTree, '--duty=0.5'] as $rejectedOption) {
+            $result = $this->runCli([
+                'files-push',
+                'https://example.test/?reprint-api=1',
+                '--state-dir=' . $this->stateDirectory,
+                '--fs-root=' . $this->localTree,
+                '--secret=token',
+                $rejectedOption,
+            ]);
+
+            $this->assertSame(1, $result['exit'], $rejectedOption . ': ' . $result['output']);
+            $this->assertStringContainsString('files-push does not accept', $result['output']);
+            $this->assertStringContainsString(strtok($rejectedOption, '='), $result['output']);
+        }
+
+        $olderCommand = $this->runCli([
+            'files-pull',
+            'https://example.test/?reprint-api=1',
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+            '--force-http',
+        ]);
+        $this->assertSame(1, $olderCommand['exit'], $olderCommand['output']);
+        $this->assertStringContainsString('--force-http is accepted only by files-push.', $olderCommand['output']);
+
+        $existingPairValue = $this->runCli([
+            'db-apply',
+            '-',
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+            '--rewrite-url',
+            '--force-http',
+            'https://example.test',
+        ]);
+        $this->assertStringNotContainsString(
+            '--force-http is accepted only by files-push.',
+            $existingPairValue['output']
+        );
+    }
+
+    public function testFilesPushRejectsInvalidInputsBeforeStartingSender(): void
+    {
+        $missingSecret = $this->runFilesPush('https://example.test/?reprint-api=1', []);
+        $this->assertSame(1, $missingSecret['exit']);
+        $this->assertStringContainsString('files-push requires --secret=TOKEN.', $missingSecret['output']);
+        $missingSecretError = $this->lastJsonLine($missingSecret['stderr']);
+        $this->assertArrayHasKey('error', $missingSecretError);
+        $this->assertArrayNotHasKey('command', $missingSecretError);
+        $this->assertArrayNotHasKey('pair', $missingSecretError);
+        $this->assertArrayNotHasKey('phase', $missingSecretError);
+
+        $querySecret = $this->runFilesPush(
+            'https://example.test/?reprint-api=1&SECRET_KEY=query-secret',
+            ['--secret=token']
+        );
+        $this->assertSame(1, $querySecret['exit']);
+        $this->assertStringContainsString(
+            'files-push does not accept SECRET_KEY in the target URL; pass --secret=TOKEN.',
+            $querySecret['output']
+        );
+        $this->assertStringNotContainsString('query-secret', $querySecret['output']);
+
+        $fragment = $this->runFilesPush(
+            'https://example.test/?reprint-api=1#section',
+            ['--secret=token']
+        );
+        $this->assertSame(1, $fragment['exit']);
+        $this->assertStringContainsString('must not contain a fragment', $fragment['output']);
+
+        $urlPassword = 'url-password-' . bin2hex(random_bytes(4)) . '@inner';
+        $userInfo = $this->runFilesPush(
+            'https://operator:' . $urlPassword . '@example.test/?reprint-api=1',
+            ['--secret=token']
+        );
+        $this->assertSame(1, $userInfo['exit']);
+        $this->assertStringContainsString('must not contain URL user-info', $userInfo['output']);
+        $this->assertStringNotContainsString($urlPassword, $userInfo['output']);
+        $this->assertStringNotContainsString($urlPassword, $this->readTree($this->stateDirectory));
+
+        $plainHttp = $this->runFilesPush(
+            'http://example.test/?reprint-api=1',
+            ['--secret=token']
+        );
+        $this->assertSame(1, $plainHttp['exit']);
+        $this->assertStringContainsString('must use HTTPS', $plainHttp['output']);
+        $this->assertStringContainsString('--force-http', $plainHttp['output']);
+
+        $missingTree = $this->root . '/missing-tree';
+        $missingTreeResult = $this->runCli([
+            'files-push',
+            'https://example.test/?reprint-api=1',
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $missingTree,
+            '--secret=token',
+        ]);
+        $this->assertSame(1, $missingTreeResult['exit']);
+        $missingTreeError = $this->lastJsonLine($missingTreeResult['stderr']);
+        $this->assertSame(
+            'The local tree does not exist or is not a directory: ' . $missingTree . '.',
+            $missingTreeError['error'] ?? null
+        );
+        $this->assertDirectoryDoesNotExist($missingTree);
+
+        $symlinkedTree = $this->root . '/symlinked-tree';
+        symlink($this->localTree, $symlinkedTree);
+        $symlinkResult = $this->runCli([
+            'files-push',
+            'https://example.test/?reprint-api=1',
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $symlinkedTree,
+            '--secret=token',
+        ]);
+        $this->assertSame(1, $symlinkResult['exit']);
+        $symlinkError = $this->lastJsonLine($symlinkResult['stderr']);
+        $this->assertSame(
+            'The local tree must not be a symlink: ' . $symlinkedTree . '.',
+            $symlinkError['error'] ?? null
+        );
+
+        $nestedState = $this->localTree . '/state';
+        $nestedStateResult = $this->runCli([
+            'files-push',
+            'https://example.test/?reprint-api=1',
+            '--state-dir=' . $nestedState,
+            '--fs-root=' . $this->localTree,
+            '--secret=token',
+        ]);
+        $this->assertSame(1, $nestedStateResult['exit']);
+        $nestedStateError = $this->lastJsonLine($nestedStateResult['stderr']);
+        $this->assertStringContainsString('must be outside the local tree', $nestedStateError['error'] ?? '');
+        $this->assertStringContainsString( (string) realpath($this->localTree), $nestedStateError['error'] ?? '' );
+
+        $this->assertNoSenderState($this->stateDirectory);
+        $this->assertFileDoesNotExist($this->stateDirectory . '/.import-state.json');
+    }
+
+    public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void
+    {
+        $secret = 'shared-secret-' . bin2hex(random_bytes(6));
+        $targetUrl = 'https://127.0.0.1:1/?reprint-api=1';
+        $result = $this->runFilesPush($targetUrl, ['--secret=' . $secret]);
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertStringNotContainsString($secret, $result['output']);
+        $this->assertStringNotContainsString($secret, $this->readTree($this->stateDirectory));
+        $this->assertStringContainsString('--secret=***', $this->readTree($this->stateDirectory));
+        $finalLine = $this->lastJsonLine($result['stdout']);
+        $this->assertSame('files-push', $finalLine['command'] ?? null);
+        $this->assertSame('failed', $finalLine['status'] ?? null);
+        $this->assertSame(1, $result['exit']);
+        $this->assertFileDoesNotExist($this->stateDirectory . '/.import-state.json');
+    }
+
+    public function testCorruptSenderStateUsesTheStructuredWorkflowErrorResult(): void
+    {
+        $targetUrl = 'https://127.0.0.1:1/?reprint-api=1';
+        $context = ImportClient::prepare_files_push_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            ['secret' => 'token', 'force_http' => false]
+        );
+        mkdir($context['push_state_directory'], 0700, true);
+        file_put_contents(
+            $context['push_state_directory'] . '/sender.json',
+            json_encode([
+                'push_session_id' => str_repeat('1', 32),
+                'phase' => 'starting_plan',
+                'push_plan_cursor' => null,
+                'local_paths_to_push_byte_offset' => 0,
+                'max_part_bytes' => null,
+                'request_sizer_state' => [
+                    'request_body_bytes' => 32 * 1024 * 1024,
+                    'ceiling_bytes' => null,
+                ],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        $result = $this->runFilesPush($targetUrl, ['--secret=token']);
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $finalLine = $this->lastJsonLine($result['stdout']);
+        $this->assertSame('files-push', $finalLine['command'] ?? null);
+        $this->assertSame($context['pair'], $finalLine['pair'] ?? null);
+        $this->assertSame('error', $finalLine['status'] ?? null);
+        $this->assertSame('starting_plan', $finalLine['phase'] ?? null);
+        $this->assertSame('unexpected_error', $finalLine['reason'] ?? null);
+        $this->assertStringContainsString('without its directory', $finalLine['detail'] ?? '');
+        $this->assertSame('', $result['stderr']);
+
+        $status = json_decode(
+            (string) file_get_contents($this->stateDirectory . '/.import-status.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame(
+            ['command', 'pair', 'status', 'phase', 'reason', 'detail', 'ts'],
+            array_keys($status)
+        );
+        $this->assertSame('error', $status['status']);
+        $audit = (string) file_get_contents($this->stateDirectory . '/.import-audit.log');
+        $this->assertSame(1, substr_count($audit, 'ERROR files-push'));
+        $this->assertStringContainsString('pair=' . $context['pair'], $audit);
+    }
+
+    /** @param list<string> $extraOptions */
+    private function runFilesPush(string $targetUrl, array $extraOptions): array
+    {
+        return $this->runCli(array_merge([
+            'files-push',
+            $targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+        ], $extraOptions));
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $arguments): array
+    {
+        $command = array_merge(
+            [PHP_BINARY, __DIR__ . '/../../importer/import.php'],
+            $arguments
+        );
+        $process = proc_open(
+            $command,
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function lastJsonLine(string $output): array
+    {
+        foreach (array_reverse(preg_split('/\R/', trim($output)) ?: []) as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+        $this->fail('No JSON line was found in output: ' . $output);
+    }
+
+    private function assertNoSenderState(string $stateDirectory): void
+    {
+        $senderPaths = glob($stateDirectory . '/push/*/sender.json');
+        $this->assertIsArray($senderPaths);
+        $this->assertSame([], $senderPaths);
+    }
+
+    private function readTree(string $path): string
+    {
+        if (is_file($path)) {
+            return (string) file_get_contents($path);
+        }
+        if (!is_dir($path)) {
+            return '';
+        }
+        $contents = '';
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $contents .= $this->readTree($path . '/' . $entry);
+            }
+        }
+        return $contents;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -29,6 +29,9 @@ final class PushEndpointsTest extends TestCase {
     private string $reprint_configuration_path;
     private string $docroot_configuration_path;
     private string $excluded_paths_configuration_path;
+    private string $gate_endpoint_configuration_path;
+    private string $gate_ready_path;
+    private string $gate_release_path;
     private string $base_url;
 
     protected function setUp(): void
@@ -48,6 +51,9 @@ final class PushEndpointsTest extends TestCase {
         $this->reprint_configuration_path = $this->root . '/reprint-directory';
         $this->docroot_configuration_path = $this->root . '/docroot-configuration.json';
         $this->excluded_paths_configuration_path = $this->root . '/excluded-paths.json';
+        $this->gate_endpoint_configuration_path = $this->root . '/gate-endpoint';
+        $this->gate_ready_path = $this->root . '/gate-ready';
+        $this->gate_release_path = $this->root . '/gate-release';
         mkdir($this->wordpress_root, 0700, true);
         mkdir($this->reprint_directory, 0700, true);
         file_put_contents($this->secret_configuration_path, self::SECRET);
@@ -55,6 +61,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->managed_push_configuration_path, '');
         file_put_contents($this->custom_auth_configuration_path, '');
         file_put_contents($this->reprint_configuration_path, $this->reprint_directory);
+        file_put_contents($this->gate_endpoint_configuration_path, '');
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
         ]);
@@ -2507,6 +2514,502 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
     }
 
+    public function testFilesPushCliPushesAndUpdatesACompleteLocalTree(): void
+    {
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => 64,
+        ]);
+        $local_docroot = $this->root . '/cli-local-docroot';
+        $state_directory = $this->root . '/cli-state';
+        mkdir($local_docroot . '/nested', 0700, true);
+        mkdir($local_docroot . '/empty-directory', 0700, true);
+        mkdir($local_docroot . '/preserved', 0700, true);
+        $initial_contents = str_repeat('initial-', 40);
+        file_put_contents($local_docroot . '/nested/multi-chunk.bin', $initial_contents);
+        file_put_contents($local_docroot . '/delete-later.txt', 'delete me later');
+        file_put_contents($local_docroot . '/preserved/value.txt', 'must not replace target');
+        symlink('nested/multi-chunk.bin', $local_docroot . '/file-link');
+
+        $initial = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $initial_result = $this->lastCliJsonLine($initial['stdout']);
+        $this->assertSame('complete', $initial_result['status'] ?? null);
+        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $this->assertSame($initial_contents, file_get_contents($this->docroot . '/nested/multi-chunk.bin'));
+        $this->assertSame('delete me later', file_get_contents($this->docroot . '/delete-later.txt'));
+        $this->assertDirectoryExists($this->docroot . '/empty-directory');
+        $this->assertTrue(is_link($this->docroot . '/file-link'));
+        $this->assertSame('nested/multi-chunk.bin', readlink($this->docroot . '/file-link'));
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertFileExists($pair_state_directory . '/local_index_at_previous_push.jsonl');
+        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
+        $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
+        $this->assertFileDoesNotExist($state_directory . '/.import-state.json');
+
+        $status = json_decode(
+            (string) file_get_contents($state_directory . '/.import-status.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame(
+            ['command', 'pair', 'status', 'phase', 'reason', 'detail', 'ts'],
+            array_keys($status)
+        );
+        $this->assertSame('complete', $status['status']);
+        $audit = (string) file_get_contents($state_directory . '/.import-audit.log');
+        $this->assertStringNotContainsString(self::SECRET, $audit . $initial['output']);
+        $this->assertStringNotContainsString('cursor', $audit . json_encode($status));
+        $files_push_lines = array_values(array_filter(
+            preg_split('/\R/', trim($audit)) ?: [],
+            static function (string $line): bool {
+                return strpos($line, 'files-push') !== false;
+            }
+        ));
+        $this->assertNotEmpty($files_push_lines);
+        foreach ($files_push_lines as $line) {
+            $this->assertStringContainsString('pair=' . $initial_result['pair'], $line);
+        }
+        preg_match_all('/PHASE files-push .* from=([^ ]+) \| to=([^ ]+)/', $audit, $phase_matches);
+        $phase_transitions = array_map(
+            static function (string $from, string $to): string {
+                return $from . '->' . $to;
+            },
+            $phase_matches[1],
+            $phase_matches[2]
+        );
+        $this->assertSame($phase_transitions, array_values(array_unique($phase_transitions)));
+
+        $updated_contents = str_repeat('updated-', 50);
+        file_put_contents($local_docroot . '/nested/multi-chunk.bin', $updated_contents);
+        unlink($local_docroot . '/delete-later.txt');
+        file_put_contents($local_docroot . '/added.txt', 'added');
+
+        $updated = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $updated['exit'], $updated['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($updated['stdout'])['status'] ?? null);
+        $this->assertSame($updated_contents, file_get_contents($this->docroot . '/nested/multi-chunk.bin'));
+        $this->assertFileDoesNotExist($this->docroot . '/delete-later.txt');
+        $this->assertSame('added', file_get_contents($this->docroot . '/added.txt'));
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+        $this->assertFileExists($pair_state_directory . '/local_index_at_previous_push.jsonl');
+        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
+        $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
+    }
+
+    public function testFilesPushCliStopsAtTheCallerDeadlineAndAnotherProcessCompletes(): void
+    {
+        $local_docroot = $this->root . '/cli-partial-local-docroot';
+        $state_directory = $this->root . '/cli-partial-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'value');
+        $push_create_requests = $this->countEndpointRequests('push_create');
+        $this->configureEndpointGate('push_create');
+        [$process, $pipes] = $this->startFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            ['max_execution_time' => '1']
+        );
+        $this->waitForPath($this->gate_ready_path);
+        usleep(850000);
+        $this->releaseEndpointGate();
+        $partial = $this->finishFilesPushCli($process, $pipes);
+        $this->clearEndpointGate();
+
+        $this->assertSame(2, $partial['exit'], $partial['output']);
+        $partial_result = $this->lastCliJsonLine($partial['stdout']);
+        $this->assertSame('partial', $partial_result['status'] ?? null);
+        $this->assertSame('time_limit', $partial_result['reason'] ?? null);
+        $this->assertSame('starting_plan', $partial_result['phase'] ?? null);
+        $this->assertSame($push_create_requests + 1, $this->countEndpointRequests('push_create'));
+        $this->assertSame(0, $this->countEndpointRequests('push_upload'));
+        $partial_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
+        $this->assertStringContainsString(
+            'PARTIAL files-push | pair=' . $partial_result['pair']
+                . ' | phase=starting_plan | cause=time_limit',
+            $partial_audit
+        );
+
+        $completed = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
+        $this->assertSame('value', file_get_contents($this->docroot . '/value.txt'));
+    }
+
+    public function testFilesPushCliFinishesTheActiveStepAfterSigtermAndAnotherProcessCompletes(): void
+    {
+        if (
+            !function_exists('pcntl_signal')
+            || !function_exists('posix_kill')
+            || !defined('SIGTERM')
+        ) {
+            $this->markTestSkipped('files-push signal coverage requires PCNTL and POSIX signals.');
+        }
+        $local_docroot = $this->root . '/cli-signal-local-docroot';
+        $state_directory = $this->root . '/cli-signal-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'signal value');
+        $this->configureEndpointGate('push_create');
+        [$process, $pipes] = $this->startFilesPushCli($local_docroot, $state_directory);
+        $this->waitForPath($this->gate_ready_path);
+        $process_status = proc_get_status($process);
+        $this->assertTrue($process_status['running']);
+        $this->assertTrue(posix_kill($process_status['pid'], SIGTERM));
+        usleep(50000);
+        $this->releaseEndpointGate();
+        $interrupted = $this->finishFilesPushCli($process, $pipes);
+        $this->clearEndpointGate();
+
+        $this->assertSame(2, $interrupted['exit'], $interrupted['output']);
+        $interrupted_result = $this->lastCliJsonLine($interrupted['stdout']);
+        $this->assertSame('interrupted', $interrupted_result['status'] ?? null);
+        $this->assertSame('signal', $interrupted_result['reason'] ?? null);
+        $this->assertSame('starting_plan', $interrupted_result['phase'] ?? null);
+        $interrupted_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
+        $this->assertStringContainsString(
+            'INTERRUPTED files-push | pair=' . $interrupted_result['pair']
+                . ' | phase=starting_plan | signal=' . SIGTERM,
+            $interrupted_audit
+        );
+
+        $completed = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
+        $this->assertSame('signal value', file_get_contents($this->docroot . '/value.txt'));
+    }
+
+    public function testFilesPushCliContinuesAfterItIsKilledDuringAnAcceptedUpload(): void
+    {
+        if (
+            !function_exists('posix_kill')
+            || !defined('SIGKILL')
+            || !defined('SIGSTOP')
+            || !defined('SIGCONT')
+        ) {
+            $this->markTestSkipped('files-push process-death coverage requires POSIX signals.');
+        }
+        $this->stopServer($this->server_process, $this->server_pipes);
+        [$this->server_process, $this->server_pipes, $this->base_url] = $this->startServer(16 * 1024 * 1024);
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => 64,
+        ]);
+        $local_docroot = $this->root . '/cli-killed-local-docroot';
+        $state_directory = $this->root . '/cli-killed-state';
+        mkdir($local_docroot, 0700, true);
+        $contents = str_repeat('killed upload contents-', 24000);
+        file_put_contents($local_docroot . '/large.bin', $contents);
+        [$process, $pipes] = $this->startFilesPushCli($local_docroot, $state_directory);
+        $accepted_data_path = $this->waitForAcceptedUploadData();
+        $this->assertGreaterThan(0, filesize($accepted_data_path));
+        $server_status = proc_get_status($this->server_process);
+        $cli_status = proc_get_status($process);
+        $this->assertTrue($server_status['running']);
+        $this->assertTrue($cli_status['running']);
+        $server_stopped = false;
+        try {
+            $this->assertTrue(posix_kill($server_status['pid'], SIGSTOP));
+            $server_stopped = true;
+            usleep(20000);
+            $this->assertTrue(posix_kill($cli_status['pid'], SIGKILL));
+            $killed = $this->finishFilesPushCli($process, $pipes);
+        } finally {
+            if ($server_stopped) {
+                posix_kill($server_status['pid'], SIGCONT);
+            }
+        }
+
+        $this->assertNotSame(0, $killed['exit']);
+        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $active_state = $this->loadActiveState($pair_state_directory);
+        $this->assertIsArray($active_state);
+        $this->waitForPushLockRelease($active_state['push_session_id']);
+
+        $completed = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
+        $this->assertSame($contents, file_get_contents($this->docroot . '/large.bin'));
+        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
+    }
+
+    public function testFilesPushCliMakesOneFailedAttemptAndALaterProcessCompletes(): void
+    {
+        $local_docroot = $this->root . '/cli-failed-local-docroot';
+        $state_directory = $this->root . '/cli-failed-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'value after failure');
+        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $sender = PushFilesSender::start(
+            $this->filesPushSenderOptions($local_docroot, $pair_state_directory)
+        );
+        try {
+            $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
+        } finally {
+            $sender->close();
+        }
+        $active_state = $this->loadActiveState($pair_state_directory);
+        $this->assertIsArray($active_state);
+        $push_lock = fopen(
+            $this->reprint_directory . '/.reprint/push/' . $active_state['push_session_id'] . '/push.lock',
+            'r+b'
+        );
+        $this->assertIsResource($push_lock);
+        $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
+        $status_requests = $this->countEndpointRequests('push_status');
+        try {
+            $failed = $this->runFilesPushCli($local_docroot, $state_directory);
+        } finally {
+            flock($push_lock, LOCK_UN);
+            fclose($push_lock);
+        }
+
+        $this->assertSame(1, $failed['exit'], $failed['output']);
+        $failed_result = $this->lastCliJsonLine($failed['stdout']);
+        $this->assertSame('failed', $failed_result['status'] ?? null);
+        $this->assertSame('lock_acquisition_failure', $failed_result['reason'] ?? null);
+        $this->assertSame($status_requests + 1, $this->countEndpointRequests('push_status'));
+        $this->assertFileExists($pair_state_directory . '/sender.json');
+        $failed_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
+        $this->assertStringContainsString(
+            'FAILED files-push | pair=' . $failed_result['pair'],
+            $failed_audit
+        );
+
+        $completed = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
+        $this->assertSame('value after failure', file_get_contents($this->docroot . '/value.txt'));
+    }
+
+    public function testFilesPushCliLeavesRestartForTheNextProcess(): void
+    {
+        $local_docroot = $this->root . '/cli-restart-local-docroot';
+        $state_directory = $this->root . '/cli-restart-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'before');
+        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $sender = PushFilesSender::start(
+            $this->filesPushSenderOptions($local_docroot, $pair_state_directory)
+        );
+        try {
+            $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
+        } finally {
+            $sender->close();
+        }
+        file_put_contents($local_docroot . '/value.txt', 'after local change');
+        clearstatcache(true, $local_docroot . '/value.txt');
+        $push_create_requests = $this->countEndpointRequests('push_create');
+
+        $restart = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(2, $restart['exit'], $restart['output']);
+        $restart_result = $this->lastCliJsonLine($restart['stdout']);
+        $this->assertSame('restart', $restart_result['status'] ?? null);
+        $this->assertSame('local_path_changed', $restart_result['reason'] ?? null);
+        $this->assertSame($push_create_requests, $this->countEndpointRequests('push_create'));
+        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
+        $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
+        $restart_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
+        $this->assertStringContainsString(
+            'RESTART files-push | pair=' . $restart_result['pair'],
+            $restart_audit
+        );
+
+        $completed = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame($push_create_requests + 1, $this->countEndpointRequests('push_create'));
+        $this->assertSame('after local change', file_get_contents($this->docroot . '/value.txt'));
+    }
+
+    /**
+     * Runs the production CLI against the production endpoint router.
+     *
+     * @param array<string,string> $ini_settings PHP ini values for the subprocess.
+     * @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesPushCli(
+        string $local_docroot,
+        string $state_directory,
+        array $ini_settings = []
+    ): array {
+        [$process, $pipes] = $this->startFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            $ini_settings
+        );
+        return $this->finishFilesPushCli($process, $pipes);
+    }
+
+    /**
+     * Starts a production files-push CLI subprocess.
+     *
+     * @param array<string,string> $ini_settings PHP ini values for the subprocess.
+     * @return array{0:resource,1:array<int,resource>}
+     */
+    private function startFilesPushCli(
+        string $local_docroot,
+        string $state_directory,
+        array $ini_settings = []
+    ): array {
+        $command = [PHP_BINARY];
+        foreach ($ini_settings as $name => $value) {
+            $command[] = '-d';
+            $command[] = $name . '=' . $value;
+        }
+        $command = array_merge($command, [
+            __DIR__ . '/../importer/import.php',
+            'files-push',
+            $this->base_url,
+            '--state-dir=' . $state_directory,
+            '--fs-root=' . $local_docroot,
+            '--secret=' . self::SECRET,
+            '--force-http',
+        ]);
+        $process = proc_open(
+            $command,
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        unset($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /**
+     * Collects one files-push CLI subprocess result.
+     *
+     * @param resource $process Running CLI process.
+     * @param array<int,resource> $pipes Process output pipes.
+     * @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function finishFilesPushCli($process, array $pipes): array
+    {
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function lastCliJsonLine(string $output): array
+    {
+        foreach (array_reverse(preg_split('/\R/', trim($output)) ?: []) as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+        $this->fail('No JSON line was found in CLI output: ' . $output);
+    }
+
+    private function filesPushPairStateDirectory(
+        string $local_docroot,
+        string $state_directory
+    ): string {
+        $canonical_local_docroot = realpath($local_docroot);
+        $this->assertIsString($canonical_local_docroot);
+        $pair = hash('sha256', rtrim($this->base_url, '?&') . "\0" . $canonical_local_docroot);
+        return $state_directory . '/push/' . $pair;
+    }
+
+    /** @return array<string,mixed> */
+    private function filesPushSenderOptions(
+        string $local_docroot,
+        string $pair_state_directory
+    ): array {
+        return [
+            'docroot' => $local_docroot,
+            'push_state_directory' => $pair_state_directory,
+            'base_url' => $this->base_url,
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'chunk_bytes' => 4 * 1024 * 1024,
+        ];
+    }
+
+    private function waitForAcceptedUploadData(): string
+    {
+        $deadline = microtime(true) + 10;
+        do {
+            $paths = glob($this->reprint_directory . '/.reprint/push/*/work/inflight.data') ?: [];
+            foreach ($paths as $path) {
+                clearstatcache(true, $path);
+                if (is_file($path) && filesize($path) > 0) {
+                    return $path;
+                }
+            }
+            usleep(1000);
+        } while (microtime(true) < $deadline);
+        $this->fail('The production endpoint did not accept upload bytes before the deadline.');
+    }
+
+    private function waitForPushLockRelease(string $push_session_id): void
+    {
+        $lock_path = $this->reprint_directory
+            . '/.reprint/push/' . $push_session_id . '/push.lock';
+        $deadline = microtime(true) + 10;
+        do {
+            $lock = @fopen($lock_path, 'r+b');
+            if (is_resource($lock)) {
+                if (flock($lock, LOCK_EX | LOCK_NB)) {
+                    flock($lock, LOCK_UN);
+                    fclose($lock);
+                    return;
+                }
+                fclose($lock);
+            }
+            usleep(1000);
+        } while (microtime(true) < $deadline);
+        $this->fail('The production endpoint did not release the push lock before the deadline.');
+    }
+
+    private function configureEndpointGate(string $endpoint): void
+    {
+        @unlink($this->gate_ready_path);
+        @unlink($this->gate_release_path);
+        file_put_contents($this->gate_endpoint_configuration_path, $endpoint);
+    }
+
+    private function releaseEndpointGate(): void
+    {
+        file_put_contents($this->gate_release_path, 'release');
+    }
+
+    private function clearEndpointGate(): void
+    {
+        file_put_contents($this->gate_endpoint_configuration_path, '');
+        @unlink($this->gate_ready_path);
+        @unlink($this->gate_release_path);
+    }
+
+    private function waitForPath(string $path): void
+    {
+        $deadline = microtime(true) + 10;
+        while (!file_exists($path) && microtime(true) < $deadline) {
+            usleep(1000);
+        }
+        $this->assertFileExists($path);
+    }
+
     /**
      * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
      */
@@ -2632,6 +3135,9 @@ final class PushEndpointsTest extends TestCase {
             'REPRINT_PUSH_TEST_DIRECTORY_CONFIG' => $this->reprint_configuration_path,
             'REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG' => $this->excluded_paths_configuration_path,
             'REPRINT_PUSH_TEST_REQUEST_LOG' => $this->root . '/request.log',
+            'REPRINT_PUSH_TEST_GATE_ENDPOINT_CONFIG' => $this->gate_endpoint_configuration_path,
+            'REPRINT_PUSH_TEST_GATE_READY' => $this->gate_ready_path,
+            'REPRINT_PUSH_TEST_GATE_RELEASE' => $this->gate_release_path,
         ]);
         $server_log_path = $this->root . '/server-' . $post_max_bytes . '-' . bin2hex(random_bytes(4)) . '.log';
         $descriptors = [

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -20,6 +20,28 @@ if ($reprint_push_test_request_log !== '' && is_string($reprint_push_test_endpoi
     );
 }
 
+$reprint_push_test_gate_endpoint_path = (string) getenv('REPRINT_PUSH_TEST_GATE_ENDPOINT_CONFIG');
+$reprint_push_test_gate_endpoint = $reprint_push_test_gate_endpoint_path === ''
+    ? ''
+    : trim( (string) file_get_contents($reprint_push_test_gate_endpoint_path) );
+if (
+    $reprint_push_test_gate_endpoint !== ''
+    && $reprint_push_test_endpoint === $reprint_push_test_gate_endpoint
+) {
+    $reprint_push_test_gate_ready_path = (string) getenv('REPRINT_PUSH_TEST_GATE_READY');
+    $reprint_push_test_gate_release_path = (string) getenv('REPRINT_PUSH_TEST_GATE_RELEASE');
+    if (!is_file($reprint_push_test_gate_ready_path)) {
+        file_put_contents($reprint_push_test_gate_ready_path, 'ready', LOCK_EX);
+        $reprint_push_test_gate_deadline = microtime(true) + 20;
+        while (
+            !is_file($reprint_push_test_gate_release_path)
+            && microtime(true) < $reprint_push_test_gate_deadline
+        ) {
+            usleep(1000);
+        }
+    }
+}
+
 $reprint_push_test_docroot_configuration = json_decode(
     (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_DOCROOT_CONFIG') ),
     true


### PR DESCRIPTION
Adds `files-push`, a CLI command that copies a local file tree to a WordPress site's web root. If a run stops, the same command can continue the work.

This command moves files only. It does not move the database, rewrite URLs, show a preview, ask for confirmation, or retry a failed request on its own.

## Do I need to pull the site first?

No. `--fs-root` can point to any existing local directory that is not a symlink. Reprint treats that directory as the root of the tree it will send.

The layout below deploys one plugin because the local path matches its path below the remote web root:

```text
local-tree/
└── wp-content/
    └── plugins/
        └── example-plugin/
```

A full tree created by `pull` also works, but `files-push` still sends files only. The target database stays as it is. Check environment-specific files such as `wp-config.php` before pushing a full tree because they may replace the target copies.

## Prepare the target site

The target must run a Reprint Exporter build that supports push. In the Reprint Exporter admin page:

1. Set a connection token.
2. Enable **Allow push to change files on this site**.
3. Copy the API endpoint, usually `https://example.com/?reprint-api`.

Pass that token to `--secret`. If the push checkbox is locked, the host controls push access and must enable it.

The machine running `files-push` needs PHP 8.1 or newer. The target's PHP process needs permission to write the web root and Reprint's private work directory.

## Where do the files go?

The API URL chooses the site. It does not choose a folder on the server. The target plugin chooses that folder, and the CLI never sees its full path.

By default, the plugin uses the real path behind the web server's `DOCUMENT_ROOT`. Each local path keeps the same path below that root:

```text
local-tree/wp-content/themes/example/style.css
→
remote-web-root/wp-content/themes/example/style.css
```

There is no `--remote-dir` option. To place files in a subdirectory, include that subdirectory in the local tree or change the target's `docroot` setting.

Uploads are first saved in Reprint's private work directory. That directory must be outside the web root and on the same filesystem. Reprint moves the files into the web root only when the upload is ready to commit.

### Hosting setups

| Setup | What to do |
| --- | --- |
| WordPress at the web root | Nothing extra. The normal `DOCUMENT_ROOT` default should point to the right place. |
| WordPress or Bedrock below the web root | Reprint uses the web root, not WordPress `ABSPATH`. Make the local tree match the web-root layout. Set `docroot` on the target if a different folder should be the push root. |
| Shared WordPress core or a custom web root | The host must set `docroot` to the writable site root before Reprint Exporter loads. |
| Managed hosting | The host should set `docroot`, the private work directory, exclusions, and push access. If the admin controls are locked, ask the host to enable push. |
| Shared hosting with no writable directory outside the web root | Push cannot run until the host provides one on the same filesystem. |
| Read-only or image-based containers | Mount both the web root and the private work directory as writable storage on the same filesystem. |

A host can set the paths from a must-use plugin so they are ready before Reprint Exporter handles the request:

```php
add_filter('site_export_api_options', static function (array $options): array {
    $options['docroot'] = '/srv/www/example/public';
    $options['reprint_directory'] = '/srv/www/example/.reprint';
    return $options;
});
```

The private directory in this example is outside `/srv/www/example/public` but on the same filesystem.

## Run the command

```bash
URL="https://example.com/?reprint-api"
STATE_DIR="/path/to/reprint-state"
FS_ROOT="/path/to/local-tree"
SECRET="the-target-connection-token"

php reprint.phar files-push "$URL" \
  --state-dir="$STATE_DIR" \
  --fs-root="$FS_ROOT" \
  --secret="$SECRET"
```

Keep `STATE_DIR` outside `FS_ROOT`, and keep using it on later runs. HTTPS is required unless `--force-http` is passed. Plain HTTP lets anyone who can watch or change the connection read or change the files being sent.

## First push and later pushes

The first push sends every file, symlink, and empty directory below `FS_ROOT`. It replaces target values at matching paths. It does not delete other target paths because there is no earlier push to compare against.

Later pushes with the same state directory, API URL, and local tree send local changes. They also delete paths that existed at the last successful push but have since been removed locally. Paths excluded by the target, including the Reprint Exporter plugin directory, are left alone.

Exit 0 means the push finished. Exit 2 means it stopped at a safe point; run the same command again. Exit 1 means the request or command failed. Correct the problem, then run the command again to continue from the saved state.

## Testing

The tests run the real CLI against the real local push endpoint. They cover a first push, file changes, deletions, a time limit, SIGTERM, SIGKILL, one failed request, restart, output, and secret masking.

The focused suite passes 70 tests and 2,048 assertions. The full suite passes 1,160 tests and 10,481 assertions with its existing warning, deprecation, and skips. PHPStan passes, PHPCS counts do not increase, the PHAR builds, and the PHP 7.4 and 8.0 version checks pass. The repository-wide compatibility command still stops in unchanged vendored Rowbot code; the importer PHP 7.4+ scan passes all 37 source files.
