### PR TITLE
Order text primary key cursors by bytes across SQL export resumes

### DIFF
--- a/packages/reprint-exporter/src/class-mysql-dump-producer.php
+++ b/packages/reprint-exporter/src/class-mysql-dump-producer.php
@@ -632,7 +632,7 @@ class MySQLDumpProducer
             }
 
             $order_cols = array_map(function ($col) {
-                return $this->quote_identifier($col) . " ASC";
+                return $this->build_primary_key_column_expression($col) . " ASC";
             }, $this->current_pk_columns);
             $query .= " ORDER BY " . implode(", ", $order_cols);
             $query .= " LIMIT {$this->batch_size}";
@@ -727,22 +727,49 @@ class MySQLDumpProducer
         return "(" . implode(" OR ", $conditions) . ")";
     }
 
-    /** Builds a single "column op value" SQL expression, handling NULL and quoting. */
+    /** Builds one primary key comparison without re-encoding database bytes. */
     private function build_comparison($column, $value, $operator)
     {
-        $quoted_col = $this->quote_identifier($column);
+        $column_expression = $this->build_primary_key_column_expression($column);
         if ($value === null) {
             return $operator === "="
-                ? "{$quoted_col} IS NULL"
-                : "{$quoted_col} IS NOT NULL";
+                ? "{$column_expression} IS NULL"
+                : "{$column_expression} IS NOT NULL";
         }
 
-        if (is_numeric($value)) {
-            return "{$quoted_col} {$operator} {$value}";
-        } else {
-            $quoted = $this->db->quote($value);
-            return "{$quoted_col} {$operator} {$quoted}";
+        if ($this->is_numeric_type($this->get_data_type($column))) {
+            return "{$column_expression} {$operator} {$value}";
         }
+
+        return "{$column_expression} {$operator} FROM_BASE64('" .
+            base64_encode($value) .
+            "')";
+    }
+
+    /**
+     * Builds the column expression shared by primary key comparison and order.
+     *
+     * Nonnumeric, nonbinary columns are cast to binary so pagination follows
+     * their raw bytes instead of a connection or column collation. Applying
+     * the same expression to WHERE and ORDER BY prevents skipped rows, although
+     * MySQL may no longer use a text primary key for an efficient range scan.
+     */
+    private function build_primary_key_column_expression($column)
+    {
+        $qualified_column =
+            $this->quote_identifier($this->current_table) .
+            "." .
+            $this->quote_identifier($column);
+        $data_type = $this->get_data_type($column);
+
+        if (
+            $this->is_numeric_type($data_type) ||
+            $this->is_binary_type($data_type)
+        ) {
+            return $qualified_column;
+        }
+
+        return "CAST({$qualified_column} AS BINARY)";
     }
 
     /** Returns primary key column names in ordinal order, or empty array if none. */
@@ -1396,14 +1423,7 @@ class MySQLDumpProducer
 
         $size = 0;
         foreach ($this->oversized_pk_values as $col => $value) {
-            $size += strlen($col) + 10; // `col` =
-            if ($value === null) {
-                $size += 10; // IS NULL
-            } elseif (is_numeric($value)) {
-                $size += strlen((string)$value);
-            } else {
-                $size += strlen((string)$value) * 1.1 + 2; // Quoted
-            }
+            $size += strlen($this->build_comparison($col, $value, "="));
             $size += 5; // AND
         }
 
@@ -1457,15 +1477,7 @@ class MySQLDumpProducer
 
         $where_parts = [];
         foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
-            $quoted_pk = $this->quote_identifier($pk_col);
-            if ($pk_value === null) {
-                $where_parts[] = "{$quoted_pk} IS NULL";
-            } elseif (is_numeric($pk_value)) {
-                $where_parts[] = "{$quoted_pk} = {$pk_value}";
-            } else {
-                // Use FROM_BASE64() to avoid having to quote() the emitted value.
-                $where_parts[] = "{$quoted_pk} = FROM_BASE64('" . base64_encode($pk_value) . "')";
-            }
+            $where_parts[] = $this->build_comparison($pk_col, $pk_value, "=");
         }
         $where_clause = implode(" AND ", $where_parts);
 
@@ -1496,22 +1508,15 @@ class MySQLDumpProducer
         $quoted_column = $this->quote_identifier($column);
 
         $where_parts = [];
-        $params = [];
         foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
-            $quoted_pk = $this->quote_identifier($pk_col);
-            if ($pk_value === null) {
-                $where_parts[] = "{$quoted_pk} IS NULL";
-            } else {
-                $where_parts[] = "{$quoted_pk} = ?";
-                $params[] = $pk_value;
-            }
+            $where_parts[] = $this->build_comparison($pk_col, $pk_value, "=");
         }
         $where_clause = implode(" AND ", $where_parts);
 
         $sql = "SELECT CAST(SUBSTRING({$quoted_column}, {$start}, {$length}) AS BINARY)"
              . " FROM {$quoted_table} WHERE {$where_clause}";
         $stmt = $this->db->prepare($sql);
-        $stmt->execute($params);
+        $stmt->execute();
         $result = $stmt->fetchColumn();
 
         if ($result === false) {

--- a/packages/reprint-exporter/src/class-sqlite-driver-pdo.php
+++ b/packages/reprint-exporter/src/class-sqlite-driver-pdo.php
@@ -2,8 +2,8 @@
 /**
  * PDO-compatible adapter for WP_SQLite_Driver.
  *
- * MySQLDumpProducer expects a PDO connection — prepare(), query(), quote(),
- * and the statement methods fetch(), fetchAll(), fetchColumn(), execute().
+ * MySQLDumpProducer expects a PDO connection — prepare(), query(), and the
+ * statement methods fetch(), fetchAll(), fetchColumn(), execute().
  * On SQLite sites, the WP_SQLite_Driver is already loaded by WordPress
  * (via the sqlite-database-integration plugin's db.php drop-in) and is
  * available at $wpdb->dbh. This adapter wraps that driver so the dump

--- a/packages/reprint-exporter/src/class-wpdb-driver-pdo.php
+++ b/packages/reprint-exporter/src/class-wpdb-driver-pdo.php
@@ -2,8 +2,8 @@
 /**
  * wpdb-backed PDO adapter for MySQL exports on PDO-less hosts.
  *
- * MySQLDumpProducer expects a PDO connection — prepare(), query(), quote(),
- * and the statement methods fetch(), fetchAll(), fetchColumn(), execute().
+ * MySQLDumpProducer expects a PDO connection — prepare(), query(), and the
+ * statement methods fetch(), fetchAll(), fetchColumn(), execute().
  * On hosts without ext-pdo / ext-pdo_mysql, this adapter wraps WordPress's
  * global $wpdb so the dump producer can run unchanged.
  *

--- a/tests/MySQLDumpProducer/EncodingTest.php
+++ b/tests/MySQLDumpProducer/EncodingTest.php
@@ -1241,4 +1241,146 @@ class EncodingTest extends MySQLDumpProducerTestBase
         $import_pdo = $this->executeDumpInNewDatabase($sql);
         $this->assertDatabasesEqual($this->pdo, $import_pdo, ["t"]);
     }
+
+    /**
+     * A text primary key may contain bytes which are valid in the column's
+     * character set but are not valid UTF-8. Each one-row batch must resume
+     * from those bytes without passing them through the connection charset.
+     */
+    public function testReentrancyWithLatin1TextPrimaryKeyBytes(): void
+    {
+        $this->pdo->exec(
+            "CREATE TABLE t (
+                id VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_bin PRIMARY KEY,
+                data VARCHAR(50)
+            )"
+        );
+        $this->pdo->exec(
+            "INSERT INTO t (id, data) VALUES
+                (CONVERT(X'41' USING latin1), 'ascii-a'),
+                (CONVERT(X'42' USING latin1), 'ascii-b'),
+                (CONVERT(X'80' USING latin1), 'byte-80'),
+                (CONVERT(X'E9' USING latin1), 'byte-e9')"
+        );
+
+        [$sql, $resume_count] = $this->exportWithResumeAfterEveryFragment([
+            "batch_size" => 1,
+        ]);
+
+        $this->assertGreaterThan(3, $resume_count);
+
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertSame(
+            ["41", "42", "80", "E9"],
+            $import_pdo
+                ->query("SELECT HEX(id) FROM t ORDER BY id")
+                ->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
+    /**
+     * Primary key comparison must follow the column type rather than PHP's
+     * classification of the fetched value. Numeric-looking VARCHAR values
+     * still use string ordering.
+     */
+    public function testReentrancyWithNumericLatin1TextPrimaryKeyValues(): void
+    {
+        $this->pdo->exec(
+            "CREATE TABLE t (
+                id VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_bin PRIMARY KEY,
+                data VARCHAR(50)
+            )"
+        );
+        $this->pdo->exec(
+            "INSERT INTO t (id, data) VALUES
+                ('10', 'ten'),
+                ('100', 'one-hundred'),
+                ('2', 'two')"
+        );
+
+        [$sql, $resume_count] = $this->exportWithResumeAfterEveryFragment([
+            "batch_size" => 1,
+        ]);
+
+        $this->assertGreaterThan(3, $resume_count);
+
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertSame(
+            ["10", "100", "2"],
+            $import_pdo
+                ->query("SELECT id FROM t ORDER BY id")
+                ->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
+    /**
+     * The resume predicate and ORDER BY must both ignore the column collation.
+     * latin1_german2_ci sorts ä before b, while raw bytes sort b, z, then ä.
+     */
+    public function testReentrancyWithLatin1TextPrimaryKeyByteOrdering(): void
+    {
+        $this->pdo->exec(
+            "CREATE TABLE t (
+                id VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_german2_ci PRIMARY KEY,
+                data VARCHAR(50)
+            )"
+        );
+        $this->pdo->exec(
+            "INSERT INTO t (id, data) VALUES
+                (CONVERT(X'E4' USING latin1), 'umlaut-a'),
+                ('b', 'b'),
+                ('z', 'z')"
+        );
+
+        [$sql, $resume_count] = $this->exportWithResumeAfterEveryFragment([
+            "batch_size" => 1,
+        ]);
+
+        $this->assertGreaterThan(3, $resume_count);
+
+        $letter_b_position = strpos($sql, "FROM_BASE64('Yg==')");
+        $letter_z_position = strpos($sql, "FROM_BASE64('eg==')");
+        $umlaut_a_position = strpos($sql, "FROM_BASE64('5A==')");
+        $this->assertNotFalse($letter_b_position);
+        $this->assertNotFalse($letter_z_position);
+        $this->assertNotFalse($umlaut_a_position);
+        $this->assertTrue(
+            $letter_b_position < $letter_z_position &&
+            $letter_z_position < $umlaut_a_position,
+            "Text primary keys must be emitted in raw byte order"
+        );
+
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertSame(
+            ["E4", "62", "7A"],
+            $import_pdo
+                ->query("SELECT HEX(id) FROM t ORDER BY id")
+                ->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
+    /**
+     * Exports while replacing the producer from its cursor after every
+     * fragment, simulating a new request at each available resume boundary.
+     *
+     * @return array{0: string, 1: int} Dump SQL and number of resumes.
+     */
+    private function exportWithResumeAfterEveryFragment(array $options): array
+    {
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        $resume_count = 0;
+
+        while ($producer->next_sql_fragment()) {
+            $fragments[] = $producer->get_sql_fragment();
+
+            if (!$producer->is_finished()) {
+                $options["cursor"] = $producer->get_reentrancy_cursor();
+                $producer = $this->createProducer($options);
+                ++$resume_count;
+            }
+        }
+
+        return [implode("\n", $fragments), $resume_count];
+    }
 }

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -336,6 +336,60 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
     }
 
     /**
+     * Fetching oversized chunks must compare a text primary key without
+     * passing its latin1 bytes through the utf8mb4 connection charset.
+     */
+    public function testReentrancyWithLatin1TextPrimaryKeyInOversizedRow(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE reentrant_large_text_key (
+                id VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_bin PRIMARY KEY,
+                content LONGBLOB
+            )
+        ");
+
+        $id = "\x80\xE9";
+        $content = random_bytes(20 * 1024);
+        $encoded_id = base64_encode($id);
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO reentrant_large_text_key (id, content)
+             VALUES (CONVERT(FROM_BASE64('{$encoded_id}') USING latin1), ?)"
+        );
+        $stmt->execute([$content]);
+
+        $options = [
+            "max_statement_size" => 8 * 1024,
+            "batch_size" => 1,
+        ];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+
+        while ($producer->next_sql_fragment()) {
+            $fragments[] = $producer->get_sql_fragment();
+
+            if (!$producer->is_finished()) {
+                $options["cursor"] = $producer->get_reentrancy_cursor();
+                $producer = $this->createProducer($options);
+            }
+        }
+
+        $sql = implode("\n", $fragments);
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertSame(
+            strtoupper(bin2hex($id)),
+            $import_pdo
+                ->query("SELECT HEX(id) FROM reentrant_large_text_key")
+                ->fetchColumn()
+        );
+        $this->assertSame(
+            $content,
+            $import_pdo
+                ->query("SELECT content FROM reentrant_large_text_key")
+                ->fetchColumn()
+        );
+    }
+
+    /**
      * Test with base64 string encoding.
      */
     public function testBase64EncodingWithLargeData(): void


### PR DESCRIPTION
SQL exports now paginate text primary keys by their stored bytes, independent of the connection charset and column collation.

## Background

Resume predicates previously passed primary key bytes through `PDO::quote()`. A `latin1 VARCHAR` key containing bytes such as `0x80` therefore failed when the exporter connected with `utf8mb4`.

The same comparison also classified values with PHP's `is_numeric()`, so a text key such as `10` was compared numerically rather than with its column's string ordering. Separately, `ORDER BY id` could resolve to the `CAST(id AS BINARY) AS id` projection alias while the resume predicate compared the source column, giving the two sides different ordering under collations such as `latin1_german2_ci`.

## Example

Given this table and data:

```sql
CREATE TABLE t (
    id VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_bin PRIMARY KEY,
    data VARCHAR(50)
);

INSERT INTO t (id, data) VALUES
    (CONVERT(X'41' USING latin1), 'ascii-a'),
    (CONVERT(X'80' USING latin1), 'byte-80'),
    (CONVERT(X'E9' USING latin1), 'byte-e9');
```

With `batch_size=1`, the exporter stores the raw `0x80` primary key after emitting that row. A new producer then passes that byte through `PDO::quote()` for the next query:

```sql
SELECT CAST(id AS BINARY) AS id, CAST(data AS BINARY) AS data
FROM t
WHERE id > '<raw 0x80 byte>'
ORDER BY id ASC
LIMIT 1;
```

The connection declares that literal as `utf8mb4`, while `id` uses `latin1_bin`, so MySQL stops the export:

```text
SQLSTATE[HY000]: General error: 1267 Illegal mix of collations
(latin1_bin,IMPLICIT) and (utf8mb4_general_ci,COERCIBLE) for operation '>'
```

## This change

Nonnumeric primary key values are carried into comparisons through `FROM_BASE64()`, while the declared column type decides whether a value is numeric. Reprint now uses the same bytewise expression for the resume predicate and ordering:

```sql
WHERE CAST(t.id AS BINARY) > FROM_BASE64('gA==')
ORDER BY CAST(t.id AS BINARY) ASC
```

Numeric primary keys retain numeric comparison, and already-binary columns retain their native byte comparison. Every other primary key is cast to binary, making SQL resume ordering independent of connection and column collations. Oversized-row chunk queries use the same comparison builder.

Casting a text primary key may prevent MySQL from using it for an efficient range scan. This is the deliberate cost of defining one collation-independent byte order for resumable exports.

## Testing

The new tests use one-row batches and recreate the producer from its cursor after every fragment. They cover non-UTF-8 `latin1 VARCHAR` bytes, numeric-looking text keys, a collation whose order differs from byte order, and an oversized row with a latin1 text key. All four fail against `trunk` and pass here on MySQL 8.0 and MariaDB 10.11.

The complete PHPUnit suite passes with 1,178 tests and 11,664 assertions. PHPStan, PHP 7.2 syntax checks, and PHPCompatibility checks for the changed production files also pass.
