### PR TITLE
Resume file and database pulls after interrupted HTTP responses

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -1023,6 +1023,10 @@ function endpoint_db_index(
 
     $creds = resolve_db_credentials();
 
+    if (getenv('SITE_EXPORT_TEST_MODE')) {
+        _e2e_load_test_hooks_if_needed($config);
+    }
+
     $tables_per_batch = $config["tables_per_batch"] ?? 1000;
     $tables_per_batch = require_int_range(
         "tables_per_batch",
@@ -1129,6 +1133,12 @@ function endpoint_db_index(
     }
 
     try {
+        if (getenv('SITE_EXPORT_TEST_MODE')) {
+            $hook_status = $aborted ? "partial" : $status;
+            $hook_args = [$hook_status, $gz, $boundary];
+            _e2e_call_hook('test_hook_before_completion', $hook_args);
+        }
+
         $gz->write(
             "--{$boundary}\r\n" .
             "Content-Type: application/octet-stream\r\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -11148,14 +11148,6 @@ class ImportClient
      */
     private function normalize_state(array $state): array
     {
-        if (
-            !array_key_exists("consecutive_interrupted_responses", $state) &&
-            array_key_exists("consecutive_timeouts", $state)
-        ) {
-            $state["consecutive_interrupted_responses"] =
-                $state["consecutive_timeouts"];
-        }
-
         $defaults = $this->default_state();
         $state = array_intersect_key($state, $defaults);
         $state = array_merge($defaults, $state);

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -252,11 +252,11 @@ class ImportClient
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
 
     /**
-     * Maximum number of consecutive cURL timeouts with no cursor progress
-     * before the importer gives up. This prevents infinite retry loops
-     * when the remote server is genuinely unresponsive.
+     * Maximum number of consecutive interrupted responses with no cursor
+     * progress before the importer gives up. This prevents endless resumption
+     * when the source cannot complete a response.
      */
-    private const MAX_CONSECUTIVE_TIMEOUTS = 3;
+    private const MAX_CONSECUTIVE_INTERRUPTED_RESPONSES = 3;
 
     /** @var string Export server URL. */
     public $remote_url;
@@ -3732,7 +3732,7 @@ class ImportClient
 
             $this->download_db_index();
 
-            // Timeout during db-index — state already saved, exit partial.
+            // Interrupted response during db-index — state already saved, exit partial.
             if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
                 return;
             }
@@ -3757,7 +3757,7 @@ class ImportClient
 
         $this->download_sql();
 
-        // Timeout during SQL download — state already saved, exit partial.
+        // Interrupted response during SQL download — state already saved, exit partial.
         if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
             return;
         }
@@ -5934,6 +5934,12 @@ class ImportClient
         $this->save_state($this->state);
 
         $this->download_db_index();
+        if (
+            $this->import_state()->active_resumable_command->completion_state ===
+            "partial"
+        ) {
+            return;
+        }
 
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->save_state($this->state);
@@ -6147,24 +6153,30 @@ class ImportClient
                 $post_data,
                 "file_fetch",
             );
-        } catch (CurlTimeoutException $e) {
-            // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
-            // with no progress, so we don't retry forever.
-            $this->assert_can_retry_consecutive_timeout("file_fetch", $cursor_before, $cursor);
-            // Save state so the next invocation resumes from the
-            // last cursor instead of crashing with exit code 1.
-            $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-            $this->finalize_index_updates();
-            if ($context->file_handle && $context->file_path) {
+        } catch (InterruptedResponseException $e) {
+            // A streaming body may have written bytes for a multipart part
+            // whose cursor is not durable yet. Keep the checkpoint saved by
+            // the last complete part; the next invocation truncates any later
+            // bytes before resuming.
+            $durable_cursor =
+                $this->get_download_list_fetch_state($state_key)->cursor;
+            $this->assert_can_resume_after_interrupted_response(
+                "file_fetch",
+                $cursor_before,
+                $durable_cursor,
+                $e,
+            );
+            if ($context->file_handle) {
                 fflush($context->file_handle);
-                $this->import_state()->current_file = $context->file_path;
-                $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                fclose($context->file_handle);
+                $context->file_handle = null;
             }
+            $this->finalize_index_updates();
             $this->import_state()->active_resumable_command->completion_state = "partial";
             $this->save_state($this->state);
             return false;
         }
-        $this->import_state()->consecutive_timeouts = 0;
+        $this->import_state()->consecutive_interrupted_responses = 0;
         $wall_time = microtime(true) - $request_start;
 
         $this->finalize_tuned_request(
@@ -6404,17 +6416,20 @@ class ImportClient
         $request_start = microtime(true);
         try {
             $this->fetch_streaming($url, $cursor, $context, null, "file_index");
-        } catch (CurlTimeoutException $e) {
-            // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
-            // with no progress, so we don't retry forever.
-            $this->assert_can_retry_consecutive_timeout("file_index", $cursor_before, $cursor);
+        } catch (InterruptedResponseException $e) {
+            $this->assert_can_resume_after_interrupted_response(
+                "file_index",
+                $cursor_before,
+                $cursor,
+                $e,
+            );
             fclose($handle);
             $this->import_state()->index->cursor = $cursor;
             $this->import_state()->active_resumable_command->completion_state = "partial";
             $this->save_state($this->state);
             return false;
         }
-        $this->import_state()->consecutive_timeouts = 0;
+        $this->import_state()->consecutive_interrupted_responses = 0;
         $wall_time = microtime(true) - $request_start;
         $this->finalize_tuned_request(
             "file_index",
@@ -7780,9 +7795,12 @@ class ImportClient
                 try {
                     $this->fetch_streaming($url, $cursor, $context, null, "sql_chunk");
                 } catch (CurlTimeoutException $e) {
-                    // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
-                    // with no progress, so we don't retry forever.
-                    $this->assert_can_retry_consecutive_timeout("sql_chunk", $cursor_before, $cursor);
+                    $this->assert_can_resume_after_interrupted_response(
+                        "sql_chunk",
+                        $cursor_before,
+                        $cursor,
+                        $e,
+                    );
                     // Save state so the next invocation resumes from the
                     // last cursor instead of crashing with exit code 1.
                     if ($sql_handle) {
@@ -7800,56 +7818,34 @@ class ImportClient
                     $sql_buffer = "";
                     $curl_timed_out = true;
                     break;
-                } catch (RuntimeException $e) {
+                } catch (InterruptedResponseException $e) {
                     // The server may crash mid-response (max_execution_time,
-                    // OOM, fatal error). This surfaces as either:
-                    //  - "missing completion chunk" (response ended without it)
-                    //  - cURL error 18/52/56 (partial transfer / recv error)
-                    //  - "missing multipart boundary" (proxy error page)
-                    // Treat these as a retryable partial response: save state
-                    // so the next invocation resumes from the cursor. Unlike
-                    // a timeout (where the buffer is discarded and re-fetched),
-                    // we keep $sql_buffer intact here so the .sql-buffer file
-                    // is preserved — the next run reloads it and continues
-                    // accumulating from where the server left off.
-                    $msg = $e->getMessage();
-                    // Only retry connection-level curl errors that indicate
-                    // the server crashed or the connection was interrupted.
-                    // Do NOT retry content-encoding errors (e.g. gzip
-                    // corruption, CURLE_BAD_CONTENT_ENCODING=61) — those
-                    // will fail identically on every retry.
-                    //   18 = CURLE_PARTIAL_FILE (transfer closed mid-stream)
-                    //   52 = CURLE_GOT_NOTHING (empty response)
-                    //   56 = CURLE_RECV_ERROR (connection reset / recv failure)
-                    $is_retryable_curl = preg_match(
-                        '/cURL error \((\d+)\):/', $msg, $curl_match
-                    ) && in_array((int) $curl_match[1], [18, 52, 56]);
-                    $is_retryable =
-                        strpos($msg, "missing completion chunk") !== false ||
-                        $is_retryable_curl ||
-                        strpos($msg, "missing multipart boundary") !== false;
-                    if ($is_retryable) {
-                        $this->audit_log(
-                            "INCOMPLETE RESPONSE | " . $msg .
-                            " | buffered_sql=" . strlen($sql_buffer) . " bytes" .
-                            " — will save state for retry",
-                            true,
-                        );
-                        $this->assert_can_retry_consecutive_timeout("sql_chunk", $cursor_before, $cursor);
-                        if ($sql_handle) {
-                            fflush($sql_handle);
-                        }
-                        $this->import_state()->active_resumable_command->remote_cursor = $cursor;
-                        $this->import_state()->sql_bytes = $sql_bytes_written;
-                        $this->import_state()->sql_statements_counted = $sql_statements_counted;
-                        $this->import_state()->active_resumable_command->completion_state = "partial";
-                        $this->save_state($this->state);
-                        $curl_timed_out = true;
-                        break;
+                    // OOM, fatal error). Keep $sql_buffer intact so the next
+                    // invocation reloads it and continues from the last
+                    // complete response part.
+                    $this->audit_log(
+                        "SQL BUFFER | buffered_sql=" . strlen($sql_buffer) .
+                        " bytes | saving state after interrupted response",
+                        true,
+                    );
+                    $this->assert_can_resume_after_interrupted_response(
+                        "sql_chunk",
+                        $cursor_before,
+                        $cursor,
+                        $e,
+                    );
+                    if ($sql_handle) {
+                        fflush($sql_handle);
                     }
-                    throw $e;
+                    $this->import_state()->active_resumable_command->remote_cursor = $cursor;
+                    $this->import_state()->sql_bytes = $sql_bytes_written;
+                    $this->import_state()->sql_statements_counted = $sql_statements_counted;
+                    $this->import_state()->active_resumable_command->completion_state = "partial";
+                    $this->save_state($this->state);
+                    $curl_timed_out = true;
+                    break;
                 }
-                $this->import_state()->consecutive_timeouts = 0;
+                $this->import_state()->consecutive_interrupted_responses = 0;
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "sql_chunk",
@@ -8335,10 +8331,13 @@ class ImportClient
                         null,
                         "db_index",
                     );
-                } catch (CurlTimeoutException $e) {
-                    // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
-                    // with no progress, so we don't retry forever.
-                    $this->assert_can_retry_consecutive_timeout("db_index", $cursor_before, $cursor);
+                } catch (InterruptedResponseException $e) {
+                    $this->assert_can_resume_after_interrupted_response(
+                        "db_index",
+                        $cursor_before,
+                        $cursor,
+                        $e,
+                    );
                     fflush($handle);
                     $this->import_state()->active_resumable_command->remote_cursor = $cursor;
                     $this->import_state()->db_index->file = $tables_file;
@@ -8350,7 +8349,7 @@ class ImportClient
                     $this->save_state($this->state);
                     return;
                 }
-                $this->import_state()->consecutive_timeouts = 0;
+                $this->import_state()->consecutive_interrupted_responses = 0;
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "db_index",
@@ -10263,8 +10262,11 @@ class ImportClient
     }
 
     /**
-     * Check for curl errors after curl_exec and record timeout state.
-     * Throws RuntimeException on any curl error.
+     * Check for cURL errors after curl_exec and record timeout state.
+     *
+     * @throws CurlTimeoutException        When the request times out.
+     * @throws InterruptedResponseException When the response ends early.
+     * @throws RuntimeException            For every other cURL error.
      */
     private function check_curl_error($ch): void
     {
@@ -10281,49 +10283,63 @@ class ImportClient
         if ($this->last_curl_timeout) {
             throw new CurlTimeoutException("cURL error: {$error}");
         }
+        // These errors mean the response ended before cURL could finish
+        // receiving it. Content-decoding failures such as
+        // CURLE_BAD_CONTENT_ENCODING (61) remain fatal because the same bytes
+        // will fail again after resumption.
+        //   18 = CURLE_PARTIAL_FILE (transfer closed mid-stream)
+        //   52 = CURLE_GOT_NOTHING (empty response)
+        //   56 = CURLE_RECV_ERROR (connection reset / receive failure)
+        if (in_array($errno, [18, 52, 56], true)) {
+            throw new InterruptedResponseException(
+                "cURL error ({$errno}): {$error}",
+            );
+        }
         throw new RuntimeException("cURL error ($errno): {$error}");
     }
 
     /**
-     * Track consecutive cURL timeouts and decide whether to retry or give up.
+     * Track consecutive interrupted responses and decide whether to resume.
      *
-     * Compares the cursor before and after the request. If the cursor advanced
-     * (we got some data before stalling), the counter resets — the stall was
-     * transient and resuming makes sense. If the cursor didn't move, the
-     * counter increments. After MAX_CONSECUTIVE_TIMEOUTS with no progress,
-     * throws a RuntimeException so the runner sees exit code 1 and stops.
+     * Compares the cursor before and after the request. A cursor advance means
+     * the request produced another durable part, so the counter resets. If the
+     * cursor did not move, the counter increments. After
+     * MAX_CONSECUTIVE_INTERRUPTED_RESPONSES with no progress, the runner stops.
      *
-     * @param string $phase   Human-readable phase name for logs (e.g. "sql_chunk")
-     * @param ?string $cursor_before Cursor value at the start of the request
-     * @param ?string $cursor_after  Cursor value when the timeout fired
+     * @param string                       $phase         Human-readable phase name.
+     * @param ?string                      $cursor_before Cursor at request start.
+     * @param ?string                      $cursor_after  Last durable cursor.
+     * @param InterruptedResponseException $exception     Response failure.
      */
-    protected function assert_can_retry_consecutive_timeout(
+    protected function assert_can_resume_after_interrupted_response(
         string $phase,
         ?string $cursor_before,
-        ?string $cursor_after
+        ?string $cursor_after,
+        InterruptedResponseException $exception
     ): void {
         if ($cursor_after !== null && $cursor_after !== $cursor_before) {
-            // Progress was made — reset the counter.
-            $this->import_state()->consecutive_timeouts = 0;
+            $this->import_state()->consecutive_interrupted_responses = 0;
         } else {
-            $this->import_state()->consecutive_timeouts =
-                ($this->import_state()->consecutive_timeouts ?? 0) + 1;
+            $this->import_state()->consecutive_interrupted_responses++;
         }
 
-        $count = $this->import_state()->consecutive_timeouts;
+        $count = $this->import_state()->consecutive_interrupted_responses;
 
         $this->audit_log(
-            "CURL TIMEOUT | {$phase} | consecutive_timeouts={$count}/" .
-                self::MAX_CONSECUTIVE_TIMEOUTS .
+            "INTERRUPTED RESPONSE | {$phase} | " .
+                "consecutive_interrupted_responses={$count}/" .
+                self::MAX_CONSECUTIVE_INTERRUPTED_RESPONSES .
                 " | cursor_moved=" .
-                ($cursor_after !== $cursor_before ? "yes" : "no"),
+                ($cursor_after !== $cursor_before ? "yes" : "no") .
+                " | " . $exception->getMessage(),
             true,
         );
 
-        if ($count >= self::MAX_CONSECUTIVE_TIMEOUTS) {
+        if ($count >= self::MAX_CONSECUTIVE_INTERRUPTED_RESPONSES) {
             throw new RuntimeException(
-                "Remote server appears unreachable: {$count} consecutive " .
-                "cURL timeouts with no progress during {$phase}. Giving up.",
+                "The remote response ended before completion {$count} " .
+                "consecutive times without cursor progress during {$phase}. " .
+                "Giving up.",
             );
         }
     }
@@ -10958,14 +10974,14 @@ class ImportClient
 
         if (!$parser) {
             $snippet = $error_body ? substr($error_body, 0, 500) : "";
-            throw new RuntimeException(
+            throw new InterruptedResponseException(
                 "Invalid response: missing multipart boundary. " .
                     ($snippet !== "" ? "Body: {$snippet}" : ""),
             );
         }
 
         if (!$context->saw_completion) {
-            throw new RuntimeException(
+            throw new InterruptedResponseException(
                 "Invalid response: missing completion chunk from server.",
             );
         }
@@ -11087,11 +11103,9 @@ class ImportClient
             "mysql_port" => null,
             "mysql_user" => null,
             "mysql_database" => null,
-            // Consecutive cURL timeout counter — tracks how many times in a
-            // row a timeout fired without the cursor advancing. After
-            // MAX_CONSECUTIVE_TIMEOUTS with no progress, the importer gives
-            // up instead of retrying forever.
-            "consecutive_timeouts" => 0,
+            // Stop resuming after repeated interrupted responses without
+            // cursor progress.
+            "consecutive_interrupted_responses" => 0,
             // Adaptive tuning state/config
             "tuning" => [
                 "config" => [],
@@ -11134,6 +11148,14 @@ class ImportClient
      */
     private function normalize_state(array $state): array
     {
+        if (
+            !array_key_exists("consecutive_interrupted_responses", $state) &&
+            array_key_exists("consecutive_timeouts", $state)
+        ) {
+            $state["consecutive_interrupted_responses"] =
+                $state["consecutive_timeouts"];
+        }
+
         $defaults = $this->default_state();
         $state = array_intersect_key($state, $defaults);
         $state = array_merge($defaults, $state);
@@ -11737,12 +11759,18 @@ class StreamingContext
 class PreserveLocalSkipException extends RuntimeException {}
 
 /**
+ * Thrown when a streaming response loses its framing or ends before a valid
+ * completion part.
+ */
+class InterruptedResponseException extends RuntimeException {}
+
+/**
  * Thrown when a cURL request times out (CURLE_OPERATION_TIMEDOUT).
  * Callers catch this to save state and exit with "partial" status instead
  * of crashing with a fatal error — the next invocation resumes from the
  * last saved cursor.
  */
-class CurlTimeoutException extends RuntimeException {}
+class CurlTimeoutException extends InterruptedResponseException {}
 
 // ============================================================================
 // CLI Entry Point
@@ -12632,7 +12660,7 @@ if (
                 "  6. Runtime   — generate server config (default: php-builtin)\n" .
                 "  7. Start     — launch the selected runtime when supported\n" .
                 "\n" .
-                "Each step retries automatically on server timeouts. If the process is\n" .
+                "Each step resumes automatically after an interrupted response. If the process is\n" .
                 "interrupted, re-run the same command to resume from where it left off.\n" .
                 "Running pull again after completion performs a delta sync.\n" .
                 "\n" .

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -10,8 +10,8 @@ class PullFailureReportedException extends RuntimeException
  * High-level pull commands — orchestrate lower-level commands into
  * resumable pipelines.
  *
- * Each step retries automatically on server timeouts (exit code 2). If
- * the process is interrupted, re-running the same high-level command
+ * Each step resumes automatically after an interrupted response (exit code 2).
+ * If the process is interrupted, re-running the same high-level command
  * resumes from the last completed step. Like `git pull` composes fetch +
  * merge, `pull` composes preflight → files-pull → db-pull → db-apply →
  * flat-docroot → apply-runtime → start. `pull-files` runs the file
@@ -277,7 +277,7 @@ class Pull
                 $state->active_resumable_command->completion_state = null;
                 $state->active_resumable_command->remote_cursor = null;
                 $state->active_resumable_command->current_stage = null;
-                $state->consecutive_timeouts = 0;
+                $state->consecutive_interrupted_responses = 0;
                 $state->current_file = null;
                 $state->current_file_bytes = null;
                 $state->diff = new FileDiffProgressState();
@@ -303,7 +303,7 @@ class Pull
                 $state->active_resumable_command->completion_state = null;
                 $state->active_resumable_command->remote_cursor = null;
                 $state->active_resumable_command->current_stage = null;
-                $state->consecutive_timeouts = 0;
+                $state->consecutive_interrupted_responses = 0;
                 $state->sql_bytes = null;
                 $state->db_index = new DatabaseTableIndexState();
                 $this->client->save_import_state();
@@ -793,7 +793,7 @@ class Pull
         $state->active_resumable_command->completion_state = null;
         $state->active_resumable_command->remote_cursor = null;
         $state->active_resumable_command->current_stage = null;
-        $state->consecutive_timeouts = 0;
+        $state->consecutive_interrupted_responses = 0;
         if ($reset_file_transfer_state) {
             $state->current_file = null;
             $state->current_file_bytes = null;

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -372,7 +372,7 @@ class ImportState
     public ?int $mysql_port = null;
     public ?string $mysql_user = null;
     public ?string $mysql_database = null;
-    public int $consecutive_timeouts = 0;
+    public int $consecutive_interrupted_responses = 0;
     public AdaptiveTuningState $tuning;
     public PullPipelineCheckpointState $pull_pipeline;
 
@@ -423,7 +423,11 @@ class ImportState
         $state->mysql_port = isset($data['mysql_port']) ? (int) $data['mysql_port'] : null;
         $state->mysql_user = isset($data['mysql_user']) ? (string) $data['mysql_user'] : null;
         $state->mysql_database = isset($data['mysql_database']) ? (string) $data['mysql_database'] : null;
-        $state->consecutive_timeouts = (int) ($data['consecutive_timeouts'] ?? 0);
+        $state->consecutive_interrupted_responses = (int) (
+            $data['consecutive_interrupted_responses']
+            ?? $data['consecutive_timeouts']
+            ?? 0
+        );
         $state->tuning = self::adaptive_tuning_from($data['tuning'] ?? []);
         $state->pull_pipeline = self::pull_pipeline_checkpoint_from($data['pull_pipeline'] ?? []);
         return $state;
@@ -462,7 +466,7 @@ class ImportState
             'mysql_port' => $this->mysql_port,
             'mysql_user' => $this->mysql_user,
             'mysql_database' => $this->mysql_database,
-            'consecutive_timeouts' => $this->consecutive_timeouts,
+            'consecutive_interrupted_responses' => $this->consecutive_interrupted_responses,
             'tuning' => $this->tuning->to_array(),
             'pull_pipeline' => $this->pull_pipeline->to_array(),
         ];

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -425,7 +425,6 @@ class ImportState
         $state->mysql_database = isset($data['mysql_database']) ? (string) $data['mysql_database'] : null;
         $state->consecutive_interrupted_responses = (int) (
             $data['consecutive_interrupted_responses']
-            ?? $data['consecutive_timeouts']
             ?? 0
         );
         $state->tuning = self::adaptive_tuning_from($data['tuning'] ?? []);

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -15,9 +15,8 @@ require_once __DIR__ . '/../../importer/import.php';
  * download_db_index) is tested by injecting a CurlTimeoutException via a
  * subclass that overrides fetch_streaming.
  *
- * Also verifies the consecutive-timeout safety net: after
- * MAX_CONSECUTIVE_TIMEOUTS with no cursor progress, the importer gives up
- * with a RuntimeException instead of retrying forever.
+ * Also verifies the no-progress safety net: after repeated interrupted
+ * responses with no cursor progress, the importer gives up.
  */
 class CurlTimeoutRecoveryTest extends TestCase
 {
@@ -423,79 +422,113 @@ class CurlTimeoutRecoveryTest extends TestCase
     {
         $e = new \CurlTimeoutException("Operation timed out");
         $this->assertInstanceOf(\RuntimeException::class, $e);
+        $this->assertInstanceOf(\InterruptedResponseException::class, $e);
     }
 
     // ---------------------------------------------------------------
-    // Consecutive timeout counter
+    // Consecutive interrupted-response counter
     // ---------------------------------------------------------------
 
     /**
-     * assert_can_retry_consecutive_timeout increments the counter when cursor didn't
-     * move. After MAX_CONSECUTIVE_TIMEOUTS it throws RuntimeException.
+     * assert_can_resume_after_interrupted_response increments the counter when the
+     * cursor did not move.
      */
-    public function testTrackConsecutiveTimeoutIncrementsOnNoProgress()
+    public function testTrackInterruptedResponsesIncrementsOnNoProgress()
     {
         $this->writeState([
             "active_resumable_command" => [
                 "command_name" => "db-pull",
                 "completion_state" => "in_progress",
             ],
-            "consecutive_timeouts" => 0,
+            "consecutive_interrupted_responses" => 0,
         ]);
 
         [$client, $reflection] = $this->prepareClient();
         $state = $reflection->getProperty('state');
 
-        $method = $reflection->getMethod('assert_can_retry_consecutive_timeout');
+        $method = $reflection->getMethod('assert_can_resume_after_interrupted_response');
 
         // First call — no progress (same cursor before and after)
-        $method->invoke($client, "sql_chunk", "abc", "abc");
-        $this->assertEquals(1, $state->getValue($client)->consecutive_timeouts);
+        $method->invoke(
+            $client,
+            "sql_chunk",
+            "abc",
+            "abc",
+            new \InterruptedResponseException("Response ended early"),
+        );
+        $this->assertEquals(
+            1,
+            $state->getValue($client)->consecutive_interrupted_responses,
+        );
 
         // Second call — still no progress
-        $method->invoke($client, "sql_chunk", "abc", "abc");
-        $this->assertEquals(2, $state->getValue($client)->consecutive_timeouts);
+        $method->invoke(
+            $client,
+            "sql_chunk",
+            "abc",
+            "abc",
+            new \InterruptedResponseException("Response ended early"),
+        );
+        $this->assertEquals(
+            2,
+            $state->getValue($client)->consecutive_interrupted_responses,
+        );
     }
 
-    public function testTrackConsecutiveTimeoutResetsOnProgress()
+    public function testTrackInterruptedResponsesResetsOnProgress()
     {
         $this->writeState([
             "active_resumable_command" => [
                 "command_name" => "db-pull",
                 "completion_state" => "in_progress",
             ],
-            "consecutive_timeouts" => 2,
+            "consecutive_interrupted_responses" => 2,
         ]);
 
         [$client, $reflection] = $this->prepareClient();
         $state = $reflection->getProperty('state');
 
-        $method = $reflection->getMethod('assert_can_retry_consecutive_timeout');
+        $method = $reflection->getMethod('assert_can_resume_after_interrupted_response');
 
         // Cursor advanced — should reset to 0
-        $method->invoke($client, "sql_chunk", "abc", "def");
-        $this->assertEquals(0, $state->getValue($client)->consecutive_timeouts);
+        $method->invoke(
+            $client,
+            "sql_chunk",
+            "abc",
+            "def",
+            new \InterruptedResponseException("Response ended early"),
+        );
+        $this->assertEquals(
+            0,
+            $state->getValue($client)->consecutive_interrupted_responses,
+        );
     }
 
-    public function testTrackConsecutiveTimeoutThrowsAtMax()
+    public function testTrackInterruptedResponsesThrowsAtMax()
     {
         $this->writeState([
             "active_resumable_command" => [
                 "command_name" => "db-pull",
                 "completion_state" => "in_progress",
             ],
-            "consecutive_timeouts" => 2,
+            "consecutive_interrupted_responses" => 2,
         ]);
 
         [$client, $reflection] = $this->prepareClient();
 
-        $method = $reflection->getMethod('assert_can_retry_consecutive_timeout');
+        $method = $reflection->getMethod('assert_can_resume_after_interrupted_response');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('consecutive');
 
-        // 3rd no-progress timeout should throw
-        $method->invoke($client, "sql_chunk", "abc", "abc");
+        // The third response without progress should throw.
+        $method->invoke(
+            $client,
+            "sql_chunk",
+            "abc",
+            "abc",
+            new \InterruptedResponseException("Response ended early"),
+        );
     }
 
     /**
@@ -512,7 +545,7 @@ class CurlTimeoutRecoveryTest extends TestCase
                 "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
             ],
             "sql_bytes" => 1024,
-            "consecutive_timeouts" => 2,
+            "consecutive_interrupted_responses" => 2,
         ]);
 
         $sql_content = str_pad("", 1024, "INSERT INTO t VALUES (1);\n");
@@ -540,7 +573,7 @@ class CurlTimeoutRecoveryTest extends TestCase
                 "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
             ],
             "sql_bytes" => 1024,
-            "consecutive_timeouts" => 0,
+            "consecutive_interrupted_responses" => 0,
         ]);
 
         $sql_content = str_pad("", 1024, "INSERT INTO t VALUES (1);\n");
@@ -558,7 +591,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         $this->assertEquals("partial", $state["active_resumable_command"]["completion_state"]);
         $this->assertEquals(
             1,
-            $state["consecutive_timeouts"],
+            $state["consecutive_interrupted_responses"],
             "First no-progress timeout should increment counter to 1"
         );
     }
@@ -574,7 +607,7 @@ class CurlTimeoutRecoveryTest extends TestCase
             "index" => [
                 "cursor" => base64_encode('{"dir":"/wp-content","offset":500}'),
             ],
-            "consecutive_timeouts" => 2,
+            "consecutive_interrupted_responses" => 2,
             "preflight" => [
                 "data" => [
                     "ok" => true,
@@ -598,8 +631,8 @@ class CurlTimeoutRecoveryTest extends TestCase
         $state = $this->readState();
         $this->assertEquals(
             0,
-            $state["consecutive_timeouts"],
-            "Successful request should reset consecutive_timeouts to 0"
+            $state["consecutive_interrupted_responses"],
+            "Successful request should reset consecutive_interrupted_responses to 0"
         );
     }
 

--- a/tests/Import/ImportStateTest.php
+++ b/tests/Import/ImportStateTest.php
@@ -67,6 +67,28 @@ class ImportStateTest extends TestCase
         $this->assertSame($default_state, \ImportState::from_array($default_state)->to_array());
     }
 
+    public function testLegacyTimeoutCounterBecomesInterruptedResponseCounter(): void
+    {
+        $client = new \ImportClient(
+            'http://example.invalid',
+            sys_get_temp_dir() . '/reprint-import-state-test-state',
+            sys_get_temp_dir() . '/reprint-import-state-test-fs',
+        );
+        $reflection = new \ReflectionClass($client);
+        $normalize_state = $reflection->getMethod('normalize_state');
+        $normalized = $normalize_state->invoke($client, [
+            'consecutive_timeouts' => 2,
+        ]);
+        $state = \ImportState::from_array($normalized);
+
+        $this->assertSame(2, $state->consecutive_interrupted_responses);
+        $this->assertSame(
+            2,
+            $state->to_array()['consecutive_interrupted_responses'],
+        );
+        $this->assertArrayNotHasKey('consecutive_timeouts', $state->to_array());
+    }
+
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void
     {
         $state = \ImportState::from_array([]);

--- a/tests/Import/ImportStateTest.php
+++ b/tests/Import/ImportStateTest.php
@@ -67,28 +67,6 @@ class ImportStateTest extends TestCase
         $this->assertSame($default_state, \ImportState::from_array($default_state)->to_array());
     }
 
-    public function testLegacyTimeoutCounterBecomesInterruptedResponseCounter(): void
-    {
-        $client = new \ImportClient(
-            'http://example.invalid',
-            sys_get_temp_dir() . '/reprint-import-state-test-state',
-            sys_get_temp_dir() . '/reprint-import-state-test-fs',
-        );
-        $reflection = new \ReflectionClass($client);
-        $normalize_state = $reflection->getMethod('normalize_state');
-        $normalized = $normalize_state->invoke($client, [
-            'consecutive_timeouts' => 2,
-        ]);
-        $state = \ImportState::from_array($normalized);
-
-        $this->assertSame(2, $state->consecutive_interrupted_responses);
-        $this->assertSame(
-            2,
-            $state->to_array()['consecutive_interrupted_responses'],
-        );
-        $this->assertArrayNotHasKey('consecutive_timeouts', $state->to_array());
-    }
-
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void
     {
         $state = \ImportState::from_array([]);

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -136,6 +136,9 @@
     },
     "adversarial-database": {
       "port": 8124
+    },
+    "db-index-interruption": {
+      "port": 8125
     }
   }
 }

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -53,14 +53,31 @@ describe('Import: Request Cutoff', () => {
         cleanupTempDir(tempDir);
     });
 
-    it('first importer run fails due to cutoff', () => {
+    it('first importer run exits partial after cutoff', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
         const result = runImporter(url, tempDir, 'files-sync', {
             secret: getSiteSecret(site),
             extraArgs: ['--max-exec=10'],
+            autoResume: false,
         });
-        // First run should fail because exit(1) was called
-        assert.notEqual(result.exitCode, 0, 'Expected first run to fail due to cutoff');
+        assert.equal(
+            result.exitCode,
+            2,
+            `Expected exit 2 after the interrupted file index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+
+        const stateFile = join(tempDir, '.import-state.json');
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assert.equal(
+            state.active_resumable_command.completion_state,
+            'partial',
+            'Expected files-pull to retain a partial checkpoint',
+        );
+        assert.equal(
+            state.active_resumable_command.current_stage,
+            'index',
+            'Expected files-pull to remain in the index stage',
+        );
     });
 
     it('hook state shows scan_count reached 5', () => {

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -5,8 +5,8 @@
  * test_hook_before_sql_batch. When PHP dies mid-stream, the multipart
  * response is truncated and no completion chunk is sent. Before this
  * fix, the importer would throw "Buffered SQL was never executed" and
- * fail fatally. Now it treats the missing completion chunk as a
- * retryable partial response, saves state, and resumes on the next run.
+ * fail fatally. Now it treats the missing completion chunk as an
+ * interrupted response, saves partial state, and resumes on the next run.
  *
  * Note: The .sql-buffer file only contains data when the crash
  * interrupts a partial SQL statement (mid-chunk). With exit(1), PHP
@@ -69,8 +69,8 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 120000 }, () => {
 
             // Deploy a hook that kills PHP after 3 SQL batches. This
             // simulates a real PHP crash (max_execution_time, OOM, fatal
-            // error) — the response is truncated mid-gzip, no completion
-            // chunk is sent, and the multipart stream is incomplete.
+            // error) — the response is truncated mid-gzip and no completion
+            // chunk is sent.
             writeTestHooks(site, [
                 'function test_hook_before_sql_batch(&$sql, $cursor) {',
                 `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
@@ -124,7 +124,7 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 120000 }, () => {
                 `Expected batch_count >= 3, got ${state.batch_count}`);
         });
 
-        it('state was saved for retry', () => {
+        it('state was saved for resume', () => {
             // The importer should have persisted its state so the next
             // run can resume. The cursor may be null if nginx buffered
             // the entire response and no multipart chunks reached the
@@ -137,14 +137,14 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 120000 }, () => {
                 `Expected status=partial, got ${state.active_resumable_command.completion_state}`);
         });
 
-        it('audit log records the incomplete response', () => {
+        it('audit log records the interrupted response', () => {
             const audit = readAuditLog(tempDir);
             assert.ok(
-                audit.includes('INCOMPLETE RESPONSE') ||
+                audit.includes('INTERRUPTED RESPONSE') ||
                 audit.includes('BUFFER PRESERVED') ||
                 audit.includes('BUFFER NOT FLUSHED') ||
                 audit.includes('missing completion chunk'),
-                'Expected audit log to record the incomplete response'
+                'Expected audit log to record the interrupted response'
             );
         });
 
@@ -180,10 +180,10 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 120000 }, () => {
             const audit = readAuditLog(tempDir);
             // The CRASH RECOVERY entry only appears when .sql-buffer had
             // data to reload. With exit(1) between batches, the buffer is
-            // typically empty. Either way, the INCOMPLETE RESPONSE entry
+            // typically empty. Either way, the INTERRUPTED RESPONSE entry
             // from the first run proves the crash was detected.
             assert.ok(
-                audit.includes('INCOMPLETE RESPONSE') ||
+                audit.includes('INTERRUPTED RESPONSE') ||
                 audit.includes('CRASH RECOVERY'),
                 'Expected audit log to mention crash detection or recovery'
             );

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -14,8 +14,11 @@
  * exits PHP on the second chunk, which forces the failure mid-file
  * (the first chunk has been written, the file is incomplete).
  *
- * After removing the hook, files-sync resumes and completes. Final
- * assertion: SHA-256 of the imported file equals the source.
+ * The source exits before it writes the boundary which would confirm the
+ * first part. The importer must leave its cursor at the preceding boundary,
+ * replay the unconfirmed bytes, and replace rather than append them. After
+ * removing the hook, files-sync resumes and completes. Final assertion:
+ * SHA-256 of the imported file equals the source.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -120,9 +123,10 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
                 '--file-chunk-start=262144',
                 '--file-chunk-max=262144',
             ],
+            autoResume: false,
         });
-        assert.notEqual(result.exitCode, 0,
-            `Expected first run to fail due to mid-file exit\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        assert.equal(result.exitCode, 2,
+            `Expected first run to retain partial progress after the interrupted response\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
     });
 
     it('partial file is on disk and smaller than source', () => {
@@ -135,13 +139,20 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
             `Expected a partial file (0 < size < ${fileSize}), got ${partialSize}`);
     });
 
-    it('state records current_file and current_file_bytes for resume', () => {
+    it('state does not checkpoint the unconfirmed file part', () => {
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected import state file to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.ok(state.current_file, 'Expected state.current_file to be set after a mid-file crash');
-        assert.ok(typeof state.current_file_bytes === 'number' && state.current_file_bytes > 0,
-            `Expected state.current_file_bytes > 0, got ${state.current_file_bytes}`);
+        assert.equal(
+            state.current_file,
+            null,
+            'Expected the unconfirmed file part to remain outside the checkpoint',
+        );
+        assert.equal(
+            state.current_file_bytes,
+            null,
+            'Expected the checkpoint not to claim the unconfirmed file bytes',
+        );
     });
 
     it('resume completes after removing the hook', () => {

--- a/tests/e2e/tests/import-54-db-index-interruption.test.js
+++ b/tests/e2e/tests/import-54-db-index-interruption.test.js
@@ -1,0 +1,101 @@
+/**
+ * Test 54: Database index response interruption.
+ *
+ * The source exits after sending its table-stat parts but before sending the
+ * completion part. The first db-index invocation must retain partial state;
+ * a later invocation resumes from the last complete table-stat part.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    writeTestHooks, removeTestHooks,
+    readHookState, clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Database Index Response Interruption', () => {
+    const site = 'db-index-interruption';
+    const hookState = `/srv/e2e-sites/.e2e-hook-state-${site}`;
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-db-index-interruption');
+        clearHookState(site);
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('first run exits partial when the completion part is interrupted', () => {
+        writeTestHooks(site, [
+            'function test_hook_before_completion($status, $gz, $boundary) {',
+            `    if (file_exists('${hookState}')) { return; }`,
+            `    file_put_contents('${hookState}', '{"fired":true}');`,
+            '    exit(1);',
+            '}',
+        ].join('\n'));
+
+        const result = runImporter(importUrl(), tempDir, 'db-index', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+        });
+
+        assert.equal(
+            result.exitCode,
+            2,
+            `Expected exit 2 after the interrupted db-index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+        assert.deepEqual(
+            readHookState(site),
+            { fired: true },
+            'Expected the completion hook to run',
+        );
+
+        const state = JSON.parse(
+            readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
+        );
+        assert.equal(
+            state.active_resumable_command.completion_state,
+            'partial',
+            'Expected db-index to retain a partial checkpoint',
+        );
+    });
+
+    it('resume completes without duplicating table rows', () => {
+        removeTestHooks(site);
+
+        const result = runImporter(importUrl(), tempDir, 'db-index', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `Expected db-index resume to complete\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+
+        const lines = readFileSync(
+            join(tempDir, 'db-tables.jsonl'),
+            'utf-8',
+        ).trim().split('\n').filter(Boolean);
+        const tableNames = lines.map((line) => JSON.parse(line).name);
+
+        assert.ok(tableNames.length > 0, 'Expected table rows after resume');
+        assert.equal(
+            new Set(tableNames).size,
+            tableNames.length,
+            'Expected each table exactly once after resume',
+        );
+    });
+});


### PR DESCRIPTION
File and database pulls now resume when a streaming response ends without its required completion part, instead of ending the migration with \`Missing completion chunk\`.

## Background

The protocol makes completion explicit. A normal response ends with a completion part whose \`X-Status\` is either \`complete\` or \`partial\`. \`partial\` is valid and tells the importer to make another request. A source crash, connection loss, or timeout can instead interrupt the response before that part arrives.

SQL already saved partial state after missing completion, missing framing, and cURL 18/52/56. File indexing, file fetching, and database indexing only saved partial state for cURL timeouts, so the same wire failure resumed in SQL but stopped \`files-pull\` and \`db-index\`.

## This change

\`InterruptedResponseException\` covers missing framing or completion, timeouts, and cURL 18/52/56. File indexing, file fetching, SQL download, and database indexing catch it and save partial state at their last durable cursor.

For file bodies, bytes become durable only at a complete multipart-part boundary. Bytes from an interrupted part remain outside the checkpoint; resume truncates and replays them. Three interrupted responses without cursor progress still stop the command.

## Testing

Interrupt each endpoint after a data part but before completion and confirm the first invocation exits partial. Resume and confirm the file bytes match the source, the file index completes, SQL continues, and the database index contains no duplicate rows.