### PR TITLE
Retry interrupted SQL source responses in the current importer run

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -7585,7 +7585,6 @@ class ImportClient
             false,
         );
 
-        $curl_timed_out = false;
         $caught_exception = null;
         $buffer_not_flushed = "";
         $chunks_since_save = 0;
@@ -7794,56 +7793,23 @@ class ImportClient
                 $request_start = microtime(true);
                 try {
                     $this->fetch_streaming($url, $cursor, $context, null, "sql_chunk");
-                } catch (CurlTimeoutException $e) {
-                    $this->assert_can_resume_after_interrupted_response(
-                        "sql_chunk",
-                        $cursor_before,
-                        $cursor,
-                        $e,
-                    );
-                    // Save state so the next invocation resumes from the
-                    // last cursor instead of crashing with exit code 1.
-                    if ($sql_handle) {
-                        fflush($sql_handle);
-                    }
-                    $this->import_state()->active_resumable_command->remote_cursor = $cursor;
-                    $this->import_state()->sql_bytes = $sql_bytes_written;
-                    $this->import_state()->sql_statements_counted = $sql_statements_counted;
-                    $this->import_state()->active_resumable_command->completion_state = "partial";
-                    $this->save_state($this->state);
-                    // Discard any pending SQL buffer — it's incomplete and
-                    // will be re-fetched on the next invocation. Setting
-                    // this to "" also prevents the finally block from
-                    // throwing about un-executed buffered SQL.
-                    $sql_buffer = "";
-                    $curl_timed_out = true;
-                    break;
                 } catch (TransientInterruptionException $e) {
-                    // The server may crash mid-response (max_execution_time,
-                    // OOM, fatal error). Keep $sql_buffer intact so the next
-                    // invocation reloads it and continues from the last
-                    // complete response part.
-                    $this->audit_log(
-                        "SQL BUFFER | buffered_sql=" . strlen($sql_buffer) .
-                        " bytes | saving state after interrupted response",
-                        true,
-                    );
+                    // The source may time out or crash after complete SQL parts
+                    // but before its completion part. SQL multipart bodies are
+                    // delivered only at a complete part boundary, so resume from
+                    // that part's cursor without closing the selected output.
                     $this->assert_can_resume_after_interrupted_response(
                         "sql_chunk",
                         $cursor_before,
                         $cursor,
                         $e,
                     );
-                    if ($sql_handle) {
-                        fflush($sql_handle);
+                    $retry_log = "SQL RETRY | resuming source request | mode={$mode}";
+                    if ($sql_buffer !== "") {
+                        $retry_log .= " | buffered_sql=" . strlen($sql_buffer) . " bytes";
                     }
-                    $this->import_state()->active_resumable_command->remote_cursor = $cursor;
-                    $this->import_state()->sql_bytes = $sql_bytes_written;
-                    $this->import_state()->sql_statements_counted = $sql_statements_counted;
-                    $this->import_state()->active_resumable_command->completion_state = "partial";
-                    $this->save_state($this->state);
-                    $curl_timed_out = true;
-                    break;
+                    $this->audit_log($retry_log, true);
+                    continue;
                 }
                 $this->import_state()->consecutive_interrupted_responses = 0;
                 $wall_time = microtime(true) - $request_start;
@@ -7937,15 +7903,6 @@ class ImportClient
                             " (original error: " . $caught_exception->getMessage() . ")",
                             true,
                         );
-                    } elseif ($curl_timed_out) {
-                        // Crash recovery — the buffer file is preserved on
-                        // disk so the next invocation reloads it and continues
-                        // accumulating from where the server left off.
-                        $this->audit_log(
-                            "BUFFER PRESERVED | " . strlen($pending) .
-                            " bytes in SQL buffer saved for crash recovery",
-                            true,
-                        );
                     } else {
                         $buffer_not_flushed = $pending;
                     }
@@ -7958,10 +7915,6 @@ class ImportClient
                 "Buffered SQL was never executed (" . strlen($buffer_not_flushed) .
                 " bytes) — incomplete export?"
             );
-        }
-
-        if ($curl_timed_out) {
-            return;
         }
     }
 

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -7,13 +7,11 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Verify that cURL timeouts during download save state and set the
- * resumable command completion state to "partial" instead of crashing with
- * a fatal RuntimeException.
+ * Verify recovery from cURL timeouts during streaming downloads.
  *
  * Each download method (download_sql, download_file_fetch, download_remote_index,
- * download_db_index) is tested by injecting a CurlTimeoutException via a
- * subclass that overrides fetch_streaming.
+ * download_db_index) is tested by injecting a CurlTimeoutException. SQL retries
+ * in the same invocation; the other phases save partial state for a later run.
  *
  * Also verifies the no-progress safety net: after repeated interrupted
  * responses with no cursor progress, the importer gives up.
@@ -142,10 +140,10 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // download_sql: timeout saves state as "partial"
+    // download_sql: timeout retries in the same invocation
     // ---------------------------------------------------------------
 
-    public function testSqlDownloadTimeoutSavesPartialState()
+    public function testSqlDownloadRetriesTimeoutUntilNoProgressLimit()
     {
         $this->writeState([
             "active_resumable_command" => [
@@ -166,21 +164,20 @@ class CurlTimeoutRecoveryTest extends TestCase
         $modeProp->setValue($client, 'file');
 
         $downloadSql = $reflection->getMethod('download_sql');
-        $downloadSql->invoke($client);
+        try {
+            $downloadSql->invoke($client);
+            $this->fail("Expected the no-progress limit to stop SQL retries");
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString(
+                "3 consecutive times without cursor progress",
+                $e->getMessage(),
+            );
+        }
 
-        $state = $this->readState();
-        $this->assertEquals(
-            "partial",
-            $state["active_resumable_command"]["completion_state"],
-            "After cURL timeout, resumable command completion state should be 'partial' not an exception"
-        );
-        $this->assertNotNull(
-            $state["active_resumable_command"]["remote_cursor"],
-            "Cursor should be preserved for resumption"
-        );
-        $this->assertNotNull(
-            $state["sql_bytes"],
-            "sql_bytes should be saved for crash recovery"
+        $this->assertSame(
+            3,
+            $client->streaming_requests,
+            "download_sql should retry timeouts until the no-progress limit",
         );
     }
 
@@ -375,46 +372,6 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // run_db_sync: timeout propagates as "partial", not exception
-    // ---------------------------------------------------------------
-
-    public function testRunDbSyncExitsPartialOnSqlTimeout()
-    {
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "db-pull",
-                "completion_state" => "in_progress",
-                "current_stage" => "sql",
-                "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
-            ],
-            "sql_bytes" => 0,
-            "db_index" => [
-                "file" => $this->stateDir . "/db-tables.jsonl",
-                "tables" => 5,
-                "rows_estimated" => 10000,
-                "bytes" => 100,
-                "updated_at" => time(),
-            ],
-        ]);
-
-        [$client, $reflection] = $this->prepareClient();
-
-        $modeProp = $reflection->getProperty('sql_output_mode');
-        $modeProp->setValue($client, 'file');
-
-        // run_db_sync should NOT throw — it should return with partial status
-        $runDbSync = $reflection->getMethod('run_db_sync');
-        $runDbSync->invoke($client);
-
-        $state = $this->readState();
-        $this->assertEquals(
-            "partial",
-            $state["active_resumable_command"]["completion_state"],
-            "run_db_sync should set resumable command completion state to 'partial' on timeout, not throw"
-        );
-    }
-
-    // ---------------------------------------------------------------
     // Exception hierarchy
     // ---------------------------------------------------------------
 
@@ -572,39 +529,6 @@ class CurlTimeoutRecoveryTest extends TestCase
         $downloadSql->invoke($client);
     }
 
-    public function testFirstTimeoutIncrementsCounterInState()
-    {
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "db-pull",
-                "completion_state" => "in_progress",
-                "current_stage" => "sql",
-                "remote_cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
-            ],
-            "sql_bytes" => 1024,
-            "consecutive_interrupted_responses" => 0,
-        ]);
-
-        $sql_content = str_pad("", 1024, "INSERT INTO t VALUES (1);\n");
-        file_put_contents($this->stateDir . '/db.sql', $sql_content);
-
-        [$client, $reflection] = $this->prepareClient();
-
-        $modeProp = $reflection->getProperty('sql_output_mode');
-        $modeProp->setValue($client, 'file');
-
-        $downloadSql = $reflection->getMethod('download_sql');
-        $downloadSql->invoke($client);
-
-        $state = $this->readState();
-        $this->assertEquals("partial", $state["active_resumable_command"]["completion_state"]);
-        $this->assertEquals(
-            1,
-            $state["consecutive_interrupted_responses"],
-            "First no-progress timeout should increment counter to 1"
-        );
-    }
-
     public function testSuccessfulRequestResetsCounter()
     {
         $this->writeState([
@@ -654,6 +578,8 @@ class CurlTimeoutRecoveryTest extends TestCase
  */
 class TimeoutTestClient extends \ImportClient
 {
+    public $streaming_requests = 0;
+
     protected function fetch_streaming(
         string $url,
         ?string $cursor,
@@ -661,6 +587,7 @@ class TimeoutTestClient extends \ImportClient
         ?array $post_data = null,
         ?string $endpoint = null
     ): void {
+        ++$this->streaming_requests;
         throw new \CurlTimeoutException(
             "cURL error: Operation timed out after 300001 milliseconds with 0 bytes received"
         );

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -1,22 +1,14 @@
 /**
- * Test 43: SQL Stream Crash Recovery (mysql mode)
+ * Test 43: SQL Stream Crash Recovery
  *
- * Simulates a PHP crash (exit(1)) mid-SQL-stream using a test hook on
- * test_hook_before_sql_batch. When PHP dies mid-stream, the multipart
- * response is truncated and no completion chunk is sent. Before this
- * fix, the importer would throw "Buffered SQL was never executed" and
- * fail fatally. Now it treats the missing completion chunk as an
- * interrupted response, saves partial state, and resumes on the next run.
- *
- * Note: The .sql-buffer file only contains data when the crash
- * interrupts a partial SQL statement (mid-chunk). With exit(1), PHP
- * dies before writing the next batch, so all previously received SQL
- * was already executed and the buffer is typically empty. The key
- * assertion is that the importer exits partial (code 2) and resumes
- * successfully — not that the buffer file has data.
+ * Simulates a PHP crash (exit(1)) after emitting a complete multipart
+ * part which ends midway through an INSERT, but before emitting the next
+ * part. Every SQL output mode must resume the REST stream from that part's
+ * cursor without repeating or skipping its SQL.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -29,164 +21,189 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: SQL Stream Crash Recovery', { timeout: 120000 }, () => {
+describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
     const site = 'sql-crash';
+    const payloadTable = 'wp_reprint_crash_payload';
+    let sourcePayloads;
 
     beforeAll(async () => {
         await ensureSite(site);
+        const conn = await createMysqlConnection();
+        await conn.query(
+            `DROP TABLE IF EXISTS \`${getDbName(site)}\`.\`${payloadTable}\``
+        );
+        // An incompressible row forces the incomplete multipart part
+        // through HTTP buffering before the exporter exits.
+        await conn.query(
+            `CREATE TABLE \`${getDbName(site)}\`.\`${payloadTable}\` (` +
+            '`id` bigint unsigned NOT NULL, ' +
+            '`payload` longblob NOT NULL, ' +
+            'PRIMARY KEY (`id`))'
+        );
+        sourcePayloads = [randomBytes(512 * 1024), randomBytes(512 * 1024)];
+        await conn.query(
+            `INSERT INTO \`${getDbName(site)}\`.\`${payloadTable}\` ` +
+            '(`id`, `payload`) VALUES (?, ?), (?, ?)',
+            [1, sourcePayloads[0], 2, sourcePayloads[1]]
+        );
+        await conn.end();
+
+        // Let one incomplete INSERT part reach the client, then kill PHP
+        // before the following part is emitted.
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = file_exists($state_file)',
+            '        ? json_decode(file_get_contents($state_file), true)',
+            '        : [];',
+            '',
+            '    if (!empty($state[\'crash_before_batch\'])) {',
+            '        $state[\'crash_before_batch\'] = false;',
+            '        $state[\'crashed\'] = true;',
+            '        file_put_contents($state_file, json_encode($state));',
+            '        exit(1);',
+            '    }',
+            '',
+            '    $trimmed = rtrim($sql);',
+            '    $large_incomplete_part = strlen($sql) > 512 * 1024',
+            '        && $trimmed !== \'\'',
+            '        && substr($trimmed, -1) === \',\';',
+            '    if (empty($state[\'crashed\']) && $large_incomplete_part) {',
+            '        $state[\'incomplete_batch_emitted\'] = true;',
+            '        $state[\'crash_before_batch\'] = true;',
+            '    }',
+            '    file_put_contents($state_file, json_encode($state));',
+            '}',
+        ].join('\n'));
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        const conn = await createMysqlConnection();
+        await conn.query(
+            `DROP TABLE IF EXISTS \`${getDbName(site)}\`.\`${payloadTable}\``
+        );
+        await conn.end();
     });
 
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    const mysqlArgs = (db) => [
-        '--sql-output=mysql',
-        `--mysql-database=${db}`,
-        '--mysql-host=127.0.0.1',
-        '--mysql-user=e2e_admin',
-        '--mysql-password=e2e_password',
-        // Force small batches so the standard WP install produces 3+
-        // SQL batches. The default (1000 fragments/batch) fits everything
-        // in one batch, so the crash hook on batch 3 would never fire.
-        '--sql-fragments-start=5',
-        '--sql-fragments-max=5',
-        '--sql-fragments-min=5',
-    ];
+    function sqlOutputArgs(mode, db) {
+        const args = [
+            `--sql-output=${mode}`,
+            // Emit one producer fragment per multipart part so the hook can
+            // stop immediately after a partial INSERT statement.
+            '--sql-fragments-start=1',
+            '--sql-fragments-max=1',
+            '--sql-fragments-min=1',
+        ];
+        if (mode === 'mysql') {
+            args.push(
+                `--mysql-database=${db}`,
+                '--mysql-host=127.0.0.1',
+                '--mysql-user=e2e_admin',
+                '--mysql-password=e2e_password',
+            );
+        }
+        return args;
+    }
 
-    describe('PHP crash mid-SQL-stream recovers via resume', () => {
-        let tempDir;
-        const importDb = 'e2e_sql_crash_import_43';
-
-        beforeAll(async () => {
-            tempDir = createTempDir('e2e-sql-stream-crash');
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.query(`CREATE DATABASE \`${importDb}\``);
-            await conn.end();
+    for (const mode of ['file', 'stdout', 'mysql']) {
+        it(`resumes the REST stream in ${mode} mode without skipping an INSERT row`, async () => {
+            const tempDir = createTempDir(`e2e-sql-stream-crash-${mode}`);
+            const importDb = `e2e_sql_crash_import_43_${mode}`;
 
             clearHookState(site);
+            writeHookState(site, {});
 
-            // Deploy a hook that kills PHP after 3 SQL batches. This
-            // simulates a real PHP crash (max_execution_time, OOM, fatal
-            // error) — the response is truncated mid-gzip and no completion
-            // chunk is sent.
-            writeTestHooks(site, [
-                'function test_hook_before_sql_batch(&$sql, $cursor) {',
-                `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
-                '    $state = file_exists($state_file)',
-                '        ? json_decode(file_get_contents($state_file), true)',
-                '        : [];',
-                '    $count = ($state[\'batch_count\'] ?? 0) + 1;',
-                '    $state[\'batch_count\'] = $count;',
-                '    file_put_contents($state_file, json_encode($state));',
-                '',
-                '    // Kill PHP on the 3rd SQL batch to simulate a crash.',
-                '    // Some data has already been flushed to the client,',
-                '    // so the importer will have partial SQL in its buffer.',
-                '    if ($count === 3) {',
-                '        exit(1);',
-                '    }',
-                '}',
-            ].join('\n'));
-            writeHookState(site, { batch_count: 0 });
+            if (mode === 'mysql') {
+                const conn = await createMysqlConnection();
+                await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+                await conn.query(`CREATE DATABASE \`${importDb}\``);
+                await conn.end();
+            }
+
+            try {
+                // autoResume=false requires this one importer invocation to
+                // recover instead of starting another process.
+                const result = runImporter(importUrl(), tempDir, 'db-sync', {
+                    secret: getSiteSecret(site),
+                    extraArgs: sqlOutputArgs(mode, importDb),
+                    autoResume: false,
+                    timeout: 270000,
+                });
+
+                assert.equal(result.exitCode, 0,
+                    `Expected ${mode} mode to complete in one invocation, got ${result.exitCode}\n` +
+                    `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+
+                const hookState = readHookState(site);
+                assert.ok(hookState, 'Hook state file should exist');
+                assert.equal(hookState.incomplete_batch_emitted, true,
+                    'Expected an incomplete SQL part to be emitted before the crash');
+                assert.equal(hookState.crashed, true,
+                    'Expected the exporter to crash before the following SQL part');
+
+                if (mode === 'mysql') {
+                    const comparison = await compareDatabases(getDbName(site), importDb);
+                    assert.ok(comparison.match,
+                        `Database mismatch after crash recovery: ` +
+                        `missing=${JSON.stringify(comparison.missingTables)}, ` +
+                        `counts=${JSON.stringify(comparison.rowCounts)}`);
+
+                    const sourceConn = await createMysqlConnection(getDbName(site));
+                    const importConn = await createMysqlConnection(importDb);
+                    const rowQuery =
+                        `SELECT id, OCTET_LENGTH(payload) AS payload_bytes, ` +
+                        `SHA2(payload, 256) AS payload_sha256 ` +
+                        `FROM \`${payloadTable}\` ORDER BY id`;
+                    const [sourceRows] = await sourceConn.query(rowQuery);
+                    const [importRows] = await importConn.query(rowQuery);
+                    await sourceConn.end();
+                    await importConn.end();
+                    assert.deepEqual(importRows, sourceRows,
+                        'Expected every split INSERT row and payload to reach MySQL');
+                } else {
+                    const sql = mode === 'file'
+                        ? readFileSync(join(tempDir, 'db.sql'), 'utf8')
+                        : result.stdout;
+                    for (const [index, payload] of sourcePayloads.entries()) {
+                        const encodedPayload = payload.toString('base64');
+                        const occurrences = sql.split(encodedPayload).length - 1;
+                        assert.equal(
+                            occurrences,
+                            1,
+                            `Expected payload ${index + 1} exactly once in ${mode} output`,
+                        );
+                    }
+                }
+
+                const stateFile = join(tempDir, '.import-state.json');
+                assert.ok(existsSync(stateFile), 'Expected state file to exist');
+                const state = JSON.parse(readFileSync(stateFile, 'utf8'));
+                assert.equal(state.active_resumable_command.completion_state, 'complete',
+                    `Expected status=complete, got ${state.active_resumable_command.completion_state}`);
+
+                const audit = readAuditLog(tempDir);
+                assert.match(
+                    audit,
+                    /SQL RETRY \| resuming source request/,
+                    `Expected ${mode} mode to retry the interrupted REST request`,
+                );
+
+                assert.ok(!existsSync(join(tempDir, '.sql-buffer')),
+                    'Expected .sql-buffer to be absent after successful completion');
+            } finally {
+                cleanupTempDir(tempDir);
+                if (mode === 'mysql') {
+                    const conn = await createMysqlConnection();
+                    await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+                    await conn.end();
+                }
+            }
         });
-
-        afterAll(async () => {
-            removeTestHooks(site);
-            clearHookState(site);
-            cleanupTempDir(tempDir);
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.end();
-        });
-
-        it('first run exits partial (not fatal) after crash', () => {
-            // Disable auto-resume so we can inspect the first-run behavior.
-            // The importer should NOT throw "Buffered SQL was never executed".
-            // Instead it should save state and exit with code 2 (partial).
-            const result = runImporter(importUrl(), tempDir, 'db-sync', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArgs(importDb),
-                autoResume: false,
-            });
-
-            // Exit code 2 = partial (retryable). Exit code 1 = fatal error.
-            // Before the fix, this would be 1 with "Buffered SQL was never executed".
-            assert.equal(result.exitCode, 2,
-                `Expected exit code 2 (partial), got ${result.exitCode}\n` +
-                `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
-
-            // Verify the hook actually fired
-            const state = readHookState(site);
-            assert.ok(state, 'Hook state file should exist');
-            assert.ok(state.batch_count >= 3,
-                `Expected batch_count >= 3, got ${state.batch_count}`);
-        });
-
-        it('state was saved for resume', () => {
-            // The importer should have persisted its state so the next
-            // run can resume. The cursor may be null if nginx buffered
-            // the entire response and no multipart chunks reached the
-            // client before the crash — in that case resume starts from
-            // scratch, which is correct.
-            const stateFile = join(tempDir, '.import-state.json');
-            assert.ok(existsSync(stateFile), 'Expected state file to exist');
-            const state = JSON.parse(readFileSync(stateFile, 'utf8'));
-            assert.equal(state.active_resumable_command.completion_state, 'partial',
-                `Expected status=partial, got ${state.active_resumable_command.completion_state}`);
-        });
-
-        it('audit log records the interrupted response', () => {
-            const audit = readAuditLog(tempDir);
-            assert.ok(
-                audit.includes('INTERRUPTED RESPONSE') ||
-                audit.includes('BUFFER PRESERVED') ||
-                audit.includes('BUFFER NOT FLUSHED') ||
-                audit.includes('missing completion chunk'),
-                'Expected audit log to record the interrupted response'
-            );
-        });
-
-        it('resume completes after removing crash hook', { timeout: 300000 }, async () => {
-            // Remove the crashing hook so subsequent requests succeed.
-            removeTestHooks(site);
-
-            const result = runImporter(importUrl(), tempDir, 'db-sync', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArgs(importDb),
-                maxResumeAttempts: 50,
-                wallTimeout: 270000,
-            });
-            assert.equal(result.exitCode, 0,
-                `Expected exit 0 on resume, got ${result.exitCode}\n` +
-                `stderr: ${result.stderr}`);
-        });
-
-        it('database matches source after recovery', async () => {
-            const comparison = await compareDatabases(getDbName(site), importDb);
-            assert.ok(comparison.match,
-                `Database mismatch after crash recovery: ` +
-                `missing=${JSON.stringify(comparison.missingTables)}, ` +
-                `counts=${JSON.stringify(comparison.rowCounts)}`);
-        });
-
-        it('.sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(tempDir, '.sql-buffer')),
-                'Expected .sql-buffer to be cleaned up after successful completion');
-        });
-
-        it('audit log shows successful completion after crash', () => {
-            const audit = readAuditLog(tempDir);
-            // The CRASH RECOVERY entry only appears when .sql-buffer had
-            // data to reload. With exit(1) between batches, the buffer is
-            // typically empty. Either way, the INTERRUPTED RESPONSE entry
-            // from the first run proves the crash was detected.
-            assert.ok(
-                audit.includes('INTERRUPTED RESPONSE') ||
-                audit.includes('CRASH RECOVERY'),
-                'Expected audit log to mention crash detection or recovery'
-            );
-        });
-    });
+    }
 });


### PR DESCRIPTION
SQL pulls now retry a timed-out or interrupted source REST response in the current importer invocation for `file`, `stdout`, and `mysql` output.

## Example

The exporter sends a complete multipart part with cursor `C1` and an unfinished statement:

```sql
INSERT INTO payloads (id, payload) VALUES (1, FROM_BASE64('...')),
```

It then exits before sending the next part or the required completion part. The importer requests the stream again from `C1` and receives:

```sql
(2, FROM_BASE64('...'));
```

A bare `;` cannot follow the first part. The producer writes `,` only after it has already fetched row 2, and `C1` stores that lookahead row. If row 2 does not exist, the first part ends in `;`. If row 2 is deleted before the retry, `C1` still supplies it, so the resumed part emits the saved tuple before `;` instead of skipping it.

File and stdout output append the second part after the first. MySQL keeps the first part buffered and executes the combined statement only after the second part arrives. No completed part is requested twice, and the unfinished statement is not discarded.

The multipart parser delivers SQL only after a complete part boundary, so the same retry rule applies to all three outputs. Three consecutive responses without cursor progress still stop the command.

This also removes the timeout path which saved an advanced cursor and then discarded the MySQL buffer. A timeout after the first part of a split `INSERT` can no longer resume after the discarded prefix.

## Testing

The E2E hook emits a two-row `INSERT` as separate multipart parts, kills the exporter after the first large row and before the second, and disables external auto-resume. File and stdout output must contain both random payloads exactly once; MySQL row sizes and hashes must match the source. A focused timeout test confirms that SQL requests retry in the same invocation until the no-progress limit.
