### PR TITLE
Paginate text primary keys in indexed collation order

### DIFF
--- a/packages/reprint-exporter/src/class-mysql-dump-producer.php
+++ b/packages/reprint-exporter/src/class-mysql-dump-producer.php
@@ -749,10 +749,14 @@ class MySQLDumpProducer
     /**
      * Builds the column expression shared by primary key comparison and order.
      *
-     * Nonnumeric, nonbinary columns are cast to binary so pagination follows
-     * their raw bytes instead of a connection or column collation. Applying
-     * the same expression to WHERE and ORDER BY prevents skipped rows, although
-     * MySQL may no longer use a text primary key for an efficient range scan.
+     * CHAR, VARCHAR, and TEXT columns keep their declared comparison semantics.
+     * FROM_BASE64() has a higher coercibility value than the column, so MySQL
+     * applies the column's declared character set and collation without reading
+     * the cursor through the connection character set. Keeping the indexed
+     * column bare also permits a primary-key range scan without a filesort.
+     *
+     * ENUM and SET are excluded because their indexes use numeric positions
+     * while their fetched values are strings.
      */
     private function build_primary_key_column_expression($column)
     {
@@ -760,12 +764,25 @@ class MySQLDumpProducer
             $this->quote_identifier($this->current_table) .
             "." .
             $this->quote_identifier($column);
-        $data_type = $this->get_data_type($column);
+        $data_type = strtoupper($this->get_data_type($column));
 
         if (
             $this->is_numeric_type($data_type) ||
             $this->is_binary_type($data_type)
         ) {
+            return $qualified_column;
+        }
+
+        $index_ordered_types = [
+            "CHAR",
+            "VARCHAR",
+            "TINYTEXT",
+            "TEXT",
+            "MEDIUMTEXT",
+            "LONGTEXT",
+        ];
+
+        if (in_array($data_type, $index_ordered_types, true)) {
             return $qualified_column;
         }
 

--- a/packages/reprint-exporter/src/class-wpdb-driver-pdo.php
+++ b/packages/reprint-exporter/src/class-wpdb-driver-pdo.php
@@ -12,9 +12,9 @@
  * bar; behavioral divergence (wpdb's HTML error rendering, sticky last_error,
  * get_results null ambiguity) is normalized inside the adapter.
  *
- * Charset: wpdb uses the site's DB_CHARSET. The dump producer wraps non-numeric
- * columns in CAST(... AS BINARY) so the connection charset doesn't influence
- * emitted bytes — same guarantee as the real-PDO path.
+ * Charset: create_db_connection() gives PDO and wpdb the same utf8mb4_bin
+ * session context. The dump producer casts non-numeric result columns to
+ * binary, while text primary key comparisons retain their stored collation.
  */
 
 /**

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -298,22 +298,31 @@ function create_db_connection(array $creds, array $options = [])
     // Gate on pdo_mysql, not pdo: ext-pdo core without the mysql driver
     // can't drive MySQL exports.
     if (!extension_loaded('pdo_mysql')) {
-        return create_wpdb_pdo_adapter();
+        $mysql = create_wpdb_pdo_adapter();
+    } else {
+        // MySQL path (also works for HyperDB — wp-config.php credentials
+        // point to the write master).
+        $default_options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ];
+        $merged_options = $options + $default_options;
+
+        $mysql = new PDO(
+            build_pdo_dsn($creds['db_host'], $creds['db_name']),
+            $creds["db_user"],
+            $creds["db_password"],
+            $merged_options
+        );
     }
 
-    // MySQL path (also works for HyperDB — wp-config.php credentials
-    // point to the write master).
-    $default_options = [
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-    ];
-    $merged_options = $options + $default_options;
-
-    return new PDO(
-        build_pdo_dsn($creds['db_host'], $creds['db_name']),
-        $creds["db_user"],
-        $creds["db_password"],
-        $merged_options
+    // SET NAMES normalizes the client, connection, and result charsets plus
+    // the connection collation for both PDO and wpdb. Text primary key
+    // comparisons still use each column's stored collation.
+    $mysql->query(
+        "SET NAMES utf8mb4 COLLATE utf8mb4_bin"
     );
+
+    return $mysql;
 }
 
 /**

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -5,6 +5,131 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 final class CreateDbConnectionTest extends TestCase {
+    public function testMysqlSessionUsesStableCharsetAndCollation(): void
+    {
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-exporter/src/export.php');
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $connection_script = <<<'PHP'
+        require $argv[1];
+        require $argv[2];
+        $mysql = create_db_connection(
+            [
+                'db_engine' => 'mysql',
+                'db_host' => getenv('DB_HOST') ?: '127.0.0.1',
+                'db_name' => 'information_schema',
+                'db_user' => getenv('DB_USER') ?: 'root',
+                'db_password' => getenv('DB_PASS') ?: '',
+            ],
+            [
+                PDO::MYSQL_ATTR_INIT_COMMAND =>
+                    "SET NAMES latin1 COLLATE latin1_swedish_ci",
+            ]
+        );
+        $session = $mysql->query(
+            "SELECT
+                @@character_set_client AS character_set_client,
+                @@character_set_connection AS character_set_connection,
+                @@character_set_results AS character_set_results,
+                @@collation_connection AS collation_connection"
+        )->fetch(PDO::FETCH_ASSOC);
+        fwrite(STDOUT, json_encode($session));
+        PHP;
+
+        $result = $this->runPhpProcess([
+            PHP_BINARY,
+            '-r',
+            $connection_script,
+            $autoload_path,
+            $export_path,
+        ]);
+        $this->assertSame(
+            0,
+            $result['status'],
+            $result['stderr'] . $result['stdout']
+        );
+
+        $this->assertSame(
+            [
+                'character_set_client' => 'utf8mb4',
+                'character_set_connection' => 'utf8mb4',
+                'character_set_results' => 'utf8mb4',
+                'collation_connection' => 'utf8mb4_bin',
+            ],
+            json_decode($result['stdout'], true)
+        );
+    }
+
+    public function testWpdbFallbackUsesStableCharsetAndCollation(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(
+                'Overriding extension_loaded() requires PHP 8.0 or later.'
+            );
+        }
+
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-exporter/src/export.php');
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $connection_script = <<<'PHP'
+        function extension_loaded($extension) {
+            return $extension !== 'pdo_mysql';
+        }
+        class WpdbSessionTestDouble {
+            public $last_error = '';
+            public $queries = [];
+            public function suppress_errors($suppress = true) {
+            }
+            public function hide_errors() {
+            }
+            public function get_results($query, $output) {
+                $this->queries[] = [$query, $output];
+                return [];
+            }
+        }
+        require $argv[1];
+        require $argv[2];
+        $wpdb = new WpdbSessionTestDouble();
+        $GLOBALS['wpdb'] = $wpdb;
+        create_db_connection(
+            [
+                'db_engine' => 'mysql',
+                'db_host' => 'unused',
+                'db_name' => 'unused',
+                'db_user' => 'unused',
+                'db_password' => 'unused',
+            ]
+        );
+        fwrite(STDOUT, json_encode($wpdb->queries));
+        PHP;
+
+        $result = $this->runPhpProcess([
+            PHP_BINARY,
+            '-d',
+            'disable_functions=extension_loaded',
+            '-r',
+            $connection_script,
+            $autoload_path,
+            $export_path,
+        ]);
+        $this->assertSame(
+            0,
+            $result['status'],
+            $result['stderr'] . $result['stdout']
+        );
+        $this->assertSame(
+            [
+                [
+                    "SET NAMES utf8mb4 COLLATE utf8mb4_bin",
+                    'ARRAY_A',
+                ],
+            ],
+            json_decode($result['stdout'], true)
+        );
+    }
+
     public function testBareSocketPathDbHostOpensUnixSocket(): void
     {
         $this->assertDbHostOpensUnixSocket(false);
@@ -111,5 +236,38 @@ final class CreateDbConnectionTest extends TestCase {
             fclose($socket_listener);
             @unlink($socket_path);
         }
+    }
+
+    /**
+     * Runs a PHP subprocess and captures its result.
+     *
+     * @param string[] $command Command and arguments.
+     * @return array {
+     *     @type string $stdout Standard output.
+     *     @type string $stderr Standard error.
+     *     @type int    $status Exit status.
+     * }
+     */
+    private function runPhpProcess(array $command): array
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($command, $descriptors, $pipes);
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $status = proc_close($process);
+
+        return [
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'status' => $status,
+        ];
     }
 }

--- a/tests/MySQLDumpProducer/EncodingTest.php
+++ b/tests/MySQLDumpProducer/EncodingTest.php
@@ -1314,10 +1314,10 @@ class EncodingTest extends MySQLDumpProducerTestBase
     }
 
     /**
-     * The resume predicate and ORDER BY must both ignore the column collation.
+     * The resume predicate and ORDER BY must both follow the primary key index.
      * latin1_german2_ci sorts ä before b, while raw bytes sort b, z, then ä.
      */
-    public function testReentrancyWithLatin1TextPrimaryKeyByteOrdering(): void
+    public function testReentrancyWithLatin1TextPrimaryKeyIndexOrdering(): void
     {
         $this->pdo->exec(
             "CREATE TABLE t (
@@ -1345,9 +1345,9 @@ class EncodingTest extends MySQLDumpProducerTestBase
         $this->assertNotFalse($letter_z_position);
         $this->assertNotFalse($umlaut_a_position);
         $this->assertTrue(
-            $letter_b_position < $letter_z_position &&
-            $letter_z_position < $umlaut_a_position,
-            "Text primary keys must be emitted in raw byte order"
+            $umlaut_a_position < $letter_b_position &&
+            $letter_b_position < $letter_z_position,
+            "Text primary keys must be emitted in primary key index order"
         );
 
         $import_pdo = $this->executeDumpInNewDatabase($sql);
@@ -1355,6 +1355,70 @@ class EncodingTest extends MySQLDumpProducerTestBase
             ["E4", "62", "7A"],
             $import_pdo
                 ->query("SELECT HEX(id) FROM t ORDER BY id")
+                ->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
+    /**
+     * A composite primary key may contain byte-distinct text values which its
+     * collation considers equal. The following numeric key part must determine
+     * their order across one-row batches and repeated resume boundaries.
+     */
+    public function testReentrancyWithCompositeLatin1TextPrimaryKey(): void
+    {
+        $this->pdo->exec(
+            "CREATE TABLE t (
+                category VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_german2_ci NOT NULL,
+                sequence_number INT NOT NULL,
+                data VARCHAR(50),
+                PRIMARY KEY (category, sequence_number)
+            )"
+        );
+        $this->pdo->exec(
+            "INSERT INTO t (category, sequence_number, data) VALUES
+                (CONVERT(X'E4' USING latin1), 1, 'umlaut-1'),
+                ('ae', 2, 'ae-2'),
+                (CONVERT(X'E4' USING latin1), 3, 'umlaut-3'),
+                ('b', 1, 'b-1'),
+                ('z', 1, 'z-1')"
+        );
+
+        [$sql, $resume_count] = $this->exportWithResumeAfterEveryFragment([
+            "batch_size" => 1,
+        ]);
+
+        $this->assertGreaterThan(5, $resume_count);
+
+        $previous_position = -1;
+        foreach (["umlaut-1", "ae-2", "umlaut-3", "b-1", "z-1"] as $data) {
+            $position = strpos(
+                $sql,
+                "FROM_BASE64('" . base64_encode($data) . "')"
+            );
+            $this->assertNotFalse($position);
+            $this->assertGreaterThan(
+                $previous_position,
+                $position,
+                "Composite primary keys must be emitted in primary key index order"
+            );
+            $previous_position = $position;
+        }
+
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertSame(
+            [
+                "E4:1:umlaut-1",
+                "6165:2:ae-2",
+                "E4:3:umlaut-3",
+                "62:1:b-1",
+                "7A:1:z-1",
+            ],
+            $import_pdo
+                ->query(
+                    "SELECT CONCAT(HEX(category), ':', sequence_number, ':', data)
+                     FROM t
+                     ORDER BY category, sequence_number"
+                )
                 ->fetchAll(PDO::FETCH_COLUMN)
         );
     }


### PR DESCRIPTION
Text-primary-key exports now resume in the source primary key's indexed collation order, so every batch can seek into the primary B-tree instead of scanning and sorting the table again.

## Background

#398 made both sides of pagination byte-ordered with `CAST(primary_key AS BINARY)`. That kept `WHERE` and `ORDER BY` consistent, but applying a function to the indexed column prevents MySQL from using the primary key for either the range or the order.

For example:

```sql
CREATE TABLE translated_keys (
    category VARCHAR(16) CHARACTER SET latin1 COLLATE latin1_german2_ci NOT NULL,
    sequence_number INT NOT NULL,
    PRIMARY KEY (category, sequence_number)
);

INSERT INTO translated_keys VALUES
    (CONVERT(X'E4' USING latin1), 1),
    ('ae', 2),
    (CONVERT(X'E4' USING latin1), 3),
    ('b', 1);
```

With `batch_size=1`, resuming after each row previously compared and ordered by `CAST(category AS BINARY)`. MySQL reported a full scan and `Using filesort` for every batch. On this table, `ä` and `ae` are equal under the indexed collation, so `sequence_number` must order those composite keys.

## This change

The SELECT list still casts text to binary, so the dump and cursor retain the original database bytes. Pagination compares the bare text column with `FROM_BASE64(...)` and orders by that same bare column. The column's declared character set and collation win the comparison; connection charset and collation do not participate.

Both the native PDO path and the `wpdb` fallback run `SET NAMES utf8mb4 COLLATE utf8mb4_bin` before exporter queries. This gives them the same client, connection, and result charsets and the same connection collation without overriding a column's stored collation.

The resulting plan uses a `PRIMARY` range scan without a filesort on MySQL 5.7, MySQL 8.0, and MariaDB 10.11. `ENUM` and `SET` retain byte ordering because their indexes order numeric positions while the cursor contains their displayed strings.

## Testing

The one-row resume tests cover raw latin1 bytes, numeric-looking text keys, a non-binary collation, and a composite `(latin1 VARCHAR, INT)` key with collation-equal text values. The new index-order and composite tests fail against #398 and pass here. The connection tests start PDO with a latin1 session and simulate the PDO-less `wpdb` path; both confirm that exporter setup ends at `utf8mb4_bin`.

```sh
cd tests && ../vendor/bin/phpunit
php vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps packages/reprint-exporter/src/class-mysql-dump-producer.php packages/reprint-exporter/src/export.php packages/reprint-exporter/src/class-wpdb-driver-pdo.php
git diff --check
```
