### PR TITLE
Preserve blob PKs in SQL resume cursors

### DIFF
--- a/packages/reprint-exporter/src/class-mysql-dump-producer.php
+++ b/packages/reprint-exporter/src/class-mysql-dump-producer.php
@@ -840,19 +840,21 @@ class MySQLDumpProducer
      * MySQLDumpProducer to resume exactly where this one left off. The JSON is
      * NOT base64-encoded — that's the HTTP layer's concern (export.php).
      *
-     * String and binary values in the in-flight row and oversized chunk queue
-     * are wrapped in {"__binary__": "<base64>"} markers because raw binary
+     * String values in the in-flight row and primary key checkpoints are
+     * wrapped in {"__binary__": "<base64>"} markers because raw database
      * bytes can't survive JSON encoding.
      */
     public function get_reentrancy_cursor()
     {
-        $encoded_current_row = $this->encode_row_for_cursor($this->current_row);
+        $encoded_last_pk_values = $this->encode_database_values_for_cursor($this->last_pk_values);
+        $encoded_current_row = $this->encode_database_values_for_cursor($this->current_row);
         $encoded_oversized_queue = $this->encode_oversized_queue_for_cursor($this->oversized_queue);
+        $encoded_oversized_pk_values = $this->encode_database_values_for_cursor($this->oversized_pk_values);
 
         $json = json_encode([
             "current_table" => $this->current_table,
             "current_pk_columns" => $this->current_pk_columns,
-            "last_pk_values" => $this->last_pk_values,
+            "last_pk_values" => $encoded_last_pk_values,
             "current_offset" => $this->current_offset,
             "state" => $this->state,
             "current_row" => $encoded_current_row,
@@ -863,7 +865,7 @@ class MySQLDumpProducer
              * max_statement_size.
              */
             "oversized_queue" => $encoded_oversized_queue,
-            "oversized_pk_values" => $this->oversized_pk_values,
+            "oversized_pk_values" => $encoded_oversized_pk_values,
             "state_after_oversized" => $this->state_after_oversized,
             "current_statement_size" => $this->current_statement_size,
         ]);
@@ -876,41 +878,41 @@ class MySQLDumpProducer
     }
 
     /**
-     * Wraps all string values in {"__binary__": base64} for JSON safety.
-     * JSON is UTF-8-encoded and cannot express arbitrary binary data. The
-     * "__binary__" "type brand" makes it easy to detect and decode binary data
-     * when restoring the cursor.
+     * Wraps every string in a row or primary key checkpoint in
+     * {"__binary__": base64} for JSON safety. JSON is UTF-8-encoded and cannot
+     * express arbitrary database bytes. The "__binary__" marker identifies
+     * strings to decode when restoring the cursor.
      */
-    private function encode_row_for_cursor($row)
+    private function encode_database_values_for_cursor($values)
     {
-        if ($row === null) {
+        if ($values === null) {
             return null;
         }
 
         $encoded = [];
-        foreach ($row as $col => $value) {
+        foreach ($values as $column_name => $value) {
             if ($value !== null && is_string($value)) {
-                $encoded[$col] = ['__binary__' => base64_encode($value)];
+                $encoded[$column_name] = ['__binary__' => base64_encode($value)];
             } else {
-                $encoded[$col] = $value;
+                $encoded[$column_name] = $value;
             }
         }
         return $encoded;
     }
 
-    /** Reverses encode_row_for_cursor(). */
-    private function decode_row_from_cursor($row)
+    /** Reverses encode_database_values_for_cursor(). */
+    private function decode_database_values_from_cursor($values)
     {
-        if ($row === null) {
+        if ($values === null) {
             return null;
         }
 
         $decoded = [];
-        foreach ($row as $col => $value) {
+        foreach ($values as $column_name => $value) {
             if (is_array($value) && isset($value['__binary__'])) {
-                $decoded[$col] = base64_decode($value['__binary__']);
+                $decoded[$column_name] = base64_decode($value['__binary__']);
             } else {
-                $decoded[$col] = $value;
+                $decoded[$column_name] = $value;
             }
         }
         return $decoded;
@@ -980,7 +982,9 @@ class MySQLDumpProducer
             }
             $this->current_pk_columns =
                 $cursor_data["current_pk_columns"] ?? null;
-            $this->last_pk_values = $cursor_data["last_pk_values"] ?? null;
+            $this->last_pk_values = $this->decode_database_values_from_cursor(
+                $cursor_data["last_pk_values"] ?? null
+            );
             $this->current_offset = $cursor_data["current_offset"] ?? 0;
             if (!is_int($this->current_offset) && !is_float($this->current_offset)) {
                 throw new \InvalidArgumentException(
@@ -990,7 +994,7 @@ class MySQLDumpProducer
             $this->current_offset = (int) $this->current_offset;
             $this->state = $cursor_data["state"] ?? self::STATE_INIT;
             $encoded_row = $cursor_data["current_row"] ?? null;
-            $this->current_row = $this->decode_row_from_cursor($encoded_row);
+            $this->current_row = $this->decode_database_values_from_cursor($encoded_row);
             $this->rows_in_batch = $cursor_data["rows_in_batch"] ?? 0;
             if (!is_int($this->rows_in_batch) && !is_float($this->rows_in_batch)) {
                 throw new \InvalidArgumentException(
@@ -1003,7 +1007,9 @@ class MySQLDumpProducer
 
             $encoded_queue = $cursor_data["oversized_queue"] ?? [];
             $this->oversized_queue = $this->decode_oversized_queue_from_cursor($encoded_queue);
-            $this->oversized_pk_values = $cursor_data["oversized_pk_values"] ?? null;
+            $this->oversized_pk_values = $this->decode_database_values_from_cursor(
+                $cursor_data["oversized_pk_values"] ?? null
+            );
             $this->state_after_oversized = $cursor_data["state_after_oversized"] ?? null;
 
             $this->current_statement_size = $cursor_data["current_statement_size"] ?? 0;

--- a/tests/MySQLDumpProducer/EncodingTest.php
+++ b/tests/MySQLDumpProducer/EncodingTest.php
@@ -1183,4 +1183,62 @@ class EncodingTest extends MySQLDumpProducerTestBase
             $this->assertSame($expected, $rows[$i], "Binary mismatch at row " . ($i + 1));
         }
     }
+
+    /**
+     * Primary key values are part of the resume cursor as well as the SQL.
+     * Arbitrary key bytes must survive a cursor round trip without being
+     * interpreted as JSON text.
+     */
+    public function testReentrancyWithInvalidUtf8PrimaryKey(): void
+    {
+        $this->pdo->exec("CREATE TABLE t (id VARBINARY(16) PRIMARY KEY, data VARCHAR(50))");
+
+        $rows = [
+            ["\x00\xFF", "first"],
+            ["\x80\xFE", "second"],
+            ["\xFF\xFE", "third"],
+        ];
+        $stmt = $this->pdo->prepare("INSERT INTO t (id, data) VALUES (?, ?)");
+        foreach ($rows as $row) {
+            $stmt->execute($row);
+        }
+
+        $options = ["batch_size" => 1];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        $saw_primary_key_checkpoint = false;
+
+        while ($producer->next_sql_fragment()) {
+            $fragments[] = $producer->get_sql_fragment();
+
+            try {
+                $cursor = $producer->get_reentrancy_cursor();
+            } catch (RuntimeException $e) {
+                $this->fail(
+                    "The cursor must preserve arbitrary primary key bytes: " .
+                    $e->getMessage()
+                );
+            }
+
+            $cursor_data = json_decode($cursor, true);
+            if ($cursor_data["last_pk_values"] !== null) {
+                $saw_primary_key_checkpoint = true;
+                $this->assertArrayHasKey(
+                    "__binary__",
+                    $cursor_data["last_pk_values"]["id"]
+                );
+            }
+
+            if (!$producer->is_finished()) {
+                $options["cursor"] = $cursor;
+                $producer = $this->createProducer($options);
+            }
+        }
+
+        $this->assertTrue($saw_primary_key_checkpoint);
+
+        $sql = implode("\n", $fragments);
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertDatabasesEqual($this->pdo, $import_pdo, ["t"]);
+    }
 }

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -270,6 +270,72 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
     }
 
     /**
+     * The oversized row checkpoint retains its primary key while UPDATE
+     * fragments are emitted. Arbitrary key bytes must survive every resume.
+     */
+    public function testReentrancyWithInvalidUtf8PrimaryKeyInOversizedRow(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE reentrant_large_binary_key (
+                id VARBINARY(16) PRIMARY KEY,
+                content LONGBLOB
+            )
+        ");
+
+        $id = "\xFF\xFE\x80";
+        $content = random_bytes(20 * 1024);
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO reentrant_large_binary_key (id, content) VALUES (?, ?)"
+        );
+        $stmt->execute([$id, $content]);
+
+        $options = [
+            "max_statement_size" => 8 * 1024,
+            "batch_size" => 1,
+        ];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        $saw_oversized_primary_key_checkpoint = false;
+
+        while ($producer->next_sql_fragment()) {
+            $fragments[] = $producer->get_sql_fragment();
+
+            try {
+                $cursor = $producer->get_reentrancy_cursor();
+            } catch (RuntimeException $e) {
+                $this->fail(
+                    "The cursor must preserve the oversized row primary key: " .
+                    $e->getMessage()
+                );
+            }
+
+            $cursor_data = json_decode($cursor, true);
+            if ($cursor_data["oversized_pk_values"] !== null) {
+                $saw_oversized_primary_key_checkpoint = true;
+                $this->assertSame(
+                    base64_encode($id),
+                    $cursor_data["oversized_pk_values"]["id"]["__binary__"]
+                );
+            }
+
+            if (!$producer->is_finished()) {
+                $options["cursor"] = $cursor;
+                $producer = $this->createProducer($options);
+            }
+        }
+
+        $this->assertTrue($saw_oversized_primary_key_checkpoint);
+
+        $sql = implode("\n", $fragments);
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertDatabasesEqual(
+            $this->pdo,
+            $import_pdo,
+            ["reentrant_large_binary_key"]
+        );
+    }
+
+    /**
      * Test with base64 string encoding.
      */
     public function testBase64EncodingWithLargeData(): void

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -133,6 +133,9 @@
     },
     "symlink-bundle": {
       "port": 8123
+    },
+    "adversarial-database": {
+      "port": 8124
     }
   }
 }

--- a/tests/e2e/tests/import-53-adversarial-database-pull.test.js
+++ b/tests/e2e/tests/import-53-adversarial-database-pull.test.js
@@ -1,0 +1,373 @@
+/**
+ * Test 53: Adversarial database pull
+ *
+ * Runs the complete pull-db pipeline against tables whose primary keys contain
+ * arbitrary bytes. Small SQL batches and short server budgets force those keys
+ * through cursors across several requests. The target schema and rows must
+ * match the source, including a composite key and an oversized binary row.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    compareDatabases, createMysqlConnection, assertPullPipelineComplete,
+    writeTestHooks, removeTestHooks,
+    writeHookState, readHookState, clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Adversarial database pull', { timeout: 300000 }, () => {
+    const site = 'adversarial-database';
+    const importDb = 'e2e_adversarial_database_import_53';
+    const adversarialTables = [
+        'aa_binary_primary_keys',
+        'ab_composite_binary_primary_key',
+        'ac_oversized_binary_primary_key',
+    ];
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            customDb: async (_dbName, conn) => {
+                await createAdversarialTables(conn);
+            },
+        });
+        tempDir = createTempDir('e2e-adversarial-database-pull');
+
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
+
+        clearHookState(site);
+        writeHookState(site, {
+            sql_requests: 0,
+            forced_partial_responses: 0,
+            cursor_tables: {},
+        });
+        writeTestHooks(site, cursorInspectionHooks(site));
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        cleanupTempDir(tempDir);
+
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    it('preserves every hostile table through a multi-request pull-db', async () => {
+        const result = runImporter(importUrl(), tempDir, 'pull-db', {
+            secret: getSiteSecret(site),
+            // PHP.wasm startup and SQL parsing add substantial overhead to
+            // each importer invocation in the Playground E2E job.
+            timeout: 240000,
+            wallTimeout: 300000,
+            maxResumeAttempts: 100,
+            extraArgs: [
+                '--target-host=127.0.0.1',
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${importDb}`,
+                '--max-allowed-packet=1M',
+                '--max-exec=1',
+                '--sql-fragments-start=1',
+                '--sql-fragments-min=1',
+                '--sql-fragments-max=1',
+            ],
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `Expected pull-db exit 0, got ${result.exitCode}\n` +
+                `stderr (${result.stderr.length} bytes, last 4000): ` +
+                `${result.stderr.slice(-4000)}\n` +
+                `stdout (${result.stdout.length} bytes, last 4000): ` +
+                `${result.stdout.slice(-4000)}`,
+        );
+        const importState = JSON.parse(
+            readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
+        );
+        assertPullPipelineComplete(importState, 'pull-db');
+
+        const hookState = readHookState(site);
+        assert.ok(hookState, 'Expected SQL cursor hook state');
+        assert.ok(
+            hookState.sql_requests >= 4,
+            `Expected at least four SQL requests, got ${hookState.sql_requests}`,
+        );
+        assert.equal(
+            hookState.forced_partial_responses,
+            3,
+            'Expected three resource-budget partial responses',
+        );
+        assertCursorCoveredTable(
+            hookState,
+            'last_pk_values',
+            'aa_binary_primary_keys',
+        );
+        assertCursorCoveredTable(
+            hookState,
+            'last_pk_values',
+            'ab_composite_binary_primary_key',
+        );
+        assertCursorCoveredTable(
+            hookState,
+            'current_row',
+            'aa_binary_primary_keys',
+        );
+        assertCursorCoveredTable(
+            hookState,
+            'oversized_pk_values',
+            'ac_oversized_binary_primary_key',
+        );
+
+        const comparison = await compareDatabases(getDbName(site), importDb);
+        assert.ok(
+            comparison.match && comparison.extraTables.length === 0,
+            `Database mismatch: missing=${JSON.stringify(comparison.missingTables)}, ` +
+                `extra=${JSON.stringify(comparison.extraTables)}, ` +
+                `counts=${JSON.stringify(comparison.rowCounts)}`,
+        );
+
+        const sourceConn = await createMysqlConnection(getDbName(site));
+        const importConn = await createMysqlConnection(importDb);
+        try {
+            for (const table of adversarialTables) {
+                assert.equal(
+                    await getCreateTable(sourceConn, table),
+                    await getCreateTable(importConn, table),
+                    `Schema mismatch for ${table}`,
+                );
+            }
+
+            assert.deepEqual(
+                await readSingleKeyRows(importConn),
+                await readSingleKeyRows(sourceConn),
+                'Single-column binary primary key rows changed',
+            );
+            assert.deepEqual(
+                await readCompositeKeyRows(importConn),
+                await readCompositeKeyRows(sourceConn),
+                'Composite binary primary key rows changed',
+            );
+            assert.deepEqual(
+                await readOversizedRows(importConn),
+                await readOversizedRows(sourceConn),
+                'Oversized binary primary key rows changed',
+            );
+        } finally {
+            await sourceConn.end();
+            await importConn.end();
+        }
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+});
+
+async function createAdversarialTables(conn) {
+    await conn.query(`
+CREATE TABLE aa_binary_primary_keys (
+    id VARBINARY(32) NOT NULL,
+    label VARCHAR(64) NOT NULL,
+    payload BLOB NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE ab_composite_binary_primary_key (
+    tenant VARBINARY(32) NOT NULL,
+    sequence BIGINT UNSIGNED NOT NULL,
+    suffix VARBINARY(32) NOT NULL,
+    payload BLOB NOT NULL,
+    PRIMARY KEY (tenant, sequence, suffix)
+) ENGINE=InnoDB;
+
+CREATE TABLE ac_oversized_binary_primary_key (
+    id VARBINARY(32) NOT NULL,
+    label VARCHAR(64) NOT NULL,
+    payload LONGBLOB NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+    `);
+
+    const singleKeyRows = [
+        [Buffer.alloc(0), 'empty key', Buffer.from('00ff80', 'hex')],
+        [Buffer.from('00', 'hex'), 'NUL key', Buffer.from('000102ff', 'hex')],
+        [Buffer.from('7f', 'hex'), 'ASCII boundary', Buffer.from('quotes-\'"\\\\\n')],
+        [Buffer.from('80', 'hex'), 'continuation byte', bytePattern(257, 3)],
+        [Buffer.from('c0af', 'hex'), 'overlong UTF-8', bytePattern(513, 7)],
+        [Buffer.from('eda080', 'hex'), 'UTF-8 surrogate', bytePattern(1025, 11)],
+        [Buffer.from('f0288cbc', 'hex'), 'invalid four-byte UTF-8', bytePattern(2049, 13)],
+        [Buffer.from('fffefdfc0080', 'hex'), 'high and NUL bytes', bytePattern(4097, 17)],
+    ];
+    for (const row of singleKeyRows) {
+        await conn.query(
+            'INSERT INTO aa_binary_primary_keys (id, label, payload) VALUES (?, ?, ?)',
+            row,
+        );
+    }
+
+    const compositeKeyRows = [
+        [Buffer.from('00ff', 'hex'), '0', Buffer.alloc(0), Buffer.from('first')],
+        [Buffer.from('00ff', 'hex'), '18446744073709551615', Buffer.from('80', 'hex'), bytePattern(300, 19)],
+        [Buffer.from('80', 'hex'), '42', Buffer.from('00ff00', 'hex'), bytePattern(600, 23)],
+        [Buffer.from('fffe', 'hex'), '42', Buffer.from('c0af', 'hex'), bytePattern(900, 29)],
+        [Buffer.from('fffe', 'hex'), '43', Buffer.from('fffefd', 'hex'), bytePattern(1200, 31)],
+    ];
+    for (const row of compositeKeyRows) {
+        await conn.query(
+            'INSERT INTO ab_composite_binary_primary_key ' +
+                '(tenant, sequence, suffix, payload) VALUES (?, ?, ?, ?)',
+            row,
+        );
+    }
+
+    await conn.query(
+        'INSERT INTO ac_oversized_binary_primary_key (id, label, payload) VALUES (?, ?, ?)',
+        [
+            Buffer.from('80ff00fe', 'hex'),
+            'oversized binary row',
+            bytePattern(2 * 1024 * 1024 + 17, 37),
+        ],
+    );
+    await conn.query(
+        'INSERT INTO ac_oversized_binary_primary_key (id, label, payload) VALUES (?, ?, ?)',
+        [
+            Buffer.from('fffefdfc', 'hex'),
+            'row after oversized key',
+            Buffer.from('00ff80fefdc0af', 'hex'),
+        ],
+    );
+}
+
+function cursorInspectionHooks(site) {
+    return `
+function _e2e_adversarial_cursor_state() {
+    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';
+    if (!file_exists($state_file)) {
+        return [$state_file, []];
+    }
+    $state = json_decode(file_get_contents($state_file), true);
+    return [$state_file, is_array($state) ? $state : []];
+}
+
+function _e2e_adversarial_cursor_has_binary_marker($value) {
+    if (!is_array($value)) {
+        return false;
+    }
+    if (array_key_exists('__binary__', $value)) {
+        return true;
+    }
+    foreach ($value as $nested) {
+        if (_e2e_adversarial_cursor_has_binary_marker($nested)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function test_hook_after_gzip_init($gz, $boundary) {
+    list($state_file, $state) = _e2e_adversarial_cursor_state();
+    $state['sql_requests'] = ($state['sql_requests'] ?? 0) + 1;
+    file_put_contents($state_file, json_encode($state));
+}
+
+function test_hook_before_sql_batch(&$sql, $cursor) {
+    list($state_file, $state) = _e2e_adversarial_cursor_state();
+    $checkpoint = json_decode($cursor, true);
+    $table = $checkpoint['current_table'] ?? null;
+    $contains_binary_checkpoint = false;
+
+    foreach (['last_pk_values', 'current_row', 'oversized_pk_values'] as $field) {
+        if (_e2e_adversarial_cursor_has_binary_marker($checkpoint[$field] ?? null)) {
+            $contains_binary_checkpoint = true;
+            if (in_array($table, [
+                'aa_binary_primary_keys',
+                'ab_composite_binary_primary_key',
+                'ac_oversized_binary_primary_key',
+            ], true)) {
+                $state['cursor_tables'][$field][$table] = true;
+            }
+        }
+    }
+
+    $forced = $state['forced_partial_responses'] ?? 0;
+    if ($contains_binary_checkpoint && $forced < 3) {
+        $state['forced_partial_responses'] = $forced + 1;
+        file_put_contents($state_file, json_encode($state));
+        usleep(1100000);
+        return;
+    }
+
+    file_put_contents($state_file, json_encode($state));
+}
+`;
+}
+
+function assertCursorCoveredTable(hookState, field, table) {
+    assert.equal(
+        hookState.cursor_tables?.[field]?.[table],
+        true,
+        `Expected ${field} cursor coverage for ${table}`,
+    );
+}
+
+async function getCreateTable(conn, table) {
+    const [[row]] = await conn.query(`SHOW CREATE TABLE \`${table}\``);
+    return row['Create Table'];
+}
+
+async function readSingleKeyRows(conn) {
+    const [rows] = await conn.query(`
+SELECT
+    HEX(id) AS id_hex,
+    label,
+    HEX(payload) AS payload_hex
+FROM aa_binary_primary_keys
+ORDER BY id
+    `);
+    return rows;
+}
+
+async function readCompositeKeyRows(conn) {
+    const [rows] = await conn.query(`
+SELECT
+    HEX(tenant) AS tenant_hex,
+    CAST(sequence AS CHAR) AS sequence_text,
+    HEX(suffix) AS suffix_hex,
+    HEX(payload) AS payload_hex
+FROM ab_composite_binary_primary_key
+ORDER BY tenant, sequence, suffix
+    `);
+    return rows;
+}
+
+async function readOversizedRows(conn) {
+    const [rows] = await conn.query(`
+SELECT
+    HEX(id) AS id_hex,
+    label,
+    OCTET_LENGTH(payload) AS payload_bytes,
+    SHA2(payload, 256) AS payload_sha256,
+    HEX(LEFT(payload, 16)) AS payload_prefix,
+    HEX(RIGHT(payload, 16)) AS payload_suffix
+FROM ac_oversized_binary_primary_key
+ORDER BY id
+    `);
+    return rows;
+}
+
+function bytePattern(length, seed) {
+    const bytes = Buffer.allocUnsafe(length);
+    for (let index = 0; index < length; index++) {
+        bytes[index] = (index * 131 + seed) % 256;
+    }
+    return bytes;
+}


### PR DESCRIPTION
SQL pulls now resume across arbitrary primary-key bytes instead of stopping when a checkpoint is not valid UTF-8.

## Background

The dump already wrapped strings in `current_row` before writing its resume cursor as JSON. It wrote `last_pk_values` and `oversized_pk_values` unchanged, so binary or legacy-character-set keys stopped the response between SQL batches.

## This change

All three database-value checkpoints now use the same reversible byte envelope. A resumed dump decodes them before building the next primary-key query.

## Cursor format

For a valid string primary key, the relevant cursor fragment changes from:

```json
{"last_pk_values":{"slug":"post-42"}}
```

to:

```json
{"last_pk_values":{"slug":{"__binary__":"cG9zdC00Mg=="}}}
```

For the primary-key bytes `ff 00 41`, the old code produced no cursor because `json_encode()` failed. The new cursor contains:

```json
{"last_pk_values":{"slug":{"__binary__":"/wBB"}}}
```

Every PHP string in `last_pk_values` and `oversized_pk_values` gets this representation, not only strings containing invalid UTF-8. This includes normal text keys and any numeric database value PDO returns as a string. Integers and `null` remain unchanged.

`current_row` already wrapped every string before this PR, so its JSON representation does not change. The other top-level cursor fields are also unchanged. The `X-Cursor` header changes whenever the JSON changes because it contains a base64 encoding of the complete cursor.

Existing cursors remain resumable: the decoder accepts both unwrapped scalar values and the `__binary__` representation.

## Testing

The end-to-end test runs the complete `pull-db` pipeline across invalid-byte single and composite primary keys and a two-megabyte oversized row. It forces three partial responses, resumes across four SQL requests, applies the dump, and compares the imported schemas and row bytes with the source.

The test stops at the malformed UTF-8 cursor error with the trunk exporter and passes with this change. The MySQLDumpProducer suite, static checks, every supported E2E PHP pairing, Playground E2E, and the pull benchmark pass.
