### PR TITLE
[Push] Serialize local commands with one state-directory lock

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -273,13 +273,21 @@ configuration; request parameters cannot select any of them.
 ## Local files sender
 
 `PushFilesSender` joins the durable `PushPlan` to the receiver's push session.
+Every local Reprint command workflow runs under `<state-dir>/.reprint.lock`.
+The production CLI acquires this non-blocking lock before it prepares pair
+context, constructs `ImportClient`, or writes the command audit entry. It
+passes the open lock to `ImportClient::run()` and releases it after the command.
+A direct `ImportClient::run()` call acquires the lock when its caller supplies
+none. The one state-directory-wide Reprint process lock prevents concurrent
+pull, push, diff, and other local Reprint processes from using that site state,
+regardless of their target or local-tree pair.
+
 An active push keeps these files under `<state-dir>/push/<pair-key>/`:
 
 ```text
 previous_local_index.jsonl          index saved after the previous commit
 excluded_paths.json                 sender-owned target exclusions
 sender.json                         active push state
-sender.lock                         lifecycle lock
 plan/
   excluded_paths.json               target exclusions for the active push
   fresh_local_index.jsonl           plan-owned fresh local index
@@ -289,20 +297,20 @@ plan/
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.
-`PushFilesSender::start()` rejects unfinished active state, writes the initial
-`creating` state, and acquires `sender.lock`. `PushFilesSender::resume()`
-acquires the same lock and reads the unfinished state once. The returned sender
-keeps that state in memory while `next_step()` performs bounded work. When the
-caller stops between steps, `cancel()` discards an open multipart request and
-returns to the preceding durable boundary. `close()` then releases the lock.
-`close()` never finishes a request or advances the workflow. A second local
-process cannot start or resume the same sender
-until the open sender is closed. `next_step()` returns true while another step
-may be performed and false after completion, restart, or failure; the caller
-reads that outcome from the sender. The caller may stop after any true return
-and close the sender. If the process stops without closing, the next process
-uses the preceding sender boundary and receiver-confirmed cursors to account
-for later remote work.
+Its caller acquires the Reprint process lock and passes the open lock to
+`PushFilesSender::start()` or `PushFilesSender::resume()`.
+`PushFilesSender::start()` rejects unfinished active state and writes the
+initial `creating` state. `PushFilesSender::resume()` reads the unfinished state
+once. The returned sender keeps that state in memory while `next_step()`
+performs bounded work. When the caller stops between steps, `cancel()` discards
+an open multipart request and returns to the preceding durable boundary.
+`close()` releases sender resources but not the caller-owned Reprint process
+lock, and never finishes a request or advances the workflow. `next_step()`
+returns true while another step may be performed and false after completion,
+restart, or failure; the caller reads that outcome from the sender. The caller
+may stop after any true return and close the sender. If the process stops
+without closing, the next process uses the preceding sender boundary and
+receiver-confirmed cursors to account for later remote work.
 
 During PushPlan's internal `indexing` phase, the plan retains one
 `FileIndexProcessor` and the open fresh local index across steps. A
@@ -312,7 +320,7 @@ processor cursor before continuing. The sender lazily opens
 It retains those handles across `next_step()` calls, lets each handle advance
 with the work, and seeks only when a newly opened or receiver-confirmed offset
 differs. It closes each handle when its phase or file ends and closes any
-remaining handles before `close()` releases the lifecycle lock.
+remaining handles before `close()` returns.
 
 The sender creates the push session and stores its exclusion policy before it
 starts PushPlan. Each internal `indexing` step completes one traversal event,
@@ -376,8 +384,8 @@ Each local-path upload or deletion step sends at most one multipart part. A file
 part contains one bounded chunk, a deletion-list part contains one complete
 path, and a directory or symlink part contains one complete value. The sender
 retains one multipart request across successive steps until its body budget is
-spent or the caller explicitly cancels it. `close()` only releases resources
-and the lifecycle lock. The sender
+spent or the caller explicitly cancels it. `close()` only releases sender
+resources. The sender
 derives Content-Length from the bytes actually read and never reads another
 local path to push until the current one is complete. Receiver
 contention, offset gaps, and transport failures end the current sender run. The
@@ -451,7 +459,8 @@ formula, including its trailing `?` and `&` trim, so another URL query or
 local tree cannot reuse the index. It accepts only `--state-dir` and
 `--fs-root`; it needs no secret, performs no preflight, and makes no network
 request. It runs one complete PushPlan against `previous_local_index.jsonl` in
-`files-diff-plan/` and holds `files-diff.lock` for the run.
+`files-diff-plan/` while the command holds the state-directory-wide Reprint
+process lock.
 
 Output is JSONL. Each selected current file, symlink, or empty directory has
 `action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -84,6 +84,22 @@ failure key is `non_recoverable_commit_failure`.
 These JSON records are unversioned while their schemas are still under
 development. There are no compatibility aliases or migration paths.
 
+## Local Reprint process lock
+
+Every local Reprint command workflow runs under the **Reprint process lock** at
+`<state-dir>/.reprint.lock`. Use `.reprint.lock` and `$process_lock`. The lock
+is non-blocking and state-directory-wide: pull, push, diff, and other local
+Reprint processes cannot run concurrently against the same state directory,
+even when their target or local-tree pairs differ.
+
+The production CLI acquires the Reprint process lock before it prepares pair
+context, constructs `ImportClient`, or writes the command audit entry. It
+passes the open lock to `ImportClient::run()` and releases it after the command.
+A direct `ImportClient::run()` call acquires the lock when its caller supplies
+none. `PushFilesSender::start()` and `PushFilesSender::resume()` receive that
+open lock from the caller; sender `close()` does not release it. This local
+lock is separate from the receiver's push-session and commit locks.
+
 ## Local push state
 
 The local machine keeps planning and active state outside the receiver push
@@ -102,13 +118,10 @@ directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
 | Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
 | Active state | `sender.json`, `$state_path` |
-| Lifecycle lock file | `sender.lock`, `$lock_path` |
-| Files-diff lifecycle lock | `files-diff.lock` |
-| Open lifecycle lock | `$lock_handle` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`sender.json`, `sender.lock`, `excluded_paths.json`, and
+`sender.json`, `excluded_paths.json`, and
 `previous_local_index.jsonl` live directly under the local push state
 directory. The sender creates `plan/` for one active plan. PushPlan copies the
 sender-owned exclusions to `plan/excluded_paths.json` when it starts.
@@ -157,13 +170,13 @@ them in memory for later steps in the same lifecycle. It does not copy them into
 `push.json` remains the receiver-owned push identity and policy, while
 `commit.json` and `$commit_state` remain the receiver commit checkpoint.
 
-`PushFilesSender::start()` and `PushFilesSender::resume()` acquire
-`sender.lock`; `PushFilesSender::close()` releases it. `next_step()` does not
-acquire or release the lock and does not reread `sender.json`. A sender retains
-one multipart request across steps. A caller stopping between steps calls
-`cancel()` to discard that request and return to the preceding durable
-boundary, then calls `close()` to release resources and the lock. `close()`
-never finishes an open request. In `pushing_paths` or
+`PushFilesSender::start()` and `PushFilesSender::resume()` require the
+caller-owned Reprint process lock. `next_step()` does not acquire or release
+the lock and does not reread `sender.json`. A sender retains one multipart
+request across steps. A caller stopping between steps calls `cancel()` to
+discard that request and return to the preceding durable boundary, then calls
+`close()` to release sender resources. `close()` never finishes an open
+request. In `pushing_paths` or
 `pushing_deletes`, one step sends at most one multipart part. `next_step()`
 returns true while another step may be performed and false when `get_status()`
 reports `complete`, `restart`, or `failed`.
@@ -184,10 +197,11 @@ and metadata-only changes to non-empty directories select no operation. The
 final record has `status: "complete"`, `local_paths_to_push`, and
 `local_paths_to_delete`.
 
-files-diff persists nothing between runs. It runs one complete PushPlan under
-`files-diff.lock` in `files-diff-plan/`, streams both finished path lists from
-the beginning, and removes the plan directory before exiting. An interrupted
-report is not resumed; running the command again prints the complete report.
+files-diff persists nothing between runs. It runs one complete PushPlan in
+`files-diff-plan/` while its command holds the state-directory-wide Reprint
+process lock, streams both finished path lists from the beginning, and removes
+the plan directory before exiting. An interrupted report is not resumed;
+running the command again prints the complete report.
 
 ## Files-push CLI names
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -62,6 +62,7 @@ require_once __DIR__ . '/lib/target-runtime/load.php';
 
 // External merge sort for large index files when exec() is unavailable
 require_once __DIR__ . '/lib/external-merge-sort.php';
+require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
 require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
@@ -883,9 +884,19 @@ class ImportClient
      *   - command: Required. One of the entries in $valid_commands below.
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
+     * @param ReprintProcessLock|null $process_lock Lock for this state directory already held by the caller.
      */
-    public function run(array $options = []): void
+    public function run(
+        array $options = [],
+        ?ReprintProcessLock $process_lock = null
+    ): void
     {
+        $process_lock = $process_lock ?? new ReprintProcessLock($this->state_dir);
+        if (!$process_lock->is_held()) {
+            throw new InvalidArgumentException(
+                'ImportClient requires a held Reprint process lock.'
+            );
+        }
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->progress->set_verbose_mode($this->verbose_mode);
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
@@ -956,7 +967,7 @@ class ImportClient
             return;
         }
         if ($command === "files-push") {
-            $this->run_files_push($options);
+            $this->run_files_push($options, $process_lock);
             return;
         }
 
@@ -1331,7 +1342,6 @@ class ImportClient
             throw new RuntimeException($missing_previous_local_index_message);
         }
 
-        $lock_handle = $this->acquire_files_diff_lock($push_state_directory);
         $plan_directory = $push_state_directory . '/files-diff-plan';
         try {
             if (!is_file($previous_local_index)) {
@@ -1416,8 +1426,6 @@ class ImportClient
             }
         } finally {
             $this->remove_local_plan_directory($plan_directory);
-            flock($lock_handle, LOCK_UN);
-            fclose($lock_handle);
         }
     }
 
@@ -1483,25 +1491,6 @@ class ImportClient
         }
     }
 
-    /**
-     * Acquires the pair's files-diff lifecycle lock.
-     *
-     * @return resource Open lock handle.
-     */
-    private function acquire_files_diff_lock(string $push_state_directory)
-    {
-        $lock_path = $push_state_directory . '/files-diff.lock';
-        $lock_handle = fopen($lock_path, 'c+b');
-        if (!is_resource($lock_handle)) {
-            throw new RuntimeException('Failed to open the files-diff lifecycle lock: ' . $lock_path . '.');
-        }
-        if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
-            fclose($lock_handle);
-            throw new RuntimeException('Another files-diff or files-pull process is using this target and local tree.');
-        }
-        return $lock_handle;
-    }
-
     /** Removes one completed or discarded local plan and confirms every removal. */
     private function remove_local_plan_directory(string $plan_directory): void
     {
@@ -1542,9 +1531,13 @@ class ImportClient
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
      * }
+     * @param ReprintProcessLock $process_lock Lock held for this command.
      * @phpstan-param array<string,mixed> $options
      */
-    private function run_files_push(array $options): void
+    private function run_files_push(
+        array $options,
+        ReprintProcessLock $process_lock
+    ): void
     {
         $started_at = hrtime(true) / 1000000000;
         $context = $options['files_push_context'] ?? self::prepare_files_push_context(
@@ -1582,8 +1575,8 @@ class ImportClient
 
         $resuming = is_file($context['push_state_directory'] . '/sender.json');
         $sender = $resuming
-            ? PushFilesSender::resume($sender_options)
-            : PushFilesSender::start($sender_options);
+            ? PushFilesSender::resume($sender_options, $process_lock)
+            : PushFilesSender::start($sender_options, $process_lock);
         $status = null;
         $reason = null;
         $detail = null;
@@ -13097,6 +13090,7 @@ if (
     }
 
     try {
+        $reprint_process_lock = new ReprintProcessLock($state_dir);
         $reprint_files_push_context = null;
         $reprint_files_diff_context = null;
         if ($command === 'files-push') {
@@ -13124,7 +13118,8 @@ if (
                     : ['files_push_context' => $reprint_files_push_context] )
                 + ( $reprint_files_diff_context === null
                     ? []
-                    : ['files_diff_context' => $reprint_files_diff_context] )
+                    : ['files_diff_context' => $reprint_files_diff_context] ),
+            $reprint_process_lock
         );
         // EXIT_AFTER_IMPORT controls whether we hand control back to
         // the caller after pull returns. Default true: standard CLI
@@ -13170,5 +13165,9 @@ if (
         // to see the failure — re-throw so its try/catch around
         // `include $phar` can surface a proper `{type:'error'}` event.
         throw $e;
+    } finally {
+        if (isset($reprint_process_lock)) {
+            $reprint_process_lock->close();
+        }
     }
 }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -878,13 +878,18 @@ class ImportClient
     }
 
     /**
-     * Run the import process with explicit command validation.
+     * Runs one import command while holding the state directory's process lock.
+     *
+     * CLI callers pass the lock acquired before pair setup and audit logging.
+     * Direct callers may omit it; this method then acquires the lock before
+     * reading or writing command state. A supplied lock remains caller-owned.
      *
      * @param array $options Options:
      *   - command: Required. One of the entries in $valid_commands below.
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
-     * @param ReprintProcessLock|null $process_lock Lock for this state directory already held by the caller.
+     * @param ReprintProcessLock|null $process_lock Optional lock already held
+     *                                               for this state directory.
      */
     public function run(
         array $options = [],
@@ -1520,9 +1525,10 @@ class ImportClient
      * Runs one caller-bounded files-push lifecycle.
      *
      * One open sender performs at most one step per loop turn. A planned stop
-     * cancels any open multipart request before close() releases the lifecycle
-     * lock. Terminal sender outcomes are reported without retrying or opening
-     * a replacement; this process never opens a second sender.
+     * cancels any open multipart request before close() releases sender
+     * resources. The caller retains the Reprint process lock throughout.
+     * Terminal sender outcomes are reported without retrying or opening a
+     * replacement; this process never opens a second sender.
      *
      * @param array $options {
      *     Parsed files-push options and context.
@@ -1531,7 +1537,7 @@ class ImportClient
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
      * }
-     * @param ReprintProcessLock $process_lock Lock held for this command.
+     * @param ReprintProcessLock $process_lock Lock held for the command's state directory.
      * @phpstan-param array<string,mixed> $options
      */
     private function run_files_push(
@@ -13090,6 +13096,8 @@ if (
     }
 
     try {
+        // Acquire the lock before pair setup and audit writes so each command
+        // owns every local state transition for its complete invocation.
         $reprint_process_lock = new ReprintProcessLock($state_dir);
         $reprint_files_push_context = null;
         $reprint_files_diff_context = null;

--- a/packages/reprint-importer/src/lib/class-reprint-process-lock.php
+++ b/packages/reprint-importer/src/lib/class-reprint-process-lock.php
@@ -5,13 +5,28 @@
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
 
 /**
- * Prevents concurrent Reprint processes from using one state directory.
+ * Serializes local Reprint commands which share one state directory.
+ *
+ * Construction acquires the non-blocking exclusive lock at
+ * `<state-directory>/.reprint.lock`. The caller retains this object for the
+ * complete command and calls close() when the command ends.
  */
 final class ReprintProcessLock
 {
-    /** @var resource|null */
+    /** @var resource|null Open lock handle, or null after close(). */
     private $handle;
 
+    /**
+     * Acquires the state directory's Reprint process lock.
+     *
+     * The state directory is created when absent. Lock acquisition is
+     * non-blocking, so construction fails while another process owns it.
+     *
+     * @param string $state_directory Local Reprint state directory.
+     *
+     * @throws RuntimeException When the directory or lock cannot be created,
+     *                          opened, or acquired.
+     */
     public function __construct(string $state_directory)
     {
         if (
@@ -39,11 +54,21 @@ final class ReprintProcessLock
         }
     }
 
+    /**
+     * Indicates whether this object still holds the process lock.
+     *
+     * @return bool True while the lock handle remains open.
+     */
     public function is_held(): bool
     {
         return is_resource($this->handle);
     }
 
+    /**
+     * Releases the process lock and closes its handle.
+     *
+     * Repeated calls have no effect.
+     */
     public function close(): void
     {
         if (!is_resource($this->handle)) {
@@ -54,6 +79,9 @@ final class ReprintProcessLock
         $this->handle = null;
     }
 
+    /**
+     * Releases the process lock when the owner leaves scope.
+     */
     public function __destruct()
     {
         $this->close();

--- a/packages/reprint-importer/src/lib/class-reprint-process-lock.php
+++ b/packages/reprint-importer/src/lib/class-reprint-process-lock.php
@@ -1,0 +1,61 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain local filesystem paths, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Prevents concurrent Reprint processes from using one state directory.
+ */
+final class ReprintProcessLock
+{
+    /** @var resource|null */
+    private $handle;
+
+    public function __construct(string $state_directory)
+    {
+        if (
+            !is_dir($state_directory)
+            && !mkdir($state_directory, 0755, true)
+            && !is_dir($state_directory)
+        ) {
+            throw new RuntimeException(
+                'Failed to create the Reprint state directory: '
+                . $state_directory . '.'
+            );
+        }
+        $lock_path = rtrim($state_directory, '/') . '/.reprint.lock';
+        $this->handle = fopen($lock_path, 'c+b');
+        if (!is_resource($this->handle)) {
+            throw new RuntimeException('Failed to open the Reprint process lock: ' . $lock_path . '.');
+        }
+        if (!flock($this->handle, LOCK_EX | LOCK_NB)) {
+            fclose($this->handle);
+            $this->handle = null;
+            throw new RuntimeException(
+                'Another Reprint process is using the state directory: '
+                . rtrim($state_directory, '/') . '.'
+            );
+        }
+    }
+
+    public function is_held(): bool
+    {
+        return is_resource($this->handle);
+    }
+
+    public function close(): void
+    {
+        if (!is_resource($this->handle)) {
+            return;
+        }
+        flock($this->handle, LOCK_UN);
+        fclose($this->handle);
+        $this->handle = null;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+}

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -7,27 +7,30 @@
 /**
  * Drives one local-files push through bounded planning and streaming requests.
  *
- * PushFilesSender owns the only caller-visible lifecycle. It holds the lock,
- * creates and removes the target push session, drives its internal PushPlan,
- * streams the selected paths, commits the push, and saves the completed fresh
- * local index as the pair's previous local index. The target owns the
+ * PushFilesSender owns the only caller-visible push lifecycle. Its caller holds
+ * the Reprint process lock while the sender creates and removes the target push
+ * session, drives its internal PushPlan, streams the selected paths, commits the
+ * push, and saves the completed fresh local index as the pair's previous local
+ * index. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
  * request limits and the PushPlan cursor needed after a process restart.
  *
  * ## Usage
  *
- *  1. Start a new sender with `start()`, or continue an unfinished sender with
- *     `resume()`. Both methods acquire the lifecycle lock.
+ *  1. Acquire the Reprint process lock, then start a new sender with `start()`
+ *     or continue an unfinished sender with `resume()`.
  *  2. Call `next_step()` while the current process has enough time and memory
  *     for another step.
- *  3. Call `close()` to release the lifecycle lock, even when more work remains.
+ *  3. Call `close()` and release the Reprint process lock, even when more work
+ *     remains.
  *
  * Example:
  *
+ *     $process_lock = new ReprintProcessLock($state_directory);
  *     $sender = $first_run
- *         ? PushFilesSender::start($options)
- *         : PushFilesSender::resume($options);
+ *         ? PushFilesSender::start($options, $process_lock)
+ *         : PushFilesSender::resume($options, $process_lock);
  *     try {
  *         while ($has_time_remaining() && $has_memory_available()) {
  *             if (!$sender->next_step()) {
@@ -40,12 +43,14 @@
  *             $sender->cancel();
  *         }
  *         $sender->close();
+ *         $process_lock->close();
  *     }
  *
  * The caller may cancel whenever next_step() returns true. cancel() abandons an
  * open multipart request and returns the in-memory sender to its preceding
- * durable boundary. close() only releases resources and the lock; it never
- * finishes an open request. If a process stops without closing, the next
+ * durable boundary. close() only releases sender resources; it never finishes
+ * an open request or releases the caller's process lock. If a process stops
+ * without closing, the next
  * process starts from the preceding durable boundary and reads
  * receiver-confirmed work before sending more data.
  *
@@ -136,14 +141,14 @@ final class PushFilesSender
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
 
-    /** @var string Advisory lock file for one open lifecycle. */
-    private string $lock_path;
-
     /** @var string Target exclusions stored once for the active push. */
     private string $excluded_paths_path;
 
-    /** @var resource|null Exclusive lock held from start() or resume() through close(). */
-    private $lock_handle = null;
+    /** @var ReprintProcessLock Reprint process lock owned by the caller. */
+    private ReprintProcessLock $process_lock;
+
+    /** @var bool Whether close() released this sender's resources. */
+    private bool $closed = false;
 
     /** @var resource|null Open local_paths_to_push list retained while pushing local paths. */
     private $local_paths_to_push_handle = null;
@@ -218,11 +223,10 @@ final class PushFilesSender
     private array $push_stream_client_options;
 
     /**
-     * Starts a new sender and acquires exclusive ownership of its push state.
+     * Starts a new sender while the caller holds the Reprint process lock.
      *
      * The returned sender begins in `creating`. An existing active state is
-     * rejected so unfinished work cannot be replaced. The returned sender
-     * retains its lock until close().
+     * rejected so unfinished work cannot be replaced.
      *
      * @param array $options {
      *     Push, push stream client, and local-file options.
@@ -239,17 +243,17 @@ final class PushFilesSender
      *     @type array                   $request_sizer_options    Optional PushRequestSizer bounds.
      * }
      * @phpstan-param array<string,mixed> $options
+     * @param ReprintProcessLock $process_lock Lock for the containing state directory.
      * @return self Open sender at its initial durable state.
      */
-    public static function start(array $options): self
+    public static function start(array $options, ReprintProcessLock $process_lock): self
     {
-        $sender = new self($options);
+        $sender = new self($options, $process_lock);
         if (!is_dir($sender->push_state_directory) && !@mkdir($sender->push_state_directory, 0755, true) && !is_dir($sender->push_state_directory)) {
             throw new RuntimeException(
                 'Failed to create the local push state directory: ' . $sender->push_state_directory
             );
         }
-        $sender->lock_handle = $sender->acquire_lock();
         try {
             clearstatcache(true, $sender->state_path);
             if (is_file($sender->state_path)) {
@@ -276,25 +280,25 @@ final class PushFilesSender
     }
 
     /**
-     * Resumes an unfinished sender while holding its exclusive lifecycle lock.
+     * Resumes an unfinished sender while the caller holds the process lock.
      *
-     * The active state is read once under the acquired lock. next_step() then
+     * The active state is read once under the lock. next_step() then
      * works from that in-memory state, storing each later durable boundary
      * without reopening sender.json.
      *
      * @param array<string,mixed> $options Options documented by start().
+     * @param ReprintProcessLock  $process_lock Lock for the containing state directory.
      * @return self Open sender at its last durable state.
      */
-    public static function resume(array $options): self
+    public static function resume(array $options, ReprintProcessLock $process_lock): self
     {
-        $sender = new self($options);
+        $sender = new self($options, $process_lock);
         if (!is_dir($sender->push_state_directory)) {
             throw new LogicException(
                 'Cannot resume a push files sender without unfinished active state: '
                 . $sender->state_path
             );
         }
-        $sender->lock_handle = $sender->acquire_lock();
         try {
             $state = $sender->load_state();
             if ($state === null) {
@@ -319,10 +323,11 @@ final class PushFilesSender
      * Configures the paths and push stream client options shared by start() and resume().
      *
      * @param array<string,mixed> $options Options documented by start().
+     * @param ReprintProcessLock  $process_lock Lock for the containing state directory.
      *
      * @throws InvalidArgumentException If local path or push stream client options are invalid.
      */
-    private function __construct(array $options)
+    private function __construct(array $options, ReprintProcessLock $process_lock)
     {
         $docroot = $options['docroot'] ?? null;
         $push_state_directory = $options['push_state_directory'] ?? null;
@@ -331,6 +336,9 @@ final class PushFilesSender
         }
         if (!is_string($push_state_directory) || $push_state_directory === '') {
             throw new InvalidArgumentException('PushFilesSender requires a push_state_directory.');
+        }
+        if (!$process_lock->is_held()) {
+            throw new InvalidArgumentException('PushFilesSender requires a held Reprint process lock.');
         }
         $request_sizer_options = $options['request_sizer_options'] ?? [];
         if (!is_array($request_sizer_options)) {
@@ -353,11 +361,11 @@ final class PushFilesSender
             throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
         }
         $this->docroot = rtrim($canonical_docroot, '/');
+        $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
         $this->previous_local_index = $this->push_state_directory . '/previous_local_index.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
-        $this->lock_path = $this->push_state_directory . '/sender.lock';
         $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
@@ -366,7 +374,7 @@ final class PushFilesSender
     /**
      * Performs the next step for the current phase.
      *
-     * start() or resume() has already acquired the lifecycle lock and loaded the
+     * start() or resume() has received the Reprint process lock and loaded the
      * durable state, so this method only dispatches its current phase. Every
      * phase step is bounded except the deliberate completed-index copy described
      * in the class documentation. A caller stopping after this method returns
@@ -382,7 +390,7 @@ final class PushFilesSender
         if ($this->status !== 'continue') {
             return false;
         }
-        if (!is_resource($this->lock_handle)) {
+        if ($this->closed || !$this->process_lock->is_held()) {
             throw new LogicException('Cannot call next_step() after close().');
         }
 
@@ -497,7 +505,7 @@ final class PushFilesSender
     }
 
     /**
-     * Releases open resources and the lifecycle lock without finishing a request.
+     * Releases open sender resources without finishing a request.
      *
      * The caller uses cancel() first when stopping with an open multipart
      * request. Durable state remains available to resume unless next_step()
@@ -516,10 +524,7 @@ final class PushFilesSender
         }
         $this->upload_request_stage = 'closed';
         $this->state_before_upload_request = null;
-        if (is_resource($this->lock_handle)) {
-            $this->release_lock($this->lock_handle);
-        }
-        $this->lock_handle = null;
+        $this->closed = true;
     }
 
     /**
@@ -1571,38 +1576,6 @@ final class PushFilesSender
         if (is_file($this->state_path) && !unlink($this->state_path)) {
             throw new RuntimeException('Failed to remove active state: ' . $this->state_path);
         }
-    }
-
-    /**
-     * Acquires non-blocking exclusive ownership of one lifecycle.
-     *
-     * @return resource Open locked handle retained until close().
-     */
-    private function acquire_lock()
-    {
-        $lock_handle = fopen($this->lock_path, 'c+');
-        if (!is_resource($lock_handle)) {
-            throw new RuntimeException('Failed to open the lifecycle lock: ' . $this->lock_path);
-        }
-        if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
-            fclose($lock_handle);
-            throw new RuntimeException(
-                'Cannot start or resume this push files sender while another process holds its lock: '
-                . $this->lock_path
-            );
-        }
-        return $lock_handle;
-    }
-
-    /**
-     * Releases and closes a lock returned by acquire_lock().
-     *
-     * @param resource $lock_handle Open locked handle.
-     */
-    private function release_lock($lock_handle): void
-    {
-        flock($lock_handle, LOCK_UN);
-        fclose($lock_handle);
     }
 
     /**

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -17,15 +17,20 @@ class PushClientPhpCompatibilityTest extends TestCase
     public function testPushLibsStayParseableOnPhp74(): void
     {
         $phpcs_path = realpath(__DIR__ . '/../../vendor/bin/phpcs');
+        $process_lock_path = realpath(
+            __DIR__ . '/../../packages/reprint-importer/src/lib/class-reprint-process-lock.php'
+        );
         $upload_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/upload');
         $push_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/push');
         $this->assertNotFalse($phpcs_path, 'vendor/bin/phpcs is missing; run composer install');
+        $this->assertNotFalse($process_lock_path);
         $this->assertNotFalse($upload_lib_path);
         $this->assertNotFalse($push_lib_path);
 
         exec(
             escapeshellarg($phpcs_path)
                 . ' --standard=PHPCompatibility --runtime-set testVersion 7.4- -q '
+                . escapeshellarg($process_lock_path) . ' '
                 . escapeshellarg($upload_lib_path) . ' '
                 . escapeshellarg($push_lib_path) . ' 2>&1',
             $scan_output,

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -1,0 +1,79 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+final class ReprintProcessLockTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/reprint-process-lock-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/state', 0700, true);
+        mkdir($this->root . '/files', 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+    }
+
+    public function testImportClientRejectsAConcurrentCommand(): void
+    {
+        $process_lock = new \ReprintProcessLock($this->root . '/state');
+        $client = new \ImportClient(
+            'https://example.com/?site-export-api',
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+
+        try {
+            $client->run(['command' => 'files-stats']);
+            $this->fail('A second Reprint command must not use the same state directory.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another Reprint process is using the state directory',
+                $exception->getMessage()
+            );
+        } finally {
+            $process_lock->close();
+        }
+    }
+
+    public function testCloseIsIdempotentAndAllowsTheNextCommand(): void
+    {
+        $process_lock = new \ReprintProcessLock($this->root . '/state');
+        $process_lock->close();
+        $process_lock->close();
+
+        $next_process_lock = new \ReprintProcessLock($this->root . '/state');
+        $this->assertTrue($next_process_lock->is_held());
+        $next_process_lock->close();
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $child = $path . '/' . $entry;
+            if (is_dir($child) && !is_link($child)) {
+                $this->removeTree($child);
+            } else {
+                @unlink($child);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -18,6 +18,9 @@ final class PushEndpointsTest extends TestCase {
     /** @var resource[] */
     private array $server_pipes = [];
 
+    /** @var array<int,ReprintProcessLock> */
+    private array $sender_process_locks = [];
+
     private string $root;
     private string $docroot;
     private string $wordpress_root;
@@ -75,6 +78,10 @@ final class PushEndpointsTest extends TestCase {
     protected function tearDown(): void
     {
         $this->stopServer($this->server_process, $this->server_pipes);
+        foreach ($this->sender_process_locks as $process_lock) {
+            $process_lock->close();
+        }
+        $this->sender_process_locks = [];
         if (isset($this->root)) {
             $this->removeTree($this->root);
         }
@@ -1397,7 +1404,7 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/large.bin', str_repeat('A', 6000));
         $push_state_directory = $this->root . '/retained-file-offset-state';
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1422,7 +1429,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame(1, $this->countEndpointRequests('push_status'));
         } finally {
             $sender->cancel();
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1441,7 +1448,7 @@ final class PushEndpointsTest extends TestCase {
         $this->writeIndex($previous_local_index_path, $previous_entries);
         $push_state_directory = $this->root . '/retained-deleted-paths-state';
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1451,7 +1458,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertGreaterThan(1, $this->countEndpointRequests('push_upload'));
             $this->assertSame(1, $this->countEndpointRequests('push_status'));
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1485,7 +1492,7 @@ final class PushEndpointsTest extends TestCase {
             PushFilesSender::class,
             'local_paths_to_delete_handle'
         );
-        $sender = PushFilesSender::resume(
+        $sender = $this->resumeSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1500,7 +1507,7 @@ final class PushEndpointsTest extends TestCase {
             if ($sender->get_status() === 'continue') {
                 $sender->cancel();
             }
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1520,12 +1527,12 @@ final class PushEndpointsTest extends TestCase {
         $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
             file_put_contents($local_docroot . '/returned.txt', 'new');
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $result = $this->runSender($local_docroot, $push_state_directory);
 
@@ -1587,7 +1594,7 @@ final class PushEndpointsTest extends TestCase {
         );
         $fresh_local_index_handle = null;
 
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
@@ -1619,7 +1626,7 @@ final class PushEndpointsTest extends TestCase {
                 $this->loadPlanPosition($push_state_directory)
             );
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $this->assertFalse(is_resource($fresh_local_index_handle));
@@ -1644,7 +1651,7 @@ final class PushEndpointsTest extends TestCase {
             'fresh_local_index_handle'
         );
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->assertSame('creating', $sender->get_phase());
             $this->takeSenderStepsUntilPhase($sender, 'planning');
@@ -1676,11 +1683,11 @@ final class PushEndpointsTest extends TestCase {
             $this->assertArrayNotHasKey('file_index_cursor', $state);
             $this->assertArrayNotHasKey('fresh_local_index_byte_offset', $state);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertFalse(is_resource($fresh_local_index_handle));
 
-        $sender = PushFilesSender::resume($options);
+        $sender = $this->resumeSender($options);
         try {
             $this->assertSame('planning', $sender->get_phase());
             $resumed_plan = $plan_property->getValue($sender);
@@ -1698,7 +1705,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertArrayNotHasKey('file_index_cursor', $state);
             $this->assertArrayNotHasKey('fresh_local_index_byte_offset', $state);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $index_lines = file($fresh_local_index_path, FILE_IGNORE_NEW_LINES);
@@ -1728,7 +1735,7 @@ final class PushEndpointsTest extends TestCase {
         $child = pcntl_fork();
         $this->assertNotSame(-1, $child);
         if ($child === 0) {
-            $sender = PushFilesSender::start($options);
+            $sender = $this->startSender($options);
             $this->takeSenderStepsUntilPhase($sender, 'planning');
             if (!$sender->next_step()) {
                 exit(2);
@@ -1787,7 +1794,7 @@ final class PushEndpointsTest extends TestCase {
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
         $options = $this->senderOptions($local_docroot, $push_state_directory);
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $planning_result = $this->senderResult($sender);
@@ -1827,7 +1834,7 @@ final class PushEndpointsTest extends TestCase {
             $finished_upload_requests_before_close = $this->countEndpointRequests('push_upload');
 
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertNull($local_paths_to_push_handle_property->getValue($sender));
         $this->assertNull($local_file_handle_property->getValue($sender));
@@ -1838,7 +1845,7 @@ final class PushEndpointsTest extends TestCase {
         clearstatcache(true, $push_state_directory . '/sender.json');
         $this->assertSame($state_inode_before_upload, fileinode($push_state_directory . '/sender.json'));
 
-        $sender = PushFilesSender::resume($options);
+        $sender = $this->resumeSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
             $sender->next_step();
@@ -1862,7 +1869,7 @@ final class PushEndpointsTest extends TestCase {
                 ftell($local_paths_to_delete_handle)
             );
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertNull($local_paths_to_delete_handle_property->getValue($sender));
         $this->assertFalse(is_resource($local_paths_to_delete_handle));
@@ -1882,7 +1889,7 @@ final class PushEndpointsTest extends TestCase {
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $this->assertSame('pushing_paths', $sender->get_phase());
@@ -1910,7 +1917,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('restart', $sender->get_status());
             $this->assertSame('local_path_changed', $sender->get_reason());
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -1927,7 +1934,7 @@ final class PushEndpointsTest extends TestCase {
         $options = $this->senderOptions($local_docroot, $push_state_directory);
         $upload_request_stage_property = new ReflectionProperty(PushFilesSender::class, 'upload_request_stage');
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $sender->next_step();
@@ -1947,7 +1954,7 @@ final class PushEndpointsTest extends TestCase {
             $sender->cancel();
             $this->assertSame('closed', $upload_request_stage_property->getValue($sender));
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $result = $this->runSender($local_docroot, $push_state_directory);
@@ -1979,7 +1986,7 @@ final class PushEndpointsTest extends TestCase {
         $child = pcntl_fork();
         $this->assertNotSame(-1, $child);
         if ($child === 0) {
-            $sender = PushFilesSender::start($options);
+            $sender = $this->startSender($options);
             for ($step = 0; $step < 300 && $sender->get_phase() !== 'pushing_paths'; ++$step) {
                 if (!$sender->next_step()) {
                     exit(2);
@@ -2113,7 +2120,7 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/changed-empty-directory-state';
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
             $this->assertSame('pushing_paths', $sender->get_phase());
@@ -2123,7 +2130,7 @@ final class PushEndpointsTest extends TestCase {
 
             $result = $this->senderResult($sender);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
 
         $this->assertSame('continue', $result['status']);
@@ -2193,33 +2200,33 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Holds the lifecycle lock while open and resumes the last returned boundary.
+     * Holds the Reprint process lock while open and resumes the last returned boundary.
      */
-    public function testHighLevelSenderOwnsLifecycleLockAndResumesAfterClose(): void
+    public function testHighLevelSenderUsesReprintProcessLockAndResumesAfterClose(): void
     {
         $local_docroot = $this->root . '/locked-local-docroot';
         $push_state_directory = $this->root . '/locked-state';
         mkdir($local_docroot, 0700, true);
         mkdir($push_state_directory, 0700, true);
-        $lock = fopen($push_state_directory . '/sender.lock', 'c+');
-        $this->assertIsResource($lock);
-        $this->assertTrue(flock($lock, LOCK_EX | LOCK_NB));
+        $process_lock = new ReprintProcessLock($this->root);
         try {
             try {
-                PushFilesSender::start(
+                $this->startSender(
                     $this->senderOptions($local_docroot, $push_state_directory)
                 );
-                $this->fail('Starting a sender must fail while another process owns its lock.');
+                $this->fail('Starting a sender must fail while another Reprint process owns the state directory.');
             } catch (RuntimeException $exception) {
-                $this->assertStringContainsString('another process holds its lock', $exception->getMessage());
+                $this->assertStringContainsString(
+                    'Another Reprint process is using the state directory',
+                    $exception->getMessage()
+                );
             }
         } finally {
-            flock($lock, LOCK_UN);
-            fclose($lock);
+            $process_lock->close();
         }
 
         $options = $this->senderOptions($local_docroot, $push_state_directory);
-        $sender = PushFilesSender::start($options);
+        $sender = $this->startSender($options);
         try {
             $sender->next_step();
             $first = $this->senderResult($sender);
@@ -2228,13 +2235,16 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('continue', $first['status']);
             $this->assertSame('continue', $second['status']);
             try {
-                PushFilesSender::resume($options);
+                $this->resumeSender($options);
                 $this->fail('Resuming a sender must fail until the open sender is closed.');
             } catch (RuntimeException $exception) {
-                $this->assertStringContainsString('another process holds its lock', $exception->getMessage());
+                $this->assertStringContainsString(
+                    'Another Reprint process is using the state directory',
+                    $exception->getMessage()
+                );
             }
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $state_at_caller_stop = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state_at_caller_stop);
@@ -2247,18 +2257,18 @@ final class PushEndpointsTest extends TestCase {
             $this->assertStringContainsString('after close()', $exception->getMessage());
         }
 
-        $resumed_sender = PushFilesSender::resume($options);
+        $resumed_sender = $this->resumeSender($options);
         try {
             $resumed_sender->next_step();
             $result_after_resume = $this->senderResult($resumed_sender);
             $this->assertSame('continue', $result_after_resume['status']);
             $this->assertSame('pushing_deletes', $result_after_resume['phase']);
         } finally {
-            $resumed_sender->close();
+            $this->closeSender($resumed_sender);
         }
 
         try {
-            PushFilesSender::start($options);
+            $this->startSender($options);
             $this->fail('Starting a sender must not replace unfinished active state.');
         } catch (LogicException $exception) {
             $this->assertStringContainsString('unfinished active state exists', $exception->getMessage());
@@ -2280,7 +2290,7 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
 
         try {
-            PushFilesSender::resume(
+            $this->resumeSender(
                 $this->senderOptions($local_docroot, $push_state_directory)
             );
             $this->fail('Resuming without active state must fail.');
@@ -2342,7 +2352,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/first.txt', 'first');
         file_put_contents($local_docroot . '/second.txt', 'second');
         $push_state_directory = $this->root . '/failed-upload-state';
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         $state_property = new ReflectionProperty(PushFilesSender::class, 'state');
@@ -2373,7 +2383,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('lock_acquisition_failure', $sender->get_reason());
             $this->assertSame($durable_state, $state_property->getValue($sender));
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -2414,7 +2424,7 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/malformed-local-docroot';
         $push_state_directory = $this->root . '/malformed-state';
         mkdir($local_docroot, 0700, true);
-        $sender = PushFilesSender::start([
+        $sender = $this->startSender([
             'docroot' => $local_docroot,
             'push_state_directory' => $push_state_directory,
             'base_url' => 'http://' . $address . '/?reprint-api=1',
@@ -2428,7 +2438,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertFalse($sender->next_step());
             $result = $this->senderResult($sender);
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->assertFalse($sender->next_step());
         pcntl_waitpid($child, $status);
@@ -2830,13 +2840,13 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'value after failure');
         $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $active_state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($active_state);
@@ -2880,13 +2890,13 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'before');
         $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
-        $sender = PushFilesSender::start(
+        $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         file_put_contents($local_docroot . '/value.txt', 'after local change');
         clearstatcache(true, $local_docroot . '/value.txt');
@@ -3292,6 +3302,47 @@ final class PushEndpointsTest extends TestCase {
         ];
     }
 
+    /** @param array<string,mixed> $options */
+    private function startSender(array $options): PushFilesSender
+    {
+        $process_lock = new ReprintProcessLock($this->root);
+        try {
+            $sender = PushFilesSender::start($options, $process_lock);
+        } catch (Throwable $throwable) {
+            $process_lock->close();
+            throw $throwable;
+        }
+        $this->sender_process_locks[spl_object_id($sender)] = $process_lock;
+        return $sender;
+    }
+
+    /** @param array<string,mixed> $options */
+    private function resumeSender(array $options): PushFilesSender
+    {
+        $process_lock = new ReprintProcessLock($this->root);
+        try {
+            $sender = PushFilesSender::resume($options, $process_lock);
+        } catch (Throwable $throwable) {
+            $process_lock->close();
+            throw $throwable;
+        }
+        $this->sender_process_locks[spl_object_id($sender)] = $process_lock;
+        return $sender;
+    }
+
+    private function closeSender(PushFilesSender $sender): void
+    {
+        $object_id = spl_object_id($sender);
+        try {
+            $sender->close();
+        } finally {
+            if (isset($this->sender_process_locks[$object_id])) {
+                $this->sender_process_locks[$object_id]->close();
+                unset($this->sender_process_locks[$object_id]);
+            }
+        }
+    }
+
     /**
      * Starts or resumes one sender and stops after its next durable boundary.
      *
@@ -3309,8 +3360,8 @@ final class PushEndpointsTest extends TestCase {
             $push_state_directory
         );
         $sender = is_file($push_state_directory . '/sender.json')
-            ? PushFilesSender::resume($options)
-            : PushFilesSender::start($options);
+            ? $this->resumeSender($options)
+            : $this->startSender($options);
         $upload_request_stage_property = new ReflectionProperty(PushFilesSender::class, 'upload_request_stage');
         try {
             do {
@@ -3324,7 +3375,7 @@ final class PushEndpointsTest extends TestCase {
             if ($sender->get_status() === 'continue') {
                 $sender->cancel();
             }
-            $sender->close();
+            $this->closeSender($sender);
         }
     }
 
@@ -3435,8 +3486,8 @@ final class PushEndpointsTest extends TestCase {
             $push_state_directory
         );
         $sender = is_file($push_state_directory . '/sender.json')
-            ? PushFilesSender::resume($options)
-            : PushFilesSender::start($options);
+            ? $this->resumeSender($options)
+            : $this->startSender($options);
         try {
             for ($step = 0; $step < 200; ++$step) {
                 $has_more_steps = $sender->next_step();
@@ -3448,7 +3499,7 @@ final class PushEndpointsTest extends TestCase {
                 }
             }
         } finally {
-            $sender->close();
+            $this->closeSender($sender);
         }
         $this->fail('The high-level sender did not reach a terminal result in 200 steps.');
     }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -3302,7 +3302,11 @@ final class PushEndpointsTest extends TestCase {
         ];
     }
 
-    /** @param array<string,mixed> $options */
+    /**
+     * Starts a sender and retains its process lock until closeSender().
+     *
+     * @param array<string,mixed> $options
+     */
     private function startSender(array $options): PushFilesSender
     {
         $process_lock = new ReprintProcessLock($this->root);
@@ -3316,7 +3320,11 @@ final class PushEndpointsTest extends TestCase {
         return $sender;
     }
 
-    /** @param array<string,mixed> $options */
+    /**
+     * Resumes a sender and retains its process lock until closeSender().
+     *
+     * @param array<string,mixed> $options
+     */
     private function resumeSender(array $options): PushFilesSender
     {
         $process_lock = new ReprintProcessLock($this->root);
@@ -3330,6 +3338,9 @@ final class PushEndpointsTest extends TestCase {
         return $sender;
     }
 
+    /**
+     * Closes a sender and releases its retained process lock.
+     */
     private function closeSender(PushFilesSender $sender): void
     {
         $object_id = spl_object_id($sender);


### PR DESCRIPTION
Serializes every local Reprint command which uses the same state directory under `<state-dir>/.reprint.lock`. A second command fails immediately instead of modifying pair metadata, import state, indexes, or push state concurrently.

For example:

```sh
# Process A
reprint pull https://example.com \
  --state-dir=./state --fs-root=./files

# While Process A is still running, Process B exits with:
reprint files-diff https://example.com \
  --state-dir=./state --fs-root=./files
# Error: Another Reprint process is using the state directory: ./state.
```

The CLI acquires the lock before pair setup and audit logging, passes it through `ImportClient::run()`, and releases it after the command. Direct `ImportClient` callers acquire it inside `run()`. `PushFilesSender::close()` releases sender resources but leaves the caller-owned lock alone.

This replaces the narrower sender and files-diff locks. Split from #386.

## Testing

Start a long-running command, then run another command with the same `--state-dir` and confirm it exits immediately. After the first command exits, rerun the second and confirm it starts.
