### PR TITLE
Derive local push state directories from remote Reprint API URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Inside a class, omit the class name when context already supplies it: use
 
 - Exercise process death with an open request, cancellation between steps,
   local path changes before and after a chunk, large indexes, oversized target
-  responses, and interruption between every pair of durable phases.
+  responses, and interruption at every boundary between durable phases.
 - Assert both sides of each boundary: no confirmed work is repeated as new
   work, and no unconfirmed work is skipped.
 - Test boundedness with data larger than one step. A test which only uses one

--- a/README.md
+++ b/README.md
@@ -516,9 +516,10 @@ whatever tool was reading stdout (typically `mysql` CLI).
 Reprint uses `$STATE_DIR` exactly as supplied. Consumers that want the state
 hidden can choose a directory named `.reprint`; Reprint does not append that
 name itself. Shared command progress and the audit log live directly in the
-state directory. Pull-owned state lives in `pull/`, while pair-specific push
-state lives in `push/<pair-key>/`. Shared and pull filenames do not begin with
-a dot or repeat the scope supplied by their parent directory.
+state directory. Pull-owned state lives in `pull/`, while remote-specific push
+state lives in `push/<md5-of-trimmed-remote-reprint-api-url>/`. Shared and pull
+filenames do not begin with a dot or repeat the scope supplied by their parent
+directory.
 
 `pull/state.json` and `progress.json` are written atomically:
 a `.tmp` file is written first and then renamed to its final name so readers

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -19,9 +19,9 @@ the end maps it to a PR stack.
    moves work files into place, executes deletions, and commits the database
    diff, and fixes symlinks — inside a maintenance window that lasts seconds,
    not the length of the transfer.
-5. It stores the current local paths as the pair's previous local index
-   and stores the current rows as the previously pushed rows. The push is
-   complete only after this step; a crashed push is
+5. It stores the current local paths as the previous local index for that
+   remote Reprint API URL and stores the current rows as the previously pushed
+   rows. The push is complete only after this step; a crashed push is
    re-driven from the top and converges.
 
 Both sides act only when the local machine calls: no worker, no polling, no
@@ -78,14 +78,15 @@ managed `false` hard-disables push without abandoning durable commit recovery.
 
 ctime is machine-local, so push never compares a local timestamp to a remote
 one. It only answers "what changed locally since my last successful push to
-this remote" by comparing the current local paths and rows against the pair's
-previous local index and the previously pushed rows.
+this remote" by comparing the current local paths and rows against the previous
+local index and previously pushed rows for that remote Reprint API URL.
 
-The local machine keeps these files **per remote Reprint API URL and resolved
-filesystem root**, overwritten after each successful commit:
+The local machine keeps these files **per remote Reprint API URL**, overwritten
+after each successful commit. The state directory already selects one
+filesystem root:
 
-    <state-dir>/push/<pair-key>/previous_local_index.jsonl
-    <state-dir>/push/<pair-key>/previously_pushed_rows.jsonl   (phase two)
+    <state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/previous_local_index.jsonl
+    <state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/previously_pushed_rows.jsonl   (phase two)
 
 The previous local index records the local path type, size, and ctime as the
 completing push observed them. Besides planning the next push, it feeds the
@@ -131,7 +132,8 @@ A push plan is an internal part of the sender lifecycle:
    copy. It then removes the complete `plan/` directory and the sender-owned
    exclusions file. After the target
    confirms removal of a discarded push session, the sender removes the same
-   files without changing the pair's previous local index.
+   files without changing the previous local index for that remote Reprint API
+   URL.
 
 Until the sender stores the initial PushPlan cursor, `starting_plan` remains
 the durable phase. An interrupted start is repeated and overwrites its initial
@@ -274,15 +276,16 @@ configuration; request parameters cannot select any of them.
 
 `PushFilesSender` joins the durable `PushPlan` to the receiver's push session.
 Every local Reprint command workflow runs under `<state-dir>/process.lock`.
-The production CLI acquires this non-blocking lock before it prepares pair
-context, constructs `ImportClient`, or writes the command audit entry. It
-passes the open lock to `ImportClient::run()` and releases it after the command.
-A direct `ImportClient::run()` call acquires the lock when its caller supplies
-none. The one state-directory-wide Reprint process lock prevents concurrent
-pull, push, diff, and other local Reprint processes from using that site state,
-regardless of their target or local-tree pair.
+The production CLI acquires this non-blocking lock before it resolves the local
+push state directory, constructs `ImportClient`, or writes the command audit
+entry. It passes the open lock to `ImportClient::run()` and releases it after
+the command. A direct `ImportClient::run()` call acquires the lock when its
+caller supplies none. The one state-directory-wide Reprint process lock
+prevents concurrent pull, push, diff, and other local Reprint processes from
+using that site state, regardless of their remote Reprint API URLs.
 
-An active push keeps these files under `<state-dir>/push/<pair-key>/`:
+An active push keeps these files under
+`<state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/`:
 
 ```text
 previous_local_index.jsonl          index saved after the previous commit
@@ -414,17 +417,17 @@ write `pull/state.json`, show a plan, ask for confirmation, transfer a
 database, retry a failed request, or start a replacement sender after a
 `restart` outcome.
 
-The command derives one pair key without general URL normalization:
+The local push state directory is `<state-dir>/push/` followed by:
 
 ```text
-sha256(rtrim(<remote-reprint-api-url>, "?&") + "\0" + <resolved-filesystem-root>)
+md5(rtrim(<remote-reprint-api-url>, "?&"))
 ```
 
-Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
-query or resolved filesystem root therefore selects a different retained local
-index. Fragments, URL user-info, and `SECRET_KEY` target parameters are
-rejected. The local push state directory must be outside the filesystem root so
-planning cannot index its own changing files.
+A different remote query therefore selects a different retained local index. A
+different filesystem root requires a different state directory and does not
+participate in the directory name. Fragments, URL user-info, and `SECRET_KEY`
+target parameters are rejected. The local push state directory must be outside
+the filesystem root so planning cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80
@@ -445,18 +448,19 @@ The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
 `restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
 same command again. After `restart`, that next run builds a fresh plan. The
 shared audit log records opening mode, phase changes, planned pauses, handled
-interruptions, and terminal outcomes with the pair key. The flat progress file
-records only the command, pair, outcome, phase, reason, detail, and timestamp;
-neither file copies receiver cursors or tentative upload positions.
+interruptions, and terminal outcomes. The flat progress file records only
+`command`, `status`, `phase`, `reason`, `detail`, and `ts`; neither file copies
+receiver cursors or tentative upload positions.
 
 ## Local files-diff command
 
 `reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR` reports a local
 minimized push operation plan before target exclusions: the local paths a
-files-push would send or delete, compared against the pair's previous local
-index published by a completed files-push. It uses the files-push pair-key
-formula, including its trailing `?` and `&` trim, so another URL query or
-filesystem root cannot reuse the index. It accepts only `--state-dir` and
+files-push would send or delete, compared against the previous local index for
+that remote Reprint API URL published by a completed files-push. It uses the
+files-push local push state directory formula, including its trailing `?` and
+`&` trim, so another URL query cannot reuse the index. A different filesystem
+root uses a different state directory. It accepts only `--state-dir` and
 `--fs-root`; it needs no secret, performs no preflight, and makes no network
 request. It runs one complete PushPlan against `previous_local_index.jsonl` in
 `files-diff-plan/` while the command holds the state-directory-wide Reprint
@@ -506,8 +510,8 @@ Order:
    `commit.json` checkpoint written before each document-root mutation. The
    future database batch and symlink updates follow the same bounded cursor.
 4. **Maintenance off:** commit releases its `commit-state` ownership after
-   completion; the driver saves the pair's previous local index and rows
-   after commit completes.
+   completion; the driver saves the previous local index and rows for that
+   remote Reprint API URL after commit completes.
 
 If the driver dies mid-commit: WordPress stops honoring the `.maintenance`
 file after 10 minutes on its own, and the next commit request resumes from
@@ -599,8 +603,8 @@ Files first, database second, each PR small and stacked in this order:
     one sender per process, applies caller time and memory admission budgets,
     and reports completion, continuation, restart, or failure without retrying.
 12. **`reprint files-diff`** — a local-only command that reports the paths a
-    files-push would send or delete against the pair's previous local index,
-    without contacting the target.
+    files-push would send or delete against the previous local index for that
+    remote Reprint API URL, without contacting the target.
 13. **`reprint push`** — the high-level command that adds a change summary,
     confirmation boundary, database work, transfer, commit, and resume.
 14. **Budgets and resumable limits** — push requests stay bounded by two

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -59,7 +59,7 @@ local relative path to a push-root-relative path.
 - The **local index WAL** records completed pull mutations awaiting application
   to the local index.
 - A **pull plan** lists remote absolute paths still scheduled for download or
-  deletion. A **push plan** pairs local relative paths with push-root-relative
+  deletion. A **push plan** maps local relative paths to push-root-relative
   paths.
 
 A **resolved path mapping** is an immutable mapping between remote absolute
@@ -181,7 +181,7 @@ scope supplied by their parent directories.
 │   ├── sql-stats.json
 │   └── sql-buffer
 └── push/
-    └── <pair-key>/
+    └── <md5-of-trimmed-remote-reprint-api-url>/
 ```
 
 Use these path names:
@@ -214,15 +214,16 @@ Every local Reprint command workflow runs under the **Reprint process lock** at
 `$process_lock_path`, and `$process_lock`. The lock is non-blocking and
 state-directory-wide: pull, push, diff, and other local Reprint processes
 cannot run concurrently against the same state directory, even when their
-remote Reprint API URL or filesystem-root pairs differ.
+remote Reprint API URLs differ.
 
-The production CLI acquires the Reprint process lock before it prepares pair
-context, constructs `ImportClient`, or writes the command audit entry. It
-passes the open lock to `ImportClient::run()` and releases it after the command.
-A direct `ImportClient::run()` call acquires the lock when its caller supplies
-none. `PushFilesSender::start()` and `PushFilesSender::resume()` receive that
-open lock from the caller; sender `close()` does not release it. This local
-lock is separate from the receiver's push-session and commit locks.
+The production CLI acquires the Reprint process lock before it resolves the
+local push state directory, constructs `ImportClient`, or writes the command
+audit entry. It passes the open lock to `ImportClient::run()` and releases it
+after the command. A direct `ImportClient::run()` call acquires the lock when
+its caller supplies none. `PushFilesSender::start()` and
+`PushFilesSender::resume()` receive that open lock from the caller; sender
+`close()` does not release it. This local lock is separate from the receiver's
+push-session and commit locks.
 
 ## Pull local index WAL
 
@@ -237,7 +238,9 @@ command; unrelated commands do not consume it.
 ## Local push state
 
 The local machine keeps planning and active state outside the receiver push
-directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
+directory. Under
+`<state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/`, use these names
+verbatim:
 
 | Surface | Name |
 | --- | --- |
@@ -262,11 +265,12 @@ sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
-The **previous local index** describes the filesystem root as the pair's last
-completed push observed it. The sender saves it after a successful commit, and
-`files-diff` reads it. PushPlan diffs its fresh local index against the copy
-its caller supplies. `byte_offset_in_previous_local_index` is the position
-from which its current lookahead entry is read again after resume.
+The **previous local index** describes the filesystem root as its last
+completed push to the remote Reprint API URL observed it. The sender saves it
+after a successful commit, and `files-diff` reads it. PushPlan diffs its fresh
+local index against the copy its caller supplies.
+`byte_offset_in_previous_local_index` is the position from which its current
+lookahead entry is read again after resume.
 
 The PushPlan cursor is stored in `sender.json`. It contains the plan
 directory, filesystem root, previous local index, and current
@@ -317,10 +321,11 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `remote Reprint API URL`, `filesystem root`, `pair
-key`, and `local push state directory` have the same meanings and pair-key
-formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
-which a completed files-push publishes, and never changes it.
+The local-only command is `files-diff`. Its `remote Reprint API URL`,
+`filesystem root`, and `local push state directory` have the same meanings and
+directory formula as `files-push`. It reads
+`previous_local_index.jsonl` for that remote Reprint API URL, which a completed
+files-push publishes, and never changes it.
 
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
 `delete`, and `path_b64`. A push record also has the local path `type`, `size`,
@@ -344,23 +349,24 @@ exporter API URL, and its `filesystem root` is the resolved absolute directory s
 `--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
 plain-HTTP opt-in.
 
-The `pair key` identifies exactly one remote Reprint API URL and resolved filesystem root:
+The **local push state directory** is `<state-dir>/push/` followed by:
 
 ```text
-sha256(rtrim(<remote-reprint-api-url>, "?&") + "\0" + <resolved-filesystem-root>)
+md5(rtrim(<remote-reprint-api-url>, "?&"))
 ```
 
-The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
-chooses `start` or `resume` only from whether `sender.json` exists there. The
-receiver-confirmed upload positions remain receiver-owned; they are not a
-files-push cursor and are not copied into `pull/state.json` or
-`progress.json`.
+The state directory belongs to one filesystem root. Use a different state
+directory for a different filesystem root; the filesystem root does not
+participate in the directory name. `files-push` chooses `start` or `resume`
+only from whether `sender.json` exists there. The receiver-confirmed upload
+positions remain receiver-owned; they are not a files-push cursor and are not
+copied into `pull/state.json` or `progress.json`.
 
 Files-push lifecycle lines use these command-first names verbatim: `START
 files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,
 `INTERRUPTED files-push`, `COMPLETE files-push`, `RESTART files-push`, `FAILED
-files-push`, and `ERROR files-push`. Every line contains `pair=<pair-key>`.
-Planned stop causes are `time_limit` and `memory_limit`.
+files-push`, and `ERROR files-push`. Planned stop causes are `time_limit` and
+`memory_limit`.
 
 The CLI outcome names are `complete`, `partial`, `interrupted`, `restart`,
 `failed`, and `error`. `complete` exits 0; `partial`, `interrupted`, and

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -698,9 +698,8 @@ class ImportClient
      *
      * @param string       $command Normalized CLI command name.
      * @param list<string> $argv    Raw command arguments.
-     * @param string|null  $pair    Files-diff or files-push pair key, when available.
      */
-    public function audit_log_argv(string $command, array $argv, ?string $pair = null): void
+    public function audit_log_argv(string $command, array $argv): void
     {
         // Mask the remote URL (argv[2]) to avoid logging secrets embedded in query strings.
         $masked = $argv;
@@ -715,8 +714,10 @@ class ImportClient
                 $masked[$argument_index] = '--secret=***';
             }
         }
-        $pair_field = $pair === null ? '' : " | pair={$pair}";
-        $this->audit_log("COMMAND | {$command}{$pair_field} | argv=" . implode(' ', $masked), false);
+        $this->audit_log(
+            "COMMAND | {$command} | argv=" . implode(' ', $masked),
+            false
+        );
     }
 
     /**
@@ -836,7 +837,8 @@ class ImportClient
     /**
      * Runs one import command while holding the state directory's process lock.
      *
-     * CLI callers pass the lock acquired before pair setup and audit logging.
+     * CLI callers pass the lock acquired before local push state setup and
+     * audit logging.
      * Direct callers may omit it; this method then acquires the lock before
      * reading or writing command state. A supplied lock remains caller-owned.
      *
@@ -1267,7 +1269,8 @@ class ImportClient
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
     /**
-     * Reports local paths changed since the pair's previous local index.
+     * Reports local paths changed since the previous push to this remote
+     * Reprint API URL.
      *
      * files-diff makes no network request. It runs one complete PushPlan
      * against the previous local index a completed files-push published, then
@@ -1276,29 +1279,28 @@ class ImportClient
      * running the command again prints the complete report.
      *
      * @param array $options {
-     *     Parsed files-diff options and context.
+     *     Parsed files-diff options.
      *
-     *     @type array $files_diff_context Validated pair context.
+     *     @type string $files_diff_push_state_directory Local push state directory resolved by the CLI entry point.
      * }
      * @phpstan-param array<string,mixed> $options
      */
     private function run_files_diff(array $options): void
     {
-        $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
+        $push_state_directory = $options['files_diff_push_state_directory'] ?? self::resolve_push_state_directory(
             $this->remote_reprint_api_url,
             $this->state_dir,
             $this->filesystem_root,
             'files-diff'
         );
-        if (!is_array($context)) {
-            throw new InvalidArgumentException('files-diff requires its validated command context.');
+        if (!is_string($push_state_directory)) {
+            throw new InvalidArgumentException('files-diff requires its resolved local push state directory.');
         }
 
-        $push_state_directory = $context['push_state_directory'];
         $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
         $missing_previous_local_index_message =
-            'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
-            . 'for the same remote Reprint API URL, state directory, and filesystem root.';
+            'files-diff requires the previous local index published by a completed files-push '
+            . 'for the same remote Reprint API URL and state directory.';
         if (!is_dir($push_state_directory)) {
             throw new RuntimeException($missing_previous_local_index_message);
         }
@@ -1321,7 +1323,7 @@ class ImportClient
             }
             $plan = PushPlan::start(
                 $plan_directory,
-                $context['filesystem_root'],
+                $this->filesystem_root,
                 $previous_local_index,
                 $excluded_paths_path
             );
@@ -1548,7 +1550,7 @@ class ImportClient
         try {
             $this->audit_log(
                 ( $resuming ? 'RESUME' : 'START' )
-                    . " files-push | pair={$context['pair']} | phase={$phase}",
+                    . " files-push | phase={$phase}",
                 false
             );
 
@@ -1577,7 +1579,7 @@ class ImportClient
                 $phase = $sender->get_phase();
                 if ($phase !== $previous_phase) {
                     $this->audit_log(
-                        "PHASE files-push | pair={$context['pair']} | from={$previous_phase} | to={$phase}",
+                        "PHASE files-push | from={$previous_phase} | to={$phase}",
                         false
                     );
                     $previous_phase = $phase;
@@ -1628,33 +1630,33 @@ class ImportClient
 
         switch ($status) {
             case 'complete':
-                $audit_line = "COMPLETE files-push | pair={$context['pair']} | phase={$phase}";
+                $audit_line = "COMPLETE files-push | phase={$phase}";
                 $message = 'Files push complete.';
                 $this->exit_code = 0;
                 break;
             case 'partial':
-                $audit_line = "PARTIAL files-push | pair={$context['pair']} | phase={$phase} | cause={$reason}";
+                $audit_line = "PARTIAL files-push | phase={$phase} | cause={$reason}";
                 $message = 'Files push paused at a durable boundary; run the same command again to continue.';
                 $this->exit_code = 2;
                 break;
             case 'interrupted':
-                $audit_line = "INTERRUPTED files-push | pair={$context['pair']} | phase={$phase} | signal={$this->files_push_stop_signal}";
+                $audit_line = "INTERRUPTED files-push | phase={$phase} | signal={$this->files_push_stop_signal}";
                 $message = 'Files push was interrupted at a durable boundary; run the same command again to continue.';
                 $this->exit_code = 2;
                 break;
             case 'restart':
-                $audit_line = "RESTART files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $audit_line = "RESTART files-push | phase={$phase} | reason={$reason}";
                 $message = 'Files push must restart; the next run will build a fresh plan.';
                 $this->exit_code = 2;
                 break;
             case 'failed':
-                $audit_line = "FAILED files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $audit_line = "FAILED files-push | phase={$phase} | reason={$reason}";
                 $message = $detail === null ? 'Files push failed.' : 'Files push failed: ' . $detail;
                 $this->exit_code = 1;
                 break;
             case 'error':
             default:
-                $audit_line = "ERROR files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $audit_line = "ERROR files-push | phase={$phase} | reason={$reason}";
                 $message = $detail === null ? 'Files push stopped with an error.' : 'Files push stopped with an error: ' . $detail;
                 $this->exit_code = 1;
                 break;
@@ -1663,7 +1665,6 @@ class ImportClient
         $this->audit_log($audit_line, false);
         $result = [
             'command' => 'files-push',
-            'pair' => $context['pair'],
             'status' => $status,
             'phase' => $phase,
             'message' => $message,
@@ -1677,7 +1678,6 @@ class ImportClient
         // Write the flat progress snapshot without consulting import state.
         $progress_payload = [
             'command' => 'files-push',
-            'pair' => $context['pair'],
             'status' => $status,
             'phase' => $phase,
             'reason' => $reason,
@@ -1724,10 +1724,9 @@ class ImportClient
      *
      *     @type string $remote_reprint_api_url Remote Reprint API URL.
      *     @type string $filesystem_root  Resolved filesystem root being sent.
-     *     @type string $pair                 Target/filesystem-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{remote_reprint_api_url:string,filesystem_root:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{remote_reprint_api_url:string,filesystem_root:string,push_state_directory:string}
      */
     public static function prepare_files_push_context(
         string $remote_reprint_api_url,
@@ -1745,7 +1744,7 @@ class ImportClient
             );
         }
 
-        $context = self::prepare_files_pair_context(
+        $push_state_directory = self::resolve_push_state_directory(
             $remote_reprint_api_url,
             $state_dir,
             $filesystem_root,
@@ -1761,32 +1760,33 @@ class ImportClient
                 . '. Pass --force-http only for a remote Reprint API URL you trust.'
             );
         }
-        return $context;
+        $resolved_local_filesystem_root = realpath($filesystem_root);
+        if ($resolved_local_filesystem_root === false) {
+            throw new InvalidArgumentException(
+                'The filesystem root does not exist or is not a directory: ' . $filesystem_root . '.'
+            );
+        }
+        return [
+            'remote_reprint_api_url' => rtrim($remote_reprint_api_url, '?&'),
+            'filesystem_root' => rtrim($resolved_local_filesystem_root, '/') ?: '/',
+            'push_state_directory' => $push_state_directory,
+        ];
     }
 
     /**
-     * Validates the local inputs shared by files-diff and files-push.
+     * Resolves the local push state directory for a remote Reprint API URL.
      *
-     * This helper deliberately does not require a secret or HTTPS. files-diff
-     * identifies the pull source by URL but performs no network request.
+     * This method deliberately does not require a secret or HTTPS. files-diff
+     * identifies the pull source by URL but makes no network request.
      *
      * @param string $command Command name used in error messages.
-     * @return array {
-     *     Validated pair context.
-     *
-     *     @type string $remote_reprint_api_url Remote Reprint API URL.
-     *     @type string $filesystem_root  Resolved filesystem root.
-     *     @type string $pair                 Target/filesystem-root pair key.
-     *     @type string $push_state_directory Local push state directory.
-     * }
-     * @phpstan-return array{remote_reprint_api_url:string,filesystem_root:string,pair:string,push_state_directory:string}
      */
-    public static function prepare_files_pair_context(
+    public static function resolve_push_state_directory(
         string $remote_reprint_api_url,
         string $state_dir,
         string $filesystem_root,
         string $command
-    ): array {
+    ): string {
         $masked_remote_reprint_api_url =
             self::mask_url_credentials($remote_reprint_api_url);
         if (strpos($remote_reprint_api_url, '#') !== false) {
@@ -1817,9 +1817,8 @@ class ImportClient
         }
         $resolved_local_filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
         $remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
-        $pair = hash('sha256', $remote_reprint_api_url . "\0" . $resolved_local_filesystem_root);
         // Resolve an absolute physical path even when its final components do not exist.
-        $push_state_directory = $state_dir . '/push/' . $pair;
+        $push_state_directory = $state_dir . '/push/' . md5($remote_reprint_api_url);
         if (strpos($push_state_directory, '/') !== 0) {
             $working_directory = getcwd();
             if ($working_directory === false) {
@@ -1857,12 +1856,7 @@ class ImportClient
             );
         }
 
-        return [
-            'remote_reprint_api_url' => $remote_reprint_api_url,
-            'filesystem_root' => $resolved_local_filesystem_root,
-            'pair' => $pair,
-            'push_state_directory' => $push_state_directory,
-        ];
+        return $push_state_directory;
     }
     // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
@@ -1912,7 +1906,7 @@ class ImportClient
         }
     }
 
-    /** Masks URL authority credentials without changing the pair-key input. */
+    /** Masks URL authority credentials without changing the URL used to name the local push state directory. */
     private static function mask_url_credentials(string $url): string
     {
         $masked = preg_replace(
@@ -5197,8 +5191,8 @@ class ImportClient
         // Parse URL mapping
         $url_mapping = [];
         if (!empty($options["rewrite_url"])) {
-            foreach ($options["rewrite_url"] as $pair) {
-                $url_mapping[$pair[0]] = $pair[1];
+            foreach ($options["rewrite_url"] as [$source_url, $target_url]) {
+                $url_mapping[$source_url] = $target_url;
             }
         }
 
@@ -8706,14 +8700,14 @@ class ImportClient
     }
 
     /**
-     * Build the remap rules from the raw remap pairs + preflight data.
+     * Build the remap rules from raw SOURCE TARGET arguments and preflight data.
      *
      * Each argument is a template string of `:token:` substitutions and/or a raw absolute path.
      * Source arguments resolve against the remote site's WordPress path tokens.
      * Target arguments resolve under --fs-root and must stay within it.
      * Each rule is a full source path => full local target path (both absolute).
      *
-     * @param array<int,array{0:string,1:string}> $remap_raw Raw (SOURCE, TARGET) pairs.
+     * @param array<int,array{0:string,1:string}> $remap_raw Raw SOURCE/TARGET mappings.
      * @return array<string,string> Source path => target path (both absolute).
      */
     private function resolve_remap(array $remap_raw): array
@@ -11577,7 +11571,7 @@ if (
     //   type           'value'         --name=VAL
     //                  'flag'          --name (sets a boolean)
     //                  'value-or-next' --name=VAL or --name VAL
-    //                  'pair'          --name A B (repeatable, takes 2 args)
+    //                  'two-arguments' --name A B (repeatable, takes 2 arguments)
     //   target         Where to store the parsed value:
     //                  'state_dir' | 'filesystem_root' → special local variables
     //                  'key'                   → $options['key']
@@ -11593,7 +11587,7 @@ if (
     //   cast           'int' | 'float' | 'size' (default: string)
     //   flag_value     What to store for flag types (default: true)
     //   valid_values   Array of allowed values (enforced at parse time)
-    //   pair_args      Arg labels for pair type help, e.g. 'FROM TO'
+    //   argument_labels Labels for two-argument type help, e.g. 'FROM TO'
     // ================================================================
     $option_defs = [
         // ── Required options ─────────────────────────────────────
@@ -11873,9 +11867,9 @@ if (
         ],
         [
             'name' => 'rewrite-url',
-            'type' => 'pair',
+            'type' => 'two-arguments',
             'target' => 'rewrite_url',
-            'pair_args' => 'FROM TO',
+            'argument_labels' => 'FROM TO',
             'help' => 'Rewrite FROM to TO (repeatable)',
             'commands' => ['pull', 'pull-db', 'db-apply'],
         ],
@@ -11889,9 +11883,9 @@ if (
         ],
         [
             'name' => 'remap',
-            'type' => 'pair',
+            'type' => 'two-arguments',
             'target' => 'remap',
-            'pair_args' => 'SOURCE TARGET',
+            'argument_labels' => 'SOURCE TARGET',
             'help' => 'Place SOURCE (a :token: like :wp-uploads: or an absolute path) at TARGET ' .
                 '(a :fs-root: path or an absolute path within --fs-root); repeatable',
             'commands' => ['pull-files', 'files-pull'],
@@ -12085,10 +12079,10 @@ if (
                             }
                             break;
 
-                        case 'pair':
+                        case 'two-arguments':
                             if ($arg === "--{$cli_name}") {
                                 if (!isset($argv[$i + 1]) || !isset($argv[$i + 2])) {
-                                    fwrite(STDERR, "--{$def['name']} requires two arguments: " . ($def['pair_args'] ?? 'ARG1 ARG2') . "\n");
+                                    fwrite(STDERR, "--{$def['name']} requires two arguments: " . ($def['argument_labels'] ?? 'ARG1 ARG2') . "\n");
                                     exit(1);
                                 }
                                 $target = $def['target'];
@@ -12366,8 +12360,8 @@ if (
             case 'value':
             case 'value-or-next':
                 return "{$name}=" . ($def['placeholder'] ?? 'VALUE');
-            case 'pair':
-                return "{$name} " . ($def['pair_args'] ?? 'ARG1 ARG2');
+            case 'two-arguments':
+                return "{$name} " . ($def['argument_labels'] ?? 'ARG1 ARG2');
             case 'flag':
             default:
                 return $name;
@@ -12559,7 +12553,7 @@ if (
             "usage" => "reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
                 "Shows which local paths a files-push would send or delete, comparing\n" .
-                "the filesystem root at --fs-root with the pair's previous local index —\n" .
+                "the filesystem root at --fs-root with the previous local index for this remote Reprint API URL —\n" .
                 "the index a completed files-push publishes for the same remote Reprint API URL,\n" .
                 "state directory, and filesystem root.\n" .
                 "The output is a local minimized push operation plan before target\n" .
@@ -12887,11 +12881,11 @@ if (
     }
 
     try {
-        // Acquire the lock before pair setup and audit writes so each command
-        // owns every local state transition for its complete invocation.
+        // Acquire the lock before local push state setup and audit writes so
+        // each command owns every local state transition for its complete invocation.
         $reprint_process_lock = new ReprintProcessLock($state_dir);
         $reprint_files_push_context = null;
-        $reprint_files_diff_context = null;
+        $reprint_files_diff_push_state_directory = null;
         if ($command === 'files-push') {
             $reprint_files_push_context = ImportClient::prepare_files_push_context(
                 $remote_reprint_api_url,
@@ -12900,7 +12894,7 @@ if (
                 $options
             );
         } elseif ($command === 'files-diff') {
-            $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
+            $reprint_files_diff_push_state_directory = ImportClient::resolve_push_state_directory(
                 $remote_reprint_api_url,
                 $state_dir,
                 $filesystem_root,
@@ -12908,16 +12902,15 @@ if (
             );
         }
         $client = new ImportClient($remote_reprint_api_url, $state_dir, $filesystem_root, $command);
-        $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
-        $client->audit_log_argv($command, $argv, $reprint_files_pair);
+        $client->audit_log_argv($command, $argv);
         $client->run(
             $options
                 + ( $reprint_files_push_context === null
                     ? []
                     : ['files_push_context' => $reprint_files_push_context] )
-                + ( $reprint_files_diff_context === null
+                + ( $reprint_files_diff_push_state_directory === null
                     ? []
-                    : ['files_diff_context' => $reprint_files_diff_context] ),
+                    : ['files_diff_push_state_directory' => $reprint_files_diff_push_state_directory] ),
             $reprint_process_lock
         );
         // EXIT_AFTER_IMPORT controls whether we hand control back to

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -658,7 +658,7 @@ class Pull
      *
      * php-builtin and playground-cli can run without a local MySQL server, so
      * pull imports into SQLite by default for those runtimes. nginx-fpm does
-     * not imply a database target because it is normally paired with an
+     * not imply a database target because it is normally used with an
      * externally managed server.
      */
     private function default_pull_target_options(array $options): array

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -10,8 +10,8 @@
  * PushFilesSender owns the only caller-visible push lifecycle. Its caller holds
  * the Reprint process lock while the sender creates and removes the target push
  * session, drives its internal PushPlan, streams the selected paths, commits the
- * push, and saves the completed fresh local index as the pair's previous local
- * index. The target owns the
+ * push, and saves the completed fresh local index as the previous local index
+ * for this remote Reprint API URL. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
  * request limits and the PushPlan cursor needed after a process restart.
@@ -56,25 +56,26 @@
  *
  * A new sender calls `push_create` to learn target-owned exclusions before
  * starting PushPlan. The plan builds the fresh local index and diffs it against
- * the pair's previous local index, one bounded step at a time. That index is
- * saved by the previous successful push and also read by files-diff. After planning
+ * the previous local index for this remote Reprint API URL, one bounded step
+ * at a time. That index is saved by the previous successful push and also read
+ * by files-diff. After planning
  * completes, local files, symlinks, and empty directories stream through
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
  * calls let the target install the work in bounded steps. A confirmed commit
- * enters another phase which saves the fresh local index as the pair's
- * previous local index through a swap file. Index completion, plan completion,
- * local-index saving, and plan discard each have a separate durable phase. A
- * stopped process therefore repeats only an idempotent boundary action rather
- * than a group of unrelated transitions.
+ * enters another phase which saves the fresh local index as the previous local
+ * index for this remote Reprint API URL through a swap file. Index completion,
+ * plan completion, local-index saving, and plan discard each have a separate
+ * durable phase. A stopped process therefore repeats only an idempotent
+ * boundary action rather than a group of unrelated transitions.
  *
  * sender.json owns the top-level phase and the cursor returned by
  * PushPlan. PushFilesSender stores that cursor after every completed planning
  * step but never interprets its internal phase or offsets. The sender creates
  * the active plan directory before planning and removes the whole directory
- * only after success or target-session removal. The pair's previous local
- * index remains beside sender.json. Once the plan result is saved or discarded,
- * the sender clears its cursor before removing the directory without reopening
- * PushPlan.
+ * only after success or target-session removal. The previous local index for
+ * this remote Reprint API URL remains beside sender.json. Once the plan result
+ * is saved or discarded, the sender clears its cursor before removing the
+ * directory without reopening PushPlan.
  *
  * ## Resume after local changes
  *
@@ -135,7 +136,7 @@ final class PushFilesSender
     /** @var string Sender-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Pair's previous local index, saved after a successful push and read by files-diff. */
+    /** @var string Previous local index for this remote Reprint API URL. */
     private string $previous_local_index;
 
     /** @var string Path where the serialized sender state is stored. */
@@ -1188,7 +1189,7 @@ final class PushFilesSender
     }
 
     /**
-     * Saves the committed fresh local index as the pair's previous local index.
+     * Saves the committed fresh local index for this remote Reprint API URL.
      *
      * If the process stops before the next phase is stored, repeating the
      * deliberate whole-index copy is safe and leaves readers on either the old

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -12,12 +12,12 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * The files-diff user contract.
  *
- * files-diff compares the filesystem root with the pair's previous local index —
- * the index a completed files-push publishes — without contacting the target,
- * and reports the complete diff on every run. These tests pin that contract:
- * local-only operation, correct change records, arbitrary path bytes, the
- * previous-local-index requirement, no mutation of that index, and a complete
- * report after an interrupted run.
+ * files-diff compares the filesystem root with the previous local index for
+ * the remote Reprint API URL — the index a completed files-push publishes —
+ * without contacting the target, and reports the complete diff on every run.
+ * These tests pin that contract: local-only operation, correct change records,
+ * arbitrary path bytes, the previous-local-index requirement, no mutation of
+ * that index, and a complete report after an interrupted run.
  */
 final class FilesDiffCommandTest extends TestCase
 {
@@ -228,7 +228,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same remote Reprint API URL, state directory, and filesystem root',
+            'same remote Reprint API URL and state directory',
             $result['output']
         );
     }
@@ -244,7 +244,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same remote Reprint API URL, state directory, and filesystem root',
+            'same remote Reprint API URL and state directory',
             $result['output']
         );
     }
@@ -393,10 +393,9 @@ final class FilesDiffCommandTest extends TestCase
 
     private function pushStateDirectory(): string
     {
-        $resolvedLocalDocumentRoot = realpath($this->localTree);
-        $this->assertIsString($resolvedLocalDocumentRoot);
-        $pair = hash('sha256', rtrim($this->targetUrl, '?&') . "\0" . $resolvedLocalDocumentRoot);
-        return realpath($this->stateDirectory) . '/push/' . $pair;
+        return realpath($this->stateDirectory)
+            . '/push/'
+            . md5(rtrim($this->targetUrl, '?&'));
     }
 
     /** @param list<string> $extraArguments

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -43,7 +43,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertNull(ImportClient::files_push_stop_cause(1000.0, PHP_INT_MAX, 0, -1, $chunkBytes));
     }
 
-    public function testPairContextUsesTheTrimmedRemoteReprintApiUrlAndResolvedFilesystemRoot(): void
+    public function testPushStateDirectoryUsesTheStateDirectoryAndTrimmedRemoteReprintApiUrl(): void
     {
         $remoteReprintApiUrl = 'https://example.test/?reprint-api=1&&';
         $context = ImportClient::prepare_files_push_context(
@@ -52,18 +52,13 @@ final class FilesPushCommandTest extends TestCase
             $this->localTree,
             ['secret' => 'token', 'force_http' => false]
         );
-        $resolvedFilesystemRoot = realpath($this->localTree);
-        $this->assertIsString($resolvedFilesystemRoot);
         $trimmedRemoteReprintApiUrl = rtrim($remoteReprintApiUrl, '?&');
-        $expectedPair = hash('sha256', $trimmedRemoteReprintApiUrl . "\0" . $resolvedFilesystemRoot);
+        $expectedPushStateDirectory =
+            realpath($this->stateDirectory) . '/push/' . md5($trimmedRemoteReprintApiUrl);
 
         $this->assertSame($trimmedRemoteReprintApiUrl, $context['remote_reprint_api_url']);
-        $this->assertSame($resolvedFilesystemRoot, $context['filesystem_root']);
-        $this->assertSame($expectedPair, $context['pair']);
-        $this->assertSame(
-            realpath($this->stateDirectory) . '/push/' . $expectedPair,
-            $context['push_state_directory']
-        );
+        $this->assertSame(realpath($this->localTree), $context['filesystem_root']);
+        $this->assertSame($expectedPushStateDirectory, $context['push_state_directory']);
 
         $differentQuery = ImportClient::prepare_files_push_context(
             'https://example.test/?reprint-api=1&directory=other',
@@ -71,17 +66,25 @@ final class FilesPushCommandTest extends TestCase
             $this->localTree,
             ['secret' => 'token', 'force_http' => false]
         );
-        $otherTree = $this->root . '/other-tree';
-        mkdir($otherTree);
-        $differentTree = ImportClient::prepare_files_push_context(
+        $otherFilesystemRoot = $this->root . '/other-filesystem-root';
+        $otherStateDirectory = $this->root . '/other-state';
+        mkdir($otherFilesystemRoot);
+        mkdir($otherStateDirectory);
+        $differentFilesystemRootContext = ImportClient::prepare_files_push_context(
             $remoteReprintApiUrl,
-            $this->stateDirectory,
-            $otherTree,
+            $otherStateDirectory,
+            $otherFilesystemRoot,
             ['secret' => 'token', 'force_http' => false]
         );
 
-        $this->assertNotSame($context['pair'], $differentQuery['pair']);
-        $this->assertNotSame($context['pair'], $differentTree['pair']);
+        $this->assertNotSame(
+            $context['push_state_directory'],
+            $differentQuery['push_state_directory']
+        );
+        $this->assertSame(
+            realpath($otherStateDirectory) . '/push/' . md5($trimmedRemoteReprintApiUrl),
+            $differentFilesystemRootContext['push_state_directory']
+        );
     }
 
     public function testFilesPushRejectsOptionsOutsideItsExactAllowlist(): void
@@ -111,7 +114,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $olderCommand['exit'], $olderCommand['output']);
         $this->assertStringContainsString('--force-http is accepted only by files-push.', $olderCommand['output']);
 
-        $existingPairValue = $this->runCli([
+        $rewriteUrlWithForceHttpSource = $this->runCli([
             'db-apply',
             '-',
             '--state-dir=' . $this->stateDirectory,
@@ -122,7 +125,7 @@ final class FilesPushCommandTest extends TestCase
         ]);
         $this->assertStringNotContainsString(
             '--force-http is accepted only by files-push.',
-            $existingPairValue['output']
+            $rewriteUrlWithForceHttpSource['output']
         );
     }
 
@@ -134,7 +137,6 @@ final class FilesPushCommandTest extends TestCase
         $missingSecretError = $this->lastJsonLine($missingSecret['stderr']);
         $this->assertArrayHasKey('error', $missingSecretError);
         $this->assertArrayNotHasKey('command', $missingSecretError);
-        $this->assertArrayNotHasKey('pair', $missingSecretError);
         $this->assertArrayNotHasKey('phase', $missingSecretError);
 
         $querySecret = $this->runFilesPush(
@@ -269,7 +271,6 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $result['exit'], $result['output']);
         $finalLine = $this->lastJsonLine($result['stdout']);
         $this->assertSame('files-push', $finalLine['command'] ?? null);
-        $this->assertSame($context['pair'], $finalLine['pair'] ?? null);
         $this->assertSame('error', $finalLine['status'] ?? null);
         $this->assertSame('starting_plan', $finalLine['phase'] ?? null);
         $this->assertSame('unexpected_error', $finalLine['reason'] ?? null);
@@ -283,13 +284,16 @@ final class FilesPushCommandTest extends TestCase
             JSON_THROW_ON_ERROR
         );
         $this->assertSame(
-            ['command', 'pair', 'status', 'phase', 'reason', 'detail', 'ts'],
+            ['command', 'status', 'phase', 'reason', 'detail', 'ts'],
             array_keys($progress)
         );
         $this->assertSame('error', $progress['status']);
         $audit = (string) file_get_contents($this->stateDirectory . '/audit.log');
         $this->assertSame(1, substr_count($audit, 'ERROR files-push'));
-        $this->assertStringContainsString('pair=' . $context['pair'], $audit);
+        $this->assertStringContainsString(
+            'ERROR files-push | phase=starting_plan | reason=unexpected_error',
+            $audit
+        );
     }
 
     /** @param list<string> $extraOptions */

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --remap: resolving template-string SOURCE TARGET pairs into remap rules.
+ * --remap: resolving template-string SOURCE TARGET mappings into remap rules.
  *
  * Each argument has its known `:token:`s substituted wherever they appear, then
  * must resolve to an absolute path. Source tokens are remote WP-layout locations
@@ -73,9 +73,9 @@ class RemapResolveTest extends TestCase
         return $c;
     }
 
-    private function resolve($c, array ...$pairs): array
+    private function resolve($c, array ...$mappings): array
     {
-        return $this->call($c, 'resolve_remap', array($pairs));
+        return $this->call($c, 'resolve_remap', array($mappings));
     }
 
     private function assertRemapConsistent($c): void
@@ -91,7 +91,7 @@ class RemapResolveTest extends TestCase
     // --- resolution: SOURCE TARGET → one source => target rule -------------
 
     /**
-     * Each case resolves a single --remap pair and asserts the resulting rule.
+     * Each case resolves a single --remap mapping and asserts the resulting rule.
      * The expected target is given as a suffix appended to the (per-test) fs root.
      *
      * @dataProvider provideResolutionCases

--- a/tests/MySQLDumpProducer/EncodingTest.php
+++ b/tests/MySQLDumpProducer/EncodingTest.php
@@ -804,7 +804,7 @@ class EncodingTest extends MySQLDumpProducerTestBase
         $this->assertEquals(4, $count);
     }
 
-    public function testSurrogatePairs(): void
+    public function testSupplementaryPlaneCharacters(): void
     {
         $this->pdo->exec("
             CREATE TABLE surrogates (
@@ -817,7 +817,7 @@ class EncodingTest extends MySQLDumpProducerTestBase
             "INSERT INTO surrogates (content) VALUES (?)",
         );
 
-        // Characters outside BMP (require surrogate pairs in UTF-16)
+        // Characters outside BMP are encoded as two UTF-16 code units.
         $stmt->execute(["𝕳𝖊𝖑𝖑𝖔"]); // Mathematical alphanumeric symbols
         $stmt->execute(["🂡🂢🂣🂤"]); // Playing cards
         $stmt->execute(["𝄞𝄢𝄫"]); // Musical symbols

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2573,7 +2573,8 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Runs the production files-diff CLI for the same pair a push CLI used.
+     * Runs files-diff for the same remote Reprint API URL and state directory
+     * a push CLI used.
      *
      * @return array{exit:int,stdout:string,stderr:string,output:string}
      */
@@ -2631,7 +2632,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $initial['exit'], $initial['output']);
         $initial_result = $this->lastCliJsonLine($initial['stdout']);
         $this->assertSame('complete', $initial_result['status'] ?? null);
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $this->assertSame($initial_contents, file_get_contents($this->docroot . '/nested/multi-chunk.bin'));
         $this->assertSame('delete me later', file_get_contents($this->docroot . '/delete-later.txt'));
         $this->assertDirectoryExists($this->docroot . '/empty-directory');
@@ -2650,7 +2651,7 @@ final class PushEndpointsTest extends TestCase {
             JSON_THROW_ON_ERROR
         );
         $this->assertSame(
-            ['command', 'pair', 'status', 'phase', 'reason', 'detail', 'ts'],
+            ['command', 'status', 'phase', 'reason', 'detail', 'ts'],
             array_keys($progress)
         );
         $this->assertSame('complete', $progress['status']);
@@ -2664,9 +2665,7 @@ final class PushEndpointsTest extends TestCase {
             }
         ));
         $this->assertNotEmpty($files_push_lines);
-        foreach ($files_push_lines as $line) {
-            $this->assertStringContainsString('pair=' . $initial_result['pair'], $line);
-        }
+        $this->assertStringContainsString('COMPLETE files-push | phase=completing', $audit);
         preg_match_all('/PHASE files-push .* from=([^ ]+) \| to=([^ ]+)/', $audit, $phase_matches);
         $phase_transitions = array_map(
             static function (string $from, string $to): string {
@@ -2723,8 +2722,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $this->countEndpointRequests('push_upload'));
         $partial_audit = (string) file_get_contents($state_directory . '/audit.log');
         $this->assertStringContainsString(
-            'PARTIAL files-push | pair=' . $partial_result['pair']
-                . ' | phase=starting_plan | cause=time_limit',
+            'PARTIAL files-push | phase=starting_plan | cause=time_limit',
             $partial_audit
         );
 
@@ -2766,8 +2764,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('starting_plan', $interrupted_result['phase'] ?? null);
         $interrupted_audit = (string) file_get_contents($state_directory . '/audit.log');
         $this->assertStringContainsString(
-            'INTERRUPTED files-push | pair=' . $interrupted_result['pair']
-                . ' | phase=starting_plan | signal=' . SIGTERM,
+            'INTERRUPTED files-push | phase=starting_plan | signal=' . SIGTERM,
             $interrupted_audit
         );
 
@@ -2820,7 +2817,7 @@ final class PushEndpointsTest extends TestCase {
         }
 
         $this->assertNotSame(0, $killed['exit']);
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $active_state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($active_state);
         $this->waitForPushLockRelease($active_state['push_session_id']);
@@ -2839,7 +2836,7 @@ final class PushEndpointsTest extends TestCase {
         $state_directory = $this->root . '/cli-failed-state';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'value after failure');
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
@@ -2872,7 +2869,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($push_state_directory . '/sender.json');
         $failed_audit = (string) file_get_contents($state_directory . '/audit.log');
         $this->assertStringContainsString(
-            'FAILED files-push | pair=' . $failed_result['pair'],
+            'FAILED files-push | phase=' . $failed_result['phase']
+                . ' | reason=lock_acquisition_failure',
             $failed_audit
         );
 
@@ -2889,7 +2887,7 @@ final class PushEndpointsTest extends TestCase {
         $state_directory = $this->root . '/cli-restart-state';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'before');
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
@@ -2913,7 +2911,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $restart_audit = (string) file_get_contents($state_directory . '/audit.log');
         $this->assertStringContainsString(
-            'RESTART files-push | pair=' . $restart_result['pair'],
+            'RESTART files-push | phase=' . $restart_result['phase']
+                . ' | reason=local_path_changed',
             $restart_audit
         );
 
@@ -3016,14 +3015,9 @@ final class PushEndpointsTest extends TestCase {
         $this->fail('No JSON line was found in CLI output: ' . $output);
     }
 
-    private function filesPushStateDirectory(
-        string $local_docroot,
-        string $state_directory
-    ): string {
-        $canonical_local_docroot = realpath($local_docroot);
-        $this->assertIsString($canonical_local_docroot);
-        $pair = hash('sha256', rtrim($this->remote_reprint_api_url, '?&') . "\0" . $canonical_local_docroot);
-        return $state_directory . '/push/' . $pair;
+    private function filesPushStateDirectory(string $state_directory): string
+    {
+        return $state_directory . '/push/' . md5(rtrim($this->remote_reprint_api_url, '?&'));
     }
 
     /** @return array<string,mixed> */
@@ -3535,7 +3529,7 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Seeds the pair's previous local index.
+     * Seeds the previous local index for one remote Reprint API URL.
      */
     private function seedPreviousLocalIndex(string $push_state_directory, string $index_path): void
     {


### PR DESCRIPTION
Files-push now stores local state under
`<state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/`. The state
directory already belongs to one filesystem root, so the filesystem root does
not need to participate in the directory name.

The previous SHA-256 name hashed both the remote Reprint API URL and resolved
filesystem root, then exposed that hash in command output, `progress.json`, and
audit entries. `resolve_push_state_directory()` now returns the directory
directly, and those duplicate hash fields are gone. A different filesystem
root requires a different state directory. There is no compatibility alias or
migration.

Other ambiguous uses of the old term are replaced with the concrete thing each
value represents: mappings, two-argument options, durable phase boundaries,
and UTF-16 code units.

## Testing

There is no useful manual test for these renames. Rely on the files-push,
files-diff, CLI, remap, PHPStan, and PHP compatibility checks in CI.
