### PR TITLE
[Push] Advance one local baseline through pull and push batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ truncated or rotated, so it provides a complete history of the migration.
 ```
 [2025-01-15 10:30:01] VOLATILE | path=/srv/htdocs/wp-content/debug.log | count=1
 [2025-01-15 10:30:05] VOLATILE CLEARED | path=/srv/htdocs/wp-content/debug.log
-[2025-01-15 10:31:12] FILE DELETE | .import-index-updates.jsonl
+[2025-01-15 10:31:12] FILE TRUNCATE | .import-index-updates.wal | WAL batch applied
 ```
 
 Pass `--verbose` to also print audit log entries to the console as they happen.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -7,9 +7,9 @@ the end maps it to a PR stack.
 
 ## Shape of a push
 
-1. The local machine knows what changed locally since its last push to this
-   remote (files, deletions, database rows), by comparing against the local
-   paths and rows stored after that push.
+1. The local machine knows what changed locally since each path's baseline was
+   recorded, and which database rows changed since the last push, by comparing
+   against the stored local paths and rows.
 2. It shows a summary of local uploads and deletions. The user confirms that
    local should win for those paths and rows.
 3. It transfers everything into a private push directory on the remote — file bytes,
@@ -19,10 +19,10 @@ the end maps it to a PR stack.
    moves work files into place, executes deletions, and commits the database
    diff, and fixes symlinks — inside a maintenance window that lasts seconds,
    not the length of the transfer.
-5. It stores the current local paths as the pair's previous local index
-   and stores the current rows as the previously pushed rows. The push is
-   complete only after this step; a crashed push is
-   re-driven from the top and converges.
+5. It merges the committed path operations into the pair's previous local
+   index and stores the current rows as the previously pushed rows. The push
+   is complete only after this step; a crashed push is re-driven from the top
+   and converges.
 
 Both sides act only when the local machine calls: no worker, no polling, no
 sessions. The remote is a passive authenticated API.
@@ -77,19 +77,66 @@ managed `false` hard-disables push without abandoning durable commit recovery.
 ## Change detection: local machine compared against itself
 
 ctime is machine-local, so push never compares a local timestamp to a remote
-one. It only answers "what changed locally since my last successful push to
-this remote" by comparing the current local paths and rows against the pair's
-previous local index and the previously pushed rows.
+one. It answers "what changed locally since this path's baseline was recorded"
+by comparing current local paths against the pair's previous local index.
+Database rows are compared against the previously pushed rows.
 
 The local machine keeps these files **per target URL and canonical local
-tree**, overwritten after each successful commit:
+tree**:
 
     <state-dir>/push/<pair-key>/previous_local_index.jsonl
     <state-dir>/push/<pair-key>/previously_pushed_rows.jsonl   (phase two)
 
-The previous local index records the local path type, size, and ctime as the
-completing push observed them. Besides planning the next push, it feeds the
-local `files-diff` command, which reports the same comparison without pushing.
+The previous local index is the pair's shared local baseline for deciding later
+local push work. A committed files-push merges only its committed push and
+delete operations and their required ancestors into the latest baseline,
+preserving other paths advanced by a compatible pull between sender processes. A
+compatible full file-only pull — standalone `files-pull` or the terminal file
+stage of `pull-files` — seeds a missing baseline from the current import index
+before mutating the tree, then advances it after every durable pull batch. A
+compatible partial
+`--only` pull advances an existing baseline but cannot seed one because the
+unselected tree is not a complete starting point. The index records the local
+path type, size, and ctime; remote values cannot stand in because ctime belongs
+to the machine where it was observed. Compatible means `--filter=none`, no
+`--remap`, and no `--on-fs-root-nonempty=preserve-local`. The high-level
+`pull` command does not maintain the baseline because later stages may change
+the local tree. Besides planning the next push, the index feeds the local
+`files-diff` command, which reports the same comparison without pushing.
+
+A files-pull lifecycle which cannot maintain the index — an incompatible
+option set or a pipeline that continues past the file stage — removes it before
+mutating the tree. Each retained entry is the path state recorded by a
+compatible pull or committed push; later local changes are found by comparing
+the live tree with that entry.
+
+The importer writes each index-update batch to the single
+`.import-index-updates.wal` write-ahead log. It first publishes the WAL into the
+import index. A maintaining file-only pull then maps only the F/D records which
+that pull applied, plus their required ancestors, into local-index order and
+publishes them into the existing previous local index. File records carry the
+local path type, size, and ctime observed when the pull applied them; a target
+deletion is included only after the local path is absent. The WAL is removed
+only after the files-pull lifecycle completes. After each batch reaches both
+indexes, its records are cleared but the empty WAL remains as the lifecycle
+marker.
+
+An interruption leaves that WAL, including when it contains no completed path
+record yet, so files-diff and files-push cannot observe an unfinished pull.
+Only resuming or aborting the interrupted files-pull consumes it, including
+through a high-level pull command; unrelated commands do not. Publishing
+either index is idempotent, so replay may safely
+repeat the import-index publication before completing the
+previous-local-index publication. An unterminated final record from a short
+write is not committed and is discarded on replay. Aborting an unfinished
+pull invalidates the previous local index because a path may have changed
+before its record was appended. Entries outside the paths applied by a partial
+pull remain unchanged during resume. Pending local additions, edits, and
+deletions elsewhere therefore stay pending, and a later local edit to an
+applied path also stays pending because the F record keeps the type, size, and
+ctime observed when that path was applied. Directory emptiness comes from
+descendants retained by the merge, not unrelated local additions on disk.
+Paths outside the files-push scope are not admitted.
 
 `PushPlan` first builds a path-sorted fresh local index, then derives the local
 paths to push and delete by diffing it against the previous local index its
@@ -126,28 +173,29 @@ A push plan is an internal part of the sender lifecycle:
    `plan/local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
    `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
-6. After the receiver commits successfully, the sender saves the retained fresh
-   local index as `previous_local_index.jsonl` through the same swap-file
-   copy. It then removes the complete `plan/` directory and the sender-owned
-   exclusions file. After the target
-   confirms removal of a discarded push session, the sender removes the same
-   files without changing the pair's previous local index.
+6. After the receiver commits successfully, the sender writes F/D updates for
+   the committed push and delete lists, then merges them into the latest
+   `previous_local_index.jsonl` through a swap file. If neither the plan
+   snapshot nor the latest baseline exists, it publishes the complete fresh
+   local index. It then removes
+   the complete `plan/` directory and the sender-owned exclusions file. After
+   the target confirms removal of a discarded push session, the sender removes
+   the same files without changing the pair's previous local index.
 
 Until the sender stores the initial PushPlan cursor, `starting_plan` remains
 the durable phase. An interrupted start is repeated and overwrites its initial
 plan files. After each later plan step, changed files are flushed before the
 sender atomically stores the returned cursor in `sender.json`.
 
-The completed-index copy after commit is a deliberate exception to bounded
-sender steps. A
-representative index entry is about 150 bytes, so one million paths produce
-roughly 150 MB, which takes about 15 seconds even at 10 MiB/s. PHP `copy()`
-streams the index without loading it into memory, and only the final rename
-moves the completed copy into place. This accepts that a 1 MiB/s drive reaches
-30 seconds at roughly 200,000 paths. A stopped copy is repeated by the next
-sender run. Keeping another cursor and retained handle for this post-commit copy
-is not justified until measurements from materially larger installations show
-that it matters.
+The plan-start baseline snapshot and post-commit baseline merge are deliberate
+exceptions to bounded sender steps. A representative index entry is about 150
+bytes, so one million paths produce roughly 150 MB, which takes about 15
+seconds even at 10 MiB/s. Both operations stream without loading the complete
+index into memory, and only the final rename publishes their output. This
+accepts that a 1 MiB/s drive reaches 30 seconds at roughly 200,000 paths. A
+stopped snapshot or merge is repeated by the next sender run. Keeping another
+cursor and retained handle for these full-index operations is not justified
+until measurements from materially larger installations show that it matters.
 
 The cursor contains the plan directory, local tree root, previous local
 index, and current planning position. During indexing, that
@@ -273,36 +321,46 @@ configuration; request parameters cannot select any of them.
 ## Local files sender
 
 `PushFilesSender` joins the durable `PushPlan` to the receiver's push session.
+Every local Reprint command workflow runs under `<state-dir>/.reprint.lock`.
+The production CLI acquires this non-blocking lock before it prepares pair
+context, constructs `ImportClient`, or writes the command audit entry. It
+passes the open lock to `ImportClient::run()` and releases it after the command.
+A direct `ImportClient::run()` call acquires the lock when its caller supplies
+none. The one state-directory-wide Reprint process lock prevents concurrent
+pull, push, diff, and other local Reprint processes from using that site state,
+regardless of their target or local-tree pair.
+
 An active push keeps these files under `<state-dir>/push/<pair-key>/`:
 
 ```text
-previous_local_index.jsonl          index saved after the previous commit
+previous_local_index.jsonl          shared pull/push baseline
 excluded_paths.json                 sender-owned target exclusions
 sender.json                         active push state
-sender.lock                         lifecycle lock
 plan/
   excluded_paths.json               target exclusions for the active push
+  previous_local_index.jsonl        plan-start baseline snapshot, when present
   fresh_local_index.jsonl           plan-owned fresh local index
   local_paths_to_push.jsonl         local paths to push
   local_paths_to_delete             raw NUL-delimited local paths to delete
   deleted_directories_stack.jsonl   append-only planning stack
+  previous_local_index_updates.jsonl  committed updates, created after commit
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.
-`PushFilesSender::start()` rejects unfinished active state, writes the initial
-`creating` state, and acquires `sender.lock`. `PushFilesSender::resume()`
-acquires the same lock and reads the unfinished state once. The returned sender
-keeps that state in memory while `next_step()` performs bounded work. When the
-caller stops between steps, `cancel()` discards an open multipart request and
-returns to the preceding durable boundary. `close()` then releases the lock.
-`close()` never finishes a request or advances the workflow. A second local
-process cannot start or resume the same sender
-until the open sender is closed. `next_step()` returns true while another step
-may be performed and false after completion, restart, or failure; the caller
-reads that outcome from the sender. The caller may stop after any true return
-and close the sender. If the process stops without closing, the next process
-uses the preceding sender boundary and receiver-confirmed cursors to account
-for later remote work.
+Its caller acquires the Reprint process lock and passes the open lock to
+`PushFilesSender::start()` or `PushFilesSender::resume()`.
+`PushFilesSender::start()` rejects unfinished active state and writes the
+initial `creating` state. `PushFilesSender::resume()` reads the unfinished state
+once. The returned sender keeps that state in memory while `next_step()`
+performs bounded work. When the caller stops between steps, `cancel()` discards
+an open multipart request and returns to the preceding durable boundary.
+`close()` releases sender resources but not the caller-owned Reprint process
+lock, and never finishes a request or advances the workflow. `next_step()`
+returns true while another step may be performed and false after completion,
+restart, or failure; the caller reads that outcome from the sender. The caller
+may stop after any true return and close the sender. If the process stops
+without closing, the next process uses the preceding sender boundary and
+receiver-confirmed cursors to account for later remote work.
 
 During PushPlan's internal `indexing` phase, the plan retains one
 `FileIndexProcessor` and the open fresh local index across steps. A
@@ -312,7 +370,7 @@ processor cursor before continuing. The sender lazily opens
 It retains those handles across `next_step()` calls, lets each handle advance
 with the work, and seeks only when a newly opened or receiver-confirmed offset
 differs. It closes each handle when its phase or file ends and closes any
-remaining handles before `close()` releases the lifecycle lock.
+remaining handles before `close()` returns.
 
 The sender creates the push session and stores its exclusion policy before it
 starts PushPlan. Each internal `indexing` step completes one traversal event,
@@ -330,13 +388,14 @@ sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_previous_local_index`, `completing`, `removing`, and
 `discarding_plan`.
-The separate start, index-save, completion, removal, and discard phases ensure
-that a process stop between durable actions repeats only the current action.
-During `planning`, the PushPlan cursor in `sender.json` contains the
-plan's internal phase and continuation offsets. A completed cursor remains until
-the local index is saved, or until the target confirms removal. The sender then
-clears the cursor, enters `completing` or `discarding_plan`, and removes the
-active plan files without reopening PushPlan.
+The separate start, baseline-publication, completion, removal, and discard
+phases ensure that a process stop between durable actions repeats only the
+current action. During `planning`, the PushPlan cursor in `sender.json`
+contains the plan's internal phase and continuation offsets. A completed cursor remains until
+the committed operations are published into the previous local index, or until
+the target confirms removal. The sender then clears the cursor, enters
+`completing` or `discarding_plan`, and removes the active plan files without
+reopening PushPlan.
 
 Each local path to push carries the type, size, and ctime from the index used to
 plan it. When the receiver position is unknown, the sender compares the live
@@ -366,18 +425,25 @@ captured by the completed fresh local index rather than attempting to describe
 the live tree at commit time.
 
 Repeated `push_commit` calls drive the receiver to `complete`. Only then does
-the sender enter `saving_previous_local_index` and copy the plan-owned
-fresh local index to `previous_local_index.jsonl`. Excluded entries
-remain in that complete index; exclusions suppress remote work rather than
-creating a second retained index representation. The sender then removes the
+the sender enter `saving_previous_local_index`. It writes F/D updates from the
+committed push and delete lists and their required ancestors, then merges them
+into the latest `previous_local_index.jsonl`, rather than replacing that
+baseline with the plan's older full-tree snapshot. A compatible pull completed
+between sender processes therefore preserves paths outside the committed
+operations. If a later incompatible pull removed the baseline, the sender
+leaves it absent rather than publishing an incomplete index. If no baseline
+existed at plan start and none exists at publication, the sender also records
+the complete fresh local index, including the initial state under target
+exclusions. Once a baseline exists, later changes under excluded paths remain
+pending instead of being marked synchronized. The sender then removes the
 entire plan directory before deleting active sender state.
 
 Each local-path upload or deletion step sends at most one multipart part. A file
 part contains one bounded chunk, a deletion-list part contains one complete
 path, and a directory or symlink part contains one complete value. The sender
 retains one multipart request across successive steps until its body budget is
-spent or the caller explicitly cancels it. `close()` only releases resources
-and the lifecycle lock. The sender
+spent or the caller explicitly cancels it. `close()` only releases sender
+resources. The sender
 derives Content-Length from the bytes actually read and never reads another
 local path to push until the current one is complete. Receiver
 contention, offset gaps, and transport failures end the current sender run. The
@@ -424,7 +490,8 @@ percent of PHP's finite `max_execution_time`; zero is unlimited. With a finite
 `memory_limit`, another step begins only when current allocated PHP memory plus
 the same 4 MiB file chunk passed to the sender remains below 80 percent of the
 limit. These checks happen between steps. An active network step that keeps
-moving bytes, and the completed-index copy, may run past the deadline.
+moving bytes, the plan-start baseline snapshot, and the post-commit baseline
+merge may run past the deadline.
 
 A planned pause or first handled SIGINT or SIGTERM calls `cancel()` while the
 sender still reports `continue`, then calls `close()`. A first handled signal
@@ -446,12 +513,28 @@ neither file copies receiver cursors or tentative upload positions.
 `reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR` reports a local
 minimized push operation plan before target exclusions: the local paths a
 files-push would send or delete, compared against the pair's previous local
-index published by a completed files-push. It uses the files-push pair-key
+index — advanced by committed files-push operations and compatible file-only
+pull batches. `<target-url>` must be the exact
+exporter API URL used by files-pull; when `pull-files` received a bare site
+URL, this means the URL including the `site-export-api` query which it added.
+`--fs-root` names the canonical document-root tree later supplied to
+files-push rather than the raw directory which held remote absolute paths
+during files-pull. It uses the files-push pair-key
 formula, including its trailing `?` and `&` trim, so another URL query or
 local tree cannot reuse the index. It accepts only `--state-dir` and
 `--fs-root`; it needs no secret, performs no preflight, and makes no network
 request. It runs one complete PushPlan against `previous_local_index.jsonl` in
-`files-diff-plan/` and holds `files-diff.lock` for the run.
+`files-diff-plan/` while the command holds the state-directory-wide Reprint
+process lock.
+
+To refresh the index from the pull side, note that a completed standalone
+files-pull does not start a fresh lifecycle when it is run again: run it with
+`--abort`, then run it once more. A completed `pull-files` starts a fresh
+pipeline when it is run again. A compatible full file-only pull can establish a
+missing baseline. A compatible partial `--only` pull advances the baseline only
+when it already exists. Each durable WAL batch merges only the paths the pull
+applied, so local additions, edits, and deletions left elsewhere stay in the
+diff.
 
 Output is JSONL. Each selected current file, symlink, or empty directory has
 `action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,
@@ -497,8 +580,8 @@ Order:
    `commit.json` checkpoint written before each document-root mutation. The
    future database batch and symlink updates follow the same bounded cursor.
 4. **Maintenance off:** commit releases its `commit-state` ownership after
-   completion; the driver saves the pair's previous local index and rows
-   after commit completes.
+   completion; the driver merges committed path operations into the pair's
+   previous local index and saves the rows after commit completes.
 
 If the driver dies mid-commit: WordPress stops honoring the `.maintenance`
 file after 10 minutes on its own, and the next commit request resumes from

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -84,6 +84,32 @@ failure key is `non_recoverable_commit_failure`.
 These JSON records are unversioned while their schemas are still under
 development. There are no compatibility aliases or migration paths.
 
+## Local Reprint process lock
+
+Every local Reprint command workflow runs under the **Reprint process lock** at
+`<state-dir>/.reprint.lock`. Use `.reprint.lock` and `$process_lock`. The lock
+is non-blocking and state-directory-wide: pull, push, diff, and other local
+Reprint processes cannot run concurrently against the same state directory,
+even when their target or local-tree pairs differ.
+
+The production CLI acquires the Reprint process lock before it prepares pair
+context, constructs `ImportClient`, or writes the command audit entry. It
+passes the open lock to `ImportClient::run()` and releases it after the command.
+A direct `ImportClient::run()` call acquires the lock when its caller supplies
+none. `PushFilesSender::start()` and `PushFilesSender::resume()` receive that
+open lock from the caller; sender `close()` does not release it. This local
+lock is separate from the receiver's push-session and commit locks.
+
+## Pull index-update WAL
+
+Call the single pull-side write-ahead log the **index-update WAL**. It lives at
+`<state-dir>/.import-index-updates.wal`; use `.import-index-updates.wal`,
+`$index_update_wal_path`, and `$index_update_wal_handle`.
+Applied batch records are cleared, but the empty WAL remains as a marker until
+files-pull completes. A retained WAL is consumed only while resuming or
+aborting the interrupted files-pull, including through a high-level pull
+command; unrelated commands do not consume it.
+
 ## Local push state
 
 The local machine keeps planning and active state outside the receiver push
@@ -102,24 +128,51 @@ directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
 | Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
 | Active state | `sender.json`, `$state_path` |
-| Lifecycle lock file | `sender.lock`, `$lock_path` |
-| Files-diff lifecycle lock | `files-diff.lock` |
-| Open lifecycle lock | `$lock_handle` |
+| Plan-owned previous-local-index snapshot | `plan/previous_local_index.jsonl` |
+| Plan-owned committed previous-local-index updates | `plan/previous_local_index_updates.jsonl` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`sender.json`, `sender.lock`, `excluded_paths.json`, and
+`sender.json`, `excluded_paths.json`, and
 `previous_local_index.jsonl` live directly under the local push state
 directory. The sender creates `plan/` for one active plan. PushPlan copies the
 sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
-`local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
+`local_paths_to_delete`, `deleted_directories_stack.jsonl`, and the
+post-commit `previous_local_index_updates.jsonl` live inside it.
 
-The **previous local index** describes the local tree as the pair's last
-completed push observed it. The sender saves it after a successful commit, and
-`files-diff` reads it. PushPlan diffs its fresh local index against the copy
-its caller supplies. `byte_offset_in_previous_local_index` is the position
-from which its current lookahead entry is read again after resume.
+The **previous local index** is the pair's shared local baseline for deciding
+later local push work. After a successful commit, the sender merges only the
+committed push and delete operations and their required ancestors into the
+latest baseline. This preserves paths which a compatible pull advanced between
+sender processes when they are outside the committed operations. If a later
+incompatible pull removed the baseline, the sender leaves it absent rather
+than publishing an incomplete index. A compatible full file-only pull seeds a
+missing baseline from the current import index before mutating the tree, then
+advances it after each durable WAL batch. A compatible partial `--only` pull
+advances an existing baseline but cannot seed one. `files-diff` reads the
+baseline, and PushPlan diffs its fresh local index against the plan-start
+snapshot its caller supplies.
+`byte_offset_in_previous_local_index` is the position from which its current
+lookahead entry is read again after resume.
+
+A file-only pull which cannot maintain the previous local index removes it
+before mutating the tree. A maintaining pull writes the current index-update
+batch to `.import-index-updates.wal`, publishes it into the import index, then
+publishes only the F/D records applied by that pull and their required
+ancestors into the previous local index. File records include the local path
+type, size, and ctime observed when applied; target deletions are included
+after the local path is absent. Once both indexes contain a batch, its WAL
+records are cleared but the empty WAL remains as the files-pull lifecycle
+marker. A files-pull resume replays any completed records; both publications
+are idempotent, and an unterminated final record is discarded. Aborting an
+unfinished pull invalidates the previous local index before removing the WAL
+because a path may have changed before its record was appended.
+
+Entries outside the paths applied by a partial pull remain unchanged, so
+pending local additions, edits, and deletions elsewhere stay pending.
+Directory emptiness comes from descendants retained by the merge. Paths
+outside the files-push scope are not admitted.
 
 The PushPlan cursor is stored in `sender.json`. It contains the plan
 directory, local tree root, previous local index, and current
@@ -134,12 +187,17 @@ paths. `sender.json` phases are `creating`, `starting_plan`,
 `saving_previous_local_index`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
-completes before local paths are sent. The index copy after a successful commit
-has no separate copy cursor and is repeated after interruption. After the index
-is saved or the target confirms removal, the sender clears the PushPlan
-cursor, then removes the entire plan directory and its exclusions file. It
-does not ask PushPlan to manage terminal cleanup; PushPlan only closes its open
-handles.
+completes before local paths are sent. After a successful commit, the sender
+writes F/D updates from the committed path lists and their required ancestors,
+then merges them into the latest previous local index. If neither the plan
+snapshot nor the latest baseline exists, it publishes the complete fresh local
+index. Once a baseline exists, later changes under excluded paths remain
+pending. The plan-start baseline
+snapshot and post-commit merge have no separate cursors and are repeated after
+interruption. After the updates are published or the target confirms removal,
+the sender clears the PushPlan cursor, then removes the entire plan directory
+and its exclusions file. It does not ask PushPlan to manage terminal cleanup;
+PushPlan only closes its open handles.
 
 A request failure ends the current sender run. The active state remains in
 place so a later push command can resume from the last durable boundary. Only
@@ -157,13 +215,13 @@ them in memory for later steps in the same lifecycle. It does not copy them into
 `push.json` remains the receiver-owned push identity and policy, while
 `commit.json` and `$commit_state` remain the receiver commit checkpoint.
 
-`PushFilesSender::start()` and `PushFilesSender::resume()` acquire
-`sender.lock`; `PushFilesSender::close()` releases it. `next_step()` does not
-acquire or release the lock and does not reread `sender.json`. A sender retains
-one multipart request across steps. A caller stopping between steps calls
-`cancel()` to discard that request and return to the preceding durable
-boundary, then calls `close()` to release resources and the lock. `close()`
-never finishes an open request. In `pushing_paths` or
+`PushFilesSender::start()` and `PushFilesSender::resume()` require the
+caller-owned Reprint process lock. `next_step()` does not acquire or release
+the lock and does not reread `sender.json`. A sender retains one multipart
+request across steps. A caller stopping between steps calls `cancel()` to
+discard that request and return to the preceding durable boundary, then calls
+`close()` to release sender resources. `close()` never finishes an open
+request. In `pushing_paths` or
 `pushing_deletes`, one step sends at most one multipart part. `next_step()`
 returns true while another step may be performed and false when `get_status()`
 reports `complete`, `restart`, or `failed`.
@@ -173,7 +231,13 @@ reports `complete`, `restart`, or `failed`.
 The local-only command is `files-diff`. Its `target URL`, `local tree`, `pair
 key`, and `local push state directory` have the same meanings and pair-key
 formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
-which a completed files-push publishes, and never changes it.
+advanced by committed files-push operations and compatible file-only pull
+batches, and never changes it. A compatible full file-only pull can establish
+a missing baseline. A compatible partial `--only` pull advances only an
+existing baseline and only the paths it applied, leaving pending changes
+elsewhere in the diff. The target URL is the exact exporter API URL used by the
+file-only pull, including the `site-export-api` query which `pull-files` adds
+to a bare site URL.
 
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
 `delete`, and `path_b64`. A push record also has the local path `type`, `size`,
@@ -184,10 +248,11 @@ and metadata-only changes to non-empty directories select no operation. The
 final record has `status: "complete"`, `local_paths_to_push`, and
 `local_paths_to_delete`.
 
-files-diff persists nothing between runs. It runs one complete PushPlan under
-`files-diff.lock` in `files-diff-plan/`, streams both finished path lists from
-the beginning, and removes the plan directory before exiting. An interrupted
-report is not resumed; running the command again prints the complete report.
+files-diff persists nothing between runs. It runs one complete PushPlan in
+`files-diff-plan/` while its command holds the state-directory-wide Reprint
+process lock, streams both finished path lists from the beginning, and removes
+the plan directory before exiting. An interrupted report is not resumed;
+running the command again prints the complete report.
 
 ## Files-push CLI names
 

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -184,6 +184,32 @@ function normalize_path(string $path): string
 }
 
 /**
+ * Compares paths in the component order emitted by depth-first traversal.
+ *
+ * @param string $left_path  First path.
+ * @param string $right_path Second path.
+ * @return int A value below, equal to, or above zero.
+ */
+function compare_paths(string $left_path, string $right_path): int
+{
+    return strcmp(
+        path_sort_key($left_path),
+        path_sort_key($right_path)
+    );
+}
+
+/**
+ * Returns a strcmp-compatible key for depth-first path order.
+ *
+ * @param string $path Filesystem path.
+ * @return string Sort key.
+ */
+function path_sort_key(string $path): string
+{
+    return str_replace("/", "\0", $path);
+}
+
+/**
  * Normalizes document-root-relative excluded paths.
  *
  * Rejects non-string, empty, absolute, NUL-containing, backslash-containing,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -16,6 +16,8 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function Reprint\Importer\merge_import_index_updates;
+use function Reprint\Importer\merge_previous_local_index_updates;
 
 error_reporting(E_ALL);
 ini_set("display_errors", "stderr");
@@ -62,6 +64,8 @@ require_once __DIR__ . '/lib/target-runtime/load.php';
 
 // External merge sort for large index files when exec() is unavailable
 require_once __DIR__ . '/lib/external-merge-sort.php';
+require_once __DIR__ . '/lib/index-update-functions.php';
+require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
 require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
@@ -250,7 +254,6 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
-
     /**
      * Maximum number of consecutive cURL timeouts with no cursor progress
      * before the importer gives up. This prevents infinite retry loops
@@ -287,23 +290,25 @@ class ImportClient
     private $index_file;
 
     /**
-     * @var string|null Path to .import-index-updates.jsonl — temporary append-only file that
-     * collects index mutations (upserts and deletes) during the current run. Merged into
-     * $index_file at the end of a successful sync.
+     * @var string Path to .import-index-updates.wal — the append-only write-ahead
+     * log for the current files-pull. Applied batches are cleared, but the file
+     * remains until the lifecycle completes or is aborted.
      */
-    private $index_updates_file;
+    private $index_update_wal_path;
 
-    /** @var resource|null Open file handle for $index_updates_file while writing. */
-    private $index_updates_handle;
+    /** @var resource|null Open file handle for $index_update_wal_path while writing. */
+    private $index_update_wal_handle;
 
-    /** @var int Number of entries written to $index_updates_file this run. */
-    private $index_updates_count = 0;
+    private $maintain_previous_local_index = false;
+
+    /** @var int Number of entries written to the open WAL batch. */
+    private $index_update_wal_record_count = 0;
 
     /**
      * Deduplication state for index updates. Consecutive upsert_index_entry() or
-     * delete_index_entry() calls for the same path are collapsed into one write.
+     * delete_index_entry() calls for the same path are collapsed into one WAL write.
      *
-     * @var string|null Last path written to the index updates file.
+     * @var string|null Last path written to the index-update WAL.
      */
     private $last_update_path = null;
 
@@ -556,8 +561,8 @@ class ImportClient
         $this->fs_root = rtrim($fs_root, "/");
         $this->state_file = $this->state_dir . "/.import-state.json";
         $this->index_file = $this->state_dir . "/.import-index.jsonl";
-        $this->index_updates_file =
-            $this->state_dir . "/.import-index-updates.jsonl";
+        $this->index_update_wal_path =
+            $this->state_dir . "/.import-index-updates.wal";
         $this->remote_index_file =
             $this->state_dir . "/.import-remote-index.jsonl";
         $this->download_list_file =
@@ -625,21 +630,19 @@ class ImportClient
     /**
      * Delete a file entry from the index.
      */
-    private function delete_index_entry(string $path): void
+    private function delete_index_entry(
+        string $path,
+        bool $path_deleted_by_files_pull = false
+    ): void
     {
-        $this->record_index_update_deletion($path);
+        $this->record_index_update_deletion($path, $path_deleted_by_files_pull);
     }
 
-    /**
-     * Recover and merge any pending index updates from a previous run.
-     */
-    private function recover_index_updates(): void
+    /** Replays a WAL left by an interrupted batch. */
+    private function replay_index_update_wal(): void
     {
-        if (
-            $this->index_updates_file &&
-            file_exists($this->index_updates_file)
-        ) {
-            $this->finalize_index_updates();
+        if (is_file($this->index_update_wal_path)) {
+            $this->apply_index_update_wal();
         }
     }
 
@@ -883,9 +886,19 @@ class ImportClient
      *   - command: Required. One of the entries in $valid_commands below.
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
+     * @param ReprintProcessLock|null $process_lock Lock for this state directory already held by the caller.
      */
-    public function run(array $options = []): void
+    public function run(
+        array $options = [],
+        ?ReprintProcessLock $process_lock = null
+    ): void
     {
+        $process_lock = $process_lock ?? new ReprintProcessLock($this->state_dir);
+        if (!$process_lock->is_held()) {
+            throw new InvalidArgumentException(
+                'ImportClient requires a held Reprint process lock.'
+            );
+        }
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->progress->set_verbose_mode($this->verbose_mode);
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
@@ -952,11 +965,21 @@ class ImportClient
         // files-diff and files-push use local push state and must not load
         // or write the pull command's .import-state.json file.
         if ($command === "files-diff") {
+            if (is_file($this->index_update_wal_path)) {
+                throw new RuntimeException(
+                    'Finish or abort the interrupted files-pull before running files-diff.'
+                );
+            }
             $this->run_files_diff($options);
             return;
         }
         if ($command === "files-push") {
-            $this->run_files_push($options);
+            if (is_file($this->index_update_wal_path)) {
+                throw new RuntimeException(
+                    'Finish or abort the interrupted files-pull before running files-push.'
+                );
+            }
+            $this->run_files_push($options, $process_lock);
             return;
         }
 
@@ -1258,7 +1281,7 @@ class ImportClient
                     return;
 
                 case "files-pull":
-                    $this->run_files_sync();
+                    $this->run_files_sync(true);
                     break;
 
                 case "files-index":
@@ -1295,11 +1318,12 @@ class ImportClient
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
     /**
-     * Reports local paths changed since the pair's previous local index.
+     * Reports local paths changed since the pair's latest durable boundary.
      *
      * files-diff makes no network request. It runs one complete PushPlan
-     * against the previous local index a completed files-push published, then
-     * streams the finished push and delete lists from the beginning. Every run
+     * against the pair's previous local index — published by a completed
+     * files-push or maintained by a compatible file-only pull — then streams
+     * the finished push and delete lists from the beginning. Every run
      * reports the whole diff, so an interrupted report needs no resume state:
      * running the command again prints the complete report.
      *
@@ -1325,13 +1349,15 @@ class ImportClient
         $push_state_directory = $context['push_state_directory'];
         $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
         $missing_previous_local_index_message =
-            'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
-            . 'for the same target URL, state directory, and local tree.';
+            'files-diff requires a fresh completed files-pull or pull-files without --only, with --filter=none, no --remap, '
+            . 'and no --on-fs-root-nonempty=preserve-local, or a completed files-push, '
+            . 'for the same target URL, state directory, and local tree. '
+            . 'The target URL must be the exact exporter API URL used by that pull. '
+            . 'If a standalone files-pull is already complete, run it with --abort and then run it again.';
         if (!is_dir($push_state_directory)) {
             throw new RuntimeException($missing_previous_local_index_message);
         }
 
-        $lock_handle = $this->acquire_files_diff_lock($push_state_directory);
         $plan_directory = $push_state_directory . '/files-diff-plan';
         try {
             if (!is_file($previous_local_index)) {
@@ -1369,7 +1395,7 @@ class ImportClient
             ];
             $local_paths_to_push_count = 0;
             foreach (
-                $this->read_planned_local_paths_to_push($plan->get_local_paths_to_push_path())
+                $plan->read_planned_local_paths_to_push()
                 as $entry
             ) {
                 $line = json_encode([
@@ -1388,7 +1414,7 @@ class ImportClient
 
             $local_paths_to_delete_count = 0;
             foreach (
-                $this->read_planned_local_paths_to_delete($plan->get_local_paths_to_delete_path())
+                $plan->read_planned_local_paths_to_delete()
                 as $local_path_to_delete
             ) {
                 $line = json_encode([
@@ -1416,90 +1442,7 @@ class ImportClient
             }
         } finally {
             $this->remove_local_plan_directory($plan_directory);
-            flock($lock_handle, LOCK_UN);
-            fclose($lock_handle);
         }
-    }
-
-    /**
-     * Reads the completed local paths-to-push list.
-     *
-     * @param string $local_paths_to_push_path Completed plan-owned JSONL path list.
-     * @return Generator Completed plan entries.
-     * @phpstan-return Generator<int,array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int},mixed,void>
-     */
-    private function read_planned_local_paths_to_push(string $local_paths_to_push_path): Generator
-    {
-        $local_paths_to_push_handle = fopen($local_paths_to_push_path, 'rb');
-        if (!is_resource($local_paths_to_push_handle)) {
-            throw new RuntimeException('Failed to open the completed local paths-to-push list.');
-        }
-        try {
-            while (true) {
-                $line = fgets($local_paths_to_push_handle);
-                if ($line === false) {
-                    if (!feof($local_paths_to_push_handle)) {
-                        throw new RuntimeException('Failed to read the completed local paths-to-push list.');
-                    }
-                    return;
-                }
-                // The plan wrote this list moments ago in this process; its
-                // entry schema is trusted, like every other plan consumer.
-                /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $entry */
-                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-                yield $entry;
-            }
-        } finally {
-            fclose($local_paths_to_push_handle);
-        }
-    }
-
-    /**
-     * Reads the completed local paths-to-delete list.
-     *
-     * @param string $local_paths_to_delete_path Completed plan-owned NUL-delimited path list.
-     * @return Generator Completed local paths to delete.
-     * @phpstan-return Generator<int,string,mixed,void>
-     */
-    private function read_planned_local_paths_to_delete(string $local_paths_to_delete_path): Generator
-    {
-        $local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
-        if (!is_resource($local_paths_to_delete_handle)) {
-            throw new RuntimeException('Failed to open the completed local paths-to-delete list.');
-        }
-        try {
-            while (true) {
-                $local_path_to_delete = stream_get_line($local_paths_to_delete_handle, 1048576, "\0");
-                if ($local_path_to_delete === false) {
-                    if (!feof($local_paths_to_delete_handle)) {
-                        throw new RuntimeException('Failed to read the completed local paths-to-delete list.');
-                    }
-                    return;
-                }
-                yield $local_path_to_delete;
-            }
-        } finally {
-            fclose($local_paths_to_delete_handle);
-        }
-    }
-
-    /**
-     * Acquires the pair's files-diff lifecycle lock.
-     *
-     * @return resource Open lock handle.
-     */
-    private function acquire_files_diff_lock(string $push_state_directory)
-    {
-        $lock_path = $push_state_directory . '/files-diff.lock';
-        $lock_handle = fopen($lock_path, 'c+b');
-        if (!is_resource($lock_handle)) {
-            throw new RuntimeException('Failed to open the files-diff lifecycle lock: ' . $lock_path . '.');
-        }
-        if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
-            fclose($lock_handle);
-            throw new RuntimeException('Another files-diff or files-pull process is using this target and local tree.');
-        }
-        return $lock_handle;
     }
 
     /** Removes one completed or discarded local plan and confirms every removal. */
@@ -1531,9 +1474,9 @@ class ImportClient
      * Runs one caller-bounded files-push lifecycle.
      *
      * One open sender performs at most one step per loop turn. A planned stop
-     * cancels any open multipart request before close() releases the lifecycle
-     * lock. Terminal sender outcomes are reported without retrying or opening
-     * a replacement; this process never opens a second sender.
+     * cancels any open multipart request before close() releases sender
+     * resources. Terminal sender outcomes are reported without retrying or
+     * opening a replacement; this process never opens a second sender.
      *
      * @param array $options {
      *     Parsed files-push options and context.
@@ -1542,9 +1485,13 @@ class ImportClient
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
      * }
+     * @param ReprintProcessLock $process_lock Lock held for this command.
      * @phpstan-param array<string,mixed> $options
      */
-    private function run_files_push(array $options): void
+    private function run_files_push(
+        array $options,
+        ReprintProcessLock $process_lock
+    ): void
     {
         $started_at = hrtime(true) / 1000000000;
         $context = $options['files_push_context'] ?? self::prepare_files_push_context(
@@ -1582,8 +1529,8 @@ class ImportClient
 
         $resuming = is_file($context['push_state_directory'] . '/sender.json');
         $sender = $resuming
-            ? PushFilesSender::resume($sender_options)
-            : PushFilesSender::start($sender_options);
+            ? PushFilesSender::resume($sender_options, $process_lock)
+            : PushFilesSender::start($sender_options, $process_lock);
         $status = null;
         $reason = null;
         $detail = null;
@@ -1871,24 +1818,10 @@ class ImportClient
             $push_state_directory = $working_directory . '/' . $push_state_directory;
         }
         $push_state_directory = normalize_path($push_state_directory);
-        $existing_state_path = $push_state_directory;
-        $missing_state_components = [];
-        while (
-            !file_exists($existing_state_path)
-            && !is_link($existing_state_path)
-            && $existing_state_path !== '/'
-        ) {
-            array_unshift($missing_state_components, basename($existing_state_path));
-            $existing_state_path = dirname($existing_state_path);
-        }
-        $canonical_existing_state_path = realpath($existing_state_path);
-        if ($canonical_existing_state_path !== false) {
-            $push_state_directory = normalize_path(
-                $canonical_existing_state_path
-                    . ( $missing_state_components === []
-                        ? ''
-                        : '/' . implode('/', $missing_state_components) )
-            );
+        $canonical_push_state_directory =
+            self::canonicalize_path_with_missing_components($push_state_directory);
+        if ($canonical_push_state_directory !== null) {
+            $push_state_directory = $canonical_push_state_directory;
         }
         if (
             $canonical_local_tree === '/'
@@ -1977,51 +1910,7 @@ class ImportClient
     {
         switch ($command) {
             case "files-pull":
-                // Clear sync progress (cursor, stage, status) and transient
-                // files, but keep the local index and downloaded files intact.
-                // This way the next `files-pull` sees a completed local index
-                // and runs a delta sync rather than re-downloading everything.
-                $this->audit_log(
-                    "RESTART | Clearing files-pull progress (keeping local index and files)",
-                    true,
-                );
-                $this->reset_state();
-
-                // Merge any pending index updates into the main index before
-                // clearing transient state so we don't lose work.
-                $this->recover_index_updates();
-                if (
-                    $this->index_updates_file &&
-                    file_exists($this->index_updates_file)
-                ) {
-                    @unlink($this->index_updates_file);
-                    $this->audit_log("FILE DELETE | {$this->index_updates_file}");
-                }
-                $this->index_updates_file = null;
-                $this->index_updates_handle = null;
-                $this->index_updates_count = 0;
-
-                if (file_exists($this->remote_index_file)) {
-                    @unlink($this->remote_index_file);
-                    $this->audit_log("FILE DELETE | {$this->remote_index_file}");
-                }
-                if (file_exists($this->download_list_file)) {
-                    @unlink($this->download_list_file);
-                    $this->audit_log("FILE DELETE | {$this->download_list_file}");
-                }
-                if (file_exists($this->skipped_download_list_file)) {
-                    @unlink($this->skipped_download_list_file);
-                    $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
-                }
-                if (file_exists($this->volatile_files_file)) {
-                    @unlink($this->volatile_files_file);
-                    $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
-                }
-                $this->import_state()->index = new RemoteFileIndexCursorState();
-                $this->import_state()->fetch = new DownloadListFetchProgressState();
-                $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
-
-                $this->save_state($this->state);
+                $this->clear_files_pull_progress();
                 break;
 
             case "files-index":
@@ -2103,6 +1992,51 @@ class ImportClient
         $this->progress->show_lifecycle_line("State cleared for {$command}.\n");
 
         $this->output_progress(["status" => "aborted", "message" => "State cleared for {$command}."]);
+    }
+
+    /**
+     * Clear sync progress and transient files while keeping the local index
+     * and downloaded files, so the next files-pull computes a delta.
+     */
+    public function clear_files_pull_progress(): void
+    {
+        $this->audit_log(
+            "RESTART | Clearing files-pull progress (keeping local index and files)",
+            true,
+        );
+        $had_index_update_wal = is_file($this->index_update_wal_path);
+        // Replay the WAL before clearing the cursor which made its records durable.
+        $this->replay_index_update_wal();
+        if ($had_index_update_wal) {
+            $this->invalidate_previous_local_index();
+        }
+        $this->remove_index_update_wal();
+        $this->maintain_previous_local_index = false;
+        $this->reset_state();
+        $this->index_update_wal_handle = null;
+        $this->index_update_wal_record_count = 0;
+
+        if (file_exists($this->remote_index_file)) {
+            @unlink($this->remote_index_file);
+            $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+        }
+        if (file_exists($this->download_list_file)) {
+            @unlink($this->download_list_file);
+            $this->audit_log("FILE DELETE | {$this->download_list_file}");
+        }
+        if (file_exists($this->skipped_download_list_file)) {
+            @unlink($this->skipped_download_list_file);
+            $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
+        }
+        if (file_exists($this->volatile_files_file)) {
+            @unlink($this->volatile_files_file);
+            $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
+        }
+        $this->import_state()->index = new RemoteFileIndexCursorState();
+        $this->import_state()->fetch = new DownloadListFetchProgressState();
+        $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+
+        $this->save_state($this->state);
     }
 
     /**
@@ -2707,8 +2641,12 @@ class ImportClient
      * - In-progress files-pull → resume from saved state
      *
      * Both modes share the same pipeline: index → diff → fetch.
+     *
+     * @param bool $maintain_previous_local_index Whether files-pull may maintain
+     *                                            the previous local index. True only when files-pull is the
+     *                                            last stage that can change the local tree.
      */
-    public function run_files_sync(): void
+    public function run_files_sync(bool $maintain_previous_local_index = false): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
 
@@ -2740,12 +2678,41 @@ class ImportClient
             $current_status !== null &&
             $current_status !== "complete";
 
-        $this->recover_index_updates();
+        $files_pair_context =
+            $this->files_pull_pair_context_if_local_tree_exists();
+        $has_previous_local_index =
+            $files_pair_context !== null
+            && is_file(
+                $files_pair_context['push_state_directory']
+                    . '/previous_local_index.jsonl'
+            );
+        // A compatible pull seeds the baseline before opening the WAL. Once
+        // that marker exists, a missing baseline keeps the lifecycle incompatible.
+        $can_maintain_after_resume =
+            !$has_progress
+            || !is_file($this->index_update_wal_path)
+            || $has_previous_local_index;
+        $maintains_previous_local_index =
+            $maintain_previous_local_index
+            && $this->filter === 'none'
+            && $this->remap_rules === []
+            && $this->fs_root_nonempty_behavior !== 'preserve-local'
+            && $can_maintain_after_resume
+            && (
+                $this->pull_only_files_with_path_prefixes === []
+                || $has_previous_local_index
+            );
         $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
         $this->assert_symlink_bundle_directory_unchanged();
+        $this->maintain_previous_local_index = $maintains_previous_local_index;
+        if ($has_progress && $maintains_previous_local_index) {
+            $this->seed_previous_local_index();
+        }
+        $this->replay_index_update_wal();
 
         // Already completed.
         if ($current_status === "complete") {
+            $this->remove_index_update_wal();
             $has_skipped =
                 file_exists($this->skipped_download_list_file) &&
                 filesize($this->skipped_download_list_file) > 0;
@@ -2777,6 +2744,10 @@ class ImportClient
                 $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
                 $this->import_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state($this->state);
+                // A skipped-earlier fetch changes the tree under a filtered
+                // lifecycle, so the previous local index cannot be maintained.
+                $this->invalidate_previous_local_index();
+                $this->open_index_update_wal();
                 $this->run_files_sync_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
                 // tail finishes, restore the completed status so later filter
@@ -2786,6 +2757,7 @@ class ImportClient
                 }
                 $this->import_state()->active_resumable_command->completion_state = "complete";
                 $this->save_state($this->state);
+                $this->remove_index_update_wal();
                 return;
             }
 
@@ -2939,6 +2911,13 @@ class ImportClient
         $this->import_state()->active_resumable_command->completion_state = "in_progress";
         $this->save_state($this->state);
 
+        if ($maintains_previous_local_index) {
+            $this->seed_previous_local_index();
+        } else {
+            $this->invalidate_previous_local_index();
+        }
+
+        $this->open_index_update_wal();
         $this->run_files_sync_pipeline();
 
         // Pipeline returns early with partial status if interrupted
@@ -2946,8 +2925,10 @@ class ImportClient
             return;
         }
 
+        $this->import_state()->active_resumable_command->current_stage = null;
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->save_state($this->state);
+        $this->remove_index_update_wal();
 
         $this->progress->clear_progress_line();
         $index_size = $this->index_count();
@@ -2972,6 +2953,407 @@ class ImportClient
 
         $this->report_volatile_files();
     }
+
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
+    /** Establishes the previous local index before files-pull mutates the tree. */
+    private function seed_previous_local_index(): void
+    {
+        $context = $this->files_pull_pair_context();
+        $previous_local_index =
+            $context['push_state_directory'] . '/previous_local_index.jsonl';
+        if (is_file($previous_local_index)) {
+            return;
+        }
+
+        $updates_path = $this->state_dir . '/.previous-local-index-updates.tmp';
+        $swap_path = $previous_local_index . '.swap';
+        try {
+            $this->write_previous_local_index_updates(
+                $this->index_file,
+                $updates_path,
+                $context,
+                false
+            );
+            merge_previous_local_index_updates(
+                $previous_local_index,
+                $updates_path,
+                $swap_path,
+                $this->state_dir
+            );
+            if (!rename($swap_path, $previous_local_index)) {
+                throw new RuntimeException(
+                    'Failed to publish the previous local index: ' . $previous_local_index . '.'
+                );
+            }
+        } finally {
+            if (is_file($updates_path)) {
+                @unlink($updates_path);
+            }
+            if (is_file($swap_path)) {
+                @unlink($swap_path);
+            }
+        }
+    }
+
+    /**
+     * Returns the current files-pull pair context, creating its local directories.
+     *
+     * @return array {
+     *     @type string $target_url            Normalized exporter API URL.
+     *     @type string $local_tree            Canonical pulled document root.
+     *     @type string $pair                  Target and local-tree pair key.
+     *     @type string $push_state_directory  Local push state directory.
+     *     @type string $remote_document_root  Remote document root without a trailing slash.
+     * }
+     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string,remote_document_root:string}
+     */
+    private function files_pull_pair_context(): array
+    {
+        $context = $this->files_pull_pair_context_if_local_tree_exists();
+        if ($context === null) {
+            $remote_document_root =
+                $this->import_state()->preflight['data']['runtime']['document_root'] ?? null;
+            if (!is_string($remote_document_root) || $remote_document_root === '') {
+                throw new RuntimeException('files-pull cannot identify the remote document root.');
+            }
+            $local_tree = $this->remote_path_to_local_path_within_import_root(
+                $remote_document_root
+            );
+            if (!is_dir($local_tree) && !mkdir($local_tree, 0755, true)) {
+                throw new RuntimeException(
+                    'Failed to create the pulled local tree: ' . $local_tree . '.'
+                );
+            }
+            $context = $this->files_pull_pair_context_if_local_tree_exists();
+        }
+        if ($context === null) {
+            throw new RuntimeException('files-pull cannot identify the pulled local tree.');
+        }
+        if (
+            !is_dir($context['push_state_directory'])
+            && !mkdir($context['push_state_directory'], 0755, true)
+        ) {
+            throw new RuntimeException(
+                'Failed to create the local push state directory: '
+                . $context['push_state_directory'] . '.'
+            );
+        }
+        return $context;
+    }
+
+    /**
+     * Writes previous-local-index updates from an import index or WAL.
+     *
+     * @param array $context {
+     *     Current files-pull pair context.
+     *
+     *     @type string $local_tree           Canonical pulled document root.
+     *     @type string $push_state_directory Local push state directory.
+     *     @type string $remote_document_root Remote document root without a trailing slash.
+     * }
+     * @phpstan-param array{target_url:string,local_tree:string,pair:string,push_state_directory:string,remote_document_root:string} $context
+     * @return int Number of source records included.
+     */
+    private function write_previous_local_index_updates(
+        string $source_path,
+        string $updates_path,
+        array $context,
+        bool $source_is_wal
+    ): int {
+        $source_handle = is_file($source_path) ? fopen($source_path, 'rb') : null;
+        $updates_handle = fopen($updates_path, 'wb');
+        if (
+            ( is_file($source_path) && !is_resource($source_handle) )
+            || !is_resource($updates_handle)
+        ) {
+            throw new RuntimeException('Failed to open previous-local-index update files.');
+        }
+
+        $position = 0;
+        $updates_written = 0;
+        try {
+            while (true) {
+                $entry = $source_is_wal
+                    ? $this->read_update_line_raw($source_handle)
+                    : $this->read_index_line($source_handle);
+                if ($entry === null) {
+                    break;
+                }
+                if ($source_is_wal && empty($entry['applied_by_files_pull'])) {
+                    continue;
+                }
+                foreach ($this->previous_local_index_updates_for_path_record(
+                    $entry,
+                    $context,
+                    $position
+                ) as $previous_local_index_update) {
+                    $line = json_encode(
+                        $previous_local_index_update,
+                        JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                    ) . "\n";
+                    if (fwrite($updates_handle, $line) !== strlen($line)) {
+                        throw new RuntimeException(
+                            'Failed to write a previous-local-index update.'
+                        );
+                    }
+                    ++$updates_written;
+                }
+                ++$position;
+            }
+            if (!fflush($updates_handle)) {
+                throw new RuntimeException(
+                    'Failed to flush the previous-local-index updates.'
+                );
+            }
+        } finally {
+            if (is_resource($source_handle)) {
+                fclose($source_handle);
+            }
+            fclose($updates_handle);
+        }
+
+        return $updates_written;
+    }
+
+    /**
+     * Returns previous-local-index updates for one import-index or WAL record.
+     *
+     * @param array $update {
+     *     Files-pull path record.
+     *
+     *     @type string      $path        Absolute remote path.
+     *     @type bool        $delete      Whether files-pull deleted the path. Defaults to false.
+     *     @type int         $ctime       Remote ctime for an upsert.
+     *     @type int         $size        Remote size for an upsert.
+     *     @type string|null $type        Remote type for an upsert.
+     *     @type int         $local_ctime Local ctime when the path was applied, when recorded.
+     *     @type int         $local_size  Local size when the path was applied, when recorded.
+     *     @type string      $local_type  Local type when the path was applied, when recorded.
+     * }
+     * @param array $context Pair context for the completing pull.
+     * @phpstan-param array{target_url:string,local_tree:string,pair:string,push_state_directory:string,remote_document_root:string} $context
+     * @param int $position Position of the update in the files-pull stream.
+     * @return \Generator<int,array{op:string,path:string,replace_subtree:bool,position:int,ctime?:int,size?:int,type?:string}>
+     */
+    private function previous_local_index_updates_for_path_record(
+        array $update,
+        array $context,
+        int $position
+    ): \Generator {
+        $remote_path = $update['path'];
+        $local_path = $this->remote_path_to_local_path_within_import_root($remote_path);
+        $path = self::path_remainder_under($local_path, $context['local_tree']);
+        if ($path === null || $path === '') {
+            return;
+        }
+        $path = ltrim($path, '/');
+        if (FileIndexProcessor::path_is_default_skipped($path)) {
+            return;
+        }
+        $current_path = $path;
+        $direct = true;
+        while ($current_path !== '') {
+            if ($direct && !empty($update['delete'])) {
+                $entry = [
+                    'op' => 'D',
+                    'path' => base64_encode($current_path),
+                    'replace_subtree' => true,
+                    'position' => $position,
+                ];
+            } else {
+                if ($direct && isset($update['local_type'])) {
+                    $type = (string) $update['local_type'];
+                    $ctime = (int) $update['local_ctime'];
+                    $size = (int) $update['local_size'];
+                } else {
+                    $absolute_path = $context['local_tree'] . '/' . $current_path;
+                    clearstatcache(true, $absolute_path);
+                    $stat = @lstat($absolute_path);
+                    if ($stat === false && $direct) {
+                        $type = (string) $update['type'];
+                        $ctime = (int) $update['ctime'];
+                        $size = (int) $update['size'];
+                    } elseif ($stat === false) {
+                        $separator = strrpos($current_path, '/');
+                        $current_path = $separator === false
+                            ? ''
+                            : substr($current_path, 0, $separator);
+                        $direct = false;
+                        continue;
+                    } else {
+                        $file_type_bits = $stat['mode'] & FileIndexProcessor::STAT_TYPE_MASK;
+                        if ($file_type_bits === FileIndexProcessor::STAT_TYPE_FILE) {
+                            $type = 'file';
+                        } elseif ($file_type_bits === FileIndexProcessor::STAT_TYPE_DIR) {
+                            $type = 'dir';
+                        } elseif ($file_type_bits === FileIndexProcessor::STAT_TYPE_LINK) {
+                            $type = 'link';
+                        } else {
+                            throw new RuntimeException(
+                                'Cannot record the unsupported pulled local path: '
+                                . base64_encode($current_path) . '.'
+                            );
+                        }
+                        if (!$direct && $type !== 'dir') {
+                            $separator = strrpos($current_path, '/');
+                            $current_path = $separator === false
+                                ? ''
+                                : substr($current_path, 0, $separator);
+                            continue;
+                        }
+                        $ctime = (int) $stat['ctime'];
+                        $size = $type === 'dir' ? 0 : (int) $stat['size'];
+                    }
+                }
+                $entry = [
+                    'op' => 'F',
+                    'path' => base64_encode($current_path),
+                    'ctime' => $ctime,
+                    'size' => $size,
+                    'type' => $type,
+                    'replace_subtree' => $direct && $type !== 'dir',
+                    'position' => $position,
+                ];
+            }
+            yield $entry;
+            $separator = strrpos($current_path, '/');
+            $current_path = $separator === false
+                ? ''
+                : substr($current_path, 0, $separator);
+            $direct = false;
+        }
+    }
+
+    /**
+     * Removes the pair's previous local index before files-pull may mutate the tree.
+     *
+     * A lifecycle that cannot maintain the index removes it before changing
+     * the tree. A files-diff plan directory left behind by an interrupted
+     * process is removed with it.
+     */
+    private function invalidate_previous_local_index(): void
+    {
+        $context = $this->files_pull_pair_context_if_local_tree_exists();
+        if ($context !== null) {
+            $push_state_directory = $context['push_state_directory'];
+        } else {
+            $remote_document_root =
+                $this->import_state()->preflight['data']['runtime']['document_root'] ?? null;
+            if (!is_string($remote_document_root) || $remote_document_root === '') {
+                return;
+            }
+            $remote_document_root = rtrim($remote_document_root, '/');
+            $local_tree = $remote_document_root === ''
+                ? $this->fs_root
+                : $this->fs_root . '/' . ltrim($remote_document_root, '/');
+            if (is_link($local_tree)) {
+                return;
+            }
+            if (strpos($local_tree, '/') !== 0) {
+                $working_directory = getcwd();
+                if ($working_directory === false) {
+                    return;
+                }
+                $local_tree = $working_directory . '/' . $local_tree;
+            }
+            $local_tree = normalize_path($local_tree);
+            $canonical_local_tree =
+                self::canonicalize_path_with_missing_components($local_tree);
+            if ($canonical_local_tree === null) {
+                return;
+            }
+            $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
+            $target_url = rtrim($this->remote_url, '?&');
+            $pair = hash('sha256', $target_url . "\0" . $canonical_local_tree);
+            $push_state_directory = realpath(
+                $this->state_dir . '/push/' . $pair
+            );
+            if ($push_state_directory === false) {
+                return;
+            }
+        }
+        if (!is_dir($push_state_directory)) {
+            return;
+        }
+        $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
+        if (is_file($previous_local_index) && !unlink($previous_local_index)) {
+            throw new RuntimeException(
+                'Failed to invalidate the previous local index: ' . $previous_local_index . '.'
+            );
+        }
+        $this->remove_local_plan_directory($push_state_directory . '/files-diff-plan');
+    }
+
+    /**
+     * Derives the files-diff pair context for the current files-pull, when possible.
+     *
+     * The pair's local tree is the pulled document root: the preflight-reported
+     * remote document root joined under this pull's --fs-root. That is the
+     * directory a later files-push receives as its --fs-root.
+     *
+     * @return array|null {
+     *     @type string $target_url            Normalized exporter API URL.
+     *     @type string $local_tree            Canonical pulled document root.
+     *     @type string $pair                  Target and local-tree pair key.
+     *     @type string $push_state_directory  Local push state directory.
+     *     @type string $remote_document_root  Remote document root without a trailing slash.
+     * }
+     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string,remote_document_root:string}|null
+     */
+    private function files_pull_pair_context_if_local_tree_exists(): ?array
+    {
+        $preflight_data = $this->import_state()->preflight['data'] ?? null;
+        $remote_document_root = is_array($preflight_data)
+            ? ( $preflight_data['runtime']['document_root'] ?? null )
+            : null;
+        if (!is_string($remote_document_root) || $remote_document_root === '') {
+            return null;
+        }
+        $remote_document_root = rtrim($remote_document_root, '/');
+        $local_tree = $remote_document_root === ''
+            ? $this->fs_root
+            : $this->fs_root . '/' . ltrim($remote_document_root, '/');
+        if (!is_dir($local_tree) || is_link($local_tree)) {
+            return null;
+        }
+        try {
+            $files_pair_context = self::prepare_files_pair_context(
+                $this->remote_url,
+                $this->state_dir,
+                $local_tree,
+                'files-diff'
+            );
+        } catch (\InvalidArgumentException $exception) {
+            return null;
+        }
+        $files_pair_context['remote_document_root'] = $remote_document_root;
+        return $files_pair_context;
+    }
+
+    private static function canonicalize_path_with_missing_components(string $path): ?string
+    {
+        $existing_path = $path;
+        $missing_components = [];
+        while (
+            !file_exists($existing_path)
+            && !is_link($existing_path)
+            && $existing_path !== '/'
+        ) {
+            array_unshift($missing_components, basename($existing_path));
+            $existing_path = dirname($existing_path);
+        }
+        $canonical_existing_path = realpath($existing_path);
+        if ($canonical_existing_path === false) {
+            return null;
+        }
+        return normalize_path(
+            $canonical_existing_path
+                . ( $missing_components === []
+                    ? ''
+                    : '/' . implode('/', $missing_components) )
+        );
+    }
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
     /**
      * Shared index → diff → fetch pipeline used by both initial and delta syncs.
@@ -6054,30 +6436,24 @@ class ImportClient
             // mid-body, the cursor already points to the end of the part
             // while file_bytes_written may still lag; at is_streaming_close
             // the bytes are on disk and we force a per-part checkpoint.
+            // Snapshot the file boundary before handle_file_chunk() may close
+            // the file so a stop after the close still retains its path and size.
             $is_streaming_body = !empty($chunk["is_streaming_body"]);
             $is_streaming_close = !empty($chunk["is_streaming_close"]);
-            if (!$is_streaming_body) {
-                $chunks_since_save++;
-                $force_save = $is_streaming_close;
-                if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
-                    $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-                    // Track current file for crash recovery
-                    if ($context->file_handle && $context->file_path) {
-                        // Flush to ensure bytes are on disk before saving state
-                        fflush($context->file_handle);
-                        $this->import_state()->current_file = $context->file_path;
-                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
-                    } else {
-                        $this->import_state()->current_file = null;
-                        $this->import_state()->current_file_bytes = null;
-                    }
-                    $this->save_state($this->state);
-                    $chunks_since_save = 0;
+            $file_path_at_completed_part = null;
+            $file_bytes_at_completed_part = null;
+            if (
+                $is_streaming_close
+                && $context->file_handle
+                && $context->file_path
+            ) {
+                if (!fflush($context->file_handle)) {
+                    throw new RuntimeException(
+                        'Failed to flush the pulled file before saving its fetch cursor.'
+                    );
                 }
-            }
-
-            if (isset($chunk["headers"]["x-cursor"])) {
-                $cursor = $chunk["headers"]["x-cursor"];
+                $file_path_at_completed_part = $context->file_path;
+                $file_bytes_at_completed_part = $context->file_bytes_written;
             }
 
             $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
@@ -6135,6 +6511,44 @@ class ImportClient
                     true,
                 );
             }
+
+            if (!$is_streaming_body) {
+                if (isset($chunk["headers"]["x-cursor"])) {
+                    $cursor = $chunk["headers"]["x-cursor"];
+                }
+                $chunks_since_save++;
+                $force_save = $is_streaming_close;
+                if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
+                    if ($file_path_at_completed_part !== null) {
+                        $this->import_state()->current_file =
+                            $file_path_at_completed_part;
+                        $this->import_state()->current_file_bytes =
+                            $file_bytes_at_completed_part;
+                    } elseif ($context->file_handle && $context->file_path) {
+                        // Flush to ensure bytes are on disk before saving state.
+                        if (!fflush($context->file_handle)) {
+                            throw new RuntimeException(
+                                'Failed to flush the pulled file before saving its fetch cursor.'
+                            );
+                        }
+                        // Track the current file for crash recovery.
+                        $this->import_state()->current_file = $context->file_path;
+                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                    } else {
+                        $this->import_state()->current_file = null;
+                        $this->import_state()->current_file_bytes = null;
+                    }
+                    if (
+                        $this->index_update_wal_handle
+                        && !fflush($this->index_update_wal_handle)
+                    ) {
+                        throw new RuntimeException('Failed to flush the index-update WAL.');
+                    }
+                    $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
+                    $this->save_state($this->state);
+                    $chunks_since_save = 0;
+                }
+            }
         };
 
         $cursor_before = $cursor;
@@ -6154,11 +6568,13 @@ class ImportClient
             // Save state so the next invocation resumes from the
             // last cursor instead of crashing with exit code 1.
             $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-            $this->finalize_index_updates();
+            $this->apply_index_update_wal();
             if ($context->file_handle && $context->file_path) {
-                fflush($context->file_handle);
-                $this->import_state()->current_file = $context->file_path;
-                $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                if (!fflush($context->file_handle)) {
+                    throw new RuntimeException(
+                        'Failed to flush the partial pulled file after a timeout.'
+                    );
+                }
             }
             $this->import_state()->active_resumable_command->completion_state = "partial";
             $this->save_state($this->state);
@@ -6173,10 +6589,14 @@ class ImportClient
             $context->response_stats ?? [],
         );
         $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-        $this->finalize_index_updates();
+        $this->apply_index_update_wal();
         // Update file tracking: track in-progress file, or clear if complete/no active file
         if ($context->file_handle && $context->file_path) {
-            fflush($context->file_handle);
+            if (!fflush($context->file_handle)) {
+                throw new RuntimeException(
+                    'Failed to flush the pulled file before saving its fetch cursor.'
+                );
+            }
             $this->import_state()->current_file = $context->file_path;
             $this->import_state()->current_file_bytes = $context->file_bytes_written;
         } else {
@@ -6502,7 +6922,7 @@ class ImportClient
                 $local = $this->read_index_line($local_handle);
             }
         }
-        $this->begin_index_updates();
+        $this->open_index_update_wal();
         $processed = 0;
 
         while (($line = fgets($remote_handle)) !== false) {
@@ -6527,8 +6947,9 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_local_file_path($local["path"]);
-                    $this->delete_index_entry($local["path"]);
+                    if ($this->delete_local_file_path($local["path"])) {
+                        $this->delete_index_entry($local["path"], true);
+                    }
                 }
                 $local_after = $local["path"];
                 $local = $this->read_index_line($local_handle);
@@ -6574,6 +6995,12 @@ class ImportClient
             if ($processed % 200 === 0) {
                 $this->import_state()->diff->remote_offset = $remote_offset;
                 $this->import_state()->diff->local_after = $local_after;
+                if (
+                    $this->index_update_wal_handle
+                    && !fflush($this->index_update_wal_handle)
+                ) {
+                    throw new RuntimeException('Failed to flush the index-update WAL.');
+                }
                 $this->save_state($this->state);
                 $this->progress->tick_spinner();
             }
@@ -6581,8 +7008,9 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_local_file_path($local["path"]);
-                $this->delete_index_entry($local["path"]);
+                if ($this->delete_local_file_path($local["path"])) {
+                    $this->delete_index_entry($local["path"], true);
+                }
             }
             $local_after = $local["path"];
             $local = $this->read_index_line($local_handle);
@@ -6599,9 +7027,8 @@ class ImportClient
 
         $this->import_state()->diff->remote_offset = $remote_offset;
         $this->import_state()->diff->local_after = $local_after;
+        $this->apply_index_update_wal();
         $this->save_state($this->state);
-
-        $this->finalize_index_updates();
 
         return !$this->shutdown_requested;
     }
@@ -6973,11 +7400,13 @@ class ImportClient
 
     /**
      * Delete a local file path safely under the fs root.
+     *
+     * @return bool Whether the path is absent after the deletion attempt.
      */
-    private function delete_local_file_path(string $path): void
+    private function delete_local_file_path(string $path): bool
     {
         if ($path === "") {
-            return;
+            return false;
         }
         try {
             $local_path = $this->remote_path_to_local_path_within_import_root($path);
@@ -6986,18 +7415,19 @@ class ImportClient
                 "Security: refusing to delete invalid path '{$path}': " . $e->getMessage(),
                 true,
             );
-            return;
+            return false;
         }
         if (!file_exists($local_path) && !is_link($local_path)) {
-            return;
+            return true;
         }
 
         if ($this->remove_local_path_without_following_symlinks($local_path)) {
             $this->audit_log("Deleted: {$path}", false);
-            return;
+            return true;
         }
 
         $this->audit_log("Failed to delete: {$path}", true);
+        return false;
     }
 
     /**
@@ -7043,7 +7473,7 @@ class ImportClient
     /**
      * Parse one JSON index line into an array.
      */
-    private function parse_index_line(string $line): ?array
+    private function parse_index_line(string $line, bool $assert_absolute_path = true): ?array
     {
         $line = trim($line);
         if ($line === "") {
@@ -7061,52 +7491,38 @@ class ImportClient
         if ($path === "" || $path === false) {
             throw new RuntimeException("Invalid index path (base64 decode failed)");
         }
-        assert_valid_path($path, "index path");
-        return [
+        if ($assert_absolute_path) {
+            assert_valid_path($path, "index path");
+        }
+        $entry = [
             "path" => $path,
             "ctime" => (int) ($data["ctime"] ?? 0),
             "size" => (int) ($data["size"] ?? 0),
             "type" => (string) ($data["type"] ?? "file"),
         ];
+        if (array_key_exists("empty", $data)) {
+            $entry["empty"] = (bool) $data["empty"];
+        }
+        return $entry;
     }
 
-    /**
-     * Start collecting index updates into a temp file for streaming merge.
-     */
-    private function begin_index_updates(): void
+    /** Opens the current index-update WAL for append. */
+    private function open_index_update_wal(): void
     {
-        if ($this->index_updates_handle) {
+        if ($this->index_update_wal_handle) {
             return;
         }
-        $is_new = false;
-        if ($this->index_updates_file === null) {
-            $tmp = tempnam(sys_get_temp_dir(), "index-updates-");
-            if ($tmp === false) {
-                throw new RuntimeException(
-                    "Failed to create temp index updates file",
-                );
-            }
-            $this->index_updates_file = $tmp;
-            $is_new = true;
-        } elseif (!file_exists($this->index_updates_file)) {
-            $dir = dirname($this->index_updates_file);
-            if (!is_dir($dir)) {
-                mkdir($dir, 0755, true);
-            }
-            $is_new = true;
-        }
-        $this->index_updates_handle = fopen($this->index_updates_file, "a");
-        if (!$this->index_updates_handle) {
-            throw new RuntimeException(
-                "Failed to open temp index updates file",
-            );
+        $is_new = !is_file($this->index_update_wal_path);
+        $this->index_update_wal_handle = fopen($this->index_update_wal_path, "a");
+        if (!$this->index_update_wal_handle) {
+            throw new RuntimeException("Failed to open the index-update WAL.");
         }
         if ($is_new) {
             $this->audit_log(
-                "FILE CREATE | {$this->index_updates_file} | index updates buffer",
+                "FILE CREATE | {$this->index_update_wal_path} | index-update WAL",
             );
         }
-        $this->index_updates_count = 0;
+        $this->index_update_wal_record_count = 0;
         $this->last_update_path = null;
         $this->last_update_delete = null;
         $this->last_update_ctime = null;
@@ -7115,7 +7531,7 @@ class ImportClient
     }
 
     /**
-     * Record a file upsert into the index updates stream.
+     * Record a file upsert in the index-update WAL.
      */
     private function record_index_update_file(
         string $path,
@@ -7123,8 +7539,8 @@ class ImportClient
         int $size,
         string $type
     ): void {
-        if (!$this->index_updates_handle) {
-            $this->begin_index_updates();
+        if (!$this->index_update_wal_handle) {
+            $this->open_index_update_wal();
         }
         if (
             $this->last_update_path === $path &&
@@ -7135,23 +7551,53 @@ class ImportClient
         ) {
             return;
         }
+        $update = [
+            "op" => "F",
+            "path" => base64_encode($path),
+            "ctime" => $ctime,
+            "size" => $size,
+            "type" => $type,
+        ];
+        if ($this->maintain_previous_local_index) {
+            $local_path = $this->remote_path_to_local_path_within_import_root($path);
+            clearstatcache(true, $local_path);
+            $stat = @lstat($local_path);
+            if ($stat === false) {
+                throw new RuntimeException("Failed to inspect the pulled local path.");
+            }
+            $file_type_bits = $stat["mode"] & FileIndexProcessor::STAT_TYPE_MASK;
+            if ($file_type_bits === FileIndexProcessor::STAT_TYPE_FILE) {
+                $local_type = "file";
+            } elseif ($file_type_bits === FileIndexProcessor::STAT_TYPE_DIR) {
+                $local_type = "dir";
+            } elseif ($file_type_bits === FileIndexProcessor::STAT_TYPE_LINK) {
+                $local_type = "link";
+            } else {
+                throw new RuntimeException("The pulled local path has an unsupported type.");
+            }
+            if (
+                $local_type === $type
+                && ( $type !== "file" || (int) $stat["size"] === $size )
+            ) {
+                $update["applied_by_files_pull"] = true;
+                $update["local_ctime"] = (int) $stat["ctime"];
+                $update["local_size"] =
+                    $local_type === "dir" ? 0 : (int) $stat["size"];
+                $update["local_type"] = $local_type;
+            }
+        }
         $line = json_encode(
-            [
-                "op" => "F",
-                "path" => base64_encode($path),
-                "ctime" => $ctime,
-                "size" => $size,
-                "type" => $type,
-            ],
+            $update,
             JSON_UNESCAPED_SLASHES,
         );
         if ($line !== false) {
-            $bytes = fwrite($this->index_updates_handle, $line . "\n");
-            if ($bytes === false) {
-                throw new RuntimeException("Failed to write to index updates file (disk full?)");
+            $line .= "\n";
+            $bytes = fwrite($this->index_update_wal_handle, $line);
+            if ($bytes !== strlen($line)) {
+                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
             }
         }
-        $this->index_updates_count++;
+        $this->index_update_wal_record_count++;
         $this->last_update_path = $path;
         $this->last_update_delete = false;
         $this->last_update_ctime = $ctime;
@@ -7160,12 +7606,15 @@ class ImportClient
     }
 
     /**
-     * Record a deletion into the index updates stream.
+     * Record a deletion in the index-update WAL.
      */
-    private function record_index_update_deletion(string $path): void
+    private function record_index_update_deletion(
+        string $path,
+        bool $path_deleted_by_files_pull
+    ): void
     {
-        if (!$this->index_updates_handle) {
-            $this->begin_index_updates();
+        if (!$this->index_update_wal_handle) {
+            $this->open_index_update_wal();
         }
         if (
             $this->last_update_path === $path &&
@@ -7173,20 +7622,25 @@ class ImportClient
         ) {
             return;
         }
+        $update = [
+            "op" => "D",
+            "path" => base64_encode($path),
+        ];
+        if ($this->maintain_previous_local_index && $path_deleted_by_files_pull) {
+            $update["applied_by_files_pull"] = true;
+        }
         $line = json_encode(
-            [
-                "op" => "D",
-                "path" => base64_encode($path),
-            ],
+            $update,
             JSON_UNESCAPED_SLASHES,
         );
         if ($line !== false) {
-            $bytes = fwrite($this->index_updates_handle, $line . "\n");
-            if ($bytes === false) {
-                throw new RuntimeException("Failed to write to index updates file (disk full?)");
+            $line .= "\n";
+            $bytes = fwrite($this->index_update_wal_handle, $line);
+            if ($bytes !== strlen($line)) {
+                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
             }
         }
-        $this->index_updates_count++;
+        $this->index_update_wal_record_count++;
         $this->last_update_path = $path;
         $this->last_update_delete = true;
         $this->last_update_ctime = null;
@@ -7194,14 +7648,15 @@ class ImportClient
         $this->last_update_type = null;
     }
 
-    /**
-     * Merge the collected updates with the existing sorted index without loading it into memory.
-     */
-    private function finalize_index_updates(): void
+    /** Applies the current WAL to every index maintained by this command. */
+    private function apply_index_update_wal(): void
     {
-        if ($this->index_updates_handle) {
-            fclose($this->index_updates_handle);
-            $this->index_updates_handle = null;
+        if ($this->index_update_wal_handle) {
+            $closed = fclose($this->index_update_wal_handle);
+            $this->index_update_wal_handle = null;
+            if (!$closed) {
+                throw new RuntimeException("Failed to flush the index-update WAL.");
+            }
         }
         $this->last_update_path = null;
         $this->last_update_delete = null;
@@ -7210,130 +7665,139 @@ class ImportClient
         $this->last_update_type = null;
 
         $has_updates =
-            $this->index_updates_count > 0 ||
-            ($this->index_updates_file &&
-                file_exists($this->index_updates_file) &&
-                filesize($this->index_updates_file) > 0);
+            $this->index_update_wal_record_count > 0 ||
+            (is_file($this->index_update_wal_path) &&
+                filesize($this->index_update_wal_path) > 0);
 
         if (!$has_updates) {
-            if (
-                $this->index_updates_file &&
-                file_exists($this->index_updates_file)
-            ) {
-                @unlink($this->index_updates_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->index_updates_file} | no updates to merge",
-                );
-            }
-            $this->index_updates_count = 0;
+            $this->index_update_wal_record_count = 0;
             return;
         }
 
-        $updates_path = $this->index_updates_file;
         $new_index = $this->index_file . ".new";
-
         $this->audit_log(
             "INDEX MERGE START | merging updates into {$this->index_file}",
         );
-
-        $old_handle = file_exists($this->index_file)
-            ? fopen($this->index_file, "r")
-            : null;
-        $upd_handle = fopen($updates_path, "r");
-        $new_handle = fopen($new_index, "w");
-
-        if (!$upd_handle || !$new_handle) {
-            throw new RuntimeException("Failed to merge index updates");
-        }
-
-        $write_line = function ($handle, array $entry): void {
-            $line = json_encode(
-                [
-                    "path" => base64_encode($entry["path"]),
-                    "ctime" => (int) $entry["ctime"],
-                    "size" => (int) $entry["size"],
-                    "type" => (string) $entry["type"],
-                ],
-                JSON_UNESCAPED_SLASHES,
-            );
-            if ($line !== false) {
-                fwrite($handle, $line . "\n");
-            }
-        };
-
-        $old = $this->read_index_line($old_handle);
-        $carry = null;
-        $upd = $this->read_update_line($upd_handle, $carry);
-        $last_written_path = null;
-
-        while ($old !== null || $upd !== null) {
-            if ($upd === null) {
-                if ($last_written_path !== $old["path"]) {
-                    $write_line($new_handle, $old);
-                    $last_written_path = $old["path"];
-                }
-                $old = $this->read_index_line($old_handle);
-                continue;
-            }
-
-            if ($old === null) {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
-                }
-                $upd = $this->read_update_line($upd_handle, $carry);
-                continue;
-            }
-
-            $cmp = strcmp($old["path"], $upd["path"]);
-            if ($cmp === 0) {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
-                }
-                $old = $this->read_index_line($old_handle);
-                $upd = $this->read_update_line($upd_handle, $carry);
-            } elseif ($cmp < 0) {
-                if ($last_written_path !== $old["path"]) {
-                    $write_line($new_handle, $old);
-                    $last_written_path = $old["path"];
-                }
-                $old = $this->read_index_line($old_handle);
-            } else {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
-                }
-                $upd = $this->read_update_line($upd_handle, $carry);
-            }
-        }
-
-        if ($old_handle) {
-            fclose($old_handle);
-        }
-        fclose($upd_handle);
-        fclose($new_handle);
-
+        merge_import_index_updates(
+            $this->index_file,
+            $this->index_update_wal_path,
+            $new_index
+        );
         if (!rename($new_index, $this->index_file)) {
             throw new RuntimeException("Failed to replace index file");
         }
         $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
 
-        @unlink($updates_path);
-        $this->audit_log("FILE DELETE | {$updates_path} | updates merged");
-        $this->index_updates_count = 0;
+        $wal_has_previous_local_index_updates = false;
+        $wal_handle = fopen($this->index_update_wal_path, 'rb');
+        if (!is_resource($wal_handle)) {
+            throw new RuntimeException('Failed to inspect the index-update WAL.');
+        }
+        try {
+            while (true) {
+                $update = $this->read_update_line_raw($wal_handle);
+                if ($update === null) {
+                    break;
+                }
+                if ($update['applied_by_files_pull']) {
+                    $wal_has_previous_local_index_updates = true;
+                    break;
+                }
+            }
+        } finally {
+            fclose($wal_handle);
+        }
+        if ($wal_has_previous_local_index_updates) {
+            $context = $this->files_pull_pair_context_if_local_tree_exists();
+            if (
+                $context === null
+                || !is_file(
+                    $context['push_state_directory']
+                        . '/previous_local_index.jsonl'
+                )
+            ) {
+                throw new RuntimeException(
+                    'Cannot publish the index-update WAL without its previous local index.'
+                );
+            }
+            $previous_local_index =
+                $context['push_state_directory'] . '/previous_local_index.jsonl';
+            $updates_path = $this->state_dir . '/.previous-local-index-updates.tmp';
+            $swap_path = $previous_local_index . '.swap';
+            try {
+                $updates_written = $this->write_previous_local_index_updates(
+                    $this->index_update_wal_path,
+                    $updates_path,
+                    $context,
+                    true
+                );
+                if ($updates_written > 0) {
+                    merge_previous_local_index_updates(
+                        $previous_local_index,
+                        $updates_path,
+                        $swap_path,
+                        $this->state_dir
+                    );
+                    if (!rename($swap_path, $previous_local_index)) {
+                        throw new RuntimeException(
+                            'Failed to advance the previous local index: '
+                            . $previous_local_index . '.'
+                        );
+                    }
+                }
+            } finally {
+                if (is_file($updates_path)) {
+                    @unlink($updates_path);
+                }
+                if (is_file($swap_path)) {
+                    @unlink($swap_path);
+                }
+            }
+        }
+        if (file_put_contents($this->index_update_wal_path, '') === false) {
+            throw new RuntimeException("Failed to clear the applied index-update WAL.");
+        }
+        $this->audit_log(
+            "FILE TRUNCATE | {$this->index_update_wal_path} | WAL batch applied"
+        );
+        $this->index_update_wal_record_count = 0;
+    }
+
+    /** Removes the WAL marker after files-pull completes or is aborted. */
+    private function remove_index_update_wal(): void
+    {
+        if (is_resource($this->index_update_wal_handle)) {
+            if (!fclose($this->index_update_wal_handle)) {
+                throw new RuntimeException("Failed to flush the index-update WAL.");
+            }
+            $this->index_update_wal_handle = null;
+        }
+        clearstatcache(true, $this->index_update_wal_path);
+        if (
+            is_file($this->index_update_wal_path)
+            && filesize($this->index_update_wal_path) > 0
+        ) {
+            throw new RuntimeException("Cannot remove an unapplied index-update WAL.");
+        }
+        if (
+            is_file($this->index_update_wal_path)
+            && !unlink($this->index_update_wal_path)
+        ) {
+            throw new RuntimeException("Failed to remove the index-update WAL.");
+        }
+        $this->index_update_wal_record_count = 0;
     }
 
     /**
      * Read one JSON record from the on-disk index.
      */
-    private function read_index_line($handle): ?array
+    private function read_index_line($handle, bool $assert_absolute_path = true): ?array
     {
         if (!$handle) {
             return null;
         }
         while (($line = fgets($handle)) !== false) {
-            $parsed = $this->parse_index_line($line);
+            $parsed = $this->parse_index_line($line, $assert_absolute_path);
             if ($parsed !== null) {
                 return $parsed;
             }
@@ -7350,6 +7814,9 @@ class ImportClient
             return null;
         }
         while (($line = fgets($handle)) !== false) {
+            if (substr($line, -1) !== "\n" && feof($handle)) {
+                return null;
+            }
             $line = trim($line);
             if ($line === "") {
                 continue;
@@ -7374,51 +7841,34 @@ class ImportClient
                     "ctime" => 0,
                     "size" => 0,
                     "type" => null,
+                    "replace_subtree" => !empty($data["replace_subtree"]),
+                    "applied_by_files_pull" => !empty($data["applied_by_files_pull"]),
                 ];
             }
             if ($op === "F") {
-                return [
+                $entry = [
                     "path" => $path,
                     "delete" => false,
                     "ctime" => (int) ($data["ctime"] ?? 0),
                     "size" => (int) ($data["size"] ?? 0),
                     "type" => (string) ($data["type"] ?? "file"),
+                    "replace_subtree" => !empty($data["replace_subtree"]),
+                    "applied_by_files_pull" => !empty($data["applied_by_files_pull"]),
                 ];
+                if (array_key_exists("empty", $data)) {
+                    $entry["empty"] = (bool) $data["empty"];
+                }
+                if (array_key_exists("local_type", $data)) {
+                    $entry["local_ctime"] = (int) $data["local_ctime"];
+                    $entry["local_size"] = (int) $data["local_size"];
+                    $entry["local_type"] = (string) $data["local_type"];
+                }
+                return $entry;
             }
         }
         return null;
     }
 
-    /**
-     * Read one update record, coalescing consecutive updates to the same path.
-     *
-     * @param mixed $handle Update file handle
-     * @param array|null $carry Read-ahead buffer for the next record
-     */
-    private function read_update_line($handle, ?array &$carry = null): ?array
-    {
-        if (!$handle) {
-            return null;
-        }
-        $current = $carry ?? $this->read_update_line_raw($handle);
-        $carry = null;
-        if ($current === null) {
-            return null;
-        }
-
-        while (true) {
-            $next = $this->read_update_line_raw($handle);
-            if ($next === null) {
-                return $current;
-            }
-            if ($next["path"] !== $current["path"]) {
-                $carry = $next;
-                return $current;
-            }
-            // Same path: keep the latest update.
-            $current = $next;
-        }
-    }
     /**
      * Download SQL from remote.
      */
@@ -9196,7 +9646,11 @@ class ImportClient
 
         // Close on last chunk
         if ($is_last && $context->file_handle) {
-            fclose($context->file_handle);
+            $closed = fclose($context->file_handle);
+            $context->file_handle = null;
+            if (!$closed) {
+                throw new RuntimeException("Failed to flush the completed pulled file.");
+            }
 
             // Set file modification time
             if ($context->file_ctime && $context->file_path) {
@@ -9231,7 +9685,6 @@ class ImportClient
                 );
             }
 
-            $context->file_handle = null;
             $context->file_path = null;
             $context->file_ctime = null;
             $context->file_bytes_written = 0;
@@ -9730,10 +10183,12 @@ class ImportClient
                 $context->file_bytes_written = 0;
             }
 
-            if (file_exists($local_path)) {
-                @unlink($local_path);
+            if (
+                ( !file_exists($local_path) && !is_link($local_path) )
+                || $this->remove_local_path_without_following_symlinks($local_path)
+            ) {
+                $this->delete_index_entry($path);
             }
-            $this->delete_index_entry($path);
 
             if ($error_type === "file_changed") {
                 $this->record_volatile_file($path);
@@ -11602,15 +12057,16 @@ class ImportClient
         $this->shutdown_requested = true;
         $this->progress->clear_progress_line();
 
-        // Flush index updates so progress is not lost on interrupt
-        try {
-            $this->finalize_index_updates();
-        } catch (Exception $e) {
-            $this->audit_log(
-                "Failed to finalize index updates on shutdown: " .
-                    $e->getMessage(),
-                true,
-            );
+        if (is_resource($this->index_update_wal_handle)) {
+            try {
+                $this->apply_index_update_wal();
+            } catch (Exception $e) {
+                $this->audit_log(
+                    "Failed to apply the index-update WAL on shutdown: " .
+                        $e->getMessage(),
+                    true,
+                );
+            }
         }
 
         // Log final progress before exit
@@ -12765,6 +13221,8 @@ if (
                 "downloads every file. On subsequent runs, re-indexes the remote tree,\n" .
                 "diffs against the local index, and downloads only what changed.\n" .
                 "Interrupted pulls resume from the last saved cursor.\n" .
+                "The state directory's .reprint.lock is held for the entire command,\n" .
+                "so another local Reprint command cannot use the same state directory.\n" .
                 "\n" .
                 "Runs files-index internally when no index exists yet.\n",
             "extra" =>
@@ -12774,9 +13232,17 @@ if (
                 "                    The skipped file list is saved for later retrieval.\n" .
                 "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
                 "\n" .
+                "A compatible full file-only pull seeds a missing previous local\n" .
+                "index before changing the tree. It then advances only the paths\n" .
+                "applied by each durable WAL batch. A compatible partial pull can\n" .
+                "advance an existing index but cannot seed a missing one. Pending\n" .
+                "local additions, edits, and deletions elsewhere remain pending.\n" .
+                "\n" .
                 "Output files:\n" .
                 "  (fs-root)/                              Downloaded files\n" .
+                "  .reprint.lock                           Local Reprint process lock\n" .
                 "  .import-index.jsonl                     Local file index\n" .
+                "  .import-index-updates.wal               Active files-pull WAL\n" .
                 "  .import-remote-index.jsonl              Remote index snapshot\n" .
                 "  .import-download-list.jsonl             Files pending download\n" .
                 "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
@@ -12785,13 +13251,21 @@ if (
         ],
         "files-diff" => [
             "level" => "low",
-            "short" => "Show local file changes since the last push",
+            "short" => "Show local file changes since the last pull or push",
             "usage" => "reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
-                "Shows which local paths a files-push would send or delete, comparing\n" .
-                "the local tree at --fs-root with the pair's previous local index —\n" .
-                "the index a completed files-push publishes for the same target URL,\n" .
-                "state directory, and local tree.\n" .
+                "Shows which local paths changed since the last synchronization with\n" .
+                "the target, comparing the local tree at --fs-root with the pair's\n" .
+                "previous local index. A compatible file-only pull — files-pull or\n" .
+                "pull-files — maintains that index after each durable WAL batch, and\n" .
+                "every completed files-push advances it, so already-pushed changes\n" .
+                "leave the diff. A compatible partial pull advances only the paths\n" .
+                "it applied when that index already exists; pending local additions,\n" .
+                "edits, and deletions elsewhere stay in the diff.\n" .
+                "The local tree at --fs-root must be the exact document root later\n" .
+                "passed to files-push. Use the exact exporter API URL used by that\n" .
+                "pull; after pull-files received a bare site URL, include the\n" .
+                "site-export-api query which pull-files added.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .
@@ -12799,8 +13273,16 @@ if (
                 "editor scratch files.\n" .
                 "Paths remain base64 text in JSONL output so\n" .
                 "arbitrary filesystem names are preserved. No network calls are made\n" .
-                "and no secret is required.\n",
+                "and no secret is required. The state directory's .reprint.lock is\n" .
+                "held for the entire command.\n",
             "extra" =>
+                "To establish or refresh the previous local index, complete a\n" .
+                "files-push or run a fresh compatible full file-only pull: an " .
+                "unfiltered files-pull or pull-files with no path selection and the\n" .
+                "default path mapping and overwrite behavior.\n" .
+                "A completed standalone files-pull does not run again. First run the\n" .
+                "same files-pull with --abort, then run it once more. Rerunning a\n" .
+                "completed pull-files starts a fresh pipeline.\n" .
                 "Every run reports the complete diff from the beginning; there is\n" .
                 "no partial resume to continue.\n",
         ],
@@ -13117,6 +13599,7 @@ if (
     }
 
     try {
+        $reprint_process_lock = new ReprintProcessLock($state_dir);
         $reprint_files_push_context = null;
         $reprint_files_diff_context = null;
         if ($command === 'files-push') {
@@ -13144,7 +13627,8 @@ if (
                     : ['files_push_context' => $reprint_files_push_context] )
                 + ( $reprint_files_diff_context === null
                     ? []
-                    : ['files_diff_context' => $reprint_files_diff_context] )
+                    : ['files_diff_context' => $reprint_files_diff_context] ),
+            $reprint_process_lock
         );
         // EXIT_AFTER_IMPORT controls whether we hand control back to
         // the caller after pull returns. Default true: standard CLI
@@ -13190,5 +13674,9 @@ if (
         // to see the failure — re-throw so its try/catch around
         // `include $phar` can surface a proper `{type:'error'}` event.
         throw $e;
+    } finally {
+        if (isset($reprint_process_lock)) {
+            $reprint_process_lock->close();
+        }
     }
 }

--- a/packages/reprint-importer/src/lib/class-reprint-process-lock.php
+++ b/packages/reprint-importer/src/lib/class-reprint-process-lock.php
@@ -1,0 +1,61 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain local filesystem paths, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Prevents concurrent Reprint processes from using one state directory.
+ */
+final class ReprintProcessLock
+{
+    /** @var resource|null */
+    private $handle;
+
+    public function __construct(string $state_directory)
+    {
+        if (
+            !is_dir($state_directory)
+            && !mkdir($state_directory, 0755, true)
+            && !is_dir($state_directory)
+        ) {
+            throw new RuntimeException(
+                'Failed to create the Reprint state directory: '
+                . $state_directory . '.'
+            );
+        }
+        $lock_path = rtrim($state_directory, '/') . '/.reprint.lock';
+        $this->handle = fopen($lock_path, 'c+b');
+        if (!is_resource($this->handle)) {
+            throw new RuntimeException('Failed to open the Reprint process lock: ' . $lock_path . '.');
+        }
+        if (!flock($this->handle, LOCK_EX | LOCK_NB)) {
+            fclose($this->handle);
+            $this->handle = null;
+            throw new RuntimeException(
+                'Another Reprint process is using the state directory: '
+                . rtrim($state_directory, '/') . '.'
+            );
+        }
+    }
+
+    public function is_held(): bool
+    {
+        return is_resource($this->handle);
+    }
+
+    public function close(): void
+    {
+        if (!is_resource($this->handle)) {
+            return;
+        }
+        flock($this->handle, LOCK_UN);
+        fclose($this->handle);
+        $this->handle = null;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+}

--- a/packages/reprint-importer/src/lib/index-update-functions.php
+++ b/packages/reprint-importer/src/lib/index-update-functions.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Reprint\Importer;
+
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\compare_paths;
+use function WordPress\Reprint\Exporter\path_sort_key;
+
+/**
+ * Merges sorted updates into the absolute-path import index.
+ */
+function merge_import_index_updates(
+    string $base_index,
+    string $updates_path,
+    string $output_index
+): void {
+    merge_index_updates(
+        $base_index,
+        $updates_path,
+        $output_index,
+        false
+    );
+}
+
+/**
+ * Sorts and merges updates into the document-root-relative previous local index.
+ */
+function merge_previous_local_index_updates(
+    string $base_index,
+    string $updates_path,
+    string $output_index,
+    string $temporary_directory
+): void {
+    $sorter = new \ExternalMergeSort(
+        static function (string $line): string {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $path = base64_decode($entry['path'], true);
+            if ($path === false) {
+                throw new \RuntimeException(
+                    'A previous-local-index update path is not valid base64.'
+                );
+            }
+            return path_sort_key($path)
+                . "\0\0"
+                . sprintf('%020d', (int) $entry['position']);
+        },
+        8 * 1024 * 1024,
+        false,
+        $temporary_directory
+    );
+    $sorter->sort($updates_path);
+
+    merge_index_updates(
+        $base_index,
+        $updates_path,
+        $output_index,
+        true
+    );
+}
+
+/**
+ * Streams one sorted F/D update file into one sorted index.
+ */
+function merge_index_updates(
+    string $base_index,
+    string $updates_path,
+    string $output_index,
+    bool $previous_local_index
+): void {
+    $base_handle = is_file($base_index) ? fopen($base_index, 'rb') : null;
+    $updates_handle = fopen($updates_path, 'rb');
+    $output_handle = fopen($output_index, 'wb');
+    if (
+        ( is_file($base_index) && !is_resource($base_handle) )
+        || !is_resource($updates_handle)
+        || !is_resource($output_handle)
+    ) {
+        throw new \RuntimeException('Failed to merge index updates.');
+    }
+
+    $read_index_entry = static function ($handle) use (
+        $previous_local_index
+    ): ?array {
+        if (!is_resource($handle)) {
+            return null;
+        }
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                if (!feof($handle)) {
+                    throw new \RuntimeException('Failed to read an index entry.');
+                }
+                return null;
+            }
+            if (trim($line) === '') {
+                continue;
+            }
+            $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $path = base64_decode($data['path'], true);
+            if ($path === false) {
+                throw new \RuntimeException('An index path is not valid base64.');
+            }
+            if (!$previous_local_index) {
+                assert_valid_path($path, 'index path');
+            }
+            $entry = [
+                'path' => $path,
+                'ctime' => (int) $data['ctime'],
+                'size' => (int) $data['size'],
+                'type' => (string) $data['type'],
+            ];
+            if (array_key_exists('empty', $data)) {
+                $entry['empty'] = (bool) $data['empty'];
+            }
+            return $entry;
+        }
+    };
+    $read_update_entry_raw = static function ($handle): ?array {
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                if (!feof($handle)) {
+                    throw new \RuntimeException(
+                        'Failed to read an index-update entry.'
+                    );
+                }
+                return null;
+            }
+            if (substr($line, -1) !== "\n" && feof($handle)) {
+                return null;
+            }
+            if (trim($line) === '') {
+                continue;
+            }
+            $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $path = base64_decode($data['path'], true);
+            if ($path === false) {
+                throw new \RuntimeException(
+                    'An index-update path is not valid base64.'
+                );
+            }
+            if ($data['op'] === 'D') {
+                return [
+                    'path' => $path,
+                    'delete' => true,
+                    'ctime' => 0,
+                    'size' => 0,
+                    'type' => null,
+                    'replace_subtree' => !empty($data['replace_subtree']),
+                ];
+            }
+            return [
+                'path' => $path,
+                'delete' => false,
+                'ctime' => (int) $data['ctime'],
+                'size' => (int) $data['size'],
+                'type' => (string) $data['type'],
+                'replace_subtree' => !empty($data['replace_subtree']),
+            ];
+        }
+    };
+    $update_carry = null;
+    $read_update_entry = static function () use (
+        $updates_handle,
+        $read_update_entry_raw,
+        &$update_carry
+    ): ?array {
+        $current = $update_carry ?? $read_update_entry_raw($updates_handle);
+        $update_carry = null;
+        if ($current === null) {
+            return null;
+        }
+        while (true) {
+            $next = $read_update_entry_raw($updates_handle);
+            if ($next === null) {
+                return $current;
+            }
+            if ($next['path'] !== $current['path']) {
+                $update_carry = $next;
+                return $current;
+            }
+            $replace_subtree =
+                $current['replace_subtree'] || $next['replace_subtree'];
+            $current = $next;
+            $current['replace_subtree'] = $replace_subtree;
+        }
+    };
+    $write_index_entry = static function ($handle, array $entry): void {
+        $encoded = [
+            'path' => base64_encode($entry['path']),
+            'ctime' => (int) $entry['ctime'],
+            'size' => (int) $entry['size'],
+            'type' => (string) $entry['type'],
+        ];
+        if ($entry['type'] === 'dir' && array_key_exists('empty', $entry)) {
+            $encoded['empty'] = (bool) $entry['empty'];
+        }
+        $line = json_encode(
+            $encoded,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (fwrite($handle, $line) !== strlen($line)) {
+            throw new \RuntimeException('Failed to write a merged index entry.');
+        }
+    };
+
+    $pending_directory = null;
+    $last_entry_path = null;
+    $write_entry = static function (array $entry) use (
+        $output_handle,
+        $previous_local_index,
+        $write_index_entry,
+        &$pending_directory,
+        &$last_entry_path
+    ): void {
+        if ($entry['path'] === $last_entry_path) {
+            return;
+        }
+        $last_entry_path = $entry['path'];
+        if ($previous_local_index && $pending_directory !== null) {
+            if (
+                strpos(
+                    $entry['path'],
+                    $pending_directory['path'] . '/'
+                ) === 0
+            ) {
+                $pending_directory['empty'] = false;
+            }
+            $write_index_entry($output_handle, $pending_directory);
+            $pending_directory = null;
+        }
+        if ($previous_local_index && $entry['type'] === 'dir') {
+            $entry['empty'] = true;
+            $pending_directory = $entry;
+            return;
+        }
+        $write_index_entry($output_handle, $entry);
+    };
+
+    try {
+        $base = $read_index_entry($base_handle);
+        $update = $read_update_entry();
+        $replaced_subtree = null;
+        while ($base !== null || $update !== null) {
+            if ($base !== null && $replaced_subtree !== null) {
+                if (
+                    $base['path'] === $replaced_subtree
+                    || strpos(
+                        $base['path'],
+                        $replaced_subtree . '/'
+                    ) === 0
+                ) {
+                    $base = $read_index_entry($base_handle);
+                    continue;
+                }
+                $subtree_comparison = $previous_local_index
+                    ? compare_paths($base['path'], $replaced_subtree)
+                    : strcmp($base['path'], $replaced_subtree);
+                if ($subtree_comparison > 0) {
+                    $replaced_subtree = null;
+                }
+            }
+
+            if ($update === null) {
+                $write_entry($base);
+                $base = $read_index_entry($base_handle);
+                continue;
+            }
+            if ($base === null) {
+                if (!$update['delete']) {
+                    $write_entry($update);
+                }
+                if (
+                    $update['replace_subtree']
+                    && (
+                        $replaced_subtree === null
+                        || strpos(
+                            $update['path'],
+                            $replaced_subtree . '/'
+                        ) !== 0
+                    )
+                ) {
+                    $replaced_subtree = $update['path'];
+                }
+                $update = $read_update_entry();
+                continue;
+            }
+
+            $comparison = $previous_local_index
+                ? compare_paths($base['path'], $update['path'])
+                : strcmp($base['path'], $update['path']);
+            if ($comparison < 0) {
+                $write_entry($base);
+                $base = $read_index_entry($base_handle);
+                continue;
+            }
+            if (!$update['delete']) {
+                $write_entry($update);
+            }
+            if (
+                $update['replace_subtree']
+                && (
+                    $replaced_subtree === null
+                    || strpos(
+                        $update['path'],
+                        $replaced_subtree . '/'
+                    ) !== 0
+                )
+            ) {
+                $replaced_subtree = $update['path'];
+            }
+            $update = $read_update_entry();
+            if ($comparison === 0) {
+                $base = $read_index_entry($base_handle);
+            }
+        }
+        if ($pending_directory !== null) {
+            $write_index_entry($output_handle, $pending_directory);
+        }
+        if (!fflush($output_handle)) {
+            throw new \RuntimeException('Failed to flush the merged index.');
+        }
+    } finally {
+        if (is_resource($base_handle)) {
+            fclose($base_handle);
+        }
+        fclose($updates_handle);
+        fclose($output_handle);
+    }
+}

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -122,6 +122,17 @@ class Pull
      */
     public function abort(string $command = 'pull'): void
     {
+        $this->normalize_url();
+        $state = $this->client->get_import_state();
+        if (
+            $command === 'pull-files'
+            || (
+                $command === 'pull'
+                && $state->active_resumable_command->command_name === 'files-pull'
+            )
+        ) {
+            $this->client->clear_files_pull_progress();
+        }
         $this->prepare_repull($command);
         $label = $command === 'pull' ? 'Pull' : $command;
         $message = "{$label} state cleared.";
@@ -358,7 +369,7 @@ class Pull
             $this->print_stage_header($stage);
 
             try {
-                $this->run_stage($stage, $options, $step, $total);
+                $this->run_stage($command, $stage, $options, $step, $total);
             } catch (\Exception $e) {
                 $this->report_failure($command, $stage, $stages, $i, $e);
                 throw new PullFailureReportedException($e->getMessage(), 0, $e);
@@ -394,7 +405,7 @@ class Pull
      * after this method returns, so a thrown exception leaves the stage
      * unfinished at the orchestration level.
      */
-    private function run_stage(string $stage, array $options, int $step, int $total): void
+    private function run_stage(string $command, string $stage, array $options, int $step, int $total): void
     {
         switch ($stage) {
             case 'preflight':
@@ -424,8 +435,11 @@ class Pull
 
             case 'files-pull':
                 $this->client->prepare_files_pull_options($options);
-                $this->run_until_complete('files-pull', function () {
-                    $this->client->run_files_sync();
+                $this->run_until_complete('files-pull', function () use ($command) {
+                    // pull-files ends with this local tree. The complete pull
+                    // pipeline may change it again in later stages, so only
+                    // pull-files can maintain the previous local index.
+                    $this->client->run_files_sync($command === 'pull-files');
                 });
                 $skipped_pending =
                     $options['filter'] === 'essential-files' &&

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Reprint\Importer\merge_previous_local_index_updates;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
@@ -7,27 +9,30 @@
 /**
  * Drives one local-files push through bounded planning and streaming requests.
  *
- * PushFilesSender owns the only caller-visible lifecycle. It holds the lock,
- * creates and removes the target push session, drives its internal PushPlan,
- * streams the selected paths, commits the push, and saves the completed fresh
- * local index as the pair's previous local index. The target owns the
+ * PushFilesSender owns the only caller-visible push lifecycle. Its caller holds
+ * the Reprint process lock while the sender creates and removes the target push
+ * session, drives its internal PushPlan, streams the selected paths, commits the
+ * push, and advances the pair's previous local index with the committed paths.
+ * An initial full push publishes its fresh local index. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
  * request limits and the PushPlan cursor needed after a process restart.
  *
  * ## Usage
  *
- *  1. Start a new sender with `start()`, or continue an unfinished sender with
- *     `resume()`. Both methods acquire the lifecycle lock.
+ *  1. Acquire the Reprint process lock, then start a new sender with `start()`
+ *     or continue an unfinished sender with `resume()`.
  *  2. Call `next_step()` while the current process has enough time and memory
  *     for another step.
- *  3. Call `close()` to release the lifecycle lock, even when more work remains.
+ *  3. Call `close()` and release the Reprint process lock, even when more work
+ *     remains.
  *
  * Example:
  *
+ *     $process_lock = new ReprintProcessLock($state_directory);
  *     $sender = $first_run
- *         ? PushFilesSender::start($options)
- *         : PushFilesSender::resume($options);
+ *         ? PushFilesSender::start($options, $process_lock)
+ *         : PushFilesSender::resume($options, $process_lock);
  *     try {
  *         while ($has_time_remaining() && $has_memory_available()) {
  *             if (!$sender->next_step()) {
@@ -40,27 +45,34 @@
  *             $sender->cancel();
  *         }
  *         $sender->close();
+ *         $process_lock->close();
  *     }
  *
  * The caller may cancel whenever next_step() returns true. cancel() abandons an
  * open multipart request and returns the in-memory sender to its preceding
- * durable boundary. close() only releases resources and the lock; it never
- * finishes an open request. If a process stops without closing, the next
+ * durable boundary. close() only releases sender resources; it never finishes
+ * an open request or releases the caller's process lock. If a process stops
+ * without closing, the next
  * process starts from the preceding durable boundary and reads
  * receiver-confirmed work before sending more data.
  *
  * A new sender calls `push_create` to learn target-owned exclusions before
- * starting PushPlan. The plan builds the fresh local index and diffs it against
- * the pair's previous local index, one bounded step at a time. That index is
- * saved by the previous successful push and also read by files-diff. After planning
+ * starting PushPlan. The pair's previous local index is shared with the pull
+ * side: a compatible file-only pull publishes it too, and files-diff reads it.
+ * Because a pull may replace that file between sender processes, the
+ * `starting_plan` step copies the current previous local index into
+ * `plan/previous_local_index.jsonl` while the caller holds the Reprint process
+ * lock. The plan then diffs the fresh local index against that immutable
+ * snapshot, one bounded step at a time. After planning
  * completes, local files, symlinks, and empty directories stream through
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
  * calls let the target install the work in bounded steps. A confirmed commit
- * enters another phase which saves the fresh local index as the pair's
- * previous local index through a swap file. Index completion, plan completion,
- * local-index saving, and plan discard each have a separate durable phase. A
- * stopped process therefore repeats only an idempotent boundary action rather
- * than a group of unrelated transitions.
+ * enters another phase which merges those operations into the latest previous
+ * local index through a swap file. With no prior index, it publishes the
+ * complete fresh local index. Index completion, plan completion,
+ * local-index publication, and plan discard each have a separate durable
+ * phase. A stopped process therefore repeats only an idempotent boundary
+ * action rather than a group of unrelated transitions.
  *
  * sender.json owns the top-level phase and the cursor returned by
  * PushPlan. PushFilesSender stores that cursor after every completed planning
@@ -99,15 +111,17 @@
  * the current path phase ends. An open sender retains that request, its
  * path-list handles, and its current local file handle between steps.
  *
- * Saving a complete local index after commit is the deliberate exception to
- * bounded steps.
+ * Copying the previous local index while starting a plan and publishing the
+ * committed paths after commit are the deliberate exceptions to bounded steps.
  * A representative index entry is about 150 bytes, so one million paths produce
  * roughly 150 MB. Even a 10 MiB/s drive copies that in about 15 seconds. Keeping
  * two copy cursors, two retained handles, and per-chunk state writes for larger
  * installations is not justified until measurements show otherwise. PHP's
- * copy() streams the bytes through a swap file, and rename() atomically moves
- * the completed copy into place. This accepts that a 1 MiB/s drive reaches 30
- * seconds at roughly 200,000 paths. A stopped copy is repeated by the next call.
+ * copy() and the merge stream bytes through swap files, and rename() atomically
+ * moves each completed index into place. This accepts that a 1 MiB/s drive
+ * reaches 30 seconds at roughly 200,000 paths. A stopped snapshot copy is
+ * refreshed while `starting_plan` remains durable; a stopped post-commit merge
+ * is repeated by the next call.
  *
  * The sender has no overall time limit. The caller decides whether to take
  * another step. Network operations apply connect, no-progress, and response
@@ -130,20 +144,20 @@ final class PushFilesSender
     /** @var string Sender-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Pair's previous local index, saved after a successful push and read by files-diff. */
+    /** @var string Pair-owned index advanced by successful pulls and pushes. */
     private string $previous_local_index;
 
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
 
-    /** @var string Advisory lock file for one open lifecycle. */
-    private string $lock_path;
-
     /** @var string Target exclusions stored once for the active push. */
     private string $excluded_paths_path;
 
-    /** @var resource|null Exclusive lock held from start() or resume() through close(). */
-    private $lock_handle = null;
+    /** @var ReprintProcessLock Reprint process lock owned by the caller. */
+    private ReprintProcessLock $process_lock;
+
+    /** @var bool Whether close() released this sender's resources. */
+    private bool $closed = false;
 
     /** @var resource|null Open local_paths_to_push list retained while pushing local paths. */
     private $local_paths_to_push_handle = null;
@@ -218,11 +232,10 @@ final class PushFilesSender
     private array $push_stream_client_options;
 
     /**
-     * Starts a new sender and acquires exclusive ownership of its push state.
+     * Starts a new sender while the caller holds the Reprint process lock.
      *
      * The returned sender begins in `creating`. An existing active state is
-     * rejected so unfinished work cannot be replaced. The returned sender
-     * retains its lock until close().
+     * rejected so unfinished work cannot be replaced.
      *
      * @param array $options {
      *     Push, push stream client, and local-file options.
@@ -239,17 +252,17 @@ final class PushFilesSender
      *     @type array                   $request_sizer_options    Optional PushRequestSizer bounds.
      * }
      * @phpstan-param array<string,mixed> $options
+     * @param ReprintProcessLock $process_lock Lock for the containing state directory.
      * @return self Open sender at its initial durable state.
      */
-    public static function start(array $options): self
+    public static function start(array $options, ReprintProcessLock $process_lock): self
     {
-        $sender = new self($options);
+        $sender = new self($options, $process_lock);
         if (!is_dir($sender->push_state_directory) && !@mkdir($sender->push_state_directory, 0755, true) && !is_dir($sender->push_state_directory)) {
             throw new RuntimeException(
                 'Failed to create the local push state directory: ' . $sender->push_state_directory
             );
         }
-        $sender->lock_handle = $sender->acquire_lock();
         try {
             clearstatcache(true, $sender->state_path);
             if (is_file($sender->state_path)) {
@@ -276,25 +289,25 @@ final class PushFilesSender
     }
 
     /**
-     * Resumes an unfinished sender while holding its exclusive lifecycle lock.
+     * Resumes an unfinished sender while the caller holds the process lock.
      *
-     * The active state is read once under the acquired lock. next_step() then
+     * The active state is read once under the lock. next_step() then
      * works from that in-memory state, storing each later durable boundary
      * without reopening sender.json.
      *
      * @param array<string,mixed> $options Options documented by start().
+     * @param ReprintProcessLock  $process_lock Lock for the containing state directory.
      * @return self Open sender at its last durable state.
      */
-    public static function resume(array $options): self
+    public static function resume(array $options, ReprintProcessLock $process_lock): self
     {
-        $sender = new self($options);
+        $sender = new self($options, $process_lock);
         if (!is_dir($sender->push_state_directory)) {
             throw new LogicException(
                 'Cannot resume a push files sender without unfinished active state: '
                 . $sender->state_path
             );
         }
-        $sender->lock_handle = $sender->acquire_lock();
         try {
             $state = $sender->load_state();
             if ($state === null) {
@@ -319,10 +332,11 @@ final class PushFilesSender
      * Configures the paths and push stream client options shared by start() and resume().
      *
      * @param array<string,mixed> $options Options documented by start().
+     * @param ReprintProcessLock  $process_lock Lock for the containing state directory.
      *
      * @throws InvalidArgumentException If local path or push stream client options are invalid.
      */
-    private function __construct(array $options)
+    private function __construct(array $options, ReprintProcessLock $process_lock)
     {
         $docroot = $options['docroot'] ?? null;
         $push_state_directory = $options['push_state_directory'] ?? null;
@@ -331,6 +345,9 @@ final class PushFilesSender
         }
         if (!is_string($push_state_directory) || $push_state_directory === '') {
             throw new InvalidArgumentException('PushFilesSender requires a push_state_directory.');
+        }
+        if (!$process_lock->is_held()) {
+            throw new InvalidArgumentException('PushFilesSender requires a held Reprint process lock.');
         }
         $request_sizer_options = $options['request_sizer_options'] ?? [];
         if (!is_array($request_sizer_options)) {
@@ -353,11 +370,11 @@ final class PushFilesSender
             throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
         }
         $this->docroot = rtrim($canonical_docroot, '/');
+        $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
         $this->previous_local_index = $this->push_state_directory . '/previous_local_index.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
-        $this->lock_path = $this->push_state_directory . '/sender.lock';
         $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
@@ -366,7 +383,7 @@ final class PushFilesSender
     /**
      * Performs the next step for the current phase.
      *
-     * start() or resume() has already acquired the lifecycle lock and loaded the
+     * start() or resume() has received the caller's process lock and loaded the
      * durable state, so this method only dispatches its current phase. Every
      * phase step is bounded except the deliberate completed-index copy described
      * in the class documentation. A caller stopping after this method returns
@@ -382,7 +399,7 @@ final class PushFilesSender
         if ($this->status !== 'continue') {
             return false;
         }
-        if (!is_resource($this->lock_handle)) {
+        if ($this->closed || !$this->process_lock->is_held()) {
             throw new LogicException('Cannot call next_step() after close().');
         }
 
@@ -497,7 +514,7 @@ final class PushFilesSender
     }
 
     /**
-     * Releases open resources and the lifecycle lock without finishing a request.
+     * Releases sender resources without finishing a request.
      *
      * The caller uses cancel() first when stopping with an open multipart
      * request. Durable state remains available to resume unless next_step()
@@ -516,10 +533,7 @@ final class PushFilesSender
         }
         $this->upload_request_stage = 'closed';
         $this->state_before_upload_request = null;
-        if (is_resource($this->lock_handle)) {
-            $this->release_lock($this->lock_handle);
-        }
-        $this->lock_handle = null;
+        $this->closed = true;
     }
 
     /**
@@ -576,13 +590,35 @@ final class PushFilesSender
 
     /**
      * Creates PushPlan and stores its initial cursor with the planning phase.
+     *
+     * A pull may replace the pair's previous local index between sender
+     * processes, so the plan never reads that file directly. The Reprint
+     * process lock prevents another command from replacing it while this step
+     * copies it into the plan. Repeating `starting_plan` refreshes a snapshot
+     * whose cursor was not stored.
      */
     private function start_plan(): void
     {
+        $plan_previous_local_index = $this->plan_directory . '/previous_local_index.jsonl';
+        clearstatcache(true, $this->previous_local_index);
+        if (is_file($this->previous_local_index)) {
+            $this->copy_through_swap_file(
+                $this->previous_local_index,
+                $plan_previous_local_index
+            );
+        } elseif (
+            is_file($plan_previous_local_index)
+            && !unlink($plan_previous_local_index)
+        ) {
+            throw new RuntimeException(
+                'Failed to remove the stale plan-owned previous local index: '
+                . $plan_previous_local_index . '.'
+            );
+        }
         $this->plan = PushPlan::start(
             $this->plan_directory,
             $this->docroot,
-            $this->previous_local_index,
+            $plan_previous_local_index,
             $this->excluded_paths_path
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
@@ -1183,20 +1219,62 @@ final class PushFilesSender
     }
 
     /**
-     * Saves the committed fresh local index as the pair's previous local index.
+     * Publishes committed paths or the first complete fresh local index.
      *
-     * If the process stops before the next phase is stored, repeating the
-     * deliberate whole-index copy is safe and leaves readers on either the old
-     * or complete new index.
+     * If a pull advanced another path between sender processes, merging into
+     * the latest index preserves it. Repeating this merge after interruption is
+     * idempotent. If an incompatible pull removed a baseline which the plan
+     * used, leaving it absent is safer than publishing only the planned paths.
      */
     private function save_previous_local_index(): void
     {
-        $fresh_local_index = $this->plan->get_fresh_local_index_path();
+        $plan_previous_local_index =
+            $this->plan_directory . '/previous_local_index.jsonl';
+        if (
+            is_file($plan_previous_local_index)
+            && !is_file($this->previous_local_index)
+        ) {
+            $this->state['push_plan_cursor'] = null;
+            $this->state['phase'] = 'completing';
+            $this->store_state($this->state);
+            return;
+        }
         try {
-            $this->copy_through_swap_file(
-                $fresh_local_index,
-                $this->previous_local_index
+            if (
+                !is_file($plan_previous_local_index)
+                && !is_file($this->previous_local_index)
+            ) {
+                $this->copy_through_swap_file(
+                    $this->plan->get_fresh_local_index_path(),
+                    $this->previous_local_index
+                );
+                $this->state['push_plan_cursor'] = null;
+                $this->state['phase'] = 'completing';
+                $this->store_state($this->state);
+                return;
+            }
+            $updates_path =
+                $this->plan_directory . '/previous_local_index_updates.jsonl';
+            $this->write_committed_previous_local_index_updates($updates_path);
+            $updated_previous_local_index =
+                $this->previous_local_index . '.swap';
+            merge_previous_local_index_updates(
+                $this->previous_local_index,
+                $updates_path,
+                $updated_previous_local_index,
+                $this->plan_directory
             );
+            if (
+                !@rename(
+                    $updated_previous_local_index,
+                    $this->previous_local_index
+                )
+            ) {
+                throw new RuntimeException(
+                    'Failed to publish the updated previous local index: '
+                    . $this->previous_local_index . '.'
+                );
+            }
         } catch (RuntimeException $exception) {
             $this->fail('local_io_error', $exception->getMessage());
             return;
@@ -1204,6 +1282,114 @@ final class PushFilesSender
         $this->state['push_plan_cursor'] = null;
         $this->state['phase'] = 'completing';
         $this->store_state($this->state);
+    }
+
+    /**
+     * Writes F/D updates for committed paths.
+     *
+     * Deletions precede F entries so a same-path replacement retains the
+     * subtree removal while ending with the planned type, size, and ctime.
+     * Directory ctime and size do not select push work, so structural ancestor
+     * entries use zero values and the merger derives their empty state.
+     */
+    private function write_committed_previous_local_index_updates(
+        string $updates_path
+    ): void {
+        $updates_handle = fopen($updates_path, 'wb');
+        if (!is_resource($updates_handle)) {
+            throw new RuntimeException(
+                'Failed to open the previous-local-index updates.'
+            );
+        }
+        try {
+            $position = 0;
+            $write_update = static function (array $update) use (
+                $updates_handle,
+                &$position
+            ): void {
+                $update['position'] = $position;
+                ++$position;
+                $line = json_encode(
+                    $update,
+                    JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                ) . "\n";
+                if (fwrite($updates_handle, $line) !== strlen($line)) {
+                    throw new RuntimeException(
+                        'Failed to write a previous-local-index update.'
+                    );
+                }
+            };
+            $write_ancestor_updates = static function (
+                string $local_path
+            ) use ($write_update): void {
+                while (true) {
+                    $separator = strrpos($local_path, '/');
+                    if ($separator === false) {
+                        return;
+                    }
+                    $local_path = substr($local_path, 0, $separator);
+                    $write_update([
+                        'op' => 'F',
+                        'path' => base64_encode($local_path),
+                        'ctime' => 0,
+                        'size' => 0,
+                        'type' => 'dir',
+                        'replace_subtree' => false,
+                    ]);
+                }
+            };
+
+            foreach (
+                $this->plan->read_planned_local_paths_to_delete()
+                as $local_path_to_delete
+            ) {
+                $write_update([
+                    'op' => 'D',
+                    'path' => base64_encode($local_path_to_delete),
+                    'replace_subtree' => true,
+                ]);
+            }
+
+            $index_type_by_local_path_type = [
+                'file' => 'file',
+                'directory' => 'dir',
+                'symlink' => 'link',
+            ];
+            foreach (
+                $this->plan->read_planned_local_paths_to_push()
+                as $local_path_to_push
+            ) {
+                $local_path = base64_decode(
+                    $local_path_to_push['path'],
+                    true
+                );
+                if ($local_path === false) {
+                    throw new RuntimeException(
+                        'Failed to decode a path in the local paths-to-push file.'
+                    );
+                }
+                $write_update([
+                    'op' => 'F',
+                    'path' => $local_path_to_push['path'],
+                    'ctime' => $local_path_to_push['ctime'],
+                    'size' => $local_path_to_push['size'],
+                    'type' => $index_type_by_local_path_type[
+                        $local_path_to_push['type']
+                    ],
+                    'replace_subtree' =>
+                        $local_path_to_push['type'] !== 'directory',
+                ]);
+                $write_ancestor_updates($local_path);
+            }
+
+            if (!fflush($updates_handle)) {
+                throw new RuntimeException(
+                    'Failed to flush the previous-local-index updates.'
+                );
+            }
+        } finally {
+            fclose($updates_handle);
+        }
     }
 
     /**
@@ -1571,38 +1757,6 @@ final class PushFilesSender
         if (is_file($this->state_path) && !unlink($this->state_path)) {
             throw new RuntimeException('Failed to remove active state: ' . $this->state_path);
         }
-    }
-
-    /**
-     * Acquires non-blocking exclusive ownership of one lifecycle.
-     *
-     * @return resource Open locked handle retained until close().
-     */
-    private function acquire_lock()
-    {
-        $lock_handle = fopen($this->lock_path, 'c+');
-        if (!is_resource($lock_handle)) {
-            throw new RuntimeException('Failed to open the lifecycle lock: ' . $this->lock_path);
-        }
-        if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
-            fclose($lock_handle);
-            throw new RuntimeException(
-                'Cannot start or resume this push files sender while another process holds its lock: '
-                . $this->lock_path
-            );
-        }
-        return $lock_handle;
-    }
-
-    /**
-     * Releases and closes a lock returned by acquire_lock().
-     *
-     * @param resource $lock_handle Open locked handle.
-     */
-    private function release_lock($lock_handle): void
-    {
-        flock($lock_handle, LOCK_UN);
-        fclose($lock_handle);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordPress\Reprint\Exporter\compare_paths;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
 /**
@@ -27,10 +29,10 @@
  * ## Change detection
  *
  * ctime is machine-local, so the previous local index must describe the same
- * local machine: PushFilesSender supplies the index saved after the previous
- * push, and files-diff supplies the index captured after the previous pull.
- * File and symlink changes are determined by type, ctime, and size. Directory
- * changes use the indexer's empty-directory marker; non-empty directories are
+ * local machine. Compatible pulls and committed pushes advance that shared
+ * index; PushFilesSender and files-diff each supply it to the plan. File and
+ * symlink changes are determined by type, ctime, and size. Directory changes
+ * use the indexer's empty-directory marker; non-empty directories are
  * represented by their descendants.
  *
  * With no previous local index, every file, symlink, and empty directory is
@@ -194,9 +196,7 @@ class PushPlan
         );
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
-        if ($position["phase"] !== "complete") {
-            $plan->excluded_paths = $plan->load_excluded_paths();
-        }
+        $plan->excluded_paths = $plan->load_excluded_paths();
         if ($position["phase"] === "indexing") {
             $plan->open_fresh_local_index_for_continuation();
         } elseif ($position["phase"] === "diffing") {
@@ -229,6 +229,64 @@ class PushPlan
     public function get_local_paths_to_delete_path(): string
     {
         return $this->local_paths_to_delete;
+    }
+
+    /**
+     * Reads the completed local paths-to-push list.
+     *
+     * @return Generator Completed plan entries.
+     * @phpstan-return Generator<int,array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int},mixed,void>
+     */
+    public function read_planned_local_paths_to_push(): Generator
+    {
+        $local_paths_to_push_handle = fopen($this->local_paths_to_push, 'rb');
+        if (!is_resource($local_paths_to_push_handle)) {
+            throw new RuntimeException('Failed to open the completed local paths-to-push list.');
+        }
+        try {
+            while (true) {
+                $line = fgets($local_paths_to_push_handle);
+                if ($line === false) {
+                    if (!feof($local_paths_to_push_handle)) {
+                        throw new RuntimeException('Failed to read the completed local paths-to-push list.');
+                    }
+                    return;
+                }
+                /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $entry */
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                yield $entry;
+            }
+        } finally {
+            fclose($local_paths_to_push_handle);
+        }
+    }
+
+    /**
+     * Reads the completed local paths-to-delete list.
+     *
+     * @return Generator Completed local paths to delete.
+     * @phpstan-return Generator<int,string,mixed,void>
+     */
+    public function read_planned_local_paths_to_delete(): Generator
+    {
+        $local_paths_to_delete_handle = fopen($this->local_paths_to_delete, 'rb');
+        if (!is_resource($local_paths_to_delete_handle)) {
+            throw new RuntimeException('Failed to open the completed local paths-to-delete list.');
+        }
+        try {
+            while (true) {
+                $local_path_to_delete = stream_get_line($local_paths_to_delete_handle, 1048576, "\0");
+                if ($local_path_to_delete === false) {
+                    if (!feof($local_paths_to_delete_handle)) {
+                        throw new RuntimeException('Failed to read the completed local paths-to-delete list.');
+                    }
+                    return;
+                }
+                yield $local_path_to_delete;
+            }
+        } finally {
+            fclose($local_paths_to_delete_handle);
+        }
     }
 
     /**
@@ -536,13 +594,16 @@ class PushPlan
         if ($entry_fresh_index !== null || $entry_previous_local_index !== null) {
             // Base64 does not preserve byte order ('0' sorts before 'A'
             // in ASCII but encodes a higher value), so ordering uses the
-            // decoded path bytes.
+            // decoded filesystem path components.
             if ($entry_previous_local_index === null) {
                 $path_comparison = -1;
             } elseif ($entry_fresh_index === null) {
                 $path_comparison = 1;
             } else {
-                $path_comparison = strcmp($entry_fresh_index["path"], $entry_previous_local_index["path"]);
+                $path_comparison = compare_paths(
+                    $entry_fresh_index["path"],
+                    $entry_previous_local_index["path"]
+                );
             }
 
             $current_shape = null;
@@ -554,21 +615,15 @@ class PushPlan
             if ($path_comparison >= 0) {
                 $previous_local_index_shape = $this->entry_shape($entry_previous_local_index);
 
-                // Byte sorting can put a sibling such as `a-other` before
-                // `a/child`. Every retained non-empty directory has a later
-                // descendant, so adjacent previous-index entries can pass at
-                // most the top sibling range.
-                if ($this->deleted_directory_stack_entry !== null) {
+                while ($this->deleted_directory_stack_entry !== null) {
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
-                    if (
-                        strpos($entry_previous_local_index["path"], $descendant_prefix) !== 0
-                        && strcmp($entry_previous_local_index["path"], $descendant_prefix) > 0
-                    ) {
-                        $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
-                        $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
-                            $deleted_directory_stack_top_byte_offset
-                        );
+                    if (strpos($entry_previous_local_index["path"], $descendant_prefix) === 0) {
+                        break;
                     }
+                    $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
+                    $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
+                        $deleted_directory_stack_top_byte_offset
+                    );
                 }
             }
 

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -63,6 +63,12 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('previous local index', $output);
         $this->assertStringContainsString('completed files-push', $output);
+        $this->assertStringContainsString('compatible file-only', $output);
+        $this->assertStringContainsString('files-pull or pull-files', $output);
+        $this->assertStringContainsString('maintains that index after each durable WAL batch', $output);
+        $this->assertStringContainsString('default path mapping', $output);
+        $this->assertStringContainsString('overwrite behavior', $output);
+        $this->assertStringContainsString('same files-pull with --abort', $output);
         $this->assertStringContainsString('push operation plan', $output);
         $this->assertStringContainsString('default-skipped paths', $output);
         $this->assertStringContainsString('No network calls', $output);

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -251,7 +251,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         ]);
 
         [$client, $reflection] = $this->prepareClient(
-            InterruptedAfterStreamedPartCloseClient::class,
+            InterruptedStreamedPartClient::class,
         );
 
         $downloadFilesFetch = $reflection->getMethod('download_file_fetch');
@@ -288,6 +288,49 @@ class CurlTimeoutRecoveryTest extends TestCase
             $savedCursorBytes,
             'A hard-crash checkpoint must not put the saved cursor behind the bytes retained on disk',
         );
+    }
+
+    public function testFileFetchTimeoutKeepsThePreviousPartBoundary()
+    {
+        $trackedPath = $this->fs_root . '/uploads/large.bin';
+        mkdir(dirname($trackedPath), 0755, true);
+        file_put_contents($trackedPath, str_repeat('a', 256));
+
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
+            "fetch" => [
+                "offset" => 0,
+                "next_offset" => 100,
+                "batch_file" => null,
+                "cursor" => self::fileCursorForBytes(256),
+            ],
+            "current_file" => $trackedPath,
+            "current_file_bytes" => 256,
+        ]);
+
+        [$client, $reflection] = $this->prepareClient(
+            InterruptedStreamedPartClient::class,
+        );
+        $downloadFilesFetch = $reflection->getMethod('download_file_fetch');
+
+        $this->assertFalse($downloadFilesFetch->invoke(
+            $client,
+            ["timeout_during_part" => true],
+            self::fileCursorForBytes(256),
+            "fetch",
+        ));
+
+        $state = $this->readState();
+        $this->assertSame(
+            256,
+            self::fileCursorBytes($state["fetch"]["cursor"] ?? null),
+        );
+        $this->assertSame(256, $state["current_file_bytes"] ?? null);
+        $this->assertSame(384, filesize($trackedPath));
     }
 
     // ---------------------------------------------------------------
@@ -626,11 +669,9 @@ class TimeoutTestClient extends \ImportClient
 }
 
 /**
- * Test double that simulates a process dying immediately after a streamed
- * file part-complete checkpoint. This is a hard crash, so download_file_fetch()
- * must not get a chance to do its normal final save.
+ * Test double that interrupts a streamed file part before or after its close.
  */
-class InterruptedAfterStreamedPartCloseClient extends \ImportClient
+class InterruptedStreamedPartClient extends \ImportClient
 {
     protected function fetch_streaming(
         string $url,
@@ -651,11 +692,17 @@ class InterruptedAfterStreamedPartCloseClient extends \ImportClient
             "x-last-chunk" => "0",
         ];
 
+        $timeout_during_part = !empty($post_data["timeout_during_part"]);
         ($context->on_chunk)([
             "headers" => $headers,
-            "body" => str_repeat('b', 256),
+            "body" => str_repeat('b', $timeout_during_part ? 128 : 256),
             "is_streaming_body" => true,
         ]);
+        if ($timeout_during_part) {
+            throw new \CurlTimeoutException(
+                "cURL error: Operation timed out while receiving a streamed file part"
+            );
+        }
         ($context->on_chunk)([
             "headers" => $headers,
             "body" => "",

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -324,6 +324,10 @@ class CurlTimeoutRecoveryTest extends TestCase
             "fetch",
         ));
 
+        // The timeout leaves half of the next 256-byte part on disk after its
+        // 512-byte cursor was advertised. Both saved boundaries must remain at
+        // the previous completed part so resume truncates the extra 128 bytes
+        // before replaying that part instead of skipping unconfirmed bytes.
         $state = $this->readState();
         $this->assertSame(
             256,

--- a/tests/Import/FailedFlushStreamWrapper.php
+++ b/tests/Import/FailedFlushStreamWrapper.php
@@ -1,0 +1,32 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+final class FailedFlushStreamWrapper
+{
+    /** @var resource|null */
+    public $context;
+
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required stream wrapper signature.
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath
+    ): bool {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return strlen($data);
+    }
+
+    public function stream_flush(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Import/FilesPullPreviousLocalIndexTest.php
+++ b/tests/Import/FilesPullPreviousLocalIndexTest.php
@@ -1,0 +1,1446 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * The pull side of the pair's previous local index.
+ *
+ * A compatible file-only pull seeds the index before changing the local tree.
+ * Each applied WAL batch advances only the paths the pull changed, keeping
+ * unrelated local changes pending for files-diff and files-push. The WAL
+ * remains as a marker until the pull completes. Incompatible pulls, pipelines
+ * that keep changing the tree, and aborts with an unfinished WAL remove the
+ * index instead. These tests run real pulls against a local index server and
+ * read the result through the files-diff CLI.
+ */
+final class FilesPullPreviousLocalIndexTest extends TestCase
+{
+    private const REMOTE_CTIME = 41;
+    private const PULLED_PATH = 'selected/written-by-files-pull.txt';
+    private const PULLED_CONTENTS = 'contents delivered by the real file_fetch endpoint';
+
+    private string $root;
+    private string $stateDirectory;
+    private string $rawFileRoot;
+    private string $localTree;
+    private string $targetUrl;
+    private string $requestsLog;
+    private ?string $invalidBytePathAtPreviousPull = null;
+
+    /** @var resource|null */
+    private $serverProcess = null;
+
+    /** @var array<int,resource> */
+    private array $serverPipes = [];
+
+    /** @var array<string,string> */
+    private array $initialFiles = [
+        'deleted.txt' => 'delete me',
+        'edited.txt' => 'old',
+        'pending-directory/child.txt' => 'pending directory child',
+        'shared/remote-deleted.txt' => 'remote deleted child',
+        'swap' => 'file before the type change',
+        'unchanged.txt' => 'same',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/files-diff-command-' . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->rawFileRoot = $this->root . '/files';
+        $this->localTree = $this->rawFileRoot . '/var/www/html';
+        $this->requestsLog = $this->root . '/requests.jsonl';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->localTree, 0700, true);
+
+        $invalidBytePathAtPreviousPull = "delete-invalid-\xff.txt";
+        if (@file_put_contents($this->localTree . '/' . $invalidBytePathAtPreviousPull, 'invalid path bytes') !== false) {
+            $this->initialFiles[$invalidBytePathAtPreviousPull] = 'invalid path bytes';
+            $this->invalidBytePathAtPreviousPull = $invalidBytePathAtPreviousPull;
+        }
+        foreach ($this->initialFiles as $path => $contents) {
+            $directory = dirname($this->localTree . '/' . $path);
+            if (!is_dir($directory)) {
+                mkdir($directory, 0700, true);
+            }
+            file_put_contents($this->localTree . '/' . $path, $contents);
+        }
+
+        $this->writePullStateAndIndex();
+        $this->targetUrl = $this->startIndexServer();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+        }
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testEligiblePullSeedsAndAdvancesThePreviousLocalIndex(): void
+    {
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME,
+            'require_previous_local_index_before_fetch' => true,
+        ]);
+        $this->completeEligiblePull();
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+
+        $this->assertFileExists($previousLocalIndex);
+        $this->assertSame(
+            self::PULLED_CONTENTS,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH),
+            'files-pull must record the local metadata written by the real file_fetch endpoint.'
+        );
+
+        $index = $this->readIndex($previousLocalIndex);
+        $expectedPaths = array_merge(
+            array_keys($this->initialFiles),
+            ['pending-directory', 'selected', 'shared', self::PULLED_PATH]
+        );
+        usort($expectedPaths, static function (string $leftPath, string $rightPath): int {
+            return strcmp(
+                str_replace('/', "\0", $leftPath),
+                str_replace('/', "\0", $rightPath)
+            );
+        });
+        $this->assertSame($expectedPaths, array_keys($index));
+        $editedStat = lstat($this->localTree . '/edited.txt');
+        $this->assertIsArray($editedStat);
+        $this->assertSame( (int) $editedStat['ctime'], $index['edited.txt']['ctime']);
+        $this->assertSame(strlen($this->initialFiles['edited.txt']), $index['edited.txt']['size']);
+        $this->assertNotSame(self::REMOTE_CTIME, $index['edited.txt']['ctime']);
+    }
+
+    public function testEmptyInitialPullPublishesAnEmptyPreviousLocalIndex(): void
+    {
+        unlink($this->stateDirectory . '/.import-index.jsonl');
+        foreach (scandir($this->rawFileRoot) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($this->rawFileRoot . '/' . $entry);
+            }
+        }
+        $this->writeRemoteOverrides([
+            'empty_index' => true,
+        ]);
+
+        $result = $this->runFilesPull();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertDirectoryExists($this->localTree);
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->assertFileExists($previousLocalIndex);
+        $this->assertSame('', file_get_contents($previousLocalIndex));
+
+        $diff = $this->runFilesDiff();
+
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testInitialIndexOrdersAnAncestorBeforeAnEarlyByteChildName(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_paths' => ['punctuation/!child.txt'],
+        ]);
+
+        $this->completeEligiblePull();
+
+        $index = $this->readIndex(
+            $this->pushStateDirectory() . '/previous_local_index.jsonl'
+        );
+        $paths = array_keys($index);
+        $this->assertLessThan(
+            array_search('punctuation/!child.txt', $paths, true),
+            array_search('punctuation', $paths, true)
+        );
+        $this->assertFalse($index['punctuation']['empty'] ?? true);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testCorruptedWALDoesNotAdvanceTheFetchCursorPastItsPathRecord(): void
+    {
+        $this->completeEligiblePull();
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $newPulledContents = 'remote change before a WAL write failure';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+            'make_wal_unwritable' => true,
+        ]);
+
+        $failed = $this->runFilesPull();
+
+        $this->assertSame(1, $failed['exit'], $failed['output']);
+        $this->assertSame(
+            $newPulledContents,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+        $state = json_decode(
+            (string) file_get_contents($this->stateDirectory . '/.import-state.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertNull($state['fetch']['cursor'] ?? null);
+
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        chmod($walPath, 0600);
+        unlink($walPath);
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+        ]);
+        $resumed = $this->runFilesPull();
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testFilesPullReplaysARetainedWALIntoBothIndexesBeforeResuming(): void
+    {
+        $newPulledContents = 'remote change retained before the import-index merge';
+        $this->corruptImportIndexOutputAfterFilesPullWritesWAL($newPulledContents);
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->assertFileExists($walPath);
+        $this->assertFileExists($previousLocalIndex);
+
+        $blockedDiff = $this->runFilesDiff();
+        $this->assertSame(1, $blockedDiff['exit'], $blockedDiff['output']);
+        $this->assertStringContainsString(
+            'Finish or abort the interrupted files-pull',
+            $blockedDiff['output']
+        );
+        $this->assertFileExists($walPath);
+
+        $resumed = $this->runFilesPull();
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $index = $this->readIndex($this->stateDirectory . '/.import-index.jsonl');
+        $this->assertSame(
+            self::REMOTE_CTIME + 1,
+            $index['/var/www/html/' . self::PULLED_PATH]['ctime'] ?? null
+        );
+        $this->assertSame(
+            strlen($newPulledContents),
+            $index['/var/www/html/' . self::PULLED_PATH]['size'] ?? null
+        );
+        $localStat = lstat($this->localTree . '/' . self::PULLED_PATH);
+        $this->assertIsArray($localStat);
+        $previousIndex = $this->readIndex($previousLocalIndex);
+        $this->assertSame(
+            (int) $localStat['ctime'],
+            $previousIndex[self::PULLED_PATH]['ctime'] ?? null
+        );
+        $this->assertSame(
+            strlen($newPulledContents),
+            $previousIndex[self::PULLED_PATH]['size'] ?? null
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testInterruptedPullKeepsTheWALMarkerUntilResume(): void
+    {
+        $this->completeEligiblePull();
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $newPulledContents = str_repeat('interrupted remote contents ', 4096);
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+            'pause_mid_file' => true,
+        ]);
+        [$process, $pipes] = $this->startCliProcess([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+        $readyPath = $this->root . '/remote-overrides.json.pause-ready';
+        $deadline = microtime(true) + 10;
+        while (!is_file($readyPath) && microtime(true) < $deadline) {
+            usleep(20000);
+        }
+        $this->assertFileExists($readyPath);
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $this->assertFileExists($walPath);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(1, $diff['exit'], $diff['output']);
+        $this->assertStringContainsString(
+            'Finish or abort the interrupted files-pull',
+            $diff['output']
+        );
+
+        file_put_contents(
+            $this->root . '/remote-overrides.json.pause-release',
+            ''
+        );
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+        ]);
+        $resumed = $this->runFilesPull();
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $this->assertSame(
+            $newPulledContents,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+    }
+
+    public function testUnrelatedCommandShutdownDoesNotConsumeTheFilesPullWAL(): void
+    {
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $walContents = json_encode([
+            'op' => 'F',
+            'path' => base64_encode('/var/www/html/retained.txt'),
+            'ctime' => 17,
+            'size' => 8,
+            'type' => 'file',
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        file_put_contents($walPath, $walContents);
+        $script = $this->root . '/unrelated-command-shutdown.php';
+        file_put_contents(
+            $script,
+            "<?php\n"
+            . 'require ' . var_export(
+                realpath(__DIR__ . '/../../packages/reprint-importer/src/import.php'),
+                true
+            ) . ";\n"
+            . '$client = new ImportClient('
+            . var_export($this->targetUrl, true) . ', '
+            . var_export($this->stateDirectory, true) . ', '
+            . var_export($this->rawFileRoot, true) . ", 'db-pull');\n"
+            . "\$client->handle_shutdown(SIGTERM);\n"
+        );
+
+        $process = proc_open(
+            [PHP_BINARY, $script],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        stream_get_contents($pipes[1]);
+        stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        $this->assertSame($walContents, file_get_contents($walPath));
+    }
+
+    public function testAbortReplaysARetainedWALThenInvalidatesTheBaseline(): void
+    {
+        $newPulledContents = 'remote change retained before abort';
+        $this->corruptImportIndexOutputAfterFilesPullWritesWAL($newPulledContents);
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->assertFileExists($walPath);
+        $this->assertFileExists($previousLocalIndex);
+
+        $abort = $this->runFilesPull(['--abort']);
+
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $index = $this->readIndex($this->stateDirectory . '/.import-index.jsonl');
+        $this->assertSame(
+            self::REMOTE_CTIME + 1,
+            $index['/var/www/html/' . self::PULLED_PATH]['ctime'] ?? null
+        );
+        $this->assertSame(
+            strlen($newPulledContents),
+            $index['/var/www/html/' . self::PULLED_PATH]['size'] ?? null
+        );
+        $this->assertFileDoesNotExist($previousLocalIndex);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(1, $diff['exit'], $diff['output']);
+        $this->assertStringContainsString(
+            'files-diff requires a fresh completed files-pull',
+            $diff['output']
+        );
+    }
+
+    public function testPullFilesAbortWithABareUrlReplaysItsWAL(): void
+    {
+        $this->corruptImportIndexOutputAfterFilesPullWritesWAL(
+            'remote change retained before a bare-URL abort'
+        );
+        $bareTargetUrl = substr($this->targetUrl, 0, -strlen('?site-export-api'));
+
+        $abort = $this->runCli([
+            'pull-files',
+            $bareTargetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+            '--abort',
+        ]);
+
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertFileDoesNotExist(
+            $this->stateDirectory . '/.import-index-updates.wal'
+        );
+    }
+
+    public function testEligiblePullDoesNotAdmitAnUntrackedUnsupportedPath(): void
+    {
+        if (!function_exists('posix_mkfifo')) {
+            $this->markTestSkipped('This PHP build does not provide posix_mkfifo().');
+        }
+        $fifoPath = $this->localTree . '/local.pipe';
+        if (!@posix_mkfifo($fifoPath, 0600)) {
+            $this->markTestSkipped('This filesystem does not support a local FIFO test path.');
+        }
+
+        try {
+            $result = $this->runFilesPull();
+
+            $this->assertSame(0, $result['exit'], $result['output']);
+            $this->assertFileExists($this->pushStateDirectory() . '/previous_local_index.jsonl');
+            $this->assertArrayNotHasKey(
+                'local.pipe',
+                $this->readIndex($this->pushStateDirectory() . '/previous_local_index.jsonl')
+            );
+            $this->assertDirectoryDoesNotExist(
+                $this->pushStateDirectory() . '/files-diff-plan'
+            );
+        } finally {
+            @unlink($fifoPath);
+        }
+    }
+
+    public function testPullFilesMaintainsThePreviousLocalIndex(): void
+    {
+        $result = $this->runCli([
+            'pull-files',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame(self::PULLED_CONTENTS, file_get_contents($this->localTree . '/' . self::PULLED_PATH));
+        $this->assertFileExists(
+            $this->pushStateDirectory() . '/previous_local_index.jsonl'
+        );
+    }
+
+    public function testPullFilesWithABareSiteUrlEstablishesTheNormalizedFilesDiffPair(): void
+    {
+        $bareTargetUrl = substr($this->targetUrl, 0, -strlen('?site-export-api'));
+
+        $pullResult = $this->runCli([
+            'pull-files',
+            $bareTargetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+        $diffResult = $this->runFilesDiff();
+
+        $this->assertSame(0, $pullResult['exit'], $pullResult['output']);
+        $this->assertSame(0, $diffResult['exit'], $diffResult['output']);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ], $this->filesDiffRecords($diffResult['stdout'])[0] ?? null);
+    }
+
+    public function testPullInvalidatesAndDoesNotRecreateThePreviousLocalIndex(): void
+    {
+        $this->completeEligiblePull();
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->assertFileExists($previousLocalIndex);
+
+        $arguments = [
+            'pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+            '--runtime=none',
+        ];
+
+        $result = $this->runCli($arguments);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame(self::PULLED_CONTENTS, file_get_contents($this->localTree . '/' . self::PULLED_PATH));
+        $this->assertFileDoesNotExist($previousLocalIndex);
+    }
+
+    /** @dataProvider incompatibleFilesPullOptionsProvider
+     *  @param list<string> $incompatibleOptions
+     */
+    public function testIncompatibleFilesPullDoesNotPublishAPreviousLocalIndex(array $incompatibleOptions): void
+    {
+        $result = $this->runFilesPull($incompatibleOptions);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertFileDoesNotExist($this->pushStateDirectory() . '/previous_local_index.jsonl');
+    }
+
+    public function testPartialPullDoesNotSeedAMissingPreviousLocalIndex(): void
+    {
+        file_put_contents(
+            $this->localTree . '/edited.txt',
+            'an edit outside the selected pull'
+        );
+
+        $result = $this->runFilesPull([
+            '--only=/var/www/html/selected',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame(
+            'an edit outside the selected pull',
+            file_get_contents($this->localTree . '/edited.txt')
+        );
+        $this->assertFileDoesNotExist(
+            $this->pushStateDirectory() . '/previous_local_index.jsonl'
+        );
+    }
+
+    /** @dataProvider incompatibleFilesPullOptionsProvider
+     *  @param list<string> $incompatibleOptions
+     */
+    public function testIncompatibleFilesPullInvalidatesThePreviousLocalIndex(array $incompatibleOptions): void
+    {
+        $this->completeEligiblePull();
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->assertFileExists($previousLocalIndex);
+
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertFileExists($previousLocalIndex);
+        $result = $this->runFilesPull($incompatibleOptions);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertFileDoesNotExist($previousLocalIndex);
+    }
+
+    public function testIncompatibleFilesPullInvalidatesAfterTheLocalTreeWasDeleted(): void
+    {
+        $this->completeEligiblePull();
+        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->removeTree($this->localTree);
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertFileExists($previousLocalIndex);
+
+        $result = $this->runFilesPull([
+            '--filter=essential-files',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertFileDoesNotExist($previousLocalIndex);
+    }
+
+    /** @return iterable<string,array{list<string>}> */
+    public static function incompatibleFilesPullOptionsProvider(): iterable
+    {
+        yield 'filtered' => [['--filter=essential-files']];
+        yield 'preserve local' => [['--on-fs-root-nonempty=preserve-local']];
+    }
+
+    public function testRemappedFilesPullDoesNotPublishAPreviousLocalIndex(): void
+    {
+        $this->removeTree($this->rawFileRoot);
+        mkdir($this->rawFileRoot, 0700, true);
+        unlink($this->stateDirectory . '/.import-index.jsonl');
+
+        $result = $this->runFilesPull([
+            '--remap',
+            '/var/www/html',
+            ':fs-root:/var/www/html',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertFileDoesNotExist($this->pushStateDirectory() . '/previous_local_index.jsonl');
+    }
+
+    public function testFilesDiffIsLocalAndReportsAnEmptyDiffImmediatelyAfterPull(): void
+    {
+        $this->completeEligiblePull();
+        $requestCountBeforeDiff = $this->requestCount();
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame($requestCountBeforeDiff, $this->requestCount());
+        $expectedRecord = [
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ];
+        $this->assertSame($this->encodeJsonLine($expectedRecord), $result['stdout']);
+        $this->assertSame('', $result['stderr']);
+    }
+
+    public function testFilesDiffGuidanceNamesTheCompatiblePullRequirements(): void
+    {
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stdout']);
+        $this->assertCanonicalSingleJsonLine($result['stderr']);
+        $this->assertStringContainsString('completed files-pull or pull-files', $result['output']);
+        $this->assertStringContainsString('--filter=none', $result['output']);
+        $this->assertStringContainsString('completed files-push', $result['output']);
+        $this->assertStringContainsString(
+            'same target URL, state directory, and local tree',
+            $result['output']
+        );
+    }
+
+    public function testCompatibleDeltaPullKeepsUnpulledLocalChangesPending(): void
+    {
+        $this->completeEligiblePull();
+
+        // Local changes the delta pull must not absorb into the index.
+        file_put_contents($this->localTree . '/edited.txt', 'local edit with a longer size');
+        unlink($this->localTree . '/deleted.txt');
+        // Remote changes the delta pull must absorb: one changed file and one
+        // remote deletion applied to the local tree.
+        $newPulledContents = 'remote change delivered by the second pull';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+            'removed_paths' => ['unchanged.txt'],
+        ]);
+
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $delta = $this->runFilesPull();
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        $this->assertSame('local edit with a longer size', file_get_contents($this->localTree . '/edited.txt'));
+        $this->assertSame($newPulledContents, file_get_contents($this->localTree . '/' . self::PULLED_PATH));
+        $this->assertFileDoesNotExist($this->localTree . '/unchanged.txt');
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame('', $result['stderr']);
+        $records = $this->filesDiffRecords($result['stdout']);
+        $finalRecord = array_pop($records);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 1,
+            'local_paths_to_delete' => 1,
+        ], $finalRecord);
+        $this->assertSame([
+            $this->expectedPushRecord('edited.txt', 'file'),
+            [
+                'command' => 'files-diff',
+                'action' => 'delete',
+                'path_b64' => base64_encode('deleted.txt'),
+            ],
+        ], $records);
+    }
+
+    public function testSelectedDeltaPullKeepsChangesOutsideItsAppliedPathsPending(): void
+    {
+        $this->completeEligiblePull();
+
+        file_put_contents($this->localTree . '/edited.txt', 'local edit with a longer size');
+        unlink($this->localTree . '/deleted.txt');
+        $this->removeTree($this->localTree . '/pending-directory');
+        $newPulledContents = 'selected remote change';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+        ]);
+
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $delta = $this->runFilesPull([
+            '--only=/var/www/html/selected',
+        ]);
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        $this->assertSame(
+            $newPulledContents,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $records = $this->filesDiffRecords($result['stdout']);
+        $finalRecord = array_pop($records);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 1,
+            'local_paths_to_delete' => 2,
+        ], $finalRecord);
+        $this->assertSame([
+            $this->expectedPushRecord('edited.txt', 'file'),
+            [
+                'command' => 'files-diff',
+                'action' => 'delete',
+                'path_b64' => base64_encode('deleted.txt'),
+            ],
+            [
+                'command' => 'files-diff',
+                'action' => 'delete',
+                'path_b64' => base64_encode('pending-directory'),
+            ],
+        ], $records);
+    }
+
+    public function testSelectedDeltaPullPreservesPendingAdditionWhenPulledDeletionMakesParentEmpty(): void
+    {
+        $this->completeEligiblePull();
+
+        file_put_contents($this->localTree . '/shared/local-added.txt', 'local addition');
+        $this->writeRemoteOverrides([
+            'removed_paths' => ['shared/remote-deleted.txt'],
+        ]);
+
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $delta = $this->runFilesPull([
+            '--only=/var/www/html/shared',
+        ]);
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        $this->assertFileDoesNotExist($this->localTree . '/shared/remote-deleted.txt');
+        $this->assertFileExists($this->localTree . '/shared/local-added.txt');
+
+        $index = $this->readIndex(
+            $this->pushStateDirectory() . '/previous_local_index.jsonl'
+        );
+        $this->assertTrue($index['shared']['empty'] ?? false);
+        $this->assertArrayNotHasKey('shared/remote-deleted.txt', $index);
+        $this->assertArrayNotHasKey('shared/local-added.txt', $index);
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame([
+            $this->expectedPushRecord('shared/local-added.txt', 'file'),
+            [
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => 1,
+                'local_paths_to_delete' => 0,
+            ],
+        ], $this->filesDiffRecords($result['stdout']));
+    }
+
+    public function testDeltaPullRemovesACompleteRemoteSubtreeFromThePreviousLocalIndex(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_directories' => ['removed-tree'],
+            'added_paths' => ['removed-tree/child.txt'],
+        ]);
+        $this->completeEligiblePull();
+        $this->assertDirectoryExists($this->localTree . '/removed-tree');
+        $this->assertFileExists($this->localTree . '/removed-tree/child.txt');
+
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->writeRemoteOverrides([]);
+        $delta = $this->runFilesPull();
+
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        clearstatcache(true, $this->localTree . '/removed-tree');
+        $this->assertDirectoryDoesNotExist($this->localTree . '/removed-tree');
+        $index = $this->readIndex(
+            $this->pushStateDirectory() . '/previous_local_index.jsonl'
+        );
+        $this->assertArrayNotHasKey('removed-tree', $index);
+        $this->assertArrayNotHasKey('removed-tree/child.txt', $index);
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($result['stdout']));
+    }
+
+    public function testDeltaPullKeepsDefaultSkippedRemotePathsOutOfTheIndex(): void
+    {
+        $this->completeEligiblePull();
+
+        // The remote gains a path files-push scope always omits. The delta
+        // pull downloads it, but the index must not admit it: a stray entry
+        // would make files-diff report a deletion files-push would then apply.
+        $this->writeRemoteOverrides([
+            'added_paths' => ['node_modules/library/index.js'],
+        ]);
+
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $delta = $this->runFilesPull();
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        $this->assertFileExists($this->localTree . '/node_modules/library/index.js');
+
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($result['stdout']));
+    }
+
+    public function testAbortedFilesPullKeepsThePreviousLocalIndexUsable(): void
+    {
+        $this->completeEligiblePull();
+        file_put_contents($this->localTree . '/added-before-abort.txt', 'new');
+
+        $abort = $this->runFilesPull(['--abort']);
+        $result = $this->runFilesDiff();
+
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $records = $this->filesDiffRecords($result['stdout']);
+        $this->assertSame(
+            $this->expectedPushRecord('added-before-abort.txt', 'file'),
+            $records[0] ?? null
+        );
+    }
+
+    /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
+    private function expectedPushRecord(string $path, string $type): array
+    {
+        $stat = lstat($this->localTree . '/' . $path);
+        $this->assertIsArray($stat);
+        return [
+            'command' => 'files-diff',
+            'action' => 'push',
+            'path_b64' => base64_encode($path),
+            'type' => $type,
+            'size' => $type === 'dir' ? 0 : (int) $stat['size'],
+            'ctime' => (int) $stat['ctime'],
+        ];
+    }
+
+    private function completeEligiblePull(): void
+    {
+        $result = $this->runFilesPull();
+        $this->assertSame(0, $result['exit'], $result['output']);
+    }
+
+    private function corruptImportIndexOutputAfterFilesPullWritesWAL(
+        string $newPulledContents
+    ): void {
+        $this->completeEligiblePull();
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($newPulledContents),
+        ]);
+        $blockedIndexOutput = $this->stateDirectory . '/.import-index.jsonl.new';
+        file_put_contents($blockedIndexOutput, '');
+        chmod($blockedIndexOutput, 0400);
+        if (is_writable($blockedIndexOutput)) {
+            $this->markTestSkipped('This runner cannot make the importer-index output unwritable.');
+        }
+        try {
+            $failed = $this->runFilesPull();
+        } finally {
+            chmod($blockedIndexOutput, 0600);
+            unlink($blockedIndexOutput);
+        }
+        $this->assertSame(1, $failed['exit'], $failed['output']);
+        $this->assertSame(
+            $newPulledContents,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+        $state = json_decode(
+            (string) file_get_contents($this->stateDirectory . '/.import-state.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('pulled-file-complete', $state['fetch']['cursor'] ?? null);
+    }
+
+    /** @param array<string,mixed> $overrides */
+    private function writeRemoteOverrides(array $overrides): void
+    {
+        file_put_contents(
+            $this->root . '/remote-overrides.json',
+            json_encode($overrides, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+    }
+
+    /** @param list<string> $extraArguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesPull(array $extraArguments = []): array
+    {
+        return $this->runCli(array_merge([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ], $extraArguments));
+    }
+
+    private function pushStateDirectory(): string
+    {
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
+        $pair = hash('sha256', rtrim($this->targetUrl, '?&') . "\0" . $canonicalLocalTree);
+        return realpath($this->stateDirectory) . '/push/' . $pair;
+    }
+
+    /** @param list<string> $extraArguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesDiff(?string $targetUrl = null, array $extraArguments = []): array
+    {
+        return $this->runCli(array_merge([
+            'files-diff',
+            $targetUrl ?? $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+        ], $extraArguments));
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $arguments): array
+    {
+        [$process, $pipes] = $this->startCliProcess($arguments);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{0:resource,1:array<int,resource>}
+     */
+    private function startCliProcess(array $arguments): array
+    {
+        $process = proc_open(
+            array_merge([PHP_BINARY, __DIR__ . '/../../importer/import.php'], $arguments),
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /** @param array<string,mixed> $record */
+    private function encodeJsonLine(array $record): string
+    {
+        return json_encode($record, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+    }
+
+    private function assertCanonicalSingleJsonLine(string $output): void
+    {
+        $record = json_decode(rtrim($output, "\n"), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($record);
+        $this->assertSame(json_encode($record, JSON_THROW_ON_ERROR) . "\n", $output);
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function filesDiffRecords(string $output): array
+    {
+        $records = [];
+        foreach (preg_split('/\R/', trim($output)) ?: [] as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded) && ( $decoded['command'] ?? null ) === 'files-diff') {
+                $records[] = $decoded;
+            }
+        }
+        return $records;
+    }
+
+    private function requestCount(): int
+    {
+        if (!file_exists($this->requestsLog)) {
+            return 0;
+        }
+        return count(file($this->requestsLog, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
+    }
+
+    private function requestEndpointCounts(): array
+    {
+        $counts = [];
+        foreach (file($this->requestsLog, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+            $request = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $endpoint = $request['endpoint'] ?? null;
+            if (is_string($endpoint)) {
+                $counts[$endpoint] = ( $counts[$endpoint] ?? 0 ) + 1;
+            }
+        }
+        return $counts;
+    }
+
+    /** @return array<string,array{path:string,type:string,size:int,ctime:int,empty?:bool}> */
+    private function readIndex(string $path): array
+    {
+        $entries = [];
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $decodedPath = base64_decode($entry['path'] ?? '', true);
+            $this->assertIsString($decodedPath);
+            $entries[$decodedPath] = [
+                'path' => $decodedPath,
+                'type' => $entry['type'],
+                'size' => $entry['size'],
+                'ctime' => $entry['ctime'],
+            ];
+            if (array_key_exists('empty', $entry)) {
+                $entries[$decodedPath]['empty'] = (bool) $entry['empty'];
+            }
+        }
+        return $entries;
+    }
+
+    private function writePullStateAndIndex(): void
+    {
+        $roots = [[
+            'path' => '/var/www/html',
+        ]];
+        file_put_contents(
+            $this->stateDirectory . '/.import-state.json',
+            json_encode([
+                'preflight' => [
+                    'http_code' => 200,
+                    'data' => [
+                        'ok' => true,
+                        'runtime' => [
+                            'document_root' => '/var/www/html',
+                        ],
+                        'wp_detect' => [
+                            'roots' => $roots,
+                        ],
+                        'database' => [
+                            'wp' => [
+                                'paths_urls' => [
+                                    'content_dir' => '/var/www/html/wp-content',
+                                    'uploads' => [
+                                        'basedir' => '/var/www/html/wp-content/uploads',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $index = '';
+        $initialFiles = $this->initialFiles;
+        uksort($initialFiles, static fn(string $left, string $right): int => strcmp($left, $right));
+        foreach ($initialFiles as $path => $contents) {
+            $index .= json_encode([
+                'path' => base64_encode('/var/www/html/' . $path),
+                'ctime' => self::REMOTE_CTIME,
+                'size' => strlen($contents),
+                'type' => 'file',
+            ], JSON_UNESCAPED_SLASHES) . "\n";
+        }
+        file_put_contents($this->stateDirectory . '/.import-index.jsonl', $index);
+    }
+
+    private function startIndexServer(): string
+    {
+        $remoteFiles = $this->initialFiles;
+        $remoteFiles[self::PULLED_PATH] = self::PULLED_CONTENTS;
+        $remoteIndex = [];
+        foreach ($remoteFiles as $path => $contents) {
+            $remoteIndex[] = [
+                'path' => base64_encode('/var/www/html/' . $path),
+                'ctime' => self::REMOTE_CTIME,
+                'size' => strlen($contents),
+                'type' => 'file',
+            ];
+        }
+
+        $router = $this->root . '/index-server.php';
+        file_put_contents($router, sprintf(<<<'PHP'
+<?php
+$requests_log = base64_decode('%s');
+$remote_index = json_decode(base64_decode('%s'), true);
+$pulled_path = base64_decode('%s');
+$pulled_contents = base64_decode('%s');
+$overrides_path = base64_decode('%s');
+$wal_path = base64_decode('%s');
+$pulled_ctime = 41;
+$overrides = is_file($overrides_path)
+    ? json_decode((string) file_get_contents($overrides_path), true)
+    : null;
+if (is_array($overrides)) {
+    if (!empty($overrides['pulled_contents_b64'])) {
+        $pulled_contents = base64_decode($overrides['pulled_contents_b64']);
+    }
+    if (isset($overrides['pulled_ctime'])) {
+        $pulled_ctime = (int) $overrides['pulled_ctime'];
+    }
+    $removed_paths = array();
+    foreach (($overrides['removed_paths'] ?? array()) as $removed_path) {
+        $removed_paths['/var/www/html/' . $removed_path] = true;
+    }
+    $updated_index = array();
+    foreach ($remote_index as $entry) {
+        $entry_path = base64_decode($entry['path']);
+        if (isset($removed_paths[$entry_path])) {
+            continue;
+        }
+        if ($entry_path === '/var/www/html/' . $pulled_path) {
+            $entry['ctime'] = $pulled_ctime;
+            $entry['size'] = strlen($pulled_contents);
+        }
+        $updated_index[] = $entry;
+    }
+    foreach (($overrides['added_paths'] ?? array()) as $added_path) {
+        $updated_index[] = array(
+            'path' => base64_encode('/var/www/html/' . $added_path),
+            'ctime' => 43,
+            'size' => strlen('added remote contents'),
+            'type' => 'file',
+        );
+    }
+    foreach (($overrides['added_directories'] ?? array()) as $added_directory) {
+        $updated_index[] = array(
+            'path' => base64_encode('/var/www/html/' . $added_directory),
+            'ctime' => 43,
+            'size' => 0,
+            'type' => 'dir',
+        );
+    }
+    $remote_index = $updated_index;
+    if (!empty($overrides['empty_index'])) {
+        $remote_index = array();
+    }
+}
+$endpoint = $_GET['endpoint'] ?? null;
+$request_cursor = $_GET['cursor'] ?? null;
+$selected_directories = $_GET['directory'] ?? array();
+if ($endpoint === 'file_index' && is_array($selected_directories) && count($selected_directories) > 0) {
+    $selected_index = array();
+    foreach ($remote_index as $entry) {
+        $entry_path = base64_decode($entry['path']);
+        foreach ($selected_directories as $selected_directory) {
+            $selected_directory = rtrim($selected_directory, '/');
+            if (
+                $entry_path === $selected_directory
+                || strpos($entry_path, $selected_directory . '/') === 0
+            ) {
+                $selected_index[] = $entry;
+                break;
+            }
+        }
+    }
+    $remote_index = $selected_index;
+}
+$requested_file_paths = null;
+if (
+    $endpoint === 'file_fetch'
+    && isset($_FILES['file_list']['tmp_name'])
+    && is_file($_FILES['file_list']['tmp_name'])
+) {
+    $requested_file_paths = array_fill_keys(
+        json_decode((string) file_get_contents($_FILES['file_list']['tmp_name']), true),
+        true
+    );
+}
+file_put_contents(
+    $requests_log,
+    json_encode(
+        array('endpoint' => $endpoint, 'cursor' => $request_cursor),
+        JSON_UNESCAPED_SLASHES
+    ) . "\n",
+    FILE_APPEND
+);
+
+if (
+    $endpoint === 'file_fetch'
+    && !empty($overrides['require_previous_local_index_before_fetch'])
+) {
+    $previous_local_indexes = glob(
+        dirname($wal_path) . '/push/*/previous_local_index.jsonl'
+    );
+    if (!is_array($previous_local_indexes) || count($previous_local_indexes) !== 1) {
+        http_response_code(500);
+        header('Content-Type: application/json');
+        echo json_encode(array('message' => 'Previous local index was not seeded before file_fetch.'));
+        exit;
+    }
+}
+
+if ($endpoint === 'preflight') {
+    header('Content-Type: application/json');
+    echo json_encode(array(
+        'ok' => true,
+        'protocol_version' => 1,
+        'protocol_min_version' => 1,
+        'runtime' => array(
+            'document_root' => '/var/www/html',
+            'ini_get_all' => array(),
+        ),
+        'wp_detect' => array(
+            'roots' => array(array('path' => '/var/www/html')),
+        ),
+        'database' => array(
+            'wp' => array(
+                'wp_version' => '6.0-test',
+                'table_prefix' => 'wp_',
+                'paths_urls' => array(
+                    'abspath' => '/var/www/html',
+                    'content_dir' => '/var/www/html/wp-content',
+                    'uploads' => array(
+                        'basedir' => '/var/www/html/wp-content/uploads',
+                    ),
+                ),
+            ),
+        ),
+        'limits' => array('max_request_bytes' => 4194304),
+    ), JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$boundary = 'reprint-files-diff-test';
+header('Content-Type: multipart/mixed; boundary=' . $boundary);
+$write_part = static function (array $headers, string $body = '') use ($boundary): void {
+    echo "--{$boundary}\r\n";
+    foreach ($headers as $name => $value) {
+        echo $name . ': ' . $value . "\r\n";
+    }
+    echo 'Content-Length: ' . strlen($body) . "\r\n\r\n";
+    echo $body . "\r\n";
+};
+
+if ($endpoint === 'file_index') {
+    $write_part(
+        array('X-Chunk-Type' => 'index_batch'),
+        json_encode($remote_index, JSON_UNESCAPED_SLASHES)
+    );
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Total-Entries' => count($remote_index),
+    ));
+} elseif ($endpoint === 'file_fetch') {
+    if (!empty($overrides['make_wal_unwritable'])) {
+        file_put_contents($wal_path, '');
+        chmod($wal_path, 0400);
+    }
+    $files_completed = 0;
+    $bytes_processed = 0;
+    if (
+        (!is_array($overrides) || isset($overrides['pulled_ctime']))
+        && $request_cursor !== 'pulled-file-complete'
+        && ($requested_file_paths === null || isset($requested_file_paths['/var/www/html/' . $pulled_path]))
+    ) {
+        $file_headers = array(
+            'X-Chunk-Type' => 'file',
+            'X-File-Path' => base64_encode('/var/www/html/' . $pulled_path),
+            'X-File-Ctime' => $pulled_ctime,
+            'X-File-Size' => strlen($pulled_contents),
+            'X-First-Chunk' => 1,
+            'X-Last-Chunk' => 1,
+            'X-Cursor' => 'pulled-file-complete',
+        );
+        if (!empty($overrides['pause_mid_file'])) {
+            echo "--{$boundary}\r\n";
+            foreach ($file_headers as $name => $value) {
+                echo $name . ': ' . $value . "\r\n";
+            }
+            echo 'Content-Length: ' . strlen($pulled_contents) . "\r\n\r\n";
+            $first_half_bytes = intdiv(strlen($pulled_contents), 2);
+            echo substr($pulled_contents, 0, $first_half_bytes);
+            flush();
+            file_put_contents($overrides_path . '.pause-ready', '');
+            while (!is_file($overrides_path . '.pause-release')) {
+                usleep(20000);
+            }
+            echo substr($pulled_contents, $first_half_bytes) . "\r\n";
+        } else {
+            $write_part($file_headers, $pulled_contents);
+        }
+        ++$files_completed;
+        $bytes_processed += strlen($pulled_contents);
+    }
+    foreach ((is_array($overrides) ? ($overrides['added_paths'] ?? array()) : array()) as $added_path) {
+        if (
+            $requested_file_paths !== null
+            && !isset($requested_file_paths['/var/www/html/' . $added_path])
+        ) {
+            continue;
+        }
+        $write_part(array(
+            'X-Chunk-Type' => 'file',
+            'X-File-Path' => base64_encode('/var/www/html/' . $added_path),
+            'X-File-Ctime' => 43,
+            'X-File-Size' => strlen('added remote contents'),
+            'X-First-Chunk' => 1,
+            'X-Last-Chunk' => 1,
+            'X-Cursor' => 'added-file-complete',
+        ), 'added remote contents');
+        ++$files_completed;
+        $bytes_processed += strlen('added remote contents');
+    }
+    foreach ((is_array($overrides) ? ($overrides['added_directories'] ?? array()) : array()) as $added_directory) {
+        if (
+            $requested_file_paths !== null
+            && !isset($requested_file_paths['/var/www/html/' . $added_directory])
+        ) {
+            continue;
+        }
+        $write_part(array(
+            'X-Chunk-Type' => 'directory',
+            'X-Directory-Path' => base64_encode('/var/www/html/' . $added_directory),
+            'X-Directory-Ctime' => 43,
+            'X-Cursor' => 'added-directory-complete',
+        ));
+        ++$files_completed;
+    }
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Files-Completed' => $files_completed,
+        'X-Bytes-Processed' => $bytes_processed,
+    ));
+} elseif ($endpoint === 'db_index') {
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Tables-Processed' => 0,
+        'X-Rows-Estimated' => 0,
+    ));
+} elseif ($endpoint === 'sql_chunk') {
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Sql-Bytes' => 0,
+    ));
+} else {
+    $write_part(array(
+        'X-Chunk-Type' => 'error',
+        'X-Status' => 'failed',
+    ), json_encode(array('message' => 'Unexpected endpoint')));
+}
+echo "--{$boundary}--\r\n";
+PHP,
+            base64_encode($this->requestsLog),
+            base64_encode( (string) json_encode($remoteIndex)),
+            base64_encode(self::PULLED_PATH),
+            base64_encode(self::PULLED_CONTENTS),
+            base64_encode($this->root . '/remote-overrides.json'),
+            base64_encode($this->stateDirectory . '/.import-index-updates.wal')
+        ));
+
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $this->serverPipes,
+            $this->root
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen('127.0.0.1', $port, $errorNumber, $errorMessage, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('Local index server did not start.');
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/FilesPullPreviousLocalIndexTest.php
+++ b/tests/Import/FilesPullPreviousLocalIndexTest.php
@@ -284,6 +284,59 @@ final class FilesPullPreviousLocalIndexTest extends TestCase
         ]], $this->filesDiffRecords($diff['stdout']));
     }
 
+    public function testIncompatibleFilesPullDoesNotStartMaintainingAfterResume(): void
+    {
+        $this->completeEligiblePull();
+        $abort = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $addedPath = 'added-before-incompatible-resume.txt';
+        $this->writeRemoteOverrides([
+            'added_paths' => [$addedPath],
+        ]);
+        $blockedIndexOutput = $this->stateDirectory . '/.import-index.jsonl.new';
+        file_put_contents($blockedIndexOutput, '');
+        chmod($blockedIndexOutput, 0400);
+        if (is_writable($blockedIndexOutput)) {
+            $this->markTestSkipped('This runner cannot make the importer-index output unwritable.');
+        }
+        try {
+            $failed = $this->runFilesPull([
+                '--on-fs-root-nonempty=preserve-local',
+            ]);
+        } finally {
+            chmod($blockedIndexOutput, 0600);
+            unlink($blockedIndexOutput);
+        }
+
+        $this->assertSame(1, $failed['exit'], $failed['output']);
+        $this->assertSame(
+            'added remote contents',
+            file_get_contents($this->localTree . '/' . $addedPath)
+        );
+        $this->assertFileExists(
+            $this->stateDirectory . '/.import-index-updates.wal'
+        );
+        $previousLocalIndex =
+            $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        $this->assertFileDoesNotExist($previousLocalIndex);
+
+        $resumed = $this->runFilesPull([
+            '--on-fs-root-nonempty=error',
+        ]);
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertFileDoesNotExist(
+            $this->stateDirectory . '/.import-index-updates.wal'
+        );
+        $this->assertFileDoesNotExist($previousLocalIndex);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(1, $diff['exit'], $diff['output']);
+        $this->assertStringContainsString(
+            'fresh completed files-pull',
+            $diff['output']
+        );
+    }
+
     public function testInterruptedPullKeepsTheWALMarkerUntilResume(): void
     {
         $this->completeEligiblePull();

--- a/tests/Import/IndexUpdateFunctionsTest.php
+++ b/tests/Import/IndexUpdateFunctionsTest.php
@@ -1,0 +1,142 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use function Reprint\Importer\merge_import_index_updates;
+
+require_once __DIR__ . '/../../importer/import.php';
+require_once __DIR__ . '/FailedFlushStreamWrapper.php';
+
+final class IndexUpdateFunctionsTest extends TestCase
+{
+    private string $root;
+    private string $stateDirectory;
+    private string $fileRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir()
+            . '/index-update-functions-'
+            . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->fileRoot = $this->root . '/files';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->fileRoot . '/site', 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider localPathDriftProvider
+     */
+    public function testLocalPathDriftIsNotMarkedAsAppliedByFilesPull(
+        string $localPathType,
+        int $expectedSize
+    ): void {
+        $localPath = $this->fileRoot . '/site/changed.txt';
+        if ($localPathType === 'dir') {
+            mkdir($localPath);
+        } else {
+            file_put_contents($localPath, 'changed after pull');
+        }
+
+        $client = new \ImportClient(
+            'http://example.test',
+            $this->stateDirectory,
+            $this->fileRoot
+        );
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('maintain_previous_local_index')
+            ->setValue($client, true);
+        $reflection->getMethod('record_index_update_file')->invoke(
+            $client,
+            '/site/changed.txt',
+            42,
+            $expectedSize,
+            'file'
+        );
+        $walHandle = $reflection->getProperty('index_update_wal_handle')
+            ->getValue($client);
+        $this->assertIsResource($walHandle);
+        $this->assertTrue(fflush($walHandle));
+        $this->assertTrue(fclose($walHandle));
+
+        $update = json_decode(
+            (string) file_get_contents(
+                $this->stateDirectory . '/.import-index-updates.wal'
+            ),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertArrayNotHasKey('applied_by_files_pull', $update);
+        $this->assertArrayNotHasKey('local_type', $update);
+    }
+
+    public static function localPathDriftProvider(): array
+    {
+        return [
+            'file size changed' => ['file', 5],
+            'path type changed' => ['dir', 5],
+        ];
+    }
+
+    public function testMergeRejectsAnOutputFlushFailure(): void
+    {
+        $updatesPath = $this->root . '/updates.jsonl';
+        file_put_contents(
+            $updatesPath,
+            json_encode([
+                'op' => 'F',
+                'path' => base64_encode('/file.txt'),
+                'ctime' => 42,
+                'size' => 5,
+                'type' => 'file',
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+        );
+        $this->assertTrue(
+            stream_wrapper_register(
+                'reprint-failed-flush',
+                FailedFlushStreamWrapper::class
+            )
+        );
+
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Failed to flush the merged index.');
+            merge_import_index_updates(
+                $this->root . '/missing-base.jsonl',
+                $updatesPath,
+                'reprint-failed-flush://output'
+            );
+        } finally {
+            stream_wrapper_unregister('reprint-failed-flush');
+        }
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) ?: [] as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+            rmdir($path);
+            return;
+        }
+        unlink($path);
+    }
+}

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -155,6 +155,9 @@ PHP, var_export($requestsLog, true)));
     {
         $data = array(
             'ok' => true,
+            'runtime' => array(
+                'document_root' => '/var/www/html',
+            ),
             'database' => array(
                 'wp' => array(
                     'paths_urls' => array(

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -90,7 +90,7 @@ class PullFilterFakeClient extends \ImportClient
         $this->save_import_state();
     }
 
-    public function run_files_sync(): void
+    public function run_files_sync(bool $maintain_previous_local_index = false): void
     {
         $state = $this->get_import_state();
         if (

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -17,15 +17,25 @@ class PushClientPhpCompatibilityTest extends TestCase
     public function testPushLibsStayParseableOnPhp74(): void
     {
         $phpcs_path = realpath(__DIR__ . '/../../vendor/bin/phpcs');
+        $process_lock_path = realpath(
+            __DIR__ . '/../../packages/reprint-importer/src/lib/class-reprint-process-lock.php'
+        );
+        $index_update_functions_path = realpath(
+            __DIR__ . '/../../packages/reprint-importer/src/lib/index-update-functions.php'
+        );
         $upload_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/upload');
         $push_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/push');
         $this->assertNotFalse($phpcs_path, 'vendor/bin/phpcs is missing; run composer install');
+        $this->assertNotFalse($process_lock_path);
+        $this->assertNotFalse($index_update_functions_path);
         $this->assertNotFalse($upload_lib_path);
         $this->assertNotFalse($push_lib_path);
 
         exec(
             escapeshellarg($phpcs_path)
                 . ' --standard=PHPCompatibility --runtime-set testVersion 7.4- -q '
+                . escapeshellarg($process_lock_path) . ' '
+                . escapeshellarg($index_update_functions_path) . ' '
                 . escapeshellarg($upload_lib_path) . ' '
                 . escapeshellarg($push_lib_path) . ' 2>&1',
             $scan_output,

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -307,7 +307,7 @@ final class PushPlanTest extends TestCase
         $this->assertSame("a\0b.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testSeenDeletedDirectorySurvivesAnInterleavedSiblingCursor(): void
+    public function testSeenDeletedDirectorySurvivesResumeBeforeTheNextSibling(): void
     {
         $this->savePreviousLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
@@ -315,7 +315,6 @@ final class PushPlanTest extends TestCase
         ]));
         $entries = [];
         for ($index = 0; $index < 3; ++$index) {
-            // `-` sorts before `/`, placing these siblings between a and a/child.txt.
             $entries[sprintf('a-%04d.txt', $index)] = [2, 1, 'file'];
         }
         $current = $this->writeIndex($entries);
@@ -331,7 +330,7 @@ final class PushPlanTest extends TestCase
         $this->assertCount(3, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
     }
 
-    public function testReplacementRootSurvivesLexicallyInterleavedSiblingPaths(): void
+    public function testReplacementRootSurvivesSiblingPaths(): void
     {
         $this->savePreviousLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
@@ -339,7 +338,6 @@ final class PushPlanTest extends TestCase
         ]));
         $current = $this->writeIndex([
             'a' => [2, 1, 'file'],
-            // `-` sorts before `/`, so this sibling appears before a/child.txt.
             'a-other' => [2, 1, 'file'],
         ]);
 
@@ -349,6 +347,27 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(2, 1);
         $this->assertSame(['a', 'a-other'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
         $this->assertSame("a\0", file_get_contents($this->planPath('local_paths_to_delete')));
+    }
+
+    public function testDescendantChangesDoNotReplanAnUnchangedSibling(): void
+    {
+        $this->savePreviousLocalIndex($this->writeIndex([
+            'a' => [1, 0, 'dir', false],
+            'a/child.txt' => [1, 1, 'file'],
+            'a-other' => [1, 1, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'a' => [2, 0, 'dir', false],
+            'a/new-child.txt' => [2, 1, 'file'],
+            'a-other' => [1, 1, 'file'],
+        ]);
+
+        $plan = $this->startPlan($current);
+        $this->planToCompletion($plan);
+
+        $this->assertPathCounts(1, 1);
+        $this->assertSame(['a/new-child.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
+        $this->assertSame("a/child.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
     public function testNewChangedDeletedAndUnchangedPathsArePlannedTogether(): void
@@ -889,7 +908,13 @@ final class PushPlanTest extends TestCase
      */
     private function writeIndex(array $entries): string
     {
-        uksort($entries, 'strcmp');
+        uksort(
+            $entries,
+            static fn(string $left, string $right): int => strcmp(
+                str_replace('/', "\0", $left),
+                str_replace('/', "\0", $right)
+            )
+        );
         $lines = '';
         foreach ($entries as $path => $entry) {
             $lines .= $this->indexLine(

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -1,0 +1,79 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+final class ReprintProcessLockTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/reprint-process-lock-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/state', 0700, true);
+        mkdir($this->root . '/files', 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+    }
+
+    public function testImportClientRejectsAConcurrentCommand(): void
+    {
+        $process_lock = new \ReprintProcessLock($this->root . '/state');
+        $client = new \ImportClient(
+            'https://example.com/?site-export-api',
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+
+        try {
+            $client->run(['command' => 'files-stats']);
+            $this->fail('A second Reprint command must not use the same state directory.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another Reprint process is using the state directory',
+                $exception->getMessage()
+            );
+        } finally {
+            $process_lock->close();
+        }
+    }
+
+    public function testCloseIsIdempotentAndAllowsTheNextCommand(): void
+    {
+        $process_lock = new \ReprintProcessLock($this->root . '/state');
+        $process_lock->close();
+        $process_lock->close();
+
+        $next_process_lock = new \ReprintProcessLock($this->root . '/state');
+        $this->assertTrue($next_process_lock->is_held());
+        $next_process_lock->close();
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $child = $path . '/' . $entry;
+            if (is_dir($child) && !is_link($child)) {
+                $this->removeTree($child);
+            } else {
+                @unlink($child);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/PathComparisonTest.php
+++ b/tests/PathComparisonTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing test class style.
+
+use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Exporter\compare_paths;
+use function WordPress\Reprint\Exporter\path_sort_key;
+
+final class PathComparisonTest extends TestCase
+{
+    public function testComparesPathsInDepthFirstComponentOrder(): void
+    {
+        $paths = ['directory-sibling', 'directory/child', 'directory', 'next'];
+
+        usort($paths, static function (string $left_path, string $right_path): int {
+            return compare_paths($left_path, $right_path);
+        });
+
+        $this->assertSame(
+            ['directory', 'directory/child', 'directory-sibling', 'next'],
+            $paths
+        );
+    }
+
+    public function testBuildsPathSortKeyFromComponents(): void
+    {
+        $this->assertSame("directory\0child", path_sort_key('directory/child'));
+    }
+}

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -18,6 +18,9 @@ final class PushEndpointsTest extends TestCase {
     /** @var resource[] */
     private array $server_pipes = [];
 
+    /** @var array<int,ReprintProcessLock> */
+    private array $sender_process_locks = [];
+
     private string $root;
     private string $docroot;
     private string $wordpress_root;
@@ -75,6 +78,10 @@ final class PushEndpointsTest extends TestCase {
     protected function tearDown(): void
     {
         $this->stopServer($this->server_process, $this->server_pipes);
+        foreach ($this->sender_process_locks as $process_lock) {
+            $process_lock->close();
+        }
+        $this->sender_process_locks = [];
         if (isset($this->root)) {
             $this->removeTree($this->root);
         }
@@ -1397,7 +1404,7 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/large.bin', str_repeat('A', 6000));
         $push_state_directory = $this->root . '/retained-file-offset-state';
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1422,7 +1429,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame(1, $this->countEndpointRequests('push_status'));
         } finally {
             $sender->cancel();
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1441,7 +1448,7 @@ final class PushEndpointsTest extends TestCase {
         $this->writeIndex($previous_local_index_path, $previous_entries);
         $push_state_directory = $this->root . '/retained-deleted-paths-state';
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1451,7 +1458,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertGreaterThan(1, $this->countEndpointRequests('push_upload'));
             $this->assertSame(1, $this->countEndpointRequests('push_status'));
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1485,7 +1492,7 @@ final class PushEndpointsTest extends TestCase {
             PushFilesSender::class,
             'local_paths_to_delete_handle'
         );
-        $sender = PushFilesSender::resume(
+        $sender = $this->resumeSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1500,7 +1507,7 @@ final class PushEndpointsTest extends TestCase {
             if ($sender->get_status() === 'continue') {
                 $sender->cancel();
             }
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1520,12 +1527,12 @@ final class PushEndpointsTest extends TestCase {
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
             file_put_contents($local_docroot . '/returned.txt', 'new');
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $result = $this->runSender($local_docroot, $push_state_directory);
 
@@ -1587,7 +1594,7 @@ final class PushEndpointsTest extends TestCase {
         );
         $fresh_local_index_handle = null;
 
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1619,7 +1626,7 @@ final class PushEndpointsTest extends TestCase {
                 $this->loadPlanPosition($push_state_directory)
             );
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $this->assertFalse(is_resource($fresh_local_index_handle));
@@ -1644,7 +1651,7 @@ final class PushEndpointsTest extends TestCase {
             'fresh_local_index_handle'
         );
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->assertSame('creating', $sender->get_phase());
             $this->takeSenderStepsUntilPhase($sender, 'planning');
@@ -1676,11 +1683,11 @@ final class PushEndpointsTest extends TestCase {
             $this->assertArrayNotHasKey('file_index_cursor', $state);
             $this->assertArrayNotHasKey('fresh_local_index_byte_offset', $state);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertFalse(is_resource($fresh_local_index_handle));
 
-        $sender = PushFilesSender::resume($options);
+        $sender = $this->resumeSender($options);
         try {
             $this->assertSame('planning', $sender->get_phase());
             $resumed_plan = $plan_property->getValue($sender);
@@ -1698,7 +1705,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertArrayNotHasKey('file_index_cursor', $state);
             $this->assertArrayNotHasKey('fresh_local_index_byte_offset', $state);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $index_lines = file($fresh_local_index_path, FILE_IGNORE_NEW_LINES);
@@ -1728,7 +1735,7 @@ final class PushEndpointsTest extends TestCase {
         $child = pcntl_fork();
         $this->assertNotSame(-1, $child);
         if ($child === 0) {
-            $sender = PushFilesSender::start($options);
+            $sender = $this->startSender($options);
             $this->takeSenderStepsUntilPhase($sender, 'planning');
             if (!$sender->next_step()) {
                 exit(2);
@@ -1787,7 +1794,7 @@ final class PushEndpointsTest extends TestCase {
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
         $options = $this->senderOptions($local_docroot, $push_state_directory);
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $planning_result = $this->senderResult($sender);
@@ -1827,7 +1834,7 @@ final class PushEndpointsTest extends TestCase {
             $finished_upload_requests_before_close = $this->countEndpointRequests('push_upload');
 
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertNull($local_paths_to_push_handle_property->getValue($sender));
         $this->assertNull($local_file_handle_property->getValue($sender));
@@ -1838,7 +1845,7 @@ final class PushEndpointsTest extends TestCase {
         clearstatcache(true, $push_state_directory . '/sender.json');
         $this->assertSame($state_inode_before_upload, fileinode($push_state_directory . '/sender.json'));
 
-        $sender = PushFilesSender::resume($options);
+        $sender = $this->resumeSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
             $sender->next_step();
@@ -1862,7 +1869,7 @@ final class PushEndpointsTest extends TestCase {
                 ftell($local_paths_to_delete_handle)
             );
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertNull($local_paths_to_delete_handle_property->getValue($sender));
         $this->assertFalse(is_resource($local_paths_to_delete_handle));
@@ -1882,7 +1889,7 @@ final class PushEndpointsTest extends TestCase {
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $this->assertSame('pushing_paths', $sender->get_phase());
@@ -1910,7 +1917,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('restart', $sender->get_status());
             $this->assertSame('local_path_changed', $sender->get_reason());
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1927,7 +1934,7 @@ final class PushEndpointsTest extends TestCase {
         $options = $this->senderOptions($local_docroot, $push_state_directory);
         $upload_request_stage_property = new ReflectionProperty(PushFilesSender::class, 'upload_request_stage');
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $sender->next_step();
@@ -1947,7 +1954,7 @@ final class PushEndpointsTest extends TestCase {
             $sender->cancel();
             $this->assertSame('closed', $upload_request_stage_property->getValue($sender));
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $result = $this->runSender($local_docroot, $push_state_directory);
@@ -1979,7 +1986,7 @@ final class PushEndpointsTest extends TestCase {
         $child = pcntl_fork();
         $this->assertNotSame(-1, $child);
         if ($child === 0) {
-            $sender = PushFilesSender::start($options);
+            $sender = $this->startSender($options);
             for ($step = 0; $step < 300 && $sender->get_phase() !== 'pushing_paths'; ++$step) {
                 if (!$sender->next_step()) {
                     exit(2);
@@ -2113,7 +2120,7 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/changed-empty-directory-state';
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $this->assertSame('pushing_paths', $sender->get_phase());
@@ -2123,7 +2130,7 @@ final class PushEndpointsTest extends TestCase {
 
             $result = $this->senderResult($sender);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $this->assertSame('continue', $result['status']);
@@ -2193,33 +2200,33 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Holds the lifecycle lock while open and resumes the last returned boundary.
+     * Holds the Reprint process lock while open and resumes the last returned boundary.
      */
-    public function testHighLevelSenderOwnsLifecycleLockAndResumesAfterClose(): void
+    public function testHighLevelSenderUsesReprintProcessLockAndResumesAfterClose(): void
     {
         $local_docroot = $this->root . '/locked-local-docroot';
         $push_state_directory = $this->root . '/locked-state';
         mkdir($local_docroot, 0700, true);
         mkdir($push_state_directory, 0700, true);
-        $lock = fopen($push_state_directory . '/sender.lock', 'c+');
-        $this->assertIsResource($lock);
-        $this->assertTrue(flock($lock, LOCK_EX | LOCK_NB));
+        $process_lock = new ReprintProcessLock($this->root);
         try {
             try {
-                PushFilesSender::start(
+                $this->startSender(
                     $this->senderOptions($local_docroot, $push_state_directory)
                 );
-                $this->fail('Starting a sender must fail while another process owns its lock.');
+                $this->fail('Starting a sender must fail while another Reprint process owns the state directory.');
             } catch (RuntimeException $exception) {
-                $this->assertStringContainsString('another process holds its lock', $exception->getMessage());
+                $this->assertStringContainsString(
+                    'Another Reprint process is using the state directory',
+                    $exception->getMessage()
+                );
             }
         } finally {
-            flock($lock, LOCK_UN);
-            fclose($lock);
+            $process_lock->close();
         }
 
         $options = $this->senderOptions($local_docroot, $push_state_directory);
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $sender->next_step();
             $first = $this->senderResult($sender);
@@ -2228,13 +2235,16 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('continue', $first['status']);
             $this->assertSame('continue', $second['status']);
             try {
-                PushFilesSender::resume($options);
+                $this->resumeSender($options);
                 $this->fail('Resuming a sender must fail until the open sender is closed.');
             } catch (RuntimeException $exception) {
-                $this->assertStringContainsString('another process holds its lock', $exception->getMessage());
+                $this->assertStringContainsString(
+                    'Another Reprint process is using the state directory',
+                    $exception->getMessage()
+                );
             }
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $state_at_caller_stop = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state_at_caller_stop);
@@ -2247,18 +2257,18 @@ final class PushEndpointsTest extends TestCase {
             $this->assertStringContainsString('after close()', $exception->getMessage());
         }
 
-        $resumed_sender = PushFilesSender::resume($options);
+        $resumed_sender = $this->resumeSender($options);
         try {
             $resumed_sender->next_step();
             $result_after_resume = $this->senderResult($resumed_sender);
             $this->assertSame('continue', $result_after_resume['status']);
             $this->assertSame('pushing_deletes', $result_after_resume['phase']);
         } finally {
-            $resumed_sender->close();
+            $this->closeSender($resumed_sender);
         }
 
         try {
-            PushFilesSender::start($options);
+            $this->startSender($options);
             $this->fail('Starting a sender must not replace unfinished active state.');
         } catch (LogicException $exception) {
             $this->assertStringContainsString('unfinished active state exists', $exception->getMessage());
@@ -2280,7 +2290,7 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
 
         try {
-            PushFilesSender::resume(
+            $this->resumeSender(
                 $this->senderOptions($local_docroot, $push_state_directory)
             );
             $this->fail('Resuming without active state must fail.');
@@ -2342,7 +2352,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/first.txt', 'first');
         file_put_contents($local_docroot . '/second.txt', 'second');
         $push_state_directory = $this->root . '/failed-upload-state';
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         $state_property = new ReflectionProperty(PushFilesSender::class, 'state');
@@ -2373,7 +2383,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('lock_acquisition_failure', $sender->get_reason());
             $this->assertSame($durable_state, $state_property->getValue($sender));
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -2414,7 +2424,7 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/malformed-local-docroot';
         $push_state_directory = $this->root . '/malformed-state';
         mkdir($local_docroot, 0700, true);
-        $sender = PushFilesSender::start([
+        $sender = $this->startSender([
             'docroot' => $local_docroot,
             'push_state_directory' => $push_state_directory,
             'base_url' => 'http://' . $address . '/?reprint-api=1',
@@ -2428,7 +2438,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertFalse($sender->next_step());
             $result = $this->senderResult($sender);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertFalse($sender->next_step());
         pcntl_waitpid($child, $status);
@@ -2512,6 +2522,128 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertFileDoesNotExist($this->docroot . '/delete-after-lost-response.txt');
         $this->assertNull($this->loadActiveState($push_state_directory));
+    }
+
+    public function testFilesPushSnapshotsTheLatestPreviousLocalIndexWhenItsPlanStarts(): void
+    {
+        $local_docroot = $this->root . '/snapshot-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($this->docroot . '/deleted-after-newer-sync.txt', 'old');
+
+        $push_state_directory = $this->root . '/snapshot-sender-state';
+        mkdir($push_state_directory, 0700, true);
+        $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
+        $this->writeIndex($previous_local_index, []);
+
+        $sender = $this->startSender($this->senderOptions($local_docroot, $push_state_directory));
+        $this->closeSender($sender);
+
+        // A pull may replace the pair's previous local index between sender
+        // processes; the plan must pin the version present when it starts.
+        $this->writeIndex(
+            $previous_local_index,
+            ['deleted-after-newer-sync.txt' => [2, 3, 'file']]
+        );
+        $sender = $this->resumeSender($this->senderOptions($local_docroot, $push_state_directory));
+        $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
+        $this->closeSender($sender);
+        $state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($state);
+        $this->assertSame(
+            $push_state_directory . '/plan/previous_local_index.jsonl',
+            $state['push_plan_cursor']['previous_local_index'] ?? null
+        );
+
+        // A later pull may advance a path which this completed plan did not
+        // select. Publishing the confirmed deletion must retain that path.
+        file_put_contents($local_docroot . '/pulled-between-processes.txt', 'new');
+        file_put_contents($this->docroot . '/pulled-between-processes.txt', 'new');
+        $pulled_stat = lstat($local_docroot . '/pulled-between-processes.txt');
+        $this->assertIsArray($pulled_stat);
+        $this->writeIndex(
+            $previous_local_index,
+            [
+                'deleted-after-newer-sync.txt' => [2, 3, 'file'],
+                'pulled-between-processes.txt' => [
+                    (int) $pulled_stat['ctime'],
+                    3,
+                    'file',
+                ],
+            ]
+        );
+
+        $result = $this->runSender($local_docroot, $push_state_directory);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertFileDoesNotExist($this->docroot . '/deleted-after-newer-sync.txt');
+        $published_index = file_get_contents($previous_local_index);
+        $this->assertIsString($published_index);
+        $this->assertStringContainsString(
+            base64_encode('pulled-between-processes.txt'),
+            $published_index
+        );
+        $this->assertStringNotContainsString(
+            base64_encode('deleted-after-newer-sync.txt'),
+            $published_index
+        );
+    }
+
+    public function testFilesPushDoesNotPublishAPartialIndexAfterLiveIndexTampering(): void
+    {
+        $local_docroot = $this->root . '/missing-live-index-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        $push_state_directory = $this->root . '/missing-live-index-sender-state';
+        mkdir($push_state_directory, 0700, true);
+        $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
+        $this->writeIndex(
+            $previous_local_index,
+            ['remove.txt' => [1, 3, 'file']]
+        );
+
+        $sender = $this->startSender(
+            $this->senderOptions($local_docroot, $push_state_directory)
+        );
+        $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
+        $this->closeSender($sender);
+        unlink($previous_local_index);
+
+        $result = $this->runSender($local_docroot, $push_state_directory);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertFileDoesNotExist($previous_local_index);
+    }
+
+    public function testFilesPushDoesNotStartWhileReprintProcessLockIsHeld(): void
+    {
+        $local_docroot = $this->root . '/process-locked-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        $push_state_directory = $this->root . '/process-locked-sender-state';
+        mkdir($push_state_directory, 0700, true);
+        $this->writeIndex(
+            $push_state_directory . '/previous_local_index.jsonl',
+            ['locked.txt' => [1, 3, 'file']]
+        );
+        $lock_process = $this->startLockProcess($this->root . '/.reprint.lock');
+        $request_count = $this->countEndpointRequests('push_create');
+        $sender = null;
+
+        try {
+            $sender = $this->startSender($this->senderOptions($local_docroot, $push_state_directory));
+            $this->fail('The sender started while another Reprint process owned the state directory.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another Reprint process is using the state directory',
+                $exception->getMessage()
+            );
+        } finally {
+            if ($sender instanceof PushFilesSender) {
+                $this->closeSender($sender);
+            }
+            $this->stopLockProcess($lock_process);
+        }
+
+        $this->assertSame($request_count, $this->countEndpointRequests('push_create'));
+        $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
     }
 
     public function testCompletedFilesPushPublishesThePreviousLocalIndexForFilesDiff(): void
@@ -2830,13 +2962,13 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'value after failure');
         $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $active_state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($active_state);
@@ -2880,13 +3012,13 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'before');
         $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         file_put_contents($local_docroot . '/value.txt', 'after local change');
         clearstatcache(true, $local_docroot . '/value.txt');
@@ -3292,6 +3424,47 @@ final class PushEndpointsTest extends TestCase {
         ];
     }
 
+    /** @param array<string,mixed> $options */
+    private function startSender(array $options): PushFilesSender
+    {
+        $process_lock = new ReprintProcessLock($this->root);
+        try {
+            $sender = PushFilesSender::start($options, $process_lock);
+        } catch (Throwable $throwable) {
+            $process_lock->close();
+            throw $throwable;
+        }
+        $this->sender_process_locks[spl_object_id($sender)] = $process_lock;
+        return $sender;
+    }
+
+    /** @param array<string,mixed> $options */
+    private function resumeSender(array $options): PushFilesSender
+    {
+        $process_lock = new ReprintProcessLock($this->root);
+        try {
+            $sender = PushFilesSender::resume($options, $process_lock);
+        } catch (Throwable $throwable) {
+            $process_lock->close();
+            throw $throwable;
+        }
+        $this->sender_process_locks[spl_object_id($sender)] = $process_lock;
+        return $sender;
+    }
+
+    private function closeSender(PushFilesSender $sender): void
+    {
+        $object_id = spl_object_id($sender);
+        try {
+            $sender->close();
+        } finally {
+            if (isset($this->sender_process_locks[$object_id])) {
+                $this->sender_process_locks[$object_id]->close();
+                unset($this->sender_process_locks[$object_id]);
+            }
+        }
+    }
+
     /**
      * Starts or resumes one sender and stops after its next durable boundary.
      *
@@ -3309,8 +3482,8 @@ final class PushEndpointsTest extends TestCase {
             $push_state_directory
         );
         $sender = is_file($push_state_directory . '/sender.json')
-            ? PushFilesSender::resume($options)
-            : PushFilesSender::start($options);
+            ? $this->resumeSender($options)
+            : $this->startSender($options);
         $upload_request_stage_property = new ReflectionProperty(PushFilesSender::class, 'upload_request_stage');
         try {
             do {
@@ -3324,7 +3497,7 @@ final class PushEndpointsTest extends TestCase {
             if ($sender->get_status() === 'continue') {
                 $sender->cancel();
             }
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -3435,8 +3608,8 @@ final class PushEndpointsTest extends TestCase {
             $push_state_directory
         );
         $sender = is_file($push_state_directory . '/sender.json')
-            ? PushFilesSender::resume($options)
-            : PushFilesSender::start($options);
+            ? $this->resumeSender($options)
+            : $this->startSender($options);
         try {
             for ($step = 0; $step < 200; ++$step) {
                 $has_more_steps = $sender->next_step();
@@ -3448,7 +3621,7 @@ final class PushEndpointsTest extends TestCase {
                 }
             }
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->fail('The high-level sender did not reach a terminal result in 200 steps.');
     }

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -4,10 +4,9 @@
  * Specifically guards the contract introduced by the "stream file parts
  * directly to disk" change: now that bytes hit the local file before a
  * multipart part finishes, a request cut mid-body leaves a partially-
- * written file on disk. The importer must resume that exact file —
- * not start over (truncation) and not append duplicates (overlap) —
- * and the server-side cursor must cooperate by skipping the bytes the
- * importer already has.
+ * written file on disk. The importer resumes from the last completed
+ * multipart part, replaying unconfirmed bytes without gaps or
+ * duplication.
  *
  * Setup: a 2 MiB random binary file. With --file-chunk-max=262144, the
  * file is sliced into eight chunks. A test_hook_before_file_chunk hook
@@ -133,15 +132,6 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         const partialSize = statSync(localPath).size;
         assert.ok(partialSize > 0 && partialSize < fileSize,
             `Expected a partial file (0 < size < ${fileSize}), got ${partialSize}`);
-    });
-
-    it('state records current_file and current_file_bytes for resume', () => {
-        const stateFile = join(tempDir, '.import-state.json');
-        assert.ok(existsSync(stateFile), 'Expected import state file to exist');
-        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.ok(state.current_file, 'Expected state.current_file to be set after a mid-file crash');
-        assert.ok(typeof state.current_file_bytes === 'number' && state.current_file_bytes > 0,
-            `Expected state.current_file_bytes > 0, got ${state.current_file_bytes}`);
     });
 
     it('resume completes after removing the hook', () => {

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -134,6 +134,15 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
             `Expected a partial file (0 < size < ${fileSize}), got ${partialSize}`);
     });
 
+    it('state records current_file and current_file_bytes for resume', () => {
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected import state file to exist');
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assert.ok(state.current_file, 'Expected state.current_file to be set after a mid-file crash');
+        assert.ok(typeof state.current_file_bytes === 'number' && state.current_file_bytes > 0,
+            `Expected state.current_file_bytes > 0, got ${state.current_file_bytes}`);
+    });
+
     it('resume completes after removing the hook', () => {
         removeTestHooks(site);
 


### PR DESCRIPTION
Compatible file-only pulls and committed `files-push` operations now advance the same `previous_local_index.jsonl` only for paths they applied. `files-diff` stops reporting transferred work while local additions, edits, and deletions elsewhere remain pending.

## Background

`files-diff` compares the current local tree with the pair's previous local index. Before this PR, `files-push` replaced that baseline with its complete plan-start local index after target commit, while pull mutations advanced only the import index. Pull and push therefore did not maintain one durable baseline, and a resumed sender could overwrite paths advanced by a compatible pull between sender processes.

## This change

A compatible full file-only pull seeds a missing previous local index before its first local mutation. Each durable WAL batch then publishes the applied paths into both the import index and the previous local index before clearing the batch. A compatible partial pull advances an existing baseline but cannot seed one; an incompatible pull removes the baseline before mutating the tree.

After target commit, `files-push` merges only its committed push and delete operations, plus their required ancestors, into the latest baseline. It no longer replaces that baseline with the plan-start snapshot.

One state-directory `.reprint.lock` excludes other local Reprint commands throughout the lifecycle. An empty `.import-index-updates.wal` remains as the `files-pull` lifecycle marker, and a non-empty WAL is replayed after interruption. Pull and push use the same streaming index merger, so large indexes remain single-pass and bounded in memory.

## Testing

Run a compatible full file-only pull, make a local change, then run a compatible partial pull for another path. Confirm that `files-diff` still reports the local change but not the pulled path.

Complete a `files-push` and confirm that its committed paths leave `files-diff` while unrelated pending paths remain. Interrupt a pull with a WAL batch open, resume it, and confirm the completed batch is applied once to both indexes.
