### PR TITLE
Add --preserve-local-content to merge wp-content instead of replacing it

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4893,6 +4893,7 @@ class ImportClient
 
         $flatten_to = rtrim($flatten_to, "/");
         $force = $options["force"] ?? false;
+        $preserve_local_content = $options["preserve_local_content"] ?? false;
 
         // Ensure the fs root exists
         if (!is_dir($this->fs_root)) {
@@ -5066,10 +5067,13 @@ class ImportClient
 
             $source = $local_abspath . "/" . $entry;
             $target = $flatten_to . "/" . $entry;
-            $this->flatten_place_symlink(
+            // wp-content is the only entry that can hold files the target
+            // owns; the rest of ABSPATH is core and is always replaced.
+            $this->flatten_merge_directory(
                 $source,
                 $target,
                 $force,
+                $preserve_local_content && $entry === "wp-content",
                 $created,
                 $refreshed,
                 $forced,
@@ -5160,10 +5164,11 @@ class ImportClient
                     }
                     $source = $local_content_dir . "/" . $entry;
                     $target = $wp_content_target . "/" . $entry;
-                    $this->flatten_place_symlink(
+                    $this->flatten_merge_directory(
                         $source,
                         $target,
                         $force,
+                        $preserve_local_content,
                         $created,
                         $refreshed,
                         $forced,
@@ -5174,10 +5179,11 @@ class ImportClient
             // Symlink detached sub-components into wp-content
             if ($plugins_detached && is_dir($local_plugins_dir)) {
                 $target = $wp_content_target . "/plugins";
-                $this->flatten_place_symlink(
+                $this->flatten_merge_directory(
                     $local_plugins_dir,
                     $target,
                     $force,
+                    $preserve_local_content,
                     $created,
                     $refreshed,
                     $forced,
@@ -5185,10 +5191,11 @@ class ImportClient
             }
             if ($mu_plugins_detached && is_dir($local_mu_plugins_dir)) {
                 $target = $wp_content_target . "/mu-plugins";
-                $this->flatten_place_symlink(
+                $this->flatten_merge_directory(
                     $local_mu_plugins_dir,
                     $target,
                     $force,
+                    $preserve_local_content,
                     $created,
                     $refreshed,
                     $forced,
@@ -5196,10 +5203,11 @@ class ImportClient
             }
             if ($uploads_detached && is_dir($local_uploads_basedir)) {
                 $target = $wp_content_target . "/uploads";
-                $this->flatten_place_symlink(
+                $this->flatten_merge_directory(
                     $local_uploads_basedir,
                     $target,
                     $force,
+                    $preserve_local_content,
                     $created,
                     $refreshed,
                     $forced,
@@ -5210,10 +5218,11 @@ class ImportClient
             // Simple case: just symlink the whole content_dir as wp-content.
             if (is_dir($local_content_dir)) {
                 $target = $flatten_to . "/wp-content";
-                $this->flatten_place_symlink(
+                $this->flatten_merge_directory(
                     $local_content_dir,
                     $target,
                     $force,
+                    $preserve_local_content,
                     $created,
                     $refreshed,
                     $forced,
@@ -5400,6 +5409,104 @@ class ImportClient
             "FLAT-DOCUMENT-ROOT | Created symlink: {$target} -> {$link_value}",
         );
         $created++;
+    }
+
+    /**
+     * Place $source at $target, merging into an existing directory instead of
+     * replacing it.
+     *
+     * Without $preserve, or when either side is not a real directory, this is
+     * {@see flatten_place_symlink}: one symlink for the whole subtree.
+     *
+     * When both sides are real directories, replacing the target would delete
+     * whatever it already holds, so the directory is kept and the source's
+     * entries are placed inside it:
+     *
+     *   - real directory on both sides -> recurse
+     *   - anything else                -> symlink (the source wins)
+     *   - present only in the target   -> untouched
+     *
+     * Recursion stops as soon as one side is not a real directory, so a subtree
+     * the target does not have still costs a single symlink.
+     */
+    private function flatten_merge_directory(
+        string $source,
+        string $target,
+        bool $force,
+        bool $preserve,
+        int &$created,
+        int &$refreshed,
+        int &$forced
+    ): void {
+        if (
+            !$preserve ||
+            is_link($source) ||
+            !is_dir($source) ||
+            is_link($target) ||
+            !is_dir($target)
+        ) {
+            // A merge implies the source wins on collisions; without this every
+            // path present on both sides would raise, and avoiding that with
+            // --force would replace whole directories instead of merging.
+            $this->flatten_place_symlink(
+                $source,
+                $target,
+                $preserve || $force,
+                $created,
+                $refreshed,
+                $forced,
+            );
+            return;
+        }
+
+        $this->audit_log(
+            "FLAT-DOCUMENT-ROOT | Merging into existing directory: {$target}",
+        );
+
+        foreach (@scandir($source) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $this->flatten_merge_directory(
+                $source . "/" . $entry,
+                $target . "/" . $entry,
+                $force,
+                $preserve,
+                $created,
+                $refreshed,
+                $forced,
+            );
+        }
+
+        // Walking the source cannot notice entries it no longer has, so links
+        // to removed files would accumulate. Only links pointing back into the
+        // fs root were created here; anything else belongs to the target.
+        $root = $this->get_filesystem_root_path();
+        foreach (@scandir($target) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $stale = $target . "/" . $entry;
+            // file_exists() follows links, so this is: a link that no longer resolves.
+            if (!is_link($stale) || file_exists($stale)) {
+                continue;
+            }
+            $link = readlink($stale);
+            if ($link === false) {
+                continue;
+            }
+            $resolved = normalize_path(
+                strpos($link, "/") === 0 ? $link : $target . "/" . $link,
+            );
+            if (!path_is_within_root($resolved, $root)) {
+                continue;
+            }
+            if (@unlink($stale)) {
+                $this->audit_log(
+                    "FLAT-DOCUMENT-ROOT | Pruned dangling symlink: {$stale}",
+                );
+            }
+        }
     }
 
     /**
@@ -12583,6 +12690,14 @@ if (
             'type' => 'flag',
             'target' => 'force',
             'help' => 'Remove conflicting non-symlink files and replace with symlinks',
+            'commands' => ['pull', 'flat-docroot'],
+        ],
+        [
+            'name' => 'preserve-local-content',
+            'type' => 'flag',
+            'target' => 'preserve_local_content',
+            'help' => 'Merge wp-content into an existing local one instead of replacing it, ' .
+                'keeping files that exist only locally (the remote wins on conflicts)',
             'commands' => ['pull', 'flat-docroot'],
         ],
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5482,6 +5482,10 @@ class ImportClient
         // to removed files would accumulate. Only links pointing back into the
         // fs root were created here; anything else belongs to the target.
         $root = $this->get_filesystem_root_path();
+        // The fs root is canonical, so the link has to be resolved against a
+        // canonical base too: a lexical one misses every link whose route
+        // passes through a symlink, and the prune then silently does nothing.
+        $base = realpath($target) ?: $target;
         foreach (@scandir($target) ?: [] as $entry) {
             if ($entry === "." || $entry === "..") {
                 continue;
@@ -5496,7 +5500,7 @@ class ImportClient
                 continue;
             }
             $resolved = normalize_path(
-                strpos($link, "/") === 0 ? $link : $target . "/" . $link,
+                strpos($link, "/") === 0 ? $link : $base . "/" . $link,
             );
             if (!path_is_within_root($resolved, $root)) {
                 continue;

--- a/tests/Import/FlatDocrootPreserveLocalContentTest.php
+++ b/tests/Import/FlatDocrootPreserveLocalContentTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify --preserve-local-content merges wp-content into an existing
+ * directory instead of replacing it, and that the flag is opt-in.
+ */
+class FlatDocrootPreserveLocalContentTest extends TestCase
+{
+    private const ABSPATH = '/srv/htdocs/wordpress/';
+
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+    private string $flattenTo;
+    private string $localAbspath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/flat-docroot-preserve-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        $this->flattenTo = $this->tempDir . '/flat';
+        $this->localAbspath = $this->fsRoot . self::ABSPATH;
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->localAbspath, 0755, true);
+        file_put_contents($this->localAbspath . 'wp-load.php', '<?php // wp-load');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testMergeKeepsEntriesThatExistOnlyInTheTarget(): void
+    {
+        $this->writeSource('wp-content/plugins/from-source/plugin.php', '<?php // source');
+        $this->writeTarget('wp-content/plugins/target-only/plugin.php', '<?php // target');
+        $this->writeTarget('wp-content/themes/target-theme/style.css', '/* target */');
+        $this->writeTarget('wp-content/custom-folder/note.txt', 'keep me');
+
+        $this->flatten(true);
+
+        $this->assertFileExists($this->flattenTo . '/wp-content/plugins/target-only/plugin.php');
+        $this->assertFileExists($this->flattenTo . '/wp-content/themes/target-theme/style.css');
+        $this->assertFileExists($this->flattenTo . '/wp-content/custom-folder/note.txt');
+        $this->assertFileExists(
+            $this->flattenTo . '/wp-content/plugins/from-source/plugin.php',
+            'source entries are still linked in',
+        );
+        $this->assertFalse(
+            is_link($this->flattenTo . '/wp-content'),
+            'wp-content stays a real directory',
+        );
+    }
+
+    public function testSourceWinsOnCollisionWithoutForce(): void
+    {
+        $this->writeSource('wp-content/plugins/shared/plugin.php', '<?php // from source');
+        $this->writeTarget('wp-content/plugins/shared/plugin.php', '<?php // from target');
+
+        $this->flatten(true);
+
+        $this->assertStringContainsString(
+            'from source',
+            file_get_contents($this->flattenTo . '/wp-content/plugins/shared/plugin.php'),
+            'a collision resolves to the source rather than raising',
+        );
+    }
+
+    public function testPrunesLinkWhoseSourceEntryIsGone(): void
+    {
+        $this->writeSource('wp-content/plugins/temporary/plugin.php', '<?php');
+        $this->writeTarget('wp-content/plugins/target-only/plugin.php', '<?php');
+        $this->flatten(true);
+
+        $link = $this->flattenTo . '/wp-content/plugins/temporary';
+        $this->assertTrue(is_link($link), 'source entry is linked on the first pass');
+
+        $this->recursiveDelete($this->localAbspath . 'wp-content/plugins/temporary');
+        $this->flatten(true);
+
+        $this->assertFalse(is_link($link), 'the link is pruned once its source entry is gone');
+        $this->assertFileExists(
+            $this->flattenTo . '/wp-content/plugins/target-only/plugin.php',
+            'pruning leaves target-only entries alone',
+        );
+    }
+
+    public function testDoesNotPruneDanglingLinkPointingOutsideTheFsRoot(): void
+    {
+        $this->writeSource('wp-content/plugins/from-source/plugin.php', '<?php');
+        mkdir($this->flattenTo . '/wp-content/plugins', 0755, true);
+        // Dangles, but resolves outside the fs root, so it is the target's own.
+        symlink($this->tempDir . '/elsewhere', $this->flattenTo . '/wp-content/plugins/target-owned');
+
+        $this->flatten(true);
+
+        $this->assertTrue(
+            is_link($this->flattenTo . '/wp-content/plugins/target-owned'),
+            'links resolving outside the fs root are not ours to prune',
+        );
+    }
+
+    public function testSubtreeMissingFromTheTargetCostsASingleLink(): void
+    {
+        $this->writeSource('wp-content/uploads/2026/01/a.jpg', 'a');
+        $this->writeSource('wp-content/uploads/2026/02/b.jpg', 'b');
+        $this->writeTarget('wp-content/plugins/target-only/plugin.php', '<?php');
+
+        $this->flatten(true);
+
+        $this->assertTrue(
+            is_link($this->flattenTo . '/wp-content/uploads'),
+            'uploads is one link, not an exploded tree',
+        );
+        $this->assertFileExists($this->flattenTo . '/wp-content/uploads/2026/01/a.jpg');
+    }
+
+    public function testWithoutTheFlagAnExistingDirectoryIsStillAConflict(): void
+    {
+        $this->writeSource('wp-content/plugins/from-source/plugin.php', '<?php');
+        $this->writeTarget('wp-content/plugins/target-only/plugin.php', '<?php');
+
+        $this->expectException(\RuntimeException::class);
+        $this->flatten(false);
+    }
+
+    public function testWithoutTheFlagForceStillReplacesWpContent(): void
+    {
+        $this->writeSource('wp-content/plugins/from-source/plugin.php', '<?php');
+        $this->writeTarget('wp-content/plugins/target-only/plugin.php', '<?php');
+
+        $this->flatten(false, true);
+
+        $this->assertTrue(
+            is_link($this->flattenTo . '/wp-content'),
+            'wp-content is replaced by a single symlink',
+        );
+        $this->assertFileDoesNotExist(
+            $this->flattenTo . '/wp-content/plugins/target-only/plugin.php',
+        );
+    }
+
+    // ---- helpers ----
+
+    private function flatten(bool $preserve, bool $force = false): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'table_prefix' => 'wp_',
+                            'paths_urls' => [
+                                'abspath' => self::ABSPATH,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'run_flat_document_root', [
+            [
+                'flatten_to' => $this->flattenTo,
+                'force' => $force,
+                'preserve_local_content' => $preserve,
+            ],
+        ]);
+    }
+
+    private function writeSource(string $relative, string $contents): void
+    {
+        $this->writeFile($this->localAbspath . $relative, $contents);
+    }
+
+    private function writeTarget(string $relative, string $contents): void
+    {
+        $this->writeFile($this->flattenTo . '/' . $relative, $contents);
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, $contents);
+    }
+
+    private function writeState(array $state): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode($state, JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $reflection = new \ReflectionClass($client);
+        $property = $reflection->getProperty('state');
+        $property->setValue($client, $state);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $m = $reflection->getMethod($method);
+        return $m->invoke($client, ...$args);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## What it does

Adds `--preserve-local-content` to `flat-docroot` and `pull`. With it, an existing `wp-content` is **merged** rather than replaced: entries the source also has get linked, entries that exist only in the target are left alone.

Opt-in — without the flag, behaviour is unchanged.

## Rationale

`flat-docroot --force` replaces a conflicting non-symlink target with a symlink, and for a directory that means deleting it first:

```php
if ( is_dir( $target ) ) {
    $this->remove_directory_recursive( $target );
}
symlink( $link_value, $target );
```

That's fine for core paths, which the source owns entirely. It isn't fine for `wp-content`: flattening onto a docroot that already has content deletes every plugin, theme and upload the target had. A consumer flattening onto a pre-existing site needs `--force` to overwrite core, but must not lose `wp-content` in the process.

## Implementation

`flatten_merge_directory()` wraps `flatten_place_symlink()`. When either side isn't a real directory it delegates unchanged — one symlink for the whole subtree. When both sides are real directories it keeps the target and walks the source:

- real directory on both sides → recurse
- anything else → symlink it (the source wins)
- present only in the target → untouched

Recursion stops as soon as one side isn't a real directory, so a subtree the target doesn't have still costs a single symlink. `uploads/` only expands into per-entry links if the target already has matching directories.

Two consequences of walking the source instead of aliasing it:

**Collisions must resolve, not raise.** A merge implies the source wins, so the delegated call passes `$preserve || $force`. Otherwise every path present on both sides — `wp-content/database`, for one — would fail unless the caller also passed `--force`, which replaces whole directories and defeats the merge.

**Removals need pruning.** Walking the source can't notice entries it no longer has, so links to deleted files would accumulate. After merging, symlinks whose target is gone are unlinked — but only when the link resolves back inside the fs root, since those are the ones the flatten created. Real files, and symlinks the target owns, are untouched.

Only `wp-content` merges; the rest of ABSPATH is core and is still replaced.

## Testing instructions

```
cd tests && phpunit Import/FlatDocrootPreserveLocalContentTest.php
```

Seven cases: the merge keeps target-only entries; the source wins a collision without `--force`; a link whose source entry is gone is pruned; a dangling link resolving *outside* the fs root is left alone; a subtree the target lacks costs a single symlink; and without the flag an existing directory is still a conflict, with `--force` still replacing it wholesale.

Writing them turned up a bug in the prune, fixed in the second commit: it resolved the link lexically while `get_filesystem_root_path()` returns a canonical path, so any link routed through a symlink — `/tmp` and `/var` on macOS, or a symlinked project directory — failed the containment check and was never pruned.

The rest of the suite is unaffected. Note that a local run without MySQL fails ~151 database-dependent tests with `Connection refused`; those are unrelated.
