### PR TITLE
Parse WordPress DB_HOST formats in exporter PDO connections

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -309,7 +309,7 @@ function create_db_connection(array $creds, array $options = [])
     $merged_options = $options + $default_options;
 
     return new PDO(
-        "mysql:host={$creds['db_host']};dbname={$creds['db_name']};charset=utf8mb4",
+        build_pdo_dsn($creds['db_host'], $creds['db_name']),
         $creds["db_user"],
         $creds["db_password"],
         $merged_options

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class CreateDbConnectionTest extends TestCase {
+    public function testBareSocketPathDbHostOpensUnixSocket(): void
+    {
+        $this->assertDbHostOpensUnixSocket(false);
+    }
+
+    public function testHostnameAndSocketPathDbHostOpensUnixSocket(): void
+    {
+        $this->assertDbHostOpensUnixSocket(true);
+    }
+
+    private function assertDbHostOpensUnixSocket(bool $include_hostname): void
+    {
+        $socket_path = tempnam(sys_get_temp_dir(), 'reprint-db-socket-');
+        $this->assertIsString($socket_path);
+        unlink($socket_path);
+
+        $socket_listener = stream_socket_server(
+            'unix://' . $socket_path,
+            $socket_error_code,
+            $socket_error_message
+        );
+        $this->assertIsResource(
+            $socket_listener,
+            "{$socket_error_code}: {$socket_error_message}"
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $pipes = [];
+        $process = null;
+        $db_host = $include_hostname
+            ? 'localhost:' . $socket_path
+            : $socket_path;
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-exporter/src/export.php');
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $connection_script = <<<'PHP'
+        require $argv[1];
+        require $argv[2];
+        try {
+            create_db_connection(
+                [
+                    'db_engine' => 'mysql',
+                    'db_host' => $argv[3],
+                    'db_name' => 'unused',
+                    'db_user' => 'unused',
+                    'db_password' => 'unused',
+                ],
+                [PDO::ATTR_TIMEOUT => 1]
+            );
+            fwrite(STDERR, "The connection unexpectedly completed.\n");
+            exit(2);
+        } catch (PDOException $exception) {
+            fwrite(STDERR, $exception->getMessage());
+        }
+        PHP;
+
+        try {
+            $process = proc_open(
+                [PHP_BINARY, '-r', $connection_script, $autoload_path, $export_path, $db_host],
+                $descriptors,
+                $pipes
+            );
+            $this->assertIsResource($process);
+            fclose($pipes[0]);
+
+            $socket_connection = @stream_socket_accept($socket_listener, 3);
+            $socket_was_opened = is_resource($socket_connection);
+            if ($socket_was_opened) {
+                fclose($socket_connection);
+            }
+
+            stream_get_contents($pipes[1]);
+            $connection_error = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $pipes = [];
+
+            $process_status = proc_close($process);
+            $process = null;
+            $this->assertTrue(
+                $socket_was_opened,
+                "PDO did not open the Unix socket. {$connection_error}"
+            );
+            $this->assertSame(
+                0,
+                $process_status,
+                "The PDO connection process failed. {$connection_error}"
+            );
+        } finally {
+            foreach ($pipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            if (is_resource($process)) {
+                proc_terminate($process);
+                proc_close($process);
+            }
+            fclose($socket_listener);
+            @unlink($socket_path);
+        }
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -25,6 +25,7 @@
         </testsuite>
         <testsuite name="Export Utility Tests">
             <file>BuildPdoDsnTest.php</file>
+            <file>CreateDbConnectionTest.php</file>
             <file>PushCommitTest.php</file>
             <file>ExportHttpServerTest.php</file>
             <file>FileIndexDedupTest.php</file>


### PR DESCRIPTION
Exporter PDO connections now parse WordPress `DB_HOST` values before connecting.

`create_db_connection()` interpolated `DB_HOST` directly into `mysql:host=...`, bypassing the existing `build_pdo_dsn()` parser. Bare socket paths and `hostname:/socket/path` values were therefore treated as hostnames, so preflight, SQL chunks, and database indexing could not connect on socket-configured sites.

This routes the centralized MySQL connection through the existing parser.

## Testing

The new tests open a Unix socket listener for both WordPress socket formats and confirm that PDO reaches it. Both tests fail against `trunk` because no socket connection arrives, and pass with this change.

The full PHPUnit suite and static analysis pass.
