### PR TITLE
[Push] Preserve unselected changes after selected files-push

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -90,11 +90,13 @@ tree**:
 The previous local index is the pair's shared local baseline for deciding later
 local push work. A committed files-push merges only its committed push and
 delete operations and their required ancestors into the latest baseline,
-preserving other paths advanced by a compatible pull between sender processes. A
-compatible full file-only pull — standalone `files-pull` or the terminal file
-stage of `pull-files` — seeds a missing baseline from the current import index
-before mutating the tree, then advances it after every durable pull batch. A
-compatible partial
+preserving other paths advanced by a compatible pull between sender processes.
+Caller-selected push paths restrict those committed operations. An initial
+selected push leaves a missing baseline absent, because the unselected tree is
+not a complete starting point. A compatible full file-only pull — standalone
+`files-pull` or the terminal file stage of `pull-files` — seeds a missing
+baseline from the current import index before mutating the tree, then advances
+it after every durable pull batch. A compatible partial
 `--only` pull advances an existing baseline but cannot seed one because the
 unselected tree is not a complete starting point. The index records the local
 path type, size, and ctime; remote values cannot stand in because ctime belongs
@@ -171,13 +173,18 @@ A push plan is an internal part of the sender lifecycle:
    writes files, symlinks, and empty directories with their planned type, size,
    and ctime to
    `plan/local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
-   `plan/local_paths_to_delete`.
+   `plan/local_paths_to_delete`. Caller-selected paths restrict both lists to
+   those paths and their descendants. A selected fresh descendant also selects
+   deletion of an old scalar ancestor which must become its directory. If a
+   receiver exclusion prevents that transition, the dependent selected subtree
+   stays pending.
 5. The sender closes the plan before consuming those two files.
 6. After the receiver commits successfully, the sender writes F/D updates for
    the committed push and delete lists, then merges them into the latest
    `previous_local_index.jsonl` through a swap file. If neither the plan
-   snapshot nor the latest baseline exists, it publishes the complete fresh
-   local index. It then removes
+   snapshot nor the latest baseline exists, files-push without `--only`
+   publishes the complete fresh local index; a selected push leaves the
+   baseline absent. It then removes
    the complete `plan/` directory and the sender-owned exclusions file. After
    the target confirms removal of a discarded push session, the sender removes
    the same files without changing the pair's previous local index.
@@ -197,20 +204,23 @@ stopped snapshot or merge is repeated by the next sender run. Keeping another
 cursor and retained handle for these full-index operations is not justified
 until measurements from materially larger installations show that it matters.
 
-The cursor contains the plan directory, local tree root, previous local
-index, and current planning position. During indexing, that
-position contains the `FileIndexProcessor` cursor and committed fresh-index byte
-offset. During diffing, each step flushes only the path list or append-only
-deleted-directory stack changed by that step before updating the two index
-offsets, two output byte offsets, and active stack byte offset. Each stack entry
-links to the preceding active directory, so continuation reads only the top
-entry. A later process passes the stored cursor to `PushPlan::resume()`. The
-plan uses its private exclusions copy, discards bytes beyond the stored output
-offsets, and continues from the retained internal phase.
+The cursor contains the plan directory, local tree root, previous local index,
+positions of selected paths which contain at least one fresh index entry, and
+current planning position. During indexing, that position contains the
+`FileIndexProcessor` cursor and committed fresh-index byte offset. During
+diffing, each step flushes only the path list or append-only deleted-directory
+stack changed by that step before updating the two index offsets, two output
+byte offsets, active stack byte offset, and any selected subtree blocked by a
+receiver exclusion. Each stack entry links to the preceding active directory,
+so continuation reads only the top entry. A later process passes the stored
+cursor to `PushPlan::resume()`. The plan uses its private exclusions copy,
+discards bytes beyond the stored output offsets, and continues from the
+retained internal phase.
 
-The first push to a site has no previous local index or previously
-pushed rows. Every current file, symlink, and empty directory is selected, and
-no local deletion can be detected yet.
+The first push to a site has no previous local index or previously pushed rows.
+Files-push without `--only` selects every current file, symlink, and empty
+directory. A selected push sends only its selected operations and leaves the
+baseline absent. No local deletion can be detected yet.
 
 Push is intentionally local-wins. If a developer edited the remote site
 outside Reprint, a later push of the same path or row overwrites that remote
@@ -382,7 +392,7 @@ upload begins until both indexes have been consumed and the two path lists are
 stable.
 
 `sender.json` contains no copied receiver cursor. It stores the push session
-and phase, the PushPlan cursor, the next byte offset in
+and phase, the selected-path fingerprint, the PushPlan cursor, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
 sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
@@ -432,11 +442,12 @@ baseline with the plan's older full-tree snapshot. A compatible pull completed
 between sender processes therefore preserves paths outside the committed
 operations. If a later incompatible pull removed the baseline, the sender
 leaves it absent rather than publishing an incomplete index. If no baseline
-existed at plan start and none exists at publication, the sender also records
-the complete fresh local index, including the initial state under target
-exclusions. Once a baseline exists, later changes under excluded paths remain
-pending instead of being marked synchronized. The sender then removes the
-entire plan directory before deleting active sender state.
+existed at plan start and none exists at publication, files-push without
+`--only` records the complete fresh local index, including the initial state
+under target exclusions. A selected sender leaves it absent. Once a baseline
+exists, later changes under excluded paths remain pending instead of being
+marked synchronized. The sender then removes the entire plan directory before
+deleting active sender state.
 
 Each local-path upload or deletion step sends at most one multipart part. A file
 part contains one bounded chunk, a deletion-list part contains one complete
@@ -471,6 +482,12 @@ the operator passes `--force-http`. It does not run pull preflight, read or
 write `.import-state.json`, show a plan, ask for confirmation, transfer a
 database, retry a failed request, or start a replacement sender after a
 `restart` outcome.
+
+Repeating `--only=PATH` selects document-root-relative paths for one sender
+lifecycle. A selected path covers itself and its descendants. Sorting,
+deduplication, and removing descendants covered by an earlier selected ancestor
+give equivalent selections one fingerprint. Resuming with another selection is
+rejected before a request.
 
 The command derives one pair key without general URL normalization:
 
@@ -534,7 +551,8 @@ pipeline when it is run again. A compatible full file-only pull can establish a
 missing baseline. A compatible partial `--only` pull advances the baseline only
 when it already exists. Each durable WAL batch merges only the paths the pull
 applied, so local additions, edits, and deletions left elsewhere stay in the
-diff.
+diff. A completed files-push without `--only` can also establish a missing
+baseline; a selected files-push cannot.
 
 Output is JSONL. Each selected current file, symlink, or empty directory has
 `action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -130,6 +130,9 @@ directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
 | Active state | `sender.json`, `$state_path` |
 | Plan-owned previous-local-index snapshot | `plan/previous_local_index.jsonl` |
 | Plan-owned committed previous-local-index updates | `plan/previous_local_index_updates.jsonl` |
+| Selected paths | `selected_paths`, `$selected_paths` |
+| Selected-path fingerprint | `selected_paths_fingerprint`, `$selected_paths_fingerprint` |
+| Blocked selected subtree path | `blocked_selected_subtree_path`, `$blocked_selected_subtree_path` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
@@ -147,12 +150,13 @@ committed push and delete operations and their required ancestors into the
 latest baseline. This preserves paths which a compatible pull advanced between
 sender processes when they are outside the committed operations. If a later
 incompatible pull removed the baseline, the sender leaves it absent rather
-than publishing an incomplete index. A compatible full file-only pull seeds a
-missing baseline from the current import index before mutating the tree, then
-advances it after each durable WAL batch. A compatible partial `--only` pull
-advances an existing baseline but cannot seed one. `files-diff` reads the
-baseline, and PushPlan diffs its fresh local index against the plan-start
-snapshot its caller supplies.
+than publishing an incomplete index. A selected push updates only its committed
+operations and cannot seed a missing baseline. A compatible full file-only pull
+seeds a missing baseline from the current import index before mutating the
+tree, then advances it after each durable WAL batch. A compatible partial
+`--only` pull advances an existing baseline but cannot seed one. `files-diff`
+reads the baseline, and PushPlan diffs its fresh local index against the
+plan-start snapshot its caller supplies.
 `byte_offset_in_previous_local_index` is the position from which its current
 lookahead entry is read again after resume.
 
@@ -174,25 +178,27 @@ pending local additions, edits, and deletions elsewhere stay pending.
 Directory emptiness comes from descendants retained by the merge. Paths
 outside the files-push scope are not admitted.
 
-The PushPlan cursor is stored in `sender.json`. It contains the plan
-directory, local tree root, previous local index, and current
-planning position. During `indexing`, that position contains the
-FileIndexProcessor cursor and the committed byte offset in
-`fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
-output offsets, and the active byte offset in
-`deleted_directories_stack.jsonl`. The stack file is append-only; each entry
-links to the preceding active directory. The exclusions have a maximum of 100
-paths. `sender.json` phases are `creating`, `starting_plan`,
+The PushPlan cursor is stored in `sender.json`. It contains the plan directory,
+local tree root, previous local index, positions of selected paths which contain
+at least one fresh index entry, and current planning position. During
+`indexing`, that position contains the FileIndexProcessor cursor and the
+committed byte offset in `fresh_local_index.jsonl`. During `diffing`, it
+contains the index offsets, output offsets, the active byte offset in
+`deleted_directories_stack.jsonl`, and any selected subtree blocked by a
+receiver exclusion. The stack file is append-only; each entry links to the
+preceding active directory. The exclusions have a maximum of 100 paths.
+`sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_previous_local_index`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
-path-list cursor, receiver part limit, and request-sizing state. The index diff
-completes before local paths are sent. After a successful commit, the sender
-writes F/D updates from the committed path lists and their required ancestors,
-then merges them into the latest previous local index. If neither the plan
-snapshot nor the latest baseline exists, it publishes the complete fresh local
-index. Once a baseline exists, later changes under excluded paths remain
-pending. The plan-start baseline
+path-list cursor, selected-path fingerprint, receiver part limit, and
+request-sizing state. The index diff completes before local paths are sent.
+After a successful commit, the sender writes F/D updates from the committed
+path lists and their required ancestors, then merges them into the latest
+previous local index. If neither the plan snapshot nor the latest baseline
+exists, files-push without `--only` publishes the complete fresh local index
+and a selected push leaves the baseline absent. Once a baseline exists, later
+changes under excluded paths remain pending. The plan-start baseline
 snapshot and post-commit merge have no separate cursors and are repeated after
 interruption. After the updates are published or the target confirms removal,
 the sender clears the PushPlan cursor, then removes the entire plan directory
@@ -273,6 +279,13 @@ receiver-confirmed upload positions remain receiver-owned; they are not a
 files-push cursor and are not copied into `.import-state.json` or
 `.import-status.json`.
 
+Each repeatable `--only=PATH` selects one document-root-relative path and its
+descendants. Sorting, deduplication, and removing descendants covered by a
+selected ancestor gives equivalent selections one fingerprint. A resumed
+sender requires that same fingerprint. A selected subtree stays pending when
+installing it would require replacing an old scalar ancestor protected by a
+receiver exclusion.
+
 Files-push lifecycle lines use these command-first names verbatim: `START
 files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,
 `INTERRUPTED files-push`, `COMPLETE files-push`, `RESTART files-push`, `FAILED
@@ -292,6 +305,8 @@ Use these names verbatim inside `PushFilesSender`:
 | --- | --- |
 | Local path to push | `LocalPathToPush`, `$local_path_to_push`, `read_next_local_path_to_push()` |
 | Local path to delete | `LocalPathToDelete`, `$local_path_to_delete`, `read_next_local_path_to_delete()` |
+| Selected paths | `$selected_paths`, `normalize_selected_paths()` |
+| Selected-path fingerprint | `$selected_paths_fingerprint` |
 | Push stream client | `$push_stream_client`, `create_push_stream_client()` |
 | Push stream client options | `$push_stream_client_options` |
 | Request sizer options | `request_sizer_options`, `$request_sizer_options` |

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -209,6 +209,8 @@ function path_sort_key(string $path): string
     return str_replace("/", "\0", $path);
 }
 
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These validation exceptions are never rendered, and arbitrary path bytes are represented as base64.
+
 /**
  * Normalizes document-root-relative excluded paths.
  *
@@ -221,34 +223,11 @@ function path_sort_key(string $path): string
  */
 function normalize_excluded_paths(array $excluded_paths): array
 {
-    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These validation exceptions are never rendered, and arbitrary path bytes are represented as base64.
     $normalized_excluded_paths = [];
     foreach ($excluded_paths as $path) {
-        if (!is_string($path)) {
-            throw new InvalidArgumentException('Each excluded path must be a string; observed ' . gettype($path) . '.');
-        }
-        if ($path === '') {
-            throw new InvalidArgumentException('Excluded path must not be empty.');
-        }
-        if ($path[0] === '/') {
-            throw new InvalidArgumentException('Excluded path must be document-root-relative: ' . base64_encode($path) . '.');
-        }
-        if (strpos($path, "\0") !== false) {
-            throw new InvalidArgumentException('Excluded path must not contain a NUL byte: ' . base64_encode($path) . '.');
-        }
+        assert_valid_document_root_relative_path($path, 'Excluded path');
         if (strpos($path, '\\') !== false) {
             throw new InvalidArgumentException('Excluded path must not contain a backslash: ' . base64_encode($path) . '.');
-        }
-        foreach (explode('/', $path) as $segment) {
-            if ($segment === '') {
-                throw new InvalidArgumentException('Excluded path must not contain an empty component: ' . base64_encode($path) . '.');
-            }
-            if ($segment === '.') {
-                throw new InvalidArgumentException('Excluded path must not contain a dot component: ' . base64_encode($path) . '.');
-            }
-            if ($segment === '..') {
-                throw new InvalidArgumentException('Excluded path must not contain a parent component: ' . base64_encode($path) . '.');
-            }
         }
         $normalized_excluded_paths[] = $path;
     }
@@ -262,6 +241,57 @@ function normalize_excluded_paths(array $excluded_paths): array
         );
     }
     return $normalized_excluded_paths;
+}
+
+/**
+ * Validates one document-root-relative path.
+ *
+ * @param mixed  $path  Path supplied by a caller.
+ * @param string $label Description used in validation errors.
+ * @phpstan-assert string $path
+ */
+function assert_valid_document_root_relative_path($path, string $label): void
+{
+    if (!is_string($path)) {
+        throw new InvalidArgumentException(
+            $label . ' must be a string; observed ' . gettype($path) . '.'
+        );
+    }
+    if ($path === '') {
+        throw new InvalidArgumentException($label . ' must not be empty.');
+    }
+    if ($path[0] === '/') {
+        throw new InvalidArgumentException(
+            $label . ' must be document-root-relative: '
+            . base64_encode($path) . '.'
+        );
+    }
+    if (strpos($path, "\0") !== false) {
+        throw new InvalidArgumentException(
+            $label . ' must not contain a NUL byte: '
+            . base64_encode($path) . '.'
+        );
+    }
+    foreach (explode('/', $path) as $path_component) {
+        if ($path_component === '') {
+            throw new InvalidArgumentException(
+                $label . ' must not contain an empty component: '
+                . base64_encode($path) . '.'
+            );
+        }
+        if ($path_component === '.') {
+            throw new InvalidArgumentException(
+                $label . ' must not contain a dot component: '
+                . base64_encode($path) . '.'
+            );
+        }
+        if ($path_component === '..') {
+            throw new InvalidArgumentException(
+                $label . ' must not contain a parent component: '
+                . base64_encode($path) . '.'
+            );
+        }
+    }
 }
 // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1350,7 +1350,7 @@ class ImportClient
         $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
         $missing_previous_local_index_message =
             'files-diff requires a fresh completed files-pull or pull-files without --only, with --filter=none, no --remap, '
-            . 'and no --on-fs-root-nonempty=preserve-local, or a completed files-push, '
+            . 'and no --on-fs-root-nonempty=preserve-local, or a completed files-push without --only, '
             . 'for the same target URL, state directory, and local tree. '
             . 'The target URL must be the exact exporter API URL used by that pull. '
             . 'If a standalone files-pull is already complete, run it with --abort and then run it again.';
@@ -1481,9 +1481,10 @@ class ImportClient
      * @param array $options {
      *     Parsed files-push options and context.
      *
-     *     @type string $secret             HMAC shared secret.
-     *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
-     *     @type array  $files_push_context Optional context already validated by the CLI entry point.
+     *     @type string       $secret             HMAC shared secret.
+     *     @type bool         $force_http         Whether the operator allowed a plain-HTTP target.
+     *     @type list<string> $only               Document-root-relative selected paths.
+     *     @type array        $files_push_context Optional context already validated by the CLI entry point.
      * }
      * @param ReprintProcessLock $process_lock Lock held for this command.
      * @phpstan-param array<string,mixed> $options
@@ -1525,6 +1526,7 @@ class ImportClient
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
             'chunk_bytes' => $chunk_bytes,
+            'selected_paths' => $options['only'] ?? [],
         ];
 
         $resuming = is_file($context['push_state_directory'] . '/sender.json');
@@ -12576,11 +12578,10 @@ if (
             'name' => 'only',
             'type' => 'value-or-next',
             'target' => 'only',
-            'placeholder' => 'SOURCE',
+            'placeholder' => 'PATH',
             'repeatable' => true,
-            'help' => 'Restrict the file pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
-                'repeat for several. Default pulls everything',
-            'commands' => ['pull-files', 'files-pull'],
+            'help' => 'Restrict file work to PATH; pulls accept a :token: or absolute source path, while files-push accepts a document-root-relative path. Repeat for several paths',
+            'commands' => ['pull-files', 'files-pull', 'files-push'],
         ],
 
         // ── flat-docroot options ────────────────────────────────
@@ -13289,12 +13290,15 @@ if (
         "files-push" => [
             "level" => "low",
             "short" => "Push one local file tree without database work",
-            "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
+            "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--only=PATH ...] [--force-http] [--verbose]",
             "description" =>
                 "Sends the existing local tree at --fs-root to the target exporter API.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It does not require pull preflight.\n" .
+                "\n" .
+                "Repeat --only with document-root-relative paths to send just the\n" .
+                "changes at or below those paths. Other changes remain pending.\n" .
                 "\n" .
                 "Each process runs one sender until it completes, reaches a caller time or\n" .
                 "memory boundary, or receives a signal handled by this PHP runtime.\n" .
@@ -13540,7 +13544,19 @@ if (
 
     $reprint_files_command_arguments = array_slice($argv, $option_start_index);
     if ($command === 'files-push') {
-        foreach ($reprint_files_command_arguments as $reprint_files_push_command_argument) {
+        $reprint_files_push_argument_count =
+            count($reprint_files_command_arguments);
+        for (
+            $reprint_files_push_argument_index = 0;
+            $reprint_files_push_argument_index < $reprint_files_push_argument_count;
+            ++$reprint_files_push_argument_index
+        ) {
+            $reprint_files_push_command_argument =
+                $reprint_files_command_arguments[$reprint_files_push_argument_index];
+            if ($reprint_files_push_command_argument === '--only') {
+                ++$reprint_files_push_argument_index;
+                continue;
+            }
             $reprint_files_push_option_allowed = in_array(
                 $reprint_files_push_command_argument,
                 ['--force-http', '--verbose', '-v'],
@@ -13548,7 +13564,8 @@ if (
             )
                 || strpos($reprint_files_push_command_argument, '--state-dir=') === 0
                 || strpos($reprint_files_push_command_argument, '--fs-root=') === 0
-                || strpos($reprint_files_push_command_argument, '--secret=') === 0;
+                || strpos($reprint_files_push_command_argument, '--secret=') === 0
+                || strpos($reprint_files_push_command_argument, '--only=') === 0;
             if (!$reprint_files_push_option_allowed) {
                 $reprint_files_push_option_name = explode('=', $reprint_files_push_command_argument, 2)[0];
                 fwrite(STDERR, "Error: files-push does not accept {$reprint_files_push_option_name}.\n");

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -1,6 +1,9 @@
 <?php
 
 use function Reprint\Importer\merge_previous_local_index_updates;
+use function WordPress\Reprint\Exporter\assert_valid_document_root_relative_path;
+use function WordPress\Reprint\Exporter\compare_paths;
+use function WordPress\Reprint\Exporter\path_is_within_root;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
@@ -13,10 +16,11 @@ use function Reprint\Importer\merge_previous_local_index_updates;
  * the Reprint process lock while the sender creates and removes the target push
  * session, drives its internal PushPlan, streams the selected paths, commits the
  * push, and advances the pair's previous local index with the committed paths.
- * An initial full push publishes its fresh local index. The target owns the
- * upload cursor for every path and for the deletion list. Durable sender state
- * retains the top-level phase, the selected path-list cursor, and learned
- * request limits and the PushPlan cursor needed after a process restart.
+ * An initial files-push without --only publishes its fresh local index; an
+ * initial selected push leaves the baseline absent. The target owns the upload
+ * cursor for every path and for the deletion list. Durable sender state retains
+ * the top-level phase, selected-path fingerprint, selected path-list cursor,
+ * learned request limits, and PushPlan cursor needed after a process restart.
  *
  * ## Usage
  *
@@ -68,11 +72,12 @@ use function Reprint\Importer\merge_previous_local_index_updates;
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
  * calls let the target install the work in bounded steps. A confirmed commit
  * enters another phase which merges those operations into the latest previous
- * local index through a swap file. With no prior index, it publishes the
- * complete fresh local index. Index completion, plan completion,
- * local-index publication, and plan discard each have a separate durable
- * phase. A stopped process therefore repeats only an idempotent boundary
- * action rather than a group of unrelated transitions.
+ * local index through a swap file. With no prior index, files-push without
+ * --only publishes the complete fresh local index and a selected push leaves
+ * the baseline absent. Index completion, plan completion, local-index
+ * publication, and plan discard each have a separate durable phase. A stopped
+ * process therefore repeats only an idempotent boundary action rather than a
+ * group of unrelated transitions.
  *
  * sender.json owns the top-level phase and the cursor returned by
  * PushPlan. PushFilesSender stores that cursor after every completed planning
@@ -131,7 +136,7 @@ use function Reprint\Importer\merge_previous_local_index_updates;
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_previous_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_previous_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,selected_paths_fingerprint:string,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -155,6 +160,12 @@ final class PushFilesSender
 
     /** @var ReprintProcessLock Reprint process lock owned by the caller. */
     private ReprintProcessLock $process_lock;
+
+    /** @var list<string> Canonical document-root-relative paths selected by the caller. */
+    private array $selected_paths;
+
+    /** @var string SHA-256 fingerprint of the canonical selected paths. */
+    private string $selected_paths_fingerprint;
 
     /** @var bool Whether close() released this sender's resources. */
     private bool $closed = false;
@@ -250,6 +261,7 @@ final class PushFilesSender
      *     @type int|float|string        $stall_timeout           No-upload-progress seconds. Default 60.
      *     @type int|float|string        $response_timeout        No-response-progress seconds. Default 300.
      *     @type array                   $request_sizer_options    Optional PushRequestSizer bounds.
+     *     @type list<string>            $selected_paths          Document-root-relative selected paths. Empty selects all paths.
      * }
      * @phpstan-param array<string,mixed> $options
      * @param ReprintProcessLock $process_lock Lock for the containing state directory.
@@ -276,6 +288,7 @@ final class PushFilesSender
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
                 'push_plan_cursor' => null,
+                'selected_paths_fingerprint' => $sender->selected_paths_fingerprint,
                 'local_paths_to_push_byte_offset' => 0,
                 'max_part_bytes' => null,
                 'request_sizer_state' => $sender->push_stream_client->get_request_sizer_state(),
@@ -317,9 +330,21 @@ final class PushFilesSender
                 );
             }
             $sender->state = $state;
+            $selected_paths_fingerprint = $state['selected_paths_fingerprint'] ?? null;
+            if (
+                !is_string($selected_paths_fingerprint)
+                || $selected_paths_fingerprint !== $sender->selected_paths_fingerprint
+            ) {
+                throw new InvalidArgumentException(
+                    'Resume files-push with the same --only paths used to start this sender.'
+                );
+            }
             $sender->push_stream_client = $sender->create_push_stream_client($state);
             if ($state['push_plan_cursor'] !== null) {
-                $sender->plan = PushPlan::resume($state['push_plan_cursor']);
+                $sender->plan = PushPlan::resume(
+                    $state['push_plan_cursor'],
+                    $sender->selected_paths
+                );
             }
             return $sender;
         } catch (Throwable $throwable) {
@@ -353,6 +378,13 @@ final class PushFilesSender
         if (!is_array($request_sizer_options)) {
             throw new InvalidArgumentException('request_sizer_options must be an array.');
         }
+        $selected_paths = $options['selected_paths'] ?? [];
+        if (!is_array($selected_paths)) {
+            throw new InvalidArgumentException(
+                'PushFilesSender selected_paths must be an array; observed '
+                . gettype($selected_paths) . '.'
+            );
+        }
 
         $push_stream_client_options = [
             'base_url' => $options['base_url'] ?? null,
@@ -376,8 +408,53 @@ final class PushFilesSender
         $this->previous_local_index = $this->push_state_directory . '/previous_local_index.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
+        $this->selected_paths = $this->normalize_selected_paths($selected_paths);
+        $this->selected_paths_fingerprint = hash(
+            'sha256',
+            implode("\0", $this->selected_paths)
+        );
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
+    }
+
+    /**
+     * Validates, sorts, deduplicates, and collapses selected paths.
+     *
+     * @param array<mixed> $selected_paths Selected paths supplied by a caller.
+     * @return list<string> Canonical selected paths in component order.
+     */
+    private function normalize_selected_paths(array $selected_paths): array
+    {
+        foreach ($selected_paths as $selected_path) {
+            assert_valid_document_root_relative_path(
+                $selected_path,
+                'A files-push --only path'
+            );
+        }
+
+        usort(
+            $selected_paths,
+            static function (string $first_path, string $second_path): int {
+                return compare_paths($first_path, $second_path);
+            }
+        );
+        $canonical_selected_paths = [];
+        foreach ($selected_paths as $selected_path) {
+            $canonical_selected_path = $canonical_selected_paths[
+                count($canonical_selected_paths) - 1
+            ] ?? null;
+            if (
+                $canonical_selected_path !== null
+                && path_is_within_root(
+                    $selected_path,
+                    $canonical_selected_path
+                )
+            ) {
+                continue;
+            }
+            $canonical_selected_paths[] = $selected_path;
+        }
+        return $canonical_selected_paths;
     }
 
     /**
@@ -619,7 +696,8 @@ final class PushFilesSender
             $this->plan_directory,
             $this->docroot,
             $plan_previous_local_index,
-            $this->excluded_paths_path
+            $this->excluded_paths_path,
+            $this->selected_paths
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         $this->state['phase'] = 'planning';
@@ -1244,10 +1322,12 @@ final class PushFilesSender
                 !is_file($plan_previous_local_index)
                 && !is_file($this->previous_local_index)
             ) {
-                $this->copy_through_swap_file(
-                    $this->plan->get_fresh_local_index_path(),
-                    $this->previous_local_index
-                );
+                if ($this->selected_paths === []) {
+                    $this->copy_through_swap_file(
+                        $this->plan->get_fresh_local_index_path(),
+                        $this->previous_local_index
+                    );
+                }
                 $this->state['push_plan_cursor'] = null;
                 $this->state['phase'] = 'completing';
                 $this->store_state($this->state);

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -1,6 +1,7 @@
 <?php
 
 use function WordPress\Reprint\Exporter\compare_paths;
+use function WordPress\Reprint\Exporter\path_is_within_root;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -35,9 +36,10 @@ use function WordPress\Reprint\Exporter\compare_paths;
  * use the indexer's empty-directory marker; non-empty directories are
  * represented by their descendants.
  *
- * With no previous local index, every file, symlink, and empty directory is
- * selected, and no deletion can be detected. Excluded paths are omitted from
- * both path lists but remain in the fresh local index.
+ * With no previous local index, every in-scope file, symlink, and empty
+ * directory is new, and no deletion can be detected. Caller-selected paths
+ * restrict both operation lists. Excluded paths are omitted from both lists
+ * but remain in the fresh local index.
  *
  * The index reader trusts the entry values produced by the indexer. It retains
  * failure handling for reading lines, decoding JSON, and decoding base64 paths.
@@ -60,10 +62,10 @@ use function WordPress\Reprint\Exporter\compare_paths;
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null,blocked_selected_subtree_path:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,previous_local_index:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,previous_local_index:string,selected_path_positions_with_fresh_entries:list<int>,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
@@ -94,6 +96,12 @@ class PushPlan
 
     /** @var list<string> Receiver-owned paths that the plan must not push or delete. */
     private array $excluded_paths = [];
+
+    /** @var list<string> Document-root-relative paths selected by the caller. */
+    private array $selected_paths = [];
+
+    /** @var list<int> Positions of selected paths which contain at least one fresh index entry. */
+    private array $selected_path_positions_with_fresh_entries = [];
 
     /** @var PushPlanCursor Current cursor returned to the caller. */
     private array $cursor;
@@ -141,15 +149,22 @@ class PushPlan
      * @param string $local_tree_root              Canonical local tree root.
      * @param string $previous_local_index Previous local index this plan diffs against.
      * @param string $excluded_paths_path          Caller-owned target exclusions file.
+     * @param list<string> $selected_paths         Canonical selected paths. Empty selects all paths.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $local_tree_root,
         string $previous_local_index,
-        string $excluded_paths_path
+        string $excluded_paths_path,
+        array $selected_paths = []
     ): self {
-        $plan = new self($plan_directory, $local_tree_root, $previous_local_index);
+        $plan = new self(
+            $plan_directory,
+            $local_tree_root,
+            $previous_local_index,
+            $selected_paths
+        );
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -169,6 +184,7 @@ class PushPlan
             "plan_directory" => $plan->plan_directory,
             "local_tree_root" => $plan->local_tree_root,
             "previous_local_index" => $plan->previous_local_index,
+            "selected_path_positions_with_fresh_entries" => [],
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" => $plan->file_index_processor->get_cursor(),
@@ -187,13 +203,29 @@ class PushPlan
      * @phpstan-param PushPlanCursor $cursor Cursor previously returned by get_cursor().
      * @return self Open plan positioned at its last durable cursor.
      */
-    public static function resume(array $cursor): self
+    public static function resume(array $cursor, array $selected_paths = []): self
     {
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["local_tree_root"],
-            $cursor["previous_local_index"]
+            $cursor["previous_local_index"],
+            $selected_paths
         );
+        foreach (
+            $cursor["selected_path_positions_with_fresh_entries"]
+            as $selected_path_position
+        ) {
+            if (
+                !is_int($selected_path_position)
+                || !array_key_exists($selected_path_position, $selected_paths)
+            ) {
+                throw new RuntimeException(
+                    "The push plan selected-path position does not identify a selected path."
+                );
+            }
+        }
+        $plan->selected_path_positions_with_fresh_entries =
+            $cursor["selected_path_positions_with_fresh_entries"];
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
         $plan->excluded_paths = $plan->load_excluded_paths();
@@ -303,11 +335,13 @@ class PushPlan
      * @param string $plan_directory              Caller-owned active plan directory.
      * @param string $local_tree_root              Canonical local tree root.
      * @param string $previous_local_index Previous local index this plan diffs against.
+     * @param list<string> $selected_paths         Canonical selected paths.
      */
     private function __construct(
         string $plan_directory,
         string $local_tree_root,
-        string $previous_local_index
+        string $previous_local_index,
+        array $selected_paths
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -316,6 +350,7 @@ class PushPlan
         $this->plan_directory = $plan_directory;
         $this->set_local_tree_root($local_tree_root);
         $this->previous_local_index = $previous_local_index;
+        $this->selected_paths = $selected_paths;
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
         $this->fresh_local_index = $plan_directory . "/fresh_local_index.jsonl";
@@ -502,6 +537,8 @@ class PushPlan
             "file_index_cursor" => $this->file_index_processor->get_cursor(),
             "fresh_local_index_byte_offset" => $fresh_local_index_byte_offset,
         ];
+        $this->cursor["selected_path_positions_with_fresh_entries"] =
+            $this->selected_path_positions_with_fresh_entries;
     }
 
     /**
@@ -519,6 +556,7 @@ class PushPlan
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
+            "blocked_selected_subtree_path" => null,
         ];
         $this->open_plan_files();
     }
@@ -543,6 +581,20 @@ class PushPlan
         }
 
         $local_path = substr($index_entry["path"], strlen($this->local_tree_root) + 1);
+        foreach ($this->selected_paths as $selected_path_position => $selected_path) {
+            if (path_is_within_root($local_path, $selected_path)) {
+                if (
+                    !in_array(
+                        $selected_path_position,
+                        $this->selected_path_positions_with_fresh_entries,
+                        true
+                    )
+                ) {
+                    $this->selected_path_positions_with_fresh_entries[] =
+                        $selected_path_position;
+                }
+            }
+        }
         $fresh_local_index_entry = [
             "path" => base64_encode($local_path),
             "ctime" => $index_entry["ctime"],
@@ -574,6 +626,8 @@ class PushPlan
         $byte_offset_in_fresh_index = $cursor["byte_offset_in_fresh_index"];
         $byte_offset_in_previous_local_index = $cursor["byte_offset_in_previous_local_index"];
         $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
+        $blocked_selected_subtree_path =
+            $cursor["blocked_selected_subtree_path"];
         $local_paths_to_push_changed = false;
         $local_paths_to_delete_changed = false;
         $deleted_directories_stack_changed = false;
@@ -605,6 +659,21 @@ class PushPlan
                     $entry_previous_local_index["path"]
                 );
             }
+            $current_path = $path_comparison <= 0
+                ? $entry_fresh_index["path"]
+                : $entry_previous_local_index["path"];
+            if (
+                $blocked_selected_subtree_path !== null
+                && !path_is_within_root(
+                    $current_path,
+                    $blocked_selected_subtree_path
+                )
+            ) {
+                $blocked_selected_subtree_path = null;
+            }
+            $current_path_is_selected =
+                $blocked_selected_subtree_path === null
+                && $this->path_is_selected($current_path);
 
             $current_shape = null;
             if ($path_comparison <= 0) {
@@ -633,6 +702,7 @@ class PushPlan
                 // descendants.
                 if (
                     $current_shape !== "non_empty_directory"
+                    && $current_path_is_selected
                     && !$this->path_conflicts_with_excluded_paths($entry_fresh_index["path"])
                 ) {
                     $this->append_local_path_to_push($entry_fresh_index);
@@ -642,7 +712,8 @@ class PushPlan
                 // A deleted non-empty directory emits one root. Its later
                 // descendant entries are already covered by that path.
                 if (
-                    !$this->path_conflicts_with_excluded_paths($entry_previous_local_index["path"])
+                    $current_path_is_selected
+                    && !$this->path_conflicts_with_excluded_paths($entry_previous_local_index["path"])
                     && !$this->deleted_directory_stack_covers_path(
                         $entry_previous_local_index["path"],
                         $this->deleted_directory_stack_entry
@@ -678,9 +749,30 @@ class PushPlan
                 $needs_push = $empty_directory_needs_push
                     || $changed_file_or_symlink_needs_push;
                 $path_is_excluded = $this->path_conflicts_with_excluded_paths($entry_fresh_index["path"]);
+                $scalar_becomes_non_empty_directory =
+                    $current_shape === "non_empty_directory"
+                    && (
+                        $previous_local_index_shape === "file"
+                        || $previous_local_index_shape === "symlink"
+                    );
+                $required_ancestor_transition = !$current_path_is_selected
+                    && $blocked_selected_subtree_path === null
+                    && $scalar_becomes_non_empty_directory
+                    && $this->path_is_ancestor_of_selected_path_with_fresh_entry(
+                        $entry_fresh_index["path"]
+                    );
+                if (
+                    $path_is_excluded
+                    && $scalar_becomes_non_empty_directory
+                    && ( $current_path_is_selected || $required_ancestor_transition )
+                ) {
+                    $blocked_selected_subtree_path =
+                        $entry_fresh_index["path"];
+                }
 
                 if (
                     $needs_delete
+                    && ( $current_path_is_selected || $required_ancestor_transition )
                     && !$path_is_excluded
                     && !$this->deleted_directory_stack_covers_path(
                         $entry_previous_local_index["path"],
@@ -697,7 +789,7 @@ class PushPlan
                         $deleted_directories_stack_changed = true;
                     }
                 }
-                if ($needs_push && !$path_is_excluded) {
+                if ($needs_push && $current_path_is_selected && !$path_is_excluded) {
                     $this->append_local_path_to_push($entry_fresh_index);
                     $local_paths_to_push_changed = true;
                 }
@@ -738,6 +830,7 @@ class PushPlan
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
+                "blocked_selected_subtree_path" => $blocked_selected_subtree_path,
             ];
         $this->cursor["position"] = $cursor_after_step;
         return !$complete;
@@ -979,6 +1072,35 @@ class PushPlan
     private function deleted_directory_stack_covers_path(string $path, ?array $entry): bool
     {
         return $entry !== null && strpos($path, $entry["path"] . "/") === 0;
+    }
+
+    /** Returns whether a path is selected directly or through a selected ancestor. */
+    private function path_is_selected(string $path): bool
+    {
+        if ($this->selected_paths === []) {
+            return true;
+        }
+        foreach ($this->selected_paths as $selected_path) {
+            if (path_is_within_root($path, $selected_path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Returns whether a path is an ancestor needed by selected fresh work. */
+    private function path_is_ancestor_of_selected_path_with_fresh_entry(string $path): bool
+    {
+        foreach ($this->selected_path_positions_with_fresh_entries as $selected_path_position) {
+            $selected_path = $this->selected_paths[$selected_path_position];
+            if (
+                $selected_path !== $path
+                && path_is_within_root($selected_path, $path)
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -21,7 +21,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('--filter=MODE', $output);
         $this->assertStringContainsString('--remap SOURCE TARGET', $output);
-        $this->assertStringContainsString('--only=SOURCE', $output);
+        $this->assertStringContainsString('--only=PATH', $output);
     }
 
     public function testPullDbHelpShowsRequiredAndDatabaseOptions(): void
@@ -51,7 +51,7 @@ class CliHelpTest extends TestCase
         $this->assertStringNotContainsString('--abort', $output);
         $this->assertStringNotContainsString('--filter', $output);
         $this->assertStringNotContainsString('--remap', $output);
-        $this->assertStringNotContainsString('--only', $output);
+        $this->assertStringContainsString('--only=PATH', $output);
     }
 
     public function testFilesDiffHelpShowsOnlyItsLocalCommandOptions(): void

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -126,6 +126,77 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testFilesPushAcceptsBothOnlyOptionForms(): void
+    {
+        foreach ([['--only=missing.txt'], ['--only', 'missing.txt']] as $onlyOption) {
+            $result = $this->runFilesPush(
+                'https://127.0.0.1:1/?reprint-api=1',
+                array_merge(['--secret=token'], $onlyOption)
+            );
+
+            $this->assertSame(1, $result['exit'], $result['output']);
+            $this->assertStringNotContainsString('does not accept --only', $result['output']);
+            $this->assertStringNotContainsString('Unknown option', $result['output']);
+        }
+    }
+
+    public function testFilesPushNamesPathWhenOnlyHasNoValue(): void
+    {
+        $result = $this->runFilesPush(
+            'https://example.test/?reprint-api=1',
+            ['--secret=token', '--only']
+        );
+
+        $this->assertSame(1, $result['exit']);
+        $this->assertStringContainsString('--only requires one argument: PATH', $result['output']);
+        $this->assertNoSenderState($this->stateDirectory);
+    }
+
+    /**
+     * @dataProvider invalidOnlyPaths
+     * @param array<mixed> $selectedPaths
+     */
+    public function testFilesPushRejectsInvalidOnlyPathsBeforeStartingSender(
+        array $selectedPaths,
+        string $expectedMessage
+    ): void {
+        $processLock = new \ReprintProcessLock($this->stateDirectory);
+        $sender = null;
+        try {
+            $sender = \PushFilesSender::start([
+                'docroot' => $this->localTree,
+                'push_state_directory' => $this->stateDirectory . '/push/test',
+                'base_url' => 'https://example.test/?reprint-api=1',
+                'hmac_client' => new \Site_Export_HMAC_Client('token'),
+                'selected_paths' => $selectedPaths,
+            ], $processLock);
+            $this->fail('The invalid --only path was accepted.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString($expectedMessage, $exception->getMessage());
+        } finally {
+            if ($sender instanceof \PushFilesSender) {
+                $sender->close();
+            }
+            $processLock->close();
+        }
+
+        $this->assertNoSenderState($this->stateDirectory);
+    }
+
+    /** @return array<string,array{0:array<mixed>,1:string}> */
+    public static function invalidOnlyPaths(): array
+    {
+        return [
+            'empty path' => [[''], 'must not be empty'],
+            'absolute path' => [['/absolute.txt'], 'document-root-relative'],
+            'NUL byte' => [["nul\0byte"], 'NUL byte'],
+            'empty component' => [['directory//file.txt'], 'empty component'],
+            'dot component' => [['directory/./file.txt'], 'dot component'],
+            'parent component' => [['directory/../file.txt'], 'parent component'],
+            'non-string' => [[123], 'must be a string; observed integer'],
+        ];
+    }
+
     public function testFilesPushRejectsInvalidInputsBeforeStartingSender(): void
     {
         $missingSecret = $this->runFilesPush('https://example.test/?reprint-api=1', []);
@@ -255,6 +326,7 @@ final class FilesPushCommandTest extends TestCase
                 'push_session_id' => str_repeat('1', 32),
                 'phase' => 'starting_plan',
                 'push_plan_cursor' => null,
+                'selected_paths_fingerprint' => hash('sha256', ''),
                 'local_paths_to_push_byte_offset' => 0,
                 'max_part_bytes' => null,
                 'request_sizer_state' => [

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -25,6 +25,9 @@ final class PushPlanTest extends TestCase
     /** @var array<string,array<string,mixed>> Last tree shape created by materializeLocalTree(). */
     private array $materializedIndexEntries = [];
 
+    /** @var list<string> Paths selected for the active plan. */
+    private array $selectedPaths = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -167,6 +170,138 @@ final class PushPlanTest extends TestCase
         $this->assertFalse($freshLocalIndexEntries['full']['empty']);
         $this->assertFalse($freshLocalIndexEntries['private']['empty']);
         $this->assertArrayNotHasKey('empty', $freshLocalIndexEntries['public.txt']);
+    }
+
+    public function testSelectedPathsFilterPushAndDeleteOperations(): void
+    {
+        $this->savePreviousLocalIndex($this->writeIndex([
+            'gone' => [1, 0, 'dir', false],
+            'gone/selected.txt' => [1, 3, 'file'],
+            'gone/sibling.txt' => [1, 3, 'file'],
+            'removed.txt' => [1, 3, 'file'],
+            'selected.txt' => [1, 3, 'file'],
+            'unchanged-for-now.txt' => [1, 3, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'chosen' => [2, 0, 'dir', false],
+            'chosen/new.txt' => [2, 3, 'file'],
+            'later.txt' => [2, 3, 'file'],
+            'selected.txt' => [2, 4, 'file'],
+            'unchanged-for-now.txt' => [2, 4, 'file'],
+        ]);
+
+        $plan = $this->startPlan(
+            $current,
+            [],
+            ['chosen', 'gone/selected.txt', 'selected.txt']
+        );
+        $this->planToCompletion($plan);
+
+        $this->assertSame(
+            ['chosen/new.txt', 'selected.txt'],
+            $this->listPaths($plan->get_local_paths_to_push_path())
+        );
+        $this->assertSame(
+            ['gone/selected.txt'],
+            $this->localPathsToDelete($plan->get_local_paths_to_delete_path())
+        );
+    }
+
+    public function testSelectedDescendantIncludesOnlyTheRequiredAncestorTransitionAfterResume(): void
+    {
+        $this->savePreviousLocalIndex($this->writeIndex([
+            'swap' => [1, 3, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'swap' => [2, 0, 'dir', false],
+            'swap/selected.txt' => [2, 3, 'file'],
+            'swap/unselected.txt' => [2, 3, 'file'],
+        ]);
+
+        $plan = $this->startPlan($current, [], ['swap/selected.txt']);
+        $this->assertSame(
+            [0],
+            $plan->get_cursor()['selected_path_positions_with_fresh_entries'] ?? null
+        );
+        $plan->close();
+        $resumedPlan = $this->resumePlan();
+        $this->planToCompletion($resumedPlan);
+
+        $this->assertSame(
+            ['swap/selected.txt'],
+            $this->listPaths($resumedPlan->get_local_paths_to_push_path())
+        );
+        $this->assertSame(
+            ['swap'],
+            $this->localPathsToDelete($resumedPlan->get_local_paths_to_delete_path())
+        );
+    }
+
+    public function testMissingSelectedDescendantDoesNotDeleteItsScalarAncestor(): void
+    {
+        $this->savePreviousLocalIndex($this->writeIndex([
+            'swap' => [1, 3, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'swap' => [2, 0, 'dir', false],
+            'swap/unselected.txt' => [2, 3, 'file'],
+        ]);
+
+        $plan = $this->startPlan($current, [], ['swap/missing.txt']);
+        $this->planToCompletion($plan);
+
+        $this->assertSame([], $this->listPaths($plan->get_local_paths_to_push_path()));
+        $this->assertSame([], $this->localPathsToDelete($plan->get_local_paths_to_delete_path()));
+    }
+
+    /**
+     * @dataProvider selectionsBlockedByAnExcludedAncestorTransition
+     * @param list<string> $selectedPaths
+     */
+    public function testExcludedAncestorTransitionLeavesItsSelectedSubtreePending(
+        array $selectedPaths
+    ): void {
+        $this->savePreviousLocalIndex($this->writeIndex([
+            'swap' => [1, 3, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'swap' => [2, 0, 'dir', false],
+            'swap/excluded.txt' => [2, 3, 'file'],
+            'swap/selected.txt' => [2, 3, 'file'],
+            'z-selected-too.txt' => [2, 3, 'file'],
+        ]);
+
+        $plan = $this->startPlan(
+            $current,
+            ['swap/excluded.txt'],
+            $selectedPaths
+        );
+        $this->assertTrue($this->nextPlanStep($plan));
+        $this->assertSame(
+            'swap',
+            $this->planCursor()['blocked_selected_subtree_path'] ?? null
+        );
+        $plan->close();
+        $resumedPlan = $this->resumePlan();
+        $this->planToCompletion($resumedPlan);
+
+        $this->assertSame(
+            ['z-selected-too.txt'],
+            $this->listPaths($resumedPlan->get_local_paths_to_push_path())
+        );
+        $this->assertSame(
+            [],
+            $this->localPathsToDelete($resumedPlan->get_local_paths_to_delete_path())
+        );
+    }
+
+    /** @return array<string,array{0:list<string>}> */
+    public static function selectionsBlockedByAnExcludedAncestorTransition(): array
+    {
+        return [
+            'selected descendant' => [['swap/selected.txt', 'z-selected-too.txt']],
+            'selected ancestor' => [['swap', 'z-selected-too.txt']],
+        ];
     }
 
     public function testUnchangedIndexProducesEmptyPlans(): void
@@ -546,11 +681,13 @@ final class PushPlanTest extends TestCase
             'plan_directory',
             'local_tree_root',
             'previous_local_index',
+            'selected_path_positions_with_fresh_entries',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
         $this->assertSame(realpath($this->localTreeRoot()), $cursor['local_tree_root']);
         $this->assertSame($this->previousLocalIndexPath(), $cursor['previous_local_index']);
+        $this->assertSame([], $cursor['selected_path_positions_with_fresh_entries']);
         $this->assertSame([
             'phase',
             'byte_offset_in_fresh_index',
@@ -558,6 +695,7 @@ final class PushPlanTest extends TestCase
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'deleted_directory_stack_top_byte_offset',
+            'blocked_selected_subtree_path',
         ], array_keys($cursor['position']));
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
@@ -662,9 +800,17 @@ final class PushPlanTest extends TestCase
     //  Helpers
     // ------------------------------------------------------------------
 
-    /** @param list<string> $excludedPaths */
-    private function startPlan(?string $treeDescriptionPath = null, array $excludedPaths = []): PushPlan
+    /**
+     * @param list<string> $excludedPaths
+     * @param list<string> $selectedPaths
+     */
+    private function startPlan(
+        ?string $treeDescriptionPath = null,
+        array $excludedPaths = [],
+        array $selectedPaths = []
+    ): PushPlan
     {
+        $this->selectedPaths = $selectedPaths;
         if ($treeDescriptionPath === null) {
             $treeDescriptionPath = $this->tempDir . '/empty-tree.jsonl';
             if (!is_file($treeDescriptionPath)) {
@@ -686,7 +832,8 @@ final class PushPlanTest extends TestCase
             $this->planDirectory(),
             $this->localTreeRoot(),
             $this->previousLocalIndexPath(),
-            $this->excludedPathsPath()
+            $this->excludedPathsPath(),
+            $selectedPaths
         );
         $this->cursor = $plan->get_cursor();
         for ($step = 0; $step < 100; ++$step) {
@@ -700,7 +847,7 @@ final class PushPlanTest extends TestCase
 
     private function resumePlan(): PushPlan
     {
-        return PushPlan::resume($this->cursor);
+        return PushPlan::resume($this->cursor, $this->selectedPaths);
     }
 
     private function savePreviousLocalIndex(string $treeDescriptionPath): void

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1395,6 +1395,172 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
     }
 
+    public function testSelectedFilesPushPreservesPendingWorkOutsideItsPaths(): void
+    {
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => 1024,
+        ]);
+        $local_docroot = $this->root . '/selected-local-docroot';
+        $state_directory = $this->root . '/selected-state';
+        mkdir($local_docroot . '/selected', 0700, true);
+        mkdir($local_docroot . '/pending', 0700, true);
+        mkdir($local_docroot . '/swap', 0700, true);
+        file_put_contents($local_docroot . '/selected/edit.txt', 'new selected');
+        file_put_contents($local_docroot . '/pending/add.txt', 'pending addition');
+        file_put_contents($local_docroot . '/pending/edit.txt', 'new pending');
+        file_put_contents($local_docroot . '/swap/selected.txt', 'selected child');
+        file_put_contents($local_docroot . '/swap/unselected.txt', 'unselected child');
+
+        mkdir($this->docroot . '/selected', 0700, true);
+        mkdir($this->docroot . '/pending', 0700, true);
+        file_put_contents($this->docroot . '/selected/edit.txt', 'old selected');
+        file_put_contents($this->docroot . '/selected/delete.txt', 'delete selected');
+        file_put_contents($this->docroot . '/pending/edit.txt', 'old pending');
+        file_put_contents($this->docroot . '/pending/delete.txt', 'delete pending');
+        file_put_contents($this->docroot . '/swap', 'old scalar');
+
+        $previous_local_index_path = $this->root . '/selected-previous-index.jsonl';
+        $this->writeIndex($previous_local_index_path, [
+            'pending' => [1, 0, 'dir', false],
+            'pending/delete.txt' => [1, 14, 'file'],
+            'pending/edit.txt' => [1, 11, 'file'],
+            'selected' => [1, 0, 'dir', false],
+            'selected/delete.txt' => [1, 15, 'file'],
+            'selected/edit.txt' => [1, 12, 'file'],
+            'swap' => [1, 10, 'file'],
+        ]);
+        $push_state_directory = $this->filesPushStateDirectory(
+            $local_docroot,
+            $state_directory
+        );
+        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+
+        $selected = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            ['--only=selected', '--only', 'swap/selected.txt']
+        );
+
+        $this->assertSame(0, $selected['exit'], $selected['output']);
+        $this->assertSame('new selected', file_get_contents($this->docroot . '/selected/edit.txt'));
+        $this->assertFileDoesNotExist($this->docroot . '/selected/delete.txt');
+        $this->assertSame('old pending', file_get_contents($this->docroot . '/pending/edit.txt'));
+        $this->assertFileExists($this->docroot . '/pending/delete.txt');
+        $this->assertFileDoesNotExist($this->docroot . '/pending/add.txt');
+        $this->assertSame('selected child', file_get_contents($this->docroot . '/swap/selected.txt'));
+        $this->assertFileDoesNotExist($this->docroot . '/swap/unselected.txt');
+
+        $diff = $this->runFilesDiffCli($local_docroot, $state_directory);
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $diff_records = array_map(
+            static fn(string $line): array => json_decode($line, true, 512, JSON_THROW_ON_ERROR),
+            preg_split('/\R/', trim($diff['stdout'])) ?: []
+        );
+        $pending_actions = [];
+        foreach ($diff_records as $record) {
+            if (isset($record['action'], $record['path_b64'])) {
+                $pending_actions[$record['action']][] = base64_decode($record['path_b64'], true);
+            }
+        }
+        $this->assertSame(
+            ['pending/add.txt', 'pending/edit.txt', 'swap/unselected.txt'],
+            $pending_actions['push'] ?? []
+        );
+        $this->assertSame(['pending/delete.txt'], $pending_actions['delete'] ?? []);
+
+        $remaining = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $remaining['exit'], $remaining['output']);
+        $this->assertSame('pending addition', file_get_contents($this->docroot . '/pending/add.txt'));
+        $this->assertSame('new pending', file_get_contents($this->docroot . '/pending/edit.txt'));
+        $this->assertFileDoesNotExist($this->docroot . '/pending/delete.txt');
+        $this->assertSame('unselected child', file_get_contents($this->docroot . '/swap/unselected.txt'));
+    }
+
+    public function testInitialSelectedFilesPushLeavesTheBaselineAbsent(): void
+    {
+        $local_docroot = $this->root . '/initial-selected-local-docroot';
+        $state_directory = $this->root . '/initial-selected-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/selected.txt', 'selected');
+        file_put_contents($local_docroot . '/pending.txt', 'pending');
+
+        $selected = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            ['--only=selected.txt']
+        );
+
+        $this->assertSame(0, $selected['exit'], $selected['output']);
+        $this->assertSame('selected', file_get_contents($this->docroot . '/selected.txt'));
+        $this->assertFileDoesNotExist($this->docroot . '/pending.txt');
+        $push_state_directory = $this->filesPushStateDirectory(
+            $local_docroot,
+            $state_directory
+        );
+        $this->assertFileDoesNotExist(
+            $push_state_directory . '/previous_local_index.jsonl'
+        );
+
+        $diff = $this->runFilesDiffCli($local_docroot, $state_directory);
+        $this->assertSame(1, $diff['exit'], $diff['output']);
+        $this->assertStringContainsString(
+            'files-push without --only',
+            $diff['output']
+        );
+
+        $remaining = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $remaining['exit'], $remaining['output']);
+        $this->assertSame('pending', file_get_contents($this->docroot . '/pending.txt'));
+        $this->assertFileExists(
+            $push_state_directory . '/previous_local_index.jsonl'
+        );
+    }
+
+    public function testFilesPushRejectsChangedSelectedPathsWhileResuming(): void
+    {
+        $local_docroot = $this->root . '/selected-resume-local-docroot';
+        mkdir($local_docroot . '/directory', 0700, true);
+        file_put_contents($local_docroot . '/directory/file.txt', 'value');
+        $push_state_directory = $this->root . '/selected-resume-state';
+        $sender = $this->startSender(
+            $this->senderOptions(
+                $local_docroot,
+                $push_state_directory,
+                ['directory/file.txt', 'directory', 'directory']
+            )
+        );
+        $this->closeSender($sender);
+        $state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($state);
+        $this->assertMatchesRegularExpression(
+            '/^[a-f0-9]{64}$/',
+            $state['selected_paths_fingerprint'] ?? ''
+        );
+        $request_count = $this->countEndpointRequests('push_create');
+
+        try {
+            $this->resumeSender(
+                $this->senderOptions($local_docroot, $push_state_directory, ['other.txt'])
+            );
+            $this->fail('A different selection resumed the active sender.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('same --only paths', $exception->getMessage());
+        }
+        $this->assertSame($request_count, $this->countEndpointRequests('push_create'));
+        $this->assertFileExists($push_state_directory . '/sender.json');
+
+        $resumed = $this->resumeSender(
+            $this->senderOptions($local_docroot, $push_state_directory, ['directory'])
+        );
+        $this->closeSender($resumed);
+        $this->assertSame($request_count, $this->countEndpointRequests('push_create'));
+    }
+
     /**
      * Continues a partial file from the successful upload response without another status request.
      */
@@ -3055,12 +3221,14 @@ final class PushEndpointsTest extends TestCase {
     private function runFilesPushCli(
         string $local_docroot,
         string $state_directory,
-        array $ini_settings = []
+        array $ini_settings = [],
+        array $extra_arguments = []
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
             $local_docroot,
             $state_directory,
-            $ini_settings
+            $ini_settings,
+            $extra_arguments
         );
         return $this->finishFilesPushCli($process, $pipes);
     }
@@ -3074,7 +3242,8 @@ final class PushEndpointsTest extends TestCase {
     private function startFilesPushCli(
         string $local_docroot,
         string $state_directory,
-        array $ini_settings = []
+        array $ini_settings = [],
+        array $extra_arguments = []
     ): array {
         $command = [PHP_BINARY];
         foreach ($ini_settings as $name => $value) {
@@ -3089,7 +3258,7 @@ final class PushEndpointsTest extends TestCase {
             '--fs-root=' . $local_docroot,
             '--secret=' . self::SECRET,
             '--force-http',
-        ]);
+        ], $extra_arguments);
         $process = proc_open(
             $command,
             [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
@@ -3399,7 +3568,8 @@ final class PushEndpointsTest extends TestCase {
      */
     private function senderOptions(
         string $local_docroot,
-        string $push_state_directory
+        string $push_state_directory,
+        array $selected_paths = []
     ): array
     {
         $this->writeDocrootConfiguration([
@@ -3421,6 +3591,7 @@ final class PushEndpointsTest extends TestCase {
             'connect_timeout' => 3,
             'stall_timeout' => 3,
             'response_timeout' => 5,
+            'selected_paths' => $selected_paths,
         ];
     }
 
@@ -3601,11 +3772,13 @@ final class PushEndpointsTest extends TestCase {
      */
     private function runSender(
         string $local_docroot,
-        string $push_state_directory
+        string $push_state_directory,
+        array $selected_paths = []
     ): array {
         $options = $this->senderOptions(
             $local_docroot,
-            $push_state_directory
+            $push_state_directory,
+            $selected_paths
         );
         $sender = is_file($push_state_directory . '/sender.json')
             ? $this->resumeSender($options)


### PR DESCRIPTION
`files-push --only=PATH` now commits only the selected document-root-relative subtrees. Additions, edits, and deletions elsewhere remain pending for `files-diff` and a later push.

Selected operations go through PushPlan's existing index merge and the shared `merge_previous_local_index_updates()` function. This advances only committed paths in `previous_local_index.jsonl`, so paths updated by a partial pull between sender processes remain intact too.

An initial `files-push --only` leaves a missing baseline absent because the unselected tree is not a complete starting point. A later files-push without `--only`, or a compatible full pull, can establish it. The canonical selected-path fingerprint prevents a resumed sender from silently changing scope.

If installing a selected descendant requires replacing an old scalar ancestor protected by a receiver exclusion, that selected subtree stays pending while later selected siblings continue.

## Testing

The tests cover both `--only` forms, normalization, resume-scope rejection, selected additions, edits and deletions, ancestor type transitions, receiver exclusions, a missing initial baseline, and pending work outside the selected tree.