### PR TITLE
[Push] Persist files-pull index updates in a write-ahead log

### DIFF
--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -100,6 +100,16 @@ none. `PushFilesSender::start()` and `PushFilesSender::resume()` receive that
 open lock from the caller; sender `close()` does not release it. This local
 lock is separate from the receiver's push-session and commit locks.
 
+## Pull index-update WAL
+
+Call the single pull-side write-ahead log the **index-update WAL**. It lives at
+`<state-dir>/.import-index-updates.wal`; use `.import-index-updates.wal`,
+`$index_update_wal_path`, and `$index_update_wal_handle`.
+Applied batch records are cleared, but the empty WAL remains as a marker until
+files-pull completes. A retained WAL is consumed only while resuming or
+aborting the interrupted files-pull, including through a high-level pull
+command; unrelated commands do not consume it.
+
 ## Local push state
 
 The local machine keeps planning and active state outside the receiver push

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6132,13 +6132,14 @@ class ImportClient
             }
 
             /**
-             * Saves only at completed multipart boundaries.
+             * Persists the fetch cursor only after its file and index state is
+             * durable.
              *
              * Streaming body callbacks may have written file bytes while the
-             * part cursor is not yet safe to save. The closing callback flushes
-             * those bytes and the index-update WAL before the cursor enters
-             * state. If the response stops mid-part, resume uses the preceding
-             * cursor and discards bytes beyond that checkpoint.
+             * part cursor is not yet safe to store in .import-state.json. The
+             * closing callback flushes those bytes and the index-update WAL
+             * before storing the cursor. If the response stops mid-part, resume
+             * uses the preceding cursor and discards bytes beyond that checkpoint.
              */
             if (!$is_streaming_body) {
                 if (isset($chunk["headers"]["x-cursor"])) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6131,6 +6131,15 @@ class ImportClient
                 );
             }
 
+            /**
+             * Saves only at completed multipart boundaries.
+             *
+             * Streaming body callbacks may have written file bytes while the
+             * part cursor is not yet safe to save. The closing callback flushes
+             * those bytes and the index-update WAL before the cursor enters
+             * state. If the response stops mid-part, resume uses the preceding
+             * cursor and discards bytes beyond that checkpoint.
+             */
             if (!$is_streaming_body) {
                 if (isset($chunk["headers"]["x-cursor"])) {
                     $cursor = $chunk["headers"]["x-cursor"];

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6132,14 +6132,19 @@ class ImportClient
             }
 
             /**
-             * Persists the fetch cursor only after its file and index state is
-             * durable.
+             * Saves the fetch cursor only after the multipart part is complete.
              *
-             * Streaming body callbacks may have written file bytes while the
-             * part cursor is not yet safe to store in .import-state.json. The
-             * closing callback flushes those bytes and the index-update WAL
-             * before storing the cursor. If the response stops mid-part, resume
-             * uses the preceding cursor and discards bytes beyond that checkpoint.
+             * One file chunk travels as one multipart part, whose body may
+             * arrive across several streaming callbacks. Each callback writes
+             * its bytes to the local file immediately. Until the parser receives
+             * the closing boundary, those bytes may be only a prefix of the file
+             * chunk. The part cursor points past the complete chunk, so saving it
+             * early would make resume skip the missing suffix.
+             *
+             * On the closing callback, flush the file and index-update WAL
+             * before storing the cursor in .import-state.json. If the response
+             * stops first, state retains the preceding cursor; resume truncates
+             * the later bytes and requests the multipart part again.
              */
             if (!$is_streaming_body) {
                 if (isset($chunk["headers"]["x-cursor"])) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -288,23 +288,23 @@ class ImportClient
     private $index_file;
 
     /**
-     * @var string|null Path to .import-index-updates.jsonl — temporary append-only file that
-     * collects index mutations (upserts and deletes) during the current run. Merged into
-     * $index_file at the end of a successful sync.
+     * @var string Path to .import-index-updates.wal — the append-only write-ahead
+     * log for the current files-pull. Applied batches are cleared, but the file
+     * remains until the lifecycle completes or is aborted.
      */
-    private $index_updates_file;
+    private $index_update_wal_path;
 
-    /** @var resource|null Open file handle for $index_updates_file while writing. */
-    private $index_updates_handle;
+    /** @var resource|null Open file handle for $index_update_wal_path while writing. */
+    private $index_update_wal_handle;
 
-    /** @var int Number of entries written to $index_updates_file this run. */
-    private $index_updates_count = 0;
+    /** @var int Number of entries written to the open WAL batch. */
+    private $index_update_wal_record_count = 0;
 
     /**
      * Deduplication state for index updates. Consecutive upsert_index_entry() or
-     * delete_index_entry() calls for the same path are collapsed into one write.
+     * delete_index_entry() calls for the same path are collapsed into one WAL write.
      *
-     * @var string|null Last path written to the index updates file.
+     * @var string|null Last path written to the index-update WAL.
      */
     private $last_update_path = null;
 
@@ -557,8 +557,8 @@ class ImportClient
         $this->fs_root = rtrim($fs_root, "/");
         $this->state_file = $this->state_dir . "/.import-state.json";
         $this->index_file = $this->state_dir . "/.import-index.jsonl";
-        $this->index_updates_file =
-            $this->state_dir . "/.import-index-updates.jsonl";
+        $this->index_update_wal_path =
+            $this->state_dir . "/.import-index-updates.wal";
         $this->remote_index_file =
             $this->state_dir . "/.import-remote-index.jsonl";
         $this->download_list_file =
@@ -631,16 +631,11 @@ class ImportClient
         $this->record_index_update_deletion($path);
     }
 
-    /**
-     * Recover and merge any pending index updates from a previous run.
-     */
-    private function recover_index_updates(): void
+    /** Replays a WAL left by an interrupted batch. */
+    private function replay_index_update_wal(): void
     {
-        if (
-            $this->index_updates_file &&
-            file_exists($this->index_updates_file)
-        ) {
-            $this->finalize_index_updates();
+        if (is_file($this->index_update_wal_path)) {
+            $this->apply_index_update_wal();
         }
     }
 
@@ -1976,51 +1971,7 @@ class ImportClient
     {
         switch ($command) {
             case "files-pull":
-                // Clear sync progress (cursor, stage, status) and transient
-                // files, but keep the local index and downloaded files intact.
-                // This way the next `files-pull` sees a completed local index
-                // and runs a delta sync rather than re-downloading everything.
-                $this->audit_log(
-                    "RESTART | Clearing files-pull progress (keeping local index and files)",
-                    true,
-                );
-                $this->reset_state();
-
-                // Merge any pending index updates into the main index before
-                // clearing transient state so we don't lose work.
-                $this->recover_index_updates();
-                if (
-                    $this->index_updates_file &&
-                    file_exists($this->index_updates_file)
-                ) {
-                    @unlink($this->index_updates_file);
-                    $this->audit_log("FILE DELETE | {$this->index_updates_file}");
-                }
-                $this->index_updates_file = null;
-                $this->index_updates_handle = null;
-                $this->index_updates_count = 0;
-
-                if (file_exists($this->remote_index_file)) {
-                    @unlink($this->remote_index_file);
-                    $this->audit_log("FILE DELETE | {$this->remote_index_file}");
-                }
-                if (file_exists($this->download_list_file)) {
-                    @unlink($this->download_list_file);
-                    $this->audit_log("FILE DELETE | {$this->download_list_file}");
-                }
-                if (file_exists($this->skipped_download_list_file)) {
-                    @unlink($this->skipped_download_list_file);
-                    $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
-                }
-                if (file_exists($this->volatile_files_file)) {
-                    @unlink($this->volatile_files_file);
-                    $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
-                }
-                $this->import_state()->index = new RemoteFileIndexCursorState();
-                $this->import_state()->fetch = new DownloadListFetchProgressState();
-                $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
-
-                $this->save_state($this->state);
+                $this->clear_files_pull_progress();
                 break;
 
             case "files-index":
@@ -2102,6 +2053,46 @@ class ImportClient
         $this->progress->show_lifecycle_line("State cleared for {$command}.\n");
 
         $this->output_progress(["status" => "aborted", "message" => "State cleared for {$command}."]);
+    }
+
+    /**
+     * Clear sync progress and transient files while keeping the local index
+     * and downloaded files, so the next files-pull computes a delta.
+     */
+    public function clear_files_pull_progress(): void
+    {
+        $this->audit_log(
+            "RESTART | Clearing files-pull progress (keeping local index and files)",
+            true,
+        );
+        // Replay the WAL before clearing the cursor which made its records durable.
+        $this->replay_index_update_wal();
+        $this->remove_index_update_wal();
+        $this->reset_state();
+        $this->index_update_wal_handle = null;
+        $this->index_update_wal_record_count = 0;
+
+        if (file_exists($this->remote_index_file)) {
+            @unlink($this->remote_index_file);
+            $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+        }
+        if (file_exists($this->download_list_file)) {
+            @unlink($this->download_list_file);
+            $this->audit_log("FILE DELETE | {$this->download_list_file}");
+        }
+        if (file_exists($this->skipped_download_list_file)) {
+            @unlink($this->skipped_download_list_file);
+            $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
+        }
+        if (file_exists($this->volatile_files_file)) {
+            @unlink($this->volatile_files_file);
+            $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
+        }
+        $this->import_state()->index = new RemoteFileIndexCursorState();
+        $this->import_state()->fetch = new DownloadListFetchProgressState();
+        $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+
+        $this->save_state($this->state);
     }
 
     /**
@@ -2739,12 +2730,13 @@ class ImportClient
             $current_status !== null &&
             $current_status !== "complete";
 
-        $this->recover_index_updates();
+        $this->replay_index_update_wal();
         $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
         $this->assert_symlink_bundle_directory_unchanged();
 
         // Already completed.
         if ($current_status === "complete") {
+            $this->remove_index_update_wal();
             $has_skipped =
                 file_exists($this->skipped_download_list_file) &&
                 filesize($this->skipped_download_list_file) > 0;
@@ -2776,6 +2768,7 @@ class ImportClient
                 $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
                 $this->import_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state($this->state);
+                $this->open_index_update_wal();
                 $this->run_files_sync_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
                 // tail finishes, restore the completed status so later filter
@@ -2785,6 +2778,7 @@ class ImportClient
                 }
                 $this->import_state()->active_resumable_command->completion_state = "complete";
                 $this->save_state($this->state);
+                $this->remove_index_update_wal();
                 return;
             }
 
@@ -2938,6 +2932,7 @@ class ImportClient
         $this->import_state()->active_resumable_command->completion_state = "in_progress";
         $this->save_state($this->state);
 
+        $this->open_index_update_wal();
         $this->run_files_sync_pipeline();
 
         // Pipeline returns early with partial status if interrupted
@@ -2947,6 +2942,7 @@ class ImportClient
 
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->save_state($this->state);
+        $this->remove_index_update_wal();
 
         $this->progress->clear_progress_line();
         $index_size = $this->index_count();
@@ -6059,30 +6055,24 @@ class ImportClient
             // mid-body, the cursor already points to the end of the part
             // while file_bytes_written may still lag; at is_streaming_close
             // the bytes are on disk and we force a per-part checkpoint.
+            // Snapshot the file boundary before handle_file_chunk() may close
+            // the file so a stop after the close still retains its path and size.
             $is_streaming_body = !empty($chunk["is_streaming_body"]);
             $is_streaming_close = !empty($chunk["is_streaming_close"]);
-            if (!$is_streaming_body) {
-                $chunks_since_save++;
-                $force_save = $is_streaming_close;
-                if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
-                    $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-                    // Track current file for crash recovery
-                    if ($context->file_handle && $context->file_path) {
-                        // Flush to ensure bytes are on disk before saving state
-                        fflush($context->file_handle);
-                        $this->import_state()->current_file = $context->file_path;
-                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
-                    } else {
-                        $this->import_state()->current_file = null;
-                        $this->import_state()->current_file_bytes = null;
-                    }
-                    $this->save_state($this->state);
-                    $chunks_since_save = 0;
+            $file_path_at_completed_part = null;
+            $file_bytes_at_completed_part = null;
+            if (
+                $is_streaming_close
+                && $context->file_handle
+                && $context->file_path
+            ) {
+                if (!fflush($context->file_handle)) {
+                    throw new RuntimeException(
+                        'Failed to flush the pulled file before saving its fetch cursor.'
+                    );
                 }
-            }
-
-            if (isset($chunk["headers"]["x-cursor"])) {
-                $cursor = $chunk["headers"]["x-cursor"];
+                $file_path_at_completed_part = $context->file_path;
+                $file_bytes_at_completed_part = $context->file_bytes_written;
             }
 
             $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
@@ -6140,6 +6130,44 @@ class ImportClient
                     true,
                 );
             }
+
+            if (!$is_streaming_body) {
+                if (isset($chunk["headers"]["x-cursor"])) {
+                    $cursor = $chunk["headers"]["x-cursor"];
+                }
+                $chunks_since_save++;
+                $force_save = $is_streaming_close;
+                if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
+                    if ($file_path_at_completed_part !== null) {
+                        $this->import_state()->current_file =
+                            $file_path_at_completed_part;
+                        $this->import_state()->current_file_bytes =
+                            $file_bytes_at_completed_part;
+                    } elseif ($context->file_handle && $context->file_path) {
+                        // Flush to ensure bytes are on disk before saving state.
+                        if (!fflush($context->file_handle)) {
+                            throw new RuntimeException(
+                                'Failed to flush the pulled file before saving its fetch cursor.'
+                            );
+                        }
+                        // Track the current file for crash recovery.
+                        $this->import_state()->current_file = $context->file_path;
+                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                    } else {
+                        $this->import_state()->current_file = null;
+                        $this->import_state()->current_file_bytes = null;
+                    }
+                    if (
+                        $this->index_update_wal_handle
+                        && !fflush($this->index_update_wal_handle)
+                    ) {
+                        throw new RuntimeException('Failed to flush the index-update WAL.');
+                    }
+                    $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
+                    $this->save_state($this->state);
+                    $chunks_since_save = 0;
+                }
+            }
         };
 
         $cursor_before = $cursor;
@@ -6170,7 +6198,7 @@ class ImportClient
                 fclose($context->file_handle);
                 $context->file_handle = null;
             }
-            $this->finalize_index_updates();
+            $this->apply_index_update_wal();
             $this->import_state()->active_resumable_command->completion_state = "partial";
             $this->save_state($this->state);
             return false;
@@ -6184,10 +6212,14 @@ class ImportClient
             $context->response_stats ?? [],
         );
         $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
-        $this->finalize_index_updates();
+        $this->apply_index_update_wal();
         // Update file tracking: track in-progress file, or clear if complete/no active file
         if ($context->file_handle && $context->file_path) {
-            fflush($context->file_handle);
+            if (!fflush($context->file_handle)) {
+                throw new RuntimeException(
+                    'Failed to flush the pulled file before saving its fetch cursor.'
+                );
+            }
             $this->import_state()->current_file = $context->file_path;
             $this->import_state()->current_file_bytes = $context->file_bytes_written;
         } else {
@@ -6516,7 +6548,7 @@ class ImportClient
                 $local = $this->read_index_line($local_handle);
             }
         }
-        $this->begin_index_updates();
+        $this->open_index_update_wal();
         $processed = 0;
 
         while (($line = fgets($remote_handle)) !== false) {
@@ -6588,6 +6620,12 @@ class ImportClient
             if ($processed % 200 === 0) {
                 $this->import_state()->diff->remote_offset = $remote_offset;
                 $this->import_state()->diff->local_after = $local_after;
+                if (
+                    $this->index_update_wal_handle
+                    && !fflush($this->index_update_wal_handle)
+                ) {
+                    throw new RuntimeException('Failed to flush the index-update WAL.');
+                }
                 $this->save_state($this->state);
                 $this->progress->tick_spinner();
             }
@@ -6613,9 +6651,8 @@ class ImportClient
 
         $this->import_state()->diff->remote_offset = $remote_offset;
         $this->import_state()->diff->local_after = $local_after;
+        $this->apply_index_update_wal();
         $this->save_state($this->state);
-
-        $this->finalize_index_updates();
 
         return !$this->shutdown_requested;
     }
@@ -7084,43 +7121,23 @@ class ImportClient
         ];
     }
 
-    /**
-     * Start collecting index updates into a temp file for streaming merge.
-     */
-    private function begin_index_updates(): void
+    /** Opens the current index-update WAL for append. */
+    private function open_index_update_wal(): void
     {
-        if ($this->index_updates_handle) {
+        if ($this->index_update_wal_handle) {
             return;
         }
-        $is_new = false;
-        if ($this->index_updates_file === null) {
-            $tmp = tempnam(sys_get_temp_dir(), "index-updates-");
-            if ($tmp === false) {
-                throw new RuntimeException(
-                    "Failed to create temp index updates file",
-                );
-            }
-            $this->index_updates_file = $tmp;
-            $is_new = true;
-        } elseif (!file_exists($this->index_updates_file)) {
-            $dir = dirname($this->index_updates_file);
-            if (!is_dir($dir)) {
-                mkdir($dir, 0755, true);
-            }
-            $is_new = true;
-        }
-        $this->index_updates_handle = fopen($this->index_updates_file, "a");
-        if (!$this->index_updates_handle) {
-            throw new RuntimeException(
-                "Failed to open temp index updates file",
-            );
+        $is_new = !is_file($this->index_update_wal_path);
+        $this->index_update_wal_handle = fopen($this->index_update_wal_path, "a");
+        if (!$this->index_update_wal_handle) {
+            throw new RuntimeException("Failed to open the index-update WAL.");
         }
         if ($is_new) {
             $this->audit_log(
-                "FILE CREATE | {$this->index_updates_file} | index updates buffer",
+                "FILE CREATE | {$this->index_update_wal_path} | index-update WAL",
             );
         }
-        $this->index_updates_count = 0;
+        $this->index_update_wal_record_count = 0;
         $this->last_update_path = null;
         $this->last_update_delete = null;
         $this->last_update_ctime = null;
@@ -7129,7 +7146,7 @@ class ImportClient
     }
 
     /**
-     * Record a file upsert into the index updates stream.
+     * Record a file upsert in the index-update WAL.
      */
     private function record_index_update_file(
         string $path,
@@ -7137,8 +7154,8 @@ class ImportClient
         int $size,
         string $type
     ): void {
-        if (!$this->index_updates_handle) {
-            $this->begin_index_updates();
+        if (!$this->index_update_wal_handle) {
+            $this->open_index_update_wal();
         }
         if (
             $this->last_update_path === $path &&
@@ -7160,12 +7177,13 @@ class ImportClient
             JSON_UNESCAPED_SLASHES,
         );
         if ($line !== false) {
-            $bytes = fwrite($this->index_updates_handle, $line . "\n");
-            if ($bytes === false) {
-                throw new RuntimeException("Failed to write to index updates file (disk full?)");
+            $line .= "\n";
+            $bytes = fwrite($this->index_update_wal_handle, $line);
+            if ($bytes !== strlen($line)) {
+                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
             }
         }
-        $this->index_updates_count++;
+        $this->index_update_wal_record_count++;
         $this->last_update_path = $path;
         $this->last_update_delete = false;
         $this->last_update_ctime = $ctime;
@@ -7174,12 +7192,12 @@ class ImportClient
     }
 
     /**
-     * Record a deletion into the index updates stream.
+     * Record a deletion in the index-update WAL.
      */
     private function record_index_update_deletion(string $path): void
     {
-        if (!$this->index_updates_handle) {
-            $this->begin_index_updates();
+        if (!$this->index_update_wal_handle) {
+            $this->open_index_update_wal();
         }
         if (
             $this->last_update_path === $path &&
@@ -7195,12 +7213,13 @@ class ImportClient
             JSON_UNESCAPED_SLASHES,
         );
         if ($line !== false) {
-            $bytes = fwrite($this->index_updates_handle, $line . "\n");
-            if ($bytes === false) {
-                throw new RuntimeException("Failed to write to index updates file (disk full?)");
+            $line .= "\n";
+            $bytes = fwrite($this->index_update_wal_handle, $line);
+            if ($bytes !== strlen($line)) {
+                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
             }
         }
-        $this->index_updates_count++;
+        $this->index_update_wal_record_count++;
         $this->last_update_path = $path;
         $this->last_update_delete = true;
         $this->last_update_ctime = null;
@@ -7208,14 +7227,15 @@ class ImportClient
         $this->last_update_type = null;
     }
 
-    /**
-     * Merge the collected updates with the existing sorted index without loading it into memory.
-     */
-    private function finalize_index_updates(): void
+    /** Applies the current WAL to the import index. */
+    private function apply_index_update_wal(): void
     {
-        if ($this->index_updates_handle) {
-            fclose($this->index_updates_handle);
-            $this->index_updates_handle = null;
+        if ($this->index_update_wal_handle) {
+            $closed = fclose($this->index_update_wal_handle);
+            $this->index_update_wal_handle = null;
+            if (!$closed) {
+                throw new RuntimeException("Failed to flush the index-update WAL.");
+            }
         }
         $this->last_update_path = null;
         $this->last_update_delete = null;
@@ -7224,26 +7244,15 @@ class ImportClient
         $this->last_update_type = null;
 
         $has_updates =
-            $this->index_updates_count > 0 ||
-            ($this->index_updates_file &&
-                file_exists($this->index_updates_file) &&
-                filesize($this->index_updates_file) > 0);
+            $this->index_update_wal_record_count > 0 ||
+            (is_file($this->index_update_wal_path) &&
+                filesize($this->index_update_wal_path) > 0);
 
         if (!$has_updates) {
-            if (
-                $this->index_updates_file &&
-                file_exists($this->index_updates_file)
-            ) {
-                @unlink($this->index_updates_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->index_updates_file} | no updates to merge",
-                );
-            }
-            $this->index_updates_count = 0;
+            $this->index_update_wal_record_count = 0;
             return;
         }
 
-        $updates_path = $this->index_updates_file;
         $new_index = $this->index_file . ".new";
 
         $this->audit_log(
@@ -7253,7 +7262,7 @@ class ImportClient
         $old_handle = file_exists($this->index_file)
             ? fopen($this->index_file, "r")
             : null;
-        $upd_handle = fopen($updates_path, "r");
+        $upd_handle = fopen($this->index_update_wal_path, "r");
         $new_handle = fopen($new_index, "w");
 
         if (!$upd_handle || !$new_handle) {
@@ -7333,9 +7342,38 @@ class ImportClient
         }
         $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
 
-        @unlink($updates_path);
-        $this->audit_log("FILE DELETE | {$updates_path} | updates merged");
-        $this->index_updates_count = 0;
+        if (file_put_contents($this->index_update_wal_path, '') === false) {
+            throw new RuntimeException("Failed to clear the applied index-update WAL.");
+        }
+        $this->audit_log(
+            "FILE TRUNCATE | {$this->index_update_wal_path} | WAL batch applied"
+        );
+        $this->index_update_wal_record_count = 0;
+    }
+
+    /** Removes the WAL marker after files-pull completes or is aborted. */
+    private function remove_index_update_wal(): void
+    {
+        if (is_resource($this->index_update_wal_handle)) {
+            if (!fclose($this->index_update_wal_handle)) {
+                throw new RuntimeException("Failed to flush the index-update WAL.");
+            }
+            $this->index_update_wal_handle = null;
+        }
+        clearstatcache(true, $this->index_update_wal_path);
+        if (
+            is_file($this->index_update_wal_path)
+            && filesize($this->index_update_wal_path) > 0
+        ) {
+            throw new RuntimeException("Cannot remove an unapplied index-update WAL.");
+        }
+        if (
+            is_file($this->index_update_wal_path)
+            && !unlink($this->index_update_wal_path)
+        ) {
+            throw new RuntimeException("Failed to remove the index-update WAL.");
+        }
+        $this->index_update_wal_record_count = 0;
     }
 
     /**
@@ -7364,6 +7402,9 @@ class ImportClient
             return null;
         }
         while (($line = fgets($handle)) !== false) {
+            if (substr($line, -1) !== "\n" && feof($handle)) {
+                return null;
+            }
             $line = trim($line);
             if ($line === "") {
                 continue;
@@ -11568,15 +11609,16 @@ class ImportClient
         $this->shutdown_requested = true;
         $this->progress->clear_progress_line();
 
-        // Flush index updates so progress is not lost on interrupt
-        try {
-            $this->finalize_index_updates();
-        } catch (Exception $e) {
-            $this->audit_log(
-                "Failed to finalize index updates on shutdown: " .
-                    $e->getMessage(),
-                true,
-            );
+        if (is_resource($this->index_update_wal_handle)) {
+            try {
+                $this->apply_index_update_wal();
+            } catch (Exception $e) {
+                $this->audit_log(
+                    "Failed to apply the index-update WAL on shutdown: " .
+                        $e->getMessage(),
+                    true,
+                );
+            }
         }
 
         // Log final progress before exit

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -122,6 +122,16 @@ class Pull
      */
     public function abort(string $command = 'pull'): void
     {
+        $state = $this->client->get_import_state();
+        if (
+            $command === 'pull-files'
+            || (
+                $command === 'pull'
+                && $state->active_resumable_command->command_name === 'files-pull'
+            )
+        ) {
+            $this->client->clear_files_pull_progress();
+        }
         $this->prepare_repull($command);
         $label = $command === 'pull' ? 'Pull' : $command;
         $message = "{$label} state cleared.";

--- a/tests/Import/IndexUpdateWalTest.php
+++ b/tests/Import/IndexUpdateWalTest.php
@@ -1,0 +1,171 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+final class IndexUpdateWalTest extends TestCase
+{
+    private string $root;
+    private string $stateDirectory;
+    private string $fileRoot;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir()
+            . '/index-update-wal-'
+            . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->fileRoot = $this->root . '/files';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->fileRoot, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+    }
+
+    public function testAppliedBatchLeavesTheWalMarkerUntilCompletion(): void
+    {
+        $client = $this->client();
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getMethod('record_index_update_file')->invoke(
+            $client,
+            '/site/file.txt',
+            42,
+            5,
+            'file'
+        );
+        $reflection->getMethod('apply_index_update_wal')->invoke($client);
+
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $this->assertFileExists($walPath);
+        $this->assertSame('', file_get_contents($walPath));
+        $this->assertSame(
+            '/site/file.txt',
+            $this->firstIndexPath()
+        );
+
+        $reflection->getMethod('remove_index_update_wal')->invoke($client);
+        $this->assertFileDoesNotExist($walPath);
+    }
+
+    public function testReplayDiscardsAnUnterminatedFinalRecord(): void
+    {
+        $completeRecord = json_encode([
+            'op' => 'F',
+            'path' => base64_encode('/site/complete.txt'),
+            'ctime' => 42,
+            'size' => 5,
+            'type' => 'file',
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        file_put_contents(
+            $this->stateDirectory . '/.import-index-updates.wal',
+            $completeRecord . '{"op":"F","path":"'
+        );
+
+        $client = $this->client();
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getMethod('replay_index_update_wal')->invoke($client);
+
+        $this->assertSame('/site/complete.txt', $this->firstIndexPath());
+        $this->assertSame(
+            '',
+            file_get_contents(
+                $this->stateDirectory . '/.import-index-updates.wal'
+            )
+        );
+    }
+
+    /**
+     * @dataProvider abortCommandProvider
+     */
+    public function testAbortReplaysAndRemovesTheWal(string $command): void
+    {
+        file_put_contents(
+            $this->stateDirectory . '/.import-index-updates.wal',
+            json_encode([
+                'op' => 'F',
+                'path' => base64_encode('/site/aborted.txt'),
+                'ctime' => 42,
+                'size' => 5,
+                'type' => 'file',
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+        );
+        file_put_contents(
+            $this->stateDirectory . '/.import-state.json',
+            json_encode([
+                'preflight' => [
+                    'data' => ['ok' => true],
+                    'http_code' => 200,
+                ],
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+
+        $this->client()->run([
+            'command' => $command,
+            'abort' => true,
+        ]);
+
+        $this->assertSame('/site/aborted.txt', $this->firstIndexPath());
+        $this->assertFileDoesNotExist(
+            $this->stateDirectory . '/.import-index-updates.wal'
+        );
+    }
+
+    /** @return array<string,array{string}> */
+    public static function abortCommandProvider(): array
+    {
+        return [
+            'files-pull' => ['files-pull'],
+            'pull-files' => ['pull-files'],
+        ];
+    }
+
+    private function client(): \ImportClient
+    {
+        return new \ImportClient(
+            'https://example.com/?site-export-api',
+            $this->stateDirectory,
+            $this->fileRoot
+        );
+    }
+
+    private function firstIndexPath(): string
+    {
+        $lines = file(
+            $this->stateDirectory . '/.import-index.jsonl',
+            FILE_IGNORE_NEW_LINES
+        );
+        $this->assertIsArray($lines);
+        $line = $lines[0] ?? null;
+        $this->assertIsString($line);
+        $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        $path = base64_decode((string) $entry['path']);
+        $this->assertIsString($path);
+        return $path;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) ?: [] as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+            rmdir($path);
+            return;
+        }
+        unlink($path);
+    }
+}

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -140,18 +140,16 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
     });
 
     it('state does not checkpoint the unconfirmed file part', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        const localPath = join(importedRoot, fileRel);
+        const serializedLocalPath = `base64:${Buffer.from(localPath).toString('base64')}`;
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected import state file to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(
+        assert.notEqual(
             state.current_file,
-            null,
+            serializedLocalPath,
             'Expected the unconfirmed file part to remain outside the checkpoint',
-        );
-        assert.equal(
-            state.current_file_bytes,
-            null,
-            'Expected the checkpoint not to claim the unconfirmed file bytes',
         );
     });
 


### PR DESCRIPTION
Prevents `files-pull` from saving a resume cursor which skips past work that is still missing from `.import-index.jsonl`.

## Background

A pull keeps two records in its state directory:

- `.import-index.jsonl` describes the local tree produced by completed pull work. Each entry stores a path, type, size, and ctime. The next pull compares this index with the source index to decide what to download or delete.
- `.import-state.json` stores the fetch and diff cursors. A cursor tells a later process where to continue without repeating all earlier work.

These records must describe the same boundary. If the cursor moves past a file or deletion before the matching index update is safely recorded, resume skips the work while the index still describes the older tree.

## Before this PR

Consider a pull receiving `wp-content/photo.jpg`:

1. The multipart parser delivered the file part through one or more callbacks, and the importer wrote each body fragment directly to `photo.jpg`.
2. The importer collected the corresponding local-index update in a temporary updates file.
3. The fetch cursor was saved separately in `.import-state.json`.
4. If the process stopped after step 3 but before the index update was flushed and merged, the saved cursor pointed past `photo.jpg` while `.import-index.jsonl` still lacked its new entry.
5. Resume started after `photo.jpg`, because that is what the cursor requested, but the next delta calculation still used the old local-tree record.

The same split existed in the diff phase. A local path could be deleted and the diff cursor could move past it before its deletion record reached `.import-index.jsonl`.

The immediate consequence was disagreement between the downloaded tree and the index used for the next pull. A completed file could be scheduled again, or a deleted path could remain in the baseline and be processed again.

## After this PR

The index updates now travel through `<state-dir>/.import-index-updates.wal`:

1. When a file completes or the diff removes a path, the importer appends an upsert or deletion record to the WAL.
2. A file part may still arrive through several callbacks. Those callbacks continue writing bytes directly to the destination file; the part is not buffered in memory.
3. When the multipart parser reaches that part's closing boundary, the importer flushes the file and the WAL. Only then does it save the fetch cursor past the part in `.import-state.json`.
4. Diff checkpoints follow the same order: flush the WAL first, then save the diff cursors.
5. At the end of the batch, or when a later process resumes, Reprint merges the complete WAL records into `.import-index.jsonl`, replaces the old index, and clears the applied records.
6. If the response stops before a multipart part closes, the cursor remains before that part. Resume truncates its incomplete bytes and requests the part again.
7. If the process stops during a WAL write, resume ignores only the unfinished final line and applies the earlier complete records.

For the same interruption, the saved state is now ordered as follows:

```text
.import-index-updates.wal  upsert wp-content/photo.jpg
.import-state.json         fetch cursor after wp-content/photo.jpg
```

Resume applies that upsert before continuing from the cursor. A saved cursor therefore cannot skip completed work without a matching index-update record. Pulling remains streaming and bounded in memory; the additional on-disk state is the small append-only WAL plus the existing temporary replacement index used by the streaming merge. The empty WAL remains as the marker for an active `files-pull` and is removed when that lifecycle completes or is aborted.

Follows #404 and was split from #386.

## Testing

Interrupt `files-pull` immediately after a completed file part and after a diff deletion, then resume and confirm `.import-index.jsonl` contains each completed change once. Repeat with the final WAL line cut short and confirm resume ignores that line while applying the preceding complete records.
