### PR TITLE
Guard the vendor autoload include against symlink double-loading

### DIFF
--- a/reprint-exporter-wp/index.php
+++ b/reprint-exporter-wp/index.php
@@ -9,6 +9,50 @@
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
 
+// ── TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE ──────────────────────────
+// Traces the double-bootstrap behind the intermittent wpcloud-flatten fatal
+// ("Cannot redeclare class ComposerAutoloaderInit*"). Gated to the wpcloud
+// E2E vhost so the rest of the suite stays quiet.
+if (
+    getenv('SITE_EXPORT_TEST_MODE') &&
+    strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
+) {
+    $stu_diag_trace = array_map(
+        static function ($f) {
+            return ($f['file'] ?? '?') . ':' . ($f['line'] ?? 0);
+        },
+        debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)
+    );
+    error_log(
+        '[E2E-DIAG] index.php __FILE__=' . __FILE__
+        . ' uri=' . ($_SERVER['REQUEST_URI'] ?? '-')
+        . ' includers=' . implode(' <- ', array_slice($stu_diag_trace, 0, 6))
+    );
+    error_log(
+        '[E2E-DIAG] init-classes=' . implode(
+            ',',
+            preg_grep('/^ComposerAutoloaderInit/', get_declared_classes()) ?: ['none']
+        )
+    );
+    if (!defined('STU_DIAG_SHUTDOWN_ARMED')) {
+        define('STU_DIAG_SHUTDOWN_ARMED', true);
+        register_shutdown_function(static function () {
+            $e = error_get_last();
+            if (!$e || strpos($e['message'], 'ComposerAutoloaderInit') === false) {
+                return;
+            }
+            error_log('[E2E-DIAG] FATAL ' . $e['message'] . ' @ ' . $e['file'] . ':' . $e['line']);
+            // Ordered include list at the moment of death: the entry just
+            // before the second autoload.php names its includer chain.
+            error_log(
+                '[E2E-DIAG] at-fatal includes: '
+                . implode(' | ', preg_grep('#site-export|autoload#', get_included_files()) ?: [])
+            );
+        });
+    }
+}
+// ── END TEMPORARY E2E DIAGNOSTIC ─────────────────────────────────────────────
+
 require_once __DIR__ . '/lib.php';
 
 // Intercept export API requests as early as possible.

--- a/reprint-exporter-wp/index.php
+++ b/reprint-exporter-wp/index.php
@@ -9,50 +9,6 @@
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
 
-// ── TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE ──────────────────────────
-// Traces the double-bootstrap behind the intermittent wpcloud-flatten fatal
-// ("Cannot redeclare class ComposerAutoloaderInit*"). Gated to the wpcloud
-// E2E vhost so the rest of the suite stays quiet.
-if (
-    getenv('SITE_EXPORT_TEST_MODE') &&
-    strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
-) {
-    $stu_diag_trace = array_map(
-        static function ($f) {
-            return ($f['file'] ?? '?') . ':' . ($f['line'] ?? 0);
-        },
-        debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)
-    );
-    error_log(
-        '[E2E-DIAG] index.php __FILE__=' . __FILE__
-        . ' uri=' . ($_SERVER['REQUEST_URI'] ?? '-')
-        . ' includers=' . implode(' <- ', array_slice($stu_diag_trace, 0, 6))
-    );
-    error_log(
-        '[E2E-DIAG] init-classes=' . implode(
-            ',',
-            preg_grep('/^ComposerAutoloaderInit/', get_declared_classes()) ?: ['none']
-        )
-    );
-    if (!defined('STU_DIAG_SHUTDOWN_ARMED')) {
-        define('STU_DIAG_SHUTDOWN_ARMED', true);
-        register_shutdown_function(static function () {
-            $e = error_get_last();
-            if (!$e || strpos($e['message'], 'ComposerAutoloaderInit') === false) {
-                return;
-            }
-            error_log('[E2E-DIAG] FATAL ' . $e['message'] . ' @ ' . $e['file'] . ':' . $e['line']);
-            // Ordered include list at the moment of death: the entry just
-            // before the second autoload.php names its includer chain.
-            error_log(
-                '[E2E-DIAG] at-fatal includes: '
-                . implode(' | ', preg_grep('#site-export|autoload#', get_included_files()) ?: [])
-            );
-        });
-    }
-}
-// ── END TEMPORARY E2E DIAGNOSTIC ─────────────────────────────────────────────
-
 require_once __DIR__ . '/lib.php';
 
 // Intercept export API requests as early as possible.

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -10,6 +10,17 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE (see index.php).
+if (
+    getenv('SITE_EXPORT_TEST_MODE') &&
+    strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
+) {
+    error_log(
+        '[E2E-DIAG] lib.php __FILE__=' . __FILE__
+        . ' plugin_dir=' . (defined('SITE_EXPORT_PLUGIN_DIR') ? SITE_EXPORT_PLUGIN_DIR : '(unset)')
+    );
+}
+
 if (!defined('SITE_EXPORT_VERSION')) {
     define('SITE_EXPORT_VERSION', '0.9.2-dev');
 }
@@ -111,6 +122,20 @@ function _site_export_load_exporter_runtime(): ?string {
         // re-declares the ComposerAutoloaderInit* class and fatals.
         // build_pdo_dsn() is a Composer `files` autoload entry, so it exists
         // exactly when the autoloader has already run.
+        // TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE (see index.php).
+        if (
+            getenv('SITE_EXPORT_TEST_MODE') &&
+            strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
+        ) {
+            error_log(
+                '[E2E-DIAG] loader candidate=' . $candidate['autoload']
+                . ' guard-skip=' . (function_exists('build_pdo_dsn') ? '1' : '0')
+                . ' init-classes=' . implode(
+                    ',',
+                    preg_grep('/^ComposerAutoloaderInit/', get_declared_classes()) ?: ['none']
+                )
+            );
+        }
         if (!function_exists('build_pdo_dsn')) {
             require_once $candidate['autoload'];
         }

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -10,17 +10,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE (see index.php).
-if (
-    getenv('SITE_EXPORT_TEST_MODE') &&
-    strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
-) {
-    error_log(
-        '[E2E-DIAG] lib.php __FILE__=' . __FILE__
-        . ' plugin_dir=' . (defined('SITE_EXPORT_PLUGIN_DIR') ? SITE_EXPORT_PLUGIN_DIR : '(unset)')
-    );
-}
-
 if (!defined('SITE_EXPORT_VERSION')) {
     define('SITE_EXPORT_VERSION', '0.9.2-dev');
 }
@@ -124,20 +113,6 @@ function _site_export_load_exporter_runtime(): ?string {
         // realpath here puts every include in the same family and lets
         // require_once dedupe natively.
         $autoload = realpath($candidate['autoload']) ?: $candidate['autoload'];
-        // TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE (see index.php).
-        if (
-            getenv('SITE_EXPORT_TEST_MODE') &&
-            strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
-        ) {
-            error_log(
-                '[E2E-DIAG] loader autoload=' . $autoload
-                . ' guard-skip=' . (function_exists('build_pdo_dsn') ? '1' : '0')
-                . ' init-classes=' . implode(
-                    ',',
-                    preg_grep('/^ComposerAutoloaderInit/', get_declared_classes()) ?: ['none']
-                )
-            );
-        }
         require_once $autoload;
         return $candidate['export'];
     }

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -104,7 +104,16 @@ function _site_export_load_exporter_runtime(): ?string {
             continue;
         }
 
-        require_once $candidate['autoload'];
+        // Guard with an existence check: when wp-content is reached through a
+        // symlink, the same physical autoload.php can be included through two
+        // different paths. With opcache.revalidate_path=0 (default),
+        // require_once does not resolve symlinks, so the second include
+        // re-declares the ComposerAutoloaderInit* class and fatals.
+        // build_pdo_dsn() is a Composer `files` autoload entry, so it exists
+        // exactly when the autoloader has already run.
+        if (!function_exists('build_pdo_dsn')) {
+            require_once $candidate['autoload'];
+        }
         return $candidate['export'];
     }
 

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -115,20 +115,22 @@ function _site_export_load_exporter_runtime(): ?string {
             continue;
         }
 
-        // Guard with an existence check: when wp-content is reached through a
-        // symlink, the same physical autoload.php can be included through two
-        // different paths. With opcache.revalidate_path=0 (default),
-        // require_once does not resolve symlinks, so the second include
-        // re-declares the ComposerAutoloaderInit* class and fatals.
-        // build_pdo_dsn() is a Composer `files` autoload entry, so it exists
-        // exactly when the autoloader has already run.
+        // Canonicalize before requiring: when wp-content is reached through a
+        // symlink, the same physical autoload.php is reachable through two
+        // path strings, and with opcache.revalidate_path=0 (default)
+        // require_once does not dedupe across them — the second include
+        // re-declares the ComposerAutoloaderInit* class and fatals. Composer's
+        // own baked __DIR__ paths resolve to the real path, so requiring the
+        // realpath here puts every include in the same family and lets
+        // require_once dedupe natively.
+        $autoload = realpath($candidate['autoload']) ?: $candidate['autoload'];
         // TEMPORARY E2E DIAGNOSTIC — REVERT BEFORE MERGE (see index.php).
         if (
             getenv('SITE_EXPORT_TEST_MODE') &&
             strpos($_SERVER['DOCUMENT_ROOT'] ?? '', 'wpcloud') !== false
         ) {
             error_log(
-                '[E2E-DIAG] loader candidate=' . $candidate['autoload']
+                '[E2E-DIAG] loader autoload=' . $autoload
                 . ' guard-skip=' . (function_exists('build_pdo_dsn') ? '1' : '0')
                 . ' init-classes=' . implode(
                     ',',
@@ -136,9 +138,7 @@ function _site_export_load_exporter_runtime(): ?string {
                 )
             );
         }
-        if (!function_exists('build_pdo_dsn')) {
-            require_once $candidate['autoload'];
-        }
+        require_once $autoload;
         return $candidate['export'];
     }
 


### PR DESCRIPTION
## What it does

Requires the plugin's Composer autoloader by its `realpath()`, so the same physical `autoload.php` can no longer be included twice through two different path strings.

## Rationale

When `wp-content` is a symlink (the WP Cloud layout), the plugin's files are reachable through two path families — the symlink path and the realpath. With `opcache.revalidate_path=0` (the default), `require_once` does not dedupe across the two strings, so a cross-family double include of `autoload.php` re-declares the `ComposerAutoloaderInit*` class:

```
PHP Fatal error: Cannot redeclare class ComposerAutoloaderInitc5be971...
  previously declared in /srv/<site>/wp-content/plugins/site-export/vendor/composer/autoload_real.php   ← symlink family
  in                     /tmp/<content>/wp-content/plugins/site-export/vendor/composer/autoload_real.php ← realpath family
```

The export endpoint answers HTTP 500 and, in CI, `import-38-flatten-wpcloud` cascades (files-sync fails, nothing lands in the fs root, flat-docroot reports "ABSPATH not found"). Which leg fails varies with per-file opcache cache-key state — it hit PHP 8.1 twice, then 8.4 — the same class of symlink double-load afc8318 (#148) fixed inside `export.php`.

A temporarily instrumented CI run (since reverted) captured the fatal in flight and pinned the mechanism:

- the plugin bootstraps once through the symlink family, but **Composer's baked `__DIR__` paths resolve symlinks**, so everything the ClassLoader itself pulls in — classmap classes, and eventually the colliding second `autoload.php` include — runs through the **realpath family**;
- a symbol guard (`function_exists` on a Composer `files` entry, the first attempt in this PR) is unsound: the trace showed the loader re-entered mid-`getLoader()`, when the `ComposerAutoloaderInit*` class is already declared but the `files` entries have not run yet.

Requiring the realpath puts this loader's include in the same family Composer already uses, so `require_once` dedupes natively whichever side runs first — no reliance on load-order symbols, no dependence on who the second includer is.

## Testing instructions

The failure is opcache- and version-dependent, so the E2E matrix is the practical test: `import-38-flatten-wpcloud` exercises exactly this layout. With the fix, the full matrix went green ([run](https://github.com/WordPress/reprint/actions/runs/29852123974) failed on 8.4 before the fix; the follow-up runs pass) — the flake had fired on every recent PR run, including twice on the same leg of #383. `php -l reprint-exporter-wp/lib.php` passes; behaviour is unchanged when no symlinks are involved (`realpath` is then the same path).
