### PR TITLE
[Push] Add a local files-diff command

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -19,7 +19,7 @@ the end maps it to a PR stack.
    moves work files into place, executes deletions, and commits the database
    diff, and fixes symlinks — inside a maintenance window that lasts seconds,
    not the length of the transfer.
-5. It stores the current local paths as the local index at the previous push
+5. It stores the current local paths as the pair's previous local index
    and stores the current rows as the previously pushed rows. The push is
    complete only after this step; a crashed push is
    re-driven from the top and converges.
@@ -78,18 +78,22 @@ managed `false` hard-disables push without abandoning durable commit recovery.
 
 ctime is machine-local, so push never compares a local timestamp to a remote
 one. It only answers "what changed locally since my last successful push to
-this remote" by comparing the current local paths and rows against the local
-index at the previous push and the previously pushed rows.
+this remote" by comparing the current local paths and rows against the pair's
+previous local index and the previously pushed rows.
 
 The local machine keeps these files **per target URL and canonical local
 tree**, overwritten after each successful commit:
 
-    <state-dir>/push/<pair-key>/local_index_at_previous_push.jsonl
+    <state-dir>/push/<pair-key>/previous_local_index.jsonl
     <state-dir>/push/<pair-key>/previously_pushed_rows.jsonl   (phase two)
 
+The previous local index records the local path type, size, and ctime as the
+completing push observed them. Besides planning the next push, it feeds the
+local `files-diff` command, which reports the same comparison without pushing.
+
 `PushPlan` first builds a path-sorted fresh local index, then derives the local
-paths to push and delete by diffing it against
-`local_index_at_previous_push.jsonl`. The indexer marks physical emptiness while
+paths to push and delete by diffing it against the previous local index its
+caller supplies. The indexer marks physical emptiness while
 it observes each directory, so a completed index distinguishes empty
 directories from non-empty ones. Files and symlinks change when their `type`,
 `ctime`, or `size` changes; unrelated index values do not select a path for
@@ -123,11 +127,11 @@ A push plan is an internal part of the sender lifecycle:
    `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
 6. After the receiver commits successfully, the sender saves the retained fresh
-   local index as `local_index_at_previous_push.jsonl` through the same swap-file
+   local index as `previous_local_index.jsonl` through the same swap-file
    copy. It then removes the complete `plan/` directory and the sender-owned
    exclusions file. After the target
    confirms removal of a discarded push session, the sender removes the same
-   files without changing the local index at the previous push.
+   files without changing the pair's previous local index.
 
 Until the sender stores the initial PushPlan cursor, `starting_plan` remains
 the durable phase. An interrupted start is repeated and overwrites its initial
@@ -145,8 +149,8 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, local tree root, local index at
-the previous push, and current planning position. During indexing, that
+The cursor contains the plan directory, local tree root, previous local
+index, and current planning position. During indexing, that
 position contains the `FileIndexProcessor` cursor and committed fresh-index byte
 offset. During diffing, each step flushes only the path list or append-only
 deleted-directory stack changed by that step before updating the two index
@@ -156,7 +160,7 @@ entry. A later process passes the stored cursor to `PushPlan::resume()`. The
 plan uses its private exclusions copy, discards bytes beyond the stored output
 offsets, and continues from the retained internal phase.
 
-The first push to a site has no local index from a previous push or previously
+The first push to a site has no previous local index or previously
 pushed rows. Every current file, symlink, and empty directory is selected, and
 no local deletion can be detected yet.
 
@@ -168,7 +172,7 @@ manager.
 ## Deletes
 
 Local deletions since the last push come from paths present in
-`local_index_at_previous_push.jsonl` but absent from the fresh local index. They
+the previous local index but absent from the fresh local index. They
 travel as NUL-delimited document-root-relative paths in `work/deletes`. Commit
 records its byte offset before and after every destructive mutation, so a later
 request can resume from a durable checkpoint instead of repeating a delete.
@@ -272,7 +276,7 @@ configuration; request parameters cannot select any of them.
 An active push keeps these files under `<state-dir>/push/<pair-key>/`:
 
 ```text
-local_index_at_previous_push.jsonl  index saved after the previous commit
+previous_local_index.jsonl          index saved after the previous commit
 excluded_paths.json                 sender-owned target exclusions
 sender.json                         active push state
 sender.lock                         lifecycle lock
@@ -324,7 +328,7 @@ and phase, the PushPlan cursor, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
 sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_local_index_at_previous_push`, `completing`, `removing`, and
+`saving_previous_local_index`, `completing`, `removing`, and
 `discarding_plan`.
 The separate start, index-save, completion, removal, and discard phases ensure
 that a process stop between durable actions repeats only the current action.
@@ -362,8 +366,8 @@ captured by the completed fresh local index rather than attempting to describe
 the live tree at commit time.
 
 Repeated `push_commit` calls drive the receiver to `complete`. Only then does
-the sender enter `saving_local_index_at_previous_push` and copy the plan-owned
-fresh local index to `local_index_at_previous_push.jsonl`. Excluded entries
+the sender enter `saving_previous_local_index` and copy the plan-owned
+fresh local index to `previous_local_index.jsonl`. Excluded entries
 remain in that complete index; exclusions suppress remote work rather than
 creating a second retained index representation. The sender then removes the
 entire plan directory before deleting active sender state.
@@ -411,8 +415,8 @@ sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
 Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
 query or canonical local tree therefore selects a different retained local
 index. Fragments, URL user-info, and `SECRET_KEY` target parameters are
-rejected. The pair state directory must be outside the local tree so planning
-cannot index its own changing files.
+rejected. The local push state directory must be outside the local tree so
+planning cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80
@@ -436,6 +440,35 @@ shared audit log records opening mode, phase changes, planned pauses, handled
 interruptions, and terminal outcomes with the pair key. The flat status file
 records only the command, pair, outcome, phase, reason, detail, and timestamp;
 neither file copies receiver cursors or tentative upload positions.
+
+## Local files-diff command
+
+`reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR` reports a local
+minimized push operation plan before target exclusions: the local paths a
+files-push would send or delete, compared against the pair's previous local
+index published by a completed files-push. It uses the files-push pair-key
+formula, including its trailing `?` and `&` trim, so another URL query or
+local tree cannot reuse the index. It accepts only `--state-dir` and
+`--fs-root`; it needs no secret, performs no preflight, and makes no network
+request. It runs one complete PushPlan against `previous_local_index.jsonl` in
+`files-diff-plan/` and holds `files-diff.lock` for the run.
+
+Output is JSONL. Each selected current file, symlink, or empty directory has
+`action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,
+`dir`, or `link`. Each selected local deletion has `action: "delete"` and
+`path_b64`. Type transitions may emit both actions for one path. This is a
+local minimized push operation plan before target exclusions, not a
+path-for-path filesystem log: descendants represent a new non-empty directory,
+one deleted subtree root covers its descendants, and metadata-only changes to
+non-empty directories select no operation. Base64 keeps arbitrary filesystem
+path bytes representable. The final record carries `status: "complete"` with
+`local_paths_to_push` and `local_paths_to_delete` counts.
+
+files-diff persists nothing between runs. The whole plan runs in one process,
+both finished path lists stream from the beginning, and the plan directory is
+removed before exit. An interrupted report is therefore never resumed
+mid-stream: running the command again always prints the complete report. The
+same-size, same-ctime-second gap described above still applies.
 
 ## Where reprint stores its own data on the remote
 
@@ -464,7 +497,7 @@ Order:
    `commit.json` checkpoint written before each document-root mutation. The
    future database batch and symlink updates follow the same bounded cursor.
 4. **Maintenance off:** commit releases its `commit-state` ownership after
-   completion; the driver saves the local index at the previous push and rows
+   completion; the driver saves the pair's previous local index and rows
    after commit completes.
 
 If the driver dies mid-commit: WordPress stops honoring the `.maintenance`
@@ -556,9 +589,12 @@ Files first, database second, each PR small and stacked in this order:
 11. **`reprint files-push`** — the low-level, files-only caller that retains
     one sender per process, applies caller time and memory admission budgets,
     and reports completion, continuation, restart, or failure without retrying.
-12. **`reprint push`** — the high-level command that adds a change summary,
+12. **`reprint files-diff`** — a local-only command that reports the paths a
+    files-push would send or delete against the pair's previous local index,
+    without contacting the target.
+13. **`reprint push`** — the high-level command that adds a change summary,
     confirmation boundary, database work, transfer, commit, and resume.
-13. **Budgets and resumable limits** — push requests stay bounded by two
+14. **Budgets and resumable limits** — push requests stay bounded by two
     budgets of different dimensions: the fixed chunk (the sender's in-memory
     unit of one read) and the host-learned request body budget that
     PushRequestSizer sizes from reported php.ini limits and 413s, plus a

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -93,7 +93,8 @@ directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
 | --- | --- |
 | Active plan directory | `plan`, `$plan_directory` |
 | Plan-owned fresh local index | `fresh_local_index.jsonl`, `$fresh_local_index` |
-| Local index at the previous push | `local_index_at_previous_push.jsonl`, `$local_index_at_previous_push` |
+| Previous local index | `previous_local_index.jsonl`, `previous_local_index`, `$previous_local_index` |
+| Byte offset in the previous local index | `byte_offset_in_previous_local_index`, `$byte_offset_in_previous_local_index` |
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
 | Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
@@ -102,19 +103,26 @@ directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
 | Active state | `sender.json`, `$state_path` |
 | Lifecycle lock file | `sender.lock`, `$lock_path` |
+| Files-diff lifecycle lock | `files-diff.lock` |
 | Open lifecycle lock | `$lock_handle` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
 `sender.json`, `sender.lock`, `excluded_paths.json`, and
-`local_index_at_previous_push.jsonl` live directly under the local push state
+`previous_local_index.jsonl` live directly under the local push state
 directory. The sender creates `plan/` for one active plan. PushPlan copies the
 sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
+The **previous local index** describes the local tree as the pair's last
+completed push observed it. The sender saves it after a successful commit, and
+`files-diff` reads it. PushPlan diffs its fresh local index against the copy
+its caller supplies. `byte_offset_in_previous_local_index` is the position
+from which its current lookahead entry is read again after resume.
+
 The PushPlan cursor is stored in `sender.json`. It contains the plan
-directory, local tree root, local index at the previous push, and current
+directory, local tree root, previous local index, and current
 planning position. During `indexing`, that position contains the
 FileIndexProcessor cursor and the committed byte offset in
 `fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
@@ -123,7 +131,7 @@ output offsets, and the active byte offset in
 links to the preceding active directory. The exclusions have a maximum of 100
 paths. `sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_local_index_at_previous_push`, `completing`,
+`saving_previous_local_index`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
 completes before local paths are sent. The index copy after a successful commit
@@ -160,6 +168,27 @@ never finishes an open request. In `pushing_paths` or
 returns true while another step may be performed and false when `get_status()`
 reports `complete`, `restart`, or `failed`.
 
+## Files-diff CLI names
+
+The local-only command is `files-diff`. Its `target URL`, `local tree`, `pair
+key`, and `local push state directory` have the same meanings and pair-key
+formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
+which a completed files-push publishes, and never changes it.
+
+Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
+`delete`, and `path_b64`. A push record also has the local path `type`, `size`,
+and `ctime`; its type is `file`, `dir`, or `link`. These records form a local
+minimized push operation plan before target exclusions: descendants represent
+a new non-empty directory, one deleted subtree root covers its descendants,
+and metadata-only changes to non-empty directories select no operation. The
+final record has `status: "complete"`, `local_paths_to_push`, and
+`local_paths_to_delete`.
+
+files-diff persists nothing between runs. It runs one complete PushPlan under
+`files-diff.lock` in `files-diff-plan/`, streams both finished path lists from
+the beginning, and removes the plan directory before exiting. An interrupted
+report is not resumed; running the command again prints the complete report.
+
 ## Files-push CLI names
 
 The low-level, files-only command is `files-push`. Its `target URL` is the
@@ -173,7 +202,7 @@ The `pair key` identifies exactly one target URL and canonical local tree:
 sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
 ```
 
-The `pair state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
+The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
 chooses `start` or `resume` only from whether `sender.json` exists there. The
 receiver-confirmed upload positions remain receiver-owned; they are not a
 files-push cursor and are not copied into `.import-state.json` or
@@ -239,6 +268,10 @@ Use these names verbatim inside `PushPlan`:
 | --- | --- |
 | Active plan directory | `$plan_directory` |
 | Local tree root | `$local_tree_root`, `set_local_tree_root()` |
+| Previous local index | `$previous_local_index` |
+| Open previous local index | `$previous_local_index_handle` |
+| Previous local index lookahead entry | `$previous_local_index_lookahead_entry`, `$previous_local_index_lookahead_entry_loaded` |
+| Byte offset in the previous local index | `$byte_offset_in_previous_local_index` |
 | Cursor | `$cursor`, `get_cursor()` |
 | Plan-owned excluded paths | `$excluded_paths_file` |
 | Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1263,7 +1263,9 @@ class ImportClient
             }
             if ($signal_handling_command === 'files-push') {
                 $this->enable_files_push_signal_handling();
-            } else {
+            } elseif ($signal_handling_command !== 'files-diff') {
+                // files-diff must not save the pull command's state from a
+                // shutdown handler; default signal behavior ends the report.
                 pcntl_signal(SIGINT, [$this, "handle_shutdown"]);
                 pcntl_signal(SIGTERM, [$this, "handle_shutdown"]);
             }
@@ -1459,7 +1461,7 @@ class ImportClient
      *
      * @param string       $command Canonical CLI command name.
      * @param list<string> $argv    Raw command arguments.
-     * @param string|null  $pair    Files-push pair key, when available.
+     * @param string|null  $pair    Files-diff or files-push pair key, when available.
      */
     public function audit_log_argv(string $command, array $argv, ?string $pair = null): void
     {
@@ -1640,6 +1642,7 @@ class ImportClient
             "pull-files",
             "pull-db",
             "files-pull",
+            "files-diff",
             "files-push",
             "files-index",
             "files-stats",
@@ -1666,8 +1669,12 @@ class ImportClient
             );
         }
 
-        // files-push owns separate pair state and must not load or write the
-        // pull command's .import-state.json file.
+        // files-diff and files-push use local push state and must not load
+        // or write the pull command's .import-state.json file.
+        if ($command === "files-diff") {
+            $this->run_files_diff($options);
+            return;
+        }
         if ($command === "files-push") {
             $this->run_files_push($options);
             return;
@@ -2006,6 +2013,240 @@ class ImportClient
         }
     }
 
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
+    /**
+     * Reports local paths changed since the pair's previous local index.
+     *
+     * files-diff makes no network request. It runs one complete PushPlan
+     * against the previous local index a completed files-push published, then
+     * streams the finished push and delete lists from the beginning. Every run
+     * reports the whole diff, so an interrupted report needs no resume state:
+     * running the command again prints the complete report.
+     *
+     * @param array $options {
+     *     Parsed files-diff options and context.
+     *
+     *     @type array $files_diff_context Validated pair context.
+     * }
+     * @phpstan-param array<string,mixed> $options
+     */
+    private function run_files_diff(array $options): void
+    {
+        $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
+            $this->remote_url,
+            $this->state_dir,
+            $this->fs_root,
+            'files-diff'
+        );
+        if (!is_array($context)) {
+            throw new InvalidArgumentException('files-diff requires its validated command context.');
+        }
+
+        $push_state_directory = $context['push_state_directory'];
+        $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
+        $missing_previous_local_index_message =
+            'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
+            . 'for the same target URL, state directory, and local tree.';
+        if (!is_dir($push_state_directory)) {
+            throw new RuntimeException($missing_previous_local_index_message);
+        }
+
+        $lock_handle = $this->acquire_files_diff_lock($push_state_directory);
+        $plan_directory = $push_state_directory . '/files-diff-plan';
+        try {
+            if (!is_file($previous_local_index)) {
+                throw new RuntimeException($missing_previous_local_index_message);
+            }
+
+            // Build the complete local-only plan from scratch without target
+            // exclusions. An interrupted files-diff discards it and runs it again.
+            $this->remove_local_plan_directory($plan_directory);
+            if (!mkdir($plan_directory, 0755, true)) {
+                throw new RuntimeException('Failed to create the local plan directory: ' . $plan_directory . '.');
+            }
+            $excluded_paths_path = $plan_directory . '/no_target_exclusions.json';
+            if (file_put_contents($excluded_paths_path, "[]\n") === false) {
+                throw new RuntimeException('Failed to write the empty exclusions file: ' . $excluded_paths_path . '.');
+            }
+            $plan = PushPlan::start(
+                $plan_directory,
+                $context['local_tree'],
+                $previous_local_index,
+                $excluded_paths_path
+            );
+            try {
+                while ($plan->next_step()) {
+                    continue;
+                }
+            } finally {
+                $plan->close();
+            }
+
+            $type_by_plan_type = [
+                'file' => 'file',
+                'directory' => 'dir',
+                'symlink' => 'link',
+            ];
+            $local_paths_to_push_count = 0;
+            foreach (
+                $this->read_planned_local_paths_to_push($plan->get_local_paths_to_push_path())
+                as $entry
+            ) {
+                $line = json_encode([
+                    'command' => 'files-diff',
+                    'action' => 'push',
+                    'path_b64' => $entry['path'],
+                    'type' => $type_by_plan_type[$entry['type']],
+                    'size' => $entry['size'],
+                    'ctime' => $entry['ctime'],
+                ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                if (fwrite($this->progress_fd, $line) !== strlen($line)) {
+                    throw new RuntimeException('Failed to write the files-diff result.');
+                }
+                ++$local_paths_to_push_count;
+            }
+
+            $local_paths_to_delete_count = 0;
+            foreach (
+                $this->read_planned_local_paths_to_delete($plan->get_local_paths_to_delete_path())
+                as $local_path_to_delete
+            ) {
+                $line = json_encode([
+                    'command' => 'files-diff',
+                    'action' => 'delete',
+                    'path_b64' => base64_encode($local_path_to_delete),
+                ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+                if (fwrite($this->progress_fd, $line) !== strlen($line)) {
+                    throw new RuntimeException('Failed to write the files-diff result.');
+                }
+                ++$local_paths_to_delete_count;
+            }
+
+            $line = json_encode([
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => $local_paths_to_push_count,
+                'local_paths_to_delete' => $local_paths_to_delete_count,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            if (fwrite($this->progress_fd, $line) !== strlen($line)) {
+                throw new RuntimeException('Failed to write the files-diff result.');
+            }
+            if (!fflush($this->progress_fd)) {
+                throw new RuntimeException('Failed to flush the files-diff result.');
+            }
+        } finally {
+            $this->remove_local_plan_directory($plan_directory);
+            flock($lock_handle, LOCK_UN);
+            fclose($lock_handle);
+        }
+    }
+
+    /**
+     * Reads the completed local paths-to-push list.
+     *
+     * @param string $local_paths_to_push_path Completed plan-owned JSONL path list.
+     * @return Generator Completed plan entries.
+     * @phpstan-return Generator<int,array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int},mixed,void>
+     */
+    private function read_planned_local_paths_to_push(string $local_paths_to_push_path): Generator
+    {
+        $local_paths_to_push_handle = fopen($local_paths_to_push_path, 'rb');
+        if (!is_resource($local_paths_to_push_handle)) {
+            throw new RuntimeException('Failed to open the completed local paths-to-push list.');
+        }
+        try {
+            while (true) {
+                $line = fgets($local_paths_to_push_handle);
+                if ($line === false) {
+                    if (!feof($local_paths_to_push_handle)) {
+                        throw new RuntimeException('Failed to read the completed local paths-to-push list.');
+                    }
+                    return;
+                }
+                // The plan wrote this list moments ago in this process; its
+                // entry schema is trusted, like every other plan consumer.
+                /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $entry */
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                yield $entry;
+            }
+        } finally {
+            fclose($local_paths_to_push_handle);
+        }
+    }
+
+    /**
+     * Reads the completed local paths-to-delete list.
+     *
+     * @param string $local_paths_to_delete_path Completed plan-owned NUL-delimited path list.
+     * @return Generator Completed local paths to delete.
+     * @phpstan-return Generator<int,string,mixed,void>
+     */
+    private function read_planned_local_paths_to_delete(string $local_paths_to_delete_path): Generator
+    {
+        $local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
+        if (!is_resource($local_paths_to_delete_handle)) {
+            throw new RuntimeException('Failed to open the completed local paths-to-delete list.');
+        }
+        try {
+            while (true) {
+                $local_path_to_delete = stream_get_line($local_paths_to_delete_handle, 1048576, "\0");
+                if ($local_path_to_delete === false) {
+                    if (!feof($local_paths_to_delete_handle)) {
+                        throw new RuntimeException('Failed to read the completed local paths-to-delete list.');
+                    }
+                    return;
+                }
+                yield $local_path_to_delete;
+            }
+        } finally {
+            fclose($local_paths_to_delete_handle);
+        }
+    }
+
+    /**
+     * Acquires the pair's files-diff lifecycle lock.
+     *
+     * @return resource Open lock handle.
+     */
+    private function acquire_files_diff_lock(string $push_state_directory)
+    {
+        $lock_path = $push_state_directory . '/files-diff.lock';
+        $lock_handle = fopen($lock_path, 'c+b');
+        if (!is_resource($lock_handle)) {
+            throw new RuntimeException('Failed to open the files-diff lifecycle lock: ' . $lock_path . '.');
+        }
+        if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
+            fclose($lock_handle);
+            throw new RuntimeException('Another files-diff or files-pull process is using this target and local tree.');
+        }
+        return $lock_handle;
+    }
+
+    /** Removes one completed or discarded local plan and confirms every removal. */
+    private function remove_local_plan_directory(string $plan_directory): void
+    {
+        if (!is_dir($plan_directory)) {
+            return;
+        }
+        $plan_files = scandir($plan_directory);
+        if ($plan_files === false) {
+            throw new RuntimeException('Failed to read the local plan directory: ' . $plan_directory . '.');
+        }
+        foreach ($plan_files as $plan_file) {
+            if ($plan_file === '.' || $plan_file === '..') {
+                continue;
+            }
+            $plan_file_path = $plan_directory . '/' . $plan_file;
+            if (!is_file($plan_file_path) || !unlink($plan_file_path)) {
+                throw new RuntimeException('Failed to remove a local plan file: ' . $plan_file_path . '.');
+            }
+        }
+        if (!rmdir($plan_directory)) {
+            throw new RuntimeException('Failed to remove the local plan directory: ' . $plan_directory . '.');
+        }
+    }
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
     /**
      * Runs one caller-bounded files-push lifecycle.
      *
@@ -2234,7 +2475,7 @@ class ImportClient
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions are CLI text, not HTML.
     /**
-     * Validates files-push inputs and derives its per-pair state path.
+     * Validates files-push inputs and derives its local push state directory.
      *
      * @param array $options {
      *     Parsed files-push options.
@@ -2249,7 +2490,7 @@ class ImportClient
      *     @type string $target_url           Target exporter API URL.
      *     @type string $local_tree           Canonical local tree being sent.
      *     @type string $pair                 Target/local-tree pair key.
-     *     @type string $push_state_directory Sender state directory for the pair.
+     *     @type string $push_state_directory Local push state directory.
      * }
      * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
      */
@@ -2269,17 +2510,58 @@ class ImportClient
             );
         }
 
+        $context = self::prepare_files_pair_context(
+            $target_url,
+            $state_directory,
+            $local_tree,
+            'files-push'
+        );
+        $masked_target_url = self::mask_files_push_url_user_info($target_url);
+        $force_http = $options['force_http'] ?? false;
+        $scheme = strtolower( (string) parse_url($target_url, PHP_URL_SCHEME) );
+        if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
+            throw new InvalidArgumentException(
+                'The files-push target must use HTTPS: ' . $masked_target_url
+                . '. Pass --force-http only for a target you trust.'
+            );
+        }
+        return $context;
+    }
+
+    /**
+     * Validates the local inputs shared by files-diff and files-push.
+     *
+     * This helper deliberately does not require a secret or HTTPS. files-diff
+     * identifies the pull source by URL but performs no network request.
+     *
+     * @param string $command Command name used in error messages.
+     * @return array {
+     *     Validated pair context.
+     *
+     *     @type string $target_url           Target exporter API URL.
+     *     @type string $local_tree           Canonical local tree.
+     *     @type string $pair                 Target/local-tree pair key.
+     *     @type string $push_state_directory Local push state directory.
+     * }
+     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
+     */
+    public static function prepare_files_pair_context(
+        string $target_url,
+        string $state_directory,
+        string $local_tree,
+        string $command
+    ): array {
         $masked_target_url = self::mask_files_push_url_user_info($target_url);
         if (strpos($target_url, '#') !== false) {
             throw new InvalidArgumentException(
-                'The files-push target URL must not contain a fragment: ' . $masked_target_url . '.'
+                'The ' . $command . ' target URL must not contain a fragment: ' . $masked_target_url . '.'
             );
         }
         $target_url_user = parse_url($target_url, PHP_URL_USER);
         $target_url_password = parse_url($target_url, PHP_URL_PASS);
         if (is_string($target_url_user) || is_string($target_url_password)) {
             throw new InvalidArgumentException(
-                'The files-push target URL must not contain URL user-info: ' . $masked_target_url . '.'
+                'The ' . $command . ' target URL must not contain URL user-info: ' . $masked_target_url . '.'
             );
         }
         if (is_link($local_tree)) {
@@ -2290,16 +2572,6 @@ class ImportClient
                 'The local tree does not exist or is not a directory: ' . $local_tree . '.'
             );
         }
-
-        $force_http = $options['force_http'] ?? false;
-        $scheme = strtolower( (string) parse_url($target_url, PHP_URL_SCHEME) );
-        if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
-            throw new InvalidArgumentException(
-                'The files-push target must use HTTPS: ' . $masked_target_url
-                . '. Pass --force-http only for a target you trust.'
-            );
-        }
-
         $canonical_local_tree = realpath($local_tree);
         if ($canonical_local_tree === false) {
             throw new InvalidArgumentException(
@@ -2343,7 +2615,7 @@ class ImportClient
             || path_is_within_root($push_state_directory, $canonical_local_tree)
         ) {
             throw new InvalidArgumentException(
-                'The push state directory ' . $push_state_directory
+                'The local push state directory ' . $push_state_directory
                 . ' must be outside the local tree ' . $canonical_local_tree . '.'
             );
         }
@@ -13225,6 +13497,27 @@ if (
                 "  .import-state.json                      Resumable state\n" .
                 "  .import-audit.log                       Audit log\n",
         ],
+        "files-diff" => [
+            "level" => "low",
+            "short" => "Show local file changes since the last push",
+            "usage" => "reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR",
+            "description" =>
+                "Shows which local paths a files-push would send or delete, comparing\n" .
+                "the local tree at --fs-root with the pair's previous local index —\n" .
+                "the index a completed files-push publishes for the same target URL,\n" .
+                "state directory, and local tree.\n" .
+                "The output is a local minimized push operation plan before target\n" .
+                "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
+                "default-skipped paths include generated wp-content caches, version-\n" .
+                "control data, node_modules, package-manager caches, OS metadata, and\n" .
+                "editor scratch files.\n" .
+                "Paths remain base64 text in JSONL output so\n" .
+                "arbitrary filesystem names are preserved. No network calls are made\n" .
+                "and no secret is required.\n",
+            "extra" =>
+                "Every run reports the complete diff from the beginning; there is\n" .
+                "no partial resume to continue.\n",
+        ],
         "files-push" => [
             "level" => "low",
             "short" => "Push one local file tree without database work",
@@ -13477,9 +13770,9 @@ if (
     );
     $options["command"] = $command;
 
-    $reprint_files_push_command_arguments = array_slice($argv, $option_start_index);
+    $reprint_files_command_arguments = array_slice($argv, $option_start_index);
     if ($command === 'files-push') {
-        foreach ($reprint_files_push_command_arguments as $reprint_files_push_command_argument) {
+        foreach ($reprint_files_command_arguments as $reprint_files_push_command_argument) {
             $reprint_files_push_option_allowed = in_array(
                 $reprint_files_push_command_argument,
                 ['--force-http', '--verbose', '-v'],
@@ -13491,6 +13784,17 @@ if (
             if (!$reprint_files_push_option_allowed) {
                 $reprint_files_push_option_name = explode('=', $reprint_files_push_command_argument, 2)[0];
                 fwrite(STDERR, "Error: files-push does not accept {$reprint_files_push_option_name}.\n");
+                exit(1);
+            }
+        }
+    } elseif ($command === 'files-diff') {
+        foreach ($reprint_files_command_arguments as $reprint_files_diff_command_argument) {
+            $reprint_files_diff_option_allowed =
+                strpos($reprint_files_diff_command_argument, '--state-dir=') === 0
+                || strpos($reprint_files_diff_command_argument, '--fs-root=') === 0;
+            if (!$reprint_files_diff_option_allowed) {
+                $reprint_files_diff_option_name = explode('=', $reprint_files_diff_command_argument, 2)[0];
+                fwrite(STDERR, "Error: files-diff does not accept {$reprint_files_diff_option_name}.\n");
                 exit(1);
             }
         }
@@ -13528,6 +13832,7 @@ if (
 
     try {
         $reprint_files_push_context = null;
+        $reprint_files_diff_context = null;
         if ($command === 'files-push') {
             $reprint_files_push_context = ImportClient::prepare_files_push_context(
                 $remote_url,
@@ -13535,14 +13840,25 @@ if (
                 $fs_root,
                 $options
             );
+        } elseif ($command === 'files-diff') {
+            $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
+                $remote_url,
+                $state_dir,
+                $fs_root,
+                'files-diff'
+            );
         }
         $client = new ImportClient($remote_url, $state_dir, $fs_root, $command);
-        $reprint_files_push_pair = $reprint_files_push_context['pair'] ?? null;
-        $client->audit_log_argv($command, $argv, $reprint_files_push_pair);
+        $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
+        $client->audit_log_argv($command, $argv, $reprint_files_pair);
         $client->run(
-            $reprint_files_push_context === null
-                ? $options
-                : $options + ['files_push_context' => $reprint_files_push_context]
+            $options
+                + ( $reprint_files_push_context === null
+                    ? []
+                    : ['files_push_context' => $reprint_files_push_context] )
+                + ( $reprint_files_diff_context === null
+                    ? []
+                    : ['files_diff_context' => $reprint_files_diff_context] )
         );
         // EXIT_AFTER_IMPORT controls whether we hand control back to
         // the caller after pull returns. Default true: standard CLI

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -10,7 +10,7 @@
  * PushFilesSender owns the only caller-visible lifecycle. It holds the lock,
  * creates and removes the target push session, drives its internal PushPlan,
  * streams the selected paths, commits the push, and saves the completed fresh
- * local index as the local index at the previous push. The target owns the
+ * local index as the pair's previous local index. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
  * request limits and the PushPlan cursor needed after a process restart.
@@ -51,12 +51,13 @@
  *
  * A new sender calls `push_create` to learn target-owned exclusions before
  * starting PushPlan. The plan builds the fresh local index and diffs it against
- * the index at the previous push, one bounded step at a time. After planning
+ * the pair's previous local index, one bounded step at a time. That index is
+ * saved by the previous successful push and also read by files-diff. After planning
  * completes, local files, symlinks, and empty directories stream through
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
  * calls let the target install the work in bounded steps. A confirmed commit
- * enters another phase which saves the fresh local index as the local index at
- * the previous push through a swap file. Index completion, plan completion,
+ * enters another phase which saves the fresh local index as the pair's
+ * previous local index through a swap file. Index completion, plan completion,
  * local-index saving, and plan discard each have a separate durable phase. A
  * stopped process therefore repeats only an idempotent boundary action rather
  * than a group of unrelated transitions.
@@ -65,8 +66,8 @@
  * PushPlan. PushFilesSender stores that cursor after every completed planning
  * step but never interprets its internal phase or offsets. The sender creates
  * the active plan directory before planning and removes the whole directory
- * only after success or target-session removal. The local index at the previous
- * push remains beside sender.json. Once the plan result is saved or discarded,
+ * only after success or target-session removal. The pair's previous local
+ * index remains beside sender.json. Once the plan result is saved or discarded,
  * the sender clears its cursor before removing the directory without reopening
  * PushPlan.
  *
@@ -116,7 +117,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index_at_previous_push'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_previous_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -129,8 +130,8 @@ final class PushFilesSender
     /** @var string Sender-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Index saved after the previous successful push. */
-    private string $local_index_at_previous_push;
+    /** @var string Pair's previous local index, saved after a successful push and read by files-diff. */
+    private string $previous_local_index;
 
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
@@ -244,7 +245,9 @@ final class PushFilesSender
     {
         $sender = new self($options);
         if (!is_dir($sender->push_state_directory) && !@mkdir($sender->push_state_directory, 0755, true) && !is_dir($sender->push_state_directory)) {
-            throw new RuntimeException('Failed to create the push state directory: ' . $sender->push_state_directory);
+            throw new RuntimeException(
+                'Failed to create the local push state directory: ' . $sender->push_state_directory
+            );
         }
         $sender->lock_handle = $sender->acquire_lock();
         try {
@@ -352,7 +355,7 @@ final class PushFilesSender
         $this->docroot = rtrim($canonical_docroot, '/');
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
-        $this->local_index_at_previous_push = $this->push_state_directory . '/local_index_at_previous_push.jsonl';
+        $this->previous_local_index = $this->push_state_directory . '/previous_local_index.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->lock_path = $this->push_state_directory . '/sender.lock';
         $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
@@ -402,8 +405,8 @@ final class PushFilesSender
             case 'committing':
                 $this->commit_push();
                 break;
-            case 'saving_local_index_at_previous_push':
-                $this->save_local_index_at_previous_push();
+            case 'saving_previous_local_index':
+                $this->save_previous_local_index();
                 break;
             case 'completing':
                 $this->complete_push();
@@ -579,7 +582,7 @@ final class PushFilesSender
         $this->plan = PushPlan::start(
             $this->plan_directory,
             $this->docroot,
-            $this->local_index_at_previous_push,
+            $this->previous_local_index,
             $this->excluded_paths_path
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
@@ -1175,24 +1178,24 @@ final class PushFilesSender
         if ($response['send_next_request']) {
             return;
         }
-        $this->state['phase'] = 'saving_local_index_at_previous_push';
+        $this->state['phase'] = 'saving_previous_local_index';
         $this->store_state($this->state);
     }
 
     /**
-     * Saves the committed fresh local index as the local index at the previous push.
+     * Saves the committed fresh local index as the pair's previous local index.
      *
      * If the process stops before the next phase is stored, repeating the
      * deliberate whole-index copy is safe and leaves readers on either the old
      * or complete new index.
      */
-    private function save_local_index_at_previous_push(): void
+    private function save_previous_local_index(): void
     {
         $fresh_local_index = $this->plan->get_fresh_local_index_path();
         try {
             $this->copy_through_swap_file(
                 $fresh_local_index,
-                $this->local_index_at_previous_push
+                $this->previous_local_index
             );
         } catch (RuntimeException $exception) {
             $this->fail('local_io_error', $exception->getMessage());

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -3,40 +3,39 @@
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
 /**
- * Internal planner for one PushFilesSender lifecycle.
+ * Internal bounded local-index and change planner.
  *
  * PushPlan builds a path-sorted fresh local index, then diffs it against the
- * local index at the previous push. It writes durable lists of local paths to
- * push and local paths to delete without accumulating an index or path list in
- * memory.
+ * previous local index supplied by its caller. It writes durable lists of
+ * local paths to push and local paths to delete without accumulating an index
+ * or path list in memory.
  *
- * PushFilesSender is the only caller-visible processor. It owns the lifecycle
- * lock, top-level phase, transport, result, commit, restart, and removal.
- * PushPlan owns FileIndexProcessor, the fresh local index, the index diff, the
- * meaning of its cursor, and the two completed path lists. PushFilesSender
- * stores the cursor returned by get_cursor().
+ * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
+ * lock, top-level phase, result, and terminal behavior. PushPlan owns
+ * FileIndexProcessor, the fresh local index, the index diff, the meaning of
+ * its cursor, and the two completed path lists. A caller which resumes across
+ * processes stores the cursor returned by get_cursor().
  *
  * ## Durable boundary
  *
- * While sender.json says `planning`, its PushPlan cursor contains one of
- * four internal phases: `indexing`, `starting_diff`, `diffing`, or `complete`.
- * A false next_step() result means both indexes reached EOF; the sender stores
- * the returned cursor and closes the plan before changing its phase. The
- * completed files remain in the sender-owned plan directory until the sender
- * finishes or discards the push.
+ * The PushPlan cursor contains one of four internal phases: `indexing`,
+ * `starting_diff`, `diffing`, or `complete`. A false next_step() result means
+ * both indexes reached EOF; the caller stores the returned cursor and closes
+ * the plan before changing its phase. The completed files remain in the
+ * caller-owned plan directory until the caller no longer needs them.
  *
  * ## Change detection
  *
- * ctime is machine-local, so PushPlan compares the local machine only with its
- * own state at the previous successful push. File and symlink changes are
- * determined by type, ctime, and size. Directory changes use the indexer's
- * empty-directory marker; non-empty directories are represented by their
- * descendants.
+ * ctime is machine-local, so the previous local index must describe the same
+ * local machine: PushFilesSender supplies the index saved after the previous
+ * push, and files-diff supplies the index captured after the previous pull.
+ * File and symlink changes are determined by type, ctime, and size. Directory
+ * changes use the indexer's empty-directory marker; non-empty directories are
+ * represented by their descendants.
  *
- * With no local index from a previous push, every file, symlink, and empty
- * directory is selected, and no deletion can be detected. Excluded paths are
- * omitted from both path lists but remain in the fresh local index saved
- * after success.
+ * With no previous local index, every file, symlink, and empty directory is
+ * selected, and no deletion can be detected. Excluded paths are omitted from
+ * both path lists but remain in the fresh local index.
  *
  * The index reader trusts the entry values produced by the indexer. It retains
  * failure handling for reading lines, decoding JSON, and decoding base64 paths.
@@ -45,10 +44,10 @@
  *
  * Each indexing step advances one FileIndexProcessor traversal event and
  * flushes any appended JSONL bytes before updating the traversal cursor and
- * committed byte offset returned to the sender.
+ * committed byte offset returned to the caller.
  * A separate step starts the index diff. Each diff step compares at most one
  * path represented by either index and flushes only the output changed by that
- * step before updating its next cursor. The sender stores that cursor before
+ * step before updating its next cursor. The caller stores that cursor before
  * returning from its own step. `resume()` discards bytes beyond saved offsets,
  * so an interrupted step cannot leave duplicate durable entries.
  *
@@ -59,10 +58,10 @@
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,local_index_at_previous_push:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,previous_local_index:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
@@ -70,11 +69,11 @@ class PushPlan
     /** @var string Canonical local tree root inspected while building the fresh local index. */
     private string $local_tree_root;
 
-    /** @var string Sender-owned active plan directory. */
+    /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Paths and metadata from the last completed push. */
-    private string $local_index_at_previous_push;
+    /** @var string Previous local index supplied by the caller. */
+    private string $previous_local_index;
 
     /** @var string JSONL file of local paths to push. */
     private string $local_paths_to_push;
@@ -94,7 +93,7 @@ class PushPlan
     /** @var list<string> Receiver-owned paths that the plan must not push or delete. */
     private array $excluded_paths = [];
 
-    /** @var PushPlanCursor Current cursor returned to PushFilesSender. */
+    /** @var PushPlanCursor Current cursor returned to the caller. */
     private array $cursor;
 
     /** @var bool Whether close() has closed this plan's file handles. */
@@ -110,10 +109,10 @@ class PushPlan
     private bool $fresh_local_index_entry_loaded = false;
 
     /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
-    private ?array $previous_local_index_entry = null;
+    private ?array $previous_local_index_lookahead_entry = null;
 
-    /** @var bool Whether $previous_local_index_entry has been read, including EOF. */
-    private bool $previous_local_index_entry_loaded = false;
+    /** @var bool Whether $previous_local_index_lookahead_entry has been read, including EOF. */
+    private bool $previous_local_index_lookahead_entry_loaded = false;
 
     /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
     private ?array $deleted_directory_stack_entry = null;
@@ -121,7 +120,7 @@ class PushPlan
     /** @var resource|null Open fresh local index retained during indexing or the index diff. */
     private $fresh_local_index_handle = null;
     /** @var resource|null */
-    private $local_index_at_previous_push_handle = null;
+    private $previous_local_index_handle = null;
     /** @var resource|null */
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
@@ -136,19 +135,19 @@ class PushPlan
      * fresh local index traversal. Until the caller stores the returned cursor,
      * an interrupted start is repeated and overwrites these initial plan files.
      *
-     * @param string $plan_directory              Sender-owned active plan directory.
+     * @param string $plan_directory              Caller-owned active plan directory.
      * @param string $local_tree_root              Canonical local tree root.
-     * @param string $local_index_at_previous_push Index saved after the previous successful push.
-     * @param string $excluded_paths_path          Sender-owned target exclusions file.
+     * @param string $previous_local_index Previous local index this plan diffs against.
+     * @param string $excluded_paths_path          Caller-owned target exclusions file.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $local_tree_root,
-        string $local_index_at_previous_push,
+        string $previous_local_index,
         string $excluded_paths_path
     ): self {
-        $plan = new self($plan_directory, $local_tree_root, $local_index_at_previous_push);
+        $plan = new self($plan_directory, $local_tree_root, $previous_local_index);
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -167,7 +166,7 @@ class PushPlan
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
             "local_tree_root" => $plan->local_tree_root,
-            "local_index_at_previous_push" => $plan->local_index_at_previous_push,
+            "previous_local_index" => $plan->previous_local_index,
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" => $plan->file_index_processor->get_cursor(),
@@ -191,7 +190,7 @@ class PushPlan
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["local_tree_root"],
-            $cursor["local_index_at_previous_push"]
+            $cursor["previous_local_index"]
         );
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
@@ -241,16 +240,16 @@ class PushPlan
     }
 
     /**
-     * Initializes paths in the sender-owned active plan directory.
+     * Initializes paths in the caller-owned active plan directory.
      *
-     * @param string $plan_directory              Sender-owned active plan directory.
+     * @param string $plan_directory              Caller-owned active plan directory.
      * @param string $local_tree_root              Canonical local tree root.
-     * @param string $local_index_at_previous_push Index saved after the previous successful push.
+     * @param string $previous_local_index Previous local index this plan diffs against.
      */
     private function __construct(
         string $plan_directory,
         string $local_tree_root,
-        string $local_index_at_previous_push
+        string $previous_local_index
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -258,7 +257,7 @@ class PushPlan
         }
         $this->plan_directory = $plan_directory;
         $this->set_local_tree_root($local_tree_root);
-        $this->local_index_at_previous_push = $local_index_at_previous_push;
+        $this->previous_local_index = $previous_local_index;
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
         $this->fresh_local_index = $plan_directory . "/fresh_local_index.jsonl";
@@ -267,9 +266,9 @@ class PushPlan
     }
 
     /**
-     * Stores the canonical root of the local tree represented by this push.
+     * Stores the canonical root of the local tree represented by this plan.
      *
-     * @param string $local_tree_root Local tree root selected by PushFilesSender.
+     * @param string $local_tree_root Local tree root selected by the caller.
      */
     private function set_local_tree_root(string $local_tree_root): void
     {
@@ -284,7 +283,7 @@ class PushPlan
     /**
      * Reopens the fresh local index at the byte offset stored with its traversal cursor.
      *
-     * Any bytes appended after the cursor last stored by the sender are
+     * Any bytes appended after the cursor last stored by the caller are
      * discarded before FileIndexProcessor continues from that same step.
      */
     private function open_fresh_local_index_for_continuation(): void
@@ -322,8 +321,8 @@ class PushPlan
         $cursor = $this->cursor["position"];
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
-        $this->previous_local_index_entry = null;
-        $this->previous_local_index_entry_loaded = false;
+        $this->previous_local_index_lookahead_entry = null;
+        $this->previous_local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
         $this->local_paths_to_push_handle = $this->open_and_truncate_and_seek(
             $this->local_paths_to_push,
@@ -338,10 +337,10 @@ class PushPlan
             throw new RuntimeException("Failed to open the retained fresh local index: {$this->fresh_local_index}");
         }
 
-        if (is_file($this->local_index_at_previous_push)) {
-            $this->local_index_at_previous_push_handle = fopen($this->local_index_at_previous_push, "rb");
-            if (!is_resource($this->local_index_at_previous_push_handle)) {
-                throw new RuntimeException("Failed to open local index at the previous push: {$this->local_index_at_previous_push}");
+        if (is_file($this->previous_local_index)) {
+            $this->previous_local_index_handle = fopen($this->previous_local_index, "rb");
+            if (!is_resource($this->previous_local_index_handle)) {
+                throw new RuntimeException("Failed to open the previous local index: {$this->previous_local_index}");
             }
         }
         $this->seek_to_cursor(
@@ -349,11 +348,11 @@ class PushPlan
             $cursor["byte_offset_in_fresh_index"],
             "fresh local index"
         );
-        if ($this->local_index_at_previous_push_handle) {
+        if ($this->previous_local_index_handle) {
             $this->seek_to_cursor(
-                $this->local_index_at_previous_push_handle,
-                $cursor["byte_offset_in_previous_index"],
-                "local index at the previous push"
+                $this->previous_local_index_handle,
+                $cursor["byte_offset_in_previous_local_index"],
+                "previous local index"
             );
         }
         $this->deleted_directories_stack_handle = fopen($this->deleted_directories_stack, "a+b");
@@ -369,7 +368,7 @@ class PushPlan
      * Performs one step for the current internal phase.
      *
      * A false return means planning is complete and remains false on later
-     * calls. The owning sender closes the plan before using its path lists.
+     * calls. The owning caller closes the plan before using its path lists.
      *
      * @return bool Whether another planning step may be performed.
      */
@@ -458,7 +457,7 @@ class PushPlan
         $this->cursor["position"] = [
             "phase" => "diffing",
             "byte_offset_in_fresh_index" => 0,
-            "byte_offset_in_previous_index" => 0,
+            "byte_offset_in_previous_local_index" => 0,
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
@@ -504,8 +503,8 @@ class PushPlan
     /**
      * Compares at most one path and updates the resulting push plan cursor.
      *
-     * Exclusions suppress network changes, not entries in the retained fresh
-     * local index saved as the local index at the previous push after success.
+     * Exclusions suppress planned changes, not entries in the retained fresh
+     * local index.
      *
      * @return bool Whether another index diff step may be performed.
      */
@@ -515,7 +514,7 @@ class PushPlan
         $cursor = $this->cursor["position"];
 
         $byte_offset_in_fresh_index = $cursor["byte_offset_in_fresh_index"];
-        $byte_offset_in_previous_index = $cursor["byte_offset_in_previous_index"];
+        $byte_offset_in_previous_local_index = $cursor["byte_offset_in_previous_local_index"];
         $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
         $local_paths_to_push_changed = false;
         $local_paths_to_delete_changed = false;
@@ -525,25 +524,25 @@ class PushPlan
             $this->fresh_local_index_entry = $this->parse_next_index_entry($this->fresh_local_index_handle);
             $this->fresh_local_index_entry_loaded = true;
         }
-        if (!$this->previous_local_index_entry_loaded) {
-            $this->previous_local_index_entry = $this->parse_next_index_entry(
-                $this->local_index_at_previous_push_handle
+        if (!$this->previous_local_index_lookahead_entry_loaded) {
+            $this->previous_local_index_lookahead_entry = $this->parse_next_index_entry(
+                $this->previous_local_index_handle
             );
-            $this->previous_local_index_entry_loaded = true;
+            $this->previous_local_index_lookahead_entry_loaded = true;
         }
         $entry_fresh_index = $this->fresh_local_index_entry;
-        $entry_previous_index = $this->previous_local_index_entry;
+        $entry_previous_local_index = $this->previous_local_index_lookahead_entry;
 
-        if ($entry_fresh_index !== null || $entry_previous_index !== null) {
+        if ($entry_fresh_index !== null || $entry_previous_local_index !== null) {
             // Base64 does not preserve byte order ('0' sorts before 'A'
             // in ASCII but encodes a higher value), so ordering uses the
             // decoded path bytes.
-            if ($entry_previous_index === null) {
+            if ($entry_previous_local_index === null) {
                 $path_comparison = -1;
             } elseif ($entry_fresh_index === null) {
                 $path_comparison = 1;
             } else {
-                $path_comparison = strcmp($entry_fresh_index["path"], $entry_previous_index["path"]);
+                $path_comparison = strcmp($entry_fresh_index["path"], $entry_previous_local_index["path"]);
             }
 
             $current_shape = null;
@@ -551,9 +550,9 @@ class PushPlan
                 $current_shape = $this->entry_shape($entry_fresh_index);
             }
 
-            $local_index_at_previous_push_shape = null;
+            $previous_local_index_shape = null;
             if ($path_comparison >= 0) {
-                $local_index_at_previous_push_shape = $this->entry_shape($entry_previous_index);
+                $previous_local_index_shape = $this->entry_shape($entry_previous_local_index);
 
                 // Byte sorting can put a sibling such as `a-other` before
                 // `a/child`. Every retained non-empty directory has a later
@@ -562,8 +561,8 @@ class PushPlan
                 if ($this->deleted_directory_stack_entry !== null) {
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                     if (
-                        strpos($entry_previous_index["path"], $descendant_prefix) !== 0
-                        && strcmp($entry_previous_index["path"], $descendant_prefix) > 0
+                        strpos($entry_previous_local_index["path"], $descendant_prefix) !== 0
+                        && strcmp($entry_previous_local_index["path"], $descendant_prefix) > 0
                     ) {
                         $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
                         $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
@@ -588,17 +587,17 @@ class PushPlan
                 // A deleted non-empty directory emits one root. Its later
                 // descendant entries are already covered by that path.
                 if (
-                    !$this->path_conflicts_with_excluded_paths($entry_previous_index["path"])
+                    !$this->path_conflicts_with_excluded_paths($entry_previous_local_index["path"])
                     && !$this->deleted_directory_stack_covers_path(
-                        $entry_previous_index["path"],
+                        $entry_previous_local_index["path"],
                         $this->deleted_directory_stack_entry
                     )
                 ) {
-                    $this->append_local_path_to_delete($entry_previous_index["path"]);
+                    $this->append_local_path_to_delete($entry_previous_local_index["path"]);
                     $local_paths_to_delete_changed = true;
-                    if ($local_index_at_previous_push_shape === "non_empty_directory") {
+                    if ($previous_local_index_shape === "non_empty_directory") {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $entry_previous_index["path"],
+                            $entry_previous_local_index["path"],
                             $deleted_directory_stack_top_byte_offset
                         );
                         $deleted_directories_stack_changed = true;
@@ -606,20 +605,20 @@ class PushPlan
                 }
             } else {
                 $current_is_file_or_symlink = $current_shape === "file" || $current_shape === "symlink";
-                $local_index_at_previous_push_is_file_or_symlink = $local_index_at_previous_push_shape === "file" || $local_index_at_previous_push_shape === "symlink";
+                $previous_local_index_is_file_or_symlink = $previous_local_index_shape === "file" || $previous_local_index_shape === "symlink";
                 $non_empty_directory_becomes_empty = $current_shape === "empty_directory"
-                    && $local_index_at_previous_push_shape === "non_empty_directory";
+                    && $previous_local_index_shape === "non_empty_directory";
                 $empty_directory_needs_push = $current_shape === "empty_directory"
-                    && $local_index_at_previous_push_shape !== "empty_directory";
+                    && $previous_local_index_shape !== "empty_directory";
                 // File and symlink changes are defined by type, ctime, and
                 // size. Other index values do not select a path for upload.
                 $changed_file_or_symlink_needs_push = $current_is_file_or_symlink
                     && (
-                        $entry_fresh_index["ctime"] !== $entry_previous_index["ctime"]
-                        || $entry_fresh_index["size"] !== $entry_previous_index["size"]
-                        || $entry_fresh_index["type"] !== $entry_previous_index["type"]
+                        $entry_fresh_index["ctime"] !== $entry_previous_local_index["ctime"]
+                        || $entry_fresh_index["size"] !== $entry_previous_local_index["size"]
+                        || $entry_fresh_index["type"] !== $entry_previous_local_index["type"]
                     );
-                $needs_delete = $current_is_file_or_symlink !== $local_index_at_previous_push_is_file_or_symlink
+                $needs_delete = $current_is_file_or_symlink !== $previous_local_index_is_file_or_symlink
                     || $non_empty_directory_becomes_empty;
                 $needs_push = $empty_directory_needs_push
                     || $changed_file_or_symlink_needs_push;
@@ -629,15 +628,15 @@ class PushPlan
                     $needs_delete
                     && !$path_is_excluded
                     && !$this->deleted_directory_stack_covers_path(
-                        $entry_previous_index["path"],
+                        $entry_previous_local_index["path"],
                         $this->deleted_directory_stack_entry
                     )
                 ) {
-                    $this->append_local_path_to_delete($entry_previous_index["path"]);
+                    $this->append_local_path_to_delete($entry_previous_local_index["path"]);
                     $local_paths_to_delete_changed = true;
-                    if ($local_index_at_previous_push_shape === "non_empty_directory") {
+                    if ($previous_local_index_shape === "non_empty_directory") {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $entry_previous_index["path"],
+                            $entry_previous_local_index["path"],
                             $deleted_directory_stack_top_byte_offset
                         );
                         $deleted_directories_stack_changed = true;
@@ -654,9 +653,9 @@ class PushPlan
                 $this->fresh_local_index_entry = $this->parse_next_index_entry($this->fresh_local_index_handle);
             }
             if ($path_comparison >= 0) {
-                $byte_offset_in_previous_index = ftell($this->local_index_at_previous_push_handle);
-                $this->previous_local_index_entry = $this->parse_next_index_entry(
-                    $this->local_index_at_previous_push_handle
+                $byte_offset_in_previous_local_index = ftell($this->previous_local_index_handle);
+                $this->previous_local_index_lookahead_entry = $this->parse_next_index_entry(
+                    $this->previous_local_index_handle
                 );
             }
         }
@@ -670,7 +669,7 @@ class PushPlan
         }
 
         $complete = $this->fresh_local_index_entry === null
-            && $this->previous_local_index_entry === null;
+            && $this->previous_local_index_lookahead_entry === null;
         if ($complete) {
             $deleted_directory_stack_top_byte_offset = null;
             $this->deleted_directory_stack_entry = null;
@@ -680,7 +679,7 @@ class PushPlan
             : [
                 "phase" => "diffing",
                 "byte_offset_in_fresh_index" => $byte_offset_in_fresh_index,
-                "byte_offset_in_previous_index" => $byte_offset_in_previous_index,
+                "byte_offset_in_previous_local_index" => $byte_offset_in_previous_local_index,
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
@@ -692,7 +691,7 @@ class PushPlan
     /**
      * Closes every plan file handle and prevents further plan steps.
      *
-     * The cursor returned to the sender and the plan-owned files remain
+     * The cursor returned to the caller and the plan-owned files remain
      * available to resume the plan or save the completed fresh local index
      * after a successful push.
      */
@@ -702,8 +701,8 @@ class PushPlan
             $this->file_index_processor->close();
         }
         $this->close_fresh_local_index_handle();
-        if (is_resource($this->local_index_at_previous_push_handle)) {
-            fclose($this->local_index_at_previous_push_handle);
+        if (is_resource($this->previous_local_index_handle)) {
+            fclose($this->previous_local_index_handle);
         }
         if (is_resource($this->local_paths_to_push_handle)) {
             fclose($this->local_paths_to_push_handle);
@@ -714,14 +713,14 @@ class PushPlan
         if (is_resource($this->deleted_directories_stack_handle)) {
             fclose($this->deleted_directories_stack_handle);
         }
-        $this->local_index_at_previous_push_handle = null;
+        $this->previous_local_index_handle = null;
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
         $this->deleted_directories_stack_handle = null;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
-        $this->previous_local_index_entry = null;
-        $this->previous_local_index_entry_loaded = false;
+        $this->previous_local_index_lookahead_entry = null;
+        $this->previous_local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
         $this->closed = true;
     }
@@ -953,7 +952,7 @@ class PushPlan
     }
 
     /**
-     * Loads the sender-owned exclusions used throughout one planning run.
+     * Loads the caller-owned exclusions used throughout one planning run.
      *
      * @return list<string> Decoded document-root-relative excluded paths.
      */
@@ -983,11 +982,11 @@ class PushPlan
     /**
      * Reads and decodes the next local index entry.
      *
-     * A null handle represents the missing local index at the previous push.
+     * A null handle represents a missing previous local index.
      * The indexer's entry schema is trusted; only file reads, JSON decoding,
      * and base64 path decoding are handled here as fallible operations.
      *
-     * @param resource|null $handle Open local index handle, or null when no previous index exists.
+     * @param resource|null $handle Open local index handle, or null when no previous local index exists.
      * @return array|null {
      *     Decoded index entry, or null at EOF or when the handle is null.
      *
@@ -1007,7 +1006,7 @@ class PushPlan
         $raw_line = fgets($handle);
         if ($raw_line === false) {
             if (!feof($handle)) {
-                throw new RuntimeException("Failed to read a local push index line.");
+                throw new RuntimeException("Failed to read a local index line.");
             }
             return null;
         }

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -54,11 +54,33 @@ class CliHelpTest extends TestCase
         $this->assertStringNotContainsString('--only', $output);
     }
 
+    public function testFilesDiffHelpShowsOnlyItsLocalCommandOptions(): void
+    {
+        $output = $this->runHelp('files-diff');
+
+        $this->assertStringContainsString('Usage: reprint files-diff <target-url>', $output);
+        $this->assertStringContainsString('--state-dir=DIR', $output);
+        $this->assertStringContainsString('--fs-root=DIR', $output);
+        $this->assertStringContainsString('previous local index', $output);
+        $this->assertStringContainsString('completed files-push', $output);
+        $this->assertStringContainsString('push operation plan', $output);
+        $this->assertStringContainsString('default-skipped paths', $output);
+        $this->assertStringContainsString('No network calls', $output);
+        $this->assertStringContainsString('complete diff from the beginning', $output);
+        $this->assertStringNotContainsString('--runtime', $output);
+        $this->assertStringNotContainsString('--secret', $output);
+        $this->assertStringNotContainsString('--force-http', $output);
+        $this->assertStringNotContainsString('--filter', $output);
+        $this->assertStringNotContainsString('--remap', $output);
+        $this->assertStringNotContainsString('--only', $output);
+    }
+
     public function testMainHelpDescribesFilesPushWithoutApplyingPullOnlyContractsGlobally(): void
     {
         $output = $this->runHelp('--help');
 
         $this->assertStringContainsString('files-push', $output);
+        $this->assertStringContainsString('files-diff', $output);
         $this->assertStringContainsString('Low-level commands:', $output);
         $this->assertStringNotContainsString('Low-level commands (used by pull internally):', $output);
         $this->assertStringNotContainsString('State is stored in --state-dir/.import-state.json', $output);

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -200,7 +200,7 @@ final class FilesDiffCommandTest extends TestCase
     public function testFilesDiffDoesNotChangeThePreviousLocalIndexAndRepeatsTheSameReport(): void
     {
         $this->writePreviousLocalIndex(array_keys($this->initialFiles));
-        $previousLocalIndex = $this->pairStateDirectory() . '/previous_local_index.jsonl';
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
         $previousLocalIndexContents = file_get_contents($previousLocalIndex);
         $this->assertIsString($previousLocalIndexContents);
         file_put_contents($this->localTree . '/added-after-index.txt', 'new');
@@ -256,7 +256,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertSame('', $result['stdout']);
         $this->assertSame("Error: files-diff does not accept --runtime.\n", $result['stderr']);
-        $this->assertDirectoryDoesNotExist($this->pairStateDirectory());
+        $this->assertDirectoryDoesNotExist($this->pushStateDirectory());
     }
 
     public function testInterruptedFilesDiffReportsTheCompleteDiffWhenItIsRunAgain(): void
@@ -318,7 +318,7 @@ final class FilesDiffCommandTest extends TestCase
             'local_paths_to_push' => count($bulkPaths),
             'local_paths_to_delete' => 0,
         ], $finalRecord);
-        $this->assertDirectoryDoesNotExist($this->pairStateDirectory() . '/files-diff-plan');
+        $this->assertDirectoryDoesNotExist($this->pushStateDirectory() . '/files-diff-plan');
     }
 
     /**
@@ -350,11 +350,11 @@ final class FilesDiffCommandTest extends TestCase
             }
             $lines .= json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         }
-        $pairStateDirectory = $this->pairStateDirectory();
-        if (!is_dir($pairStateDirectory)) {
-            mkdir($pairStateDirectory, 0700, true);
+        $pushStateDirectory = $this->pushStateDirectory();
+        if (!is_dir($pushStateDirectory)) {
+            mkdir($pushStateDirectory, 0700, true);
         }
-        file_put_contents($pairStateDirectory . '/previous_local_index.jsonl', $lines);
+        file_put_contents($pushStateDirectory . '/previous_local_index.jsonl', $lines);
     }
 
     /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
@@ -391,7 +391,7 @@ final class FilesDiffCommandTest extends TestCase
         return $paths;
     }
 
-    private function pairStateDirectory(): string
+    private function pushStateDirectory(): string
     {
         $canonicalLocalTree = realpath($this->localTree);
         $this->assertIsString($canonicalLocalTree);

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -1,0 +1,494 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * The files-diff user contract.
+ *
+ * files-diff compares the local tree with the pair's previous local index —
+ * the index a completed files-push publishes — without contacting the target,
+ * and reports the complete diff on every run. These tests pin that contract:
+ * local-only operation, correct change records, arbitrary path bytes, the
+ * previous-local-index requirement, no mutation of that index, and a complete
+ * report after an interrupted run.
+ */
+final class FilesDiffCommandTest extends TestCase
+{
+    private string $root;
+    private string $stateDirectory;
+    private string $localTree;
+    private string $targetUrl = 'https://example.test/export.php?site-export-api';
+    private ?string $invalidBytePathInIndex = null;
+
+    /** @var array<string,string> */
+    private array $initialFiles = [
+        'deleted.txt' => 'delete me',
+        'edited.txt' => 'old',
+        'swap' => 'file before the type change',
+        'unchanged.txt' => 'same',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/files-diff-command-' . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->localTree = $this->root . '/local-tree';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->localTree, 0700, true);
+
+        $invalidBytePathInIndex = "delete-invalid-\xff.txt";
+        if (@file_put_contents($this->localTree . '/' . $invalidBytePathInIndex, 'invalid path bytes') !== false) {
+            $this->initialFiles[$invalidBytePathInIndex] = 'invalid path bytes';
+            $this->invalidBytePathInIndex = $invalidBytePathInIndex;
+        }
+        foreach ($this->initialFiles as $path => $contents) {
+            file_put_contents($this->localTree . '/' . $path, $contents);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testFilesDiffReportsAnEmptyDiffWhenTheLocalTreeMatchesTheIndex(): void
+    {
+        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $expectedRecord = [
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ];
+        $this->assertSame($this->encodeJsonLine($expectedRecord), $result['stdout']);
+        $this->assertSame('', $result['stderr']);
+    }
+
+    public function testFilesDiffReportsAddedEditedDeletedAndTypeChangedPaths(): void
+    {
+        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+
+        $arbitraryBytePath = "arbitrary-\nname.txt";
+        file_put_contents($this->localTree . '/added.txt', 'new file');
+        file_put_contents($this->localTree . '/' . $arbitraryBytePath, 'raw path byte');
+        file_put_contents($this->localTree . '/edited.txt', 'edited local contents');
+        unlink($this->localTree . '/deleted.txt');
+        unlink($this->localTree . '/swap');
+        mkdir($this->localTree . '/swap');
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $records = $this->filesDiffRecords($result['stdout']);
+        $finalRecord = array_pop($records);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 4,
+            'local_paths_to_delete' => 2,
+        ], $finalRecord);
+
+        $recordsByActionAndPath = [];
+        foreach ($records as $record) {
+            $path = base64_decode($record['path_b64'] ?? '', true);
+            $this->assertIsString($path);
+            $recordsByActionAndPath[( $record['action'] ?? '' ) . ':' . $path] = $record;
+        }
+        $this->assertCount(6, $recordsByActionAndPath);
+        $recordKeys = array_keys($recordsByActionAndPath);
+        sort($recordKeys, SORT_STRING);
+        $expectedRecordKeys = [
+            'delete:deleted.txt',
+            'delete:swap',
+            'push:added.txt',
+            'push:' . $arbitraryBytePath,
+            'push:edited.txt',
+            'push:swap',
+        ];
+        sort($expectedRecordKeys, SORT_STRING);
+        $this->assertSame(
+            $expectedRecordKeys,
+            $recordKeys
+        );
+
+        $this->assertSame(
+            $this->expectedPushRecord('added.txt', 'file'),
+            $recordsByActionAndPath['push:added.txt']
+        );
+        $this->assertSame(
+            $this->expectedPushRecord($arbitraryBytePath, 'file'),
+            $recordsByActionAndPath['push:' . $arbitraryBytePath]
+        );
+        $this->assertSame(
+            $this->expectedPushRecord('edited.txt', 'file'),
+            $recordsByActionAndPath['push:edited.txt']
+        );
+        $this->assertSame(
+            $this->expectedPushRecord('swap', 'dir'),
+            $recordsByActionAndPath['push:swap']
+        );
+        $this->assertSame([
+            'command' => 'files-diff',
+            'action' => 'delete',
+            'path_b64' => base64_encode('deleted.txt'),
+        ], $recordsByActionAndPath['delete:deleted.txt']);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'action' => 'delete',
+            'path_b64' => base64_encode('swap'),
+        ], $recordsByActionAndPath['delete:swap']);
+        $this->assertSame('', $result['stderr']);
+        $this->assertSame(
+            implode('', array_map(
+                fn(array $record): string => $this->encodeJsonLine($record),
+                array_merge($records, [$finalRecord])
+            )),
+            $result['stdout']
+        );
+    }
+
+    public function testFilesDiffPreservesInvalidUtf8PathBytesInPushAndDeleteRecords(): void
+    {
+        if ($this->invalidBytePathInIndex === null) {
+            $this->markTestSkipped('This filesystem does not accept invalid UTF-8 path bytes.');
+        }
+        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+
+        $invalidBytePathToPush = "push-invalid-\xfe.txt";
+        if (@file_put_contents($this->localTree . '/' . $invalidBytePathToPush, 'new invalid path bytes') === false) {
+            $this->markTestSkipped('This filesystem does not accept a second invalid UTF-8 path.');
+        }
+        unlink($this->localTree . '/' . $this->invalidBytePathInIndex);
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stderr']);
+        $records = $this->filesDiffRecords($result['stdout']);
+        $finalRecord = array_pop($records);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 1,
+            'local_paths_to_delete' => 1,
+        ], $finalRecord);
+        $this->assertSame([
+            $this->expectedPushRecord($invalidBytePathToPush, 'file'),
+            [
+                'command' => 'files-diff',
+                'action' => 'delete',
+                'path_b64' => base64_encode($this->invalidBytePathInIndex),
+            ],
+        ], $records);
+        $this->assertStringNotContainsString($invalidBytePathToPush, $result['stdout']);
+        $this->assertStringNotContainsString($this->invalidBytePathInIndex, $result['stdout']);
+    }
+
+    public function testFilesDiffDoesNotChangeThePreviousLocalIndexAndRepeatsTheSameReport(): void
+    {
+        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $previousLocalIndex = $this->pairStateDirectory() . '/previous_local_index.jsonl';
+        $previousLocalIndexContents = file_get_contents($previousLocalIndex);
+        $this->assertIsString($previousLocalIndexContents);
+        file_put_contents($this->localTree . '/added-after-index.txt', 'new');
+
+        $firstResult = $this->runFilesDiff();
+        $secondResult = $this->runFilesDiff();
+
+        $this->assertSame(0, $firstResult['exit'], $firstResult['output']);
+        $this->assertSame(0, $secondResult['exit'], $secondResult['output']);
+        $this->assertSame($firstResult['stdout'], $secondResult['stdout']);
+        $this->assertSame($previousLocalIndexContents, file_get_contents($previousLocalIndex));
+        $records = $this->filesDiffRecords($secondResult['stdout']);
+        $this->assertSame(
+            $this->expectedPushRecord('added-after-index.txt', 'file'),
+            $records[0] ?? null
+        );
+    }
+
+    public function testFilesDiffWithoutAPreviousLocalIndexFailsWithPointedGuidance(): void
+    {
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stdout']);
+        $this->assertCanonicalSingleJsonLine($result['stderr']);
+        $this->assertStringContainsString('completed files-push', $result['output']);
+        $this->assertStringContainsString(
+            'same target URL, state directory, and local tree',
+            $result['output']
+        );
+    }
+
+    public function testFilesDiffDoesNotReuseThePreviousLocalIndexForADifferentTargetUrlQuery(): void
+    {
+        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+
+        $result = $this->runFilesDiff($this->targetUrl . '&site=other');
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stdout']);
+        $this->assertCanonicalSingleJsonLine($result['stderr']);
+        $this->assertStringContainsString('completed files-push', $result['output']);
+        $this->assertStringContainsString(
+            'same target URL, state directory, and local tree',
+            $result['output']
+        );
+    }
+
+    public function testFilesDiffRejectsRuntimeOptionsBeforeStateChanges(): void
+    {
+        $result = $this->runFilesDiff(null, ['--runtime=php-builtin']);
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stdout']);
+        $this->assertSame("Error: files-diff does not accept --runtime.\n", $result['stderr']);
+        $this->assertDirectoryDoesNotExist($this->pairStateDirectory());
+    }
+
+    public function testInterruptedFilesDiffReportsTheCompleteDiffWhenItIsRunAgain(): void
+    {
+        // An empty previous local index selects every current path for push.
+        $this->removeTree($this->localTree);
+        mkdir($this->localTree, 0700, true);
+        $this->writePreviousLocalIndex([]);
+        $bulkPaths = $this->createBulkFiles('rerun');
+
+        // Backpressure from the unread stdout pipe holds the first process
+        // mid-report, so the kill interrupts an in-progress record stream.
+        [$process, $pipes] = $this->startCliProcess([
+            'files-diff',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+        ]);
+        stream_set_blocking($pipes[1], false);
+        $firstOutput = '';
+        for ($attempt = 0; $attempt < 30000; ++$attempt) {
+            $chunk = fread($pipes[1], 8192);
+            if (is_string($chunk) && $chunk !== '') {
+                $firstOutput .= $chunk;
+            }
+            if (strpos($firstOutput, "\n") !== false) {
+                break;
+            }
+            $processStatus = proc_get_status($process);
+            if (!( $processStatus['running'] ?? false )) {
+                break;
+            }
+            usleep(1000);
+        }
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+        $this->assertStringContainsString(
+            "\n",
+            $firstOutput,
+            'files-diff exited before the test could interrupt its report.'
+        );
+        $this->assertStringNotContainsString('"status":"complete"', $firstOutput);
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stderr']);
+        $records = $this->filesDiffRecords($result['stdout']);
+        $finalRecord = array_pop($records);
+        $this->assertSame(
+            array_map(fn(string $path): array => $this->expectedPushRecord($path, 'file'), $bulkPaths),
+            $records
+        );
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => count($bulkPaths),
+            'local_paths_to_delete' => 0,
+        ], $finalRecord);
+        $this->assertDirectoryDoesNotExist($this->pairStateDirectory() . '/files-diff-plan');
+    }
+
+    /**
+     * Publishes a previous local index describing the named paths as they
+     * exist right now, the way a completed files-push saves its index.
+     *
+     * @param list<string> $paths Document-root-relative paths to record.
+     */
+    private function writePreviousLocalIndex(array $paths): void
+    {
+        usort($paths, 'strcmp');
+        $lines = '';
+        foreach ($paths as $path) {
+            $stat = lstat($this->localTree . '/' . $path);
+            $this->assertIsArray($stat);
+            $fileTypeBits = $stat['mode'] & 0170000;
+            $type = $fileTypeBits === 0040000 ? 'dir' : ( $fileTypeBits === 0120000 ? 'link' : 'file' );
+            $entry = [
+                'path' => base64_encode($path),
+                'ctime' => (int) $stat['ctime'],
+                'size' => $type === 'dir' ? 0 : (int) $stat['size'],
+                'type' => $type,
+            ];
+            if ($type === 'dir') {
+                $entry['empty'] = count(array_diff(
+                    scandir($this->localTree . '/' . $path) ?: [],
+                    ['.', '..']
+                )) === 0;
+            }
+            $lines .= json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        }
+        $pairStateDirectory = $this->pairStateDirectory();
+        if (!is_dir($pairStateDirectory)) {
+            mkdir($pairStateDirectory, 0700, true);
+        }
+        file_put_contents($pairStateDirectory . '/previous_local_index.jsonl', $lines);
+    }
+
+    /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
+    private function expectedPushRecord(string $path, string $type): array
+    {
+        $stat = lstat($this->localTree . '/' . $path);
+        $this->assertIsArray($stat);
+        return [
+            'command' => 'files-diff',
+            'action' => 'push',
+            'path_b64' => base64_encode($path),
+            'type' => $type,
+            'size' => $type === 'dir' ? 0 : (int) $stat['size'],
+            'ctime' => (int) $stat['ctime'],
+        ];
+    }
+
+    /** @return list<string> Created document-root-relative paths. */
+    private function createBulkFiles(string $prefix, int $count = 1000): array
+    {
+        $paths = [];
+        for ($index = 0; $index < $count; ++$index) {
+            $path = sprintf(
+                '%s-%04d-%s.txt',
+                $prefix,
+                $index,
+                str_repeat('x', 180)
+            );
+            if (file_put_contents($this->localTree . '/' . $path, 'x') === false) {
+                $this->fail('Failed to create a bulk files-diff test path.');
+            }
+            $paths[] = $path;
+        }
+        return $paths;
+    }
+
+    private function pairStateDirectory(): string
+    {
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
+        $pair = hash('sha256', rtrim($this->targetUrl, '?&') . "\0" . $canonicalLocalTree);
+        return realpath($this->stateDirectory) . '/push/' . $pair;
+    }
+
+    /** @param list<string> $extraArguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesDiff(?string $targetUrl = null, array $extraArguments = []): array
+    {
+        return $this->runCli(array_merge([
+            'files-diff',
+            $targetUrl ?? $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+        ], $extraArguments));
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $arguments): array
+    {
+        [$process, $pipes] = $this->startCliProcess($arguments);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{0:resource,1:array<int,resource>}
+     */
+    private function startCliProcess(array $arguments): array
+    {
+        $process = proc_open(
+            array_merge([PHP_BINARY, __DIR__ . '/../../importer/import.php'], $arguments),
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /** @param array<string,mixed> $record */
+    private function encodeJsonLine(array $record): string
+    {
+        return json_encode($record, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+    }
+
+    private function assertCanonicalSingleJsonLine(string $output): void
+    {
+        $record = json_decode(rtrim($output, "\n"), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($record);
+        $this->assertSame(json_encode($record, JSON_THROW_ON_ERROR) . "\n", $output);
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function filesDiffRecords(string $output): array
+    {
+        $records = [];
+        foreach (preg_split('/\R/', trim($output)) ?: [] as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded) && ( $decoded['command'] ?? null ) === 'files-diff') {
+                $records[] = $decoded;
+            }
+        }
+        return $records;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -7,11 +7,11 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-plan.php';
 
 /**
- * Coverage for PushPlan's per-target local index at the previous push and bounded steps.
+ * Coverage for PushPlan's previous local index and bounded steps.
  *
  * The plan diffs the fresh local index, whose directory entries carry an
- * `empty` boolean from the indexer, against the local index at the previous
- * push. The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
+ * `empty` boolean from the indexer, against the previous local index.
+ * The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
  * local paths to delete, cursor replay, and every transition among files,
  * symlinks, empty directories, and non-empty directories.
  */
@@ -43,37 +43,37 @@ final class PushPlanTest extends TestCase
     // ------------------------------------------------------------------
 
     // ------------------------------------------------------------------
-    //  Successful push
+    //  Previous local index
     // ------------------------------------------------------------------
 
     public function testSavedIndexCanBeUsedByTheNextPlan(): void
     {
-        $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath());
+        $this->assertFileDoesNotExist($this->previousLocalIndexPath());
 
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
-        $this->assertFileExists($this->localIndexAtPreviousPushPath());
-        $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath() . '.tmp');
+        $this->assertFileExists($this->previousLocalIndexPath());
+        $this->assertFileDoesNotExist($this->previousLocalIndexPath() . '.tmp');
         $this->assertDirectoryDoesNotExist($this->planDirectory());
 
         // A second successful push replaces the first. Comparing that same index
         // again produces no paths to push or delete.
         $second = $this->writeIndex(['b.txt' => [200, 9, 'file']]);
-        $this->saveSuccessfulPush($second);
+        $this->savePreviousLocalIndex($second);
         $plan = $this->startPlan($second);
         $this->planToCompletion($plan);
         $this->assertPathCounts(0, 0);
     }
 
-    public function testStartRequiresTheSenderToCreateThePlanDirectory(): void
+    public function testStartRequiresTheCallerToCreateThePlanDirectory(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('without its directory');
         PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
-            $this->localIndexAtPreviousPushPath(),
+            $this->previousLocalIndexPath(),
             $this->excludedPathsPath()
         );
     }
@@ -86,7 +86,7 @@ final class PushPlanTest extends TestCase
         $this->removePlanDirectory();
 
         $this->assertDirectoryDoesNotExist($this->planDirectory());
-        $this->assertFileDoesNotExist($this->localIndexAtPreviousPushPath());
+        $this->assertFileDoesNotExist($this->previousLocalIndexPath());
 
         $secondIndex = $this->writeIndex(['second.txt' => [200, 6, 'file']]);
         $secondPlan = $this->startPlan($secondIndex);
@@ -137,7 +137,7 @@ final class PushPlanTest extends TestCase
 
     public function testPlanCopiesEveryFreshLocalIndexEntryAndExcludesOnlyPushAndDeletePaths(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
             'private' => [1, 0, 'dir', false],
             'private/gone.txt' => [1, 1, 'file'],
@@ -175,7 +175,7 @@ final class PushPlanTest extends TestCase
             'a.txt' => [100, 5, 'file'],
             'b/c.txt' => [200, 7, 'file'],
         ]);
-        $this->saveSuccessfulPush($index);
+        $this->savePreviousLocalIndex($index);
 
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
@@ -187,7 +187,7 @@ final class PushPlanTest extends TestCase
 
     public function testCtimeSizeOrTypeChangeEachMarksThePathChanged(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'ctime-bump.txt' => [100, 5, 'file'],
             'size-bump.txt' => [100, 5, 'file'],
             'type-swap' => [100, 5, 'file'],
@@ -247,7 +247,7 @@ final class PushPlanTest extends TestCase
 
         foreach ($matrix as $previousType => $transitions) {
             foreach ($transitions as $currentType => [$expectedPushes, $expectedDeletes]) {
-                $this->saveSuccessfulPush($this->writeLogicalIndex($previousType, 1));
+                $this->savePreviousLocalIndex($this->writeLogicalIndex($previousType, 1));
                 $current = $this->writeLogicalIndex($currentType, 2);
 
                 $plan = $this->startPlan($current);
@@ -264,7 +264,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedSubtreeEmitsOnlyItsRootAsALocalPathToDelete(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'gone' => [1, 0, 'dir', false],
             'gone/child.txt' => [1, 1, 'file'],
             'gone/nested' => [1, 0, 'dir', false],
@@ -283,7 +283,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedDirectoryStackAppendsWithoutGrowingTheCursor(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
             'b.txt' => [1, 1, 'file'],
@@ -309,7 +309,7 @@ final class PushPlanTest extends TestCase
 
     public function testSeenDeletedDirectorySurvivesAnInterleavedSiblingCursor(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
@@ -333,7 +333,7 @@ final class PushPlanTest extends TestCase
 
     public function testReplacementRootSurvivesLexicallyInterleavedSiblingPaths(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
@@ -353,7 +353,7 @@ final class PushPlanTest extends TestCase
 
     public function testNewChangedDeletedAndUnchangedPathsArePlannedTogether(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'changed.txt' => [100, 5, 'file'],
             'deleted.txt' => [100, 5, 'file'],
             'unchanged.txt' => [100, 5, 'file'],
@@ -373,7 +373,7 @@ final class PushPlanTest extends TestCase
         $this->assertSame("deleted.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testAfterSuccessfulPushClearsPreviousOutputForTheNextDiff(): void
+    public function testSavingTheFreshIndexAsThePreviousLocalIndexClearsPlanOutput(): void
     {
         $index = $this->writeIndex(['a.txt' => [100, 5, 'file']]);
         $plan = $this->startPlan($index);
@@ -381,7 +381,7 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
         $this->assertSame(['a.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
 
-        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexAtPreviousPushPath());
+        copy($this->planPath('fresh_local_index.jsonl'), $this->previousLocalIndexPath());
         $this->removePlanDirectory();
         $this->assertDirectoryDoesNotExist($this->planDirectory());
         $plan = $this->startPlan($index);
@@ -397,7 +397,7 @@ final class PushPlanTest extends TestCase
         // Newlines and non-ASCII bytes are why JSONL indexes encode paths.
         $newPath = "wp-content/uploads/line\nbreak.png";
         $deletedPath = 'wp-content/uploads/naïve-café.jpg';
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             $deletedPath => [100, 6, 'file'],
         ]));
         $current = $this->writeIndex([
@@ -418,7 +418,7 @@ final class PushPlanTest extends TestCase
 
     public function testIndexingFinishesBeforeDiffingAndClearsOldOutput(): void
     {
-        $this->saveSuccessfulPush($this->writeIndex([
+        $this->savePreviousLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
         ]));
         $oldIndex = $this->writeIndex(['old.txt' => [1, 1, 'file']]);
@@ -526,16 +526,16 @@ final class PushPlanTest extends TestCase
         $this->assertSame([
             'plan_directory',
             'local_tree_root',
-            'local_index_at_previous_push',
+            'previous_local_index',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
         $this->assertSame(realpath($this->localTreeRoot()), $cursor['local_tree_root']);
-        $this->assertSame($this->localIndexAtPreviousPushPath(), $cursor['local_index_at_previous_push']);
+        $this->assertSame($this->previousLocalIndexPath(), $cursor['previous_local_index']);
         $this->assertSame([
             'phase',
             'byte_offset_in_fresh_index',
-            'byte_offset_in_previous_index',
+            'byte_offset_in_previous_local_index',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'deleted_directory_stack_top_byte_offset',
@@ -555,15 +555,15 @@ final class PushPlanTest extends TestCase
     public function testNewInstanceResumesFromTheRetainedCursor(): void
     {
         $currentEntries = [];
-        $localIndexAtPreviousPushEntries = [];
+        $previousLocalIndexEntries = [];
         for ($index = 0; $index < 3; ++$index) {
             // The current and deleted names alternate in decoded sort order,
             // so every batch appends to both path files.
             $currentEntries[sprintf('item-%04d-current.txt', $index)] = [$index + 1, 1, 'file'];
-            $localIndexAtPreviousPushEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
+            $previousLocalIndexEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
         }
         $current = $this->writeIndex($currentEntries);
-        $this->saveSuccessfulPush($this->writeIndex($localIndexAtPreviousPushEntries));
+        $this->savePreviousLocalIndex($this->writeIndex($previousLocalIndexEntries));
         $plan = $this->startPlan($current);
 
         $this->assertTrue($this->nextPlanStep($plan));
@@ -586,7 +586,7 @@ final class PushPlanTest extends TestCase
 
         $this->assertPathCounts(3, 3);
         $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(array_keys($localIndexAtPreviousPushEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
+        $this->assertSame(array_keys($previousLocalIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
@@ -666,7 +666,7 @@ final class PushPlanTest extends TestCase
         $plan = PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
-            $this->localIndexAtPreviousPushPath(),
+            $this->previousLocalIndexPath(),
             $this->excludedPathsPath()
         );
         $this->cursor = $plan->get_cursor();
@@ -684,11 +684,11 @@ final class PushPlanTest extends TestCase
         return PushPlan::resume($this->cursor);
     }
 
-    private function saveSuccessfulPush(string $treeDescriptionPath): void
+    private function savePreviousLocalIndex(string $treeDescriptionPath): void
     {
         $plan = $this->startPlan($treeDescriptionPath);
         $this->planToCompletion($plan);
-        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexAtPreviousPushPath());
+        copy($this->planPath('fresh_local_index.jsonl'), $this->previousLocalIndexPath());
         $this->removePlanDirectory();
     }
 
@@ -753,9 +753,9 @@ final class PushPlanTest extends TestCase
         return $this->tempDir . '/state/push/example.com';
     }
 
-    private function localIndexAtPreviousPushPath(): string
+    private function previousLocalIndexPath(): string
     {
-        return $this->pushStateDirectory() . '/local_index_at_previous_push.jsonl';
+        return $this->pushStateDirectory() . '/previous_local_index.jsonl';
     }
 
     private function excludedPathsPath(): string

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1385,7 +1385,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
-        $this->assertFileExists($push_state_directory . '/local_index_at_previous_push.jsonl');
+        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
     }
 
     /**
@@ -1751,7 +1751,7 @@ final class PushEndpointsTest extends TestCase {
 
         $this->assertSame('complete', $result['status']);
         $index_lines = file(
-            $push_state_directory . '/local_index_at_previous_push.jsonl',
+            $push_state_directory . '/previous_local_index.jsonl',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($index_lines);
@@ -2183,7 +2183,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertSame('public-change', file_get_contents($this->docroot . '/public.txt'));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $saved_local_index = file_get_contents($push_state_directory . '/local_index_at_previous_push.jsonl');
+        $saved_local_index = file_get_contents($push_state_directory . '/previous_local_index.jsonl');
         $this->assertIsString($saved_local_index);
         $this->assertStringContainsString(
             '"path":"' . base64_encode('preserved/value.txt') . '"',
@@ -2271,7 +2271,7 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Leaves a missing push state directory absent when there is nothing to resume.
+     * Leaves a missing local push state directory absent when there is nothing to resume.
      */
     public function testHighLevelSenderDoesNotCreateStateDirectoryWhenResumeHasNoState(): void
     {
@@ -2621,16 +2621,16 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $initial['exit'], $initial['output']);
         $initial_result = $this->lastCliJsonLine($initial['stdout']);
         $this->assertSame('complete', $initial_result['status'] ?? null);
-        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
         $this->assertSame($initial_contents, file_get_contents($this->docroot . '/nested/multi-chunk.bin'));
         $this->assertSame('delete me later', file_get_contents($this->docroot . '/delete-later.txt'));
         $this->assertDirectoryExists($this->docroot . '/empty-directory');
         $this->assertTrue(is_link($this->docroot . '/file-link'));
         $this->assertSame('nested/multi-chunk.bin', readlink($this->docroot . '/file-link'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
-        $this->assertFileExists($pair_state_directory . '/local_index_at_previous_push.jsonl');
-        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
-        $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
+        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileDoesNotExist($state_directory . '/.import-state.json');
 
         $status = json_decode(
@@ -2680,9 +2680,9 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileDoesNotExist($this->docroot . '/delete-later.txt');
         $this->assertSame('added', file_get_contents($this->docroot . '/added.txt'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
-        $this->assertFileExists($pair_state_directory . '/local_index_at_previous_push.jsonl');
-        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
-        $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
+        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
     }
 
     public function testFilesPushCliStopsAtTheCallerDeadlineAndAnotherProcessCompletes(): void
@@ -2810,8 +2810,8 @@ final class PushEndpointsTest extends TestCase {
         }
 
         $this->assertNotSame(0, $killed['exit']);
-        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
-        $active_state = $this->loadActiveState($pair_state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $active_state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($active_state);
         $this->waitForPushLockRelease($active_state['push_session_id']);
 
@@ -2820,7 +2820,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $completed['exit'], $completed['output']);
         $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
         $this->assertSame($contents, file_get_contents($this->docroot . '/large.bin'));
-        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
+        $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
     }
 
     public function testFilesPushCliMakesOneFailedAttemptAndALaterProcessCompletes(): void
@@ -2829,16 +2829,16 @@ final class PushEndpointsTest extends TestCase {
         $state_directory = $this->root . '/cli-failed-state';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'value after failure');
-        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
         $sender = PushFilesSender::start(
-            $this->filesPushSenderOptions($local_docroot, $pair_state_directory)
+            $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
         } finally {
             $sender->close();
         }
-        $active_state = $this->loadActiveState($pair_state_directory);
+        $active_state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($active_state);
         $push_lock = fopen(
             $this->reprint_directory . '/.reprint/push/' . $active_state['push_session_id'] . '/push.lock',
@@ -2859,7 +2859,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('failed', $failed_result['status'] ?? null);
         $this->assertSame('lock_acquisition_failure', $failed_result['reason'] ?? null);
         $this->assertSame($status_requests + 1, $this->countEndpointRequests('push_status'));
-        $this->assertFileExists($pair_state_directory . '/sender.json');
+        $this->assertFileExists($push_state_directory . '/sender.json');
         $failed_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'FAILED files-push | pair=' . $failed_result['pair'],
@@ -2879,9 +2879,9 @@ final class PushEndpointsTest extends TestCase {
         $state_directory = $this->root . '/cli-restart-state';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'before');
-        $pair_state_directory = $this->filesPushPairStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
         $sender = PushFilesSender::start(
-            $this->filesPushSenderOptions($local_docroot, $pair_state_directory)
+            $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
@@ -2899,8 +2899,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('restart', $restart_result['status'] ?? null);
         $this->assertSame('local_path_changed', $restart_result['reason'] ?? null);
         $this->assertSame($push_create_requests, $this->countEndpointRequests('push_create'));
-        $this->assertFileDoesNotExist($pair_state_directory . '/sender.json');
-        $this->assertDirectoryDoesNotExist($pair_state_directory . '/plan');
+        $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
+        $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $restart_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'RESTART files-push | pair=' . $restart_result['pair'],
@@ -3006,7 +3006,7 @@ final class PushEndpointsTest extends TestCase {
         $this->fail('No JSON line was found in CLI output: ' . $output);
     }
 
-    private function filesPushPairStateDirectory(
+    private function filesPushStateDirectory(
         string $local_docroot,
         string $state_directory
     ): string {
@@ -3019,11 +3019,11 @@ final class PushEndpointsTest extends TestCase {
     /** @return array<string,mixed> */
     private function filesPushSenderOptions(
         string $local_docroot,
-        string $pair_state_directory
+        string $push_state_directory
     ): array {
         return [
             'docroot' => $local_docroot,
-            'push_state_directory' => $pair_state_directory,
+            'push_state_directory' => $push_state_directory,
             'base_url' => $this->base_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -3473,14 +3473,14 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Seeds PushPlan's local index at the previous successful push.
+     * Seeds the pair's previous local index.
      */
     private function seedPreviousLocalIndex(string $push_state_directory, string $index_path): void
     {
         if (!is_dir($push_state_directory)) {
             mkdir($push_state_directory, 0700, true);
         }
-        $this->assertTrue(copy($index_path, $push_state_directory . '/local_index_at_previous_push.jsonl'));
+        $this->assertTrue(copy($index_path, $push_state_directory . '/previous_local_index.jsonl'));
     }
 
     /**

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2514,6 +2514,91 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
     }
 
+    public function testCompletedFilesPushPublishesThePreviousLocalIndexForFilesDiff(): void
+    {
+        $local_docroot = $this->root . '/push-diff-local-docroot';
+        $state_directory = $this->root . '/push-diff-state';
+        mkdir($local_docroot, 0700, true);
+        mkdir($state_directory, 0700, true);
+        file_put_contents($local_docroot . '/pushed.txt', 'pushed content');
+
+        $push = $this->runFilesPushCli($local_docroot, $state_directory);
+        $this->assertSame(0, $push['exit'], $push['output']);
+
+        $empty_diff = $this->runFilesDiffCli($local_docroot, $state_directory);
+        $this->assertSame(0, $empty_diff['exit'], $empty_diff['output']);
+        $this->assertSame(
+            json_encode([
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => 0,
+                'local_paths_to_delete' => 0,
+            ], JSON_UNESCAPED_SLASHES) . "\n",
+            $empty_diff['stdout']
+        );
+
+        file_put_contents($local_docroot . '/pushed.txt', 'edited after the push');
+
+        $changed_diff = $this->runFilesDiffCli($local_docroot, $state_directory);
+        $this->assertSame(0, $changed_diff['exit'], $changed_diff['output']);
+        $changed_stat = lstat($local_docroot . '/pushed.txt');
+        $this->assertIsArray($changed_stat);
+        $this->assertSame(
+            json_encode([
+                'command' => 'files-diff',
+                'action' => 'push',
+                'path_b64' => base64_encode('pushed.txt'),
+                'type' => 'file',
+                'size' => (int) $changed_stat['size'],
+                'ctime' => (int) $changed_stat['ctime'],
+            ], JSON_UNESCAPED_SLASHES) . "\n"
+            . json_encode([
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => 1,
+                'local_paths_to_delete' => 0,
+            ], JSON_UNESCAPED_SLASHES) . "\n",
+            $changed_diff['stdout']
+        );
+    }
+
+    /**
+     * Runs the production files-diff CLI for the same pair a push CLI used.
+     *
+     * @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesDiffCli(string $local_docroot, string $state_directory): array
+    {
+        $process = proc_open(
+            [
+                PHP_BINARY,
+                __DIR__ . '/../importer/import.php',
+                'files-diff',
+                $this->base_url,
+                '--state-dir=' . $state_directory,
+                '--fs-root=' . $local_docroot,
+            ],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
     public function testFilesPushCliPushesAndUpdatesACompleteLocalTree(): void
     {
         $this->writeDocrootConfiguration([


### PR DESCRIPTION
`reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR` prints the pair's local minimized push operation plan before target exclusions by comparing the local tree with its previous local index. It makes no network request and requires no secret.

## Background

A completed files-push saves the local path type, size, and ctime used to plan the next push. Until now that comparison was only available inside files-push.

## This change

files-diff derives the same pair key as files-push and requires the same target URL, state directory, and local tree that produced the previous local index. It emits JSONL push records with `path_b64`, `type`, `size`, and `ctime`, followed by delete records with `path_b64` and a `complete` record with both counts. Paths remain base64 so arbitrary filesystem bytes survive JSON.

After adding `wp-content/themes/my-theme/style.css` and deleting `wp-content/plugins/old-plugin`, a report looks like this:

```console
$ reprint files-diff 'https://example.com/export.php?site-export-api' --state-dir=.reprint --fs-root=public
{"command":"files-diff","action":"push","path_b64":"d3AtY29udGVudC90aGVtZXMvbXktdGhlbWUvc3R5bGUuY3Nz","type":"file","size":8421,"ctime":1784822400}
{"command":"files-diff","action":"delete","path_b64":"d3AtY29udGVudC9wbHVnaW5zL29sZC1wbHVnaW4="}
{"command":"files-diff","status":"complete","local_paths_to_push":1,"local_paths_to_delete":1}
```

The command leaves the previous local index unchanged and stores no resume state. An interrupted run discards its temporary plan; the next run rebuilds and prints the complete report from the beginning.

This renames `local_index_at_previous_push.jsonl` to `previous_local_index.jsonl` and gives PushPlan a caller-supplied previous local index, so files-push and files-diff use the same local diff implementation.

## Testing

Complete a files-push, stop the target, then add, edit, delete, and change the type of paths in the same local tree. Run files-diff with the same target URL, state directory, and local tree; check the base64 JSONL push and delete records and final counts. Run it again without changing the tree and confirm it prints the same complete report without changing `previous_local_index.jsonl`.