### PR TITLE
[Push] Serve every push request without loading WordPress

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -54,25 +54,29 @@ size. The secret travels in no URL and no body, so it never lands in an
 access log.
 
 Authentication does not grant write authority. Connection tokens are
-download-only by default, including tokens that predate push endpoints. Except
-for the bounded recovery case below, every `push_*` operation requires current
-push authorization before upload data is read, a push directory is created, or
-the document root changes; custom authentication uses the same gate.
+download-only by default, including tokens that predate push endpoints.
+`push_create` requires current push authorization, but it does not boot
+WordPress. The bundled push route reads the connection secret from a private
+PHP configuration file and authenticates the signed request itself.
 
-Revocation does not abandon durable recovery state. An authenticated caller
-may keep calling `push_commit` only when that push session already has a durable
-commit checkpoint. Those requests converge the already-started document-root
-mutation; they cannot upload more work, inspect or remove private work, or
-start commit for another push session. Other push operations return HTTP 403
-with `reason: "push_disabled"`. This keeps token rotation or a managed policy
-change from stranding a partial commit and its maintenance marker.
+`push_create` issues a random push session secret. Upload, status, commit, and
+remove requests use that secret at the same push route. The session secret
+cannot create another push session. The WordPress route accepts no push
+operation as a fallback.
 
-Personal consent stores only the current connection token's SHA-256
-fingerprint. Rotating the token therefore revokes push access. A hosting
-provider may override local consent by defining the boolean
+Revocation blocks new push sessions. It does not abandon a push session which
+already has its own secret. That session may still receive work, report status,
+commit, or be removed. A bad push can therefore stop WordPress from booting and
+a later `files-push` command can still create a fresh session and repair the
+site, as long as push access remains enabled.
+
+Personal consent stores the current connection token's SHA-256 fingerprint in
+WordPress and copies the token into the mode-0600 PHP configuration read by the
+push route. Rotating the token therefore revokes push access until the new
+token is granted access. A hosting provider may override local consent by defining the boolean
 `SITE_EXPORT_PUSH_ENABLED` constant before active plugins load or by setting
 the environment variable of the same name. Managed `true` enables push and
-managed `false` hard-disables push without abandoning durable commit recovery.
+managed `false` removes the configuration used to create new push sessions.
 
 ## Change detection: local machine compared against itself
 
@@ -103,8 +107,9 @@ the push plan.
 A push plan is an internal part of the sender lifecycle:
 
 1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
-   100 target exclusions, which the sender stores once in
-   `excluded_paths.json` after creating the active `plan/` directory.
+   100 target exclusions plus the push session secret. The sender stores them,
+   configures session authentication, and creates the active `plan/` directory
+   and `excluded_paths.json` before starting the plan.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
    `plan/excluded_paths.json`, then opens
    `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
@@ -176,10 +181,10 @@ request can resume from a durable checkpoint instead of repeating a delete.
 ## The push session
 
 `Site_Export_Push_Session` stores each session at
-`<reprint-directory>/.reprint/push/<push-session-id>/`. `push.json` is the
-push identity and policy plus whether the work-delete stream is complete.
-`commit.json` holds the bounded commit cursor. Both are atomically replaced
-and validated against the current schema.
+`<reprint-directory>/.reprint/push/<push-session-id>/`. `push-metadata.php`
+returns the push identity and policy array plus whether the work-delete stream
+is complete. `commit.json` holds the bounded commit cursor. Both are atomically
+replaced and validated against the current schema.
 
 `work/files/` contains completed work values only. A single `work/inflight.json`
 record identifies the value currently being received or completed, and
@@ -202,7 +207,7 @@ not removable; its next commit request resumes the durable cursor instead.
 
 ## Push HTTP operations
 
-The production exporter router exposes five authenticated push operations.
+The production push route exposes five authenticated push operations.
 Every request uses the envelope signature described above. `push_upload` passes
 `php://input` directly to the multipart processor instead of reading the
 complete request for authentication.
@@ -210,14 +215,15 @@ complete request for authentication.
 - `POST push_create` creates or reopens the caller's 32-character lowercase
   hexadecimal `push_session_id`. A successful response contains `status`,
   `push_session_id`, `max_part_bytes`, `post_max_bytes`, and
-  `excluded_paths_b64`. The two limits describe different dimensions: one
-  multipart part and the complete decoded request body. The endpoint enforces
-  the request-body limit while reading bounded fragments, including chunked
+  `excluded_paths_b64`, plus the target-issued `push_session_secret` used for
+  later requests. The two limits describe different dimensions: one multipart
+  part and the complete decoded request body. The endpoint enforces the
+  request-body limit while reading bounded fragments, including chunked
   requests without `Content-Length`. `excluded_paths_b64` is the normalized,
   sorted, immutable server policy stored for the push session; base64 preserves
-  arbitrary path bytes which JSON cannot represent directly. A sender
-  consuming this field must omit indexed paths equal to, below, or ancestors
-  of any advertised exclusion.
+  arbitrary path bytes which JSON cannot represent directly. A sender consuming
+  this field must omit indexed paths equal to, below, or ancestors of any
+  advertised exclusion.
 - `POST push_upload` accepts `multipart/mixed`. A successful response contains
   `status`, `push_session_id`, `changes_accepted`, and `last_change`. The last
   change is null for an empty request. Otherwise it contains `state`, `type`,
@@ -226,9 +232,10 @@ complete request for authentication.
   response; request memory does not grow with the number of parts.
 - `GET push_status` accepts an optional base64 `path_b64`. A successful
   response contains `status`, `push_session_id`, `phase`,
-  `work_deletes_bytes`, `work_deletes_complete`, and `path`. The path is null
-  when none was requested. Otherwise it contains `path_b64`, `state`, and
-  `accepted_bytes`; a non-missing path also contains `type`.
+  `work_deletes_bytes`, `work_deletes_complete`, `max_part_bytes`,
+  `post_max_bytes`, and `path`. The path is null when none was requested.
+  Otherwise it contains `path_b64`, `state`, and `accepted_bytes`; a
+  non-missing path also contains `type`.
 - `POST push_commit` performs one server-bounded commit call. A successful
   response contains `status`, `push_session_id`, `phase`,
   `send_next_request`, and `entries_processed`. The sender repeats it while
@@ -249,21 +256,18 @@ resets, empty responses, and malformed responses end the current sender run
 without changing request sizing. A later push command reconciles the receiver
 cursor before continuing.
 
-The WordPress plugin passes the platform-supplied `docroot` to push endpoints,
-defaulting to the web server's `DOCUMENT_ROOT`. A platform supplies the complete
-trusted API-options array through the early `site_export_api_options` filter; a
-direct embedder passes the same array to `_site_export_handle_api_request()`.
-The document-root path must resolve to an existing directory. `ABSPATH` remains
-the default only for pull endpoints because it may point at a separate shared
-WordPress core tree. Push work lives in a document-root-specific private
-directory beside the canonical document root unless server configuration
-supplies `reprint_directory`.
+The bundled push route reads the document root from the web server's
+`DOCUMENT_ROOT`. The path must resolve to an existing directory. Push work
+lives in a document-root-specific private directory beside that canonical
+document root. A custom standalone route passes its document root, reprint
+directory, and excluded paths directly to
+`Site_Export_HTTP_Server::serve_push()`.
 Configured reprint directories must remain outside the document root; the HTTP
 endpoints reject an inside path because they do not yet apply the indexing and
-web-access protections described below. The plugin always excludes its logical
-installed directory from push, including when that directory is a symlink to a
-physical target outside the document root. A platform hook or embedding router
-must choose its document root, reprint directory, and excluded paths as server
+web-access protections described below. The bundled route always excludes its
+logical installed directory from push, including when that directory is a
+symlink to a physical target outside the document root. A custom route must
+choose its document root, reprint directory, and excluded paths as server
 configuration; request parameters cannot select any of them.
 
 ## Local files sender
@@ -320,9 +324,10 @@ upload begins until both indexes have been consumed and the two path lists are
 stable.
 
 `sender.json` contains no copied receiver cursor. It stores the push session
-and phase, the PushPlan cursor, the next byte offset in
+and its secret, the phase, the PushPlan cursor, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
-sizing state. Its phases are `creating`, `starting_plan`, `planning`,
+sizing state. The file uses mode 0600 because it contains the push session
+secret. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index_at_previous_push`, `completing`, `removing`, and
 `discarding_plan`.
@@ -455,11 +460,10 @@ Order:
 1. **Receive work, outside maintenance:** multipart requests write one bounded
    chunk at a time into `work/inflight.data` and move complete values into
    `work/files`. The site runs normally throughout receipt.
-2. **Maintenance on.** Commit writes the `.maintenance` file itself, and since
-   WordPress executes that file, ours whitelists reprint API requests
-   (`$upgrading = 0` for us, `time()` for everyone else). WordPress's own
+2. **Maintenance on.** Commit writes the `.maintenance` file itself. WordPress's
    rule that a `.maintenance` file older than 10 minutes is ignored stays
-   intact, so an interrupted commit can never leave the site down for good.
+   intact, so an interrupted commit cannot leave the site down for good. Push
+   requests use the standalone route and never execute this WordPress marker.
 3. **Commit:** consume `work/deletes`, then `work/files`, with the durable
    `commit.json` checkpoint written before each document-root mutation. The
    future database batch and symlink updates follow the same bounded cursor.
@@ -475,16 +479,39 @@ file after 10 minutes on its own, and the next commit request resumes from
 excluded from installs and deletes and reported as excluded in the summary.
 Updating reprint itself is a separate concern, never part of a sync.
 
-## Escape hatch: commit without booting WordPress
+## Push route
 
-Normally the endpoint runs through the WordPress boot because it is
-convenient. But a commit step can break that boot — a fatal in a partially
-committed plugin — so the same endpoint is also reachable as a standalone PHP file that
-never loads WordPress: it reads database credentials from `wp-config.php`
-directly and operates on the filesystem and database with reprint's own code.
-The driver falls back to it automatically when the normal route stops
-answering sensibly. This is what makes commit failures recoverable from the
-outside instead of requiring SSH.
+All five push operations use one standalone route. `push_create` authenticates
+with the connection secret. The other four operations load the push session
+secret from private metadata and authenticate with it. Endpoint dispatch still
+uses the existing `Site_Export_Push_Endpoints` methods; the route adds no second
+endpoint implementation.
+
+The bundled `push.php` loads the exporter runtime but not WordPress. It reads
+the document root from `DOCUMENT_ROOT`, derives a private sibling reprint
+directory, and excludes its own plugin directory from push. It never accepts a
+caller-selected document root, reprint directory, or excluded path.
+
+The connection secret lives in the mode-0600
+`<reprint-directory>/.reprint/push-config.php`. The file returns an array and
+prints nothing, so executing it through a PHP server does not send the secret.
+The bundled route reads this file only for `push_create`. Removing it disables
+new push sessions without breaking a created session.
+
+Each created session keeps its own secret in mode-0600 `push-metadata.php`.
+That file also returns an array without printing it. The sender stores its copy
+in the local pair's mode-0600 `sender.json` until the lifecycle ends. Neither
+secret appears in request URLs or request bodies.
+
+Sites using the default document root and reprint directory use the `push.php`
+URL shown in WordPress admin. A host which blocks direct PHP in the plugin
+directory, or which uses different server-owned paths, must expose
+`Site_Export_HTTP_Server::serve_push()` from another PHP route. That route must
+not load `wp-load.php`, theme code, or plugin code. It reads its connection
+secret from server configuration for `push_create`, and passes the document
+root, reprint directory, and excluded paths directly to `serve_push()`. The
+operator gives that standalone URL to `files-push`; it is not discovered
+through the WordPress route.
 
 ## Database diff (phase two)
 
@@ -548,9 +575,9 @@ Files first, database second, each PR small and stacked in this order:
    package (lite = serve-only build). Placed here because commit is the
    first piece that needs import-side code running on the remote.
 8. **Commit engine, files** — delete `work/deletes`, then rename values from
-   `work/files` into the document root with the whitelisted maintenance file
-   and resumable `commit.json` cursor.
-9. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
+   `work/files` into the document root with the maintenance file and resumable
+   `commit.json` cursor.
+9. **Push route** — all push operations run without booting WordPress.
 10. **Row index and database diff** — the local row index, previously pushed
     rows, diff generation and URL rewrite, the commit batch.
 11. **`reprint files-push`** — the low-level, files-only caller that retains

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -17,6 +17,16 @@ messages, or pull-request descriptions.
 - **Commit** consumes work deletes and work files; it does not create or remove
   a push session.
 - **Remove** deletes a push directory in bounded calls.
+- The **WordPress route** is the normal exporter API route reached during
+  plugin loading. It serves pull operations only.
+- The **push route** creates a push session, receives work, reports status,
+  commits work, and removes work without booting WordPress.
+- The **connection secret** authenticates `push_create` at the push route.
+- The target-issued **push session secret** authenticates every later request
+  for one push session. It cannot create another push session.
+
+All five push operations use the push route. The WordPress route rejects the
+push namespace instead of serving any push operation as a fallback.
 
 ## PHP names
 
@@ -26,6 +36,8 @@ Use these names verbatim:
 | --- | --- |
 | Exception class and file | `Site_Export_Push_Exception`, `class-push-exception.php` |
 | Session class and file | `Site_Export_Push_Session`, `class-push-session.php` |
+| Push route entry point | `Site_Export_HTTP_Server::serve_push()` |
+| Load push connection secret | `Site_Export_HTTP_Server::load_push_connection_secret()` |
 | reprint directory | `$reprint_directory` |
 | Document root | `$docroot` |
 | Excluded paths | `$excluded_paths` |
@@ -43,7 +55,7 @@ Use these names verbatim:
 The public operations are `create()`, `open()`, `remove()`, and `commit()`.
 Use `get_push_session_id()` and `get_push_directory()` for their accessors.
 
-## Durable layout and JSON
+## Durable layout and metadata
 
 Every push directory is located at:
 
@@ -51,17 +63,26 @@ Every push directory is located at:
 <reprint-directory>/.reprint/push/<push-session-id>/
 ```
 
-It contains `push.json`, `push.lock`, optional `commit.json`, and `work/`. The
-work directory contains `files/`, optional `inflight.json` and
+It contains `push-metadata.php`, `push.lock`, optional `commit.json`, and
+`work/`. The work directory contains `files/`, optional `inflight.json` and
 `inflight.data`, `deletes`, and an optional private maintenance copy. `files/`
 is the only path-shaped work tree. The shared `.reprint/push/` directory contains
 `push-create.lock`, `commit-state`, `commit-state.lock`, and bounded removal
 tombstones named `.removing-<push-session-id>/`.
 
+The bundled push route reads
+`<reprint-directory>/.reprint/push-config.php`. This mode-0600 PHP file returns
+an array whose `connection_secret` value permits new push-session creation.
+Removing it blocks `push_create` without taking the per-session secrets away
+from push sessions which already exist.
+
 `push-create.lock` is the create/remove lock. Create and every bounded remove
 call acquire it non-blockingly. Remove holds it while inspecting and renaming
 the live push directory and while performing one tombstone cleanup step, so
 create cannot recreate the same push session until that cleanup finishes.
+The tombstone keeps `push-metadata.php` and `push.lock` until its other entries
+are gone, so every bounded remove request can authenticate and lock the same
+push session.
 
 `inflight.json` records the path and type of the one in-flight work value.
 File records use `preparing`, `receiving`, or `completing` and also contain
@@ -70,9 +91,10 @@ symlink records also contain `target_b64`. `inflight.data` contains in-flight
 file bytes, and its actual size is the receiver-confirmed cursor. Both paths
 are absent when no work is in flight.
 
-`push.json` has the keys
+`push-metadata.php` returns an array with the keys
 `push_session_id`, `docroot_b64`, `excluded_paths_b64`,
-and `work_deletes_complete`.
+`push_session_secret`, `maximum_part_bytes`, `maximum_commit_entries`, and
+`work_deletes_complete`.
 
 `commit.json` has the phases `deleting_files`,
 `installing_files`, and `complete`. Its cursor keys are
@@ -81,7 +103,7 @@ and `work_deletes_complete`.
 base64 text even where a key does not include a suffix. Its non-recoverable
 failure key is `non_recoverable_commit_failure`.
 
-These JSON records are unversioned while their schemas are still under
+These metadata records are unversioned while their schemas are still under
 development. There are no compatibility aliases or migration paths.
 
 ## Local push state
@@ -121,11 +143,13 @@ FileIndexProcessor cursor and the committed byte offset in
 output offsets, and the active byte offset in
 `deleted_directories_stack.jsonl`. The stack file is append-only; each entry
 links to the preceding active directory. The exclusions have a maximum of 100
-paths. `sender.json` phases are `creating`, `starting_plan`,
-`planning`, `pushing_paths`, `pushing_deletes`, `committing`,
+paths. `sender.json` phases are `creating`, `starting_plan`, `planning`,
+`pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index_at_previous_push`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
-path-list cursor, receiver part limit, and request-sizing state. The index diff
+path-list cursor, receiver part limit, push session secret, and request-sizing
+state. `sender.json` uses mode 0600 because it contains that session-scoped
+secret. The index diff
 completes before local paths are sent. The index copy after a successful commit
 has no separate copy cursor and is repeated after interruption. After the index
 is saved or the target confirms removal, the sender clears the PushPlan
@@ -146,7 +170,7 @@ Receiver-confirmed file and work-delete cursors remain receiver state. A newly
 opened sender reads them from `push_status`, while a successful upload retains
 them in memory for later steps in the same lifecycle. It does not copy them into
 `sender.json`.
-`push.json` remains the receiver-owned push identity and policy, while
+`push-metadata.php` remains the receiver-owned push identity and policy, while
 `commit.json` and `$commit_state` remain the receiver commit checkpoint.
 
 `PushFilesSender::start()` and `PushFilesSender::resume()` acquire
@@ -162,10 +186,9 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-push CLI names
 
-The low-level, files-only command is `files-push`. Its `target URL` is the
-exporter API URL, and its `local tree` is the canonical directory supplied by
-`--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
-plain-HTTP opt-in.
+The low-level, files-only command is `files-push`. Its `target URL` is the push
+URL, and its `local tree` is the canonical directory supplied by `--fs-root`.
+It requires `--secret=TOKEN`; `--force-http` is the explicit plain-HTTP opt-in.
 
 The `pair key` identifies exactly one target URL and canonical local tree:
 
@@ -201,10 +224,13 @@ Use these names verbatim inside `PushFilesSender`:
 | Push stream client | `$push_stream_client`, `create_push_stream_client()` |
 | Push stream client options | `$push_stream_client_options` |
 | Request sizer options | `request_sizer_options`, `$request_sizer_options` |
-| Push request | `send_push_request()` |
+| Connection-authenticated request | `send_connection_request()` |
+| Push-session-authenticated request | `send_push_session_request()` |
+| Configure push session authentication | `set_push_session_hmac_client()` |
 | Open upload request stage | `$upload_request_stage`: `closed`, `sending_parts`, or `finishing` |
 | Whether the open request has sent parts | `MultipartPushStreamClient::has_sent_parts()` |
 | Create push session | `create_push_session()` |
+| Commit push | `commit_push()` |
 | Remove push session | `remove_push_session()` |
 | Upload next file chunk | `upload_next_file_chunk()` |
 | Upload next chunk of deleted paths | `upload_next_chunk_of_deleted_paths()` |
@@ -253,7 +279,11 @@ Use these names verbatim inside `PushPlan`:
 The work-upload endpoint is `push_upload` and its push-session parameter is
 `push_session_id`. Endpoint names and endpoint prefixes begin with `push_`.
 JSON responses use `push_session_id`, `receiving_work`, and
-`work_deletes_bytes`. Push-session failures are
+`work_deletes_bytes`. `push_create` uses the connection secret and returns
+`push_session_secret`. `push_upload`, `push_status`, `push_commit`, and
+`push_remove` use that push session secret at the same push route. Every commit
+request is idempotent, including the request which creates `commit.json`.
+Push-session failures are
 `lock_acquisition_failure`, `offset_gap`, `push_not_found`, `filesystem_error`,
 `commit_required`, `unexpected_docroot_mutation`, `corrupted_push_state`, and
 `same_device`. Authentication, authorization, and request-boundary failures

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -188,6 +188,213 @@ final class Site_Export_HTTP_Server {
     }
 
     /**
+     * Authenticates and dispatches one push request without loading WordPress.
+     *
+     * Session creation uses the connection secret supplied by server
+     * configuration. Every later request uses the secret stored in that push
+     * session's private metadata. A created session therefore remains usable
+     * when WordPress cannot boot or new push sessions have been disabled.
+     *
+     * @param array $options {
+     *     Trusted push-route configuration.
+     *
+     *     @type callable $authenticate Optional push_create authentication.
+     *         When absent, connection_secret authenticates the request.
+     *     @type string $connection_secret Optional secret required by
+     *         push_create when authenticate is absent.
+     *     @type string $reprint_directory Private reprint directory. Defaults
+     *         to a document-root-specific sibling.
+     *     @type string $docroot Required document-root directory.
+     *     @type list<string> $excluded_paths Document-root-relative paths which
+     *         push must preserve. Default empty.
+     *     @type int|float|string $maximum_part_bytes Maximum Content-Length
+     *         accepted for one multipart part. Default 4 MiB.
+     *     @type int|float|string $maximum_commit_entries Maximum entries one
+     *         commit request may process. Default 256.
+     * }
+     * @phpstan-param array{authenticate?:mixed,connection_secret?:mixed,reprint_directory?:mixed,docroot?:mixed,excluded_paths?:mixed,maximum_part_bytes?:mixed,maximum_commit_entries?:mixed} $options
+     */
+    public static function serve_push(array $options): void {
+        if (!class_exists('Site_Export_Push_Endpoints', false)) {
+            require_once __DIR__ . '/class-push-endpoints.php';
+        }
+
+        // The HMAC authenticates the exact raw request target without
+        // loading the WordPress nonce, slashing, or sanitization helpers.
+        // phpcs:disable WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput
+        $endpoint = $_GET['endpoint'] ?? null;
+        if (!is_string($endpoint) || !self::is_push_endpoint($endpoint)) {
+            Site_Export_Push_Endpoints::emit_response(404, [
+                'status' => 'rejected',
+                'reason' => 'invalid_request',
+                'detail' => 'The push route accepts push_create, push_upload, push_status, push_commit, and push_remove.',
+            ]);
+            return;
+        }
+
+        $connection_secret = $options['connection_secret'] ?? null;
+        $reprint_directory = $options['reprint_directory'] ?? null;
+        $docroot = $options['docroot'] ?? null;
+        if (!is_string($docroot) || $docroot === '') {
+            Site_Export_Push_Endpoints::emit_response(503, [
+                'status' => 'rejected',
+                'reason' => 'not_configured',
+                'detail' => 'The push route requires docroot to name an existing directory; observed ' . json_encode($docroot) . '.',
+            ]);
+            return;
+        }
+        $canonical_docroot = realpath($docroot);
+        if ($canonical_docroot === false || !is_dir($canonical_docroot)) {
+            Site_Export_Push_Endpoints::emit_response(503, [
+                'status' => 'rejected',
+                'reason' => 'not_configured',
+                'detail' => 'The push route requires docroot to name an existing directory; observed ' . json_encode($docroot) . '.',
+            ]);
+            return;
+        }
+        $docroot = $canonical_docroot === '/' ? '/' : rtrim($canonical_docroot, '/\\');
+        if ($reprint_directory === null) {
+            $reprint_directory = self::default_reprint_directory($docroot);
+        }
+        if (!is_string($reprint_directory) || $reprint_directory === '') {
+            Site_Export_Push_Endpoints::emit_response(503, [
+                'status' => 'rejected',
+                'reason' => 'not_configured',
+                'detail' => 'The push route requires reprint_directory to be a non-empty string; observed ' . json_encode($reprint_directory) . '.',
+            ]);
+            return;
+        }
+        $options['docroot'] = $docroot;
+        $options['reprint_directory'] = $reprint_directory;
+        if (!array_key_exists('excluded_paths', $options)) {
+            $options['excluded_paths'] = [];
+        }
+
+        $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
+        $request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
+        $authentication_secret = null;
+        if ($endpoint === 'push_create') {
+            $authenticate = $options['authenticate'] ?? null;
+            if ($authenticate !== null) {
+                if (!is_callable($authenticate)) {
+                    Site_Export_Push_Endpoints::emit_response(503, [
+                        'status' => 'rejected',
+                        'reason' => 'not_configured',
+                        'detail' => 'The push route authenticate option must be callable.',
+                    ]);
+                    return;
+                }
+                try {
+                    call_user_func($authenticate);
+                } catch (Throwable $exception) {
+                    Site_Export_Push_Endpoints::emit_failure($exception);
+                    return;
+                }
+            } else {
+                if (!is_string($connection_secret) || $connection_secret === '') {
+                    Site_Export_Push_Endpoints::emit_response(403, [
+                        'status' => 'rejected',
+                        'reason' => 'push_disabled',
+                        'detail' => 'Push access is disabled for new push sessions.',
+                    ]);
+                    return;
+                }
+                $authentication_secret = $connection_secret;
+            }
+
+            $push_options = $options;
+            unset($push_options['authenticate'], $push_options['connection_secret']);
+        } else {
+            try {
+                $push_session_id = Site_Export_Push_Endpoints::read_push_session_id($_GET);
+            } catch (Throwable $exception) {
+                Site_Export_Push_Endpoints::emit_failure($exception);
+                return;
+            }
+
+            try {
+                $push_session_configuration = Site_Export_Push_Session::load_push_session_configuration(
+                    $reprint_directory,
+                    $docroot,
+                    $push_session_id
+                );
+            } catch (Throwable $exception) {
+                if (
+                    $endpoint === 'push_remove'
+                    && $exception instanceof Site_Export_Push_Exception
+                    && $exception->get_error_code() === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND
+                ) {
+                    try {
+                        // The final bounded remove deletes its authentication state.
+                        // A lost response may therefore repeat remove without a secret.
+                        // Only an unfinished tombstone needs another cleanup step.
+                        $removal_tombstone = rtrim($reprint_directory, '/\\')
+                            . '/.reprint/push/.removing-' . $push_session_id;
+                        $removed = true;
+                        if (is_dir($removal_tombstone)) {
+                            $removed = Site_Export_Push_Session::remove(
+                                $reprint_directory,
+                                $docroot,
+                                $push_session_id,
+                                []
+                            );
+                        }
+                        Site_Export_Push_Endpoints::emit_response(200, [
+                            'status' => 'accepted',
+                            'push_session_id' => $push_session_id,
+                            'removed' => $removed,
+                        ]);
+                    } catch (Throwable $remove_exception) {
+                        Site_Export_Push_Endpoints::emit_failure($remove_exception);
+                    }
+                    return;
+                }
+                Site_Export_Push_Endpoints::emit_failure($exception);
+                return;
+            }
+
+            $authentication_secret = $push_session_configuration['push_session_secret'];
+            $push_options = [
+                'reprint_directory' => $reprint_directory,
+                'docroot' => $docroot,
+                'excluded_paths' => $push_session_configuration['excluded_paths'],
+                'maximum_part_bytes' => $push_session_configuration['maximum_part_bytes'],
+                'maximum_commit_entries' => $push_session_configuration['maximum_commit_entries'],
+                'expected_push_session_secret' => $push_session_configuration['push_session_secret'],
+            ];
+        }
+
+        if ($authentication_secret !== null) {
+            $authentication_error = ( new Site_Export_HMAC_Server($authentication_secret) )->verify_envelope(
+                $_SERVER,
+                $request_method,
+                $request_target
+            );
+            if ($authentication_error !== null) {
+                Site_Export_Push_Endpoints::emit_response(403, [
+                    'status' => 'rejected',
+                    'reason' => 'auth_failed',
+                    'detail' => $authentication_error,
+                ]);
+                return;
+            }
+        }
+        // phpcs:enable WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput
+
+        try {
+            self::serve(['push' => $push_options]);
+        } catch (Site_Export_Push_Configuration_Exception $exception) {
+            Site_Export_Push_Endpoints::emit_response(503, [
+                'status' => 'rejected',
+                'reason' => 'not_configured',
+                'detail' => $exception->getMessage(),
+            ]);
+        } catch (Throwable $exception) {
+            Site_Export_Push_Endpoints::emit_failure($exception);
+        }
+    }
+
+    /**
      * @param array<string, mixed> $get
      * @param array<string, mixed> $post
      * @param array<string, mixed> $server
@@ -330,9 +537,41 @@ final class Site_Export_HTTP_Server {
         return isset(self::PUSH_ENDPOINT_METHODS[$endpoint]);
     }
 
-    /**
-     * @return array<string, callable>
-     */
+    /** Returns the private sibling directory used by the bundled push route. */
+    public static function default_reprint_directory(string $docroot): string {
+        return dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12);
+    }
+
+    /** Loads the connection secret from a private PHP configuration file. */
+    public static function load_push_connection_secret(string $configuration_path): ?string {
+        if (!is_file($configuration_path) || is_link($configuration_path)) {
+            return null;
+        }
+        if (function_exists('opcache_invalidate')) {
+            @opcache_invalidate($configuration_path, true);
+        }
+        ob_start();
+        try {
+            $configuration = ( static function (string $path) {
+                return include $path;
+            } )($configuration_path);
+        } catch (Throwable $throwable) {
+            ob_end_clean();
+            return null;
+        }
+        $output = ob_get_clean();
+        if (
+            $output !== ''
+            || !is_array($configuration)
+            || !is_string($configuration['connection_secret'] ?? null)
+            || $configuration['connection_secret'] === ''
+        ) {
+            return null;
+        }
+        return $configuration['connection_secret'];
+    }
+
+    /** @return array<string, callable> */
     private function default_handlers(): array {
         $handlers = [
             'file_index' => 'endpoint_file_index',

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -43,7 +43,7 @@ final class Site_Export_Push_Endpoints {
     private $maximum_commit_entries;
 
     /** @var string|null */
-    private $commit_start_denial_detail;
+    private $expected_push_session_secret;
 
     /** @var int|null */
     private $post_max_bytes;
@@ -66,9 +66,8 @@ final class Site_Export_Push_Endpoints {
      *         accepted for one multipart part. Default 4 MiB.
      *     @type int|float|string $maximum_commit_entries Maximum entries one
      *         commit request may process. Default 256.
-     *     @type string $commit_start_denial_detail When present, starting commit
-     *         returns `push_disabled` with this detail. A commit with a durable
-     *         checkpoint remains recoverable.
+     *     @type string $expected_push_session_secret Session secret authenticated
+     *         by the push route. Session creation omits it.
      *     @type int|float|string|null $post_max_bytes Decoded request-body
      *         limit enforced and reported to senders. Defaults to PHP's
      *         post_max_size; null means PHP reports no positive limit.
@@ -79,13 +78,13 @@ final class Site_Export_Push_Endpoints {
      *     excluded_paths?:mixed,
      *     maximum_part_bytes?:mixed,
      *     maximum_commit_entries?:mixed,
-     *     commit_start_denial_detail?:mixed,
+     *     expected_push_session_secret?:mixed,
      *     post_max_bytes?:mixed
      * } $options
      *
      * @throws InvalidArgumentException If required configuration is absent, a
-     *     present numeric limit is not positive, or a commit-start denial detail
-     *     is not a non-empty string.
+     *     present numeric limit is not positive, or the expected push session
+     *     secret is malformed.
      */
     public function __construct(array $options) {
         $reprint_directory = $options['reprint_directory'] ?? null;
@@ -162,12 +161,15 @@ final class Site_Export_Push_Endpoints {
         $this->excluded_paths = $excluded_paths;
         $this->maximum_part_bytes = (int) $maximum_part_bytes;
         $this->maximum_commit_entries = (int) $maximum_commit_entries;
-        $this->commit_start_denial_detail = null;
-        if (array_key_exists('commit_start_denial_detail', $options)) {
-            if (!is_string($options['commit_start_denial_detail']) || $options['commit_start_denial_detail'] === '') {
-                throw new InvalidArgumentException('commit_start_denial_detail must be a non-empty string.');
+        $this->expected_push_session_secret = null;
+        if (array_key_exists('expected_push_session_secret', $options)) {
+            if (
+                !is_string($options['expected_push_session_secret'])
+                || preg_match('/^[a-f0-9]{64}$/D', $options['expected_push_session_secret']) !== 1
+            ) {
+                throw new InvalidArgumentException('expected_push_session_secret must be 64 lowercase hexadecimal characters.');
             }
-            $this->commit_start_denial_detail = $options['commit_start_denial_detail'];
+            $this->expected_push_session_secret = $options['expected_push_session_secret'];
         }
     }
 
@@ -186,6 +188,7 @@ final class Site_Export_Push_Endpoints {
      * - `max_part_bytes`: the maximum multipart-part Content-Length.
      * - `post_max_bytes`: the decoded request-body limit, or null.
      * - `excluded_paths_b64`: the stored excluded paths in base64.
+     * - `push_session_secret`: the session-scoped HMAC secret for later requests.
      *
      * @param array $config {
      *     Create request parameters.
@@ -197,22 +200,30 @@ final class Site_Export_Push_Endpoints {
     public function create(array $config): void {
         try {
             $this->assert_request_method('POST');
-            $push_session_id = $this->read_push_session_id($config);
+            $push_session_id = self::read_push_session_id($config);
             Site_Export_Push_Session::create(
                 $this->reprint_directory,
                 $this->docroot,
                 $this->excluded_paths,
+                $push_session_id,
+                $this->maximum_part_bytes,
+                $this->maximum_commit_entries
+            );
+            $push_session_configuration = Site_Export_Push_Session::load_push_session_configuration(
+                $this->reprint_directory,
+                $this->docroot,
                 $push_session_id
             );
-            $this->respond(200, [
+            self::emit_response(200, [
                 'status' => 'created',
                 'push_session_id' => $push_session_id,
-                'max_part_bytes' => $this->maximum_part_bytes,
+                'max_part_bytes' => $push_session_configuration['maximum_part_bytes'],
                 'post_max_bytes' => $this->post_max_bytes,
-                'excluded_paths_b64' => array_map('base64_encode', $this->excluded_paths),
+                'excluded_paths_b64' => array_map('base64_encode', $push_session_configuration['excluded_paths']),
+                'push_session_secret' => $push_session_configuration['push_session_secret'],
             ]);
         } catch (Throwable $exception) {
-            $this->respond_to_failure($exception);
+            self::emit_failure($exception, $this->post_max_bytes);
         }
     }
 
@@ -248,7 +259,7 @@ final class Site_Export_Push_Endpoints {
         $upload_open = false;
         try {
             $this->assert_request_method('POST');
-            $push_session_id = $this->read_push_session_id($config);
+            $push_session_id = self::read_push_session_id($config);
             $content_type = (string) ( $_SERVER['CONTENT_TYPE'] ?? '' );
             $boundary = Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
             $declared_request_bytes = $_SERVER['CONTENT_LENGTH'] ?? null;
@@ -257,7 +268,7 @@ final class Site_Export_Push_Endpoints {
                 && is_numeric($declared_request_bytes)
                 && (int) $declared_request_bytes > $this->post_max_bytes
             ) {
-                $this->respond(413, [
+                self::emit_response(413, [
                     'status' => 'rejected',
                     'reason' => 'request_too_large',
                     'detail' => 'The decoded request body declares ' . (int) $declared_request_bytes
@@ -277,7 +288,8 @@ final class Site_Export_Push_Endpoints {
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
-                $this->excluded_paths
+                $this->excluded_paths,
+                $this->expected_push_session_secret
             );
             $push_session->accept_upload(
                 $input,
@@ -306,7 +318,7 @@ final class Site_Export_Push_Endpoints {
             $upload_open = false;
             fclose($input);
             $input = null;
-            $this->respond(200, [
+            self::emit_response(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
                 'changes_accepted' => $changes_accepted,
@@ -319,7 +331,7 @@ final class Site_Export_Push_Endpoints {
             if (is_resource($input)) {
                 fclose($input);
             }
-            $this->respond_to_failure($exception);
+            self::emit_failure($exception, $this->post_max_bytes);
         }
     }
 
@@ -338,6 +350,8 @@ final class Site_Export_Push_Endpoints {
      *   `complete`.
      * - `work_deletes_bytes`: receiver-confirmed delete-list bytes.
      * - `work_deletes_complete`: whether the sender closed the delete list.
+     * - `max_part_bytes`: the session's maximum multipart-part Content-Length.
+     * - `post_max_bytes`: the decoded request-body limit on this route, or null.
      * - `path`: null when no path was requested. Otherwise it contains
      *   `path_b64`, `state`, and `accepted_bytes`; non-missing paths also have
      *   `type`.
@@ -354,7 +368,7 @@ final class Site_Export_Push_Endpoints {
     public function status(array $config): void {
         try {
             $this->assert_request_method('GET');
-            $push_session_id = $this->read_push_session_id($config);
+            $push_session_id = self::read_push_session_id($config);
             $path = null;
             if (array_key_exists('path_b64', $config)) {
                 if (!is_string($config['path_b64'])) {
@@ -369,7 +383,8 @@ final class Site_Export_Push_Endpoints {
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
-                $this->excluded_paths
+                $this->excluded_paths,
+                $this->expected_push_session_secret
             );
             $push_status = $push_session->get_status($path);
             $path_status = null;
@@ -383,16 +398,18 @@ final class Site_Export_Push_Endpoints {
                 }
                 $path_status['accepted_bytes'] = $push_status['path']['accepted_bytes'];
             }
-            $this->respond(200, [
+            self::emit_response(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
                 'phase' => $push_status['phase'],
                 'work_deletes_bytes' => $push_status['work_deletes_bytes'],
                 'work_deletes_complete' => $push_status['work_deletes_complete'],
+                'max_part_bytes' => $this->maximum_part_bytes,
+                'post_max_bytes' => $this->post_max_bytes,
                 'path' => $path_status,
             ]);
         } catch (Throwable $exception) {
-            $this->respond_to_failure($exception);
+            self::emit_failure($exception, $this->post_max_bytes);
         }
     }
 
@@ -417,18 +434,16 @@ final class Site_Export_Push_Endpoints {
     public function commit(array $config): void {
         try {
             $this->assert_request_method('POST');
-            $push_session_id = $this->read_push_session_id($config);
+            $push_session_id = self::read_push_session_id($config);
             $push_session = Site_Export_Push_Session::open(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
-                $this->excluded_paths
+                $this->excluded_paths,
+                $this->expected_push_session_secret
             );
-            $commit = $push_session->commit(
-                $this->maximum_commit_entries,
-                $this->commit_start_denial_detail
-            );
-            $this->respond(200, [
+            $commit = $push_session->commit($this->maximum_commit_entries);
+            self::emit_response(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
                 'phase' => $commit['phase'],
@@ -436,19 +451,7 @@ final class Site_Export_Push_Endpoints {
                 'entries_processed' => $commit['entries_processed'],
             ]);
         } catch (Throwable $exception) {
-            if (
-                $this->commit_start_denial_detail !== null
-                && $exception instanceof Site_Export_Push_Exception
-                && $exception->get_error_code() === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND
-            ) {
-                $this->respond(403, [
-                    'status' => 'rejected',
-                    'reason' => Site_Export_Push_Session::ERROR_PUSH_DISABLED,
-                    'detail' => $this->commit_start_denial_detail,
-                ]);
-                return;
-            }
-            $this->respond_to_failure($exception);
+            self::emit_failure($exception, $this->post_max_bytes);
         }
     }
 
@@ -471,20 +474,21 @@ final class Site_Export_Push_Endpoints {
     public function remove(array $config): void {
         try {
             $this->assert_request_method('POST');
-            $push_session_id = $this->read_push_session_id($config);
+            $push_session_id = self::read_push_session_id($config);
             $remove_complete = Site_Export_Push_Session::remove(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
-                $this->excluded_paths
+                $this->excluded_paths,
+                $this->expected_push_session_secret
             );
-            $this->respond(200, [
+            self::emit_response(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
                 'removed' => $remove_complete,
             ]);
         } catch (Throwable $exception) {
-            $this->respond_to_failure($exception);
+            self::emit_failure($exception, $this->post_max_bytes);
         }
     }
 
@@ -521,7 +525,7 @@ final class Site_Export_Push_Endpoints {
      *
      * @throws InvalidArgumentException If `push_session_id` is not a string.
      */
-    private function read_push_session_id(array $config): string {
+    public static function read_push_session_id(array $config): string {
         $push_session_id = $config['push_session_id'] ?? null;
         if (!is_string($push_session_id)) {
             throw new InvalidArgumentException('push_session_id must be a string.');
@@ -530,7 +534,7 @@ final class Site_Export_Push_Endpoints {
     }
 
     /**
-     * Maps a push exception onto its stable protocol reason and HTTP status.
+     * Maps a push failure onto its stable protocol reason and HTTP status.
      *
      * The response owns its public fields instead of copying an exception's
      * internal context. A streamed request-size rejection deliberately exposes
@@ -538,16 +542,19 @@ final class Site_Export_Push_Endpoints {
      * receives `invalid_request`; unexpected failures receive
      * `filesystem_error` without exposing a PHP trace.
      *
-     * @param Throwable $exception Failure raised while handling an endpoint.
+     * The push route uses this same mapping before or during endpoint dispatch,
+     * so a failure has one wire representation.
+     *
+     * @param Throwable $exception Failure raised while handling a push request.
+     * @param int|null  $post_max_bytes Target request-body limit included with
+     *                                  request_too_large failures.
      */
-    private function respond_to_failure(Throwable $exception): void {
+    public static function emit_failure(Throwable $exception, ?int $post_max_bytes = null): void {
         if ($exception instanceof Site_Export_Push_Exception) {
             $reason = $exception->get_error_code();
             $http_code = 409;
             if ($reason === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND) {
                 $http_code = 404;
-            } elseif ($reason === Site_Export_Push_Session::ERROR_PUSH_DISABLED) {
-                $http_code = 403;
             } elseif ($reason === Site_Export_Push_Session::ERROR_LOCK_ACQUISITION_FAILURE) {
                 $http_code = 423;
             } elseif ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
@@ -568,23 +575,23 @@ final class Site_Export_Push_Endpoints {
                 if (is_int($context['observed_request_body_bytes'] ?? null)) {
                     $response['observed_request_body_bytes'] = $context['observed_request_body_bytes'];
                 }
-                $response['post_max_bytes'] = $this->post_max_bytes;
+                $response['post_max_bytes'] = $post_max_bytes;
             }
-            $this->respond($http_code, $response);
+            self::emit_response($http_code, $response);
             return;
         }
         if (
             $exception instanceof InvalidArgumentException
             || $exception instanceof RuntimeException
         ) {
-            $this->respond(400, [
+            self::emit_response(400, [
                 'status' => 'rejected',
                 'reason' => 'invalid_request',
                 'detail' => $exception->getMessage(),
             ]);
             return;
         }
-        $this->respond(500, [
+        self::emit_response(500, [
             'status' => 'rejected',
             'reason' => Site_Export_Push_Session::ERROR_FILESYSTEM,
             'detail' => 'The push endpoint failed while processing the request.',
@@ -592,14 +599,14 @@ final class Site_Export_Push_Endpoints {
     }
 
     /**
-     * Emits one complete JSON protocol response.
+     * Emits one complete push-protocol JSON response.
      *
      * @param int $http_code HTTP status code.
      * @param array $body Exact endpoint-specific response object whose keys
      *                    are documented by the calling endpoint.
      * @phpstan-param array<string,mixed> $body
      */
-    private function respond(int $http_code, array $body): void {
+    public static function emit_response(int $http_code, array $body): void {
         http_response_code($http_code);
         header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
         header('Pragma: no-cache');

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -60,7 +60,6 @@ final class Site_Export_Push_Session {
     public const ERROR_CORRUPTED_PUSH_STATE = 'corrupted_push_state';
     public const ERROR_SAME_DEVICE = 'same_device';
     public const ERROR_REQUEST_TOO_LARGE = 'request_too_large';
-    public const ERROR_PUSH_DISABLED = 'push_disabled';
 
     private const MAX_PATH_BYTES = 4096;
     private const MAX_METADATA_BYTES = 1048576;
@@ -74,6 +73,8 @@ final class Site_Export_Push_Session {
     private $push_session_id;
     /** @var list<string> */
     private $excluded_paths;
+    /** @var string|null */
+    private $expected_push_session_secret;
     /** @var string */
     private $push_directory;
     /** @var string */
@@ -87,7 +88,7 @@ final class Site_Export_Push_Session {
     /** @var string */
     private $work_deletes_path;
     /** @var string */
-    private $push_json_path;
+    private $push_metadata_path;
     /** @var string */
     private $commit_json_path;
     /** @var string */
@@ -124,11 +125,25 @@ final class Site_Export_Push_Session {
      *
      * @param list<string> $excluded_paths Document-root-relative paths which a push
      *                                      must never receive, delete, or replace.
+     * @param string|null $expected_push_session_secret Session secret already authenticated by the push route.
      */
-    private function __construct(string $reprint_directory, string $docroot, string $push_session_id, array $excluded_paths) {
+    private function __construct(
+        string $reprint_directory,
+        string $docroot,
+        string $push_session_id,
+        array $excluded_paths,
+        ?string $expected_push_session_secret = null
+    ) {
         $this->reprint_directory = rtrim($reprint_directory, '/');
         $this->docroot = $docroot === '/' ? '/' : rtrim($docroot, '/');
         $this->push_session_id = $push_session_id;
+        if (
+            $expected_push_session_secret !== null
+            && preg_match('/^[a-f0-9]{64}$/D', $expected_push_session_secret) !== 1
+        ) {
+            throw new InvalidArgumentException('Expected push session secret must be 64 lowercase hexadecimal characters.');
+        }
+        $this->expected_push_session_secret = $expected_push_session_secret;
         if ($reprint_directory === $this->docroot) {
             throw new InvalidArgumentException('The reprint directory must not be the document root itself.');
         }
@@ -141,7 +156,7 @@ final class Site_Export_Push_Session {
         }
         $this->excluded_paths = normalize_excluded_paths($excluded_paths);
         $this->push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
-        $this->push_json_path = $this->push_directory . '/push.json';
+        $this->push_metadata_path = $this->push_directory . '/push-metadata.php';
         $this->commit_json_path = $this->push_directory . '/commit.json';
         $this->push_lock_path = $this->push_directory . '/push.lock';
         $this->work_dir = $this->push_directory . '/work';
@@ -171,10 +186,25 @@ final class Site_Export_Push_Session {
      * @param string $docroot Document-root directory receiving committed values.
      * @param list<string> $excluded_paths Document-root-relative paths which a push must preserve.
      * @param string $push_session_id Stable lowercase hexadecimal push session ID.
+     * @param int $maximum_part_bytes Maximum Content-Length accepted for one multipart part.
+     * @param int $maximum_commit_entries Maximum entries processed by one commit request.
      * @return self New or existing push-session handle.
      */
-    public static function create(string $reprint_directory, string $docroot, array $excluded_paths, string $push_session_id): self {
+    public static function create(
+        string $reprint_directory,
+        string $docroot,
+        array $excluded_paths,
+        string $push_session_id,
+        int $maximum_part_bytes,
+        int $maximum_commit_entries
+    ): self {
         self::require_push_session_id($push_session_id);
+        if ($maximum_part_bytes <= 0) {
+            throw new InvalidArgumentException('Maximum multipart part bytes must be greater than zero.');
+        }
+        if ($maximum_commit_entries <= 0) {
+            throw new InvalidArgumentException('Maximum commit entries must be greater than zero.');
+        }
         $reprint_directory = self::require_directory($reprint_directory, 'reprint directory', true);
         $docroot = self::require_directory($docroot, 'document root', false);
         $push_session = new self($reprint_directory, $docroot, $push_session_id, $excluded_paths);
@@ -208,10 +238,13 @@ final class Site_Export_Push_Session {
                 self::remove_tree($push_session->push_directory);
                 throw $exception;
             }
-            $push_session->write_json($push_session->push_json_path, [
+            $push_session->write_metadata($push_session->push_metadata_path, [
                 'push_session_id' => $push_session_id,
                 'docroot_b64' => base64_encode($docroot),
                 'excluded_paths_b64' => array_map('base64_encode', $push_session->excluded_paths),
+                'push_session_secret' => bin2hex(random_bytes(32)),
+                'maximum_part_bytes' => $maximum_part_bytes,
+                'maximum_commit_entries' => $maximum_commit_entries,
                 'work_deletes_complete' => false,
             ]);
             return $push_session;
@@ -233,14 +266,111 @@ final class Site_Export_Push_Session {
      * @param string $docroot Document-root directory.
      * @param string $push_session_id Lowercase hexadecimal push session ID.
      * @param list<string> $excluded_paths Document-root-relative paths which a push must preserve.
+     * @param string|null $expected_push_session_secret Session secret already authenticated by the push route.
      * @return self Push-session handle; the push session may prove missing or invalid
      *              when its first operation acquires the lock.
      */
-    public static function open(string $reprint_directory, string $docroot, string $push_session_id, array $excluded_paths): self {
+    public static function open(
+        string $reprint_directory,
+        string $docroot,
+        string $push_session_id,
+        array $excluded_paths,
+        ?string $expected_push_session_secret = null
+    ): self {
         self::require_push_session_id($push_session_id);
         $reprint_directory = self::require_directory($reprint_directory, 'reprint directory', false);
         $docroot = self::require_directory($docroot, 'document root', false);
-        return new self($reprint_directory, $docroot, $push_session_id, $excluded_paths);
+        return new self(
+            $reprint_directory,
+            $docroot,
+            $push_session_id,
+            $excluded_paths,
+            $expected_push_session_secret
+        );
+    }
+
+    /**
+     * Loads the private values needed by the push route.
+     *
+     * The route supplies the reprint directory and document root from server
+     * configuration. Excluded paths, endpoint limits, and the session-scoped
+     * secret come from the push metadata created by the authenticated
+     * `push_create` request. Reading occurs under the push lock. A removal
+     * tombstone keeps its metadata and lock until its other entries are gone,
+     * so later bounded remove requests can still authenticate.
+     *
+     * @param string $reprint_directory Durable private reprint directory.
+     * @param string $docroot Server-configured document-root directory.
+     * @param string $push_session_id Lowercase hexadecimal push session ID.
+     * @return array {
+     *     Configuration for one existing push session.
+     *
+     *     @type string       $push_session_secret    Session-scoped HMAC secret.
+     *     @type list<string> $excluded_paths         Stored excluded paths.
+     *     @type int          $maximum_part_bytes     Maximum multipart part bytes.
+     *     @type int          $maximum_commit_entries Maximum entries per commit request.
+     * }
+     * @phpstan-return array{push_session_secret:string,excluded_paths:list<string>,maximum_part_bytes:int,maximum_commit_entries:int}
+     */
+    public static function load_push_session_configuration(string $reprint_directory, string $docroot, string $push_session_id): array {
+        self::require_push_session_id($push_session_id);
+        $reprint_directory = self::require_directory($reprint_directory, 'reprint directory', false);
+        $docroot = self::require_directory($docroot, 'document root', false);
+        $push_session = new self($reprint_directory, $docroot, $push_session_id, []);
+        $push_directory_identity = $push_session->lstat_path($push_session->push_directory);
+        $push_metadata_path = $push_session->push_metadata_path;
+        $live_push_session = $push_directory_identity !== null;
+        if ($live_push_session) {
+            $lock = $push_session->acquire_push_lock();
+        } else {
+            $tombstone = $reprint_directory . '/.reprint/push/.removing-' . $push_session_id;
+            $tombstone_identity = $push_session->lstat_path($tombstone);
+            if ($tombstone_identity === null) {
+                throw new Site_Export_Push_Exception(self::ERROR_PUSH_NOT_FOUND, 'The push session does not exist: ' . $push_session_id . '.');
+            }
+            if ($tombstone_identity['type'] !== 'directory') {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The push removal tombstone is not a real directory: ' . $tombstone . '.');
+            }
+            $push_metadata_path = $tombstone . '/push-metadata.php';
+            if ($push_session->lstat_path($push_metadata_path) === null) {
+                throw new Site_Export_Push_Exception(self::ERROR_PUSH_NOT_FOUND, 'The removed push session no longer has authentication state: ' . $push_session_id . '.');
+            }
+            $lock_path = $tombstone . '/push.lock';
+            $lock_identity = $push_session->lstat_path($lock_path);
+            if ($lock_identity === null || $lock_identity['type'] !== 'file') {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The push removal tombstone lock is missing or not regular: ' . $lock_path . '.');
+            }
+            $lock = @fopen($lock_path, 'r+b');
+            if ($lock === false) {
+                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the push removal tombstone lock.');
+            }
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                fclose($lock);
+                throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push removal cleanup is busy. Retry the request.');
+            }
+        }
+        try {
+            $push_metadata = $push_session->read_metadata($push_metadata_path);
+            $configuration = $push_session->decode_push_metadata($push_metadata);
+            if ($configuration['docroot'] !== $docroot) {
+                throw new Site_Export_Push_Exception(
+                    self::ERROR_CORRUPTED_PUSH_STATE,
+                    'Push metadata does not match the push route document root.'
+                );
+            }
+            if ($live_push_session) {
+                $push_session->require_same_device($push_session->work_files_directory, $docroot, 'receive', '');
+            }
+            return [
+                'push_session_secret' => $configuration['push_session_secret'],
+                'excluded_paths' => $configuration['excluded_paths'],
+                'maximum_part_bytes' => $configuration['maximum_part_bytes'],
+                'maximum_commit_entries' => $configuration['maximum_commit_entries'],
+            ];
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
     }
 
     /**
@@ -255,13 +385,26 @@ final class Site_Export_Push_Session {
      * @param string $docroot Currently configured document-root directory.
      * @param string $push_session_id Lowercase hexadecimal push session ID.
      * @param list<string> $excluded_paths Currently configured excluded paths.
+     * @param string|null $expected_push_session_secret Session secret already authenticated by the push route.
      * @return bool True when the push directory and any remove tombstone are gone.
      */
-    public static function remove(string $reprint_directory, string $docroot, string $push_session_id, array $excluded_paths): bool {
+    public static function remove(
+        string $reprint_directory,
+        string $docroot,
+        string $push_session_id,
+        array $excluded_paths,
+        ?string $expected_push_session_secret = null
+    ): bool {
         self::require_push_session_id($push_session_id);
         $reprint_directory = self::require_directory($reprint_directory, 'reprint directory', false);
         $docroot = self::require_directory($docroot, 'document root', false);
-        return ( new self($reprint_directory, $docroot, $push_session_id, $excluded_paths) )->remove_push_directory();
+        return ( new self(
+            $reprint_directory,
+            $docroot,
+            $push_session_id,
+            $excluded_paths,
+            $expected_push_session_secret
+        ) )->remove_push_directory();
     }
 
     /**
@@ -570,7 +713,7 @@ final class Site_Export_Push_Session {
                     $reported_path = ['path_b64' => base64_encode($path), 'state' => 'missing', 'accepted_bytes' => 0];
                 }
             }
-            $commit_state = $this->read_json($this->commit_json_path);
+            $commit_state = $this->read_metadata($this->commit_json_path);
             return [
                 'push_session_id' => $this->push_session_id,
                 'phase' => $commit_state === null ? 'receiving_work' : $commit_state['phase'],
@@ -597,9 +740,6 @@ final class Site_Export_Push_Session {
      * retry the same bounded step from the durable state.
      *
      * @param int $maximum_entries Maximum bounded commit entries to process in this call.
-     * @param string|null $commit_start_denial_detail When present, commit may
-     *     resume a durable checkpoint but may not create one. The string
-     *     describes why starting commit is denied.
      * @return array {
      *     Current bounded commit result.
      *
@@ -610,25 +750,13 @@ final class Site_Export_Push_Session {
      * }
      * @phpstan-return array{phase:'deleting_files'|'installing_files'|'complete',send_next_request:bool,entries_processed:int}
      */
-    public function commit(int $maximum_entries = 1, ?string $commit_start_denial_detail = null): array {
+    public function commit(int $maximum_entries = 1): array {
         if ($maximum_entries <= 0) {
             throw new InvalidArgumentException('The commit entry limit must be greater than zero.');
         }
-        if ($commit_start_denial_detail === '') {
-            throw new InvalidArgumentException('The commit start denial detail must be a non-empty string.');
-        }
-        return $this->with_push_lock(function () use ($maximum_entries, $commit_start_denial_detail): array {
-            $commit_state = $this->read_json($this->commit_json_path);
+        return $this->with_push_lock(function () use ($maximum_entries): array {
+            $commit_state = $this->read_metadata($this->commit_json_path);
             if ($commit_state === null) {
-                // The authorization decision and checkpoint creation share the
-                // push lock so a denied request cannot race another lifecycle
-                // operation into starting a new commit.
-                if ($commit_start_denial_detail !== null) {
-                    throw new Site_Export_Push_Exception(
-                        self::ERROR_PUSH_DISABLED,
-                        $commit_start_denial_detail
-                    );
-                }
                 if (!$this->work_deletes_are_complete()) {
                     throw new InvalidArgumentException('Commit requires an explicit completed delete upload declaration.');
                 }
@@ -658,7 +786,7 @@ final class Site_Export_Push_Session {
                     'current_work_files_descendant' => null,
                     'commit_cursor' => [],
                 ];
-                $this->write_json($this->commit_json_path, $commit_state);
+                $this->write_metadata($this->commit_json_path, $commit_state);
             }
             if (isset($commit_state['non_recoverable_commit_failure'])) {
                 throw new Site_Export_Push_Exception(
@@ -691,13 +819,7 @@ final class Site_Export_Push_Session {
                 throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A foreign WordPress maintenance marker already exists. Retry after its owner removes it.');
             }
             $maintenance_contents = "<?php\n"
-                . "\$reprint_push_request = (isset(\$_GET['reprint-api']) || isset(\$_GET['site-export-api']))\n"
-                . "    && isset(\$_GET['endpoint']) && is_string(\$_GET['endpoint'])\n"
-                . "    && strpos(\$_GET['endpoint'], 'push_') === 0;\n"
-                . "if (!\$reprint_push_request) {\n"
-                . "    \$upgrading = " . time() . ";\n"
-                . "}\n"
-                . "unset(\$reprint_push_request);\n"
+                . "\$upgrading = " . time() . ";\n"
                 . "// reprint-push-session:" . $this->push_session_id . "\n";
             $this->write_atomic_file($this->maintenance_copy_path, $maintenance_contents, 0600);
             $this->write_atomic_file($maintenance_docroot_path, $maintenance_contents, 0644);
@@ -716,7 +838,7 @@ final class Site_Export_Push_Session {
                         'detail' => $exception->getMessage(),
                         'context' => $exception->get_context(),
                     ];
-                    $this->write_json($this->commit_json_path, $commit_state);
+                    $this->write_metadata($this->commit_json_path, $commit_state);
                 }
                 throw $exception;
             }
@@ -731,7 +853,7 @@ final class Site_Export_Push_Session {
     /**
      * Advances bounded cleanup of an upload-only or completed push directory.
      *
-     * A push session which has begun an incomplete commit remains recovery state and
+     * A push session which has begun an incomplete commit remains recoverable state and
      * cannot be removed. An eligible push session is atomically renamed to a
      * private tombstone before entries are removed, so a lost response or later
      * request resumes cleanup without making the old push session addressable again.
@@ -749,7 +871,11 @@ final class Site_Export_Push_Session {
             }
             $lock = $this->acquire_push_lock();
             try {
-                $commit_state = $this->read_json($this->commit_json_path);
+                if ($this->expected_push_session_secret !== null) {
+                    $configuration = $this->decode_push_metadata($this->read_metadata($this->push_metadata_path));
+                    $this->assert_expected_push_session_secret($configuration['push_session_secret']);
+                }
+                $commit_state = $this->read_metadata($this->commit_json_path);
                 if ($commit_state !== null && $commit_state['phase'] !== 'complete') {
                     throw new Site_Export_Push_Exception(self::ERROR_COMMIT_REQUIRED, 'Document-root mutation has begun. Resume commit instead of removing this push session.');
                 }
@@ -897,7 +1023,7 @@ final class Site_Export_Push_Session {
      * @phpstan-return InFlightWork|null
      */
     private function read_inflight(): ?array {
-        return $this->read_json($this->work_inflight_path);
+        return $this->read_metadata($this->work_inflight_path);
     }
 
     /**
@@ -1020,14 +1146,14 @@ final class Site_Export_Push_Session {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard in-flight file data for restart.');
             }
             $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'file', 'total_bytes' => $total_bytes];
-            $this->write_json($this->work_inflight_path, $inflight);
+            $this->write_metadata($this->work_inflight_path, $inflight);
             $handle = @fopen($this->work_inflight_data_path, 'wb');
             if ($handle === false) {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create in-flight file data for ' . base64_encode($path) . '.');
             }
             fclose($handle);
             $inflight['phase'] = 'receiving';
-            $this->write_json($this->work_inflight_path, $inflight);
+            $this->write_metadata($this->work_inflight_path, $inflight);
             $actual_bytes = 0;
         } else {
             if ($inflight['type'] !== 'file' || $inflight['phase'] !== 'receiving' || $inflight['total_bytes'] !== $total_bytes) {
@@ -1057,7 +1183,7 @@ final class Site_Export_Push_Session {
         $accepted_bytes = $actual_bytes + $received;
         if ($accepted_bytes === $total_bytes) {
             $inflight['phase'] = 'completing';
-            $this->write_json($this->work_inflight_path, $inflight);
+            $this->write_metadata($this->work_inflight_path, $inflight);
             $this->ensure_private_parent($complete_path);
             if (($existing = $this->lstat_path($complete_path)) !== null) {
                 $this->remove_work_path($complete_path);
@@ -1114,7 +1240,7 @@ final class Site_Export_Push_Session {
             return;
         }
         $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'directory'];
-        $this->write_json($this->work_inflight_path, $inflight);
+        $this->write_metadata($this->work_inflight_path, $inflight);
         if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
         }
@@ -1122,7 +1248,7 @@ final class Site_Export_Push_Session {
             $this->remove_work_path($target);
         }
         $inflight['phase'] = 'completing';
-        $this->write_json($this->work_inflight_path, $inflight);
+        $this->write_metadata($this->work_inflight_path, $inflight);
         $this->ensure_private_parent($target);
         if (!is_dir($target) && !@mkdir($target, 0777)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not stage explicit empty directory ' . base64_encode($path) . '.');
@@ -1184,7 +1310,7 @@ final class Site_Export_Push_Session {
             return;
         }
         $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'symlink', 'target_b64' => base64_encode($target_value)];
-        $this->write_json($this->work_inflight_path, $inflight);
+        $this->write_metadata($this->work_inflight_path, $inflight);
         if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
         }
@@ -1192,7 +1318,7 @@ final class Site_Export_Push_Session {
             $this->remove_work_path($target);
         }
         $inflight['phase'] = 'completing';
-        $this->write_json($this->work_inflight_path, $inflight);
+        $this->write_metadata($this->work_inflight_path, $inflight);
         $this->ensure_private_parent($target);
         if (!@symlink($target_value, $target)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not stage symlink ' . base64_encode($path) . '.');
@@ -1324,12 +1450,12 @@ final class Site_Export_Push_Session {
             fclose($handle);
         }
         if ($complete) {
-            $push_metadata = $this->read_json($this->push_json_path);
+            $push_metadata = $this->read_metadata($this->push_metadata_path);
             if (!is_array($push_metadata)) {
                 throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata is missing while completing the delete upload.');
             }
             $push_metadata['work_deletes_complete'] = true;
-            $this->write_json($this->push_json_path, $push_metadata);
+            $this->write_metadata($this->push_metadata_path, $push_metadata);
         }
         $this->current_change = ['state' => $complete ? 'complete' : 'partial', 'type' => 'delete-list', 'accepted_bytes' => $stored_bytes];
     }
@@ -1363,7 +1489,7 @@ final class Site_Export_Push_Session {
             $delete_size = $this->file_size($this->work_deletes_path);
             if ($work_deletes_byte_offset === $delete_size) {
                 $commit_state['phase'] = 'installing_files';
-                $this->write_json($this->commit_json_path, $commit_state);
+                $this->write_metadata($this->commit_json_path, $commit_state);
                 return;
             }
             if ($work_deletes_byte_offset < 0 || $work_deletes_byte_offset > $delete_size) {
@@ -1393,7 +1519,7 @@ final class Site_Export_Push_Session {
                         }
                         $this->assert_path_does_not_overlap_excluded_paths($path);
                         $commit_state['current_delete_path'] = base64_encode($path);
-                        $this->write_json($this->commit_json_path, $commit_state);
+                        $this->write_metadata($this->commit_json_path, $commit_state);
                         return;
                     }
                     $path .= $byte;
@@ -1426,7 +1552,7 @@ final class Site_Export_Push_Session {
         }
         $commit_state['work_deletes_byte_offset'] += strlen($path) + 1;
         $commit_state['current_delete_path'] = null;
-        $this->write_json($this->commit_json_path, $commit_state);
+        $this->write_metadata($this->commit_json_path, $commit_state);
     }
 
     /**
@@ -1532,7 +1658,7 @@ final class Site_Export_Push_Session {
                 }
                 $commit_state['current_work_files_descendant'] = null;
                 array_pop($commit_state['commit_cursor']);
-                $this->write_json($this->commit_json_path, $commit_state);
+                $this->write_metadata($this->commit_json_path, $commit_state);
                 return;
             }
 
@@ -1547,7 +1673,7 @@ final class Site_Export_Push_Session {
                 $this->throw_unexpected_docroot_mutation('install', $path, $path, $expected_type, [$expected_type], $docroot_identity);
             }
             $commit_state['current_work_files_descendant'] = null;
-            $this->write_json($this->commit_json_path, $commit_state);
+            $this->write_metadata($this->commit_json_path, $commit_state);
 
             return;
         }
@@ -1586,7 +1712,7 @@ final class Site_Export_Push_Session {
                     throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove the private maintenance ownership marker.');
                 }
                 $commit_state['phase'] = 'complete';
-                $this->write_json($this->commit_json_path, $commit_state);
+                $this->write_metadata($this->commit_json_path, $commit_state);
                 $this->release_commit_state();
                 return;
             }
@@ -1596,13 +1722,13 @@ final class Site_Export_Push_Session {
                 $this->throw_unexpected_docroot_mutation('install', $parent_path, $parent_path, 'directory', ['directory'], $docroot_identity);
             }
             $commit_state['current_work_files_descendant'] = ['path_b64' => base64_encode($parent_path), 'expected_type' => 'directory'];
-            $this->write_json($this->commit_json_path, $commit_state);
+            $this->write_metadata($this->commit_json_path, $commit_state);
             if (!@rmdir($work_directory_path)) {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not consume empty work ancestor directory ' . base64_encode($parent_path) . '.');
             }
             $commit_state['current_work_files_descendant'] = null;
             array_pop($commit_state['commit_cursor']);
-            $this->write_json($this->commit_json_path, $commit_state);
+            $this->write_metadata($this->commit_json_path, $commit_state);
             return;
         }
 
@@ -1616,7 +1742,7 @@ final class Site_Export_Push_Session {
         if ($identity['type'] === 'directory' && $this->first_directory_entry($work_path) !== null) {
             $this->assert_path_is_not_excluded($path);
             $commit_state['commit_cursor'][] = ['component_b64' => base64_encode($entry)];
-            $this->write_json($this->commit_json_path, $commit_state);
+            $this->write_metadata($this->commit_json_path, $commit_state);
             $requested_path = $this->first_work_files_descendant_path($work_path, $path);
             $parent_device = $this->require_docroot_ancestors($path, 'install', 'directory');
             $docroot_value_path = $this->docroot_path($path);
@@ -1687,7 +1813,7 @@ final class Site_Export_Push_Session {
         }
         if (!$recovering) {
             $commit_state['current_work_files_descendant'] = ['path_b64' => base64_encode($path), 'expected_type' => $expected_type];
-            $this->write_json($this->commit_json_path, $commit_state);
+            $this->write_metadata($this->commit_json_path, $commit_state);
         }
         error_clear_last();
         if (!@rename($work_path, $docroot_value_path)) {
@@ -1707,7 +1833,7 @@ final class Site_Export_Push_Session {
             );
         }
         $commit_state['current_work_files_descendant'] = null;
-        $this->write_json($this->commit_json_path, $commit_state);
+        $this->write_metadata($this->commit_json_path, $commit_state);
     }
 
 
@@ -2054,7 +2180,7 @@ final class Site_Export_Push_Session {
                     throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push directory is missing or not real: ' . $directory . '.');
                 }
             }
-            foreach ([$this->push_json_path, $this->push_lock_path, $this->work_deletes_path] as $file) {
+            foreach ([$this->push_metadata_path, $this->push_lock_path, $this->work_deletes_path] as $file) {
                 $identity = $this->lstat_path($file);
                 if ($identity === null || $identity['type'] !== 'file') {
                     throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push file is missing or not regular: ' . $file . '.');
@@ -2083,7 +2209,44 @@ final class Site_Export_Push_Session {
      * and retain the same-device guarantee under which the push was made.
      */
     private function assert_push_configuration(): void {
-        $push_metadata = $this->read_json($this->push_json_path);
+        $push_metadata = $this->read_metadata($this->push_metadata_path);
+        $configuration = $this->decode_push_metadata($push_metadata);
+        $this->assert_expected_push_session_secret($configuration['push_session_secret']);
+        if ($configuration['docroot'] !== $this->docroot || $configuration['excluded_paths'] !== $this->excluded_paths) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not match the current push configuration.');
+        }
+        $this->require_same_device($this->work_files_directory, $this->docroot, 'receive', '');
+    }
+
+    /**
+     * Confirms that the route-authenticated secret still belongs to this session.
+     *
+     * Another request may remove and recreate the same public push session ID
+     * after route authentication but before this operation acquires its lock.
+     * Treat the replacement as absent so an old session secret cannot inspect
+     * or mutate the new session.
+     *
+     * @param string $stored_push_session_secret Secret read under the session lock.
+     */
+    private function assert_expected_push_session_secret(string $stored_push_session_secret): void {
+        if (
+            $this->expected_push_session_secret !== null
+            && !hash_equals($stored_push_session_secret, $this->expected_push_session_secret)
+        ) {
+            throw new Site_Export_Push_Exception(
+                self::ERROR_PUSH_NOT_FOUND,
+                'The authenticated push session no longer exists.'
+            );
+        }
+    }
+
+    /**
+     * Decodes the immutable push configuration stored in push-metadata.php.
+     *
+     * @param array<string,mixed>|null $push_metadata Bounded push metadata.
+     * @return array{docroot:string,excluded_paths:list<string>,push_session_secret:string,maximum_part_bytes:int,maximum_commit_entries:int}
+     */
+    private function decode_push_metadata(?array $push_metadata): array {
         if (!is_array($push_metadata) || ( $push_metadata['push_session_id'] ?? null ) !== $this->push_session_id
             || !is_bool($push_metadata['work_deletes_complete'] ?? null)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has an invalid push session ID or work-deletes completion state.');
@@ -2091,33 +2254,51 @@ final class Site_Export_Push_Session {
         if (!is_string($push_metadata['docroot_b64'] ?? null) || !is_array($push_metadata['excluded_paths_b64'] ?? null)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain the configured document root and excluded paths.');
         }
+        $push_session_secret = $push_metadata['push_session_secret'] ?? null;
+        if (!is_string($push_session_secret) || preg_match('/^[a-f0-9]{64}$/D', $push_session_secret) !== 1) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain a valid push session secret.');
+        }
+        $maximum_part_bytes = $push_metadata['maximum_part_bytes'] ?? null;
+        $maximum_commit_entries = $push_metadata['maximum_commit_entries'] ?? null;
+        if (!is_int($maximum_part_bytes) || $maximum_part_bytes <= 0) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain a positive maximum multipart part size.');
+        }
+        if (!is_int($maximum_commit_entries) || $maximum_commit_entries <= 0) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain a positive maximum commit entry count.');
+        }
         $docroot = base64_decode($push_metadata['docroot_b64'], true);
-        $excluded = [];
+        if (!is_string($docroot)) {
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata contains an invalid document root.');
+        }
+        $excluded_paths = [];
         foreach ($push_metadata['excluded_paths_b64'] as $encoded) {
             $decoded = is_string($encoded) ? base64_decode($encoded, true) : false;
             if (!is_string($decoded)) {
                 throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata contains an invalid excluded path.');
             }
-            $excluded[] = $decoded;
+            $excluded_paths[] = $decoded;
         }
-        if ($docroot !== $this->docroot || $excluded !== $this->excluded_paths) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not match the current push configuration.');
-        }
-        $this->require_same_device($this->work_files_directory, $this->docroot, 'receive', '');
+        return [
+            'docroot' => $docroot,
+            'excluded_paths' => $excluded_paths,
+            'push_session_secret' => $push_session_secret,
+            'maximum_part_bytes' => $maximum_part_bytes,
+            'maximum_commit_entries' => $maximum_commit_entries,
+        ];
     }
 
     /**
-     * Reads a bounded JSON object from private push metadata.
+     * Reads one bounded private metadata array.
      *
-     * Missing files return null so callers can distinguish optional checkpoints
-     * from malformed ones. Existing files must be regular, within the metadata
-     * size ceiling, and decode to a JSON object.
+     * `push-metadata.php` returns the receiver-owned push identity and policy.
+     * Commit checkpoints and in-flight work remain JSON. Missing files return
+     * null so callers can distinguish optional checkpoints from malformed ones.
      *
      * @param string $path Absolute metadata file path.
-     * @return array<string,mixed>|null Decoded caller-specific object, or null
+     * @return array<string,mixed>|null Decoded caller-specific metadata, or null
      *                                  if absent.
      */
-    private function read_json(string $path): ?array {
+    private function read_metadata(string $path): ?array {
         $identity = $this->lstat_path($path);
         if ($identity === null) {
             return null;
@@ -2125,23 +2306,44 @@ final class Site_Export_Push_Session {
         if ($identity['type'] !== 'file' || $identity['size'] > self::MAX_METADATA_BYTES) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' is not a bounded regular file.');
         }
+        if (substr($path, -4) === '.php') {
+            // This array changes between requests. Do not let an opcode cache retain
+            // an earlier delete-completion state or a removed session's secret.
+            if (function_exists('opcache_invalidate')) {
+                @opcache_invalidate($path, true);
+            }
+            ob_start();
+            try {
+                $metadata = ( static function (string $metadata_path) {
+                    return @include $metadata_path;
+                } )($path);
+            } catch (Throwable $exception) {
+                ob_end_clean();
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' does not return a PHP array without output.');
+            }
+            $output = ob_get_clean();
+            if ($output !== '' || !is_array($metadata)) {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' does not return a PHP array without output.');
+            }
+            return $metadata;
+        }
         $contents = @file_get_contents($path);
         if (!is_string($contents)) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read metadata file ' . $path . '.');
         }
-        $decoded = json_decode($contents, true);
-        if (!is_array($decoded)) {
+        $metadata = json_decode($contents, true);
+        if (!is_array($metadata)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' does not contain a JSON object.');
         }
-        return $decoded;
+        return $metadata;
     }
 
     /**
-     * Atomically writes one bounded JSON metadata object.
+     * Atomically writes one bounded private metadata array.
      *
-     * JSON is encoded without slash escaping because metadata contains many
-     * filesystem paths already excluded by base64 where necessary. The encoded
-     * object must fit the same ceiling enforced by read_json().
+     * PHP metadata returns its array without printing it, so a direct request
+     * which executes the file receives no secret bytes. Checkpoints and in-flight
+     * work use JSON. Both formats use the same atomic 0600 writer.
      *
      * @param string $path Absolute metadata file path.
      * @param array $value {
@@ -2150,6 +2352,9 @@ final class Site_Export_Push_Session {
      *     @type string $push_session_id Push session ID. Present only in push metadata.
      *     @type string $docroot_b64 Base64-encoded document root. Present only in push metadata.
      *     @type string[] $excluded_paths_b64 Base64-encoded excluded paths. Present only in push metadata.
+     *     @type string $push_session_secret Session-scoped HMAC secret. Present only in push metadata.
+     *     @type int $maximum_part_bytes Maximum multipart part bytes. Present only in push metadata.
+     *     @type int $maximum_commit_entries Maximum entries per commit request. Present only in push metadata.
      *     @type bool $work_deletes_complete Delete-list completion. Present only in push metadata.
      *     @type string $phase In-flight or commit phase. Absent from push metadata.
      *     @type string $path_b64 In-flight work path. Present only in in-flight work.
@@ -2162,15 +2367,20 @@ final class Site_Export_Push_Session {
      *     @type array $commit_cursor Bounded tree cursor. Present only in a commit checkpoint.
      *     @type array $non_recoverable_commit_failure Persisted failure. Present only after a non-recoverable commit failure.
      * }
-     * @phpstan-param array{push_session_id:string,docroot_b64:string,excluded_paths_b64:list<string>,work_deletes_complete:bool}|InFlightWork|CommitState $value
+     * @phpstan-param array{push_session_id:string,docroot_b64:string,excluded_paths_b64:list<string>,push_session_secret:string,maximum_part_bytes:int,maximum_commit_entries:int,work_deletes_complete:bool}|InFlightWork|CommitState $value
      */
-    private function write_json(string $path, array $value): void {
-        $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
-        if (!is_string($contents)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Could not encode bounded push metadata.');
+    private function write_metadata(string $path, array $value): void {
+        if (substr($path, -4) === '.php') {
+            // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- This is the PHP metadata serializer, not debug output.
+            $contents = "<?php\nreturn " . var_export($value, true) . ";\n";
+        } else {
+            $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
+            if (!is_string($contents)) {
+                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Could not encode bounded metadata.');
+            }
         }
         if (strlen($contents) > self::MAX_METADATA_BYTES) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Encoded push metadata exceeds the maximum of ' . self::MAX_METADATA_BYTES . ' bytes.');
+            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Encoded metadata exceeds the maximum of ' . self::MAX_METADATA_BYTES . ' bytes.');
         }
         $this->write_atomic_file($path, $contents, 0600);
     }
@@ -2302,7 +2512,7 @@ final class Site_Export_Push_Session {
      * @return bool True once a delete-list part declared completion.
      */
     private function work_deletes_are_complete(): bool {
-        $push_metadata = $this->read_json($this->push_json_path);
+        $push_metadata = $this->read_metadata($this->push_metadata_path);
         if (!is_array($push_metadata) || !is_bool($push_metadata['work_deletes_complete'] ?? null)) {
             throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has no valid work-deletes completion state.');
         }
@@ -2697,6 +2907,10 @@ final class Site_Export_Push_Session {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
                 throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push removal cleanup is busy. Retry remove.');
             }
+            if ($this->expected_push_session_secret !== null) {
+                $configuration = $this->decode_push_metadata($this->read_metadata($tombstone . '/push-metadata.php'));
+                $this->assert_expected_push_session_secret($configuration['push_session_secret']);
+            }
             // The push directory rename is durable before commit ownership is released.
             // Retry that release while the tombstone still preserves push state.
             $this->release_commit_state();
@@ -2709,7 +2923,12 @@ final class Site_Export_Push_Session {
             flock($lock, LOCK_UN);
             fclose($lock);
         }
-        if (!@unlink($push_lock_path) || !@rmdir($tombstone)) {
+        $push_metadata_path = $tombstone . '/push-metadata.php';
+        if (
+            ( is_file($push_metadata_path) && !@unlink($push_metadata_path) )
+            || !@unlink($push_lock_path)
+            || !@rmdir($tombstone)
+        ) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove the completed push removal tombstone.');
         }
         return true;
@@ -2765,10 +2984,10 @@ final class Site_Export_Push_Session {
      *
      * @param string $directory_path Absolute directory currently being drained.
      * @param int $remaining_entries Remaining unlink/rmdir operations allowed.
-     * @param bool $preserve_lock Whether to keep a child named `lock`.
+     * @param bool $preserve_control_files Whether to keep `push-metadata.php` and `push.lock`.
      * @return bool True when this directory is empty enough to remove.
      */
-    private static function remove_directory_entries(string $directory_path, int &$remaining_entries, bool $preserve_lock = false): bool {
+    private static function remove_directory_entries(string $directory_path, int &$remaining_entries, bool $preserve_control_files = false): bool {
         $handle = @opendir($directory_path);
         if ($handle === false) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read push removal directory: ' . $directory_path . '.');
@@ -2779,7 +2998,11 @@ final class Site_Export_Push_Session {
                 if ($entry === false) {
                     break;
                 }
-                if ($entry === '.' || $entry === '..' || ( $preserve_lock && $entry === 'push.lock' )) {
+                if (
+                    $entry === '.'
+                    || $entry === '..'
+                    || ( $preserve_control_files && in_array($entry, ['push-metadata.php', 'push.lock'], true) )
+                ) {
                     continue;
                 }
                 if ($remaining_entries === 0) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2246,7 +2246,7 @@ class ImportClient
      * @return array {
      *     Validated files-push command context.
      *
-     *     @type string $target_url           Target exporter API URL.
+     *     @type string $target_url           Target push URL.
      *     @type string $local_tree           Canonical local tree being sent.
      *     @type string $pair                 Target/local-tree pair key.
      *     @type string $push_state_directory Sender state directory for the pair.
@@ -13230,7 +13230,7 @@ if (
             "short" => "Push one local file tree without database work",
             "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
             "description" =>
-                "Sends the existing local tree at --fs-root to the target exporter API.\n" .
+                "Sends the existing local tree at --fs-root to the target push URL.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It does not require pull preflight.\n" .

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -49,17 +49,17 @@
  * process starts from the preceding durable boundary and reads
  * receiver-confirmed work before sending more data.
  *
- * A new sender calls `push_create` to learn target-owned exclusions before
- * starting PushPlan. The plan builds the fresh local index and diffs it against
- * the index at the previous push, one bounded step at a time. After planning
- * completes, local files, symlinks, and empty directories stream through
- * multipart requests. The raw deletion list follows, and repeated `push_commit`
- * calls let the target install the work in bounded steps. A confirmed commit
- * enters another phase which saves the fresh local index as the local index at
- * the previous push through a swap file. Index completion, plan completion,
- * local-index saving, and plan discard each have a separate durable phase. A
- * stopped process therefore repeats only an idempotent boundary action rather
- * than a group of unrelated transitions.
+ * A new sender calls `push_create` through the push route to learn target-owned
+ * exclusions and receive a push session secret. The plan builds the fresh
+ * local index and diffs it against the index at the previous push, one bounded
+ * step at a time. After planning completes, local files, symlinks, empty
+ * directories, the raw deletion list, and repeated `push_commit` requests use
+ * the same route with that session secret. A confirmed commit enters another
+ * phase which saves the fresh local index as the local index at the previous
+ * push through a swap file. Index completion, plan completion, local-index
+ * saving, and plan discard each have a separate durable phase. A stopped
+ * process therefore repeats only an idempotent boundary action rather than a
+ * group of unrelated transitions.
  *
  * sender.json owns the top-level phase and the cursor returned by
  * PushPlan. PushFilesSender stores that cursor after every completed planning
@@ -116,7 +116,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index_at_previous_push'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index_at_previous_push'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,push_session_secret:string|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -228,7 +228,7 @@ final class PushFilesSender
      *
      *     @type string                  $docroot                Required local document-root directory.
      *     @type string                  $push_state_directory    Required local push state directory.
-     *     @type string                  $base_url                Required exporter API URL.
+     *     @type string                  $base_url                Required push URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
      *     @type int|float|string        $chunk_bytes             Maximum bytes read from one local file. Default 4 MiB.
@@ -262,6 +262,7 @@ final class PushFilesSender
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'max_part_bytes' => null,
+                'push_session_secret' => null,
                 'request_sizer_state' => $sender->push_stream_client->get_request_sizer_state(),
             ];
             $sender->store_state($sender->state);
@@ -524,14 +525,14 @@ final class PushFilesSender
      */
     private function create_push_session(): void
     {
-        $request_result = $this->push_stream_client->send_push_request('POST', 'push_create', [
+        $request_result = $this->push_stream_client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $this->state['push_session_id'],
         ], ['created']);
         if ($this->handle_request_failure($request_result)) {
             return;
         }
 
-        /** @var array{max_part_bytes:int,post_max_bytes:?int,excluded_paths_b64:list<string>} $response */
+        /** @var array{max_part_bytes:int,post_max_bytes:?int,excluded_paths_b64:list<string>,push_session_secret:mixed} $response */
         $response = $request_result['response'];
         if (count($response['excluded_paths_b64']) > 100) {
             $this->fail(
@@ -547,12 +548,21 @@ final class PushFilesSender
                 return;
             }
         }
+        $push_session_secret = $response['push_session_secret'] ?? null;
+        if (!is_string($push_session_secret) || preg_match('/^[a-f0-9]{64}$/D', $push_session_secret) !== 1) {
+            $this->fail('unexpected_response', 'push_create did not return a valid push_session_secret.');
+            return;
+        }
+        $this->push_stream_client->set_push_session_hmac_client(
+            new Site_Export_HMAC_Client($push_session_secret)
+        );
         $this->create_plan_directory();
         $this->store_excluded_paths($response['excluded_paths_b64']);
 
         $this->push_stream_client->set_max_part_bytes($response['max_part_bytes']);
         $this->push_stream_client->apply_reported_limits([$response['post_max_bytes']]);
         $this->state['max_part_bytes'] = $response['max_part_bytes'];
+        $this->state['push_session_secret'] = $push_session_secret;
         $this->state['request_sizer_state'] = $this->push_stream_client->get_request_sizer_state();
         $this->state['phase'] = 'starting_plan';
         $this->store_state($this->state);
@@ -705,7 +715,7 @@ final class PushFilesSender
         } elseif ($this->receiver_confirmed_file_byte_offset !== null) {
             $file_byte_offset = $this->receiver_confirmed_file_byte_offset;
         } else {
-            $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
+            $request_result = $this->push_stream_client->send_push_session_request('GET', 'push_status', [
                 'push_session_id' => $this->state['push_session_id'],
                 'path_b64' => $local_path_to_push['path_b64'],
             ], ['accepted']);
@@ -938,7 +948,7 @@ final class PushFilesSender
                 // Without a cached position, ask how much of the list the target accepted.
                 // The same call then sends one part so even a one-step process makes progress.
                 if ($this->receiver_confirmed_deleted_paths_byte_offset === null) {
-                    $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
+                    $request_result = $this->push_stream_client->send_push_session_request('GET', 'push_status', [
                         'push_session_id' => $this->state['push_session_id'],
                     ], ['accepted']);
                     if ($this->handle_request_failure($request_result)) {
@@ -1163,16 +1173,18 @@ final class PushFilesSender
      */
     private function commit_push(): void
     {
-        $request_result = $this->push_stream_client->send_push_request('POST', 'push_commit', [
+        $request_result = $this->push_stream_client->send_push_session_request('POST', 'push_commit', [
             'push_session_id' => $this->state['push_session_id'],
         ], ['accepted']);
         if ($this->handle_request_failure($request_result)) {
             return;
         }
-        /** @var array{send_next_request:bool} $response */
         $response = $request_result['response'];
-
-        if ($response['send_next_request']) {
+        if ( ( $response['send_next_request'] ?? null ) === true ) {
+            return;
+        }
+        if ( ( $response['send_next_request'] ?? null ) !== false || ( $response['phase'] ?? null ) !== 'complete' ) {
+            $this->fail('unexpected_response', 'push_commit returned an invalid completion state.');
             return;
         }
         $this->state['phase'] = 'saving_local_index_at_previous_push';
@@ -1240,7 +1252,7 @@ final class PushFilesSender
      */
     private function remove_push_session(): void
     {
-        $request_result = $this->push_stream_client->send_push_request('POST', 'push_remove', [
+        $request_result = $this->push_stream_client->send_push_session_request('POST', 'push_remove', [
             'push_session_id' => $this->state['push_session_id'],
         ], ['accepted']);
         if ($this->handle_request_failure($request_result)) {
@@ -1325,6 +1337,11 @@ final class PushFilesSender
         $push_stream_client = new MultipartPushStreamClient($push_stream_client_options);
         if ($state !== null && $state['max_part_bytes'] !== null) {
             $push_stream_client->set_max_part_bytes($state['max_part_bytes']);
+        }
+        if ($state !== null && is_string($state['push_session_secret'] ?? null)) {
+            $push_stream_client->set_push_session_hmac_client(
+                new Site_Export_HMAC_Client($state['push_session_secret'])
+            );
         }
         return $push_stream_client;
     }
@@ -1530,6 +1547,13 @@ final class PushFilesSender
             throw new RuntimeException('Failed to encode active state.', 0, $exception);
         }
         $temporary_path = $this->state_path . '.tmp';
+        if (file_put_contents($temporary_path, '') !== 0) {
+            throw new RuntimeException('Failed to create temporary active state: ' . $temporary_path);
+        }
+        if (!chmod($temporary_path, 0600)) {
+            @unlink($temporary_path);
+            throw new RuntimeException('Failed to protect active state: ' . $temporary_path);
+        }
         if (file_put_contents($temporary_path, $json) !== strlen($json)) {
             throw new RuntimeException('Failed to write active state: ' . $temporary_path);
         }

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -61,11 +61,14 @@ class MultipartPushStreamClient
     /** Maximum JSON response bytes retained from the target. */
     private const MAX_RESPONSE_BYTES = 1024 * 1024;
 
-    /** @var string Exporter API URL used as the base of every signed request target. */
+    /** @var string Push route used for every request. */
     private string $base_url;
 
-    /** @var Site_Export_HMAC_Client Signs the exact method and URL before transfer. */
-    private Site_Export_HMAC_Client $hmac_client;
+    /** @var Site_Export_HMAC_Client Signs session creation with the connection token. */
+    private Site_Export_HMAC_Client $connection_hmac_client;
+
+    /** @var Site_Export_HMAC_Client|null Signs requests for one created push session. */
+    private ?Site_Export_HMAC_Client $push_session_hmac_client = null;
 
     /** @var PushRequestSizer Learns the decoded entity-body budget across requests. */
     private PushRequestSizer $request_sizer;
@@ -164,7 +167,7 @@ class MultipartPushStreamClient
      * @param array<string,mixed> $options {
      *     Transport, authentication, and limit options.
      *
-     *     @type string $base_url Required exporter API URL. Must use HTTPS
+     *     @type string $base_url Required push URL. Must use HTTPS
      *         unless `allow_http` is true.
      *     @type Site_Export_HMAC_Client $hmac_client Required signer for the
      *         exact method and request URL.
@@ -200,9 +203,13 @@ class MultipartPushStreamClient
         if (!is_string($base_url) || $base_url === '') {
             throw new InvalidArgumentException('MultipartPushStreamClient requires a non-empty base_url option.');
         }
-        $scheme = strtolower((string) parse_url($base_url, PHP_URL_SCHEME));
         $allow_http = $options['allow_http'] ?? false;
-        if (!is_bool($allow_http) || ($scheme !== 'https' && $scheme !== 'http') || ($scheme === 'http' && !$allow_http)) {
+        $scheme = strtolower( (string) parse_url( $base_url, PHP_URL_SCHEME ) );
+        if (
+            !is_bool($allow_http)
+            || ( $scheme !== 'https' && $scheme !== 'http' )
+            || ( $scheme === 'http' && !$allow_http )
+        ) {
             throw new InvalidArgumentException(
                 'Push base_url must be https://, unless allow_http is true for an explicit http:// target.'
             );
@@ -212,7 +219,7 @@ class MultipartPushStreamClient
             throw new InvalidArgumentException('MultipartPushStreamClient requires a Site_Export_HMAC_Client.');
         }
         $this->base_url = rtrim($base_url, '?&');
-        $this->hmac_client = $hmac_client;
+        $this->connection_hmac_client = $hmac_client;
         $this->request_sizer = $options['request_sizer'] ?? new PushRequestSizer();
         if (!$this->request_sizer instanceof PushRequestSizer) {
             throw new InvalidArgumentException('request_sizer must be a PushRequestSizer.');
@@ -254,6 +261,9 @@ class MultipartPushStreamClient
         if (preg_match('/^[a-f0-9]{32}$/D', $push_session_id) !== 1) {
             throw new InvalidArgumentException('Target push_session_id must be a 32-character lowercase hexadecimal value.');
         }
+        if ($this->push_session_hmac_client === null) {
+            throw new LogicException('Cannot start an upload request before set_push_session_hmac_client().');
+        }
         $this->boundary = 'reprint-' . bin2hex(random_bytes(16));
         $this->outbound_prefix = '';
         $this->outbound_payload = '';
@@ -271,7 +281,7 @@ class MultipartPushStreamClient
         $this->response_too_large = false;
 
         $request_url = $this->endpoint_url('push_upload', ['push_session_id' => $push_session_id]);
-        $headers = $this->hmac_client->get_envelope_auth_headers('POST', $request_url);
+        $headers = $this->push_session_hmac_client->get_envelope_auth_headers('POST', $request_url);
         $headers['Content-Type'] = 'multipart/mixed; boundary=' . $this->boundary;
         $header_lines = [];
         foreach ($headers as $name => $value) {
@@ -753,12 +763,62 @@ class MultipartPushStreamClient
         $this->response_too_large = false;
     }
 
+    /** Stores the target-issued signer for one created push session. */
+    public function set_push_session_hmac_client(Site_Export_HMAC_Client $push_session_hmac_client): void
+    {
+        $this->push_session_hmac_client = $push_session_hmac_client;
+    }
+
+    /**
+     * Sends session creation with the connection token.
+     *
+     * @param string $method GET or POST.
+     * @param string $endpoint Push endpoint name.
+     * @param array<string,mixed> $parameters Signed query parameters.
+     * @param string[] $expected_statuses Successful response statuses.
+     * @return array<string,mixed> Classified request result.
+     */
+    public function send_connection_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
+    {
+        return $this->send_control_request(
+            $this->connection_hmac_client,
+            $method,
+            $endpoint,
+            $parameters,
+            $expected_statuses
+        );
+    }
+
+    /**
+     * Sends one request authenticated for the created push session.
+     *
+     * @param string $method GET or POST.
+     * @param string $endpoint Push endpoint name.
+     * @param array<string,mixed> $parameters Signed query parameters.
+     * @param string[] $expected_statuses Successful response statuses.
+     * @return array<string,mixed> Classified request result.
+     */
+    public function send_push_session_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
+    {
+        if ($this->push_session_hmac_client === null) {
+            throw new LogicException('Cannot send a push session request before set_push_session_hmac_client().');
+        }
+        return $this->send_control_request(
+            $this->push_session_hmac_client,
+            $method,
+            $endpoint,
+            $parameters,
+            $expected_statuses
+        );
+    }
+
     /**
      * Sends one signed push request and decodes its JSON response.
      *
      * Push requests use a no-progress timeout rather than a total-transfer
      * deadline and refuse redirects so signatures are never replayed elsewhere.
      *
+     * @param Site_Export_HMAC_Client $hmac_client Signer for that route.
      * @param string $method GET or POST.
      * @param string $endpoint Protocol endpoint query value.
      * @param array<string,mixed> $parameters Endpoint-specific query parameters.
@@ -788,7 +848,13 @@ class MultipartPushStreamClient
      *
      * @throws InvalidArgumentException If the method is unsupported.
      */
-    public function send_push_request(string $method, string $endpoint, array $parameters, array $expected_statuses): array
+    private function send_control_request(
+        Site_Export_HMAC_Client $hmac_client,
+        string $method,
+        string $endpoint,
+        array $parameters,
+        array $expected_statuses
+    ): array
     {
         $method = strtoupper($method);
         if (!in_array($method, ['GET', 'POST'], true)) {
@@ -798,7 +864,7 @@ class MultipartPushStreamClient
             throw new InvalidArgumentException('Push requests require one or more string success statuses.');
         }
         $url = $this->endpoint_url($endpoint, $parameters);
-        $headers = $this->hmac_client->get_envelope_auth_headers($method, $url);
+        $headers = $hmac_client->get_envelope_auth_headers($method, $url);
         $lines = ['Accept: application/json', 'Expect:'];
         foreach ($headers as $name => $value) {
             $lines[] = $name . ': ' . $value;
@@ -1109,7 +1175,7 @@ class MultipartPushStreamClient
     private function endpoint_url(string $endpoint, array $parameters): string
     {
         $parameters = array_merge(['endpoint' => $endpoint], $parameters);
-        return $this->base_url . (strpos($this->base_url, '?') === false ? '?' : '&') . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
+        return $this->base_url . ( strpos( $this->base_url, '?' ) === false ? '?' : '&' ) . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
     }
 
     /**

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -4,118 +4,180 @@ When working from this monorepo checkout, run `composer install` in
 `reprint-exporter-wp/` to populate the bundled `vendor/` directory used by the
 plugin runtime. GitHub release ZIPs already include that vendor tree.
 
-## API Routing
+## HTTP routes
 
-Many shared hosts (SiteGround, GoDaddy, etc.) block direct PHP execution inside `wp-content/plugins/` at the web server level, returning a 403 before the request ever reaches PHP. To work around this, export API requests are routed through WordPress's front controller (`index.php` at the site root), which hosts never block.
+The plugin exposes separate URLs for pull and push because they have different
+boot requirements.
 
-### How it works
+### Download route
 
-The plugin file (`index.php`) is `include`'d by WordPress during its plugin loading loop — this happens *before* the `plugins_loaded` hook fires, making it the earliest interception point available to a regular plugin.
+Many shared hosts block direct PHP execution below `wp-content/plugins/`.
+Pull requests therefore use WordPress's front controller:
 
-When a request arrives at `https://example.com/?reprint-api` (or the legacy `?site-export-api` alias, kept for backwards compatibility), the plugin:
+```text
+https://example.com/?reprint-api
+```
 
-1. Detects `$_GET['reprint-api']` or `$_GET['site-export-api']` during plugin file load
-2. Reverts WordPress error display settings (`display_errors`, `html_errors`) that `wp_debug_mode()` may have turned on
-3. Clears any output buffering WordPress started
-4. Sets up error handlers, HMAC auth, and runs the export endpoint
-5. Calls `exit` — WordPress never finishes booting
+The legacy `?site-export-api` query remains available. WordPress includes the
+plugin before `plugins_loaded`; the plugin sees the query, authenticates the
+request, dispatches it, and exits before WordPress finishes booting.
 
-This gives us a clean execution environment while using WordPress's front controller as the entry point.
-
-### Platform configuration
-
-The bundled WordPress entry point passes the result of the
-`site_export_api_options` filter to the export handler. A platform must
-register this filter before the regular Reprint Exporter plugin file loads;
-registering it on `plugins_loaded` is too late. A must-use plugin is the usual
-place to register it:
+A platform may replace the built-in authentication through an early
+`site_export_api_options` filter. Register it before regular plugins load, such
+as from a must-use plugin:
 
 ```php
 add_filter('site_export_api_options', static function (array $options): array {
-    $options['docroot'] = '/srv/www/public';
-    $options['reprint_directory'] = '/srv/www/.reprint';
+    $options['authenticate'] = static function (): void {
+        if (!my_auth_check()) {
+            _site_export_error(403, 'Unauthorized');
+        }
+    };
     return $options;
 });
 ```
 
-The supported options are:
+This filter applies to the WordPress download route only. Push does not pass
+through WordPress.
 
-- `authenticate` — a callback that authenticates every non-preflight API
-  request instead of the built-in HMAC verifier. For a push request, this
-  callback must authenticate from request metadata without reading or
-  buffering `php://input`; the endpoint streams that body after authentication.
-- `docroot` — the document root for push. It must resolve to an
-  existing directory and defaults to `$_SERVER['DOCUMENT_ROOT']`.
-- `reprint_directory` — the private push storage directory outside `docroot`.
-  It defaults to a document-root-specific sibling directory.
-- `excluded_paths` — document-root-relative paths that push must preserve. The
-  exporter plugin directory is also preserved automatically when it is below
-  `docroot`.
-- `maximum_part_bytes` — the maximum `Content-Length` accepted for one push
-  upload part. It defaults to 4 MiB.
-- `maximum_commit_entries` — the maximum number of bounded entries processed
-  by one `push_commit` request. It defaults to 256.
+### Push route
+
+Every push operation uses a standalone PHP route. This includes
+`push_create`, so `files-push` can start a new push when a prior push left
+WordPress unable to boot. The WordPress route rejects all `push_*` requests.
+
+The bundled URL is:
+
+```text
+https://example.com/wp-content/plugins/reprint-exporter/push.php
+```
+
+The exact URL is shown on the **Reprint Exporter** settings screen after push
+access is enabled. Give this URL, not `?reprint-api`, to `files-push`:
+
+```bash
+php reprint.phar files-push "https://example.com/wp-content/plugins/reprint-exporter/push.php" \
+  --state-dir="/path/to/reprint-state" \
+  --fs-root="/path/to/local-tree" \
+  --secret="the-target-connection-token"
+```
+
+`push.php` loads Reprint but does not load WordPress, `wp-load.php`, themes, or
+plugins. It reads the canonical document root from `DOCUMENT_ROOT`. Its
+private reprint directory is a document-root-specific sibling:
+
+```text
+<parent-of-document-root>/.reprint-<first-12-sha256-characters>/.reprint/
+```
+
+The route excludes its own plugin directory from push. This keeps the push
+route available even when the pushed tree would otherwise replace or delete it.
+
+The connection token used to create new push sessions is stored in:
+
+```text
+<reprint-directory>/.reprint/push-config.php
+```
+
+The file has mode 0600 and returns an array with `connection_secret`. It is
+outside the document root and prints nothing when PHP executes it. Enabling
+push access writes this file. Disabling push access or rotating the token
+removes it.
+
+`push_create` authenticates with that connection secret and returns a random
+secret scoped to the new push session. Upload, status, commit, and remove use
+the session secret at the same URL. The target stores it in the session's
+mode-0600 `push-metadata.php`; `files-push` stores its copy in the local pair's
+mode-0600 `sender.json`. Neither secret is sent in a URL or request body.
+
+Removing `push-config.php` blocks new sessions. It does not break a session
+which already has its own secret, so an in-progress commit can still finish.
+
+### Hosts which block the bundled push URL
+
+A host which blocks direct PHP below `wp-content/plugins`, or which needs a
+custom document root or reprint directory, must expose another PHP URL which
+does not load WordPress. The host owns this route and its private configuration.
+For example:
+
+```php
+<?php
+require_once '/srv/reprint-exporter/vendor/autoload.php';
+
+$connection_secret = null;
+if (($_GET['endpoint'] ?? null) === 'push_create' && is_file('/srv/reprint/push-config.php')) {
+    $connection_secret = Site_Export_HTTP_Server::load_push_connection_secret(
+        '/srv/reprint/push-config.php'
+    );
+}
+
+Site_Export_HTTP_Server::serve_push([
+    'connection_secret' => $connection_secret,
+    'docroot' => '/srv/www/public',
+    'reprint_directory' => '/srv/reprint',
+    'excluded_paths' => ['reprint-push.php'],
+]);
+```
+
+The configuration file should return an array, produce no output, and be
+readable only by the web-server account. Read it only for `push_create`;
+created sessions authenticate from their own private metadata. The document
+root, reprint directory, and excluded paths are server configuration, never
+request parameters. Give this route's URL directly to `files-push`.
+
+If the custom route is outside the document root, it does not need to exclude
+itself. If it is inside, its document-root-relative directory must be in
+`excluded_paths`.
 
 ## Push access
 
-Connection tokens authorize downloads only by default. This also applies to
-tokens that already existed when the plugin was upgraded; no migration enables
-push access. A site administrator can grant push access from the plugin settings
-page. The grant stores a fingerprint of the current connection token, so rotating
-that token revokes the grant and requires fresh consent.
+Connection tokens authorize downloads only by default, including tokens which
+predate push support. A site administrator can grant the current token push
+access from the plugin settings page. The grant stores a token fingerprint in
+WordPress and the token itself in the private PHP configuration described
+above. Rotating the token revokes the grant.
 
-Hosts can manage push access before active plugins load with an immutable boolean:
+Hosts can manage push access before active plugins load with a boolean:
 
 ```php
 define('SITE_EXPORT_PUSH_ENABLED', true);
 ```
 
-The `SITE_EXPORT_PUSH_ENABLED` environment variable accepts the same boolean
-policy. The constant wins when both are present. `true` enables push without a
-local grant; `false` hard-disables push even when a local grant exists. The sole
-recovery exception lets an authenticated caller finish a commit which already
-has a durable checkpoint, so revocation cannot strand a partially changed
-document root. It cannot start commit or use any other push operation until
-push is authorized again. Managed sites show the effective state as read-only
-in WordPress admin. Custom authentication does not bypass this authorization
-gate.
+The `SITE_EXPORT_PUSH_ENABLED` environment variable accepts the same values.
+The constant wins when both are present. Managed `true` writes the current
+token to the standalone configuration; managed `false` removes it. Managed
+sites show push access as read-only in WordPress admin.
 
-## Using as a library
+Disabling push prevents new session creation. Existing session secrets remain
+valid so their work can reach a terminal result; this avoids stranding a
+partially changed document root.
 
-The export engine can be embedded in another PHP project without the WordPress plugin wrapper. Require `lib.php` instead of `index.php` — it defines constants and functions but does not handle any HTTP requests or check any URLs.
+## Using the download route as a library
+
+The pull engine can be embedded in another PHP project without the plugin's URL
+check. Require `lib.php` instead of `index.php`; it declares functions but does
+not handle a request by itself.
 
 ```php
-// Your project must define ABSPATH before requiring lib.php.
+// lib.php expects the WordPress path constants and plugin_dir_path().
 define('ABSPATH', '/path/to/wordpress/');
 
 require_once '/path/to/reprint-exporter-wp/lib.php';
 
-// Route however you like — lib.php doesn't check URLs.
 if ($myRouter->matches('/export')) {
-    // Use default HMAC authentication (reads secret.php when present,
-    // otherwise falls back to the site option):
     _site_export_handle_api_request();
-
-    // Or supply your own authentication:
-    _site_export_handle_api_request([
-        'authenticate' => function () {
-            if (!my_auth_check()) {
-                _site_export_error(403, 'Unauthorized');
-            }
-        },
-    ]);
 }
 ```
 
-`_site_export_handle_api_request()` accepts the same options documented under
-Platform configuration. Direct `lib.php` embedders pass them as the function's
-array argument and do not use the WordPress filter.
+Supply an `authenticate` callback to `_site_export_handle_api_request()` to
+replace its built-in pull authentication. Use
+`Site_Export_HTTP_Server::serve_push()` for a standalone push route instead.
 
-`lib.php` defines these constants (using WordPress's `plugin_dir_path`):
+`lib.php` defines these constants:
 
 - `SITE_EXPORT_VERSION` — plugin version string
 - `SITE_EXPORT_PLUGIN_DIR` — absolute path to the plugin directory
-- `SITE_EXPORT_SECRET_FILE` — optional path to a PHP file that overrides the stored HMAC shared secret
-- `SITE_EXPORT_SECRET_OPTION` — WordPress site option name used for the stored HMAC shared secret
-- `SITE_EXPORT_PUSH_AUTHORIZATION_OPTION` — WordPress site option containing the token fingerprint granted personal push access
-- `SITE_EXPORT_TIMESTAMP_TOLERANCE` — max request age in seconds (default 300)
+- `SITE_EXPORT_SECRET_FILE` — optional PHP file overriding the stored HMAC shared secret
+- `SITE_EXPORT_SECRET_OPTION` — WordPress option containing the shared secret
+- `SITE_EXPORT_PUSH_AUTHORIZATION_OPTION` — WordPress option containing the token fingerprint granted push access
+- `SITE_EXPORT_TIMESTAMP_TOLERANCE` — maximum request age in seconds

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -166,6 +166,98 @@ function _site_export_update_shared_secret(string $secret): bool {
     return (bool) update_option(SITE_EXPORT_SECRET_OPTION, $secret, false);
 }
 
+/** Returns the private PHP configuration read by the bundled push route. */
+function _site_export_get_push_config_file(): ?string {
+    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted server configuration and must retain exact filesystem bytes.
+    $configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+    if (!is_string($configured_docroot) || $configured_docroot === '') {
+        return null;
+    }
+    $docroot = realpath($configured_docroot);
+    if ($docroot === false || !is_dir($docroot)) {
+        return null;
+    }
+    $docroot = $docroot === '/' ? '/' : rtrim($docroot, '/\\');
+    if (!class_exists('Site_Export_HTTP_Server')) {
+        _site_export_load_exporter_runtime();
+    }
+    if (!class_exists('Site_Export_HTTP_Server')) {
+        return null;
+    }
+    return Site_Export_HTTP_Server::default_reprint_directory($docroot)
+        . '/.reprint/push-config.php';
+}
+
+/** Reads the connection secret granted to the standalone push route. */
+function _site_export_get_push_config_secret(): ?string {
+    $configuration_path = _site_export_get_push_config_file();
+    if ($configuration_path === null) {
+        return null;
+    }
+    return Site_Export_HTTP_Server::load_push_connection_secret($configuration_path);
+}
+
+/** Atomically grants the bundled push route access with the current token. */
+function _site_export_write_push_config(string $connection_secret): bool {
+    if ($connection_secret === '') {
+        return false;
+    }
+    $configuration_path = _site_export_get_push_config_file();
+    if ($configuration_path === null) {
+        return false;
+    }
+    $configuration_directory = dirname($configuration_path);
+    if (
+        !is_dir($configuration_directory)
+        && !@mkdir($configuration_directory, 0700, true)
+        && !is_dir($configuration_directory)
+    ) {
+        return false;
+    }
+    try {
+        $suffix = bin2hex(random_bytes(8));
+    } catch (Throwable $throwable) {
+        return false;
+    }
+    $temporary_path = $configuration_path . '.' . $suffix . '.tmp';
+    // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The private configuration needs a PHP array literal.
+    $contents = "<?php\n\nreturn " . var_export([
+        'connection_secret' => $connection_secret,
+    ], true) . ";\n";
+    if (@file_put_contents($temporary_path, '') !== 0) {
+        return false;
+    }
+    if (!@chmod($temporary_path, 0600)) {
+        @unlink($temporary_path);
+        return false;
+    }
+    if (@file_put_contents($temporary_path, $contents) !== strlen($contents)) {
+        @unlink($temporary_path);
+        return false;
+    }
+    if (!@rename($temporary_path, $configuration_path)) {
+        @unlink($temporary_path);
+        return false;
+    }
+    if (function_exists('opcache_invalidate')) {
+        @opcache_invalidate($configuration_path, true);
+    }
+    return true;
+}
+
+/** Revokes new push-session creation through the bundled push route. */
+function _site_export_remove_push_config(): bool {
+    $configuration_path = _site_export_get_push_config_file();
+    if ($configuration_path === null) {
+        return false;
+    }
+    clearstatcache(true, $configuration_path);
+    if (!file_exists($configuration_path) && !is_link($configuration_path)) {
+        return true;
+    }
+    return @unlink($configuration_path);
+}
+
 /**
  * Returns the hosting provider's push policy, or null when the site controls it.
  *
@@ -195,9 +287,17 @@ function _site_export_is_push_authorized(): bool {
 function _site_export_get_push_authorization_error(): ?string {
     $managed_enabled = _site_export_get_managed_push_enabled();
     if ($managed_enabled !== null) {
-        return $managed_enabled
-            ? null
-            : 'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.';
+        if (!$managed_enabled) {
+            return 'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.';
+        }
+        $secret = _site_export_get_shared_secret();
+        if (
+            $secret === null
+            || !hash_equals($secret, _site_export_get_push_config_secret() ?? '')
+        ) {
+            return 'Push access is enabled by the hosting provider, but the standalone push route is not configured for the current connection token.';
+        }
+        return null;
     }
 
     $secret = _site_export_get_shared_secret();
@@ -208,8 +308,29 @@ function _site_export_get_push_authorization_error(): ?string {
     $authorized_fingerprint = get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '');
     $authorized = is_string($authorized_fingerprint)
         && $authorized_fingerprint !== ''
-        && hash_equals(hash('sha256', $secret), $authorized_fingerprint);
+        && hash_equals(hash('sha256', $secret), $authorized_fingerprint)
+        && hash_equals($secret, _site_export_get_push_config_secret() ?? '');
     return $authorized ? null : 'Push access is disabled for the current connection token.';
+}
+
+/** Copies managed push policy into the configuration read without WordPress. */
+function _site_export_sync_managed_push_config(): bool {
+    $managed_enabled = _site_export_get_managed_push_enabled();
+    if ($managed_enabled === null) {
+        return true;
+    }
+    if (!$managed_enabled) {
+        return _site_export_remove_push_config();
+    }
+    $secret = _site_export_get_shared_secret();
+    if ($secret === null) {
+        return false;
+    }
+    $configured_secret = _site_export_get_push_config_secret();
+    return (
+        is_string($configured_secret)
+        && hash_equals($secret, $configured_secret)
+    ) || _site_export_write_push_config($secret);
 }
 
 /**
@@ -228,15 +349,24 @@ function _site_export_update_push_authorization(bool $enabled): bool {
         return false;
     }
 
-    $fingerprint = '';
+    $fingerprint = $enabled ? hash('sha256', $secret) : '';
     if ($enabled) {
-        $fingerprint = hash('sha256', $secret);
+        if (!_site_export_write_push_config($secret)) {
+            return false;
+        }
+    } elseif (!_site_export_remove_push_config()) {
+        return false;
     }
     if (function_exists('get_option') && get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint) {
         return true;
     }
-
-    return (bool) update_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, $fingerprint, false);
+    if ( (bool) update_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, $fingerprint, false) ) {
+        return true;
+    }
+    if ($enabled) {
+        _site_export_remove_push_config();
+    }
+    return false;
 }
 
 /**
@@ -308,30 +438,8 @@ function _site_export_default_authenticate(): void {
  *
  *     @type callable $authenticate Optional. Authenticates the request.
  *                                  Defaults to _site_export_default_authenticate().
- *     @type string $docroot Optional. Document root for push. Defaults
- *                           to the server's DOCUMENT_ROOT. The configured path
- *                           must resolve to an existing directory.
- *     @type string $reprint_directory Optional. Private push storage path
- *                                     outside the document root.
- *                                     Defaults to a document-root-specific sibling.
- *     @type string[] $excluded_paths Optional. Document-root-relative paths
- *                                    push must preserve. The exporter plugin
- *                                    directory is always included when it is
- *                                    below the document root.
- *     @type int $maximum_part_bytes Optional. Maximum Content-Length for one
- *                                   push upload part. Defaults to 4 MiB.
- *     @type int $maximum_commit_entries Optional. Maximum bounded entries one
- *                                       push_commit request processes. Defaults
- *                                       to 256.
  * }
- * @phpstan-param array{
- *     authenticate?:callable,
- *     docroot?:string,
- *     reprint_directory?:string,
- *     excluded_paths?:string[],
- *     maximum_part_bytes?:int,
- *     maximum_commit_entries?:int
- * } $options
+ * @phpstan-param array{authenticate?:callable} $options
  */
 function _site_export_handle_api_request(array $options = []): void {
     // Revert WordPress error display settings (wp_debug_mode may
@@ -393,68 +501,19 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    // Push requests use envelope authentication: the signature covers the
-    // method and exact request target while TLS protects the streamed body.
-    // The legacy verifier hashes php://input and remains only for the existing
-    // pull endpoints with bounded command bodies. A custom authenticate
-    // callable still runs for every endpoint; its embedder owns that policy.
-    // filter_input, not WP sanitizers: lib.php also runs without WordPress
-    // bootstrapped (hosts that route the API from their own index.php).
     $endpoint = (string) filter_input(INPUT_GET, 'endpoint');
+    if (_site_export_is_push_endpoint($endpoint)) {
+        _site_export_push_error(
+            404,
+            'invalid_request',
+            'Push requests must use the standalone push URL shown on the Reprint Exporter settings screen.'
+        );
+    }
     $authenticate = $options['authenticate'] ?? null;
     if ($authenticate !== null) {
         $authenticate();
-    } elseif (_site_export_is_push_endpoint($endpoint)) {
-        if (_site_export_has_secret_file()) {
-            $secret = _site_export_get_file_secret();
-            if (empty($secret)) {
-                _site_export_push_error(503, 'not_configured', 'Invalid secret.php configuration. Remove it or replace it with a valid shared secret.');
-            }
-        } else {
-            $secret = _site_export_get_option_secret();
-        }
-        if (empty($secret) || !is_string($secret)) {
-            _site_export_push_error(503, 'not_configured', 'Configure the shared secret in WordPress admin under Tools > Reprint Exporter.');
-        }
-        if (!class_exists('Site_Export_HMAC_Server')) {
-            _site_export_load_exporter_runtime();
-        }
-        if (!class_exists('Site_Export_HMAC_Server')) {
-            _site_export_push_error(500, 'filesystem_error', 'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.');
-        }
-        // These exact request-line values are covered by the HMAC; WordPress
-        // slashing or sanitization would verify a different target.
-        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-        $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
-        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-        $request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
-        $hmac_server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
-        $auth_error = $hmac_server->verify_envelope($_SERVER, $request_method, $request_target);
-        if ($auth_error !== null) {
-            _site_export_push_error(403, 'auth_failed', $auth_error);
-        }
     } else {
         _site_export_default_authenticate();
-    }
-
-    // Authentication completes first. Every push operation requires current
-    // authorization except resuming commit from its durable checkpoint, which
-    // must remain available so revocation cannot strand document-root changes.
-    // Push endpoint parameters travel in the query string, so the dispatcher
-    // does not need to read php://input after this gate.
-    $push_authorization_error = null;
-    if (_site_export_is_push_endpoint($endpoint)) {
-        $push_authorization_error = _site_export_get_push_authorization_error();
-    }
-    if (
-        $push_authorization_error !== null
-        && $endpoint !== 'push_commit'
-    ) {
-        _site_export_push_error(
-            403,
-            'push_disabled',
-            $push_authorization_error
-        );
     }
 
     // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server
@@ -470,132 +529,8 @@ function _site_export_handle_api_request(array $options = []): void {
     // -- Dispatch --
     try {
         $server_options = ['default_directory' => ABSPATH];
-        if (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
-            // Push changes the web server's document root. ABSPATH remains the
-            // pull default because it may point at a separate shared core tree.
-            if (array_key_exists('docroot', $options)) {
-                $configured_docroot = $options['docroot'];
-            } else {
-                // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted server configuration and must retain exact filesystem bytes.
-                $configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
-            }
-            if (!is_string($configured_docroot) || $configured_docroot === '') {
-                throw new Site_Export_Push_Configuration_Exception(
-                    'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed '
-                    . json_encode($configured_docroot) . '.'
-                );
-            }
-            $canonical_docroot = realpath($configured_docroot);
-            if ($canonical_docroot === false || !is_dir($canonical_docroot)) {
-                throw new Site_Export_Push_Configuration_Exception(
-                    'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed '
-                    . json_encode($configured_docroot) . '.'
-                );
-            }
-            $docroot = $canonical_docroot === '/' ? '/' : rtrim($canonical_docroot, '/\\');
-            $lexical_docroot = \WordPress\Reprint\Exporter\normalize_path(str_replace('\\', '/', $configured_docroot));
-            $reprint_directory = $options['reprint_directory'] ?? (
-                dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
-            );
-            $excluded_paths = $options['excluded_paths'] ?? [];
-            if (!is_array($excluded_paths)) {
-                throw new Site_Export_Push_Configuration_Exception('excluded_paths must be an array.');
-            }
-            $canonical_plugin_directory = realpath(SITE_EXPORT_PLUGIN_DIR);
-            $plugin_directory = rtrim($canonical_plugin_directory === false ? SITE_EXPORT_PLUGIN_DIR : $canonical_plugin_directory, '/\\');
-            $docroot_relative_offset = $docroot === '/' ? 1 : strlen($docroot) + 1;
-            $logical_plugin_path_added = false;
-            if (defined('WP_PLUGIN_DIR') && function_exists('plugin_basename')) {
-                // Keep the registered installation path lexical until its
-                // document-root-relative name is known. realpath() would turn a
-                // symlinked plugin into its outside target and omit protection.
-                $registered_plugin_file = str_replace('\\', '/', plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'));
-                $registered_plugin_directory = dirname($registered_plugin_file);
-                $logical_plugin_directory = \WordPress\Reprint\Exporter\normalize_path(
-                    str_replace('\\', '/', (string) WP_PLUGIN_DIR)
-                    . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
-                );
-                $logical_plugin_directory_to_verify = $logical_plugin_directory;
-                $logical_plugin_relative_path = null;
-                if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $lexical_docroot)) {
-                    $lexical_docroot_relative_offset = $lexical_docroot === '/' ? 1 : strlen($lexical_docroot) + 1;
-                    $logical_plugin_relative_path = substr($logical_plugin_directory, $lexical_docroot_relative_offset);
-                } elseif (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $docroot)) {
-                    $logical_plugin_relative_path = substr($logical_plugin_directory, $docroot_relative_offset);
-                } else {
-                    // WP_PLUGIN_DIR may itself be a symlink alias into the
-                    // document root. Resolve that parent, but keep the
-                    // registered plugin subdirectory lexical so its installed
-                    // path survives a final symlink to the outside target.
-                    $canonical_wordpress_plugin_directory = realpath( (string) WP_PLUGIN_DIR );
-                    if ($canonical_wordpress_plugin_directory !== false) {
-                        $logical_plugin_directory_from_canonical_parent = \WordPress\Reprint\Exporter\normalize_path(
-                            str_replace('\\', '/', $canonical_wordpress_plugin_directory)
-                            . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
-                        );
-                        if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory_from_canonical_parent, $docroot)) {
-                            $logical_plugin_relative_path = substr($logical_plugin_directory_from_canonical_parent, $docroot_relative_offset);
-                            $logical_plugin_directory_to_verify = $logical_plugin_directory_from_canonical_parent;
-                        }
-                    }
-                }
-                if ($logical_plugin_relative_path !== null) {
-                    $resolved_logical_plugin_directory = realpath($logical_plugin_directory_to_verify);
-                    if (
-                        $logical_plugin_relative_path === ''
-                        || $resolved_logical_plugin_directory === false
-                        || $canonical_plugin_directory === false
-                        || rtrim($resolved_logical_plugin_directory, '/\\') !== $plugin_directory
-                    ) {
-                        throw new Site_Export_Push_Configuration_Exception(
-                            'WordPress reports the Reprint Exporter plugin inside the document root at '
-                            . json_encode($logical_plugin_directory_to_verify)
-                            . ', but that path does not resolve to SITE_EXPORT_PLUGIN_DIR '
-                            . json_encode(SITE_EXPORT_PLUGIN_DIR) . '.'
-                        );
-                    }
-                    $excluded_paths[] = $logical_plugin_relative_path;
-                    $logical_plugin_path_added = true;
-                }
-            }
-            if (
-                !$logical_plugin_path_added
-                && \WordPress\Reprint\Exporter\path_is_within_root($plugin_directory, $docroot)
-                && $plugin_directory !== $docroot
-            ) {
-                $excluded_paths[] = str_replace('\\', '/', substr($plugin_directory, $docroot_relative_offset));
-            }
-            $push_options = [
-                'reprint_directory' => $reprint_directory,
-                'docroot' => $docroot,
-                'excluded_paths' => $excluded_paths,
-            ];
-            if (array_key_exists('maximum_part_bytes', $options)) {
-                $push_options['maximum_part_bytes'] = $options['maximum_part_bytes'];
-            }
-            if (array_key_exists('maximum_commit_entries', $options)) {
-                $push_options['maximum_commit_entries'] = $options['maximum_commit_entries'];
-            }
-            if ($push_authorization_error !== null) {
-                $push_options['commit_start_denial_detail'] = $push_authorization_error;
-            }
-            $server_options['push'] = $push_options;
-        }
         Site_Export_HTTP_Server::serve($server_options);
     } catch (Exception $e) {
-        if (_site_export_is_push_endpoint($endpoint)) {
-            if ($e instanceof Site_Export_Push_Configuration_Exception) {
-                _site_export_push_error(503, 'not_configured', $e->getMessage());
-            }
-            if ($e instanceof InvalidArgumentException) {
-                _site_export_push_error(400, 'invalid_request', $e->getMessage());
-            }
-            _site_export_push_error(
-                500,
-                'filesystem_error',
-                'The push endpoint failed while processing the request.'
-            );
-        }
         if (!headers_sent()) {
             http_response_code(400);
             header('Content-Type: application/json');

--- a/reprint-exporter-wp/push.php
+++ b/reprint-exporter-wp/push.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Standalone push route for the plugin's default document root.
+ *
+ * This file deliberately does not load WordPress. Hosting integrations which
+ * override the push document root or reprint directory must expose their own
+ * route with the same server-owned paths.
+ */
+
+@ini_set('display_errors', '0');
+@ini_set('html_errors', '0');
+
+$site_export_plugin_directory = __DIR__ . '/';
+$site_export_repo_root = dirname(__DIR__);
+$site_export_runtime = null;
+foreach ([
+    [
+        'autoload' => $site_export_plugin_directory . 'vendor/autoload.php',
+        'http_server' => $site_export_plugin_directory . 'vendor/wp-php-toolkit/reprint-exporter/src/class-http-server.php',
+    ],
+    [
+        'autoload' => $site_export_repo_root . '/vendor/autoload.php',
+        'http_server' => $site_export_repo_root . '/vendor/wp-php-toolkit/reprint-exporter/src/class-http-server.php',
+    ],
+] as $site_export_candidate) {
+    if (
+        is_file($site_export_candidate['autoload'])
+        && is_file($site_export_candidate['http_server'])
+    ) {
+        $site_export_runtime = $site_export_candidate;
+        break;
+    }
+}
+if ($site_export_runtime === null) {
+    _site_export_push_route_error(
+        'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
+    );
+}
+require_once $site_export_runtime['autoload'];
+require_once $site_export_runtime['http_server'];
+
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted server configuration and must retain exact filesystem bytes.
+$site_export_configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+if (!is_string($site_export_configured_docroot) || $site_export_configured_docroot === '') {
+    _site_export_push_route_error('The push route requires DOCUMENT_ROOT to name an existing directory.');
+}
+$site_export_docroot = realpath($site_export_configured_docroot);
+if ($site_export_docroot === false || !is_dir($site_export_docroot)) {
+    _site_export_push_route_error(
+        'The push route requires DOCUMENT_ROOT to name an existing directory; observed '
+        . json_encode($site_export_configured_docroot) . '.'
+    );
+}
+$site_export_docroot = $site_export_docroot === '/' ? '/' : rtrim($site_export_docroot, '/\\');
+$site_export_reprint_directory = Site_Export_HTTP_Server::default_reprint_directory($site_export_docroot);
+
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- SCRIPT_FILENAME is trusted server configuration and must retain exact filesystem bytes.
+$site_export_script_filename = $_SERVER['SCRIPT_FILENAME'] ?? null;
+if (!is_string($site_export_script_filename) || $site_export_script_filename === '') {
+    _site_export_push_route_error('The push route requires SCRIPT_FILENAME to identify its excluded path.');
+}
+// Keep the route directory lexical until its document-root-relative name is
+// known. realpath() may turn a symlinked plugin into an outside target and
+// would then omit the installed route from the push exclusions.
+$site_export_route_directory = \WordPress\Reprint\Exporter\normalize_path(
+    str_replace('\\', '/', dirname($site_export_script_filename))
+);
+$site_export_lexical_docroot = rtrim(
+    \WordPress\Reprint\Exporter\normalize_path(str_replace('\\', '/', $site_export_configured_docroot)),
+    '/'
+);
+$site_export_lexical_docroot = $site_export_lexical_docroot === '' ? '/' : $site_export_lexical_docroot;
+$site_export_normalized_docroot = str_replace('\\', '/', $site_export_docroot);
+$site_export_route_relative_path = null;
+foreach (array_unique([$site_export_lexical_docroot, $site_export_normalized_docroot]) as $site_export_route_docroot) {
+    $site_export_docroot_prefix = $site_export_route_docroot === '/'
+        ? '/'
+        : $site_export_route_docroot . '/';
+    if (strpos($site_export_route_directory . '/', $site_export_docroot_prefix) === 0) {
+        $site_export_docroot_relative_offset = $site_export_route_docroot === '/'
+            ? 1
+            : strlen($site_export_route_docroot) + 1;
+        $site_export_route_relative_path = substr(
+            $site_export_route_directory,
+            $site_export_docroot_relative_offset
+        );
+        break;
+    }
+}
+$site_export_canonical_route_directory = realpath($site_export_route_directory);
+$site_export_canonical_plugin_directory = realpath(__DIR__);
+if (
+    $site_export_route_relative_path === null
+    || $site_export_canonical_route_directory === false
+    || $site_export_canonical_plugin_directory === false
+    || rtrim($site_export_canonical_route_directory, '/\\') !== rtrim($site_export_canonical_plugin_directory, '/\\')
+) {
+    _site_export_push_route_error(
+        'The push route must run from the Reprint Exporter directory below DOCUMENT_ROOT so that directory can be excluded from push.'
+    );
+}
+if ($site_export_route_relative_path === '') {
+    _site_export_push_route_error('The push route directory must not be the document root.');
+}
+
+$site_export_connection_secret = null;
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput -- The endpoint is validated by serve_push() and authenticated from the exact signed request target.
+$site_export_endpoint = $_GET['endpoint'] ?? null;
+if ($site_export_endpoint === 'push_create') {
+    $site_export_push_configuration_path = $site_export_reprint_directory . '/.reprint/push-config.php';
+    if (file_exists($site_export_push_configuration_path) || is_link($site_export_push_configuration_path)) {
+        $site_export_connection_secret = Site_Export_HTTP_Server::load_push_connection_secret(
+            $site_export_push_configuration_path
+        );
+        if ($site_export_connection_secret === null) {
+            _site_export_push_route_error(
+                'The private push configuration must be a PHP file which returns a non-empty connection_secret without producing output.'
+            );
+        }
+    }
+    $site_export_managed_push_enabled = getenv('SITE_EXPORT_PUSH_ENABLED');
+    if (
+        $site_export_managed_push_enabled !== false
+        && filter_var($site_export_managed_push_enabled, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== true
+    ) {
+        $site_export_connection_secret = null;
+    }
+}
+
+Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('*');
+Site_Export_HTTP_Server::serve_push([
+    'connection_secret' => $site_export_connection_secret,
+    'reprint_directory' => $site_export_reprint_directory,
+    'docroot' => $site_export_docroot,
+    'excluded_paths' => [$site_export_route_relative_path],
+]);
+
+/** Sends one push-route configuration failure without loading WordPress. */
+function _site_export_push_route_error(string $detail): void {
+    http_response_code(503);
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Content-Type: application/json');
+    echo json_encode([
+        'status' => 'rejected',
+        'reason' => 'not_configured',
+        'detail' => $detail,
+    ]);
+    exit;
+}

--- a/reprint-exporter-wp/wordpress/site-export.php
+++ b/reprint-exporter-wp/wordpress/site-export.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Admin interface for Reprint Exporter plugin.
+ * Admin interface for the Reprint Exporter plugin.
  *
  * This plugin provides a WordPress admin UI for configuring the export API.
- * The export API is triggered via `?reprint-api` (or the legacy
+ * The pull API is triggered via `?reprint-api` (or the legacy
  * `?site-export-api` alias) during plugin load,
  * before WordPress finishes booting. It reads the secret from a site option,
  * with secret.php supported only as an override when present.
  *
- * Authentication uses HMAC signatures: the importing side generates a secret,
- * the user enters it here, and all requests must include a valid signature
- * computed from the nonce, timestamp, and request content hash.
+ * The separate push.php route does not load WordPress. This screen grants the
+ * current connection token access to that route and shows its URL.
  */
 class Site_Export_Plugin {
 
@@ -24,6 +23,7 @@ class Site_Export_Plugin {
     }
 
     private function __construct() {
+        _site_export_sync_managed_push_config();
         add_action('init', [$this, 'register_settings']);
         add_action(
             'update_option_' . SITE_EXPORT_SECRET_OPTION,
@@ -197,6 +197,7 @@ class Site_Export_Plugin {
         $stored_secret = _site_export_get_option_secret();
         $effective_secret = _site_export_get_shared_secret() ?? '';
         $api_url = home_url('?reprint-api');
+        $push_url = plugin_dir_url(SITE_EXPORT_PLUGIN_DIR . 'index.php') . 'push.php';
         $is_configured = $effective_secret !== '';
         $has_file_override = _site_export_has_secret_file();
         $managed_push_enabled = _site_export_get_managed_push_enabled();
@@ -432,13 +433,26 @@ class Site_Export_Plugin {
 
             <?php if ($is_configured): ?>
             <div class="site-export-card">
-                <h2>API Endpoint</h2>
+                <h2>Download endpoint</h2>
                 <p class="card-desc">
-                    If your import tool asks for an endpoint URL, copy this:
+                    Use this URL to pull the site:
                 </p>
                 <div class="site-export-endpoint">
                     <code id="site-export-api-url"><?php echo esc_html($api_url); ?></code>
-                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl()">Copy</button>
+                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl('site-export-api-url', this)">Copy</button>
+                </div>
+            </div>
+            <?php endif; ?>
+
+            <?php if ($push_enabled): ?>
+            <div class="site-export-card">
+                <h2>Push endpoint</h2>
+                <p class="card-desc">
+                    Use this URL with <code>files-push</code>. It remains available when WordPress cannot boot.
+                </p>
+                <div class="site-export-endpoint">
+                    <code id="site-export-push-url"><?php echo esc_html($push_url); ?></code>
+                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl('site-export-push-url', this)">Copy</button>
                 </div>
             </div>
             <?php endif; ?>
@@ -449,13 +463,12 @@ class Site_Export_Plugin {
             var input = document.getElementById('site_export_secret');
             input.type = input.type === 'password' ? 'text' : 'password';
         }
-        function siteExportCopyUrl() {
-            var url = document.getElementById('site-export-api-url').textContent.trim();
+        function siteExportCopyUrl(elementId, button) {
+            var url = document.getElementById(elementId).textContent.trim();
             navigator.clipboard.writeText(url).then(function() {
-                var btn = document.querySelector('.site-export-copy-btn');
-                var original = btn.textContent;
-                btn.textContent = 'Copied!';
-                setTimeout(function() { btn.textContent = original; }, 1500);
+                var original = button.textContent;
+                button.textContent = 'Copied!';
+                setTimeout(function() { button.textContent = original; }, 1500);
             });
         }
         </script>

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -119,16 +119,15 @@ final class ExportHttpServerTest extends TestCase
             is_callable([$server, 'is_push_endpoint']),
             'The HTTP server must expose its push endpoint classification.'
         );
-
         foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'] as $endpoint) {
             $this->assertTrue($server->is_push_endpoint($endpoint), $endpoint);
         }
-        foreach (['preflight', 'file_index', 'unknown'] as $endpoint) {
+        foreach (['preflight', 'file_index', 'push_future', 'unknown'] as $endpoint) {
             $this->assertFalse($server->is_push_endpoint($endpoint), $endpoint);
         }
     }
 
-    public function testDefaultHandlersMatchPushEndpointMethodRegistry(): void
+    public function testDefaultHandlersRegisterEveryPushOperationOnce(): void
     {
         $root = sys_get_temp_dir() . '/export-http-server-' . bin2hex(random_bytes(6));
         $docroot = $root . '/docroot';
@@ -147,6 +146,7 @@ final class ExportHttpServerTest extends TestCase
             $handlers_property = new ReflectionProperty(Site_Export_HTTP_Server::class, 'handlers');
             $handlers_property->setAccessible(true);
             $handlers = $handlers_property->getValue($server);
+            $this->assertIsArray($handlers);
             $registered_push_endpoint_methods = [];
             foreach ($handlers as $endpoint => $handler) {
                 if (strpos($endpoint, 'push_') !== 0) {
@@ -156,7 +156,6 @@ final class ExportHttpServerTest extends TestCase
                 $this->assertInstanceOf(Site_Export_Push_Endpoints::class, $handler[0]);
                 $registered_push_endpoint_methods[$endpoint] = $handler[1];
             }
-
             $this->assertSame([
                 'push_create' => 'create',
                 'push_upload' => 'upload',

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -21,7 +21,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -155,7 +155,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -189,7 +189,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -221,7 +221,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'start_bytes' => 512,
             'max_bytes' => 512,
         ]);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -262,6 +262,20 @@ final class MultipartPushStreamClientTest extends TestCase {
         ]);
     }
 
+    public function testUploadRequiresPushSessionAuthentication(): void {
+        if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
+        }
+        $client = new MultipartPushStreamClient([
+            'base_url' => 'https://example.test/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+        ]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('before set_push_session_hmac_client()');
+        $client->start_upload_request(str_repeat('a', 32));
+    }
+
     public function testRawHttp413LearnsASmallerRequestCeilingWithoutRequiringJson(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
@@ -269,7 +283,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -318,7 +332,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'start_bytes' => 512,
             'max_bytes' => 2048,
         ]);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -352,7 +366,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -397,7 +411,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -476,7 +490,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'connect_timeout' => 2,
             'response_timeout' => 2,
         ]);
-        $result = $client->send_push_request('POST', 'push_create', [
+        $result = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => str_repeat('7', 32),
         ], ['created']);
         pcntl_waitpid($child, $status);
@@ -540,7 +554,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -633,7 +647,7 @@ final class MultipartPushStreamClientTest extends TestCase {
                 'response_timeout' => 2,
             ]);
             if ($case === 'redirect') {
-                $result = $client->send_push_request('POST', 'push_create', [
+                $result = $client->send_connection_request('POST', 'push_create', [
                     'push_session_id' => str_repeat('8', 32),
                 ], ['created']);
                 $this->assertSame('failed', $result['status']);
@@ -643,7 +657,7 @@ final class MultipartPushStreamClientTest extends TestCase {
                     $result['detail']
                 );
             } else {
-                $result = $client->send_push_request('POST', 'push_create', [
+                $result = $client->send_connection_request('POST', 'push_create', [
                     'push_session_id' => str_repeat('9', 32),
                 ], ['created']);
                 $this->assertSame('failed', $result['status']);
@@ -664,7 +678,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -707,7 +721,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -790,7 +804,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -871,7 +885,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newPushSessionClient([
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -899,6 +913,21 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertGreaterThan(1.0, $elapsed);
         $this->assertTrue($sent, (string) json_encode($result));
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
+    }
+
+    /**
+     * @param array $options {
+     *     Client options for one raw push route.
+     *
+     *     @type string                  $base_url    Route URL.
+     *     @type Site_Export_HMAC_Client $hmac_client Route signer.
+     * }
+     * @phpstan-param array{base_url:string,hmac_client:Site_Export_HMAC_Client,...} $options
+     */
+    private function newPushSessionClient(array $options): MultipartPushStreamClient {
+        $client = new MultipartPushStreamClient($options);
+        $client->set_push_session_hmac_client($options['hmac_client']);
+        return $client;
     }
 
     private function read_available($connection): string {

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -816,7 +816,9 @@ final class PushCommitTest extends TestCase {
             $this->reprint_directory,
             $this->docroot,
             ['wp-content/plugins/reprint'],
-            $id
+            $id,
+            4194304,
+            256
         );
     }
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -30,8 +30,11 @@ final class PushEndpointsTest extends TestCase {
     private string $docroot_configuration_path;
     private string $excluded_paths_configuration_path;
     private string $gate_endpoint_configuration_path;
+    private string $bundled_push_route_configuration_path;
     private string $gate_ready_path;
     private string $gate_release_path;
+    private string $wordpress_defunct_path;
+    private string $push_session_while_wordpress_defunct_path;
     private string $base_url;
 
     protected function setUp(): void
@@ -52,8 +55,11 @@ final class PushEndpointsTest extends TestCase {
         $this->docroot_configuration_path = $this->root . '/docroot-configuration.json';
         $this->excluded_paths_configuration_path = $this->root . '/excluded-paths.json';
         $this->gate_endpoint_configuration_path = $this->root . '/gate-endpoint';
+        $this->bundled_push_route_configuration_path = $this->root . '/bundled-push-route';
         $this->gate_ready_path = $this->root . '/gate-ready';
         $this->gate_release_path = $this->root . '/gate-release';
+        $this->wordpress_defunct_path = $this->docroot . '/wp-content/plugins/defunct/defunct.php';
+        $this->push_session_while_wordpress_defunct_path = $this->root . '/push-session-while-wordpress-defunct';
         mkdir($this->wordpress_root, 0700, true);
         mkdir($this->reprint_directory, 0700, true);
         file_put_contents($this->secret_configuration_path, self::SECRET);
@@ -62,6 +68,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->custom_auth_configuration_path, '');
         file_put_contents($this->reprint_configuration_path, $this->reprint_directory);
         file_put_contents($this->gate_endpoint_configuration_path, '');
+        file_put_contents($this->bundled_push_route_configuration_path, '');
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
         ]);
@@ -81,66 +88,27 @@ final class PushEndpointsTest extends TestCase {
         parent::tearDown();
     }
 
-    public function testExistingTokenCannotUsePushEndpointsWithoutAuthorization(): void
+    public function testExistingTokenCannotCreatePushSessionWithoutAuthorization(): void
     {
         file_put_contents($this->push_authorization_configuration_path, '');
         $push_session_id = str_repeat('0', 32);
 
-        $authentication = $this->requestPushEndpoint(
-            'not-the-server-secret',
+        $response = $this->requestPushEndpoint(
+            self::SECRET,
             'POST',
             'push_create',
             $push_session_id
         );
-        $this->assertSame(403, $authentication['http_code']);
-        $this->assertSame('auth_failed', $authentication['response']['reason']);
 
-        $requests = [
-            ['POST', 'push_create', null, null],
-            ['POST', 'push_upload', 'not a multipart body', 'application/octet-stream'],
-            ['GET', 'push_status', null, null],
-            ['POST', 'push_commit', null, null],
-            ['POST', 'push_remove', null, null],
-        ];
-        foreach ($requests as [$method, $endpoint, $body, $content_type]) {
-            $response = $this->requestPushEndpoint(
-                self::SECRET,
-                $method,
-                $endpoint,
-                $push_session_id,
-                $body,
-                $content_type
-            );
-            $this->assertSame(403, $response['http_code'], $endpoint . ': ' . $response['body']);
-            $this->assertSame('rejected', $response['response']['status']);
-            $this->assertSame('push_disabled', $response['response']['reason']);
-        }
-
-        $future_endpoint = $this->requestPushEndpoint(
-            self::SECRET,
-            'POST',
-            'push_future_operation',
-            $push_session_id
-        );
-        $this->assertSame(403, $future_endpoint['http_code']);
-        $this->assertSame('push_disabled', $future_endpoint['response']['reason']);
-
-        $overridden_commit = $this->requestPushEndpoint(
-            self::SECRET,
-            'POST',
-            'push_commit',
-            $push_session_id,
-            'endpoint=push_create&push_session_id=' . str_repeat('1', 32),
-            'application/x-www-form-urlencoded'
-        );
-        $this->assertSame(403, $overridden_commit['http_code'], $overridden_commit['body']);
-        $this->assertSame('push_disabled', $overridden_commit['response']['reason']);
+        $this->assertSame(403, $response['http_code'], $response['body']);
+        $this->assertSame('rejected', $response['response']['status']);
+        $this->assertSame('push_disabled', $response['response']['reason']);
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push');
         $this->assertSame('old', file_get_contents($this->docroot . '/remove.txt'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
     }
 
-    public function testAuthorizedFuturePushEndpointUsesPushErrorContract(): void
+    public function testUnknownPushEndpointIsRejectedByThePushRoute(): void
     {
         $response = $this->requestPushEndpoint(
             self::SECRET,
@@ -149,10 +117,10 @@ final class PushEndpointsTest extends TestCase {
             str_repeat('f', 32)
         );
 
-        $this->assertSame(400, $response['http_code'], $response['body']);
+        $this->assertSame(404, $response['http_code'], $response['body']);
         $this->assertSame('rejected', $response['response']['status']);
         $this->assertSame('invalid_request', $response['response']['reason']);
-        $this->assertStringContainsString('Invalid endpoint', $response['response']['detail']);
+        $this->assertStringContainsString('push route accepts', $response['response']['detail']);
         $this->assertArrayNotHasKey('error', $response['response']);
         $this->assertArrayNotHasKey('trace', $response['response']);
     }
@@ -225,27 +193,28 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(403, $managed_disabled['http_code'], $managed_disabled['body']);
         $this->assertSame('push_disabled', $managed_disabled['response']['reason']);
         $this->assertSame(
-            'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.',
+            'Push access is disabled for new push sessions.',
             $managed_disabled['response']['detail']
         );
     }
 
-    public function testRevokedAuthorizationCannotStartCommit(): void
+    public function testCreatedPushSessionCanStartCommitAfterAuthorizationIsRevoked(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('6', 32);
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->configurePushSessionAuthentication($client, $create['response']);
 
         $upload = $this->sendUploadRequest($client, $push_session_id, [
             [
                 'type' => 'file',
-                'path' => 'must-not-install.txt',
+                'path' => 'installed-after-revocation.txt',
                 'total_bytes' => 4,
                 'offset' => 0,
-                'payload' => 'deny',
+                'payload' => 'work',
             ],
             [
                 'type' => 'delete-list',
@@ -257,31 +226,30 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
 
         file_put_contents($this->push_authorization_configuration_path, '');
-        $commit = $this->requestPushEndpoint(
-            self::SECRET,
-            'POST',
-            'push_commit',
-            $push_session_id
-        );
+        do {
+            $commit = $client->send_push_session_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        } while ($commit['response']['send_next_request']);
 
-        $this->assertSame(403, $commit['http_code'], $commit['body']);
-        $this->assertSame('push_disabled', $commit['response']['reason']);
-        $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
-        $this->assertFileDoesNotExist($push_directory . '/commit.json');
-        $this->assertFileDoesNotExist($this->reprint_directory . '/.reprint/push/commit-state');
-        $this->assertFileDoesNotExist($this->docroot . '/.maintenance');
-        $this->assertFileDoesNotExist($this->docroot . '/must-not-install.txt');
-        $this->assertSame('old', file_get_contents($this->docroot . '/remove.txt'));
+        $this->assertSame('work', file_get_contents($this->docroot . '/installed-after-revocation.txt'));
+        $blocked_create = $client->send_connection_request('POST', 'push_create', [
+            'push_session_id' => str_repeat('a', 32),
+        ], ['created']);
+        $this->assertSame('failed', $blocked_create['status']);
+        $this->assertSame('push_disabled', $blocked_create['reason']);
     }
 
-    public function testRevokedAuthorizationAllowsDurableCommitRecovery(): void
+    public function testPushRouteContinuesDurableCommitAfterAuthorizationIsRevoked(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('7', 32);
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->configurePushSessionAuthentication($client, $create['response']);
 
         $upload = $this->sendUploadRequest($client, $push_session_id, [
             [
@@ -300,9 +268,12 @@ final class PushEndpointsTest extends TestCase {
         ]);
         $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
 
-        $commit_before_revocation = null;
+        $commit_before_revocation = $client->send_push_session_request('POST', 'push_commit', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $commit_before_revocation['status'], (string) json_encode($commit_before_revocation));
         for ($request = 0; $request < 10; ++$request) {
-            $commit_before_revocation = $client->send_push_request('POST', 'push_commit', [
+            $commit_before_revocation = $client->send_push_session_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $commit_before_revocation['status'], (string) json_encode($commit_before_revocation));
@@ -317,7 +288,7 @@ final class PushEndpointsTest extends TestCase {
 
         file_put_contents($this->push_authorization_configuration_path, '');
         do {
-            $commit = $client->send_push_request('POST', 'push_commit', [
+            $commit = $client->send_push_session_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
@@ -328,12 +299,102 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileDoesNotExist($this->reprint_directory . '/.reprint/push/commit-state');
     }
 
+    public function testPushRouteUsesConnectionSecretForCreateAndSessionSecretAfterward(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('8', 32);
+        $create = $client->send_connection_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $push_session_secret = $create['response']['push_session_secret'];
+        $this->assertIsString($push_session_secret);
+
+        $wrong_client = $this->newClient(self::SECRET);
+        $wrong_client->set_push_session_hmac_client(
+            new Site_Export_HMAC_Client('wrong-push-session-secret')
+        );
+        $wrong_status = $wrong_client->send_push_session_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('failed', $wrong_status['status']);
+        $this->assertSame('auth_failed', $wrong_status['reason']);
+
+        $session_client = $this->newClient(self::SECRET);
+        $session_client->set_push_session_hmac_client(
+            new Site_Export_HMAC_Client($push_session_secret)
+        );
+        $status = $session_client->send_push_session_request('GET', 'push_status', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $status['status'], (string) json_encode($status));
+        $this->assertSame('receiving_work', $status['response']['phase']);
+        $this->assertSame(4, $status['response']['max_part_bytes']);
+        $this->assertSame(self::POST_MAX_BYTES, $status['response']['post_max_bytes']);
+
+        $second_create = $session_client->send_push_session_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('failed', $second_create['status']);
+        $this->assertSame('auth_failed', $second_create['reason']);
+
+        $upload = $this->sendUploadRequest($session_client, $push_session_id, [
+            [
+                'type' => 'file',
+                'path' => 'session-authentication.txt',
+                'total_bytes' => 4,
+                'offset' => 0,
+                'payload' => 'work',
+            ],
+            [
+                'type' => 'delete-list',
+                'offset' => 0,
+                'complete' => true,
+                'payload' => '',
+            ],
+        ]);
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+
+        do {
+            $commit = $session_client->send_push_session_request('POST', 'push_commit', [
+                'push_session_id' => $push_session_id,
+            ], ['accepted']);
+            $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        } while ($commit['response']['send_next_request']);
+        $this->assertSame('work', file_get_contents($this->docroot . '/session-authentication.txt'));
+
+        $remove = $session_client->send_push_session_request('POST', 'push_remove', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
+        $this->assertTrue($remove['response']['removed']);
+    }
+
+    public function testWordPressRouteRejectsEveryPushRequest(): void
+    {
+        foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'] as $endpoint) {
+            $response = $this->requestPushEndpoint(
+                self::SECRET,
+                $endpoint === 'push_status' ? 'GET' : 'POST',
+                $endpoint,
+                str_repeat('9', 32),
+                null,
+                null,
+                $this->wordpressUrl()
+            );
+            $this->assertSame(404, $response['http_code'], $endpoint . ': ' . $response['body']);
+            $this->assertSame('invalid_request', $response['response']['reason']);
+            $this->assertStringContainsString('standalone push URL', $response['response']['detail']);
+        }
+        $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push');
+    }
+
     public function testPersonalOptInEnablesSignedEndpointsReceiveManyChangesCommitAndRemove(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('a', 32);
 
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
@@ -342,8 +403,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(4, $create['response']['max_part_bytes']);
         $this->assertSame(self::POST_MAX_BYTES, $create['response']['post_max_bytes']);
         $this->assertSame(200, $create['response']['http_code']);
+        $this->configurePushSessionAuthentication($client, $create['response']);
         $client->set_max_part_bytes($create['response']['max_part_bytes']);
-        $client->apply_reported_limits([$create['response']['post_max_bytes']]);
 
         $this->assertTrue($client->start_upload_request($push_session_id));
         $this->assertTrue($client->send_part([
@@ -401,7 +462,7 @@ final class PushEndpointsTest extends TestCase {
             'http_code' => 200,
         ], $upload['response']);
 
-        $status = $client->send_push_request('GET', 'push_status', [
+        $status = $client->send_push_session_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
             'path_b64' => base64_encode('nested/file.bin'),
         ], ['accepted']);
@@ -412,6 +473,8 @@ final class PushEndpointsTest extends TestCase {
             'phase' => 'receiving_work',
             'work_deletes_bytes' => strlen($delete_payload),
             'work_deletes_complete' => true,
+            'max_part_bytes' => 4,
+            'post_max_bytes' => self::POST_MAX_BYTES,
             'path' => [
                 'path_b64' => base64_encode('nested/file.bin'),
                 'state' => 'complete',
@@ -423,7 +486,7 @@ final class PushEndpointsTest extends TestCase {
 
         $commit_requests = 0;
         do {
-            $commit = $client->send_push_request('POST', 'push_commit', [
+            $commit = $client->send_push_session_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
@@ -459,7 +522,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(dirname($this->docroot), dirname($this->reprint_directory));
 
         do {
-            $remove = $client->send_push_request('POST', 'push_remove', [
+            $remove = $client->send_push_session_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
@@ -473,22 +536,31 @@ final class PushEndpointsTest extends TestCase {
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
         clearstatcache(true, $push_directory);
         $this->assertDirectoryDoesNotExist($push_directory);
+        $this->assertSame(1, $this->countEndpointRequests('push_create'));
+        $this->assertSame(1, $this->countEndpointRequests('push_upload'));
+        $this->assertSame(1, $this->countEndpointRequests('push_status'));
+        $this->assertGreaterThan(1, $this->countEndpointRequests('push_commit'));
+        $this->assertGreaterThan(0, $this->countEndpointRequests('push_remove'));
+        foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'] as $endpoint) {
+            $this->assertSame(0, $this->countWordPressEndpointRequests($endpoint));
+        }
     }
 
     public function testPushRemoveReportsCreateRemoveLockContentionWithoutRenamingTheLiveDirectory(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('c', 32);
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->configurePushSessionAuthentication($client, $create['response']);
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
         $push_sessions_directory = dirname($push_directory);
         $lock_process = $this->startLockProcess($push_sessions_directory . '/push-create.lock');
 
         try {
-            $remove = $client->send_push_request('POST', 'push_remove', [
+            $remove = $client->send_push_session_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
         } finally {
@@ -507,10 +579,11 @@ final class PushEndpointsTest extends TestCase {
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('d', 32);
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->configurePushSessionAuthentication($client, $create['response']);
 
         $directory_parts = [];
         for ($index = 0; $index < 270; ++$index) {
@@ -530,7 +603,7 @@ final class PushEndpointsTest extends TestCase {
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
         $push_sessions_directory = dirname($push_directory);
         $tombstone = $push_sessions_directory . '/.removing-' . $push_session_id;
-        $first_remove = $client->send_push_request('POST', 'push_remove', [
+        $first_remove = $client->send_push_session_request('POST', 'push_remove', [
             'push_session_id' => $push_session_id,
         ], ['accepted']);
         $this->assertSame('complete', $first_remove['status'], (string) json_encode($first_remove));
@@ -545,7 +618,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_directory);
         $this->assertDirectoryExists($tombstone);
 
-        $blocked_create = $client->send_push_request('POST', 'push_create', [
+        $blocked_create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('retry', $blocked_create['status'], (string) json_encode($blocked_create));
@@ -558,7 +631,7 @@ final class PushEndpointsTest extends TestCase {
 
         $lock_process = $this->startLockProcess($push_sessions_directory . '/push-create.lock');
         try {
-            $blocked_remove = $client->send_push_request('POST', 'push_remove', [
+            $blocked_remove = $client->send_push_session_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
         } finally {
@@ -572,7 +645,7 @@ final class PushEndpointsTest extends TestCase {
 
         $remove_requests = 0;
         do {
-            $remove = $client->send_push_request('POST', 'push_remove', [
+            $remove = $client->send_push_session_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             ++$remove_requests;
@@ -586,7 +659,7 @@ final class PushEndpointsTest extends TestCase {
             ], $remove['response']);
         } while (!$remove['response']['removed']);
 
-        $repeated_remove = $client->send_push_request('POST', 'push_remove', [
+        $repeated_remove = $client->send_push_session_request('POST', 'push_remove', [
             'push_session_id' => $push_session_id,
         ], ['accepted']);
         $this->assertSame('complete', $repeated_remove['status'], (string) json_encode($repeated_remove));
@@ -599,7 +672,7 @@ final class PushEndpointsTest extends TestCase {
         clearstatcache(true, $tombstone);
         $this->assertDirectoryDoesNotExist($tombstone);
 
-        $recreated = $client->send_push_request('POST', 'push_create', [
+        $recreated = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $recreated['status'], (string) json_encode($recreated));
@@ -625,42 +698,45 @@ final class PushEndpointsTest extends TestCase {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('1', 32);
 
-        $created = $client->send_push_request('POST', 'push_create', [
+        $created = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
-        $reopened = $client->send_push_request('POST', 'push_create', [
+        $reopened = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
 
+        $push_session_secret = $created['response']['push_session_secret'] ?? null;
+        $this->assertIsString($push_session_secret);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/D', $push_session_secret);
         $expected_response = [
             'status' => 'created',
             'push_session_id' => $push_session_id,
             'max_part_bytes' => 4,
             'post_max_bytes' => self::POST_MAX_BYTES,
             'excluded_paths_b64' => $expected_excluded_paths_b64,
+            'push_session_secret' => $push_session_secret,
             'http_code' => 200,
         ];
         $this->assertSame('complete', $created['status'], (string) json_encode($created));
         $this->assertSame($expected_response, $created['response']);
         $this->assertSame('complete', $reopened['status'], (string) json_encode($reopened));
         $this->assertSame($expected_response, $reopened['response']);
-        $push_metadata = json_decode(
-            (string) file_get_contents($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
+        $push_metadata = $this->loadPushMetadata($push_session_id);
         $this->assertSame($expected_excluded_paths_b64, $push_metadata['excluded_paths_b64']);
+        $this->assertSame($push_session_secret, $push_metadata['push_session_secret']);
+        $this->assertSame(4, $push_metadata['maximum_part_bytes']);
+        $this->assertSame(1, $push_metadata['maximum_commit_entries']);
     }
 
     public function testUploadAndMissingPathStatusExposeOnlyDocumentedFields(): void
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('b', 32);
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $this->configurePushSessionAuthentication($client, $create['response']);
 
         $upload = $this->sendUploadRequest($client, $push_session_id, [[
             'type' => 'file',
@@ -683,7 +759,7 @@ final class PushEndpointsTest extends TestCase {
             'http_code' => 200,
         ], $upload['response']);
 
-        $status = $client->send_push_request('GET', 'push_status', [
+        $status = $client->send_push_session_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
             'path_b64' => base64_encode('missing.txt'),
         ], ['accepted']);
@@ -694,6 +770,8 @@ final class PushEndpointsTest extends TestCase {
             'phase' => 'receiving_work',
             'work_deletes_bytes' => 0,
             'work_deletes_complete' => false,
+            'max_part_bytes' => 4,
+            'post_max_bytes' => self::POST_MAX_BYTES,
             'path' => [
                 'path_b64' => base64_encode('missing.txt'),
                 'state' => 'missing',
@@ -706,8 +784,14 @@ final class PushEndpointsTest extends TestCase {
     public function testUploadReportsDeclaredRequestBodyLimitOn413(): void
     {
         $push_session_id = str_repeat('d', 32);
-        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
-        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $create = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $push_session_secret = $create['response']['push_session_secret'];
+        $this->assertIsString($push_session_secret);
+        $url = $this->pushUrl() . '?endpoint=push_upload&push_session_id=' . $push_session_id;
+        $headers = ( new Site_Export_HMAC_Client($push_session_secret) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: multipart/mixed; boundary=oversized-endpoint-test'];
         foreach ($headers as $name => $value) {
             $curl_headers[] = $name . ': ' . $value;
@@ -736,11 +820,12 @@ final class PushEndpointsTest extends TestCase {
     {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('f', 32);
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $this->assertSame(self::POST_MAX_BYTES, $create['response']['post_max_bytes']);
+        $this->configurePushSessionAuthentication($client, $create['response']);
 
         // MultipartPushStreamClient uses CURLOPT_UPLOAD without a known body
         // length, so this reaches the production router as chunked transport.
@@ -780,7 +865,7 @@ final class PushEndpointsTest extends TestCase {
         try {
             $client = $this->newClient(self::SECRET, $base_url);
             $clean_push_session_id = str_repeat('0', 32);
-            $clean_create = $client->send_push_request('POST', 'push_create', [
+            $clean_create = $client->send_connection_request('POST', 'push_create', [
                 'push_session_id' => $clean_push_session_id,
             ], ['created']);
             $this->assertSame('complete', $clean_create['status'], (string) json_encode($clean_create));
@@ -804,6 +889,7 @@ final class PushEndpointsTest extends TestCase {
 
             $clean_upload = $this->sendChunkedUploadRequest(
                 $base_url,
+                $clean_create['response']['push_session_secret'],
                 $clean_push_session_id,
                 $boundary,
                 $multipart_body
@@ -812,12 +898,13 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('accepted', $clean_upload['response']['status']);
 
             $over_limit_push_session_id = str_repeat('1', 32);
-            $over_limit_create = $client->send_push_request('POST', 'push_create', [
+            $over_limit_create = $client->send_connection_request('POST', 'push_create', [
                 'push_session_id' => $over_limit_push_session_id,
             ], ['created']);
             $this->assertSame('complete', $over_limit_create['status'], (string) json_encode($over_limit_create));
             $over_limit_upload = $this->sendChunkedUploadRequest(
                 $base_url,
+                $over_limit_create['response']['push_session_secret'],
                 $over_limit_push_session_id,
                 $boundary,
                 $multipart_body,
@@ -837,7 +924,7 @@ final class PushEndpointsTest extends TestCase {
         try {
             $client = $this->newClient(self::SECRET, $base_url);
             $trailing_byte_push_session_id = str_repeat('2', 32);
-            $create = $client->send_push_request('POST', 'push_create', [
+            $create = $client->send_connection_request('POST', 'push_create', [
                 'push_session_id' => $trailing_byte_push_session_id,
             ], ['created']);
             $this->assertSame('complete', $create['status'], (string) json_encode($create));
@@ -845,6 +932,7 @@ final class PushEndpointsTest extends TestCase {
 
             $trailing_byte_upload = $this->sendChunkedUploadRequest(
                 $base_url,
+                $create['response']['push_session_secret'],
                 $trailing_byte_push_session_id,
                 $boundary,
                 $multipart_body,
@@ -864,16 +952,9 @@ final class PushEndpointsTest extends TestCase {
 
     public function testLogicExceptionUsesGenericServerFailureResponse(): void
     {
-        $endpoints = new Site_Export_Push_Endpoints([
-            'reprint_directory' => $this->reprint_directory,
-            'docroot' => $this->docroot,
-            'excluded_paths' => [],
-        ]);
-        $respond_to_failure = new ReflectionMethod($endpoints, 'respond_to_failure');
-        $respond_to_failure->setAccessible(true);
         http_response_code(200);
         ob_start();
-        $respond_to_failure->invoke($endpoints, new LogicException('Internal multipart invariant failed.'));
+        Site_Export_Push_Endpoints::emit_failure(new LogicException('Internal multipart invariant failed.'));
         $body = (string) ob_get_clean();
 
         $this->assertSame(500, http_response_code());
@@ -887,17 +968,9 @@ final class PushEndpointsTest extends TestCase {
 
     public function testFailureResponseDoesNotExposeInternalExceptionContext(): void
     {
-        $endpoints = new Site_Export_Push_Endpoints([
-            'reprint_directory' => $this->reprint_directory,
-            'docroot' => $this->docroot,
-            'excluded_paths' => [],
-        ]);
-        $respond_to_failure = new ReflectionMethod($endpoints, 'respond_to_failure');
-        $respond_to_failure->setAccessible(true);
         http_response_code(200);
         ob_start();
-        $respond_to_failure->invoke(
-            $endpoints,
+        Site_Export_Push_Endpoints::emit_failure(
             new Site_Export_Push_Exception(
                 Site_Export_Push_Session::ERROR_SAME_DEVICE,
                 'The work and document-root filesystems differ.',
@@ -922,7 +995,7 @@ final class PushEndpointsTest extends TestCase {
 
     public function testInvalidBase64CursorReturnsInvalidRequestBeforePushDispatch(): void
     {
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => str_repeat('9', 32),
             'cursor' => 'not-base64',
         ], ['created']);
@@ -964,7 +1037,7 @@ final class PushEndpointsTest extends TestCase {
 
         $configured_reprint_directory = $this->docroot . '/router-reprint-directory';
         file_put_contents($this->reprint_configuration_path, $configured_reprint_directory);
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => str_repeat('e', 32),
         ], ['created']);
         $this->assertSame('failed', $response['status']);
@@ -986,7 +1059,7 @@ final class PushEndpointsTest extends TestCase {
             'document_root' => $this->root . '/missing-document-root',
         ]);
 
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => str_repeat('4', 32),
         ], ['created']);
 
@@ -1001,14 +1074,14 @@ final class PushEndpointsTest extends TestCase {
         $this->writeDocrootConfiguration([]);
         $push_session_id = str_repeat('a', 32);
 
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
 
         $this->assertSame('failed', $response['status'], (string) json_encode($response));
         $this->assertSame('not_configured', $response['reason']);
         $this->assertSame(
-            'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed null.',
+            'The push route requires docroot to name an existing directory; observed null.',
             $response['detail']
         );
         $this->assertSame(503, $response['response']['http_code']);
@@ -1026,17 +1099,12 @@ final class PushEndpointsTest extends TestCase {
         ]);
         $push_session_id = str_repeat('5', 32);
 
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
 
         $this->assertSame('complete', $response['status'], (string) json_encode($response));
-        $push_metadata = json_decode(
-            (string) file_get_contents($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
+        $push_metadata = $this->loadPushMetadata($push_session_id);
         $this->assertSame(realpath($explicit_docroot), base64_decode($push_metadata['docroot_b64'], true));
         $this->assertNotSame(realpath($this->docroot), base64_decode($push_metadata['docroot_b64'], true));
     }
@@ -1050,7 +1118,7 @@ final class PushEndpointsTest extends TestCase {
             'document_root' => $document_root_link,
         ]);
         $push_session_id = str_repeat('7', 32);
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
 
@@ -1071,7 +1139,7 @@ final class PushEndpointsTest extends TestCase {
     public function testParentSegmentInExcludedPathReturnsNotConfigured(): void
     {
         $this->writeExcludedPaths(['../bad']);
-        $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
+        $response = $this->newClient(self::SECRET)->send_connection_request('POST', 'push_create', [
             'push_session_id' => str_repeat('8', 32),
         ], ['created']);
 
@@ -1100,7 +1168,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame($canonical_plugins_directory, realpath($plugins_directory_alias));
         $plugin_entrypoint_hash = hash_file('sha256', $physical_plugin_directory . '/index.php');
         $this->assertIsString($plugin_entrypoint_hash);
-        $this->writeExcludedPaths([]);
+        $this->writeExcludedPaths([$logical_plugin_path]);
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
             'wp_plugin_dir' => $plugins_directory_alias,
@@ -1110,7 +1178,7 @@ final class PushEndpointsTest extends TestCase {
         $client = $this->newClient(self::SECRET);
         $push_session_id = str_repeat('6', 32);
 
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
@@ -1120,8 +1188,10 @@ final class PushEndpointsTest extends TestCase {
             'max_part_bytes' => 1024,
             'post_max_bytes' => self::POST_MAX_BYTES,
             'excluded_paths_b64' => [base64_encode($logical_plugin_path)],
+            'push_session_secret' => $create['response']['push_session_secret'],
             'http_code' => 200,
         ], $create['response']);
+        $this->configurePushSessionAuthentication($client, $create['response']);
 
         $upload_plugin = $this->sendUploadRequest($client, $push_session_id, [[
             'type' => 'directory',
@@ -1169,12 +1239,16 @@ final class PushEndpointsTest extends TestCase {
         ]);
         $this->assertSame('complete', $upload_sibling['status'], (string) json_encode($upload_sibling));
         $this->assertSame(2, $upload_sibling['parts_sent']);
-        do {
-            $commit = $client->send_push_request('POST', 'push_commit', [
+        $commit = $client->send_push_session_request('POST', 'push_commit', [
+            'push_session_id' => $push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        while ($commit['response']['send_next_request']) {
+            $commit = $client->send_push_session_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
-        } while ($commit['response']['send_next_request']);
+        }
 
         $this->assertSame('safe', file_get_contents($this->docroot . '/' . $sibling_path));
         $this->assertTrue(is_link($logical_plugin_directory));
@@ -1187,7 +1261,7 @@ final class PushEndpointsTest extends TestCase {
     {
         file_put_contents($this->push_authorization_configuration_path, '');
         file_put_contents($this->reprint_configuration_path, $this->docroot . '/invalid-push-directory');
-        $url = $this->base_url . '&endpoint=preflight';
+        $url = $this->wordpressUrl() . '&endpoint=preflight';
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_curl_headers();
         $handle = curl_init($url);
         curl_setopt_array($handle, [
@@ -1207,25 +1281,15 @@ final class PushEndpointsTest extends TestCase {
     public function testSuccessfulPushResponseSendsNoCacheHeaders(): void
     {
         $push_session_id = str_repeat('2', 32);
-        $create = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
-            'push_session_id' => $push_session_id,
-        ], ['created']);
-        $this->assertSame('complete', $create['status'], (string) json_encode($create));
-
-        $status = $this->sendPushRequestWithHeaders('GET', 'push_status', [
+        $create = $this->sendPushRequestWithHeaders('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], self::SECRET);
 
-        $this->assertSame(200, $status['http_code'], $status['body']);
-        $this->assertSame([
-            'status' => 'accepted',
-            'push_session_id' => $push_session_id,
-            'phase' => 'receiving_work',
-            'work_deletes_bytes' => 0,
-            'work_deletes_complete' => false,
-            'path' => null,
-        ], json_decode($status['body'], true, 512, JSON_THROW_ON_ERROR));
-        $this->assertNoCacheHeaders($status['headers']);
+        $this->assertSame(200, $create['http_code'], $create['body']);
+        $response = json_decode($create['body'], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('created', $response['status']);
+        $this->assertSame($push_session_id, $response['push_session_id']);
+        $this->assertNoCacheHeaders($create['headers']);
     }
 
     public function testPushAuthenticationFailureSendsNoCacheHeaders(): void
@@ -1244,7 +1308,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('b', 32);
         $client = $this->newClient(self::SECRET);
 
-        $wrong_method = $client->send_push_request('GET', 'push_create', [
+        $wrong_method = $client->send_connection_request('GET', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('failed', $wrong_method['status']);
@@ -1252,21 +1316,24 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('Push endpoint requires POST; observed GET.', $wrong_method['detail']);
 
         $wrong_secret = $this->newClient('not-the-server-secret');
-        $authentication = $wrong_secret->send_push_request('POST', 'push_create', [
+        $authentication = $wrong_secret->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('failed', $authentication['status']);
         $this->assertSame('auth_failed', $authentication['reason']);
         $this->assertStringContainsString('HMAC signature verification failed', $authentication['detail']);
 
-        $create = $client->send_push_request('POST', 'push_create', [
+        $create = $client->send_connection_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
         ], ['created']);
         $this->assertSame('complete', $create['status']);
+        $this->configurePushSessionAuthentication($client, $create['response']);
+        $push_session_secret = $create['response']['push_session_secret'] ?? null;
+        $this->assertIsString($push_session_secret);
         $push_lock = fopen($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.lock', 'c+b');
         $this->assertIsResource($push_lock);
         $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
-        $lock_contention = $client->send_push_request('GET', 'push_status', [
+        $lock_contention = $client->send_push_session_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
         ], ['accepted']);
         $this->assertSame('retry', $lock_contention['status']);
@@ -1274,8 +1341,8 @@ final class PushEndpointsTest extends TestCase {
         flock($push_lock, LOCK_UN);
         fclose($push_lock);
 
-        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
-        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $url = $this->pushUrl() . '?endpoint=push_upload&push_session_id=' . $push_session_id;
+        $headers = ( new Site_Export_HMAC_Client($push_session_secret) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: application/json'];
         foreach ($headers as $name => $value) {
             $curl_headers[] = $name . ': ' . $value;
@@ -1303,7 +1370,7 @@ final class PushEndpointsTest extends TestCase {
             . "X-Chunk-Offset: 0\r\n"
             . "Content-Length: 1\r\n\r\n"
             . 'x';
-        $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $headers = ( new Site_Export_HMAC_Client($push_session_secret) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: multipart/mixed; boundary=' . $boundary];
         foreach ($headers as $name => $value) {
             $curl_headers[] = $name . ': ' . $value;
@@ -2465,6 +2532,9 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         $this->assertIsArray($state);
+        $push_session_secret = $state['push_session_secret'];
+        $this->assertIsString($push_session_secret);
+        $separator = strpos($this->base_url, '?') === false ? '?' : '&';
         $deletions = (string) file_get_contents($push_state_directory . '/plan/local_paths_to_delete');
         $this->assertSame("delete-after-lost-response.txt\0", $deletions);
         $boundary = 'reprint-lost-delete-response';
@@ -2482,9 +2552,10 @@ final class PushEndpointsTest extends TestCase {
             . "Content-Length: 0\r\n\r\n\r\n"
             . '--' . $boundary . "--\r\n";
         $this->sendPostAndDiscardResponse(
-            $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'],
+            $this->base_url . $separator . 'endpoint=push_upload&push_session_id=' . $state['push_session_id'],
             'multipart/mixed; boundary=' . $boundary,
-            $delete_body
+            $delete_body,
+            $push_session_secret
         );
 
         for (; $step < 70; ++$step) {
@@ -2497,9 +2568,10 @@ final class PushEndpointsTest extends TestCase {
         }
         $this->assertIsArray($state);
         $this->sendPostAndDiscardResponse(
-            $this->base_url . '&endpoint=push_commit&push_session_id=' . $state['push_session_id'],
+            $this->base_url . $separator . 'endpoint=push_commit&push_session_id=' . $state['push_session_id'],
             null,
-            ''
+            '',
+            self::SECRET
         );
 
         for (; $step < 140; ++$step) {
@@ -2600,6 +2672,88 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
     }
 
+    public function testFilesPushCliCanStartAnotherPushAndFixDefunctWordPress(): void
+    {
+        $local_docroot = $this->root . '/cli-defunct-wordpress-local-docroot';
+        $state_directory = $this->root . '/cli-defunct-wordpress-state';
+        $plugin_directory = $local_docroot . '/wp-content/plugins/defunct';
+        mkdir($plugin_directory, 0700, true);
+        file_put_contents(
+            $plugin_directory . '/defunct.php',
+            "<?php\nthrow new RuntimeException('The pushed plugin broke WordPress boot.');\n"
+        );
+        $this->enableBundledPushRoute();
+
+        $break_site = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $break_site['exit'], $break_site['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($break_site['stdout'])['status'] ?? null);
+        $this->assertFileExists($this->wordpress_defunct_path);
+
+        $handle = curl_init($this->wordpressUrl());
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(500, curl_getinfo($handle, CURLINFO_HTTP_CODE));
+        curl_close($handle);
+        $this->assertStringContainsString('WordPress could not boot', $body);
+
+        $push_create_requests = $this->countEndpointRequests('push_create');
+        file_put_contents($plugin_directory . '/defunct.php', "<?php\n// WordPress can boot again.\n");
+
+        $fix_site = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $fix_site['exit'], $fix_site['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($fix_site['stdout'])['status'] ?? null);
+        $this->assertSame(
+            "<?php\n// WordPress can boot again.\n",
+            file_get_contents($this->wordpress_defunct_path)
+        );
+        $this->assertSame($push_create_requests + 1, $this->countEndpointRequests('push_create'));
+        $this->assertGreaterThan(0, $this->countEndpointRequests('push_upload'));
+        $this->assertGreaterThan(0, $this->countEndpointRequests('push_commit'));
+        $this->assertFileExists($this->push_session_while_wordpress_defunct_path);
+        foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove'] as $endpoint) {
+            $this->assertSame(0, $this->countWordPressEndpointRequests($endpoint));
+        }
+    }
+
+    public function testFilesPushCliRepeatsCommitAfterTheFirstResponseIsLost(): void
+    {
+        if (!function_exists('posix_kill') || !defined('SIGKILL')) {
+            $this->markTestSkipped('files-push process-death coverage requires POSIX signals.');
+        }
+        $local_docroot = $this->root . '/cli-lost-first-commit-local-docroot';
+        $state_directory = $this->root . '/cli-lost-first-commit-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'committed after a lost response');
+        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $this->configureEndpointGate('push_commit');
+        [$process, $pipes] = $this->startFilesPushCli($local_docroot, $state_directory);
+        $this->waitForPath($this->gate_ready_path);
+        $process_status = proc_get_status($process);
+        $this->assertTrue($process_status['running']);
+        $this->assertTrue(posix_kill($process_status['pid'], SIGKILL));
+        $killed = $this->finishFilesPushCli($process, $pipes);
+        $this->releaseEndpointGate();
+
+        $active_state = $this->loadActiveState($pair_state_directory);
+        $this->assertIsArray($active_state);
+        $this->assertSame('committing', $active_state['phase']);
+        $commit_state_path = $this->reprint_directory
+            . '/.reprint/push/' . $active_state['push_session_id'] . '/commit.json';
+        $this->waitForPath($commit_state_path);
+        $this->waitForPushLockRelease($active_state['push_session_id']);
+        $this->clearEndpointGate();
+
+        $this->assertNotSame(0, $killed['exit']);
+        $completed = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
+        $this->assertSame('committed after a lost response', file_get_contents($this->docroot . '/value.txt'));
+    }
+
     public function testFilesPushCliStopsAtTheCallerDeadlineAndAnotherProcessCompletes(): void
     {
         $local_docroot = $this->root . '/cli-partial-local-docroot';
@@ -2626,6 +2780,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('starting_plan', $partial_result['phase'] ?? null);
         $this->assertSame($push_create_requests + 1, $this->countEndpointRequests('push_create'));
         $this->assertSame(0, $this->countEndpointRequests('push_upload'));
+        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $this->assertSame(0600, fileperms($pair_state_directory . '/sender.json') & 0777);
         $partial_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'PARTIAL files-push | pair=' . $partial_result['pair']
@@ -3014,20 +3170,22 @@ final class PushEndpointsTest extends TestCase {
      * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
      */
     private function sendChunkedUploadRequest(
-        string $base_url,
+        string $push_url,
+        string $push_session_secret,
         string $push_session_id,
         string $boundary,
         string $multipart_body,
         string $trailing_bytes = ''
     ): array {
-        $request_url = $base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $separator = strpos($push_url, '?') === false ? '?' : '&';
+        $request_url = $push_url . $separator . 'endpoint=push_upload&push_session_id=' . $push_session_id;
         $url = parse_url($request_url);
         $this->assertIsArray($url);
         $this->assertSame('http', $url['scheme'] ?? null);
         $host = (string) ( $url['host'] ?? '' );
         $port = (int) ( $url['port'] ?? 0 );
         $request_target = (string) ( $url['path'] ?? '/' ) . '?' . (string) ( $url['query'] ?? '' );
-        $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $request_url);
+        $authentication_headers = ( new Site_Export_HMAC_Client($push_session_secret) )->get_envelope_auth_headers('POST', $request_url);
         $request_headers = '';
         foreach ($authentication_headers as $name => $value) {
             $request_headers .= $name . ': ' . $value . "\r\n";
@@ -3136,8 +3294,11 @@ final class PushEndpointsTest extends TestCase {
             'REPRINT_PUSH_TEST_EXCLUDED_PATHS_CONFIG' => $this->excluded_paths_configuration_path,
             'REPRINT_PUSH_TEST_REQUEST_LOG' => $this->root . '/request.log',
             'REPRINT_PUSH_TEST_GATE_ENDPOINT_CONFIG' => $this->gate_endpoint_configuration_path,
+            'REPRINT_PUSH_TEST_BUNDLED_ROUTE_CONFIG' => $this->bundled_push_route_configuration_path,
             'REPRINT_PUSH_TEST_GATE_READY' => $this->gate_ready_path,
             'REPRINT_PUSH_TEST_GATE_RELEASE' => $this->gate_release_path,
+            'REPRINT_PUSH_TEST_WORDPRESS_DEFUNCT_PATH' => $this->wordpress_defunct_path,
+            'REPRINT_PUSH_TEST_PUSH_SESSION_WHILE_WORDPRESS_DEFUNCT_PATH' => $this->push_session_while_wordpress_defunct_path,
         ]);
         $server_log_path = $this->root . '/server-' . $post_max_bytes . '-' . bin2hex(random_bytes(4)) . '.log';
         $descriptors = [
@@ -3166,13 +3327,36 @@ final class PushEndpointsTest extends TestCase {
             $connection = @stream_socket_client('tcp://' . $address, $connect_error, $connect_error_message, 0.1);
             if (is_resource($connection)) {
                 fclose($connection);
-                return [$process, $pipes, 'http://' . $address . '/?reprint-api=1'];
+                return [$process, $pipes, 'http://' . $address . '/push.php'];
             }
             usleep(20000);
         } while (microtime(true) < $deadline);
         $server_log = file_get_contents($server_log_path);
         $this->stopServer($process, $pipes);
         $this->fail('Push endpoint test server did not start: ' . $server_log);
+    }
+
+    /** Makes /push.php execute the bundled no-WordPress route for this test. */
+    private function enableBundledPushRoute(): void
+    {
+        $canonical_docroot = realpath($this->docroot);
+        $canonical_plugin_directory = realpath(dirname(__DIR__) . '/reprint-exporter-wp');
+        $this->assertIsString($canonical_docroot);
+        $this->assertIsString($canonical_plugin_directory);
+        $route_directory = $canonical_docroot . '/reprint-exporter-wp';
+        symlink($canonical_plugin_directory, $route_directory);
+
+        $reprint_directory = Site_Export_HTTP_Server::default_reprint_directory($canonical_docroot);
+        $configuration_directory = $reprint_directory . '/.reprint';
+        mkdir($configuration_directory, 0700, true);
+        $configuration_path = $configuration_directory . '/push-config.php';
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The fixture needs the production PHP array shape.
+        $contents = "<?php\n\nreturn " . var_export([
+            'connection_secret' => self::SECRET,
+        ], true) . ";\n";
+        file_put_contents($configuration_path, $contents);
+        chmod($configuration_path, 0600);
+        file_put_contents($this->bundled_push_route_configuration_path, 'enabled');
     }
 
     /**
@@ -3329,11 +3513,39 @@ final class PushEndpointsTest extends TestCase {
         $this->assertIsArray($request_endpoints);
         $request_count = 0;
         foreach ($request_endpoints as $request_endpoint) {
-            if ($request_endpoint === $endpoint) {
+            if ($request_endpoint === 'push:' . $endpoint) {
                 ++$request_count;
             }
         }
         return $request_count;
+    }
+
+    private function countWordPressEndpointRequests(string $endpoint): int
+    {
+        $request_log_path = $this->root . '/request.log';
+        if (!is_file($request_log_path)) {
+            return 0;
+        }
+        $request_endpoints = file($request_log_path, FILE_IGNORE_NEW_LINES);
+        $this->assertIsArray($request_endpoints);
+        return count(array_filter(
+            $request_endpoints,
+            static function (string $request_endpoint) use ($endpoint): bool {
+                return $request_endpoint === 'wordpress:' . $endpoint;
+            }
+        ));
+    }
+
+    private function pushUrl(): string
+    {
+        return $this->base_url;
+    }
+
+    private function wordpressUrl(): string
+    {
+        $url = parse_url($this->base_url);
+        $this->assertIsArray($url);
+        return (string) $url['scheme'] . '://' . (string) $url['host'] . ':' . (int) $url['port'] . '/?reprint-api=1';
     }
 
     /**
@@ -3416,6 +3628,16 @@ final class PushEndpointsTest extends TestCase {
         proc_close($process);
     }
 
+    /** @return array<string,mixed> */
+    private function loadPushMetadata(string $push_session_id): array
+    {
+        $push_metadata = ( static function (string $push_metadata_path) {
+            return include $push_metadata_path;
+        } )($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push-metadata.php');
+        $this->assertIsArray($push_metadata);
+        return $push_metadata;
+    }
+
     private function newClient(string $secret, ?string $base_url = null): MultipartPushStreamClient
     {
         return new MultipartPushStreamClient([
@@ -3427,6 +3649,18 @@ final class PushEndpointsTest extends TestCase {
             'stall_timeout' => 3,
             'response_timeout' => 5,
         ]);
+    }
+
+    /** @param array<string,mixed> $create_response Accepted push_create response. */
+    private function configurePushSessionAuthentication(
+        MultipartPushStreamClient $client,
+        array $create_response
+    ): void {
+        $push_session_secret = $create_response['push_session_secret'] ?? null;
+        $this->assertIsString($push_session_secret);
+        $client->set_push_session_hmac_client(
+            new Site_Export_HMAC_Client($push_session_secret)
+        );
     }
 
     /** @param array<string,mixed> $configuration Trusted router configuration. */
@@ -3472,7 +3706,7 @@ final class PushEndpointsTest extends TestCase {
             '&',
             PHP_QUERY_RFC3986
         );
-        $url = $this->base_url . '&' . $query;
+        $url = $this->base_url . ( strpos($this->base_url, '?') === false ? '?' : '&' ) . $query;
         $authentication_headers = ( new Site_Export_HMAC_Client($secret) )->get_envelope_auth_headers($method, $url);
         $request_headers = [];
         foreach ($authentication_headers as $name => $value) {
@@ -3525,10 +3759,13 @@ final class PushEndpointsTest extends TestCase {
         string $endpoint,
         string $push_session_id,
         ?string $body = null,
-        ?string $content_type = null
+        ?string $content_type = null,
+        ?string $base_url = null
     ): array {
-        $url = $this->base_url
-            . '&endpoint=' . rawurlencode($endpoint)
+        $base_url = $base_url ?? $this->base_url;
+        $url = $base_url
+            . ( strpos($base_url, '?') === false ? '?' : '&' )
+            . 'endpoint=' . rawurlencode($endpoint)
             . '&push_session_id=' . rawurlencode($push_session_id);
         $curl_headers = [];
         if ($content_type !== null) {
@@ -3574,14 +3811,15 @@ final class PushEndpointsTest extends TestCase {
      * @param string|null $content_type Request Content-Type, or null when the
      *     endpoint has no body format.
      * @param string $body Decoded HTTP entity body.
+     * @param string $secret Secret which authenticates this route.
      */
-    private function sendPostAndDiscardResponse(string $url, ?string $content_type, string $body): void
+    private function sendPostAndDiscardResponse(string $url, ?string $content_type, string $body, string $secret): void
     {
         $target = parse_url($url);
         $this->assertIsArray($target);
         $this->assertIsString($target['host'] ?? null);
         $this->assertIsInt($target['port'] ?? null);
-        $authentication_headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
+        $authentication_headers = ( new Site_Export_HMAC_Client($secret) )->get_envelope_auth_headers('POST', $url);
         $connection = stream_socket_client(
             'tcp://' . $target['host'] . ':' . $target['port'],
             $error_number,

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -37,13 +37,20 @@ final class PushSessionTest extends TestCase {
         $this->assertFileDoesNotExist($work_directory . '/partial');
         $this->assertFileDoesNotExist($work_directory . '/inflight.json');
         $this->assertFileDoesNotExist($work_directory . '/inflight.data');
-        $push_metadata = json_decode(
-            (string) file_get_contents($push_session->get_push_directory() . '/push.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
+        $push_metadata = $this->load_push_metadata($push_session->get_push_directory());
         $this->assertArrayNotHasKey('version', $push_metadata);
+    }
+
+    public function testPushMetadataPhpFileReturnsItsArrayWithoutOutput(): void {
+        $push_session = $this->push_session('10101010101010101010101010101011');
+        $push_directory = $push_session->get_push_directory();
+        $push_metadata_path = $push_directory . '/push-metadata.php';
+
+        $this->assertFileExists($push_metadata_path);
+        $this->assertFileDoesNotExist($push_directory . '/push.json');
+        $this->assertSame(0600, fileperms($push_metadata_path) & 0777);
+        $push_metadata = $this->load_push_metadata($push_directory);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/D', $push_metadata['push_session_secret']);
     }
 
     public function testPushSessionRejectsMoreThanOneHundredExcludedPaths(): void {
@@ -58,7 +65,9 @@ final class PushSessionTest extends TestCase {
             $this->reprint_directory,
             $this->docroot,
             $excluded_paths,
-            '11111111111111111111111111111110'
+            '11111111111111111111111111111110',
+            4194304,
+            256
         );
     }
 
@@ -326,7 +335,7 @@ final class PushSessionTest extends TestCase {
 
     public function testReprintDirectoryBelowDocumentRootIsExcludedAndRootCanBeReopened(): void {
         $reprint_directory = $this->docroot . '/private-work';
-        $push_session = Site_Export_Push_Session::create($reprint_directory, $this->docroot, [], str_repeat('a', 32));
+        $push_session = Site_Export_Push_Session::create($reprint_directory, $this->docroot, [], str_repeat('a', 32), 4194304, 256);
         try {
             $this->push_parts($push_session, [[
                 'headers' => [
@@ -342,7 +351,7 @@ final class PushSessionTest extends TestCase {
             $this->assertStringContainsString('Excluded', $exception->getMessage());
         }
 
-        $root_session = Site_Export_Push_Session::create($this->reprint_directory, '/', [], str_repeat('b', 32));
+        $root_session = Site_Export_Push_Session::create($this->reprint_directory, '/', [], str_repeat('b', 32), 4194304, 256);
         $reopened = Site_Export_Push_Session::open($this->reprint_directory, '/', $root_session->get_push_session_id(), []);
         $this->assertSame($root_session->get_push_directory(), $reopened->get_push_directory());
     }
@@ -449,7 +458,7 @@ final class PushSessionTest extends TestCase {
         $this->assertStringContainsString('// reprint-push-session:' . $push_session->get_push_session_id(), (string) $first);
         $this->assertTrue($marker_blocks_request([]));
         $this->assertTrue($marker_blocks_request(['reprint-api' => '', 'endpoint' => 'preflight']));
-        $this->assertFalse($marker_blocks_request(['reprint-api' => '', 'endpoint' => 'push_commit']));
+        $this->assertTrue($marker_blocks_request(['reprint-api' => '', 'endpoint' => 'push_commit']));
         sleep(1);
         $push_session->commit(1);
         $second = file_get_contents($this->docroot . '/.maintenance');
@@ -777,19 +786,21 @@ final class PushSessionTest extends TestCase {
 
     public function testMalformedMetadataAndPushDirectorySymlinksAreRejected(): void {
         $push_metadata_session = $this->push_session('23452345234523452345234523452345');
-        file_put_contents($push_metadata_session->get_push_directory() . '/push.json', '{not-json');
+        file_put_contents($push_metadata_session->get_push_directory() . '/push-metadata.php', "<?php\nreturn [\n");
         try {
             $push_metadata_session->get_status();
             $this->fail('Malformed push metadata was accepted.');
         } catch (Site_Export_Push_Exception $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
+            $this->assertStringContainsString('does not return a PHP array', $exception->getMessage());
         }
 
         $shape_session = $this->push_session('34563456345634563456345634563455');
-        $push_metadata_path = $shape_session->get_push_directory() . '/push.json';
-        $push_metadata = json_decode( (string) file_get_contents($push_metadata_path), true, 512, JSON_THROW_ON_ERROR);
+        $push_metadata_path = $shape_session->get_push_directory() . '/push-metadata.php';
+        $push_metadata = $this->load_push_metadata($shape_session->get_push_directory());
         $push_metadata['excluded_paths_b64'] = 'not-a-list';
-        file_put_contents($push_metadata_path, json_encode($push_metadata, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The test rewrites the real PHP metadata format with one corrupt field.
+        file_put_contents($push_metadata_path, "<?php\nreturn " . var_export($push_metadata, true) . ";\n");
         try {
             $shape_session->get_status();
             $this->fail('Push metadata with a scalar excluded-path list was accepted.');
@@ -890,7 +901,9 @@ final class PushSessionTest extends TestCase {
                 $this->reprint_directory,
                 $this->docroot,
                 ['wp-content/plugins/reprint', 'wp-config.php'],
-                $push_session->get_push_session_id()
+                $push_session->get_push_session_id(),
+                4194304,
+                256
             );
             $this->fail('Repeated create accepted different immutable excluded paths.');
         } catch (Site_Export_Push_Exception $exception) {
@@ -1530,6 +1543,123 @@ final class PushSessionTest extends TestCase {
         $this->assertSame('receiving_work', $recreated->get_status()['phase']);
     }
 
+    public function testSessionSecretCannotAddressARecreatedPushSession(): void {
+        $push_session_id = 'efefefefefefefefefefefefefefefef';
+        $old_push_session = $this->push_session($push_session_id);
+        $old_metadata = $this->load_push_metadata($old_push_session->get_push_directory());
+        $old_push_session_secret = $old_metadata['push_session_secret'];
+        $this->assertIsString($old_push_session_secret);
+        do {
+            $removed = $old_push_session->remove_push_directory();
+        } while (!$removed);
+
+        $new_push_session = $this->push_session($push_session_id);
+        $new_metadata = $this->load_push_metadata($new_push_session->get_push_directory());
+        $this->assertNotSame($old_push_session_secret, $new_metadata['push_session_secret']);
+
+        $stale_push_session = Site_Export_Push_Session::open(
+            $this->reprint_directory,
+            $this->docroot,
+            $push_session_id,
+            ['wp-content/plugins/reprint'],
+            $old_push_session_secret
+        );
+        try {
+            $stale_push_session->get_status();
+            $this->fail('An old push session secret inspected a recreated session.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('push_not_found', $exception->get_error_code());
+        }
+
+        try {
+            Site_Export_Push_Session::remove(
+                $this->reprint_directory,
+                $this->docroot,
+                $push_session_id,
+                ['wp-content/plugins/reprint'],
+                $old_push_session_secret
+            );
+            $this->fail('An old push session secret removed a recreated session.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('push_not_found', $exception->get_error_code());
+        }
+        $this->assertDirectoryExists($new_push_session->get_push_directory());
+    }
+
+    public function testOpcodeCacheCannotRetainARecreatedPushSessionSecret(): void {
+        if (!function_exists('opcache_get_status')) {
+            $this->markTestSkipped('The opcode cache extension is unavailable.');
+        }
+
+        // The child must enable the CLI opcode cache before PHP starts.
+        $script = <<<'PHP'
+require $argv[1] . '/vendor/autoload.php';
+$root = $argv[2];
+$docroot = $root . '/docroot';
+$reprint_directory = $root . '/reprint';
+mkdir($docroot, 0700, true);
+mkdir($reprint_directory, 0700, true);
+$push_session_id = str_repeat('f', 32);
+$old_push_session = Site_Export_Push_Session::create($reprint_directory, $docroot, [], $push_session_id, 1024, 10);
+$old_push_session_secret = Site_Export_Push_Session::load_push_session_configuration($reprint_directory, $docroot, $push_session_id)['push_session_secret'];
+$push_metadata_path = $old_push_session->get_push_directory() . '/push-metadata.php';
+$opcode_cache = opcache_get_status(true);
+if (!isset($opcode_cache['scripts'][$push_metadata_path])) {
+    fwrite(STDERR, "The push metadata file was not cached.\n");
+    exit(2);
+}
+do {
+    $removed = $old_push_session->remove_push_directory();
+} while (!$removed);
+Site_Export_Push_Session::create($reprint_directory, $docroot, [], $push_session_id, 1024, 10);
+$new_push_session_secret = Site_Export_Push_Session::load_push_session_configuration($reprint_directory, $docroot, $push_session_id)['push_session_secret'];
+if (hash_equals($old_push_session_secret, $new_push_session_secret)) {
+    fwrite(STDERR, "The recreated push session reused the cached secret.\n");
+    exit(3);
+}
+PHP;
+        $process = proc_open(
+            [
+                PHP_BINARY,
+                '-d',
+                'opcache.enable_cli=1',
+                '-d',
+                'opcache.validate_timestamps=0',
+                '-d',
+                'opcache.file_update_protection=0',
+                '-r',
+                $script,
+                dirname(__DIR__),
+                $this->root . '/opcode-cache',
+            ],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $this->assertSame(0, proc_close($process), $stdout . $stderr);
+    }
+
+    /** @return array<string,mixed> */
+    private function load_push_metadata(string $push_directory): array {
+        ob_start();
+        try {
+            $push_metadata = ( static function (string $push_metadata_path) {
+                return include $push_metadata_path;
+            } )($push_directory . '/push-metadata.php');
+        } finally {
+            $output = ob_get_clean();
+        }
+        $this->assertSame('', $output);
+        $this->assertIsArray($push_metadata);
+        return $push_metadata;
+    }
+
     /**
      * Runs an upload while one named filesystem call fails in production code.
      *
@@ -1639,7 +1769,9 @@ final class PushSessionTest extends TestCase {
             $this->reprint_directory,
             $this->docroot,
             ['wp-content/plugins/reprint'],
-            $id
+            $id,
+            4194304,
+            256
         );
     }
 

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -15,7 +15,6 @@ if (!defined('SITE_EXPORT_PLUGIN_DIR')) {
 if (!defined('SITE_EXPORT_SECRET_FILE')) {
     define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
 }
-
 $GLOBALS['site_export_test_options'] = [];
 $GLOBALS['site_export_registered_settings'] = [];
 $GLOBALS['site_export_settings_errors'] = [];
@@ -85,6 +84,14 @@ if (!function_exists('add_filter')) {
 if (!function_exists('plugin_basename')) {
     function plugin_basename(string $file): string {
         return basename($file);
+    }
+}
+
+if (!function_exists('plugin_dir_url')) {
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WordPress test stub.
+    function plugin_dir_url(string $file): string {
+        unset($file);
+        return 'https://example.test/wp-content/plugins/site-export/';
     }
 }
 
@@ -202,6 +209,9 @@ final class SiteExportSecretTest extends TestCase
     /** @var string|false */
     private $original_push_enabled_environment;
 
+    /** @var string */
+    private $push_config_file = '';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -219,7 +229,9 @@ final class SiteExportSecretTest extends TestCase
         $GLOBALS['site_export_test_options'] = [];
         $GLOBALS['site_export_registered_settings'] = [];
         $GLOBALS['site_export_settings_errors'] = [];
-        $_SERVER = [];
+        $_SERVER = [
+            'DOCUMENT_ROOT' => rtrim(SITE_EXPORT_PLUGIN_DIR, '/\\'),
+        ];
         $_FILES = [];
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
         $_POST = [];
@@ -228,12 +240,25 @@ final class SiteExportSecretTest extends TestCase
         if (file_exists(SITE_EXPORT_SECRET_FILE)) {
             unlink(SITE_EXPORT_SECRET_FILE);
         }
+        $push_config_file = _site_export_get_push_config_file();
+        $this->assertIsString($push_config_file);
+        $this->push_config_file = $push_config_file;
+        if (file_exists($this->push_config_file)) {
+            unlink($this->push_config_file);
+        }
     }
 
     protected function tearDown(): void
     {
         if (file_exists(SITE_EXPORT_SECRET_FILE)) {
             unlink(SITE_EXPORT_SECRET_FILE);
+        }
+        if ($this->push_config_file !== '' && file_exists($this->push_config_file)) {
+            unlink($this->push_config_file);
+        }
+        if ($this->push_config_file !== '') {
+            @rmdir(dirname($this->push_config_file));
+            @rmdir(dirname(dirname($this->push_config_file)));
         }
 
         if (is_dir(SITE_EXPORT_PLUGIN_DIR)) {
@@ -319,6 +344,7 @@ final class SiteExportSecretTest extends TestCase
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
         putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        $this->assertTrue(_site_export_sync_managed_push_config());
         $this->assertTrue(_site_export_is_push_authorized());
 
         $this->assertTrue(_site_export_update_push_authorization(true));
@@ -416,6 +442,32 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
+    public function testPushAccessWritesPrivatePhpConfigurationForStandaloneRoute(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        $this->assertFileExists($this->push_config_file);
+        $this->assertSame(0600, fileperms($this->push_config_file) & 0777);
+        ob_start();
+        $configuration = include $this->push_config_file;
+        $output = ob_get_clean();
+        $this->assertSame('', $output);
+        $this->assertSame(['connection_secret' => 'current-token'], $configuration);
+    }
+
+    public function testDisablingPushRemovesStandaloneRouteConfiguration(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        $this->assertTrue(_site_export_update_push_authorization(false));
+
+        $this->assertFileDoesNotExist($this->push_config_file);
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
     public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
@@ -439,12 +491,19 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertStringContainsString('<strong>Connected for downloads and push.</strong>', $html);
         $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked', $html);
+        $this->assertStringContainsString('<h2>Push endpoint</h2>', $html);
+        $this->assertStringContainsString(
+            'https://example.test/wp-content/plugins/site-export/push.php',
+            $html
+        );
+        $this->assertStringContainsString('It remains available when WordPress cannot boot.', $html);
     }
 
     public function testManagedAdminCopyIsReadOnlyAndShowsEffectiveState(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        $this->assertTrue(_site_export_sync_managed_push_config());
 
         $html = $this->renderAdminPage();
 

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -1,23 +1,50 @@
 <?php
 
-// This fixture supplies the WordPress functions and values the production
-// plugin entry point reads. API routing, authentication, and dispatch all run
-// through index.php and its site_export_api_options filter.
+// This fixture exposes the production push route separately from a WordPress
+// route which can be made defunct by committed files.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 
 $reprint_push_test_request_log = (string) getenv('REPRINT_PUSH_TEST_REQUEST_LOG');
 $reprint_push_test_endpoint = filter_input(INPUT_GET, 'endpoint', FILTER_UNSAFE_RAW);
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- The router needs the raw request path to select the test route.
+$reprint_push_test_request_path = parse_url( (string) ( $_SERVER['REQUEST_URI'] ?? '' ), PHP_URL_PATH );
+$reprint_push_test_is_push_request = $reprint_push_test_request_path === '/push.php';
 if ($reprint_push_test_request_log !== '' && is_string($reprint_push_test_endpoint)) {
     register_shutdown_function(
-        static function () use ($reprint_push_test_request_log, $reprint_push_test_endpoint): void {
+        static function () use ($reprint_push_test_request_log, $reprint_push_test_endpoint, $reprint_push_test_is_push_request): void {
             file_put_contents(
                 $reprint_push_test_request_log,
-                $reprint_push_test_endpoint . "\n",
+                ( $reprint_push_test_is_push_request ? 'push:' : 'wordpress:' ) . $reprint_push_test_endpoint . "\n",
                 FILE_APPEND | LOCK_EX
             );
         }
     );
+}
+
+$reprint_push_test_wordpress_defunct_path = (string) getenv('REPRINT_PUSH_TEST_WORDPRESS_DEFUNCT_PATH');
+$reprint_push_test_wordpress_is_defunct = $reprint_push_test_wordpress_defunct_path !== ''
+    && is_file($reprint_push_test_wordpress_defunct_path)
+    && strpos(
+        (string) file_get_contents($reprint_push_test_wordpress_defunct_path),
+        'The pushed plugin broke WordPress boot.'
+    ) !== false;
+$reprint_push_test_push_session_while_wordpress_defunct_path = (string) getenv('REPRINT_PUSH_TEST_PUSH_SESSION_WHILE_WORDPRESS_DEFUNCT_PATH');
+if (
+    $reprint_push_test_is_push_request
+    && $reprint_push_test_wordpress_is_defunct
+    && $reprint_push_test_endpoint === 'push_create'
+) {
+    file_put_contents($reprint_push_test_push_session_while_wordpress_defunct_path, 'observed');
+}
+if (
+    !$reprint_push_test_is_push_request
+    && $reprint_push_test_wordpress_is_defunct
+) {
+    http_response_code(500);
+    header('Content-Type: text/plain');
+    echo 'WordPress could not boot after loading the pushed plugin.';
+    return;
 }
 
 $reprint_push_test_gate_endpoint_path = (string) getenv('REPRINT_PUSH_TEST_GATE_ENDPOINT_CONFIG');
@@ -119,6 +146,54 @@ if (trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_CUSTOM_
 $reprint_push_test_directory = trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_DIRECTORY_CONFIG') ) );
 if ($reprint_push_test_directory !== '') {
     $reprint_push_test_options['reprint_directory'] = $reprint_push_test_directory;
+}
+
+if ($reprint_push_test_is_push_request) {
+    $reprint_push_test_bundled_route_configuration_path = (string) getenv('REPRINT_PUSH_TEST_BUNDLED_ROUTE_CONFIG');
+    $reprint_push_test_use_bundled_route = $reprint_push_test_bundled_route_configuration_path !== ''
+        && trim( (string) file_get_contents($reprint_push_test_bundled_route_configuration_path) ) === 'enabled';
+    if ($reprint_push_test_use_bundled_route) {
+        $_SERVER['SCRIPT_FILENAME'] = rtrim(
+            (string) $reprint_push_test_docroot_configuration['document_root'],
+            '/\\'
+        ) . '/reprint-exporter-wp/push.php';
+        require dirname(__DIR__, 2) . '/reprint-exporter-wp/push.php';
+        return;
+    }
+
+    require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+    require_once dirname(__DIR__, 2) . '/packages/reprint-exporter/src/class-http-server.php';
+    $reprint_push_test_connection_secret = trim(
+        (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_SECRET_CONFIG') )
+    );
+    $reprint_push_test_authorized_fingerprint = trim(
+        (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_AUTHORIZATION_CONFIG') )
+    );
+    $reprint_push_test_personally_authorized = hash_equals(
+        hash('sha256', $reprint_push_test_connection_secret),
+        $reprint_push_test_authorized_fingerprint
+    );
+    $reprint_push_test_push_is_authorized = $reprint_push_test_managed_state === ''
+        ? $reprint_push_test_personally_authorized
+        : $reprint_push_test_managed_state === 'true';
+    $reprint_push_test_connection_secret = $reprint_push_test_push_is_authorized
+        ? $reprint_push_test_connection_secret
+        : null;
+    $reprint_push_test_push_options = [
+        'connection_secret' => $reprint_push_test_connection_secret,
+        'docroot' => $reprint_push_test_docroot_configuration['docroot'] ?? $reprint_push_test_docroot_configuration['document_root'] ?? null,
+        'excluded_paths' => $reprint_push_test_options['excluded_paths'],
+        'maximum_part_bytes' => $reprint_push_test_options['maximum_part_bytes'],
+        'maximum_commit_entries' => $reprint_push_test_options['maximum_commit_entries'],
+    ];
+    if ($reprint_push_test_directory !== '') {
+        $reprint_push_test_push_options['reprint_directory'] = $reprint_push_test_directory;
+    }
+    if ($reprint_push_test_push_is_authorized && isset($reprint_push_test_options['authenticate'])) {
+        $reprint_push_test_push_options['authenticate'] = $reprint_push_test_options['authenticate'];
+    }
+    Site_Export_HTTP_Server::serve_push($reprint_push_test_push_options);
+    return;
 }
 
 function apply_filters(string $hook_name, $value) {


### PR DESCRIPTION
All `files-push` requests now use a PHP route that does not boot WordPress, so a new push can replace files which broke WordPress startup.

## Background

A push can install a plugin which throws while WordPress starts. If `push_create` goes through WordPress, the next push cannot start and replace that plugin.

## This change

Create, upload, status, commit, and remove now use one push URL. The WordPress route serves pull requests only and rejects every `push_*` request.

`push_create` uses the connection token. It returns a random secret for that push session. The other four operations use the session secret at the same URL.

There is still one implementation of each push operation. `Site_Export_HTTP_Server::serve_push()` authenticates the request and dispatches it to the existing `Site_Export_Push_Endpoints` methods. The old WordPress-side push setup and dispatch are removed.

The bundled URL ends in:

```text
/wp-content/plugins/reprint-exporter/push.php
```

The Reprint Exporter settings screen shows the exact URL. Pass it to `files-push` instead of `?reprint-api`:

```bash
php reprint.phar files-push "https://example.com/wp-content/plugins/reprint-exporter/push.php" \
  --state-dir="/path/to/reprint-state" \
  --fs-root="/path/to/local-tree" \
  --secret="the-target-connection-token"
```

The bundled route reads `DOCUMENT_ROOT`, uses its private sibling reprint directory, and excludes its own plugin directory from push.

Enabling push writes the connection token to the mode-0600 `<reprint-directory>/.reprint/push-config.php`. The file returns a PHP array and prints nothing. Each push session keeps its secret and policy in a mode-0600 `push-metadata.php`, which also returns an array without printing it. Removing `push-config.php` blocks new sessions without breaking a session already in progress.

Some hosts block direct PHP below `wp-content/plugins`, or use different server-owned paths. Those hosts must expose another PHP URL which does not load WordPress:

```php
require_once '/srv/reprint-exporter/vendor/autoload.php';

$connection_secret = ($_GET['endpoint'] ?? null) === 'push_create'
    ? Site_Export_HTTP_Server::load_push_connection_secret('/srv/reprint/push-config.php')
    : null;

Site_Export_HTTP_Server::serve_push([
    'connection_secret' => $connection_secret,
    'docroot' => '/srv/www/public',
    'reprint_directory' => '/srv/reprint',
    'excluded_paths' => ['reprint-push.php'],
]);
```

Give that URL directly to `files-push`. The WordPress `site_export_api_options` filter no longer configures push.

## Testing

Push a plugin which makes the WordPress route return HTTP 500. Replace the local plugin with a safe version and run `files-push` again with the same state directory. Confirm that the second run creates a new push session and repairs the site through `push.php`.
