### PR TITLE
[Push] Store file indexes under target relationship directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 The pipeline proceeds as usual through indexing and diffing, but skips uploads. When the essential
 files are done, the sync marks itself **complete**. The skipped file list stays on disk at
-`.import-download-list-skipped.jsonl`. At this point you can apply the database and bring the site online.
+`remote-<hash>/pull-plan.skipped.jsonl`. At this point you can apply the
+database and bring the site online.
 
 ```bash
 # Step 2: download the uploads
@@ -647,11 +648,11 @@ stable JSON contract for host integrations:
 php reprint.phar import-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
 ```
 
-#### `.import-volatile-files.json` — files that changed during sync
+#### `remote-<hash>/pull-volatile-files.json` — files that changed during sync
 
 During `files-pull`, a file on the source may be modified while the importer is
 streaming it. When that happens, the server returns a different content hash than
-expected and the importer records the file in `.import-volatile-files.json`
+expected and the importer records the file in `pull-volatile-files.json`
 instead of failing.
 
 The file is a flat JSON object mapping paths to the number of times each file
@@ -679,7 +680,7 @@ truncated or rotated, so it provides a complete history of the migration.
 ```
 [2025-01-15 10:30:01] VOLATILE | path=/srv/htdocs/wp-content/debug.log | count=1
 [2025-01-15 10:30:05] VOLATILE CLEARED | path=/srv/htdocs/wp-content/debug.log
-[2025-01-15 10:31:12] FILE TRUNCATE | .import-index-updates.wal | WAL batch applied
+[2025-01-15 10:31:12] FILE TRUNCATE | remote-<hash>/pull-index-updates.wal | WAL batch applied
 ```
 
 Pass `--verbose` to also print audit log entries to the console as they happen.
@@ -710,17 +711,19 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 
 `files-pull`, `files-diff`, and `files-push` use one local index for each target
-URL and canonical local tree:
+URL in a state directory:
 
 ```text
-<state-dir>/local-index/<sha256(target URL with user-info and SECRET_KEY removed + NUL + canonical local tree)>.jsonl
+<state-dir>/remote-<sha256(target URL with user-info and SECRET_KEY removed)>/.local-index.jsonl
 ```
 
 URL user-info and `SECRET_KEY` do not affect the hash; changing any other query
-parameter selects a different local index and push-state directory.
+parameter selects a different local index and push-state directory. Use a
+different state directory for a different local document root.
 
-files-pull records each local path it changes through its existing index-update
-WAL, except paths skipped by the local indexer's default rules. Selected,
+files-pull records each local path it changes through
+`remote-<hash>/pull-index-updates.wal`, except paths skipped by the local
+indexer's default rules. Selected,
 filtered, remapped, and preserve-local pulls also refresh those paths'
 directory ancestors and remove descendants of deleted or replaced paths.
 Other branches remain unchanged. A completed files-push updates the index
@@ -730,7 +733,7 @@ after its target commit succeeds.
 `files-index`, `db-pull`, `db-index`, and `db-apply`. It clears that command's
 current sync state and exits. Aborting `files-pull`, `pull-files`, or `pull`
 while its files-pull stage is active applies any retained index-update WAL
-batch to the import index and local index, clears sync progress, and keeps
+batch to the remote index and local index, clears sync progress, and keeps
 downloaded files; the next run performs a delta sync. For `db-pull` and
 `db-index`, `--abort` clears the output file so the next run starts from
 scratch. Interrupted commands automatically resume from the last saved cursor.

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ truncated or rotated, so it provides a complete history of the migration.
 ```
 [2025-01-15 10:30:01] VOLATILE | path=/srv/htdocs/wp-content/debug.log | count=1
 [2025-01-15 10:30:05] VOLATILE CLEARED | path=/srv/htdocs/wp-content/debug.log
-[2025-01-15 10:31:12] FILE DELETE | .import-index-updates.jsonl
+[2025-01-15 10:31:12] FILE TRUNCATE | .import-index-updates.wal | WAL batch applied
 ```
 
 Pass `--verbose` to also print audit log entries to the console as they happen.
@@ -698,6 +698,8 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
+* `files-diff` — Reports the local paths that files-push would send or delete. Makes no network request.
+* `files-push` — Pushes one local file tree without database work, a plan display, or a confirmation prompt.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
@@ -707,4 +709,28 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 
-All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.
+`files-pull`, `files-diff`, and `files-push` use one local index for each target
+URL and canonical local tree:
+
+```text
+<state-dir>/local-index/<sha256(target URL with user-info and SECRET_KEY removed + NUL + canonical local tree)>.jsonl
+```
+
+URL user-info and `SECRET_KEY` do not affect the hash; changing any other query
+parameter selects a different local index and push-state directory.
+
+files-pull records each local path it changes through its existing index-update
+WAL, except paths skipped by the local indexer's default rules. Selected,
+filtered, remapped, and preserve-local pulls also refresh those paths'
+directory ancestors and remove descendants of deleted or replaced paths.
+Other branches remain unchanged. A completed files-push updates the index
+after its target commit succeeds.
+
+`--abort` is available for `pull`, `pull-files`, `pull-db`, `files-pull`,
+`files-index`, `db-pull`, `db-index`, and `db-apply`. It clears that command's
+current sync state and exits. Aborting `files-pull`, `pull-files`, or `pull`
+while its files-pull stage is active applies any retained index-update WAL
+batch to the import index and local index, clears sync progress, and keeps
+downloaded files; the next run performs a delta sync. For `db-pull` and
+`db-index`, `--abort` clears the output file so the next run starts from
+scratch. Interrupted commands automatically resume from the last saved cursor.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -77,19 +77,20 @@ managed `false` hard-disables push without abandoning durable commit recovery.
 ## Change detection: local machine compared against itself
 
 ctime is machine-local, so push never compares a local timestamp to a remote
-one. It compares current local paths with one local index for the target URL
-and canonical local tree. Database rows are compared with the previously pushed
-rows.
+one. It compares current local paths with one local index for the target URL in
+the caller-selected state directory. Database rows are compared with the
+previously pushed rows.
 
 The local index lives at:
 
 ```text
-<state-dir>/local-index/<sha256(target URL with user-info and SECRET_KEY removed + NUL + canonical local tree)>.jsonl
+<state-dir>/remote-<sha256(target URL with user-info and SECRET_KEY removed)>/.local-index.jsonl
 ```
 
 The hash omits URL user-info and `SECRET_KEY`, so pull URL authentication and
 push's `--secret` select the same local index. Changing any other query
-parameter selects a different local index and push-state directory.
+parameter selects a different local index and push-state directory. A different
+local document root uses a different state directory.
 
 Entries for actual pulled or pushed paths record the locally observed type,
 size, and ctime. Remote values cannot stand in for these fields because ctime
@@ -100,14 +101,15 @@ changes, files-diff reads the index, and files-push updates it after the target
 commit succeeds. Paths skipped by the local indexer's default rules do not
 enter the local index.
 
-files-pull writes each import-index update batch to the existing
-`.import-index-updates.wal`. A record for an actual local mutation also carries
-the resulting local path and, for an F record, its local type, size, and ctime.
-The importer applies the batch to the import index, derives local-index updates
-from those mutation records, then applies them to the local index. An F update
-also adds its directory ancestors. A D update removes the path and its
-descendants. The importer clears the WAL batch only after both index updates
-finish.
+files-pull writes each completed operation to
+`remote-<hash>/pull-index-updates.wal`. Each record carries the
+`remote_path_b64` projection for `.remote-index.jsonl`. A record for an actual
+local mutation also carries the `local_path_b64` projection and, for an F
+record, separate remote and local type, size, and ctime fields. The importer
+applies the remote projection, derives local-index updates from the local
+projection, then applies them to `.local-index.jsonl`. An F update also adds
+its directory ancestors. A D update removes the path and its descendants. The
+importer clears the WAL batch only after both index replacements finish.
 
 A selected, filtered, remapped, or preserve-local pull updates only local paths
 it actually changes, their directory ancestors, and descendants removed by a
@@ -117,10 +119,10 @@ to a path changed by pull also remains pending because the F record contains
 the type, size, and ctime observed immediately after that pull mutation.
 Directory emptiness comes from descendants retained by the local-index merge.
 
-An interruption leaves `.import-index-updates.wal`, so files-diff and
+An interruption leaves `pull-index-updates.wal`, so files-diff and
 files-push do not read the local index while the files-pull lifecycle is
 unfinished. Resuming files-pull applies any retained batch before continuing.
-Aborting files-pull replays the current WAL batch into the import index and
+Aborting files-pull replays the current WAL batch into the remote index and
 local index, then clears pull progress and the WAL marker while keeping the
 local index and downloaded files.
 files-pull also refuses to start while the same target and local tree have an
@@ -312,8 +314,13 @@ regardless of their target URL or local tree.
 The local index and active push files use the same target/local-tree hash:
 
 ```text
-<state-dir>/local-index/<hash>.jsonl  local index
-<state-dir>/push/<hash>/
+<state-dir>/remote-<hash>/
+  .remote-index.jsonl                 target-observed index
+  .remote-index.next.jsonl            next target index
+  .local-index.jsonl                  locally accounted index
+  pull-plan.jsonl                     files pending download
+  pull-index-updates.wal              completed pull operations
+  push/
   excluded_paths.json                 sender-owned target exclusions
   sender.json                         active push state
   plan/
@@ -448,15 +455,17 @@ The command uses this digest to name its local index and sender directory,
 without general URL normalization:
 
 ```text
-sha256(<target-url-without-authentication> + "\0" + <canonical-local-tree-path>)
+sha256(<target-url-without-authentication>)
 ```
 
-The local index is `<state-dir>/local-index/<hash>.jsonl`; sender state lives at
-`<state-dir>/push/<hash>/`. A different target query or canonical local tree
-therefore selects a different local index and sender directory. The hash omits
-URL user-info and `SECRET_KEY`; files-push rejects both and receives its secret
-through `--secret`. Fragments are rejected. The local push state directory must
-be outside the local tree so planning cannot index its own changing files.
+The local index is
+`<state-dir>/remote-<hash>/.local-index.jsonl`; sender state lives at
+`<state-dir>/remote-<hash>/push/`. A different target query selects a different
+remote state directory. A different local tree uses a different state
+directory. The hash omits URL user-info and `SECRET_KEY`; files-push rejects
+both and receives its secret through `--secret`. Fragments are rejected. The
+local push state directory must be outside the local tree so planning cannot
+index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -7,9 +7,10 @@ the end maps it to a PR stack.
 
 ## Shape of a push
 
-1. The local machine knows what changed locally since its last push to this
-   remote (files, deletions, database rows), by comparing against the local
-   paths and rows stored after that push.
+1. The local machine compares the current tree with its local index. Each
+   pulled path mutation and committed push operation updates the matching
+   local-index entries. Database rows are compared with the previously pushed
+   rows.
 2. It shows a summary of local uploads and deletions. The user confirms that
    local should win for those paths and rows.
 3. It transfers everything into a private push directory on the remote — file bytes,
@@ -19,10 +20,9 @@ the end maps it to a PR stack.
    moves work files into place, executes deletions, and commits the database
    diff, and fixes symlinks — inside a maintenance window that lasts seconds,
    not the length of the transfer.
-5. It stores the current local paths as the pair's previous local index
-   and stores the current rows as the previously pushed rows. The push is
-   complete only after this step; a crashed push is
-   re-driven from the top and converges.
+5. It applies the committed path operations to the local index and stores the
+   current rows as the previously pushed rows. The push is complete only after
+   this step; a crashed push is re-driven from the top and converges.
 
 Both sides act only when the local machine calls: no worker, no polling, no
 sessions. The remote is a passive authenticated API.
@@ -77,92 +77,118 @@ managed `false` hard-disables push without abandoning durable commit recovery.
 ## Change detection: local machine compared against itself
 
 ctime is machine-local, so push never compares a local timestamp to a remote
-one. It only answers "what changed locally since my last successful push to
-this remote" by comparing the current local paths and rows against the pair's
-previous local index and the previously pushed rows.
+one. It compares current local paths with one local index for the target URL
+and canonical local tree. Database rows are compared with the previously pushed
+rows.
 
-The local machine keeps these files **per target URL and canonical local
-tree**, overwritten after each successful commit:
+The local index lives at:
 
-    <state-dir>/push/<pair-key>/previous_local_index.jsonl
-    <state-dir>/push/<pair-key>/previously_pushed_rows.jsonl   (phase two)
+```text
+<state-dir>/local-index/<sha256(target URL with user-info and SECRET_KEY removed + NUL + canonical local tree)>.jsonl
+```
 
-The previous local index records the local path type, size, and ctime as the
-completing push observed them. Besides planning the next push, it feeds the
-local `files-diff` command, which reports the same comparison without pushing.
+The hash omits URL user-info and `SECRET_KEY`, so pull URL authentication and
+push's `--secret` select the same local index. Changing any other query
+parameter selects a different local index and push-state directory.
 
-`PushPlan` first builds a path-sorted fresh local index, then derives the local
-paths to push and delete by diffing it against the previous local index its
-caller supplies. The indexer marks physical emptiness while
-it observes each directory, so a completed index distinguishes empty
-directories from non-empty ones. Files and symlinks change when their `type`,
-`ctime`, or `size` changes; unrelated index values do not select a path for
-upload.
+Entries for actual pulled or pushed paths record the locally observed type,
+size, and ctime. Remote values cannot stand in for these fields because ctime
+belongs to the machine where it was observed. The merge adds directory
+ancestors with type `dir` and zero size and ctime, then derives their `empty`
+field from the retained descendants. files-pull records the local paths it
+changes, files-diff reads the index, and files-push updates it after the target
+commit succeeds. Paths skipped by the local indexer's default rules do not
+enter the local index.
 
-The index reader trusts the indexer's entry values. It handles only failures to
-read a line, decode its JSON, or decode its base64 path. This keeps schema
-ownership with the indexer instead of partially validating the same index entry in
-the push plan.
+files-pull writes each import-index update batch to the existing
+`.import-index-updates.wal`. A record for an actual local mutation also carries
+the resulting local path and, for an F record, its local type, size, and ctime.
+The importer applies the batch to the import index, derives local-index updates
+from those mutation records, then applies them to the local index. An F update
+also adds its directory ancestors. A D update removes the path and its
+descendants. The importer clears the WAL batch only after both index updates
+finish.
+
+A selected, filtered, remapped, or preserve-local pull updates only local paths
+it actually changes, their directory ancestors, and descendants removed by a
+deletion or type replacement. Other branches remain untouched, so local
+additions, edits, and deletions elsewhere remain pending. A later local edit
+to a path changed by pull also remains pending because the F record contains
+the type, size, and ctime observed immediately after that pull mutation.
+Directory emptiness comes from descendants retained by the local-index merge.
+
+An interruption leaves `.import-index-updates.wal`, so files-diff and
+files-push do not read the local index while the files-pull lifecycle is
+unfinished. Resuming files-pull applies any retained batch before continuing.
+Aborting files-pull replays the current WAL batch into the import index and
+local index, then clears pull progress and the WAL marker while keeping the
+local index and downloaded files.
+files-pull also refuses to start while the same target and local tree have an
+unfinished files-push, so the local index cannot change while PushPlan is
+between processes.
+
+`PushPlan` builds a path-sorted fresh local index and diffs it against the
+local index at the path supplied by its caller. The indexer marks physical
+emptiness while it observes each directory, so a completed index distinguishes
+empty directories from non-empty ones. Files and symlinks change when their
+`type`, `ctime`, or `size` changes; unrelated index values do not select a path
+for upload. The index reader trusts the indexer's entry values rather than
+revalidating the same serialized record.
 
 A push plan is an internal part of the sender lifecycle:
 
 1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
-   100 target exclusions, which the sender stores once in
-   `excluded_paths.json` after creating the active `plan/` directory.
-2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
-   `plan/excluded_paths.json`, then opens
-   `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
-   step advances one traversal event, appends its JSONL entries when applicable,
-   flushes those bytes, and then updates its traversal cursor and committed byte
-   offset. The sender stores that cursor in `sender.json` before returning
-   from its step.
-3. Once traversal is complete, the plan enters `starting_diff`. The next step
-   starts the index diff and enters `diffing`.
-4. Each later `next_step()` compares at most one path represented by either
-   index. It returns true while another planning step remains and false when
-   both indexes reach EOF. It
-   writes files, symlinks, and empty directories with their planned type, size,
-   and ctime to
-   `plan/local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
+   100 target exclusions, which the sender stores in `excluded_paths.json`.
+2. The sender starts PushPlan with the local index path and sender-owned
+   exclusions, opens `plan/fresh_local_index.jsonl`, and starts one
+   `FileIndexProcessor`.
+3. Each `indexing` step advances one traversal event, appends its JSONL entry
+   when applicable, flushes those bytes, and updates the traversal cursor and
+   committed byte offset. Once traversal completes, a separate step starts the
+   index diff.
+4. Each `diffing` step compares at most one path from the fresh index or local
+   index. It writes files, symlinks, and empty directories to
+   `plan/local_paths_to_push.jsonl` and raw NUL-delimited paths to
    `plan/local_paths_to_delete`.
-5. The sender closes the plan before consuming those two files.
-6. After the receiver commits successfully, the sender saves the retained fresh
-   local index as `previous_local_index.jsonl` through the same swap-file
-   copy. It then removes the complete `plan/` directory and the sender-owned
-   exclusions file. After the target
-   confirms removal of a discarded push session, the sender removes the same
-   files without changing the pair's previous local index.
+5. The sender closes the completed plan before it consumes those two files.
+6. After the receiver commit succeeds, the sender writes
+   `plan/local_index_updates.jsonl` from the committed push and delete lists and
+   applies those updates to the local index. The merge adds directory ancestors
+   for each F update and removes the path and its descendants for each D update.
+   If the index does not exist, the same atomic merge creates it. Finally the
+   sender removes the plan directory and sender-owned exclusions file.
 
 Until the sender stores the initial PushPlan cursor, `starting_plan` remains
-the durable phase. An interrupted start is repeated and overwrites its initial
-plan files. After each later plan step, changed files are flushed before the
-sender atomically stores the returned cursor in `sender.json`.
+the durable phase. An interrupted start overwrites the initial plan files.
+After each later plan step, changed files are flushed before the sender
+atomically stores the returned cursor in `sender.json`.
 
-The completed-index copy after commit is a deliberate exception to bounded
-sender steps. A
-representative index entry is about 150 bytes, so one million paths produce
-roughly 150 MB, which takes about 15 seconds even at 10 MiB/s. PHP `copy()`
-streams the index without loading it into memory, and only the final rename
-moves the completed copy into place. This accepts that a 1 MiB/s drive reaches
-30 seconds at roughly 200,000 paths. A stopped copy is repeated by the next
-sender run. Keeping another cursor and retained handle for this post-commit copy
-is not justified until measurements from materially larger installations show
-that it matters.
+The post-commit local-index update is a deliberate exception to bounded sender
+steps. A representative index entry is about 150 bytes, so one million paths
+produce roughly 150 MB, which takes about 15 seconds even at 10 MiB/s. The
+update streams without loading the complete index into memory, and only the
+final rename publishes its output. This accepts that a 1 MiB/s drive reaches
+30 seconds at roughly 200,000 paths. An interrupted merge is repeated by the
+next sender run. Another cursor and retained handle for this full-index
+operation are not justified until measurements from materially larger
+installations show that they matter.
 
-The cursor contains the plan directory, local tree root, previous local
-index, and current planning position. During indexing, that
-position contains the `FileIndexProcessor` cursor and committed fresh-index byte
-offset. During diffing, each step flushes only the path list or append-only
-deleted-directory stack changed by that step before updating the two index
-offsets, two output byte offsets, and active stack byte offset. Each stack entry
-links to the preceding active directory, so continuation reads only the top
-entry. A later process passes the stored cursor to `PushPlan::resume()`. The
-plan uses its private exclusions copy, discards bytes beyond the stored output
-offsets, and continues from the retained internal phase.
+During indexing, the PushPlan cursor contains the `FileIndexProcessor` cursor
+and committed fresh-index byte offset. During diffing,
+`byte_offset_in_local_index` records where reading the local index continues;
+the cursor also holds the fresh-index offset, both output byte offsets, and
+`deleted_directory_path_b64` while descendants of one deleted directory need
+no separate deletion. A later process passes the plan directory, local tree,
+local index path, excluded paths file, and stored cursor to
+`PushPlan::resume()`. Resume discards bytes beyond the stored output offsets
+and continues from that cursor.
 
-The first push to a site has no previous local index or previously
-pushed rows. Every current file, symlink, and empty directory is selected, and
-no local deletion can be detected yet.
+The first push without a local index selects every indexed current file,
+symlink, and empty directory, and no local deletion can be detected yet. Paths
+which the indexer skips by default, such as caches, VCS metadata, and
+`node_modules`, are absent from the fresh index and are not selected. After the
+target commit succeeds, only paths which the target committed enter the local
+index.
 
 Push is intentionally local-wins. If a developer edited the remote site
 outside Reprint, a later push of the same path or row overwrites that remote
@@ -171,11 +197,11 @@ manager.
 
 ## Deletes
 
-Local deletions since the last push come from paths present in
-the previous local index but absent from the fresh local index. They
-travel as NUL-delimited document-root-relative paths in `work/deletes`. Commit
-records its byte offset before and after every destructive mutation, so a later
-request can resume from a durable checkpoint instead of repeating a delete.
+A local deletion is a path present in the local index but absent from the fresh
+local index. Deletions travel as NUL-delimited document-root-relative paths in
+`work/deletes`. Commit records its byte offset before and after every
+destructive mutation, so a later request can resume from a durable checkpoint
+instead of repeating a delete.
 
 ## The push session
 
@@ -274,26 +300,27 @@ configuration; request parameters cannot select any of them.
 
 `PushFilesSender` joins the durable `PushPlan` to the receiver's push session.
 Every local Reprint command workflow runs under `<state-dir>/.reprint.lock`.
-The production CLI acquires this non-blocking lock before it prepares pair
-context, constructs `ImportClient`, or writes the command audit entry. It
-passes the open lock to `ImportClient::run()` and releases it after the command.
+The production CLI acquires this non-blocking lock before it prepares the files
+command context, constructs `ImportClient`, or writes the command audit entry.
+It passes the open lock to `ImportClient::run()` and releases it after the
+command.
 A direct `ImportClient::run()` call acquires the lock when its caller supplies
 none. The one state-directory-wide Reprint process lock prevents concurrent
 pull, push, diff, and other local Reprint processes from using that site state,
-regardless of their target or local-tree pair.
+regardless of their target URL or local tree.
 
-An active push keeps these files under `<state-dir>/push/<pair-key>/`:
+The local index and active push files use the same target/local-tree hash:
 
 ```text
-previous_local_index.jsonl          index saved after the previous commit
-excluded_paths.json                 sender-owned target exclusions
-sender.json                         active push state
-plan/
-  excluded_paths.json               target exclusions for the active push
-  fresh_local_index.jsonl           plan-owned fresh local index
-  local_paths_to_push.jsonl         local paths to push
-  local_paths_to_delete             raw NUL-delimited local paths to delete
-  deleted_directories_stack.jsonl   append-only planning stack
+<state-dir>/local-index/<hash>.jsonl  local index
+<state-dir>/push/<hash>/
+  excluded_paths.json                 sender-owned target exclusions
+  sender.json                         active push state
+  plan/
+    fresh_local_index.jsonl           plan-owned fresh local index
+    local_paths_to_push.jsonl         local paths to push
+    local_paths_to_delete             raw NUL-delimited local paths to delete
+    local_index_updates.jsonl         committed updates, created after commit
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.
@@ -336,15 +363,16 @@ and phase, the PushPlan cursor, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
 sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_previous_local_index`, `completing`, `removing`, and
+`updating_local_index`, `completing`, `removing`, and
 `discarding_plan`.
-The separate start, index-save, completion, removal, and discard phases ensure
-that a process stop between durable actions repeats only the current action.
-During `planning`, the PushPlan cursor in `sender.json` contains the
-plan's internal phase and continuation offsets. A completed cursor remains until
-the local index is saved, or until the target confirms removal. The sender then
-clears the cursor, enters `completing` or `discarding_plan`, and removes the
-active plan files without reopening PushPlan.
+The separate start, local-index update, completion, removal, and discard
+phases ensure that a process stop between durable actions repeats only the
+current action. During `planning`, the PushPlan cursor in `sender.json`
+contains the plan's internal phase and continuation offsets. A completed cursor
+remains until the committed operations are applied to the local index, or until
+the target confirms removal. The sender then clears the cursor, enters
+`completing` or `discarding_plan`, and removes the active plan files without
+reopening PushPlan.
 
 Each local path to push carries the type, size, and ctime from the index used to
 plan it. When the receiver position is unknown, the sender compares the live
@@ -374,10 +402,12 @@ captured by the completed fresh local index rather than attempting to describe
 the live tree at commit time.
 
 Repeated `push_commit` calls drive the receiver to `complete`. Only then does
-the sender enter `saving_previous_local_index` and copy the plan-owned
-fresh local index to `previous_local_index.jsonl`. Excluded entries
-remain in that complete index; exclusions suppress remote work rather than
-creating a second retained index representation. The sender then removes the
+the sender enter `updating_local_index`. It writes F/D updates from the
+committed push and delete lists to `plan/local_index_updates.jsonl`, then
+applies them to the local index. The merge adds directory ancestors for
+each F update and removes the path and its descendants for each D update.
+Other branches remain unchanged. Target-excluded paths do not enter the local
+index because the target did not commit them. The sender then removes the
 entire plan directory before deleting active sender state.
 
 Each local-path upload or deletion step sends at most one multipart part. A file
@@ -414,17 +444,19 @@ write `.import-state.json`, show a plan, ask for confirmation, transfer a
 database, retry a failed request, or start a replacement sender after a
 `restart` outcome.
 
-The command derives one pair key without general URL normalization:
+The command uses this digest to name its local index and sender directory,
+without general URL normalization:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
+sha256(<target-url-without-authentication> + "\0" + <canonical-local-tree-path>)
 ```
 
-Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
-query or canonical local tree therefore selects a different retained local
-index. Fragments, URL user-info, and `SECRET_KEY` target parameters are
-rejected. The local push state directory must be outside the local tree so
-planning cannot index its own changing files.
+The local index is `<state-dir>/local-index/<hash>.jsonl`; sender state lives at
+`<state-dir>/push/<hash>/`. A different target query or canonical local tree
+therefore selects a different local index and sender directory. The hash omits
+URL user-info and `SECRET_KEY`; files-push rejects both and receives its secret
+through `--secret`. Fragments are rejected. The local push state directory must
+be outside the local tree so planning cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80
@@ -432,7 +464,7 @@ percent of PHP's finite `max_execution_time`; zero is unlimited. With a finite
 `memory_limit`, another step begins only when current allocated PHP memory plus
 the same 4 MiB file chunk passed to the sender remains below 80 percent of the
 limit. These checks happen between steps. An active network step that keeps
-moving bytes, and the completed-index copy, may run past the deadline.
+moving bytes and the post-commit local-index merge may run past the deadline.
 
 A planned pause or first handled SIGINT or SIGTERM calls `cancel()` while the
 sender still reports `continue`, then calls `close()`. A first handled signal
@@ -444,23 +476,36 @@ continues through the same hard-death contract used after SIGKILL.
 The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
 `restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
 same command again. After `restart`, that next run builds a fresh plan. The
-shared audit log records opening mode, phase changes, planned pauses, handled
-interruptions, and terminal outcomes with the pair key. The flat status file
-records only the command, pair, outcome, phase, reason, detail, and timestamp;
+audit log records opening mode, phase changes, planned pauses, handled
+interruptions, and terminal outcomes. The flat status file records only the
+command, outcome, phase, reason, detail, and timestamp;
 neither file copies receiver cursors or tentative upload positions.
 
 ## Local files-diff command
 
 `reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR` reports a local
 minimized push operation plan before target exclusions: the local paths a
-files-push would send or delete, compared against the pair's previous local
-index published by a completed files-push. It uses the files-push pair-key
-formula, including its trailing `?` and `&` trim, so another URL query or
-local tree cannot reuse the index. It accepts only `--state-dir` and
+files-push would send or delete, compared against the local index which
+files-pull and committed files-push operations both update. `<target-url>` uses
+the same exporter endpoint path and query as files-pull but omits URL user-info
+and `SECRET_KEY`. When `pull-files` received a bare site URL, include the
+`site-export-api` query which it added.
+`--fs-root` names the canonical document-root tree later supplied to
+files-push rather than the raw directory which held remote absolute paths
+during files-pull. It uses the same target URL and canonical-local-tree digest
+as files-push, so another non-authentication query or local tree cannot reuse
+the index. It accepts only `--state-dir` and
 `--fs-root`; it needs no secret, performs no preflight, and makes no network
-request. It runs one complete PushPlan against `previous_local_index.jsonl` in
+request. It runs one complete PushPlan against the local index in
 `files-diff-plan/` while the command holds the state-directory-wide Reprint
 process lock.
+
+To refresh the index from the pull side, note that a completed standalone
+files-pull does not start a fresh lifecycle when it is run again: run it with
+`--abort`, then run it once more. A completed `pull-files` starts a fresh
+pipeline when it is run again. Completing files-pull creates the local index if
+it is missing. Each applied WAL batch updates only the paths that pull changed,
+so local additions, edits, and deletions left elsewhere stay in the diff.
 
 Output is JSONL. Each selected current file, symlink, or empty directory has
 `action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,
@@ -506,8 +551,8 @@ Order:
    `commit.json` checkpoint written before each document-root mutation. The
    future database batch and symlink updates follow the same bounded cursor.
 4. **Maintenance off:** commit releases its `commit-state` ownership after
-   completion; the driver saves the pair's previous local index and rows
-   after commit completes.
+   completion; the driver applies committed path operations to the local index
+   and saves the rows after commit completes.
 
 If the driver dies mid-commit: WordPress stops honoring the `.maintenance`
 file after 10 minutes on its own, and the next commit request resumes from
@@ -599,7 +644,7 @@ Files first, database second, each PR small and stacked in this order:
     one sender per process, applies caller time and memory admission budgets,
     and reports completion, continuation, restart, or failure without retrying.
 12. **`reprint files-diff`** — a local-only command that reports the paths a
-    files-push would send or delete against the pair's previous local index,
+    files-push would send or delete against the local index,
     without contacting the target.
 13. **`reprint push`** — the high-level command that adds a change summary,
     confirmation boundary, database work, transfer, commit, and resume.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -104,27 +104,45 @@ lock is separate from the receiver's push-session and commit locks.
 ## Pull index-update WAL
 
 Call the single pull-side write-ahead log the **index-update WAL**. It lives at
-`<state-dir>/.import-index-updates.wal`; use `.import-index-updates.wal`,
+`<state-dir>/remote-<hash>/pull-index-updates.wal`; use
+`pull-index-updates.wal`,
 `$index_update_wal_path`, and `$index_update_wal_handle`.
 Applied batch records are cleared, but the empty WAL remains as a marker until
 files-pull completes. A retained WAL is consumed only while resuming or
 aborting the interrupted files-pull, including through a high-level pull
 command; unrelated commands do not consume it.
 
+Each WAL record has an `op` of `F` or `D` and a
+`remote_path_b64`. F records also have `remote_type`, `remote_size`, and
+`remote_ctime`. A completed local mutation adds `local_path_b64`; its F record
+also has `local_type`, `local_size`, and `local_ctime`. Replay applies the
+remote projection to `.remote-index.jsonl`, then applies the local projection
+to `.local-index.jsonl`. The WAL is cleared only after both replacements
+succeed.
+
 ## Local index and push state
 
-The local index for one target URL and canonical local tree lives at:
+One target URL in a state directory uses:
 
 ```text
-<state-dir>/local-index/<sha256(target URL with user-info and SECRET_KEY removed + NUL + canonical local tree)>.jsonl
+<state-dir>/remote-<sha256(target URL with user-info and SECRET_KEY removed)>/
+  .remote-index.jsonl
+  .remote-index.next.jsonl
+  .local-index.jsonl
+  pull-plan.jsonl
+  pull-index-updates.wal
+  push/
 ```
 
 The hash omits URL user-info and `SECRET_KEY`; changing any other query
-parameter selects a different local index and push-state directory.
+parameter selects a different remote state directory. A different local
+document root uses a different state directory.
 
-Use `local_index_path`, `$local_index_path`, and `local index`. The same hash names
-the sender directory under `<state-dir>/push/<hash>/`. The hash is only a
-directory and file name; it is not part of the command result or sender cursor.
+Use `remote_state_directory`, `$remote_state_directory`, and `remote state
+directory` for `remote-<hash>/`. Use `local_index_path`, `$local_index_path`,
+and `local index` for `.local-index.jsonl`. The local push state directory is
+`remote-<hash>/push/`. The hash is only a directory name; it is not part of
+the command result or sender cursor.
 
 Use these names verbatim:
 
@@ -153,19 +171,19 @@ PushPlan with the local index path and sender-owned excluded paths.
 inside `plan/`.
 
 Completing files-pull creates the local index when it is missing. Each actual
-local mutation is recorded in the existing `.import-index-updates.wal` with the
-local path and, for an F record, the local path type, size, and ctime observed
-after the mutation. Applying a WAL batch first updates the import index, then
-applies those local mutation records to the local index. An F update also adds
-its directory ancestors. A D update removes the path and its descendants.
+local mutation is recorded in `pull-index-updates.wal` with the local path and,
+for an F record, the local path type, size, and ctime observed after the
+mutation. Applying a WAL batch first updates the remote index, then applies
+those local mutation records to the local index. An F update also adds its
+directory ancestors. A D update removes the path and its descendants.
 Default-skipped paths do not enter the local index. The WAL batch is cleared
-only after both index updates finish.
+only after both index replacements finish.
 
 Selected, filtered, remapped, and preserve-local pulls update only paths they
 actually change, their directory ancestors, and descendants removed by a
 deletion or type replacement. Other branches remain unchanged, so local
 additions, edits, and deletions elsewhere remain pending. Aborting files-pull
-replays the current WAL batch into the import index and local index before it
+replays the current WAL batch into the remote index and local index before it
 clears pull progress and keeps the local index. Resuming or aborting files-pull
 is the only way to consume its retained WAL. files-pull refuses to start while
 the same target and local tree have an unfinished files-push, so the local
@@ -261,14 +279,14 @@ plain-HTTP opt-in.
 The same SHA-256 digest names the local index and local push state directory:
 
 ```text
-sha256(<target-url-without-authentication> + "\0" + <canonical-local-tree-path>)
+sha256(<target-url-without-authentication>)
 ```
 
-The local index is `<state-dir>/local-index/<hash>.jsonl`, and the `local push
-state directory` is `<state-dir>/push/<hash>/`. `files-push`
+The local index is `<state-dir>/remote-<hash>/.local-index.jsonl`, and the
+`local push state directory` is `<state-dir>/remote-<hash>/push/`. `files-push`
 chooses `start` or `resume` only from whether `sender.json` exists there. The
 hash omits URL user-info and `SECRET_KEY`; files-push receives its secret
-through `--secret`.
+through `--secret`. A different local tree uses a different state directory.
 receiver-confirmed upload positions remain receiver-owned; they are not a
 files-push cursor and are not copied into `.import-state.json` or
 `.import-status.json`.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -90,11 +90,12 @@ Every local Reprint command workflow runs under the **Reprint process lock** at
 `<state-dir>/.reprint.lock`. Use `.reprint.lock` and `$process_lock`. The lock
 is non-blocking and state-directory-wide: pull, push, diff, and other local
 Reprint processes cannot run concurrently against the same state directory,
-even when their target or local-tree pairs differ.
+even when they use different target URLs or local trees.
 
-The production CLI acquires the Reprint process lock before it prepares pair
-context, constructs `ImportClient`, or writes the command audit entry. It
-passes the open lock to `ImportClient::run()` and releases it after the command.
+The production CLI acquires the Reprint process lock before it prepares the
+files command context, constructs `ImportClient`, or writes the command audit
+entry. It passes the open lock to `ImportClient::run()` and releases it after
+the command.
 A direct `ImportClient::run()` call acquires the lock when its caller supplies
 none. `PushFilesSender::start()` and `PushFilesSender::resume()` receive that
 open lock from the caller; sender `close()` does not release it. This local
@@ -110,59 +111,92 @@ files-pull completes. A retained WAL is consumed only while resuming or
 aborting the interrupted files-pull, including through a high-level pull
 command; unrelated commands do not consume it.
 
-## Local push state
+## Local index and push state
 
-The local machine keeps planning and active state outside the receiver push
-directory. Under `<state-dir>/push/<pair-key>/`, use these names verbatim:
+The local index for one target URL and canonical local tree lives at:
+
+```text
+<state-dir>/local-index/<sha256(target URL with user-info and SECRET_KEY removed + NUL + canonical local tree)>.jsonl
+```
+
+The hash omits URL user-info and `SECRET_KEY`; changing any other query
+parameter selects a different local index and push-state directory.
+
+Use `local_index_path`, `$local_index_path`, and `local index`. The same hash names
+the sender directory under `<state-dir>/push/<hash>/`. The hash is only a
+directory and file name; it is not part of the command result or sender cursor.
+
+Use these names verbatim:
 
 | Surface | Name |
 | --- | --- |
+| Local index path | `local_index_path`, `$local_index_path` |
 | Active plan directory | `plan`, `$plan_directory` |
 | Plan-owned fresh local index | `fresh_local_index.jsonl`, `$fresh_local_index` |
-| Previous local index | `previous_local_index.jsonl`, `previous_local_index`, `$previous_local_index` |
-| Byte offset in the previous local index | `byte_offset_in_previous_local_index`, `$byte_offset_in_previous_local_index` |
+| Byte offset in the local index | `byte_offset_in_local_index`, `$byte_offset_in_local_index` |
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
 | Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
 | PushPlan cursor | `push_plan_cursor`, `$push_plan_cursor`, `get_cursor()` |
 | Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
-| Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
+| Deleted directory path | `deleted_directory_path_b64`, `$deleted_directory_path` |
 | Active state | `sender.json`, `$state_path` |
+| Plan-owned committed local-index updates | `plan/local_index_updates.jsonl` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`sender.json`, `excluded_paths.json`, and
-`previous_local_index.jsonl` live directly under the local push state
-directory. The sender creates `plan/` for one active plan. PushPlan copies the
-sender-owned exclusions to `plan/excluded_paths.json` when it starts.
+`sender.json` and `excluded_paths.json` live directly under the local push
+state directory. The sender creates `plan/` for one active plan and starts
+PushPlan with the local index path and sender-owned excluded paths.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
-`local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
+`local_paths_to_delete`, and the post-commit `local_index_updates.jsonl` live
+inside `plan/`.
 
-The **previous local index** describes the local tree as the pair's last
-completed push observed it. The sender saves it after a successful commit, and
-`files-diff` reads it. PushPlan diffs its fresh local index against the copy
-its caller supplies. `byte_offset_in_previous_local_index` is the position
-from which its current lookahead entry is read again after resume.
+Completing files-pull creates the local index when it is missing. Each actual
+local mutation is recorded in the existing `.import-index-updates.wal` with the
+local path and, for an F record, the local path type, size, and ctime observed
+after the mutation. Applying a WAL batch first updates the import index, then
+applies those local mutation records to the local index. An F update also adds
+its directory ancestors. A D update removes the path and its descendants.
+Default-skipped paths do not enter the local index. The WAL batch is cleared
+only after both index updates finish.
 
-The PushPlan cursor is stored in `sender.json`. It contains the plan
-directory, local tree root, previous local index, and current
-planning position. During `indexing`, that position contains the
-FileIndexProcessor cursor and the committed byte offset in
+Selected, filtered, remapped, and preserve-local pulls update only paths they
+actually change, their directory ancestors, and descendants removed by a
+deletion or type replacement. Other branches remain unchanged, so local
+additions, edits, and deletions elsewhere remain pending. Aborting files-pull
+replays the current WAL batch into the import index and local index before it
+clears pull progress and keeps the local index. Resuming or aborting files-pull
+is the only way to consume its retained WAL. files-pull refuses to start while
+the same target and local tree have an unfinished files-push, so the local
+index cannot change while PushPlan is between processes.
+
+files-diff reads the local index without changing it. PushPlan diffs its fresh
+local index directly against that local index.
+`byte_offset_in_local_index` is the position from which PushPlan reads its
+current local-index lookahead entry again after resume.
+
+The PushPlan cursor is stored in `sender.json`. During `indexing`, it contains
+the FileIndexProcessor cursor and the committed byte offset in
 `fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
-output offsets, and the active byte offset in
-`deleted_directories_stack.jsonl`. The stack file is append-only; each entry
-links to the preceding active directory. The exclusions have a maximum of 100
-paths. `sender.json` phases are `creating`, `starting_plan`,
+output offsets, and `deleted_directory_path_b64` while descendants of one
+deleted directory need no separate deletion. The exclusions have a maximum of
+100 paths. `sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_previous_local_index`, `completing`,
+`updating_local_index`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
-completes before local paths are sent. The index copy after a successful commit
-has no separate copy cursor and is repeated after interruption. After the index
-is saved or the target confirms removal, the sender clears the PushPlan
-cursor, then removes the entire plan directory and its exclusions file. It
-does not ask PushPlan to manage terminal cleanup; PushPlan only closes its open
-handles.
+completes before local paths are sent. After a successful commit, the sender
+writes `plan/local_index_updates.jsonl` from the committed path lists and
+applies it to the local index. The merge adds directory ancestors for each F
+update and removes the path and its descendants for each D update. If the local
+index does not exist, the same atomic merge creates it. Paths excluded by the
+target do not enter the local index. The post-commit update has no separate
+cursor and is repeated after interruption.
+After the updates are applied or the target confirms removal,
+the sender clears the PushPlan cursor, then removes the entire plan directory
+and the sender-owned excluded paths file. It does not ask PushPlan to manage
+terminal cleanup; PushPlan only closes its open handles.
 
 A request failure ends the current sender run. The active state remains in
 place so a later push command can resume from the last durable boundary. Only
@@ -193,10 +227,14 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `target URL`, `local tree`, `pair
-key`, and `local push state directory` have the same meanings and pair-key
-formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
-which a completed files-push publishes, and never changes it.
+The local-only command is `files-diff`. Its `target URL`, `local tree`, and
+`local push state directory` have the same meanings as `files-push`. It reads
+the local index updated by files-pull and committed files-push operations and
+never changes it. A partial pull updates only the paths it changed, leaving
+pending changes elsewhere in the diff. The target URL uses the same exporter
+endpoint path and query as the file-only pull but omits URL user-info and
+`SECRET_KEY`. It includes the `site-export-api` query which `pull-files` adds
+to a bare site URL.
 
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
 `delete`, and `path_b64`. A push record also has the local path `type`, `size`,
@@ -220,14 +258,17 @@ exporter API URL, and its `local tree` is the canonical directory supplied by
 `--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
 plain-HTTP opt-in.
 
-The `pair key` identifies exactly one target URL and canonical local tree:
+The same SHA-256 digest names the local index and local push state directory:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
+sha256(<target-url-without-authentication> + "\0" + <canonical-local-tree-path>)
 ```
 
-The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
+The local index is `<state-dir>/local-index/<hash>.jsonl`, and the `local push
+state directory` is `<state-dir>/push/<hash>/`. `files-push`
 chooses `start` or `resume` only from whether `sender.json` exists there. The
+hash omits URL user-info and `SECRET_KEY`; files-push receives its secret
+through `--secret`.
 receiver-confirmed upload positions remain receiver-owned; they are not a
 files-push cursor and are not copied into `.import-state.json` or
 `.import-status.json`.
@@ -235,8 +276,8 @@ files-push cursor and are not copied into `.import-state.json` or
 Files-push lifecycle lines use these command-first names verbatim: `START
 files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,
 `INTERRUPTED files-push`, `COMPLETE files-push`, `RESTART files-push`, `FAILED
-files-push`, and `ERROR files-push`. Every line contains `pair=<pair-key>`.
-Planned stop causes are `time_limit` and `memory_limit`.
+files-push`, and `ERROR files-push`. Planned stop causes are `time_limit` and
+`memory_limit`.
 
 The CLI outcome names are `complete`, `partial`, `interrupted`, `restart`,
 `failed`, and `error`. `complete` exits 0; `partial`, `interrupted`, and
@@ -292,12 +333,12 @@ Use these names verbatim inside `PushPlan`:
 | --- | --- |
 | Active plan directory | `$plan_directory` |
 | Local tree root | `$local_tree_root`, `set_local_tree_root()` |
-| Previous local index | `$previous_local_index` |
-| Open previous local index | `$previous_local_index_handle` |
-| Previous local index lookahead entry | `$previous_local_index_lookahead_entry`, `$previous_local_index_lookahead_entry_loaded` |
-| Byte offset in the previous local index | `$byte_offset_in_previous_local_index` |
+| Local index path | `$local_index_path` |
+| Open local index | `$local_index_handle` |
+| Local index lookahead entry | `$local_index_lookahead_entry`, `$local_index_lookahead_entry_loaded` |
+| Byte offset in the local index | `$byte_offset_in_local_index` |
 | Cursor | `$cursor`, `get_cursor()` |
-| Plan-owned excluded paths | `$excluded_paths_file` |
+| Excluded paths file | `$excluded_paths_path` |
 | Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
 | Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -16,6 +16,12 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function Reprint\Importer\apply_local_index_updates;
+use function Reprint\Importer\decode_index_entry;
+use function Reprint\Importer\read_index_entry;
+use function Reprint\Importer\read_index_updates;
+use function Reprint\Importer\write_index_entry;
+use function Reprint\Importer\write_local_index_update;
 
 error_reporting(E_ALL);
 ini_set("display_errors", "stderr");
@@ -62,6 +68,7 @@ require_once __DIR__ . '/lib/target-runtime/load.php';
 
 // External merge sort for large index files when exec() is unavailable
 require_once __DIR__ . '/lib/external-merge-sort.php';
+require_once __DIR__ . '/lib/index-update-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
@@ -251,7 +258,6 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
-
     /**
      * Maximum number of consecutive interrupted responses with no cursor
      * progress before the importer gives up. This prevents endless resumption
@@ -297,36 +303,13 @@ class ImportClient
     /** @var resource|null Open file handle for $index_update_wal_path while writing. */
     private $index_update_wal_handle;
 
-    /** @var int Number of entries written to the open WAL batch. */
-    private $index_update_wal_record_count = 0;
-
-    /**
-     * Deduplication state for index updates. Consecutive upsert_index_entry() or
-     * delete_index_entry() calls for the same path are collapsed into one WAL write.
-     *
-     * @var string|null Last path written to the index-update WAL.
-     */
-    private $last_update_path = null;
-
-    /** @var bool|null Whether the last index update was a deletion (true) or upsert (false). */
-    private $last_update_delete = null;
-
-    /** @var int|null ctime of the last upserted index entry. */
-    private $last_update_ctime = null;
-
-    /** @var int|null Size in bytes of the last upserted index entry. */
-    private $last_update_size = null;
-
-    /** @var string|null Type ("file", "link", "dir") of the last upserted index entry. */
-    private $last_update_type = null;
-
     /**
      * @var string Path to .import-remote-index.jsonl — latest file index received
      * from the server, including directory `empty` fields when available.
      */
     private $remote_index_file;
 
-    /** @var string Path to .import-download-list.jsonl — files to download, computed by diffing remote vs local index. */
+    /** @var string Path to .import-download-list.jsonl — files to download, computed by diffing the remote and import indexes. */
     private $download_list_file;
 
     /** @var string Path to .import-download-list-skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
@@ -611,31 +594,115 @@ class ImportClient
         return $count;
     }
 
-    /**
-     * Upsert a file entry in the index.
-     */
-    private function upsert_index_entry(
+    /** Appends one F record for the import index to the current WAL batch. */
+    private function upsert_import_index_entry(
         string $path,
         int $ctime,
         int $size,
         string $type
     ): void {
-        $this->record_index_update_file($path, $ctime, $size, $type);
+        $this->write_index_update([
+            "op" => "F",
+            "path" => base64_encode($path),
+            "ctime" => $ctime,
+            "size" => $size,
+            "type" => $type,
+        ]);
     }
 
     /**
-     * Delete a file entry from the index.
+     * Appends one F record for a completed files-pull change.
+     *
+     * The record updates the import index and, when the local path belongs in
+     * it, the local index.
      */
-    private function delete_index_entry(string $path): void
-    {
-        $this->record_index_update_deletion($path);
+    private function record_pulled_path(
+        string $path,
+        string $local_path,
+        int $ctime,
+        int $size,
+        string $type
+    ): void {
+        $update = [
+            "op" => "F",
+            "path" => base64_encode($path),
+            "ctime" => $ctime,
+            "size" => $size,
+            "type" => $type,
+        ];
+        $local_index_entry_path =
+            $this->local_index_entry_path($local_path);
+        if ($local_index_entry_path !== null) {
+            $update["local_path_b64"] =
+                base64_encode($local_index_entry_path);
+            clearstatcache(true, $local_path);
+            $stat = lstat($local_path);
+            if ($stat === false) {
+                throw new RuntimeException(
+                    'Failed to inspect the pulled local path: '
+                    . $local_path
+                    . '.'
+                );
+            }
+            $update["local_ctime"] = (int) $stat["ctime"];
+            $update["local_size"] =
+                $type === "dir" ? 0 : (int) $stat["size"];
+        }
+        $this->write_index_update($update);
     }
 
-    /** Replays a WAL left by an interrupted batch. */
-    private function replay_index_update_wal(): void
+    /**
+     * Returns the local-index entry path for one local path, or null when the
+     * path does not belong in the local index.
+     */
+    private function local_index_entry_path(string $local_path): ?string
     {
-        if (is_file($this->index_update_wal_path)) {
-            $this->apply_index_update_wal();
+        /** @var string $local_tree */
+        $local_tree = realpath($this->local_tree());
+        $local_index_entry_path =
+            self::path_remainder_under($local_path, $local_tree);
+        if ($local_index_entry_path === null || $local_index_entry_path === '') {
+            return null;
+        }
+        $local_index_entry_path = ltrim($local_index_entry_path, '/');
+        return FileIndexProcessor::path_is_default_skipped(
+            $local_index_entry_path
+        )
+            ? null
+            : $local_index_entry_path;
+    }
+
+    /**
+     * Appends one complete record to the index-update WAL.
+     *
+     * @param array $update {
+     *     One import-index update, with local-index fields when files-pull
+     *     changed a non-skipped path.
+     *
+     *     @type string $op          `F` or `D`.
+     *     @type string $path        Base64-encoded import-index path.
+     *     @type int    $ctime       Remote ctime for an `F` record.
+     *     @type int    $size        Remote size for an `F` record.
+     *     @type string $type        Pulled path type used by both indexes for
+     *                               an `F` record.
+     *     @type string $local_path_b64 Base64-encoded local-index path.
+     *     @type int    $local_ctime    Local ctime for an `F` record.
+     *     @type int    $local_size     Local size for an `F` record.
+     * }
+     */
+    private function write_index_update(array $update): void
+    {
+        if (!$this->index_update_wal_handle) {
+            $this->open_index_update_wal();
+        }
+        $line = json_encode(
+            $update,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (fwrite($this->index_update_wal_handle, $line) !== strlen($line)) {
+            throw new RuntimeException(
+                "Failed to write to the index-update WAL (disk full?)."
+            );
         }
     }
 
@@ -737,9 +804,8 @@ class ImportClient
      *
      * @param string       $command Canonical CLI command name.
      * @param list<string> $argv    Raw command arguments.
-     * @param string|null  $pair    Files-diff or files-push pair key, when available.
      */
-    public function audit_log_argv(string $command, array $argv, ?string $pair = null): void
+    public function audit_log_argv(string $command, array $argv): void
     {
         // Mask the remote URL (argv[2]) to avoid logging secrets embedded in query strings.
         $masked = $argv;
@@ -754,8 +820,10 @@ class ImportClient
                 $masked[$argument_index] = '--secret=***';
             }
         }
-        $pair_field = $pair === null ? '' : " | pair={$pair}";
-        $this->audit_log("COMMAND | {$command}{$pair_field} | argv=" . implode(' ', $masked), false);
+        $this->audit_log(
+            "COMMAND | {$command} | argv=" . implode(' ', $masked),
+            false
+        );
     }
 
     /**
@@ -875,7 +943,7 @@ class ImportClient
     /**
      * Runs one import command while holding the state directory's process lock.
      *
-     * CLI callers pass the lock acquired before pair setup and audit logging.
+     * CLI callers pass the lock acquired before command setup and audit logging.
      * Direct callers may omit it; this method then acquires the lock before
      * reading or writing command state. A supplied lock remains caller-owned.
      *
@@ -963,10 +1031,20 @@ class ImportClient
         // files-diff and files-push use local push state and must not load
         // or write the pull command's .import-state.json file.
         if ($command === "files-diff") {
+            if (is_file($this->index_update_wal_path)) {
+                throw new RuntimeException(
+                    'Finish or abort the interrupted files-pull before running files-diff.'
+                );
+            }
             $this->run_files_diff($options);
             return;
         }
         if ($command === "files-push") {
+            if (is_file($this->index_update_wal_path)) {
+                throw new RuntimeException(
+                    'Finish or abort the interrupted files-pull before running files-push.'
+                );
+            }
             $this->run_files_push($options, $process_lock);
             return;
         }
@@ -1306,24 +1384,26 @@ class ImportClient
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
     /**
-     * Reports local paths changed since the pair's previous local index.
+     * Reports the push operations produced by comparing the local tree with
+     * the local index.
      *
      * files-diff makes no network request. It runs one complete PushPlan
-     * against the previous local index a completed files-push published, then
-     * streams the finished push and delete lists from the beginning. Every run
+     * against the local index updated by files-pull and completed files-push
+     * operations, then streams
+     * the finished push and delete lists from the beginning. Every run
      * reports the whole diff, so an interrupted report needs no resume state:
      * running the command again prints the complete report.
      *
      * @param array $options {
      *     Parsed files-diff options and context.
      *
-     *     @type array $files_diff_context Validated pair context.
+     *     @type array $files_diff_context Validated files-diff context.
      * }
      * @phpstan-param array<string,mixed> $options
      */
     private function run_files_diff(array $options): void
     {
-        $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
+        $context = $options['files_diff_context'] ?? self::prepare_files_command_context(
             $this->remote_url,
             $this->state_dir,
             $this->fs_root,
@@ -1334,18 +1414,15 @@ class ImportClient
         }
 
         $push_state_directory = $context['push_state_directory'];
-        $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
-        $missing_previous_local_index_message =
-            'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
+        $local_index_path = $context['local_index_path'];
+        $missing_local_index_message =
+            'files-diff requires the local index created by files-pull or files-push '
             . 'for the same target URL, state directory, and local tree.';
-        if (!is_dir($push_state_directory)) {
-            throw new RuntimeException($missing_previous_local_index_message);
-        }
 
         $plan_directory = $push_state_directory . '/files-diff-plan';
         try {
-            if (!is_file($previous_local_index)) {
-                throw new RuntimeException($missing_previous_local_index_message);
+            if (!is_file($local_index_path)) {
+                throw new RuntimeException($missing_local_index_message);
             }
 
             // Build the complete local-only plan from scratch without target
@@ -1361,7 +1438,7 @@ class ImportClient
             $plan = PushPlan::start(
                 $plan_directory,
                 $context['local_tree'],
-                $previous_local_index,
+                $local_index_path,
                 $excluded_paths_path
             );
             try {
@@ -1372,21 +1449,16 @@ class ImportClient
                 $plan->close();
             }
 
-            $type_by_plan_type = [
-                'file' => 'file',
-                'directory' => 'dir',
-                'symlink' => 'link',
-            ];
             $local_paths_to_push_count = 0;
             foreach (
-                $this->read_planned_local_paths_to_push($plan->get_local_paths_to_push_path())
+                $plan->read_planned_local_paths_to_push()
                 as $entry
             ) {
                 $line = json_encode([
                     'command' => 'files-diff',
                     'action' => 'push',
-                    'path_b64' => $entry['path'],
-                    'type' => $type_by_plan_type[$entry['type']],
+                    'path_b64' => $entry['path_b64'],
+                    'type' => $entry['type'],
                     'size' => $entry['size'],
                     'ctime' => $entry['ctime'],
                 ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
@@ -1398,7 +1470,7 @@ class ImportClient
 
             $local_paths_to_delete_count = 0;
             foreach (
-                $this->read_planned_local_paths_to_delete($plan->get_local_paths_to_delete_path())
+                $plan->read_planned_local_paths_to_delete()
                 as $local_path_to_delete
             ) {
                 $line = json_encode([
@@ -1426,68 +1498,6 @@ class ImportClient
             }
         } finally {
             $this->remove_local_plan_directory($plan_directory);
-        }
-    }
-
-    /**
-     * Reads the completed local paths-to-push list.
-     *
-     * @param string $local_paths_to_push_path Completed plan-owned JSONL path list.
-     * @return Generator Completed plan entries.
-     * @phpstan-return Generator<int,array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int},mixed,void>
-     */
-    private function read_planned_local_paths_to_push(string $local_paths_to_push_path): Generator
-    {
-        $local_paths_to_push_handle = fopen($local_paths_to_push_path, 'rb');
-        if (!is_resource($local_paths_to_push_handle)) {
-            throw new RuntimeException('Failed to open the completed local paths-to-push list.');
-        }
-        try {
-            while (true) {
-                $line = fgets($local_paths_to_push_handle);
-                if ($line === false) {
-                    if (!feof($local_paths_to_push_handle)) {
-                        throw new RuntimeException('Failed to read the completed local paths-to-push list.');
-                    }
-                    return;
-                }
-                // The plan wrote this list moments ago in this process; its
-                // entry schema is trusted, like every other plan consumer.
-                /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $entry */
-                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-                yield $entry;
-            }
-        } finally {
-            fclose($local_paths_to_push_handle);
-        }
-    }
-
-    /**
-     * Reads the completed local paths-to-delete list.
-     *
-     * @param string $local_paths_to_delete_path Completed plan-owned NUL-delimited path list.
-     * @return Generator Completed local paths to delete.
-     * @phpstan-return Generator<int,string,mixed,void>
-     */
-    private function read_planned_local_paths_to_delete(string $local_paths_to_delete_path): Generator
-    {
-        $local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
-        if (!is_resource($local_paths_to_delete_handle)) {
-            throw new RuntimeException('Failed to open the completed local paths-to-delete list.');
-        }
-        try {
-            while (true) {
-                $local_path_to_delete = stream_get_line($local_paths_to_delete_handle, 1048576, "\0");
-                if ($local_path_to_delete === false) {
-                    if (!feof($local_paths_to_delete_handle)) {
-                        throw new RuntimeException('Failed to read the completed local paths-to-delete list.');
-                    }
-                    return;
-                }
-                yield $local_path_to_delete;
-            }
-        } finally {
-            fclose($local_paths_to_delete_handle);
         }
     }
 
@@ -1568,6 +1578,7 @@ class ImportClient
         $sender_options = [
             'docroot' => $context['local_tree'],
             'push_state_directory' => $context['push_state_directory'],
+            'local_index_path' => $context['local_index_path'],
             'base_url' => $context['target_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
@@ -1587,7 +1598,7 @@ class ImportClient
         try {
             $this->audit_log(
                 ( $resuming ? 'RESUME' : 'START' )
-                    . " files-push | pair={$context['pair']} | phase={$phase}",
+                    . " files-push | phase={$phase}",
                 false
             );
 
@@ -1616,7 +1627,7 @@ class ImportClient
                 $phase = $sender->get_phase();
                 if ($phase !== $previous_phase) {
                     $this->audit_log(
-                        "PHASE files-push | pair={$context['pair']} | from={$previous_phase} | to={$phase}",
+                        "PHASE files-push | from={$previous_phase} | to={$phase}",
                         false
                     );
                     $previous_phase = $phase;
@@ -1667,33 +1678,33 @@ class ImportClient
 
         switch ($status) {
             case 'complete':
-                $audit_line = "COMPLETE files-push | pair={$context['pair']} | phase={$phase}";
+                $audit_line = "COMPLETE files-push | phase={$phase}";
                 $message = 'Files push complete.';
                 $this->exit_code = 0;
                 break;
             case 'partial':
-                $audit_line = "PARTIAL files-push | pair={$context['pair']} | phase={$phase} | cause={$reason}";
+                $audit_line = "PARTIAL files-push | phase={$phase} | cause={$reason}";
                 $message = 'Files push paused at a durable boundary; run the same command again to continue.';
                 $this->exit_code = 2;
                 break;
             case 'interrupted':
-                $audit_line = "INTERRUPTED files-push | pair={$context['pair']} | phase={$phase} | signal={$this->files_push_stop_signal}";
+                $audit_line = "INTERRUPTED files-push | phase={$phase} | signal={$this->files_push_stop_signal}";
                 $message = 'Files push was interrupted at a durable boundary; run the same command again to continue.';
                 $this->exit_code = 2;
                 break;
             case 'restart':
-                $audit_line = "RESTART files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $audit_line = "RESTART files-push | phase={$phase} | reason={$reason}";
                 $message = 'Files push must restart; the next run will build a fresh plan.';
                 $this->exit_code = 2;
                 break;
             case 'failed':
-                $audit_line = "FAILED files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $audit_line = "FAILED files-push | phase={$phase} | reason={$reason}";
                 $message = $detail === null ? 'Files push failed.' : 'Files push failed: ' . $detail;
                 $this->exit_code = 1;
                 break;
             case 'error':
             default:
-                $audit_line = "ERROR files-push | pair={$context['pair']} | phase={$phase} | reason={$reason}";
+                $audit_line = "ERROR files-push | phase={$phase} | reason={$reason}";
                 $message = $detail === null ? 'Files push stopped with an error.' : 'Files push stopped with an error: ' . $detail;
                 $this->exit_code = 1;
                 break;
@@ -1702,7 +1713,6 @@ class ImportClient
         $this->audit_log($audit_line, false);
         $result = [
             'command' => 'files-push',
-            'pair' => $context['pair'],
             'status' => $status,
             'phase' => $phase,
             'message' => $message,
@@ -1716,7 +1726,6 @@ class ImportClient
         // Write the flat run status without consulting import state.
         $status_payload = [
             'command' => 'files-push',
-            'pair' => $context['pair'],
             'status' => $status,
             'phase' => $phase,
             'reason' => $reason,
@@ -1763,10 +1772,10 @@ class ImportClient
      *
      *     @type string $target_url           Target exporter API URL.
      *     @type string $local_tree           Canonical local tree being sent.
-     *     @type string $pair                 Target/local-tree pair key.
      *     @type string $push_state_directory Local push state directory.
+     *     @type string $local_index_path      Local index used by pull and push.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{target_url:string,local_tree:string,push_state_directory:string,local_index_path:string}
      */
     public static function prepare_files_push_context(
         string $target_url,
@@ -1784,7 +1793,7 @@ class ImportClient
             );
         }
 
-        $context = self::prepare_files_pair_context(
+        $context = self::prepare_files_command_context(
             $target_url,
             $state_directory,
             $local_tree,
@@ -1810,16 +1819,16 @@ class ImportClient
      *
      * @param string $command Command name used in error messages.
      * @return array {
-     *     Validated pair context.
+     *     Validated files command context.
      *
      *     @type string $target_url           Target exporter API URL.
      *     @type string $local_tree           Canonical local tree.
-     *     @type string $pair                 Target/local-tree pair key.
      *     @type string $push_state_directory Local push state directory.
+     *     @type string $local_index_path      Local index used by pull and push.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{target_url:string,local_tree:string,push_state_directory:string,local_index_path:string}
      */
-    public static function prepare_files_pair_context(
+    public static function prepare_files_command_context(
         string $target_url,
         string $state_directory,
         string $local_tree,
@@ -1854,36 +1863,28 @@ class ImportClient
         }
         $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
         $target_url = rtrim($target_url, '?&');
-        $pair = hash('sha256', $target_url . "\0" . $canonical_local_tree);
-        // Resolve an absolute physical path even when its final components do not exist.
-        $push_state_directory = $state_directory . '/push/' . $pair;
-        if (strpos($push_state_directory, '/') !== 0) {
+        $target_local_tree_hash = self::target_url_and_local_tree_hash(
+            $target_url,
+            $canonical_local_tree
+        );
+        // Resolve an absolute physical state path even when its final components do not exist.
+        if (strpos($state_directory, '/') !== 0) {
             $working_directory = getcwd();
             if ($working_directory === false) {
                 throw new RuntimeException('Could not resolve the current working directory.');
             }
-            $push_state_directory = $working_directory . '/' . $push_state_directory;
+            $state_directory = $working_directory . '/' . $state_directory;
         }
-        $push_state_directory = normalize_path($push_state_directory);
-        $existing_state_path = $push_state_directory;
-        $missing_state_components = [];
-        while (
-            !file_exists($existing_state_path)
-            && !is_link($existing_state_path)
-            && $existing_state_path !== '/'
-        ) {
-            array_unshift($missing_state_components, basename($existing_state_path));
-            $existing_state_path = dirname($existing_state_path);
+        $state_directory = normalize_path($state_directory);
+        $canonical_state_directory =
+            self::canonicalize_path_with_missing_components($state_directory);
+        if ($canonical_state_directory !== null) {
+            $state_directory = $canonical_state_directory;
         }
-        $canonical_existing_state_path = realpath($existing_state_path);
-        if ($canonical_existing_state_path !== false) {
-            $push_state_directory = normalize_path(
-                $canonical_existing_state_path
-                    . ( $missing_state_components === []
-                        ? ''
-                        : '/' . implode('/', $missing_state_components) )
-            );
-        }
+        $push_state_directory =
+            rtrim($state_directory, '/')
+            . '/push/'
+            . $target_local_tree_hash;
         if (
             $canonical_local_tree === '/'
             || path_is_within_root($push_state_directory, $canonical_local_tree)
@@ -1897,9 +1898,54 @@ class ImportClient
         return [
             'target_url' => $target_url,
             'local_tree' => $canonical_local_tree,
-            'pair' => $pair,
             'push_state_directory' => $push_state_directory,
+            'local_index_path' => self::local_index_path(
+                $target_url,
+                $state_directory,
+                $canonical_local_tree
+            ),
         ];
+    }
+
+    /**
+     * Hashes the target endpoint and canonical local tree without URL user-info
+     * or SECRET_KEY.
+     */
+    private static function target_url_and_local_tree_hash(
+        string $target_url,
+        string $local_tree
+    ): string {
+        /** @var string $target_url */
+        $target_url = preg_replace(
+            '~^([a-z][a-z0-9+.-]*://)[^/?#]*@~i',
+            '$1',
+            $target_url
+        );
+        $query_start = strpos($target_url, '?');
+        if ($query_start !== false) {
+            $query_parts = [];
+            foreach (
+                explode('&', substr($target_url, $query_start + 1))
+                as $query_part
+            ) {
+                $query_name = explode('=', $query_part, 2)[0];
+                if (
+                    $query_part !== ''
+                    && rawurldecode($query_name) !== 'SECRET_KEY'
+                ) {
+                    $query_parts[] = $query_part;
+                }
+            }
+            $target_url = substr($target_url, 0, $query_start)
+                . ( $query_parts === []
+                    ? ''
+                    : '?' . implode('&', $query_parts) );
+        }
+
+        return hash(
+            'sha256',
+            rtrim($target_url, '?&') . "\0" . $local_tree
+        );
     }
     // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
@@ -1949,7 +1995,7 @@ class ImportClient
         }
     }
 
-    /** Masks URL authority credentials without changing the pair-key input. */
+    /** Masks URL authority credentials in error text. */
     private static function mask_files_push_url_user_info(string $url): string
     {
         $masked = preg_replace(
@@ -2056,21 +2102,21 @@ class ImportClient
     }
 
     /**
-     * Clear sync progress and transient files while keeping the local index
-     * and downloaded files, so the next files-pull computes a delta.
+     * Clear sync progress and transient files while keeping the import index,
+     * local index, and downloaded files, so the next files-pull computes a delta.
      */
     public function clear_files_pull_progress(): void
     {
         $this->audit_log(
-            "RESTART | Clearing files-pull progress (keeping local index and files)",
+            "RESTART | Clearing files-pull progress (keeping import index, local index, and files)",
             true,
         );
-        // Replay the WAL before clearing the cursor which made its records durable.
-        $this->replay_index_update_wal();
+        // Apply completed file changes to both indexes before discarding
+        // files-pull progress.
+        $this->apply_index_update_wal();
         $this->remove_index_update_wal();
         $this->reset_state();
         $this->index_update_wal_handle = null;
-        $this->index_update_wal_record_count = 0;
 
         if (file_exists($this->remote_index_file)) {
             @unlink($this->remote_index_file);
@@ -2697,9 +2743,46 @@ class ImportClient
      * - In-progress files-pull → resume from saved state
      *
      * Both modes share the same pipeline: index → diff → fetch.
+     *
      */
     public function run_files_sync(): void
     {
+        $local_tree = $this->local_tree();
+        if (strpos($local_tree, '/') !== 0) {
+            /** @var string $working_directory */
+            $working_directory = getcwd();
+            $local_tree = $working_directory . '/' . $local_tree;
+        }
+        $canonical_local_tree =
+            self::canonicalize_path_with_missing_components($local_tree);
+        if ($canonical_local_tree === null) {
+            throw new RuntimeException(
+                'Failed to resolve the local tree: ' . $local_tree . '.'
+            );
+        }
+        $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
+        /** @var string $canonical_state_directory */
+        $canonical_state_directory = realpath($this->state_dir);
+        $target_local_tree_hash = self::target_url_and_local_tree_hash(
+            $this->remote_url,
+            $canonical_local_tree
+        );
+        $local_index_path = self::local_index_path(
+            $this->remote_url,
+            $canonical_state_directory,
+            $canonical_local_tree
+        );
+        $sender_state_path =
+            $canonical_state_directory
+            . '/push/'
+            . $target_local_tree_hash
+            . '/sender.json';
+        if (is_file($sender_state_path)) {
+            throw new RuntimeException(
+                'Finish the unfinished files-push before running files-pull.'
+            );
+        }
+
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
 
         // A full `pull` leaves active_resumable_command on its last stage
@@ -2730,9 +2813,10 @@ class ImportClient
             $current_status !== null &&
             $current_status !== "complete";
 
-        $this->replay_index_update_wal();
         $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
         $this->assert_symlink_bundle_directory_unchanged();
+
+        $this->apply_index_update_wal();
 
         // Already completed.
         if ($current_status === "complete") {
@@ -2834,8 +2918,8 @@ class ImportClient
             [".", ".."]
         )) === 0;
 
-        // A local index from a prior completed sync means the next run is a
-        // delta: re-index the remote, diff against local, fetch only changes.
+        // An import index from a prior completed sync means the next run is a
+        // delta: re-index the remote, diff against that index, fetch only changes.
         $is_delta =
             file_exists($this->index_file) &&
             filesize($this->index_file) > 0;
@@ -2940,6 +3024,28 @@ class ImportClient
             return;
         }
 
+        if (!is_file($local_index_path)) {
+            $local_index_directory = dirname($local_index_path);
+            if (
+                !is_dir($local_index_directory)
+                && !mkdir($local_index_directory, 0755, true)
+            ) {
+                throw new RuntimeException(
+                    'Failed to create the local-index directory: '
+                    . $local_index_directory
+                    . '.'
+                );
+            }
+            if (file_put_contents($local_index_path, '') === false) {
+                throw new RuntimeException(
+                    'Failed to create the empty local index: '
+                    . $local_index_path
+                    . '.'
+                );
+            }
+        }
+
+        $this->import_state()->active_resumable_command->current_stage = null;
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->save_state($this->state);
         $this->remove_index_update_wal();
@@ -2968,8 +3074,82 @@ class ImportClient
         $this->report_volatile_files();
     }
 
+    /** Returns the local index path for one target and local tree. */
+    private static function local_index_path(
+        string $target_url,
+        string $state_directory,
+        string $local_tree
+    ): string
+    {
+        if (strpos($state_directory, '/') !== 0) {
+            /** @var string $working_directory */
+            $working_directory = getcwd();
+            $state_directory = $working_directory . '/' . $state_directory;
+        }
+        if (strpos($local_tree, '/') !== 0) {
+            /** @var string $working_directory */
+            $working_directory = getcwd();
+            $local_tree = $working_directory . '/' . $local_tree;
+        }
+        $canonical_state_directory =
+            self::canonicalize_path_with_missing_components($state_directory);
+        $canonical_local_tree =
+            self::canonicalize_path_with_missing_components($local_tree);
+        if (
+            $canonical_state_directory === null
+            || $canonical_local_tree === null
+        ) {
+            throw new RuntimeException(
+                'Failed to resolve the local-index path.'
+            );
+        }
+        $target_local_tree_hash = self::target_url_and_local_tree_hash(
+            $target_url,
+            rtrim($canonical_local_tree, '/') ?: '/'
+        );
+        return rtrim($canonical_state_directory, '/')
+            . '/local-index/'
+            . $target_local_tree_hash
+            . '.jsonl';
+    }
+
+    /** Returns the document root under this import's filesystem root. */
+    private function local_tree(): string
+    {
+        /** @var string $document_root */
+        $document_root =
+            $this->import_state()->preflight['data']['runtime']['document_root'];
+        $document_root = rtrim($document_root, '/');
+        return $document_root === ''
+            ? $this->fs_root
+            : $this->fs_root . '/' . ltrim($document_root, '/');
+    }
+
+    private static function canonicalize_path_with_missing_components(string $path): ?string
+    {
+        $existing_path = $path;
+        $missing_components = [];
+        while (
+            !file_exists($existing_path)
+            && !is_link($existing_path)
+            && $existing_path !== '/'
+        ) {
+            array_unshift($missing_components, basename($existing_path));
+            $existing_path = dirname($existing_path);
+        }
+        $canonical_existing_path = realpath($existing_path);
+        if ($canonical_existing_path === false) {
+            return null;
+        }
+        return normalize_path(
+            $canonical_existing_path
+                . ( $missing_components === []
+                    ? ''
+                    : '/' . implode('/', $missing_components) )
+        );
+    }
     /**
-     * Shared index → diff → fetch pipeline used by both initial and delta syncs.
+     * Index → diff → fetch pipeline used by both initial and delta syncs.
      *
      * Reads the current stage from state and runs each stage in sequence.
      * Returns early (with partial status) if any stage doesn't complete.
@@ -3884,10 +4064,7 @@ class ImportClient
             $handle = fopen($remote_index, "r");
             if ($handle) {
                 while (($line = fgets($handle)) !== false) {
-                    $entry = $this->parse_index_line($line);
-                    if ($entry === null) {
-                        continue;
-                    }
+                    $entry = decode_index_entry($line);
                     $size_by_path[$entry["path"]] = $entry["size"];
                 }
                 fclose($handle);
@@ -6491,7 +6668,7 @@ class ImportClient
     }
 
     /**
-     * Diff local index against remote index and build download list.
+     * Diff the import index against the remote index and build the download list.
      */
     private function diff_indexes_and_build_fetch_list(): bool
     {
@@ -6554,13 +6731,13 @@ class ImportClient
         $local_handle = file_exists($this->index_file)
             ? fopen($this->index_file, "r")
             : null;
-        $local = $this->read_index_line($local_handle);
+        $local = read_index_entry($local_handle);
         if ($local_after) {
             while (
                 $local !== null &&
                 strcmp($local["path"], $local_after) <= 0
             ) {
-                $local = $this->read_index_line($local_handle);
+                $local = read_index_entry($local_handle);
             }
         }
         $this->open_index_update_wal();
@@ -6576,10 +6753,7 @@ class ImportClient
             }
 
             $remote_offset = ftell($remote_handle);
-            $remote = $this->parse_index_line($line);
-            if (!$remote) {
-                continue;
-            }
+            $remote = decode_index_entry($line);
 
             while (
                 $local !== null &&
@@ -6588,11 +6762,10 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_local_file_path($local["path"]);
-                    $this->delete_index_entry($local["path"]);
+                    $this->delete_pulled_path($local["path"]);
                 }
                 $local_after = $local["path"];
-                $local = $this->read_index_line($local_handle);
+                $local = read_index_entry($local_handle);
             }
 
             if ($local !== null && $local["path"] === $remote["path"]) {
@@ -6602,7 +6775,7 @@ class ImportClient
                     $local["type"] !== $remote["type"]
                 ) {
                     // File is in both indexes but changed on the remote.
-                    // Always re-download — this file is in our local index,
+                    // Always re-download — this file is in our import index,
                     // meaning we synced it before; preserve-local does not
                     // protect files we own.
                     $target_handle = ($skipped_handle !== null && $this->is_uploads_path($remote["path"], $uploads_basedir))
@@ -6614,7 +6787,7 @@ class ImportClient
                     );
                 }
                 $local_after = $local["path"];
-                $local = $this->read_index_line($local_handle);
+                $local = read_index_entry($local_handle);
             } elseif (
                 $local === null ||
                 strcmp($local["path"], $remote["path"]) > 0
@@ -6648,11 +6821,10 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_local_file_path($local["path"]);
-                $this->delete_index_entry($local["path"]);
+                $this->delete_pulled_path($local["path"]);
             }
             $local_after = $local["path"];
-            $local = $this->read_index_line($local_handle);
+            $local = read_index_entry($local_handle);
         }
 
         if ($local_handle) {
@@ -7037,10 +7209,8 @@ class ImportClient
         $this->audit_log("Added to the download list: {$path}", false);
     }
 
-    /**
-     * Delete a local file path safely under the fs root.
-     */
-    private function delete_local_file_path(string $path): void
+    /** Deletes one pulled path and records its resulting absence. */
+    private function delete_pulled_path(string $path): void
     {
         if ($path === "") {
             return;
@@ -7054,16 +7224,29 @@ class ImportClient
             );
             return;
         }
-        if (!file_exists($local_path) && !is_link($local_path)) {
+        $path_exists = file_exists($local_path) || is_link($local_path);
+        if (
+            $path_exists
+            && !$this->remove_local_path_without_following_symlinks($local_path)
+        ) {
+            $this->audit_log("Failed to delete: {$path}", true);
             return;
         }
-
-        if ($this->remove_local_path_without_following_symlinks($local_path)) {
+        if ($path_exists) {
             $this->audit_log("Deleted: {$path}", false);
-            return;
         }
 
-        $this->audit_log("Failed to delete: {$path}", true);
+        $update = [
+            "op" => "D",
+            "path" => base64_encode($path),
+        ];
+        $local_index_entry_path =
+            $this->local_index_entry_path($local_path);
+        if ($local_index_entry_path !== null) {
+            $update["local_path_b64"] =
+                base64_encode($local_index_entry_path);
+        }
+        $this->write_index_update($update);
     }
 
     /**
@@ -7106,36 +7289,6 @@ class ImportClient
         return true === @unlink($local_path);
     }
 
-    /**
-     * Parse one JSON index line into an array.
-     */
-    private function parse_index_line(string $line): ?array
-    {
-        $line = trim($line);
-        if ($line === "") {
-            return null;
-        }
-        $data = json_decode($line, true);
-        if (!is_array($data)) {
-            throw new RuntimeException("Invalid index line format");
-        }
-        $path_encoded = $data["path"] ?? "";
-        if (!is_string($path_encoded) || $path_encoded === "") {
-            throw new RuntimeException("Invalid index path");
-        }
-        $path = base64_decode($path_encoded, true);
-        if ($path === "" || $path === false) {
-            throw new RuntimeException("Invalid index path (base64 decode failed)");
-        }
-        assert_valid_path($path, "index path");
-        return [
-            "path" => $path,
-            "ctime" => (int) ($data["ctime"] ?? 0),
-            "size" => (int) ($data["size"] ?? 0),
-            "type" => (string) ($data["type"] ?? "file"),
-        ];
-    }
-
     /** Opens the current index-update WAL for append. */
     private function open_index_update_wal(): void
     {
@@ -7152,97 +7305,9 @@ class ImportClient
                 "FILE CREATE | {$this->index_update_wal_path} | index-update WAL",
             );
         }
-        $this->index_update_wal_record_count = 0;
-        $this->last_update_path = null;
-        $this->last_update_delete = null;
-        $this->last_update_ctime = null;
-        $this->last_update_size = null;
-        $this->last_update_type = null;
     }
 
-    /**
-     * Record a file upsert in the index-update WAL.
-     */
-    private function record_index_update_file(
-        string $path,
-        int $ctime,
-        int $size,
-        string $type
-    ): void {
-        if (!$this->index_update_wal_handle) {
-            $this->open_index_update_wal();
-        }
-        if (
-            $this->last_update_path === $path &&
-            $this->last_update_delete === false &&
-            $this->last_update_ctime === $ctime &&
-            $this->last_update_size === $size &&
-            $this->last_update_type === $type
-        ) {
-            return;
-        }
-        $line = json_encode(
-            [
-                "op" => "F",
-                "path" => base64_encode($path),
-                "ctime" => $ctime,
-                "size" => $size,
-                "type" => $type,
-            ],
-            JSON_UNESCAPED_SLASHES,
-        );
-        if ($line !== false) {
-            $line .= "\n";
-            $bytes = fwrite($this->index_update_wal_handle, $line);
-            if ($bytes !== strlen($line)) {
-                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
-            }
-        }
-        $this->index_update_wal_record_count++;
-        $this->last_update_path = $path;
-        $this->last_update_delete = false;
-        $this->last_update_ctime = $ctime;
-        $this->last_update_size = $size;
-        $this->last_update_type = $type;
-    }
-
-    /**
-     * Record a deletion in the index-update WAL.
-     */
-    private function record_index_update_deletion(string $path): void
-    {
-        if (!$this->index_update_wal_handle) {
-            $this->open_index_update_wal();
-        }
-        if (
-            $this->last_update_path === $path &&
-            $this->last_update_delete === true
-        ) {
-            return;
-        }
-        $line = json_encode(
-            [
-                "op" => "D",
-                "path" => base64_encode($path),
-            ],
-            JSON_UNESCAPED_SLASHES,
-        );
-        if ($line !== false) {
-            $line .= "\n";
-            $bytes = fwrite($this->index_update_wal_handle, $line);
-            if ($bytes !== strlen($line)) {
-                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
-            }
-        }
-        $this->index_update_wal_record_count++;
-        $this->last_update_path = $path;
-        $this->last_update_delete = true;
-        $this->last_update_ctime = null;
-        $this->last_update_size = null;
-        $this->last_update_type = null;
-    }
-
-    /** Applies the current WAL to the import index. */
+    /** Applies the current WAL to the import index and local index. */
     private function apply_index_update_wal(): void
     {
         if ($this->index_update_wal_handle) {
@@ -7252,118 +7317,175 @@ class ImportClient
                 throw new RuntimeException("Failed to flush the index-update WAL.");
             }
         }
-        $this->last_update_path = null;
-        $this->last_update_delete = null;
-        $this->last_update_ctime = null;
-        $this->last_update_size = null;
-        $this->last_update_type = null;
-
-        $has_updates =
-            $this->index_update_wal_record_count > 0 ||
-            (is_file($this->index_update_wal_path) &&
-                filesize($this->index_update_wal_path) > 0);
-
-        if (!$has_updates) {
-            $this->index_update_wal_record_count = 0;
+        clearstatcache(true, $this->index_update_wal_path);
+        if (
+            !is_file($this->index_update_wal_path)
+            || filesize($this->index_update_wal_path) === 0
+        ) {
             return;
         }
 
         $new_index = $this->index_file . ".new";
-
         $this->audit_log(
             "INDEX MERGE START | merging updates into {$this->index_file}",
         );
-
-        $old_handle = file_exists($this->index_file)
-            ? fopen($this->index_file, "r")
-            : null;
-        $upd_handle = fopen($this->index_update_wal_path, "r");
-        $new_handle = fopen($new_index, "w");
-
-        if (!$upd_handle || !$new_handle) {
-            throw new RuntimeException("Failed to merge index updates");
-        }
-
-        $write_line = function ($handle, array $entry): void {
-            $line = json_encode(
-                [
-                    "path" => base64_encode($entry["path"]),
-                    "ctime" => (int) $entry["ctime"],
-                    "size" => (int) $entry["size"],
-                    "type" => (string) $entry["type"],
-                ],
-                JSON_UNESCAPED_SLASHES,
-            );
-            if ($line !== false) {
-                fwrite($handle, $line . "\n");
-            }
-        };
-
-        $old = $this->read_index_line($old_handle);
-        $carry = null;
-        $upd = $this->read_update_line($upd_handle, $carry);
-        $last_written_path = null;
-
-        while ($old !== null || $upd !== null) {
-            if ($upd === null) {
-                if ($last_written_path !== $old["path"]) {
-                    $write_line($new_handle, $old);
-                    $last_written_path = $old["path"];
+        $base_index_handle = null;
+        $wal_handle = null;
+        $new_index_handle = null;
+        try {
+            if (is_file($this->index_file)) {
+                $base_index_handle = fopen($this->index_file, 'rb');
+                if (!is_resource($base_index_handle)) {
+                    throw new RuntimeException(
+                        'Failed to open the import index.'
+                    );
                 }
-                $old = $this->read_index_line($old_handle);
-                continue;
+            }
+            $wal_handle = fopen($this->index_update_wal_path, 'rb');
+            $new_index_handle = fopen($new_index, 'wb');
+            if (
+                !is_resource($wal_handle)
+                || !is_resource($new_index_handle)
+            ) {
+                throw new RuntimeException(
+                    'Failed to merge import-index updates.'
+                );
             }
 
-            if ($old === null) {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
-                }
-                $upd = $this->read_update_line($upd_handle, $carry);
-                continue;
-            }
+            $base = read_index_entry($base_index_handle);
+            $updates = read_index_updates($wal_handle);
+            $updates->rewind();
+            while ($base !== null || $updates->valid()) {
+                $update = $updates->valid() ? $updates->current() : null;
+                $comparison =
+                    $base !== null && $update !== null
+                        ? strcmp($base['path'], $update['path'])
+                        : null;
 
-            $cmp = strcmp($old["path"], $upd["path"]);
-            if ($cmp === 0) {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
+                if (
+                    $update === null
+                    || ( $comparison !== null && $comparison < 0 )
+                ) {
+                    write_index_entry($new_index_handle, $base);
+                    $base = read_index_entry($base_index_handle);
+                    continue;
                 }
-                $old = $this->read_index_line($old_handle);
-                $upd = $this->read_update_line($upd_handle, $carry);
-            } elseif ($cmp < 0) {
-                if ($last_written_path !== $old["path"]) {
-                    $write_line($new_handle, $old);
-                    $last_written_path = $old["path"];
+
+                if (!$update['delete']) {
+                    write_index_entry($new_index_handle, $update);
                 }
-                $old = $this->read_index_line($old_handle);
-            } else {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
+                $updates->next();
+                if ($comparison === 0) {
+                    $base = read_index_entry($base_index_handle);
                 }
-                $upd = $this->read_update_line($upd_handle, $carry);
+            }
+        } finally {
+            if (is_resource($base_index_handle)) {
+                fclose($base_index_handle);
+            }
+            if (is_resource($wal_handle)) {
+                fclose($wal_handle);
+            }
+            if (is_resource($new_index_handle)) {
+                fclose($new_index_handle);
             }
         }
-
-        if ($old_handle) {
-            fclose($old_handle);
-        }
-        fclose($upd_handle);
-        fclose($new_handle);
-
         if (!rename($new_index, $this->index_file)) {
             throw new RuntimeException("Failed to replace index file");
         }
         $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
 
+        $updates_path = $this->state_dir . '/.local-index-updates.tmp';
+        $wal_handle = null;
+        $updates_handle = null;
+        try {
+            $updates_written = 0;
+            try {
+                $wal_handle = fopen($this->index_update_wal_path, 'rb');
+                $updates_handle = fopen($updates_path, 'wb');
+                if (
+                    !is_resource($wal_handle)
+                    || !is_resource($updates_handle)
+                ) {
+                    throw new RuntimeException(
+                        'Failed to prepare the local-index updates.'
+                    );
+                }
+                while (true) {
+                    $line = fgets($wal_handle);
+                    if ($line === false) {
+                        break;
+                    }
+                    if (substr($line, -1) !== "\n" && feof($wal_handle)) {
+                        break;
+                    }
+                    /** @var array{op:'D'|'F',path:string,ctime?:int,size?:int,type?:string,local_path_b64?:string,local_ctime?:int,local_size?:int} $update */
+                    $update = json_decode(
+                        $line,
+                        true,
+                        512,
+                        JSON_THROW_ON_ERROR
+                    );
+                    if (!array_key_exists('local_path_b64', $update)) {
+                        continue;
+                    }
+                    $local_index_update = [
+                        'op' => $update['op'],
+                        'path' => $update['local_path_b64'],
+                    ];
+                    if ($update['op'] === 'F') {
+                        $local_index_update += [
+                            'ctime' => $update['local_ctime'],
+                            'size' => $update['local_size'],
+                            'type' => $update['type'],
+                        ];
+                    }
+                    write_local_index_update(
+                        $updates_handle,
+                        $local_index_update
+                    );
+                    ++$updates_written;
+                }
+                if (!feof($wal_handle)) {
+                    throw new RuntimeException(
+                        'Failed to read the index-update WAL.'
+                    );
+                }
+                if (!fflush($updates_handle)) {
+                    throw new RuntimeException(
+                        'Failed to flush the local-index updates.'
+                    );
+                }
+            } finally {
+                if (is_resource($wal_handle)) {
+                    fclose($wal_handle);
+                }
+                if (is_resource($updates_handle)) {
+                    fclose($updates_handle);
+                }
+            }
+
+            if ($updates_written > 0) {
+                apply_local_index_updates(
+                    self::local_index_path(
+                        $this->remote_url,
+                        $this->state_dir,
+                        $this->local_tree()
+                    ),
+                    $updates_path
+                );
+            }
+        } finally {
+            if (is_file($updates_path)) {
+                @unlink($updates_path);
+            }
+        }
         if (file_put_contents($this->index_update_wal_path, '') === false) {
             throw new RuntimeException("Failed to clear the applied index-update WAL.");
         }
         $this->audit_log(
             "FILE TRUNCATE | {$this->index_update_wal_path} | WAL batch applied"
         );
-        $this->index_update_wal_record_count = 0;
     }
 
     /** Removes the WAL marker after files-pull completes or is aborted. */
@@ -7388,107 +7510,8 @@ class ImportClient
         ) {
             throw new RuntimeException("Failed to remove the index-update WAL.");
         }
-        $this->index_update_wal_record_count = 0;
     }
 
-    /**
-     * Read one JSON record from the on-disk index.
-     */
-    private function read_index_line($handle): ?array
-    {
-        if (!$handle) {
-            return null;
-        }
-        while (($line = fgets($handle)) !== false) {
-            $parsed = $this->parse_index_line($line);
-            if ($parsed !== null) {
-                return $parsed;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Read one raw update record (F/D) from the updates file.
-     */
-    private function read_update_line_raw($handle): ?array
-    {
-        if (!$handle) {
-            return null;
-        }
-        while (($line = fgets($handle)) !== false) {
-            if (substr($line, -1) !== "\n" && feof($handle)) {
-                return null;
-            }
-            $line = trim($line);
-            if ($line === "") {
-                continue;
-            }
-            $data = json_decode($line, true);
-            if (!is_array($data)) {
-                throw new RuntimeException("Invalid index update line format");
-            }
-            $op = $data["op"] ?? null;
-            $path_encoded = $data["path"] ?? null;
-            if (!is_string($path_encoded) || $path_encoded === "") {
-                throw new RuntimeException("Invalid index update path");
-            }
-            $path = base64_decode($path_encoded);
-            if ($path === false || $path === "") {
-                throw new RuntimeException("Invalid index update path (base64 decode failed)");
-            }
-            if ($op === "D") {
-                return [
-                    "path" => $path,
-                    "delete" => true,
-                    "ctime" => 0,
-                    "size" => 0,
-                    "type" => null,
-                ];
-            }
-            if ($op === "F") {
-                return [
-                    "path" => $path,
-                    "delete" => false,
-                    "ctime" => (int) ($data["ctime"] ?? 0),
-                    "size" => (int) ($data["size"] ?? 0),
-                    "type" => (string) ($data["type"] ?? "file"),
-                ];
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Read one update record, coalescing consecutive updates to the same path.
-     *
-     * @param mixed $handle Update file handle
-     * @param array|null $carry Read-ahead buffer for the next record
-     */
-    private function read_update_line($handle, ?array &$carry = null): ?array
-    {
-        if (!$handle) {
-            return null;
-        }
-        $current = $carry ?? $this->read_update_line_raw($handle);
-        $carry = null;
-        if ($current === null) {
-            return null;
-        }
-
-        while (true) {
-            $next = $this->read_update_line_raw($handle);
-            if ($next === null) {
-                return $current;
-            }
-            if ($next["path"] !== $current["path"]) {
-                $carry = $next;
-                return $current;
-            }
-            // Same path: keep the latest update.
-            $current = $next;
-        }
-    }
     /**
      * Download SQL from remote.
      */
@@ -8510,14 +8533,7 @@ class ImportClient
         $prefix = $path . "/";
         $found = false;
         while (($line = fgets($h)) !== false) {
-            try {
-                $entry = $this->parse_index_line($line);
-            } catch (RuntimeException $e) {
-                continue;
-            }
-            if ($entry === null) {
-                continue;
-            }
+            $entry = decode_index_entry($line);
             $entry_path = $entry["path"];
             if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
                 $found = true;
@@ -8605,7 +8621,7 @@ class ImportClient
      * The in-progress remote index cursor/file was built from one directory[]
      * allowlist. Switching the selected source path prefixes mid-resume would
      * mix indexes from different traversals. Completed runs are allowed to use
-     * different --only prefixes because the local index is intentionally a union
+     * different --only prefixes because the import index is intentionally a union
      * across files-pull --only runs.
      */
     private function assert_files_pull_only_unchanged_while_resuming(bool $has_progress): void
@@ -9219,8 +9235,9 @@ class ImportClient
             $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
 
             if ($context->file_ctime && !$file_changed) {
-                $this->upsert_index_entry(
+                $this->record_pulled_path(
                     $path,
+                    $local_path,
                     $context->file_ctime,
                     $file_size,
                     "file",
@@ -9492,7 +9509,7 @@ class ImportClient
                 $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$path}", true);
                 $this->emit_skip_progress($path);
                 if ($ctime > 0) {
-                    $this->upsert_index_entry($path, $ctime, 0, "dir");
+                    $this->upsert_import_index_entry($path, $ctime, 0, "dir");
                 }
                 return;
             }
@@ -9500,7 +9517,7 @@ class ImportClient
                 $this->audit_log("PRESERVE-LOCAL skip directory (symlink in path): {$path}", true);
                 $this->emit_skip_progress($path);
                 if ($ctime > 0) {
-                    $this->upsert_index_entry($path, $ctime, 0, "dir");
+                    $this->upsert_import_index_entry($path, $ctime, 0, "dir");
                 }
                 return;
             }
@@ -9531,7 +9548,13 @@ class ImportClient
         $this->audit_log("Directory: {$path}", false);
 
         if ($ctime > 0) {
-            $this->upsert_index_entry($path, $ctime, 0, "dir");
+            $this->record_pulled_path(
+                $path,
+                $local_path,
+                $ctime,
+                0,
+                "dir"
+            );
         }
     }
 
@@ -9683,7 +9706,13 @@ class ImportClient
         $this->audit_log("Symlink: {$path} -> {$target_for_local}", false);
 
         if ($ctime > 0) {
-            $this->upsert_index_entry($path, $ctime, 0, "link");
+            $this->record_pulled_path(
+                $path,
+                $local_path,
+                $ctime,
+                0,
+                "link"
+            );
         }
 
         $this->output_progress([
@@ -9740,7 +9769,10 @@ class ImportClient
             if (file_exists($local_path)) {
                 @unlink($local_path);
             }
-            $this->delete_index_entry($path);
+            $this->write_index_update([
+                "op" => "D",
+                "path" => base64_encode($path),
+            ]);
 
             if ($error_type === "file_changed") {
                 $this->record_volatile_file($path);
@@ -9989,10 +10021,7 @@ class ImportClient
             if ($line === "") {
                 continue;
             }
-            $entry = $this->parse_index_line($line);
-            if ($entry === null) {
-                continue;
-            }
+            $entry = decode_index_entry($line);
             $key = bin2hex($entry["path"]);
             fwrite($out, $key . "\t" . $line . "\n");
             if (++$lines_read % 500 === 0) {
@@ -10109,9 +10138,8 @@ class ImportClient
             ? (int) (($mem_limit - $mem_used) * 0.6)
             : 256 * 1024 * 1024;
 
-        $key_extractor = function (string $line): ?string {
-            $entry = $this->parse_index_line($line);
-            return $entry !== null ? $entry['path'] : null;
+        $key_extractor = function (string $line): string {
+            return decode_index_entry($line)['path'];
         };
         $sorter = new ExternalMergeSort(
             $key_extractor,
@@ -12799,8 +12827,10 @@ if (
                 "\n" .
                 "On the first run, indexes the full remote directory tree and then\n" .
                 "downloads every file. On subsequent runs, re-indexes the remote tree,\n" .
-                "diffs against the local index, and downloads only what changed.\n" .
+                "diffs against the import index, and downloads only what changed.\n" .
                 "Interrupted pulls resume from the last saved cursor.\n" .
+                "The state directory's .reprint.lock is held for the entire command,\n" .
+                "so another local Reprint command cannot use the same state directory.\n" .
                 "\n" .
                 "Runs files-index internally when no index exists yet.\n",
             "extra" =>
@@ -12810,9 +12840,17 @@ if (
                 "                    The skipped file list is saved for later retrieval.\n" .
                 "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
                 "\n" .
+                "A completed files-pull creates the local index when needed. Each\n" .
+                "applied WAL batch updates paths which files-pull changed, except\n" .
+                "default-skipped paths. It also refreshes their directory ancestors\n" .
+                "and removes descendants of deleted or replaced paths. Other branches\n" .
+                "remain unchanged.\n" .
+                "\n" .
                 "Output files:\n" .
                 "  (fs-root)/                              Downloaded files\n" .
-                "  .import-index.jsonl                     Local file index\n" .
+                "  .reprint.lock                           Local Reprint process lock\n" .
+                "  .import-index.jsonl                     Import index\n" .
+                "  .import-index-updates.wal               Active files-pull WAL\n" .
                 "  .import-remote-index.jsonl              Remote index snapshot\n" .
                 "  .import-download-list.jsonl             Files pending download\n" .
                 "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
@@ -12821,13 +12859,17 @@ if (
         ],
         "files-diff" => [
             "level" => "low",
-            "short" => "Show local file changes since the last push",
+            "short" => "Compare the local tree with the local index",
             "usage" => "reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
-                "Shows which local paths a files-push would send or delete, comparing\n" .
-                "the local tree at --fs-root with the pair's previous local index —\n" .
-                "the index a completed files-push publishes for the same target URL,\n" .
-                "state directory, and local tree.\n" .
+                "Compares the local tree at --fs-root with the local index and shows\n" .
+                "which paths files-push would send or delete. files-pull and pull-files\n" .
+                "update entries for paths they change, and every completed files-push\n" .
+                "updates entries for paths committed by the target.\n" .
+                "The local tree at --fs-root must be the exact document root later\n" .
+                "passed to files-push. Use the same exporter endpoint as pull but\n" .
+                "omit URL user-info and SECRET_KEY. After pull-files received a bare\n" .
+                "site URL, include the site-export-api query which it added.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .
@@ -12835,8 +12877,14 @@ if (
                 "editor scratch files.\n" .
                 "Paths remain base64 text in JSONL output so\n" .
                 "arbitrary filesystem names are preserved. No network calls are made\n" .
-                "and no secret is required.\n",
+                "and no secret is required. The state directory's .reprint.lock is\n" .
+                "held for the entire command.\n",
             "extra" =>
+                "Complete files-pull, pull-files, or files-push once to create the\n" .
+                "local index used by files-diff.\n" .
+                "A completed standalone files-pull does not run again. First run the\n" .
+                "same files-pull with --abort, then run it once more. Rerunning a\n" .
+                "completed pull-files starts a fresh pipeline.\n" .
                 "Every run reports the complete diff from the beginning; there is\n" .
                 "no partial resume to continue.\n",
         ],
@@ -12880,9 +12928,9 @@ if (
         ],
         "files-stats" => [
             "level" => "low",
-            "short" => "Show file counts and sizes from the local index",
+            "short" => "Show file counts and sizes from the import index",
             "description" =>
-                "Reads local index files to report (no network calls):\n" .
+                "Reads import index files to report (no network calls):\n" .
                 "\n" .
                 "  - Total indexed files and their combined size\n" .
                 "  - Files not yet downloaded and their combined size\n" .
@@ -13153,7 +13201,7 @@ if (
     }
 
     try {
-        // Acquire the lock before pair setup and audit writes so each command
+        // Acquire the lock before command setup and audit writes so each command
         // owns every local state transition for its complete invocation.
         $reprint_process_lock = new ReprintProcessLock($state_dir);
         $reprint_files_push_context = null;
@@ -13166,7 +13214,7 @@ if (
                 $options
             );
         } elseif ($command === 'files-diff') {
-            $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
+            $reprint_files_diff_context = ImportClient::prepare_files_command_context(
                 $remote_url,
                 $state_dir,
                 $fs_root,
@@ -13174,8 +13222,7 @@ if (
             );
         }
         $client = new ImportClient($remote_url, $state_dir, $fs_root, $command);
-        $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
-        $client->audit_log_argv($command, $argv, $reprint_files_pair);
+        $client->audit_log_argv($command, $argv);
         $client->run(
             $options
                 + ( $reprint_files_push_context === null

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -268,11 +268,14 @@ class ImportClient
     /** @var string Export server URL. */
     public $remote_url;
 
-    /** @var string Directory for import state files (.import-state.json, db.sql, etc.). */
+    /** @var string Directory for import state files shared across target relationships. */
     public $state_dir;
 
     /** @var string Directory where downloaded site files are written (no filesystem-root/ wrapper). */
     public $fs_root;
+
+    /** @var string State directory for one target URL. */
+    public $remote_state_directory;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
@@ -287,16 +290,15 @@ class ImportClient
     private $progress_throttle = 1.0;
 
     /**
-     * @var string Path to .import-index.jsonl — sorted JSON-lines file tracking every
-     * imported file's path, ctime, size, and type. Used for delta detection: on the next
-     * sync we compare this against the remote index to decide what to download or delete.
+     * @var string Path to .remote-index.jsonl — sorted JSON-lines file tracking
+     * the last target-observed path, ctime, size, and type.
      */
-    private $index_file;
+    private $remote_index_file;
 
     /**
-     * @var string Path to .import-index-updates.wal — the append-only write-ahead
-     * log for the current files-pull. Applied batches are cleared, but the file
-     * remains until the lifecycle completes or is aborted.
+     * @var string Path to pull-index-updates.wal — the append-only write-ahead
+     * log for the current files-pull. Applied batches are cleared, but the
+     * file remains until the lifecycle completes or is aborted.
      */
     private $index_update_wal_path;
 
@@ -304,15 +306,16 @@ class ImportClient
     private $index_update_wal_handle;
 
     /**
-     * @var string Path to .import-remote-index.jsonl — latest file index received
-     * from the server, including directory `empty` fields when available.
+     * @var string Path to .remote-index.next.jsonl — latest file index
+     * received from the server, including directory `empty` fields when
+     * available.
      */
-    private $remote_index_file;
+    private $remote_index_next_file;
 
-    /** @var string Path to .import-download-list.jsonl — files to download, computed by diffing the remote and import indexes. */
+    /** @var string Path to pull-plan.jsonl — files to download, computed by diffing the remote indexes. */
     private $download_list_file;
 
-    /** @var string Path to .import-download-list-skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
+    /** @var string Path to pull-plan.skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
     private $skipped_download_list_file;
 
     /** @var string Path to .import-audit.log — append-only log of every operation for debugging. */
@@ -538,26 +541,6 @@ class ImportClient
         $this->remote_url = rtrim($remote_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
         $this->fs_root = rtrim($fs_root, "/");
-        $this->state_file = $this->state_dir . "/.import-state.json";
-        $this->index_file = $this->state_dir . "/.import-index.jsonl";
-        $this->index_update_wal_path =
-            $this->state_dir . "/.import-index-updates.wal";
-        $this->remote_index_file =
-            $this->state_dir . "/.import-remote-index.jsonl";
-        $this->download_list_file =
-            $this->state_dir . "/.import-download-list.jsonl";
-        $this->skipped_download_list_file =
-            $this->state_dir . "/.import-download-list-skipped.jsonl";
-        $this->audit_log = $this->state_dir . "/.import-audit.log";
-        $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
-        $this->status_file = $this->state_dir . "/.import-status.json";
-
-        // Detect TTY for progress display. In stdout mode this is re-evaluated
-        // against STDERR in run() once we know the output mode.
-        $this->is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
-        $this->progress_fd = STDOUT;
-        $this->progress = new TerminalProgress($this->is_tty, $this->progress_fd);
-        $this->pull = new Pull($this, $this->progress);
 
         // Create directories
         if (!is_dir($this->state_dir)) {
@@ -570,8 +553,60 @@ class ImportClient
                 throw new RuntimeException("Failed to create directory: {$this->fs_root}");
             }
         }
+        $this->remote_state_directory = $this->state_dir;
+        $this->state_file = $this->state_dir . "/.import-state.json";
+        $this->remote_index_file =
+            $this->state_dir . "/.remote-index.jsonl";
+        $this->index_update_wal_path =
+            $this->state_dir . "/pull-index-updates.wal";
+        $this->remote_index_next_file =
+            $this->state_dir . "/.remote-index.next.jsonl";
+        $this->download_list_file =
+            $this->state_dir . "/pull-plan.jsonl";
+        $this->skipped_download_list_file =
+            $this->state_dir . "/pull-plan.skipped.jsonl";
+        $this->audit_log = $this->state_dir . "/.import-audit.log";
+        $this->volatile_files_file =
+            $this->state_dir . "/pull-volatile-files.json";
+        $this->status_file = $this->state_dir . "/.import-status.json";
+
+        // Detect TTY for progress display. In stdout mode this is re-evaluated
+        // against STDERR in run() once we know the output mode.
+        $this->is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
+        $this->progress_fd = STDOUT;
+        $this->progress = new TerminalProgress($this->is_tty, $this->progress_fd);
+        $this->pull = new Pull($this, $this->progress);
 
         $this->state = ImportState::from_array($this->default_state());
+    }
+
+    /** Selects the per-target files state directory. */
+    private function configure_remote_state_directory(): void
+    {
+        $this->remote_state_directory = self::remote_state_directory(
+            $this->remote_url,
+            $this->state_dir
+        );
+        if (
+            !is_dir($this->remote_state_directory)
+            && !mkdir($this->remote_state_directory, 0755, true)
+        ) {
+            throw new RuntimeException(
+                "Failed to create directory: {$this->remote_state_directory}"
+            );
+        }
+        $this->remote_index_file =
+            $this->remote_state_directory . "/.remote-index.jsonl";
+        $this->index_update_wal_path =
+            $this->remote_state_directory . "/pull-index-updates.wal";
+        $this->remote_index_next_file =
+            $this->remote_state_directory . "/.remote-index.next.jsonl";
+        $this->download_list_file =
+            $this->remote_state_directory . "/pull-plan.jsonl";
+        $this->skipped_download_list_file =
+            $this->remote_state_directory . "/pull-plan.skipped.jsonl";
+        $this->volatile_files_file =
+            $this->remote_state_directory . "/pull-volatile-files.json";
     }
 
     /**
@@ -579,10 +614,10 @@ class ImportClient
      */
     public function index_count(): int
     {
-        if (!is_file($this->index_file)) {
+        if (!is_file($this->remote_index_file)) {
             return 0;
         }
-        $handle = fopen($this->index_file, "r");
+        $handle = fopen($this->remote_index_file, "r");
         if (!$handle) {
             return 0;
         }
@@ -594,8 +629,8 @@ class ImportClient
         return $count;
     }
 
-    /** Appends one F record for the import index to the current WAL batch. */
-    private function upsert_import_index_entry(
+    /** Appends one target-observed F record to the current WAL batch. */
+    private function upsert_remote_index_entry(
         string $path,
         int $ctime,
         int $size,
@@ -603,17 +638,17 @@ class ImportClient
     ): void {
         $this->write_index_update([
             "op" => "F",
-            "path" => base64_encode($path),
-            "ctime" => $ctime,
-            "size" => $size,
-            "type" => $type,
+            "remote_path_b64" => base64_encode($path),
+            "remote_ctime" => $ctime,
+            "remote_size" => $size,
+            "remote_type" => $type,
         ]);
     }
 
     /**
      * Appends one F record for a completed files-pull change.
      *
-     * The record updates the import index and, when the local path belongs in
+     * The record updates the remote index and, when the local path belongs in
      * it, the local index.
      */
     private function record_pulled_path(
@@ -625,10 +660,10 @@ class ImportClient
     ): void {
         $update = [
             "op" => "F",
-            "path" => base64_encode($path),
-            "ctime" => $ctime,
-            "size" => $size,
-            "type" => $type,
+            "remote_path_b64" => base64_encode($path),
+            "remote_ctime" => $ctime,
+            "remote_size" => $size,
+            "remote_type" => $type,
         ];
         $local_index_entry_path =
             $this->local_index_entry_path($local_path);
@@ -647,6 +682,7 @@ class ImportClient
             $update["local_ctime"] = (int) $stat["ctime"];
             $update["local_size"] =
                 $type === "dir" ? 0 : (int) $stat["size"];
+            $update["local_type"] = $type;
         }
         $this->write_index_update($update);
     }
@@ -676,18 +712,18 @@ class ImportClient
      * Appends one complete record to the index-update WAL.
      *
      * @param array $update {
-     *     One import-index update, with local-index fields when files-pull
+     *     One remote-index update, with local-index fields when files-pull
      *     changed a non-skipped path.
      *
-     *     @type string $op          `F` or `D`.
-     *     @type string $path        Base64-encoded import-index path.
-     *     @type int    $ctime       Remote ctime for an `F` record.
-     *     @type int    $size        Remote size for an `F` record.
-     *     @type string $type        Pulled path type used by both indexes for
-     *                               an `F` record.
+     *     @type string $op              `F` or `D`.
+     *     @type string $remote_path_b64 Base64-encoded remote-index path.
+     *     @type int    $remote_ctime    Remote ctime for an `F` record.
+     *     @type int    $remote_size     Remote size for an `F` record.
+     *     @type string $remote_type     Remote type for an `F` record.
      *     @type string $local_path_b64 Base64-encoded local-index path.
      *     @type int    $local_ctime    Local ctime for an `F` record.
      *     @type int    $local_size     Local size for an `F` record.
+     *     @type string $local_type     Local type for an `F` record.
      * }
      */
     private function write_index_update(array $update): void
@@ -771,6 +807,7 @@ class ImportClient
      */
     public function prepare_files_pull_options(array $options, bool $assert_remap = true): void
     {
+        $this->configure_remote_state_directory();
         $remap_raw = $options["remap"] ?? [];
         if (!empty($remap_raw)) {
             $this->remap_rules = $this->resolve_remap($remap_raw);
@@ -1031,6 +1068,7 @@ class ImportClient
         // files-diff and files-push use local push state and must not load
         // or write the pull command's .import-state.json file.
         if ($command === "files-diff") {
+            $this->configure_remote_state_directory();
             if (is_file($this->index_update_wal_path)) {
                 throw new RuntimeException(
                     'Finish or abort the interrupted files-pull before running files-diff.'
@@ -1040,6 +1078,7 @@ class ImportClient
             return;
         }
         if ($command === "files-push") {
+            $this->configure_remote_state_directory();
             if (is_file($this->index_update_wal_path)) {
                 throw new RuntimeException(
                     'Finish or abort the interrupted files-pull before running files-push.'
@@ -1057,6 +1096,9 @@ class ImportClient
         }
 
         $this->state = ImportState::from_array($this->load_state());
+        if (($this->import_state()->preflight ?? null) !== null) {
+            $this->configure_remote_state_directory();
+        }
 
         if ($command === "import-metadata") {
             $this->run_import_metadata();
@@ -1417,7 +1459,7 @@ class ImportClient
         $local_index_path = $context['local_index_path'];
         $missing_local_index_message =
             'files-diff requires the local index created by files-pull or files-push '
-            . 'for the same target URL, state directory, and local tree.';
+            . 'for the same target URL and state directory.';
 
         $plan_directory = $push_state_directory . '/files-diff-plan';
         try {
@@ -1772,10 +1814,11 @@ class ImportClient
      *
      *     @type string $target_url           Target exporter API URL.
      *     @type string $local_tree           Canonical local tree being sent.
-     *     @type string $push_state_directory Local push state directory.
-     *     @type string $local_index_path      Local index used by pull and push.
+     *     @type string $remote_state_directory State directory for the target relationship.
+     *     @type string $push_state_directory   Local push state directory.
+     *     @type string $local_index_path        Local index used by pull and push.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,push_state_directory:string,local_index_path:string}
+     * @phpstan-return array{target_url:string,local_tree:string,remote_state_directory:string,push_state_directory:string,local_index_path:string}
      */
     public static function prepare_files_push_context(
         string $target_url,
@@ -1823,10 +1866,11 @@ class ImportClient
      *
      *     @type string $target_url           Target exporter API URL.
      *     @type string $local_tree           Canonical local tree.
-     *     @type string $push_state_directory Local push state directory.
-     *     @type string $local_index_path      Local index used by pull and push.
+     *     @type string $remote_state_directory State directory for the target relationship.
+     *     @type string $push_state_directory   Local push state directory.
+     *     @type string $local_index_path        Local index used by pull and push.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,push_state_directory:string,local_index_path:string}
+     * @phpstan-return array{target_url:string,local_tree:string,remote_state_directory:string,push_state_directory:string,local_index_path:string}
      */
     public static function prepare_files_command_context(
         string $target_url,
@@ -1863,10 +1907,6 @@ class ImportClient
         }
         $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
         $target_url = rtrim($target_url, '?&');
-        $target_local_tree_hash = self::target_url_and_local_tree_hash(
-            $target_url,
-            $canonical_local_tree
-        );
         // Resolve an absolute physical state path even when its final components do not exist.
         if (strpos($state_directory, '/') !== 0) {
             $working_directory = getcwd();
@@ -1881,10 +1921,11 @@ class ImportClient
         if ($canonical_state_directory !== null) {
             $state_directory = $canonical_state_directory;
         }
-        $push_state_directory =
-            rtrim($state_directory, '/')
-            . '/push/'
-            . $target_local_tree_hash;
+        $remote_state_directory = self::remote_state_directory(
+            $target_url,
+            $state_directory
+        );
+        $push_state_directory = $remote_state_directory . '/push';
         if (
             $canonical_local_tree === '/'
             || path_is_within_root($push_state_directory, $canonical_local_tree)
@@ -1898,22 +1939,15 @@ class ImportClient
         return [
             'target_url' => $target_url,
             'local_tree' => $canonical_local_tree,
+            'remote_state_directory' => $remote_state_directory,
             'push_state_directory' => $push_state_directory,
-            'local_index_path' => self::local_index_path(
-                $target_url,
-                $state_directory,
-                $canonical_local_tree
-            ),
+            'local_index_path' => $remote_state_directory . '/.local-index.jsonl',
         ];
     }
 
-    /**
-     * Hashes the target endpoint and canonical local tree without URL user-info
-     * or SECRET_KEY.
-     */
-    private static function target_url_and_local_tree_hash(
-        string $target_url,
-        string $local_tree
+    /** Removes authentication inputs which do not identify a target. */
+    private static function target_url_for_relationship(
+        string $target_url
     ): string {
         /** @var string $target_url */
         $target_url = preg_replace(
@@ -1942,10 +1976,7 @@ class ImportClient
                     : '?' . implode('&', $query_parts) );
         }
 
-        return hash(
-            'sha256',
-            rtrim($target_url, '?&') . "\0" . $local_tree
-        );
+        return rtrim($target_url, '?&');
     }
     // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
@@ -2029,9 +2060,9 @@ class ImportClient
                 $this->import_state()->active_resumable_command->completion_state = null;
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->import_state()->index = new RemoteFileIndexCursorState();
-                if (file_exists($this->remote_index_file)) {
-                    @unlink($this->remote_index_file);
-                    $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+                if (file_exists($this->remote_index_next_file)) {
+                    @unlink($this->remote_index_next_file);
+                    $this->audit_log("FILE DELETE | {$this->remote_index_next_file}");
                 }
                 $this->save_state($this->state);
                 break;
@@ -2102,13 +2133,13 @@ class ImportClient
     }
 
     /**
-     * Clear sync progress and transient files while keeping the import index,
+     * Clear sync progress and transient files while keeping the remote index,
      * local index, and downloaded files, so the next files-pull computes a delta.
      */
     public function clear_files_pull_progress(): void
     {
         $this->audit_log(
-            "RESTART | Clearing files-pull progress (keeping import index, local index, and files)",
+            "RESTART | Clearing files-pull progress (keeping remote index, local index, and files)",
             true,
         );
         // Apply completed file changes to both indexes before discarding
@@ -2118,9 +2149,9 @@ class ImportClient
         $this->reset_state();
         $this->index_update_wal_handle = null;
 
-        if (file_exists($this->remote_index_file)) {
-            @unlink($this->remote_index_file);
-            $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+        if (file_exists($this->remote_index_next_file)) {
+            @unlink($this->remote_index_next_file);
+            $this->audit_log("FILE DELETE | {$this->remote_index_next_file}");
         }
         if (file_exists($this->download_list_file)) {
             @unlink($this->download_list_file);
@@ -2747,36 +2778,9 @@ class ImportClient
      */
     public function run_files_sync(): void
     {
-        $local_tree = $this->local_tree();
-        if (strpos($local_tree, '/') !== 0) {
-            /** @var string $working_directory */
-            $working_directory = getcwd();
-            $local_tree = $working_directory . '/' . $local_tree;
-        }
-        $canonical_local_tree =
-            self::canonicalize_path_with_missing_components($local_tree);
-        if ($canonical_local_tree === null) {
-            throw new RuntimeException(
-                'Failed to resolve the local tree: ' . $local_tree . '.'
-            );
-        }
-        $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
-        /** @var string $canonical_state_directory */
-        $canonical_state_directory = realpath($this->state_dir);
-        $target_local_tree_hash = self::target_url_and_local_tree_hash(
-            $this->remote_url,
-            $canonical_local_tree
-        );
-        $local_index_path = self::local_index_path(
-            $this->remote_url,
-            $canonical_state_directory,
-            $canonical_local_tree
-        );
-        $sender_state_path =
-            $canonical_state_directory
-            . '/push/'
-            . $target_local_tree_hash
-            . '/sender.json';
+        $local_index_path =
+            $this->remote_state_directory . '/.local-index.jsonl';
+        $sender_state_path = $this->remote_state_directory . '/push/sender.json';
         if (is_file($sender_state_path)) {
             throw new RuntimeException(
                 'Finish the unfinished files-push before running files-pull.'
@@ -2918,11 +2922,11 @@ class ImportClient
             [".", ".."]
         )) === 0;
 
-        // An import index from a prior completed sync means the next run is a
+        // A remote index from a prior completed sync means the next run is a
         // delta: re-index the remote, diff against that index, fetch only changes.
         $is_delta =
-            file_exists($this->index_file) &&
-            filesize($this->index_file) > 0;
+            file_exists($this->remote_index_file) &&
+            filesize($this->remote_index_file) > 0;
 
         // Resuming an in-progress sync
         if ($has_progress) {
@@ -3031,7 +3035,7 @@ class ImportClient
                 && !mkdir($local_index_directory, 0755, true)
             ) {
                 throw new RuntimeException(
-                    'Failed to create the local-index directory: '
+                    'Failed to create the remote state directory: '
                     . $local_index_directory
                     . '.'
                 );
@@ -3074,11 +3078,10 @@ class ImportClient
         $this->report_volatile_files();
     }
 
-    /** Returns the local index path for one target and local tree. */
-    private static function local_index_path(
+    /** Returns the state directory for one target. */
+    private static function remote_state_directory(
         string $target_url,
-        string $state_directory,
-        string $local_tree
+        string $state_directory
     ): string
     {
         if (strpos($state_directory, '/') !== 0) {
@@ -3086,31 +3089,20 @@ class ImportClient
             $working_directory = getcwd();
             $state_directory = $working_directory . '/' . $state_directory;
         }
-        if (strpos($local_tree, '/') !== 0) {
-            /** @var string $working_directory */
-            $working_directory = getcwd();
-            $local_tree = $working_directory . '/' . $local_tree;
-        }
         $canonical_state_directory =
             self::canonicalize_path_with_missing_components($state_directory);
-        $canonical_local_tree =
-            self::canonicalize_path_with_missing_components($local_tree);
-        if (
-            $canonical_state_directory === null
-            || $canonical_local_tree === null
-        ) {
+        if ($canonical_state_directory === null) {
             throw new RuntimeException(
-                'Failed to resolve the local-index path.'
+                'Failed to resolve the remote state directory.'
             );
         }
-        $target_local_tree_hash = self::target_url_and_local_tree_hash(
-            $target_url,
-            rtrim($canonical_local_tree, '/') ?: '/'
+        $target_url_hash = hash(
+            'sha256',
+            self::target_url_for_relationship($target_url)
         );
         return rtrim($canonical_state_directory, '/')
-            . '/local-index/'
-            . $target_local_tree_hash
-            . '.jsonl';
+            . '/remote-'
+            . $target_url_hash;
     }
 
     /** Returns the document root under this import's filesystem root. */
@@ -3173,7 +3165,7 @@ class ImportClient
                     return;
                 }
             }
-            $this->sort_index_file($this->remote_index_file);
+            $this->sort_index_file($this->remote_index_next_file);
             $this->import_state()->active_resumable_command->current_stage = "diff";
             $this->import_state()->diff = new FileDiffProgressState();
             if (file_exists($this->download_list_file)) {
@@ -3426,14 +3418,14 @@ class ImportClient
             $this->discover_symlink_targets();
         }
 
-        $this->sort_index_file($this->remote_index_file);
+        $this->sort_index_file($this->remote_index_next_file);
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->import_state()->active_resumable_command->current_stage = null;
         $this->save_state($this->state);
 
         $count = 0;
-        if (file_exists($this->remote_index_file)) {
-            $h = fopen($this->remote_index_file, "r");
+        if (file_exists($this->remote_index_next_file)) {
+            $h = fopen($this->remote_index_next_file, "r");
             if ($h) {
                 while (fgets($h) !== false) {
                     $count++;
@@ -3447,14 +3439,14 @@ class ImportClient
         );
 
         $this->progress->show_lifecycle_line("files-index complete: {$count} entries indexed\n");
-        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_file}\n");
+        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_next_file}\n");
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
             "command" => "files-index",
             "entries_indexed" => $count,
-            "remote_index" => $this->remote_index_file,
+            "remote_index" => $this->remote_index_next_file,
             "audit_log" => $this->audit_log,
             "message" => "files-index complete: {$count} entries indexed",
         ], true);
@@ -3605,11 +3597,11 @@ class ImportClient
     private function extract_symlink_dirs_from_index(array $visited): array
     {
         $targets = [];
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->remote_index_next_file)) {
             return $targets;
         }
 
-        $handle = fopen($this->remote_index_file, "r");
+        $handle = fopen($this->remote_index_next_file, "r");
         if (!$handle) {
             return $targets;
         }
@@ -3677,11 +3669,11 @@ class ImportClient
      */
     private function recreate_intermediate_symlinks(): void
     {
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->remote_index_next_file)) {
             return;
         }
 
-        $h = fopen($this->remote_index_file, "r");
+        $h = fopen($this->remote_index_next_file, "r");
         if (!$h) {
             return;
         }
@@ -4046,12 +4038,12 @@ class ImportClient
      * Print file index statistics: total indexed files and their size,
      * plus pending downloads and their size.
      *
-     * Reads .import-remote-index.jsonl for all indexed files and
-     * .import-download-list.jsonl for files not yet downloaded.
+     * Reads .remote-index.next.jsonl for all indexed files and pull-plan.jsonl
+     * for files not yet downloaded.
      */
     private function run_files_stats(): void
     {
-        $remote_index = $this->remote_index_file;
+        $remote_index = $this->remote_index_next_file;
         $download_list = $this->download_list_file;
 
         // Single pass over the remote index to build a path→size map.
@@ -4526,7 +4518,7 @@ class ImportClient
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
             rtrim($state_dir, "/") . "/.import-state.json";
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
-            rtrim($state_dir, "/") . "/.import-download-list-skipped.jsonl";
+            $this->skipped_download_list_file;
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -6438,22 +6430,22 @@ class ImportClient
             );
         }
 
-        $mode = file_exists($this->remote_index_file) ? "a" : "w";
+        $mode = file_exists($this->remote_index_next_file) ? "a" : "w";
         // Initialize the index counter from the existing file so resume
         // shows a monotonically increasing count.
         if ($mode === "a" && $this->index_entries_counted === 0) {
-            $this->index_entries_counted = $this->count_newlines($this->remote_index_file);
+            $this->index_entries_counted = $this->count_newlines($this->remote_index_next_file);
         }
         if ($mode === "w") {
             $this->audit_log(
-                "FILE CREATE | {$this->remote_index_file} | downloading fresh remote index",
+                "FILE CREATE | {$this->remote_index_next_file} | downloading fresh remote index",
             );
         } else {
             $this->audit_log(
-                "FILE APPEND | {$this->remote_index_file} | resuming remote index download",
+                "FILE APPEND | {$this->remote_index_next_file} | resuming remote index download",
             );
         }
-        $handle = fopen($this->remote_index_file, $mode);
+        $handle = fopen($this->remote_index_next_file, $mode);
         if (!$handle) {
             throw new RuntimeException("Failed to open remote index file");
         }
@@ -6668,11 +6660,11 @@ class ImportClient
     }
 
     /**
-     * Diff the import index against the remote index and build the download list.
+     * Diff the remote index against the next remote index and build the pull plan.
      */
     private function diff_indexes_and_build_fetch_list(): bool
     {
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->remote_index_next_file)) {
             throw new RuntimeException("Remote index file not found");
         }
 
@@ -6719,7 +6711,7 @@ class ImportClient
             );
         }
 
-        $remote_handle = fopen($this->remote_index_file, "r");
+        $remote_handle = fopen($this->remote_index_next_file, "r");
         if (!$remote_handle) {
             fclose($download_handle);
             throw new RuntimeException("Failed to open remote index file");
@@ -6728,8 +6720,8 @@ class ImportClient
             fseek($remote_handle, $remote_offset);
         }
 
-        $local_handle = file_exists($this->index_file)
-            ? fopen($this->index_file, "r")
+        $local_handle = file_exists($this->remote_index_file)
+            ? fopen($this->remote_index_file, "r")
             : null;
         $local = read_index_entry($local_handle);
         if ($local_after) {
@@ -6775,7 +6767,7 @@ class ImportClient
                     $local["type"] !== $remote["type"]
                 ) {
                     // File is in both indexes but changed on the remote.
-                    // Always re-download — this file is in our import index,
+                    // Always re-download — this file is in our remote index,
                     // meaning we synced it before; preserve-local does not
                     // protect files we own.
                     $target_handle = ($skipped_handle !== null && $this->is_uploads_path($remote["path"], $uploads_basedir))
@@ -6999,7 +6991,7 @@ class ImportClient
     /**
      * Builds a JSON batch file listing the next set of paths to download.
      *
-     * Reads from the download list (.import-download-list.jsonl) starting at
+     * Reads from the download list (pull-plan.jsonl) starting at
      * $offset, accumulating paths into a JSON array until the batch approaches
      * 80% of the server's max request size.  Always includes at least one path,
      * even if it alone exceeds the limit.
@@ -7238,7 +7230,7 @@ class ImportClient
 
         $update = [
             "op" => "D",
-            "path" => base64_encode($path),
+            "remote_path_b64" => base64_encode($path),
         ];
         $local_index_entry_path =
             $this->local_index_entry_path($local_path);
@@ -7307,7 +7299,7 @@ class ImportClient
         }
     }
 
-    /** Applies the current WAL to the import index and local index. */
+    /** Applies the current WAL to the remote index and local index. */
     private function apply_index_update_wal(): void
     {
         if ($this->index_update_wal_handle) {
@@ -7325,19 +7317,19 @@ class ImportClient
             return;
         }
 
-        $new_index = $this->index_file . ".new";
+        $new_index = $this->remote_index_file . ".new";
         $this->audit_log(
-            "INDEX MERGE START | merging updates into {$this->index_file}",
+            "INDEX MERGE START | merging updates into {$this->remote_index_file}",
         );
         $base_index_handle = null;
         $wal_handle = null;
         $new_index_handle = null;
         try {
-            if (is_file($this->index_file)) {
-                $base_index_handle = fopen($this->index_file, 'rb');
+            if (is_file($this->remote_index_file)) {
+                $base_index_handle = fopen($this->remote_index_file, 'rb');
                 if (!is_resource($base_index_handle)) {
                     throw new RuntimeException(
-                        'Failed to open the import index.'
+                        'Failed to open the remote index.'
                     );
                 }
             }
@@ -7348,12 +7340,12 @@ class ImportClient
                 || !is_resource($new_index_handle)
             ) {
                 throw new RuntimeException(
-                    'Failed to merge import-index updates.'
+                    'Failed to merge remote-index updates.'
                 );
             }
 
             $base = read_index_entry($base_index_handle);
-            $updates = read_index_updates($wal_handle);
+            $updates = read_index_updates($wal_handle, 'remote_');
             $updates->rewind();
             while ($base !== null || $updates->valid()) {
                 $update = $updates->valid() ? $updates->current() : null;
@@ -7390,12 +7382,13 @@ class ImportClient
                 fclose($new_index_handle);
             }
         }
-        if (!rename($new_index, $this->index_file)) {
+        if (!rename($new_index, $this->remote_index_file)) {
             throw new RuntimeException("Failed to replace index file");
         }
-        $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
+        $this->audit_log("INDEX MERGE COMPLETE | {$this->remote_index_file} updated");
 
-        $updates_path = $this->state_dir . '/.local-index-updates.tmp';
+        $updates_path =
+            $this->remote_state_directory . '/.local-index-updates.tmp';
         $wal_handle = null;
         $updates_handle = null;
         try {
@@ -7419,7 +7412,7 @@ class ImportClient
                     if (substr($line, -1) !== "\n" && feof($wal_handle)) {
                         break;
                     }
-                    /** @var array{op:'D'|'F',path:string,ctime?:int,size?:int,type?:string,local_path_b64?:string,local_ctime?:int,local_size?:int} $update */
+                    /** @var array{op:'D'|'F',remote_path_b64:string,remote_ctime?:int,remote_size?:int,remote_type?:string,local_path_b64?:string,local_ctime?:int,local_size?:int,local_type?:string} $update */
                     $update = json_decode(
                         $line,
                         true,
@@ -7437,7 +7430,7 @@ class ImportClient
                         $local_index_update += [
                             'ctime' => $update['local_ctime'],
                             'size' => $update['local_size'],
-                            'type' => $update['type'],
+                            'type' => $update['local_type'],
                         ];
                     }
                     write_local_index_update(
@@ -7467,11 +7460,8 @@ class ImportClient
 
             if ($updates_written > 0) {
                 apply_local_index_updates(
-                    self::local_index_path(
-                        $this->remote_url,
-                        $this->state_dir,
-                        $this->local_tree()
-                    ),
+                    $this->remote_state_directory
+                        . '/.local-index.jsonl',
                     $updates_path
                 );
             }
@@ -8506,7 +8496,7 @@ class ImportClient
 
     /**
      * Checks if the remote index contains $path or any descendant under it.
-     * Runs a memoized O(N) scan of .import-remote-index.jsonl.
+     * Runs a memoized O(N) scan of .remote-index.next.jsonl.
      */
     private function remote_index_contains_path_prefix(string $path): bool
     {
@@ -8519,12 +8509,12 @@ class ImportClient
             return $this->remote_index_prefix_cache[$path];
         }
 
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->remote_index_next_file)) {
             $this->remote_index_prefix_cache[$path] = false;
             return false;
         }
 
-        $h = fopen($this->remote_index_file, "r");
+        $h = fopen($this->remote_index_next_file, "r");
         if (!$h) {
             $this->remote_index_prefix_cache[$path] = false;
             return false;
@@ -8581,7 +8571,9 @@ class ImportClient
         $fingerprint = $this->files_remap_fingerprint();
         $previous = $this->import_state()->files_remap_fingerprint ?? null;
 
-        $has_existing_index = file_exists($this->index_file) && filesize($this->index_file) > 0;
+        $has_existing_index =
+            file_exists($this->remote_index_file)
+            && filesize($this->remote_index_file) > 0;
         if ($previous === null && $has_existing_index && !empty($this->remap_rules)) {
             throw new RuntimeException(
                 "Cannot use --remap with an existing files index that was created before remap tracking. " .
@@ -8621,7 +8613,7 @@ class ImportClient
      * The in-progress remote index cursor/file was built from one directory[]
      * allowlist. Switching the selected source path prefixes mid-resume would
      * mix indexes from different traversals. Completed runs are allowed to use
-     * different --only prefixes because the import index is intentionally a union
+     * different --only prefixes because the remote index is intentionally a union
      * across files-pull --only runs.
      */
     private function assert_files_pull_only_unchanged_while_resuming(bool $has_progress): void
@@ -9509,7 +9501,7 @@ class ImportClient
                 $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$path}", true);
                 $this->emit_skip_progress($path);
                 if ($ctime > 0) {
-                    $this->upsert_import_index_entry($path, $ctime, 0, "dir");
+                    $this->upsert_remote_index_entry($path, $ctime, 0, "dir");
                 }
                 return;
             }
@@ -9517,7 +9509,7 @@ class ImportClient
                 $this->audit_log("PRESERVE-LOCAL skip directory (symlink in path): {$path}", true);
                 $this->emit_skip_progress($path);
                 if ($ctime > 0) {
-                    $this->upsert_import_index_entry($path, $ctime, 0, "dir");
+                    $this->upsert_remote_index_entry($path, $ctime, 0, "dir");
                 }
                 return;
             }
@@ -9771,7 +9763,7 @@ class ImportClient
             }
             $this->write_index_update([
                 "op" => "D",
-                "path" => base64_encode($path),
+                "remote_path_b64" => base64_encode($path),
             ]);
 
             if ($error_type === "file_changed") {
@@ -12827,7 +12819,7 @@ if (
                 "\n" .
                 "On the first run, indexes the full remote directory tree and then\n" .
                 "downloads every file. On subsequent runs, re-indexes the remote tree,\n" .
-                "diffs against the import index, and downloads only what changed.\n" .
+                "diffs against the remote index, and downloads only what changed.\n" .
                 "Interrupted pulls resume from the last saved cursor.\n" .
                 "The state directory's .reprint.lock is held for the entire command,\n" .
                 "so another local Reprint command cannot use the same state directory.\n" .
@@ -12849,11 +12841,12 @@ if (
                 "Output files:\n" .
                 "  (fs-root)/                              Downloaded files\n" .
                 "  .reprint.lock                           Local Reprint process lock\n" .
-                "  .import-index.jsonl                     Import index\n" .
-                "  .import-index-updates.wal               Active files-pull WAL\n" .
-                "  .import-remote-index.jsonl              Remote index snapshot\n" .
-                "  .import-download-list.jsonl             Files pending download\n" .
-                "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
+                "  remote-<hash>/.remote-index.jsonl       Target-observed index\n" .
+                "  remote-<hash>/.local-index.jsonl        Locally accounted index\n" .
+                "  remote-<hash>/.remote-index.next.jsonl  Next target index\n" .
+                "  remote-<hash>/pull-index-updates.wal    Active files-pull WAL\n" .
+                "  remote-<hash>/pull-plan.jsonl           Files pending download\n" .
+                "  remote-<hash>/pull-plan.skipped.jsonl   Skipped files (when --filter=essential-files)\n" .
                 "  .import-state.json                      Resumable state\n" .
                 "  .import-audit.log                       Audit log\n",
         ],
@@ -12914,7 +12907,7 @@ if (
             "description" =>
                 "Streams the full remote directory tree over HTTP and writes each\n" .
                 "entry (path, size, ctime, type, and directory emptiness) to\n" .
-                ".import-remote-index.jsonl.\n" .
+                "remote-<hash>/.remote-index.next.jsonl.\n" .
                 "\n" .
                 "On the first run, builds the complete index. On subsequent runs,\n" .
                 "re-indexes and diffs against the prior snapshot to produce a\n" .
@@ -12928,9 +12921,9 @@ if (
         ],
         "files-stats" => [
             "level" => "low",
-            "short" => "Show file counts and sizes from the import index",
+            "short" => "Show file counts and sizes from the remote index",
             "description" =>
-                "Reads import index files to report (no network calls):\n" .
+                "Reads remote index files to report (no network calls):\n" .
                 "\n" .
                 "  - Total indexed files and their combined size\n" .
                 "  - Files not yet downloaded and their combined size\n" .

--- a/packages/reprint-importer/src/lib/index-update-functions.php
+++ b/packages/reprint-importer/src/lib/index-update-functions.php
@@ -368,12 +368,18 @@ function read_index_entry($handle): ?array
  * Yields the final update for each path and the latest operation which removed
  * its descendants.
  *
- * @param resource $handle Open path-sorted update file. Local-index update
- *                         batches also carry their operation positions.
+ * @param resource $handle       Open path-sorted update file. Local-index
+ *                               update batches also carry their operation
+ *                               positions.
+ * @param string   $field_prefix Field prefix in a pull WAL projection.
  * @return \Generator<int,array{path:string,delete:bool,ctime:int,size:int,type:string|null,operation_position:int|null,last_descendant_removal_position:int|null},mixed,void>
  */
-function read_index_updates($handle): \Generator
+function read_index_updates($handle, string $field_prefix = ''): \Generator
 {
+    $path_key = $field_prefix === '' ? 'path' : $field_prefix . 'path_b64';
+    $ctime_key = $field_prefix . 'ctime';
+    $size_key = $field_prefix . 'size';
+    $type_key = $field_prefix . 'type';
     $current = null;
     while (true) {
         $line = fgets($handle);
@@ -387,23 +393,23 @@ function read_index_updates($handle): \Generator
         if (substr($line, -1) !== "\n" && feof($handle)) {
             break;
         }
-        /** @var array{op:'D'|'F',path:string,operation_position?:int,ctime?:int,size?:int,type?:'file'|'link'|'dir'} $data */
+        /** @var array<string,mixed> $data */
         $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
         /** @var string $path */
-        $path = base64_decode($data['path']);
+        $path = base64_decode($data[$path_key]);
         $delete = $data['op'] === 'D';
         $operation_position = $data['operation_position'] ?? null;
         $last_descendant_removal_position =
             $operation_position !== null
-            && ( $delete || $data['type'] !== 'dir' )
+            && ( $delete || $data[$type_key] !== 'dir' )
                 ? $operation_position
                 : null;
         $entry = [
             'path' => $path,
             'delete' => $delete,
-            'ctime' => $delete ? 0 : $data['ctime'],
-            'size' => $delete ? 0 : $data['size'],
-            'type' => $delete ? null : $data['type'],
+            'ctime' => $delete ? 0 : $data[$ctime_key],
+            'size' => $delete ? 0 : $data[$size_key],
+            'type' => $delete ? null : $data[$type_key],
             'operation_position' => $operation_position,
             'last_descendant_removal_position' =>
                 $last_descendant_removal_position,

--- a/packages/reprint-importer/src/lib/index-update-functions.php
+++ b/packages/reprint-importer/src/lib/index-update-functions.php
@@ -1,0 +1,499 @@
+<?php
+
+namespace Reprint\Importer;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exceptions contain CLI filesystem paths, never HTML output.
+
+/**
+ * Sorts one update batch, merges it into the local index, and replaces the
+ * index atomically.
+ */
+function apply_local_index_updates(
+    string $local_index_path,
+    string $updates_path
+): void {
+    $prepared_updates_path = $updates_path . '.prepared';
+    $swap_path = $local_index_path . '.swap';
+    $local_index_directory = dirname($local_index_path);
+    if (
+        !is_dir($local_index_directory)
+        && !mkdir($local_index_directory, 0755, true)
+    ) {
+        throw new \RuntimeException(
+            'Failed to create the local-index directory: '
+            . $local_index_directory
+            . '.'
+        );
+    }
+
+    try {
+        $updates_handle = null;
+        $prepared_updates_handle = null;
+        try {
+            $updates_handle = fopen($updates_path, 'rb');
+            $prepared_updates_handle = fopen($prepared_updates_path, 'wb');
+            if (
+                !is_resource($updates_handle)
+                || !is_resource($prepared_updates_handle)
+            ) {
+                throw new \RuntimeException(
+                    'Failed to prepare the local-index updates.'
+                );
+            }
+            $operation_position = 0;
+            while (true) {
+                $line = fgets($updates_handle);
+                if ($line === false) {
+                    break;
+                }
+                $update = json_decode(
+                    $line,
+                    true,
+                    512,
+                    JSON_THROW_ON_ERROR
+                );
+                $update['operation_position'] = $operation_position;
+                write_local_index_update($prepared_updates_handle, $update);
+
+                if ($update['op'] === 'F') {
+                    /** @var string $path */
+                    $path = base64_decode($update['path']);
+                    /*
+                     * Directory ctime and size do not select push work. Zeroes
+                     * let the generated ancestors use the normal index shape.
+                     */
+                    while (true) {
+                        $separator = strrpos($path, '/');
+                        if ($separator === false) {
+                            break;
+                        }
+                        $path = substr($path, 0, $separator);
+                        write_local_index_update($prepared_updates_handle, [
+                            'op' => 'F',
+                            'path' => base64_encode($path),
+                            'ctime' => 0,
+                            'size' => 0,
+                            'type' => 'dir',
+                            'operation_position' => $operation_position,
+                        ]);
+                    }
+                }
+                ++$operation_position;
+            }
+            if (!feof($updates_handle)) {
+                throw new \RuntimeException(
+                    'Failed to read the local-index updates.'
+                );
+            }
+            if (!fflush($prepared_updates_handle)) {
+                throw new \RuntimeException(
+                    'Failed to flush the local-index updates.'
+                );
+            }
+        } finally {
+            if (is_resource($updates_handle)) {
+                fclose($updates_handle);
+            }
+            if (is_resource($prepared_updates_handle)) {
+                fclose($prepared_updates_handle);
+            }
+        }
+
+        // Limit each sort run to 8 MiB of update-line bytes.
+        $sorter = new \ExternalMergeSort(
+            static function (string $line): string {
+                /** @var array{path:string,operation_position:int} $entry */
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                /** @var string $path */
+                $path = base64_decode($entry['path']);
+                /*
+                 * The fixed-width suffix retains operation order among
+                 * updates for the same path after sorting.
+                 */
+                return local_index_path_sort_key($path)
+                    . "\0\0"
+                    . sprintf('%020d', $entry['operation_position']);
+            },
+            8 * 1024 * 1024,
+            false,
+            dirname($updates_path)
+        );
+        $sorter->sort($prepared_updates_path);
+
+        $base_handle = null;
+        $prepared_updates_handle = null;
+        $swap_handle = null;
+        try {
+            if (is_file($local_index_path)) {
+                $base_handle = fopen($local_index_path, 'rb');
+                if (!is_resource($base_handle)) {
+                    throw new \RuntimeException(
+                        'Failed to open the local index.'
+                    );
+                }
+            }
+            $prepared_updates_handle = fopen($prepared_updates_path, 'rb');
+            $swap_handle = fopen($swap_path, 'wb');
+            if (
+                !is_resource($prepared_updates_handle)
+                || !is_resource($swap_handle)
+            ) {
+                throw new \RuntimeException(
+                    'Failed to merge local-index updates.'
+                );
+            }
+            $base = read_index_entry($base_handle);
+            $updates = read_index_updates($prepared_updates_handle);
+            $updates->rewind();
+            $directory_waiting_for_next_entry = null;
+            /*
+             * A later deletion or non-directory F update at a parent removes
+             * older descendants. Component ordering keeps each subtree
+             * contiguous, so this stack holds only the descendant-removal
+             * operations which can affect the current entry.
+             */
+            $descendant_removal_stack = [];
+
+            while ($base !== null || $updates->valid()) {
+                $update = $updates->valid() ? $updates->current() : null;
+                $comparison =
+                    $base !== null && $update !== null
+                        ? compare_local_index_paths(
+                            $base['path'],
+                            $update['path']
+                        )
+                        : null;
+
+                if (
+                    $update === null
+                    || ( $comparison !== null && $comparison < 0 )
+                ) {
+                    $path = $base['path'];
+                    $entry = $base;
+                    $operation_position = null;
+                    $last_descendant_removal_position = null;
+                    $base = read_index_entry($base_handle);
+                } else {
+                    $path = $update['path'];
+                    $entry = $update['delete'] ? null : $update;
+                    $operation_position = $update['operation_position'];
+                    $last_descendant_removal_position =
+                        $update['last_descendant_removal_position'];
+                    $updates->next();
+                    if ($comparison === 0) {
+                        $base = read_index_entry($base_handle);
+                    }
+                }
+
+                while ($descendant_removal_stack !== []) {
+                    $ancestor_removal = $descendant_removal_stack[
+                        count($descendant_removal_stack) - 1
+                    ];
+                    if (
+                        strpos(
+                            $path,
+                            $ancestor_removal['path'] . '/'
+                        ) === 0
+                    ) {
+                        break;
+                    }
+                    array_pop($descendant_removal_stack);
+                }
+                $active_ancestor_removal_position =
+                    $descendant_removal_stack === []
+                        ? null
+                        : $descendant_removal_stack[
+                            count($descendant_removal_stack) - 1
+                        ]['operation_position'];
+                $entry_survives =
+                    $active_ancestor_removal_position === null
+                    || (
+                        $operation_position !== null
+                        && $operation_position
+                            >= $active_ancestor_removal_position
+                    );
+
+                if ($entry !== null && $entry_survives) {
+                    if ($directory_waiting_for_next_entry !== null) {
+                        $directory_waiting_for_next_entry['empty'] =
+                            strpos(
+                                $entry['path'],
+                                $directory_waiting_for_next_entry['path'] . '/'
+                            ) !== 0;
+                        write_index_entry(
+                            $swap_handle,
+                            $directory_waiting_for_next_entry
+                        );
+                        $directory_waiting_for_next_entry = null;
+                    }
+                    if ($entry['type'] === 'dir') {
+                        $entry['empty'] = true;
+                        $directory_waiting_for_next_entry = $entry;
+                    } else {
+                        write_index_entry($swap_handle, $entry);
+                    }
+                }
+                if (
+                    $last_descendant_removal_position !== null
+                    && (
+                        $active_ancestor_removal_position === null
+                        || $last_descendant_removal_position
+                            >= $active_ancestor_removal_position
+                    )
+                ) {
+                    $descendant_removal_stack[] = [
+                        'path' => $path,
+                        'operation_position' =>
+                            $last_descendant_removal_position,
+                    ];
+                }
+            }
+
+            if ($directory_waiting_for_next_entry !== null) {
+                write_index_entry(
+                    $swap_handle,
+                    $directory_waiting_for_next_entry
+                );
+            }
+            if (!fflush($swap_handle)) {
+                throw new \RuntimeException(
+                    'Failed to flush the merged index.'
+                );
+            }
+        } finally {
+            if (is_resource($base_handle)) {
+                fclose($base_handle);
+            }
+            if (is_resource($prepared_updates_handle)) {
+                fclose($prepared_updates_handle);
+            }
+            if (is_resource($swap_handle)) {
+                fclose($swap_handle);
+            }
+        }
+
+        if (!rename($swap_path, $local_index_path)) {
+            throw new \RuntimeException(
+                'Failed to replace the local index: '
+                . $local_index_path
+                . '.'
+            );
+        }
+    } finally {
+        if (is_file($prepared_updates_path)) {
+            @unlink($prepared_updates_path);
+        }
+        if (is_file($swap_path)) {
+            @unlink($swap_path);
+        }
+    }
+}
+
+/**
+ * Compares local-index paths component by component.
+ */
+function compare_local_index_paths(string $left, string $right): int
+{
+    return strcmp(
+        local_index_path_sort_key($left),
+        local_index_path_sort_key($right)
+    );
+}
+
+/**
+ * Returns the byte-sortable key for one local-index path.
+ *
+ * Filesystem paths cannot contain NUL. Using it as the component separator
+ * sorts each directory immediately before its descendants.
+ */
+function local_index_path_sort_key(string $path): string
+{
+    return str_replace('/', "\0", $path) . "\0";
+}
+
+/**
+ * Decodes one Reprint index entry.
+ *
+ * @return array {
+ *     @type string $path  Decoded filesystem path.
+ *     @type int    $ctime Indexed change timestamp.
+ *     @type int    $size  Indexed size.
+ *     @type string $type  `file`, `link`, or `dir`.
+ *     @type bool   $empty Whether a directory has no descendant entries in
+ *                         this index.
+ * }
+ * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool}
+ */
+function decode_index_entry(string $line): array
+{
+    /** @var array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool} $data */
+    $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+    /** @var string $path */
+    $path = base64_decode($data['path']);
+    $entry = [
+        'path' => $path,
+        'ctime' => $data['ctime'],
+        'size' => $data['size'],
+        'type' => $data['type'],
+    ];
+    if (array_key_exists('empty', $data)) {
+        $entry['empty'] = $data['empty'];
+    }
+    return $entry;
+}
+
+/**
+ * Reads one Reprint index entry.
+ *
+ * @param resource|null $handle Open index, or null when no index exists.
+ * @return array|null Decoded index entry, or null at EOF.
+ * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool}|null
+ */
+function read_index_entry($handle): ?array
+{
+    if (!is_resource($handle)) {
+        return null;
+    }
+    $line = fgets($handle);
+    if ($line === false) {
+        if (!feof($handle)) {
+            throw new \RuntimeException('Failed to read an index entry.');
+        }
+        return null;
+    }
+    return decode_index_entry($line);
+}
+
+/**
+ * Yields the final update for each path and the latest operation which removed
+ * its descendants.
+ *
+ * @param resource $handle Open path-sorted update file. Local-index update
+ *                         batches also carry their operation positions.
+ * @return \Generator<int,array{path:string,delete:bool,ctime:int,size:int,type:string|null,operation_position:int|null,last_descendant_removal_position:int|null},mixed,void>
+ */
+function read_index_updates($handle): \Generator
+{
+    $current = null;
+    while (true) {
+        $line = fgets($handle);
+        if ($line === false) {
+            break;
+        }
+        /*
+         * A process may stop while appending the final WAL record.
+         * Only newline-terminated records were written completely.
+         */
+        if (substr($line, -1) !== "\n" && feof($handle)) {
+            break;
+        }
+        /** @var array{op:'D'|'F',path:string,operation_position?:int,ctime?:int,size?:int,type?:'file'|'link'|'dir'} $data */
+        $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        /** @var string $path */
+        $path = base64_decode($data['path']);
+        $delete = $data['op'] === 'D';
+        $operation_position = $data['operation_position'] ?? null;
+        $last_descendant_removal_position =
+            $operation_position !== null
+            && ( $delete || $data['type'] !== 'dir' )
+                ? $operation_position
+                : null;
+        $entry = [
+            'path' => $path,
+            'delete' => $delete,
+            'ctime' => $delete ? 0 : $data['ctime'],
+            'size' => $delete ? 0 : $data['size'],
+            'type' => $delete ? null : $data['type'],
+            'operation_position' => $operation_position,
+            'last_descendant_removal_position' =>
+                $last_descendant_removal_position,
+        ];
+
+        if ($current !== null && $entry['path'] !== $current['path']) {
+            yield $current;
+            $current = null;
+        }
+        if ($current !== null) {
+            if (
+                $current['last_descendant_removal_position'] !== null
+                && (
+                    $entry['last_descendant_removal_position'] === null
+                    || $current['last_descendant_removal_position']
+                        > $entry['last_descendant_removal_position']
+                )
+            ) {
+                $entry['last_descendant_removal_position'] =
+                    $current['last_descendant_removal_position'];
+            }
+        }
+        $current = $entry;
+    }
+    if (!feof($handle)) {
+        throw new \RuntimeException('Failed to read an index-update entry.');
+    }
+    if ($current !== null) {
+        yield $current;
+    }
+}
+
+/**
+ * Writes one JSONL index entry.
+ *
+ * @param resource $handle Open index output.
+ * @param array    $entry {
+ *     Decoded index entry.
+ *
+ *     @type string $path  Path bytes.
+ *     @type int    $ctime Entry ctime.
+ *     @type int    $size  Entry size.
+ *     @type string $type  `file`, `link`, or `dir`.
+ *     @type bool   $empty Whether a directory has no descendant entries in
+ *                         this index.
+ * }
+ */
+function write_index_entry($handle, array $entry): void
+{
+    $encoded = [
+        'path' => base64_encode($entry['path']),
+        'ctime' => $entry['ctime'],
+        'size' => $entry['size'],
+        'type' => $entry['type'],
+    ];
+    if ($entry['type'] === 'dir' && array_key_exists('empty', $entry)) {
+        $encoded['empty'] = $entry['empty'];
+    }
+    $line = json_encode(
+        $encoded,
+        JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+    ) . "\n";
+    if (fwrite($handle, $line) !== strlen($line)) {
+        throw new \RuntimeException('Failed to write an index entry.');
+    }
+}
+
+/**
+ * Writes one JSONL local-index update.
+ *
+ * @param resource $handle Open update output.
+ * @param array    $update {
+ *     One local-index operation.
+ *
+ *     @type string $op       `F` or `D`.
+ *     @type string $path     Base64-encoded path.
+ *     @type int    $ctime    Local ctime for an `F` operation.
+ *     @type int    $size     Local size for an `F` operation.
+ *     @type string $type     Local type for an `F` operation.
+ *     @type int    $operation_position Operation order present only in the
+ *                                      prepared batch.
+ * }
+ */
+function write_local_index_update($handle, array $update): void
+{
+    $line = json_encode(
+        $update,
+        JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+    ) . "\n";
+    if (fwrite($handle, $line) !== strlen($line)) {
+        throw new \RuntimeException('Failed to write a local-index update.');
+    }
+}

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -278,6 +278,7 @@ class Pull
             // recorded that stage as complete. Clear the direct command
             // checkpoint first so the stage computes a fresh delta.
             $state_dir = $this->client->state_dir;
+            $remote_state_directory = $this->client->remote_state_directory;
             if ($state_command === 'files-pull' && in_array('files-pull', $stages, true)) {
                 // Keep the local file index, but clear transient files-pull
                 // download state so this pipeline computes a fresh
@@ -298,9 +299,9 @@ class Pull
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_import_state();
                 foreach ([
-                    "{$state_dir}/.import-remote-index.jsonl",
-                    "{$state_dir}/.import-download-list.jsonl",
-                    "{$state_dir}/.import-download-list-skipped.jsonl",
+                    "{$remote_state_directory}/.remote-index.next.jsonl",
+                    "{$remote_state_directory}/pull-plan.jsonl",
+                    "{$remote_state_directory}/pull-plan.skipped.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -768,6 +769,7 @@ class Pull
     private function prepare_repull(string $command): void
     {
         $state_dir = $this->client->state_dir;
+        $remote_state_directory = $this->client->remote_state_directory;
         switch ($command) {
             case 'pull':
                 $reset_file_transfer_state = true;
@@ -826,9 +828,9 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $state_dir . "/.import-remote-index.jsonl";
-            $paths[] = $state_dir . "/.import-download-list.jsonl";
-            $paths[] = $state_dir . "/.import-download-list-skipped.jsonl";
+            $paths[] = $remote_state_directory . "/.remote-index.next.jsonl";
+            $paths[] = $remote_state_directory . "/pull-plan.jsonl";
+            $paths[] = $remote_state_directory . "/pull-plan.skipped.jsonl";
         }
         if ($reset_db_state) {
             $paths[] = $state_dir . "/db.sql";

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -1,5 +1,8 @@
 <?php
 
+use function Reprint\Importer\apply_local_index_updates;
+use function Reprint\Importer\write_local_index_update;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
@@ -10,8 +13,7 @@
  * PushFilesSender owns the only caller-visible push lifecycle. Its caller holds
  * the Reprint process lock while the sender creates and removes the target push
  * session, drives its internal PushPlan, streams the selected paths, commits the
- * push, and saves the completed fresh local index as the pair's previous local
- * index. The target owns the
+ * push, and applies the committed paths to the local index. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
  * request limits and the PushPlan cursor needed after a process restart.
@@ -55,26 +57,26 @@
  * receiver-confirmed work before sending more data.
  *
  * A new sender calls `push_create` to learn target-owned exclusions before
- * starting PushPlan. The plan builds the fresh local index and diffs it against
- * the pair's previous local index, one bounded step at a time. That index is
- * saved by the previous successful push and also read by files-diff. After planning
+ * starting PushPlan. files-pull and files-push update the same local index, and
+ * files-diff reads it. files-pull refuses to run while `sender.json` exists, so
+ * PushPlan reads the local index directly across sender processes. It diffs the
+ * fresh local index against that file, one bounded step at a time. After planning
  * completes, local files, symlinks, and empty directories stream through
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
  * calls let the target install the work in bounded steps. A confirmed commit
- * enters another phase which saves the fresh local index as the pair's
- * previous local index through a swap file. Index completion, plan completion,
- * local-index saving, and plan discard each have a separate durable phase. A
- * stopped process therefore repeats only an idempotent boundary action rather
- * than a group of unrelated transitions.
+ * enters another phase which applies those operations to the local index
+ * through a swap file. Index completion, plan completion, local-index update,
+ * and plan discard each have a separate durable
+ * phase. A stopped process therefore repeats only an idempotent boundary
+ * action rather than a group of unrelated transitions.
  *
  * sender.json owns the top-level phase and the cursor returned by
  * PushPlan. PushFilesSender stores that cursor after every completed planning
  * step but never interprets its internal phase or offsets. The sender creates
  * the active plan directory before planning and removes the whole directory
- * only after success or target-session removal. The pair's previous local
- * index remains beside sender.json. Once the plan result is saved or discarded,
- * the sender clears its cursor before removing the directory without reopening
- * PushPlan.
+ * only after success or target-session removal. Once the local index is
+ * updated or the plan is discarded, the sender clears its cursor before
+ * removing the directory without reopening PushPlan.
  *
  * ## Resume after local changes
  *
@@ -104,25 +106,26 @@
  * the current path phase ends. An open sender retains that request, its
  * path-list handles, and its current local file handle between steps.
  *
- * Saving a complete local index after commit is the deliberate exception to
+ * Applying the committed paths after commit is the deliberate exception to
  * bounded steps.
  * A representative index entry is about 150 bytes, so one million paths produce
- * roughly 150 MB. Even a 10 MiB/s drive copies that in about 15 seconds. Keeping
- * two copy cursors, two retained handles, and per-chunk state writes for larger
- * installations is not justified until measurements show otherwise. PHP's
- * copy() streams the bytes through a swap file, and rename() atomically moves
- * the completed copy into place. This accepts that a 1 MiB/s drive reaches 30
- * seconds at roughly 200,000 paths. A stopped copy is repeated by the next call.
+ * roughly 150 MB. Even a 10 MiB/s drive streams that in about 15 seconds.
+ * Keeping another cursor, retained handle, and per-chunk state writes for larger
+ * installations is not justified until measurements show otherwise. The merge
+ * streams bytes through a swap file, and rename() atomically moves the completed
+ * index into place. This accepts that a 1 MiB/s drive reaches 30 seconds at
+ * roughly 200,000 paths. A stopped post-commit merge is repeated by the next
+ * call.
  *
  * The sender has no overall time limit. The caller decides whether to take
  * another step. Network operations apply connect, no-progress, and response
  * wait limits, while a connection that continues moving bytes may run longer.
  *
- * @phpstan-type LocalPathTypeSizeAndCtime array{type:'file'|'directory'|'symlink',size:int,ctime:int}
- * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
+ * @phpstan-type LocalPathTypeSizeAndCtime array{type:'file'|'dir'|'link',size:int,ctime:int}
+ * @phpstan-type LocalPathStat array{type:'file'|'dir'|'link'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_previous_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'updating_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -135,8 +138,8 @@ final class PushFilesSender
     /** @var string Sender-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Pair's previous local index, saved after a successful push and read by files-diff. */
-    private string $previous_local_index;
+    /** @var string Local index updated by successful pulls and pushes. */
+    private string $local_index_path;
 
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
@@ -233,6 +236,7 @@ final class PushFilesSender
      *
      *     @type string                  $docroot                Required local document-root directory.
      *     @type string                  $push_state_directory    Required local push state directory.
+     *     @type string                  $local_index_path        Required local index used by pull and push.
      *     @type string                  $base_url                Required exporter API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
@@ -310,7 +314,13 @@ final class PushFilesSender
             $sender->state = $state;
             $sender->push_stream_client = $sender->create_push_stream_client($state);
             if ($state['push_plan_cursor'] !== null) {
-                $sender->plan = PushPlan::resume($state['push_plan_cursor']);
+                $sender->plan = PushPlan::resume(
+                    $sender->plan_directory,
+                    $sender->docroot,
+                    $sender->local_index_path,
+                    $sender->excluded_paths_path,
+                    $state['push_plan_cursor']
+                );
             }
             return $sender;
         } catch (Throwable $throwable) {
@@ -331,11 +341,15 @@ final class PushFilesSender
     {
         $docroot = $options['docroot'] ?? null;
         $push_state_directory = $options['push_state_directory'] ?? null;
+        $local_index_path = $options['local_index_path'] ?? null;
         if (!is_string($docroot) || !is_dir($docroot) || is_link($docroot)) {
             throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
         }
         if (!is_string($push_state_directory) || $push_state_directory === '') {
             throw new InvalidArgumentException('PushFilesSender requires a push_state_directory.');
+        }
+        if (!is_string($local_index_path) || $local_index_path === '') {
+            throw new InvalidArgumentException('PushFilesSender requires a local_index_path.');
         }
         if (!$process_lock->is_held()) {
             throw new InvalidArgumentException('PushFilesSender requires a held Reprint process lock.');
@@ -364,7 +378,7 @@ final class PushFilesSender
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
-        $this->previous_local_index = $this->push_state_directory . '/previous_local_index.jsonl';
+        $this->local_index_path = $local_index_path;
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
         $this->request_sizer_options = $request_sizer_options;
@@ -374,9 +388,9 @@ final class PushFilesSender
     /**
      * Performs the next step for the current phase.
      *
-     * start() or resume() has received the Reprint process lock and loaded the
+     * start() or resume() has received the caller's process lock and loaded the
      * durable state, so this method only dispatches its current phase. Every
-     * phase step is bounded except the deliberate completed-index copy described
+     * phase step is bounded except the post-commit local-index rewrite described
      * in the class documentation. A caller stopping after this method returns
      * true calls cancel() before close(); close() does not finish an open
      * multipart request. A false return directs the caller to get_status(),
@@ -413,8 +427,8 @@ final class PushFilesSender
             case 'committing':
                 $this->commit_push();
                 break;
-            case 'saving_previous_local_index':
-                $this->save_previous_local_index();
+            case 'updating_local_index':
+                $this->update_local_index();
                 break;
             case 'completing':
                 $this->complete_push();
@@ -505,7 +519,7 @@ final class PushFilesSender
     }
 
     /**
-     * Releases open sender resources without finishing a request.
+     * Releases sender resources without finishing a request.
      *
      * The caller uses cancel() first when stopping with an open multipart
      * request. Durable state remains available to resume unless next_step()
@@ -581,13 +595,16 @@ final class PushFilesSender
 
     /**
      * Creates PushPlan and stores its initial cursor with the planning phase.
+     *
+     * files-pull refuses to run while this sender exists, so the plan can keep
+     * reading the same local index across sender processes.
      */
     private function start_plan(): void
     {
         $this->plan = PushPlan::start(
             $this->plan_directory,
             $this->docroot,
-            $this->previous_local_index,
+            $this->local_index_path,
             $this->excluded_paths_path
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
@@ -702,6 +719,14 @@ final class PushFilesSender
             $this->start_removing_push_session_after_local_change();
             return;
         }
+        $multipart_part_type =
+            $local_path_type_size_and_ctime['type'] === 'dir'
+                ? 'directory'
+                : (
+                    $local_path_type_size_and_ctime['type'] === 'link'
+                        ? 'symlink'
+                        : 'file'
+                );
 
         // Continue at the tentative byte offset in an open request, then at the
         // target-confirmed offset cached during this run. Ask the target only
@@ -727,7 +752,7 @@ final class PushFilesSender
 
             if (
                 $receiver_path_status['state'] === 'complete'
-                && $receiver_path_type === $local_path_type_size_and_ctime['type']
+                && $receiver_path_type === $multipart_part_type
                 && ( $local_path_type_size_and_ctime['type'] !== 'file' || $receiver_path_status['accepted_bytes'] === $local_path_type_size_and_ctime['size'] )
             ) {
                 $this->close_local_file_handle();
@@ -749,7 +774,7 @@ final class PushFilesSender
         $upload_completes_local_path = false;
 
         // Directory and symlink values each fit in one MIME part and need no byte cursor.
-        if ($local_path_type_size_and_ctime['type'] === 'directory') {
+        if ($local_path_type_size_and_ctime['type'] === 'dir') {
             $directory_is_empty = $this->directory_is_empty($local_path_to_push['path']);
             if ($directory_is_empty === null) {
                 $this->fail('local_io_error', 'Could not read the local directory to push: ' . base64_encode($local_path_to_push['path']) . '.');
@@ -772,12 +797,12 @@ final class PushFilesSender
                 return;
             }
             $upload_part = [
-                'type' => 'directory',
+                'type' => $multipart_part_type,
                 'path' => $local_path_to_push['path'],
                 'payload' => '',
             ];
             $upload_completes_local_path = true;
-        } elseif ($local_path_type_size_and_ctime['type'] === 'symlink') {
+        } elseif ($local_path_type_size_and_ctime['type'] === 'link') {
             $symlink_target = @readlink($this->docroot . '/' . $local_path_to_push['path']);
             $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
@@ -795,7 +820,7 @@ final class PushFilesSender
                 return;
             }
             $upload_part = [
-                'type' => 'symlink',
+                'type' => $multipart_part_type,
                 'path' => $local_path_to_push['path'],
                 'target' => $symlink_target,
                 'payload' => '',
@@ -873,7 +898,7 @@ final class PushFilesSender
             }
 
             $upload_part = [
-                'type' => 'file',
+                'type' => $multipart_part_type,
                 'path' => $local_path_to_push['path'],
                 'total_bytes' => $local_path_type_size_and_ctime['size'],
                 'offset' => $file_byte_offset,
@@ -1183,24 +1208,70 @@ final class PushFilesSender
         if ($response['send_next_request']) {
             return;
         }
-        $this->state['phase'] = 'saving_previous_local_index';
+        $this->state['phase'] = 'updating_local_index';
         $this->store_state($this->state);
     }
 
     /**
-     * Saves the committed fresh local index as the pair's previous local index.
+     * Applies the committed push operations to the local index.
      *
-     * If the process stops before the next phase is stored, repeating the
-     * deliberate whole-index copy is safe and leaves readers on either the old
-     * or complete new index.
+     * Repeating this merge after interruption is idempotent. It applies only
+     * operations committed by the target. If the local index does not exist,
+     * the merge starts with an empty index.
      */
-    private function save_previous_local_index(): void
+    private function update_local_index(): void
     {
-        $fresh_local_index = $this->plan->get_fresh_local_index_path();
         try {
-            $this->copy_through_swap_file(
-                $fresh_local_index,
-                $this->previous_local_index
+            $local_index_updates_path =
+                $this->plan_directory . '/local_index_updates.jsonl';
+            $local_index_updates_handle =
+                fopen($local_index_updates_path, 'wb');
+            if (!is_resource($local_index_updates_handle)) {
+                throw new RuntimeException(
+                    'Failed to open the local-index updates.'
+                );
+            }
+            try {
+                /*
+                 * Deletions precede F entries so a same-path replacement
+                 * removes the old descendants while ending with the planned
+                 * type, size, and ctime. The local-index merger adds parent
+                 * directories and derives their empty state.
+                 */
+                foreach (
+                    $this->plan->read_planned_local_paths_to_delete()
+                    as $local_path_to_delete
+                ) {
+                    write_local_index_update($local_index_updates_handle, [
+                        'op' => 'D',
+                        'path' => base64_encode($local_path_to_delete),
+                    ]);
+                }
+
+                foreach (
+                    $this->plan->read_planned_local_paths_to_push()
+                    as $local_path_to_push
+                ) {
+                    write_local_index_update($local_index_updates_handle, [
+                        'op' => 'F',
+                        'path' => $local_path_to_push['path_b64'],
+                        'ctime' => $local_path_to_push['ctime'],
+                        'size' => $local_path_to_push['size'],
+                        'type' => $local_path_to_push['type'],
+                    ]);
+                }
+
+                if (!fflush($local_index_updates_handle)) {
+                    throw new RuntimeException(
+                        'Failed to flush the local-index updates.'
+                    );
+                }
+            } finally {
+                fclose($local_index_updates_handle);
+            }
+            apply_local_index_updates(
+                $this->local_index_path,
+                $local_index_updates_path
             );
         } catch (RuntimeException $exception) {
             $this->fail('local_io_error', $exception->getMessage());
@@ -1209,27 +1280,6 @@ final class PushFilesSender
         $this->state['push_plan_cursor'] = null;
         $this->state['phase'] = 'completing';
         $this->store_state($this->state);
-    }
-
-    /**
-     * Copies one complete index through a swap file and moves it into place.
-     *
-     * copy() streams without holding the complete index in memory. Only the
-     * final rename is atomic: interruption during copy leaves the existing
-     * index untouched and a later call overwrites the partial swap file.
-     *
-     * @param string $source_path Complete index to copy.
-     * @param string $target_path Final path for the copied index.
-     */
-    private function copy_through_swap_file(string $source_path, string $target_path): void
-    {
-        $swap_index = $target_path . '.swap';
-        if (!@copy($source_path, $swap_index)) {
-            throw new RuntimeException('Failed to copy the index to its swap file: ' . $swap_index);
-        }
-        if (!@rename($swap_index, $target_path)) {
-            throw new RuntimeException('Failed to move the copied index into place: ' . $target_path);
-        }
     }
 
     /**
@@ -1356,17 +1406,16 @@ final class PushFilesSender
         if (!is_int($next_local_paths_to_push_byte_offset)) {
             throw new RuntimeException('Failed to determine the next byte offset in the local paths to push.');
         }
-        try {
-            $decoded_local_path = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException('Failed to decode a local path to push.', 0, $exception);
-        }
-        /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $decoded_local_path */
-        $path_b64 = $decoded_local_path['path'];
-        $path = base64_decode($path_b64, true);
-        if ($path === false) {
-            throw new RuntimeException('Failed to decode a path in the local paths-to-push file.');
-        }
+        /** @var array{path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int} $decoded_local_path */
+        $decoded_local_path = json_decode(
+            $line,
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $path_b64 = $decoded_local_path['path_b64'];
+        /** @var string $path */
+        $path = base64_decode($path_b64);
         return [
             'path' => $path,
             'path_b64' => $path_b64,
@@ -1466,15 +1515,15 @@ final class PushFilesSender
         if ($file_type_bits === 0100000) {
             $type = 'file';
         } elseif ($file_type_bits === 0040000) {
-            $type = 'directory';
+            $type = 'dir';
         } elseif ($file_type_bits === 0120000) {
-            $type = 'symlink';
+            $type = 'link';
         } else {
             $type = 'unsupported';
         }
         return [
             'type' => $type,
-            'size' => $type === 'directory' ? 0 : (int) $path_stat['size'],
+            'size' => $type === 'dir' ? 0 : (int) $path_stat['size'],
             'ctime' => (int) $path_stat['ctime'],
         ];
     }

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -1,14 +1,18 @@
 <?php
 
+use function Reprint\Importer\compare_local_index_paths;
+use function Reprint\Importer\read_index_entry;
+use function Reprint\Importer\write_index_entry;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
 /**
  * Internal bounded local-index and change planner.
  *
  * PushPlan builds a path-sorted fresh local index, then diffs it against the
- * previous local index supplied by its caller. It writes durable lists of
- * local paths to push and local paths to delete without accumulating an index
- * or path list in memory.
+ * local index at the caller-supplied path. It writes durable lists of local
+ * paths to push and local paths to delete without accumulating an index or
+ * path list in memory.
  *
  * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
  * lock, top-level phase, result, and terminal behavior. PushPlan owns
@@ -26,19 +30,18 @@
  *
  * ## Change detection
  *
- * ctime is machine-local, so the previous local index must describe the same
- * local machine: PushFilesSender supplies the index saved after the previous
- * push, and files-diff supplies the index captured after the previous pull.
- * File and symlink changes are determined by type, ctime, and size. Directory
- * changes use the indexer's empty-directory marker; non-empty directories are
- * represented by their descendants.
+ * ctime is machine-local, so the local index must describe the same local
+ * machine. files-pull and committed files-push operations update the local
+ * index; PushFilesSender and files-diff each supply its path and prevent it
+ * from changing during the plan lifecycle. File and symlink changes are
+ * determined by type, ctime, and size.
+ * Directory changes use the indexer's empty-directory marker; non-empty
+ * directories are represented by their descendants.
  *
- * With no previous local index, every file, symlink, and empty directory is
- * selected, and no deletion can be detected. Excluded paths are omitted from
- * both path lists but remain in the fresh local index.
- *
- * The index reader trusts the entry values produced by the indexer. It retains
- * failure handling for reading lines, decoding JSON, and decoding base64 paths.
+ * With no local index, every indexed file, symlink, and empty directory is
+ * selected, and no deletion can be detected. Paths skipped by the indexer's
+ * default rules are absent from the fresh local index. Excluded paths are
+ * omitted from both path lists but remain in the fresh local index.
  *
  * ## Durability and memory
  *
@@ -51,18 +54,16 @@
  * returning from its own step. `resume()` discards bytes beyond saved offsets,
  * so an interrupted step cannot leave duplicate durable entries.
  *
- * PushPlan retains the next entry from each index and the top of an append-only
- * deleted-directory stack needed to suppress redundant descendant deletions. It
- * never loads an index, path list, or the stack in full.
+ * PushPlan retains the next entry from each index and one deleted directory
+ * whose descendants need no separate deletion. It never loads an index or path
+ * list in full.
  *
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_path_b64:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
- * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,previous_local_index:string,position:PushPlanPosition}
- * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
+ * @phpstan-type PushPlanCursor IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  */
 class PushPlan
 {
@@ -72,8 +73,8 @@ class PushPlan
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Previous local index supplied by the caller. */
-    private string $previous_local_index;
+    /** @var string Local index path supplied by the caller. */
+    private string $local_index_path;
 
     /** @var string JSONL file of local paths to push. */
     private string $local_paths_to_push;
@@ -84,13 +85,10 @@ class PushPlan
     /** @var string Plan-owned fresh local index. */
     private string $fresh_local_index;
 
-    /** @var string Plan path containing receiver-owned exclusions for the active push. */
-    private string $excluded_paths_file;
+    /** @var string Excluded paths file supplied by the caller. */
+    private string $excluded_paths_path;
 
-    /** @var string Append-only deleted-directory stack for the active plan. */
-    private string $deleted_directories_stack;
-
-    /** @var list<string> Receiver-owned paths that the plan must not push or delete. */
+    /** @var list<string> Decoded excluded paths. */
     private array $excluded_paths = [];
 
     /** @var PushPlanCursor Current cursor returned to the caller. */
@@ -109,48 +107,43 @@ class PushPlan
     private bool $fresh_local_index_entry_loaded = false;
 
     /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
-    private ?array $previous_local_index_lookahead_entry = null;
+    private ?array $local_index_lookahead_entry = null;
 
-    /** @var bool Whether $previous_local_index_lookahead_entry has been read, including EOF. */
-    private bool $previous_local_index_lookahead_entry_loaded = false;
+    /** @var bool Whether $local_index_lookahead_entry has been read, including EOF. */
+    private bool $local_index_lookahead_entry_loaded = false;
 
-    /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
-    private ?array $deleted_directory_stack_entry = null;
+    /** @var string|null Deleted directory whose descendants need no separate deletion. */
+    private ?string $deleted_directory_path = null;
 
     /** @var resource|null Open fresh local index retained during indexing or the index diff. */
     private $fresh_local_index_handle = null;
     /** @var resource|null */
-    private $previous_local_index_handle = null;
+    private $local_index_handle = null;
     /** @var resource|null */
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
     private $local_paths_to_delete_handle = null;
-    /** @var resource|null */
-    private $deleted_directories_stack_handle = null;
-
     /**
      * Starts a push plan by opening a fresh local index traversal.
      *
-     * Copies the target exclusions into the plan directory before opening the
-     * fresh local index traversal. Until the caller stores the returned cursor,
-     * an interrupted start is repeated and overwrites these initial plan files.
-     *
      * @param string $plan_directory              Caller-owned active plan directory.
      * @param string $local_tree_root              Canonical local tree root.
-     * @param string $previous_local_index Previous local index this plan diffs against.
-     * @param string $excluded_paths_path          Caller-owned target exclusions file.
+     * @param string $local_index_path             Local index this plan diffs against.
+     * @param string $excluded_paths_path          Excluded paths file.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $local_tree_root,
-        string $previous_local_index,
+        string $local_index_path,
         string $excluded_paths_path
     ): self {
-        $plan = new self($plan_directory, $local_tree_root, $previous_local_index);
-        if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
-            throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
-        }
+        $plan = new self(
+            $plan_directory,
+            $local_tree_root,
+            $local_index_path,
+            $excluded_paths_path
+        );
         $plan->excluded_paths = $plan->load_excluded_paths();
         $plan->fresh_local_index_handle = fopen($plan->fresh_local_index, "w+b");
         if (!is_resource($plan->fresh_local_index_handle)) {
@@ -164,14 +157,9 @@ class PushPlan
             $plan->plan_directory
         );
         $plan->cursor = [
-            "plan_directory" => $plan->plan_directory,
-            "local_tree_root" => $plan->local_tree_root,
-            "previous_local_index" => $plan->previous_local_index,
-            "position" => [
-                "phase" => "indexing",
-                "file_index_cursor" => $plan->file_index_processor->get_cursor(),
-                "fresh_local_index_byte_offset" => 0,
-            ],
+            "phase" => "indexing",
+            "file_index_cursor" => $plan->file_index_processor->get_cursor(),
+            "fresh_local_index_byte_offset" => 0,
         ];
         return $plan;
     }
@@ -182,24 +170,33 @@ class PushPlan
      * Reopens only the processor and files required by the cursor's current
      * internal phase.
      *
+     * @param string $plan_directory      Caller-owned active plan directory.
+     * @param string $local_tree_root     Canonical local tree root.
+     * @param string $local_index_path    Local index this plan diffs against.
+     * @param string $excluded_paths_path Excluded paths file.
      * @phpstan-param PushPlanCursor $cursor Cursor previously returned by get_cursor().
      * @return self Open plan positioned at its last durable cursor.
      */
-    public static function resume(array $cursor): self
-    {
+    public static function resume(
+        string $plan_directory,
+        string $local_tree_root,
+        string $local_index_path,
+        string $excluded_paths_path,
+        array $cursor
+    ): self {
         $plan = new self(
-            $cursor["plan_directory"],
-            $cursor["local_tree_root"],
-            $cursor["previous_local_index"]
+            $plan_directory,
+            $local_tree_root,
+            $local_index_path,
+            $excluded_paths_path
         );
         $plan->cursor = $cursor;
-        $position = $plan->cursor["position"];
-        if ($position["phase"] !== "complete") {
+        if ($cursor["phase"] !== "complete") {
             $plan->excluded_paths = $plan->load_excluded_paths();
         }
-        if ($position["phase"] === "indexing") {
+        if ($cursor["phase"] === "indexing") {
             $plan->open_fresh_local_index_for_continuation();
-        } elseif ($position["phase"] === "diffing") {
+        } elseif ($cursor["phase"] === "diffing") {
             $plan->open_plan_files();
         }
         return $plan;
@@ -232,11 +229,61 @@ class PushPlan
     }
 
     /**
-     * Returns the plan-owned fresh local index path.
+     * Reads the completed local paths-to-push list.
+     *
+     * @return Generator Completed plan entries.
+     * @phpstan-return Generator<int,array{path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int},mixed,void>
      */
-    public function get_fresh_local_index_path(): string
+    public function read_planned_local_paths_to_push(): Generator
     {
-        return $this->fresh_local_index;
+        $local_paths_to_push_handle = fopen($this->local_paths_to_push, 'rb');
+        if (!is_resource($local_paths_to_push_handle)) {
+            throw new RuntimeException('Failed to open the completed local paths-to-push list.');
+        }
+        try {
+            while (true) {
+                $line = fgets($local_paths_to_push_handle);
+                if ($line === false) {
+                    if (!feof($local_paths_to_push_handle)) {
+                        throw new RuntimeException('Failed to read the completed local paths-to-push list.');
+                    }
+                    return;
+                }
+                /** @var array{path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int} $entry */
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                yield $entry;
+            }
+        } finally {
+            fclose($local_paths_to_push_handle);
+        }
+    }
+
+    /**
+     * Reads the completed local paths-to-delete list.
+     *
+     * @return Generator Completed local paths to delete.
+     * @phpstan-return Generator<int,string,mixed,void>
+     */
+    public function read_planned_local_paths_to_delete(): Generator
+    {
+        $local_paths_to_delete_handle = fopen($this->local_paths_to_delete, 'rb');
+        if (!is_resource($local_paths_to_delete_handle)) {
+            throw new RuntimeException('Failed to open the completed local paths-to-delete list.');
+        }
+        try {
+            while (true) {
+                $local_path_to_delete = stream_get_line($local_paths_to_delete_handle, 1048576, "\0");
+                if ($local_path_to_delete === false) {
+                    if (!feof($local_paths_to_delete_handle)) {
+                        throw new RuntimeException('Failed to read the completed local paths-to-delete list.');
+                    }
+                    return;
+                }
+                yield $local_path_to_delete;
+            }
+        } finally {
+            fclose($local_paths_to_delete_handle);
+        }
     }
 
     /**
@@ -244,12 +291,14 @@ class PushPlan
      *
      * @param string $plan_directory              Caller-owned active plan directory.
      * @param string $local_tree_root              Canonical local tree root.
-     * @param string $previous_local_index Previous local index this plan diffs against.
+     * @param string $local_index_path    Local index this plan diffs against.
+     * @param string $excluded_paths_path Excluded paths file.
      */
     private function __construct(
         string $plan_directory,
         string $local_tree_root,
-        string $previous_local_index
+        string $local_index_path,
+        string $excluded_paths_path
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -257,12 +306,11 @@ class PushPlan
         }
         $this->plan_directory = $plan_directory;
         $this->set_local_tree_root($local_tree_root);
-        $this->previous_local_index = $previous_local_index;
+        $this->local_index_path = $local_index_path;
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
         $this->fresh_local_index = $plan_directory . "/fresh_local_index.jsonl";
-        $this->excluded_paths_file = $plan_directory . "/excluded_paths.json";
-        $this->deleted_directories_stack = $plan_directory . "/deleted_directories_stack.jsonl";
+        $this->excluded_paths_path = $excluded_paths_path;
     }
 
     /**
@@ -289,7 +337,7 @@ class PushPlan
     private function open_fresh_local_index_for_continuation(): void
     {
         /** @var IndexingCursor $cursor */
-        $cursor = $this->cursor["position"];
+        $cursor = $this->cursor;
         $this->fresh_local_index_handle = fopen($this->fresh_local_index, "r+b");
         if (!is_resource($this->fresh_local_index_handle)) {
             throw new RuntimeException("Failed to reopen the fresh local index: {$this->fresh_local_index}");
@@ -318,12 +366,15 @@ class PushPlan
     private function open_plan_files(): void
     {
         /** @var IndexDiffCursor $cursor */
-        $cursor = $this->cursor["position"];
+        $cursor = $this->cursor;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
-        $this->previous_local_index_lookahead_entry = null;
-        $this->previous_local_index_lookahead_entry_loaded = false;
-        $this->deleted_directory_stack_entry = null;
+        $this->local_index_lookahead_entry = null;
+        $this->local_index_lookahead_entry_loaded = false;
+        $this->deleted_directory_path =
+            $cursor["deleted_directory_path_b64"] === null
+                ? null
+                : base64_decode($cursor["deleted_directory_path_b64"]);
         $this->local_paths_to_push_handle = $this->open_and_truncate_and_seek(
             $this->local_paths_to_push,
             $cursor["byte_offset_in_local_paths_to_push"]
@@ -337,10 +388,10 @@ class PushPlan
             throw new RuntimeException("Failed to open the retained fresh local index: {$this->fresh_local_index}");
         }
 
-        if (is_file($this->previous_local_index)) {
-            $this->previous_local_index_handle = fopen($this->previous_local_index, "rb");
-            if (!is_resource($this->previous_local_index_handle)) {
-                throw new RuntimeException("Failed to open the previous local index: {$this->previous_local_index}");
+        if (is_file($this->local_index_path)) {
+            $this->local_index_handle = fopen($this->local_index_path, "rb");
+            if (!is_resource($this->local_index_handle)) {
+                throw new RuntimeException("Failed to open the local index: {$this->local_index_path}");
             }
         }
         $this->seek_to_cursor(
@@ -348,20 +399,13 @@ class PushPlan
             $cursor["byte_offset_in_fresh_index"],
             "fresh local index"
         );
-        if ($this->previous_local_index_handle) {
+        if ($this->local_index_handle) {
             $this->seek_to_cursor(
-                $this->previous_local_index_handle,
-                $cursor["byte_offset_in_previous_local_index"],
-                "previous local index"
+                $this->local_index_handle,
+                $cursor["byte_offset_in_local_index"],
+                "local index"
             );
         }
-        $this->deleted_directories_stack_handle = fopen($this->deleted_directories_stack, "a+b");
-        if (!is_resource($this->deleted_directories_stack_handle)) {
-            throw new RuntimeException("Failed to open the deleted-directory stack: {$this->deleted_directories_stack}");
-        }
-        $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
-            $cursor["deleted_directory_stack_top_byte_offset"]
-        );
     }
 
     /**
@@ -374,15 +418,14 @@ class PushPlan
      */
     public function next_step(): bool
     {
-        $position = $this->cursor["position"];
-        if ($position["phase"] === "complete") {
+        if ($this->cursor["phase"] === "complete") {
             return false;
         }
         if ($this->closed) {
             throw new LogicException("Cannot take a push plan step after close().");
         }
 
-        switch ($position["phase"]) {
+        switch ($this->cursor["phase"]) {
             case "indexing":
                 $this->next_file_index_step();
                 return true;
@@ -407,7 +450,7 @@ class PushPlan
         if (!$this->file_index_processor->next_index_step()) {
             $this->file_index_processor->close();
             $this->close_fresh_local_index_handle();
-            $this->cursor["position"] = ["phase" => "starting_diff"];
+            $this->cursor = ["phase" => "starting_diff"];
             return;
         }
 
@@ -439,7 +482,7 @@ class PushPlan
         if (!is_int($fresh_local_index_byte_offset)) {
             throw new RuntimeException("Failed to determine the fresh local index byte offset.");
         }
-        $this->cursor["position"] = [
+        $this->cursor = [
             "phase" => "indexing",
             "file_index_cursor" => $this->file_index_processor->get_cursor(),
             "fresh_local_index_byte_offset" => $fresh_local_index_byte_offset,
@@ -451,16 +494,13 @@ class PushPlan
      */
     private function start_index_diff(): void
     {
-        if (file_put_contents($this->deleted_directories_stack, "") !== 0) {
-            throw new RuntimeException("Failed to initialize the deleted-directory stack: {$this->deleted_directories_stack}");
-        }
-        $this->cursor["position"] = [
+        $this->cursor = [
             "phase" => "diffing",
             "byte_offset_in_fresh_index" => 0,
-            "byte_offset_in_previous_local_index" => 0,
+            "byte_offset_in_local_index" => 0,
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
-            "deleted_directory_stack_top_byte_offset" => null,
+            "deleted_directory_path_b64" => null,
         ];
         $this->open_plan_files();
     }
@@ -475,29 +515,24 @@ class PushPlan
     {
         if ($index_entry["type"] === "other") {
             throw new RuntimeException(
-                "Cannot push the unsupported local path: " . base64_encode($index_entry["path"]) . "."
+                "Cannot push the unsupported local path: "
+                . base64_encode($index_entry["path"])
+                . "."
             );
         }
-        if ($index_entry["type"] === "dir" && !array_key_exists("empty", $index_entry)) {
+        if (
+            $index_entry["type"] === "dir"
+            && !array_key_exists("empty", $index_entry)
+        ) {
             throw new RuntimeException(
-                "Could not inspect the local directory: " . base64_encode($index_entry["path"]) . "."
+                "Could not inspect the local directory: "
+                . base64_encode($index_entry["path"])
+                . "."
             );
         }
-
         $local_path = substr($index_entry["path"], strlen($this->local_tree_root) + 1);
-        $fresh_local_index_entry = [
-            "path" => base64_encode($local_path),
-            "ctime" => $index_entry["ctime"],
-            "size" => $index_entry["size"],
-            "type" => $index_entry["type"],
-        ];
-        if ($index_entry["type"] === "dir") {
-            $fresh_local_index_entry["empty"] = $index_entry["empty"];
-        }
-        $line = json_encode($fresh_local_index_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-        if (fwrite($this->fresh_local_index_handle, $line) !== strlen($line)) {
-            throw new RuntimeException("Failed to write a fresh local index entry.");
-        }
+        $index_entry["path"] = $local_path;
+        write_index_entry($this->fresh_local_index_handle, $index_entry);
     }
 
     /**
@@ -511,64 +546,71 @@ class PushPlan
     private function next_index_diff_step(): bool
     {
         /** @var IndexDiffCursor $cursor */
-        $cursor = $this->cursor["position"];
+        $cursor = $this->cursor;
 
         $byte_offset_in_fresh_index = $cursor["byte_offset_in_fresh_index"];
-        $byte_offset_in_previous_local_index = $cursor["byte_offset_in_previous_local_index"];
-        $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
+        $byte_offset_in_local_index = $cursor["byte_offset_in_local_index"];
         $local_paths_to_push_changed = false;
         $local_paths_to_delete_changed = false;
-        $deleted_directories_stack_changed = false;
 
         if (!$this->fresh_local_index_entry_loaded) {
-            $this->fresh_local_index_entry = $this->parse_next_index_entry($this->fresh_local_index_handle);
+            $this->fresh_local_index_entry =
+                read_index_entry($this->fresh_local_index_handle);
             $this->fresh_local_index_entry_loaded = true;
         }
-        if (!$this->previous_local_index_lookahead_entry_loaded) {
-            $this->previous_local_index_lookahead_entry = $this->parse_next_index_entry(
-                $this->previous_local_index_handle
+        if (!$this->local_index_lookahead_entry_loaded) {
+            $this->local_index_lookahead_entry = read_index_entry(
+                $this->local_index_handle
             );
-            $this->previous_local_index_lookahead_entry_loaded = true;
+            $this->local_index_lookahead_entry_loaded = true;
         }
-        $entry_fresh_index = $this->fresh_local_index_entry;
-        $entry_previous_local_index = $this->previous_local_index_lookahead_entry;
+        $fresh_local_index_entry = $this->fresh_local_index_entry;
+        $local_index_entry = $this->local_index_lookahead_entry;
 
-        if ($entry_fresh_index !== null || $entry_previous_local_index !== null) {
+        if (
+            $fresh_local_index_entry !== null
+            || $local_index_entry !== null
+        ) {
             // Base64 does not preserve byte order ('0' sorts before 'A'
             // in ASCII but encodes a higher value), so ordering uses the
-            // decoded path bytes.
-            if ($entry_previous_local_index === null) {
+            // decoded filesystem path components.
+            if ($local_index_entry === null) {
                 $path_comparison = -1;
-            } elseif ($entry_fresh_index === null) {
+            } elseif ($fresh_local_index_entry === null) {
                 $path_comparison = 1;
             } else {
-                $path_comparison = strcmp($entry_fresh_index["path"], $entry_previous_local_index["path"]);
+                $path_comparison = compare_local_index_paths(
+                    $fresh_local_index_entry["path"],
+                    $local_index_entry["path"]
+                );
             }
 
-            $current_shape = null;
+            $fresh_is_non_empty_directory = false;
             if ($path_comparison <= 0) {
-                $current_shape = $this->entry_shape($entry_fresh_index);
+                $fresh_is_non_empty_directory =
+                    $fresh_local_index_entry["type"] === "dir"
+                    && !$fresh_local_index_entry["empty"];
             }
 
-            $previous_local_index_shape = null;
+            $local_index_is_non_empty_directory = false;
             if ($path_comparison >= 0) {
-                $previous_local_index_shape = $this->entry_shape($entry_previous_local_index);
+                $local_index_is_non_empty_directory =
+                    $local_index_entry["type"] === "dir"
+                    && !$local_index_entry["empty"];
 
-                // Byte sorting can put a sibling such as `a-other` before
-                // `a/child`. Every retained non-empty directory has a later
-                // descendant, so adjacent previous-index entries can pass at
-                // most the top sibling range.
-                if ($this->deleted_directory_stack_entry !== null) {
-                    $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
-                    if (
-                        strpos($entry_previous_local_index["path"], $descendant_prefix) !== 0
-                        && strcmp($entry_previous_local_index["path"], $descendant_prefix) > 0
-                    ) {
-                        $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
-                        $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
-                            $deleted_directory_stack_top_byte_offset
-                        );
-                    }
+                /*
+                 * Directory entries sort immediately before one contiguous
+                 * run of descendants. Once this entry leaves the deleted
+                 * directory, no later entry can return to it.
+                 */
+                if (
+                    $this->deleted_directory_path !== null
+                    && strpos(
+                        $local_index_entry["path"],
+                        $this->deleted_directory_path . "/"
+                    ) !== 0
+                ) {
+                    $this->deleted_directory_path = null;
                 }
             }
 
@@ -577,85 +619,105 @@ class PushPlan
                 // pushed. A new non-empty directory is represented by its
                 // descendants.
                 if (
-                    $current_shape !== "non_empty_directory"
-                    && !$this->path_conflicts_with_excluded_paths($entry_fresh_index["path"])
+                    !$fresh_is_non_empty_directory
+                    && !$this->path_conflicts_with_excluded_paths(
+                        $fresh_local_index_entry["path"]
+                    )
                 ) {
-                    $this->append_local_path_to_push($entry_fresh_index);
+                    $this->append_local_path_to_push(
+                        $fresh_local_index_entry
+                    );
                     $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
                 // A deleted non-empty directory emits one root. Its later
                 // descendant entries are already covered by that path.
                 if (
-                    !$this->path_conflicts_with_excluded_paths($entry_previous_local_index["path"])
-                    && !$this->deleted_directory_stack_covers_path(
-                        $entry_previous_local_index["path"],
-                        $this->deleted_directory_stack_entry
+                    !$this->path_conflicts_with_excluded_paths(
+                        $local_index_entry["path"]
                     )
+                    && $this->deleted_directory_path === null
                 ) {
-                    $this->append_local_path_to_delete($entry_previous_local_index["path"]);
+                    $this->append_local_path_to_delete(
+                        $local_index_entry["path"]
+                    );
                     $local_paths_to_delete_changed = true;
-                    if ($previous_local_index_shape === "non_empty_directory") {
-                        $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $entry_previous_local_index["path"],
-                            $deleted_directory_stack_top_byte_offset
-                        );
-                        $deleted_directories_stack_changed = true;
+                    if ($local_index_is_non_empty_directory) {
+                        $this->deleted_directory_path =
+                            $local_index_entry["path"];
                     }
                 }
             } else {
-                $current_is_file_or_symlink = $current_shape === "file" || $current_shape === "symlink";
-                $previous_local_index_is_file_or_symlink = $previous_local_index_shape === "file" || $previous_local_index_shape === "symlink";
-                $non_empty_directory_becomes_empty = $current_shape === "empty_directory"
-                    && $previous_local_index_shape === "non_empty_directory";
-                $empty_directory_needs_push = $current_shape === "empty_directory"
-                    && $previous_local_index_shape !== "empty_directory";
+                $fresh_is_file_or_link =
+                    $fresh_local_index_entry["type"] === "file"
+                    || $fresh_local_index_entry["type"] === "link";
+                $local_index_is_file_or_link =
+                    $local_index_entry["type"] === "file"
+                    || $local_index_entry["type"] === "link";
+                $fresh_is_empty_directory =
+                    $fresh_local_index_entry["type"] === "dir"
+                    && $fresh_local_index_entry["empty"];
+                $local_index_is_empty_directory =
+                    $local_index_entry["type"] === "dir"
+                    && $local_index_entry["empty"];
+                $non_empty_directory_becomes_empty =
+                    $fresh_is_empty_directory
+                    && $local_index_is_non_empty_directory;
+                $empty_directory_needs_push =
+                    $fresh_is_empty_directory
+                    && !$local_index_is_empty_directory;
                 // File and symlink changes are defined by type, ctime, and
                 // size. Other index values do not select a path for upload.
-                $changed_file_or_symlink_needs_push = $current_is_file_or_symlink
+                $changed_file_or_link_needs_push = $fresh_is_file_or_link
                     && (
-                        $entry_fresh_index["ctime"] !== $entry_previous_local_index["ctime"]
-                        || $entry_fresh_index["size"] !== $entry_previous_local_index["size"]
-                        || $entry_fresh_index["type"] !== $entry_previous_local_index["type"]
+                        $fresh_local_index_entry["ctime"]
+                            !== $local_index_entry["ctime"]
+                        || $fresh_local_index_entry["size"]
+                            !== $local_index_entry["size"]
+                        || $fresh_local_index_entry["type"]
+                            !== $local_index_entry["type"]
                     );
-                $needs_delete = $current_is_file_or_symlink !== $previous_local_index_is_file_or_symlink
+                $needs_delete =
+                    $fresh_is_file_or_link !== $local_index_is_file_or_link
                     || $non_empty_directory_becomes_empty;
                 $needs_push = $empty_directory_needs_push
-                    || $changed_file_or_symlink_needs_push;
-                $path_is_excluded = $this->path_conflicts_with_excluded_paths($entry_fresh_index["path"]);
+                    || $changed_file_or_link_needs_push;
+                $path_is_excluded =
+                    $this->path_conflicts_with_excluded_paths(
+                        $fresh_local_index_entry["path"]
+                    );
 
                 if (
                     $needs_delete
                     && !$path_is_excluded
-                    && !$this->deleted_directory_stack_covers_path(
-                        $entry_previous_local_index["path"],
-                        $this->deleted_directory_stack_entry
-                    )
+                    && $this->deleted_directory_path === null
                 ) {
-                    $this->append_local_path_to_delete($entry_previous_local_index["path"]);
+                    $this->append_local_path_to_delete(
+                        $local_index_entry["path"]
+                    );
                     $local_paths_to_delete_changed = true;
-                    if ($previous_local_index_shape === "non_empty_directory") {
-                        $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $entry_previous_local_index["path"],
-                            $deleted_directory_stack_top_byte_offset
-                        );
-                        $deleted_directories_stack_changed = true;
+                    if ($local_index_is_non_empty_directory) {
+                        $this->deleted_directory_path =
+                            $local_index_entry["path"];
                     }
                 }
                 if ($needs_push && !$path_is_excluded) {
-                    $this->append_local_path_to_push($entry_fresh_index);
+                    $this->append_local_path_to_push(
+                        $fresh_local_index_entry
+                    );
                     $local_paths_to_push_changed = true;
                 }
             }
 
             if ($path_comparison <= 0) {
                 $byte_offset_in_fresh_index = ftell($this->fresh_local_index_handle);
-                $this->fresh_local_index_entry = $this->parse_next_index_entry($this->fresh_local_index_handle);
+                $this->fresh_local_index_entry =
+                    read_index_entry($this->fresh_local_index_handle);
             }
             if ($path_comparison >= 0) {
-                $byte_offset_in_previous_local_index = ftell($this->previous_local_index_handle);
-                $this->previous_local_index_lookahead_entry = $this->parse_next_index_entry(
-                    $this->previous_local_index_handle
+                $byte_offset_in_local_index = ftell($this->local_index_handle);
+                $this->local_index_lookahead_entry = read_index_entry(
+                    $this->local_index_handle
                 );
             }
         }
@@ -663,28 +725,29 @@ class PushPlan
         if (
             ( $local_paths_to_push_changed && !fflush($this->local_paths_to_push_handle) )
             || ( $local_paths_to_delete_changed && !fflush($this->local_paths_to_delete_handle) )
-            || ( $deleted_directories_stack_changed && !fflush($this->deleted_directories_stack_handle) )
         ) {
             throw new RuntimeException("Failed to flush a push-plan output.");
         }
 
         $complete = $this->fresh_local_index_entry === null
-            && $this->previous_local_index_lookahead_entry === null;
+            && $this->local_index_lookahead_entry === null;
         if ($complete) {
-            $deleted_directory_stack_top_byte_offset = null;
-            $this->deleted_directory_stack_entry = null;
+            $this->deleted_directory_path = null;
         }
         $cursor_after_step = $complete
             ? ["phase" => "complete"]
             : [
                 "phase" => "diffing",
                 "byte_offset_in_fresh_index" => $byte_offset_in_fresh_index,
-                "byte_offset_in_previous_local_index" => $byte_offset_in_previous_local_index,
+                "byte_offset_in_local_index" => $byte_offset_in_local_index,
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
-                "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
+                "deleted_directory_path_b64" =>
+                    $this->deleted_directory_path === null
+                        ? null
+                        : base64_encode($this->deleted_directory_path),
             ];
-        $this->cursor["position"] = $cursor_after_step;
+        $this->cursor = $cursor_after_step;
         return !$complete;
     }
 
@@ -692,8 +755,7 @@ class PushPlan
      * Closes every plan file handle and prevents further plan steps.
      *
      * The cursor returned to the caller and the plan-owned files remain
-     * available to resume the plan or save the completed fresh local index
-     * after a successful push.
+     * available until the caller no longer needs them.
      */
     public function close(): void
     {
@@ -701,8 +763,8 @@ class PushPlan
             $this->file_index_processor->close();
         }
         $this->close_fresh_local_index_handle();
-        if (is_resource($this->previous_local_index_handle)) {
-            fclose($this->previous_local_index_handle);
+        if (is_resource($this->local_index_handle)) {
+            fclose($this->local_index_handle);
         }
         if (is_resource($this->local_paths_to_push_handle)) {
             fclose($this->local_paths_to_push_handle);
@@ -710,18 +772,14 @@ class PushPlan
         if (is_resource($this->local_paths_to_delete_handle)) {
             fclose($this->local_paths_to_delete_handle);
         }
-        if (is_resource($this->deleted_directories_stack_handle)) {
-            fclose($this->deleted_directories_stack_handle);
-        }
-        $this->previous_local_index_handle = null;
+        $this->local_index_handle = null;
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
-        $this->deleted_directories_stack_handle = null;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
-        $this->previous_local_index_lookahead_entry = null;
-        $this->previous_local_index_lookahead_entry_loaded = false;
-        $this->deleted_directory_stack_entry = null;
+        $this->local_index_lookahead_entry = null;
+        $this->local_index_lookahead_entry_loaded = false;
+        $this->deleted_directory_path = null;
         $this->closed = true;
     }
 
@@ -779,32 +837,6 @@ class PushPlan
     }
 
     /**
-     * Returns the logical entry kind used by the transition table.
-     *
-     * @param array $entry {
-     *     Parsed local index entry.
-     *
-     *     @type string $path  Decoded filesystem path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $ctime Indexed change timestamp.
-     *     @type int    $size  Indexed size used for change detection.
-     *     @type bool   $empty Whether a directory is empty. Present for directory entries.
-     * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $entry
-     * @return 'file'|'symlink'|'empty_directory'|'non_empty_directory'
-     */
-    private function entry_shape(array $entry): string
-    {
-        if ($entry["type"] === "file") {
-            return "file";
-        }
-        if ($entry["type"] === "link") {
-            return "symlink";
-        }
-        return $entry["empty"] ? "empty_directory" : "non_empty_directory";
-    }
-
-    /**
      * Appends one path and its planned type, size, and ctime to the JSONL list.
      *
      * Base64 keeps arbitrary filesystem path bytes representable in JSON.
@@ -823,8 +855,8 @@ class PushPlan
     {
         $line = json_encode(
             [
-                "path" => base64_encode($entry["path"]),
-                "type" => $entry["type"] === "link" ? "symlink" : ($entry["type"] === "dir" ? "directory" : "file"),
+                "path_b64" => base64_encode($entry["path"]),
+                "type" => $entry["type"],
                 "size" => $entry["size"],
                 "ctime" => $entry["ctime"],
             ],
@@ -846,84 +878,6 @@ class PushPlan
         if (fwrite($this->local_paths_to_delete_handle, $path_with_nul) !== strlen($path_with_nul)) {
             throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
         }
-    }
-
-    /**
-     * Appends one active directory and links it to the preceding stack entry.
-     *
-     * @param string   $path                 Raw directory path selected for deletion.
-     * @param int|null $previous_byte_offset Byte offset of the preceding active entry.
-     * @return int Byte offset of the appended entry.
-     */
-    private function append_deleted_directory_stack_entry(string $path, ?int $previous_byte_offset): int
-    {
-        if (fseek($this->deleted_directories_stack_handle, 0, SEEK_END) !== 0) {
-            throw new RuntimeException("Failed to seek to the end of the deleted-directory stack.");
-        }
-        $byte_offset = ftell($this->deleted_directories_stack_handle);
-        if (!is_int($byte_offset)) {
-            throw new RuntimeException("Failed to determine the deleted-directory stack byte offset.");
-        }
-        $line = json_encode(
-            [
-                "path_b64" => base64_encode($path),
-                "previous_byte_offset" => $previous_byte_offset,
-            ],
-            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
-        ) . "\n";
-        if (fwrite($this->deleted_directories_stack_handle, $line) !== strlen($line)) {
-            throw new RuntimeException("Failed to append to the deleted-directory stack.");
-        }
-        $this->deleted_directory_stack_entry = [
-            "path" => $path,
-            "previous_byte_offset" => $previous_byte_offset,
-        ];
-        return $byte_offset;
-    }
-
-    /**
-     * Reads one stack entry addressed by the planning cursor.
-     *
-     * @param int|null $byte_offset Entry byte offset, or null for an empty stack.
-     * @return DeletedDirectoryStackEntry|null Decoded stack entry, or null.
-     */
-    private function read_deleted_directory_stack_entry(?int $byte_offset): ?array
-    {
-        if ($byte_offset === null) {
-            return null;
-        }
-        if (fseek($this->deleted_directories_stack_handle, $byte_offset) !== 0) {
-            throw new RuntimeException("Failed to seek in the deleted-directory stack.");
-        }
-        $line = fgets($this->deleted_directories_stack_handle);
-        if (!is_string($line)) {
-            throw new RuntimeException("Failed to read the deleted-directory stack entry at byte {$byte_offset}.");
-        }
-        try {
-            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException("Failed to decode the deleted-directory stack entry at byte {$byte_offset}.", 0, $exception);
-        }
-        /** @var array{path_b64:string,previous_byte_offset:int|null} $entry */
-        $path = base64_decode($entry["path_b64"], true);
-        if ($path === false) {
-            throw new RuntimeException("Failed to decode the deleted-directory path at byte {$byte_offset}.");
-        }
-        return [
-            "path" => $path,
-            "previous_byte_offset" => $entry["previous_byte_offset"],
-        ];
-    }
-
-    /**
-     * Reports whether the active deleted directory contains the path.
-     *
-     * @param string                          $path  Raw filesystem path to classify.
-     * @param DeletedDirectoryStackEntry|null $entry Top active stack entry.
-     */
-    private function deleted_directory_stack_covers_path(string $path, ?array $entry): bool
-    {
-        return $entry !== null && strpos($path, $entry["path"] . "/") === 0;
     }
 
     /**
@@ -952,81 +906,32 @@ class PushPlan
     }
 
     /**
-     * Loads the caller-owned exclusions used throughout one planning run.
+     * Loads the excluded paths used throughout one planning run.
      *
      * @return list<string> Decoded document-root-relative excluded paths.
      */
     private function load_excluded_paths(): array
     {
-        $contents = file_get_contents($this->excluded_paths_file);
+        $contents = file_get_contents($this->excluded_paths_path);
         if (!is_string($contents)) {
-            throw new RuntimeException("Failed to read excluded paths: {$this->excluded_paths_file}");
+            throw new RuntimeException(
+                "Failed to read excluded paths: {$this->excluded_paths_path}"
+            );
         }
-        try {
-            $excluded_paths_b64 = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException("Failed to decode excluded paths: {$this->excluded_paths_file}", 0, $exception);
-        }
+        $excluded_paths_b64 = json_decode(
+            $contents,
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
         /** @var list<string> $excluded_paths_b64 */
         $excluded_paths = [];
         foreach ($excluded_paths_b64 as $excluded_path_b64) {
-            $excluded_path = base64_decode($excluded_path_b64, true);
-            if ($excluded_path === false) {
-                throw new RuntimeException("Failed to decode an excluded path: {$this->excluded_paths_file}");
-            }
+            /** @var string $excluded_path */
+            $excluded_path = base64_decode($excluded_path_b64);
             $excluded_paths[] = $excluded_path;
         }
         return $excluded_paths;
-    }
-
-    /**
-     * Reads and decodes the next local index entry.
-     *
-     * A null handle represents a missing previous local index.
-     * The indexer's entry schema is trusted; only file reads, JSON decoding,
-     * and base64 path decoding are handled here as fallible operations.
-     *
-     * @param resource|null $handle Open local index handle, or null when no previous local index exists.
-     * @return array|null {
-     *     Decoded index entry, or null at EOF or when the handle is null.
-     *
-     *     @type string $path  Decoded filesystem path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $ctime Indexed change timestamp.
-     *     @type int    $size  Indexed size used for change detection.
-     *     @type bool   $empty Whether a directory is empty. Present for directory entries.
-     * }
-     * @phpstan-return array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null
-     */
-    private function parse_next_index_entry($handle): ?array
-    {
-        if (!$handle) {
-            return null;
-        }
-        $raw_line = fgets($handle);
-        if ($raw_line === false) {
-            if (!feof($handle)) {
-                throw new RuntimeException("Failed to read a local index line.");
-            }
-            return null;
-        }
-
-        try {
-            $entry = json_decode($raw_line, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException(
-                "Unexpected index line, it is not valid JSON: " . substr($raw_line, 0, 120),
-                0,
-                $exception
-            );
-        }
-        /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $entry */
-        $path = base64_decode($entry["path"], true);
-        if ($path === false) {
-            throw new RuntimeException("The index path is not valid base64: " . substr($raw_line, 0, 120));
-        }
-        $entry["path"] = $path;
-        return $entry;
     }
 
 }

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -156,7 +156,7 @@ class PlaygroundCliApplier implements RuntimeApplier
             'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE'
                 => '/tmp/reprint/.import-state.json',
             'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'
-                => '/tmp/reprint/.import-download-list-skipped.jsonl',
+                => '/tmp/reprint/pull-plan.skipped.jsonl',
         ];
 
         foreach ($runtime_file_mounts as $constant_name => $vfs_path) {

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -61,8 +61,14 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('Usage: reprint files-diff <target-url>', $output);
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
-        $this->assertStringContainsString('previous local index', $output);
+        $this->assertStringContainsString('Compares the local tree at --fs-root with the local index', $output);
         $this->assertStringContainsString('completed files-push', $output);
+        $this->assertStringContainsString('files-pull and pull-files', $output);
+        $this->assertStringContainsString('update entries for paths they change', $output);
+        $this->assertStringContainsString('paths committed by the target', $output);
+        $this->assertStringContainsString('Complete files-pull, pull-files, or files-push once', $output);
+        $this->assertStringContainsString('omit URL user-info and SECRET_KEY', $output);
+        $this->assertStringContainsString('same files-pull with --abort', $output);
         $this->assertStringContainsString('push operation plan', $output);
         $this->assertStringContainsString('default-skipped paths', $output);
         $this->assertStringContainsString('No network calls', $output);

--- a/tests/Import/DownloadListProgressTest.php
+++ b/tests/Import/DownloadListProgressTest.php
@@ -65,7 +65,7 @@ class DownloadListProgressTest extends TestCase
      */
     private function writeDownloadList(int $count, ?string $file = null): string
     {
-        $file = $file ?? $this->stateDir . '/.import-download-list.jsonl';
+        $file = $file ?? $this->remoteStateDirectory() . '/pull-plan.jsonl';
         $handle = fopen($file, 'w');
         for ($i = 0; $i < $count; $i++) {
             fwrite($handle, json_encode(["path" => base64_encode("/file-{$i}.txt")]) . "\n");
@@ -83,7 +83,15 @@ class DownloadListProgressTest extends TestCase
                 "current_stage" => null,
                 "remote_cursor" => null,
             ],
-            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "preflight" => [
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "document_root" => "",
+                    ],
+                ],
+                "http_code" => 200,
+            ],
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
             "version" => null,
@@ -107,6 +115,10 @@ class DownloadListProgressTest extends TestCase
         $loadState = $reflection->getMethod('load_state');
         $stateProperty = $reflection->getProperty('state');
         $stateProperty->setValue($client, $loadState->invoke($client));
+        $reflection->getMethod('configure_remote_state_directory')->invoke(
+            $client,
+            $this->fs_root
+        );
 
         $ttyProperty = $reflection->getProperty('is_tty');
         $ttyProperty->setValue($client, false);
@@ -115,6 +127,21 @@ class DownloadListProgressTest extends TestCase
         $filterProp->setValue($client, $filter);
 
         return [$client, $reflection];
+    }
+
+    private function remoteStateDirectory(): string
+    {
+        $context = \ImportClient::prepare_files_command_context(
+            'http://fake.url',
+            $this->stateDir,
+            $this->fs_root,
+            'files-diff'
+        );
+        $remoteStateDirectory = $context['remote_state_directory'];
+        if (!is_dir($remoteStateDirectory)) {
+            mkdir($remoteStateDirectory);
+        }
+        return $remoteStateDirectory;
     }
 
     private function readCounters(\ImportClient $client, \ReflectionClass $reflection): array
@@ -287,7 +314,8 @@ class DownloadListProgressTest extends TestCase
     public function testSkippedListHasOwnCounters()
     {
         $this->writeDownloadList(50);
-        $skippedList = $this->stateDir . '/.import-download-list-skipped.jsonl';
+        $skippedList =
+            $this->remoteStateDirectory() . '/pull-plan.skipped.jsonl';
         $this->writeDownloadList(200, $skippedList);
         $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
 

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -5,6 +5,7 @@
 
 namespace ImportTests;
 
+use ImportClient;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../importer/import.php';
@@ -12,12 +13,12 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * The files-diff user contract.
  *
- * files-diff compares the local tree with the pair's previous local index —
- * the index a completed files-push publishes — without contacting the target,
- * and reports the complete diff on every run. These tests pin that contract:
- * local-only operation, correct change records, arbitrary path bytes, the
- * previous-local-index requirement, no mutation of that index, and a complete
- * report after an interrupted run.
+ * files-diff compares the local tree with the local index updated by
+ * files-pull and files-push, without contacting the target. It reports the
+ * complete diff on every run. These tests pin that contract: local-only
+ * operation, correct change records, arbitrary path bytes, the local-index
+ * requirement, no mutation of that index, and a complete report after an
+ * interrupted run.
  */
 final class FilesDiffCommandTest extends TestCase
 {
@@ -62,7 +63,7 @@ final class FilesDiffCommandTest extends TestCase
 
     public function testFilesDiffReportsAnEmptyDiffWhenTheLocalTreeMatchesTheIndex(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
         $result = $this->runFilesDiff();
 
@@ -79,7 +80,7 @@ final class FilesDiffCommandTest extends TestCase
 
     public function testFilesDiffReportsAddedEditedDeletedAndTypeChangedPaths(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
         $arbitraryBytePath = "arbitrary-\nname.txt";
         file_put_contents($this->localTree . '/added.txt', 'new file');
@@ -165,7 +166,7 @@ final class FilesDiffCommandTest extends TestCase
         if ($this->invalidBytePathInIndex === null) {
             $this->markTestSkipped('This filesystem does not accept invalid UTF-8 path bytes.');
         }
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
         $invalidBytePathToPush = "push-invalid-\xfe.txt";
         if (@file_put_contents($this->localTree . '/' . $invalidBytePathToPush, 'new invalid path bytes') === false) {
@@ -197,12 +198,12 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertStringNotContainsString($this->invalidBytePathInIndex, $result['stdout']);
     }
 
-    public function testFilesDiffDoesNotChangeThePreviousLocalIndexAndRepeatsTheSameReport(): void
+    public function testFilesDiffDoesNotChangeTheLocalIndexAndRepeatsTheSameReport(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
-        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
-        $previousLocalIndexContents = file_get_contents($previousLocalIndex);
-        $this->assertIsString($previousLocalIndexContents);
+        $this->writeLocalIndex(array_keys($this->initialFiles));
+        $localIndex = $this->localIndexPath();
+        $localIndexContents = file_get_contents($localIndex);
+        $this->assertIsString($localIndexContents);
         file_put_contents($this->localTree . '/added-after-index.txt', 'new');
 
         $firstResult = $this->runFilesDiff();
@@ -211,7 +212,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertSame(0, $firstResult['exit'], $firstResult['output']);
         $this->assertSame(0, $secondResult['exit'], $secondResult['output']);
         $this->assertSame($firstResult['stdout'], $secondResult['stdout']);
-        $this->assertSame($previousLocalIndexContents, file_get_contents($previousLocalIndex));
+        $this->assertSame($localIndexContents, file_get_contents($localIndex));
         $records = $this->filesDiffRecords($secondResult['stdout']);
         $this->assertSame(
             $this->expectedPushRecord('added-after-index.txt', 'file'),
@@ -219,30 +220,36 @@ final class FilesDiffCommandTest extends TestCase
         );
     }
 
-    public function testFilesDiffWithoutAPreviousLocalIndexFailsWithPointedGuidance(): void
+    public function testFilesDiffWithoutALocalIndexFailsWithPointedGuidance(): void
     {
         $result = $this->runFilesDiff();
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertSame('', $result['stdout']);
         $this->assertCanonicalSingleJsonLine($result['stderr']);
-        $this->assertStringContainsString('completed files-push', $result['output']);
+        $this->assertStringContainsString(
+            'local index created by files-pull or files-push',
+            $result['output']
+        );
         $this->assertStringContainsString(
             'same target URL, state directory, and local tree',
             $result['output']
         );
     }
 
-    public function testFilesDiffDoesNotReuseThePreviousLocalIndexForADifferentTargetUrlQuery(): void
+    public function testFilesDiffDoesNotReuseTheLocalIndexForADifferentTargetUrlQuery(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
         $result = $this->runFilesDiff($this->targetUrl . '&site=other');
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertSame('', $result['stdout']);
         $this->assertCanonicalSingleJsonLine($result['stderr']);
-        $this->assertStringContainsString('completed files-push', $result['output']);
+        $this->assertStringContainsString(
+            'local index created by files-pull or files-push',
+            $result['output']
+        );
         $this->assertStringContainsString(
             'same target URL, state directory, and local tree',
             $result['output']
@@ -261,10 +268,10 @@ final class FilesDiffCommandTest extends TestCase
 
     public function testInterruptedFilesDiffReportsTheCompleteDiffWhenItIsRunAgain(): void
     {
-        // An empty previous local index selects every current path for push.
+        // An empty local index selects every current path for push.
         $this->removeTree($this->localTree);
         mkdir($this->localTree, 0700, true);
-        $this->writePreviousLocalIndex([]);
+        $this->writeLocalIndex([]);
         $bulkPaths = $this->createBulkFiles('rerun');
 
         // Backpressure from the unread stdout pipe holds the first process
@@ -322,12 +329,11 @@ final class FilesDiffCommandTest extends TestCase
     }
 
     /**
-     * Publishes a previous local index describing the named paths as they
-     * exist right now, the way a completed files-push saves its index.
+     * Writes a local index describing the named paths as they exist right now.
      *
      * @param list<string> $paths Document-root-relative paths to record.
      */
-    private function writePreviousLocalIndex(array $paths): void
+    private function writeLocalIndex(array $paths): void
     {
         usort($paths, 'strcmp');
         $lines = '';
@@ -350,11 +356,12 @@ final class FilesDiffCommandTest extends TestCase
             }
             $lines .= json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         }
-        $pushStateDirectory = $this->pushStateDirectory();
-        if (!is_dir($pushStateDirectory)) {
-            mkdir($pushStateDirectory, 0700, true);
+        $localIndex = $this->localIndexPath();
+        $localIndexDirectory = dirname($localIndex);
+        if (!is_dir($localIndexDirectory)) {
+            mkdir($localIndexDirectory, 0700, true);
         }
-        file_put_contents($pushStateDirectory . '/previous_local_index.jsonl', $lines);
+        file_put_contents($localIndex, $lines);
     }
 
     /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
@@ -393,10 +400,24 @@ final class FilesDiffCommandTest extends TestCase
 
     private function pushStateDirectory(): string
     {
-        $canonicalLocalTree = realpath($this->localTree);
-        $this->assertIsString($canonicalLocalTree);
-        $pair = hash('sha256', rtrim($this->targetUrl, '?&') . "\0" . $canonicalLocalTree);
-        return realpath($this->stateDirectory) . '/push/' . $pair;
+        $context = ImportClient::prepare_files_command_context(
+            $this->targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        return $context['push_state_directory'];
+    }
+
+    private function localIndexPath(): string
+    {
+        $context = ImportClient::prepare_files_command_context(
+            $this->targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        return $context['local_index_path'];
     }
 
     /** @param list<string> $extraArguments

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -232,7 +232,7 @@ final class FilesDiffCommandTest extends TestCase
             $result['output']
         );
         $this->assertStringContainsString(
-            'same target URL, state directory, and local tree',
+            'same target URL and state directory',
             $result['output']
         );
     }
@@ -251,7 +251,7 @@ final class FilesDiffCommandTest extends TestCase
             $result['output']
         );
         $this->assertStringContainsString(
-            'same target URL, state directory, and local tree',
+            'same target URL and state directory',
             $result['output']
         );
     }

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -50,8 +50,8 @@ final class FilesPullLocalIndexTest extends TestCase
         $this->localTree = $this->rawFileRoot . '/var/www/html';
         mkdir($this->stateDirectory, 0700, true);
         mkdir($this->rawFileRoot, 0700, true);
-        $this->writePullState();
         $this->targetUrl = $this->startIndexServer();
+        $this->writePullState();
     }
 
     protected function tearDown(): void
@@ -112,7 +112,7 @@ final class FilesPullLocalIndexTest extends TestCase
         $this->completeFilesPull();
 
         $localIndexes = glob(
-            $this->stateDirectory . '/local-index/*.jsonl'
+            $this->stateDirectory . '/remote-*' . '/.local-index.jsonl'
         );
         $this->assertIsArray($localIndexes);
         $this->assertCount(1, $localIndexes);
@@ -303,7 +303,8 @@ final class FilesPullLocalIndexTest extends TestCase
         $this->completeFilesPull();
         $pulledContents = 'complete file retained in the WAL before interruption';
         $this->interruptPullAfterFile($pulledContents);
-        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $walPath =
+            $this->remoteStateDirectory() . '/pull-index-updates.wal';
 
         $this->assertFileExists($walPath);
         $blockedDiff = $this->runFilesDiff();
@@ -327,7 +328,8 @@ final class FilesPullLocalIndexTest extends TestCase
     {
         $this->completeFilesPull();
         $this->interruptPullAfterFile('complete file retained before abort');
-        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $walPath =
+            $this->remoteStateDirectory() . '/pull-index-updates.wal';
         $this->assertFileExists($walPath);
 
         $abort = $this->runFilesPull(['--abort']);
@@ -507,7 +509,8 @@ final class FilesPullLocalIndexTest extends TestCase
             '--fs-root=' . $this->rawFileRoot,
         ]);
         $readyPath = $this->root . '/remote-overrides.json.pause-ready';
-        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $walPath =
+            $this->remoteStateDirectory() . '/pull-index-updates.wal';
         $deadline = microtime(true) + 10;
         while (
             ( !is_file($readyPath) || !is_file($walPath) || filesize($walPath) === 0 )
@@ -674,6 +677,25 @@ final class FilesPullLocalIndexTest extends TestCase
         return $context['local_index_path'];
     }
 
+    private function remoteStateDirectory(): string
+    {
+        if (is_dir($this->localTree)) {
+            $context = \ImportClient::prepare_files_command_context(
+                $this->targetUrl,
+                $this->stateDirectory,
+                $this->localTree,
+                'files-diff'
+            );
+            return $context['remote_state_directory'];
+        }
+        return realpath($this->stateDirectory)
+            . '/remote-'
+            . hash(
+                'sha256',
+                rtrim($this->targetUrl, '?&')
+            );
+    }
+
     private function writePullState(): void
     {
         file_put_contents(
@@ -705,7 +727,12 @@ final class FilesPullLocalIndexTest extends TestCase
                 ],
             ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
         );
-        file_put_contents($this->stateDirectory . '/.import-index.jsonl', '');
+        $remoteStateDirectory = $this->remoteStateDirectory();
+        mkdir($remoteStateDirectory);
+        file_put_contents(
+            $remoteStateDirectory . '/.remote-index.jsonl',
+            ''
+        );
     }
 
     private function startIndexServer(): string

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -1,0 +1,971 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * The local index used by files-pull, files-push, and files-diff.
+ *
+ * Pull records each non-skipped local path it changes. A later diff therefore
+ * ignores pulled changes while still reporting unrelated local changes.
+ */
+final class FilesPullLocalIndexTest extends TestCase
+{
+    private const REMOTE_CTIME = 41;
+    private const PULLED_PATH = 'selected/written-by-files-pull.txt';
+    private const PULLED_CONTENTS = 'contents delivered by file_fetch';
+
+    private string $root;
+    private string $stateDirectory;
+    private string $rawFileRoot;
+    private string $localTree;
+    private string $targetUrl;
+
+    /** @var resource|null */
+    private $serverProcess = null;
+
+    /** @var array<int,resource> */
+    private array $serverPipes = [];
+
+    /** @var array<string,string> */
+    private array $remoteFiles = [
+        'deleted.txt' => 'delete me',
+        'edited.txt' => 'old',
+        'folder/remote-deleted.txt' => 'remote child',
+        'unchanged.txt' => 'same',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/files-pull-local-index-' . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->rawFileRoot = $this->root . '/files';
+        $this->localTree = $this->rawFileRoot . '/var/www/html';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->rawFileRoot, 0700, true);
+        $this->writePullState();
+        $this->targetUrl = $this->startIndexServer();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+        }
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testInitialPullCreatesTheLocalIndex(): void
+    {
+        $this->completeFilesPull();
+
+        $this->assertSame(
+            self::PULLED_CONTENTS,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+        $this->assertSame(
+            [
+                'deleted.txt',
+                'edited.txt',
+                'folder',
+                'folder/remote-deleted.txt',
+                'selected',
+                self::PULLED_PATH,
+                'unchanged.txt',
+            ],
+            array_keys($this->readIndex($this->localIndexPath()))
+        );
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testEmptyInitialPullCreatesAnEmptyLocalIndex(): void
+    {
+        $this->writeRemoteOverrides([
+            'removed_paths' => array_merge(
+                array_keys($this->remoteFiles),
+                [self::PULLED_PATH]
+            ),
+        ]);
+
+        $this->completeFilesPull();
+
+        $localIndexes = glob(
+            $this->stateDirectory . '/local-index/*.jsonl'
+        );
+        $this->assertIsArray($localIndexes);
+        $this->assertCount(1, $localIndexes);
+        $this->assertSame([], $this->readIndex($localIndexes[0]));
+        mkdir($this->localTree, 0700, true);
+        $this->assertSame(
+            realpath($localIndexes[0]),
+            $this->localIndexPath()
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testPullDoesNotAddDefaultSkippedPathsToTheLocalIndex(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'node_modules/pulled-package.js' => 'pulled dependency',
+            ],
+        ]);
+
+        $this->completeFilesPull();
+
+        $this->assertSame(
+            'pulled dependency',
+            file_get_contents(
+                $this->localTree . '/node_modules/pulled-package.js'
+            )
+        );
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayNotHasKey('node_modules', $index);
+        $this->assertArrayNotHasKey(
+            'node_modules/pulled-package.js',
+            $index
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(
+            0,
+            $this->filesDiffRecords($diff['stdout'])[0][
+                'local_paths_to_push'
+            ]
+        );
+    }
+
+    public function testPullFilesBareUrlAndFilesDiffUseTheSameLocalIndex(): void
+    {
+        $target = parse_url($this->targetUrl);
+        $this->assertIsArray($target);
+        $bareTargetUrl =
+            $target['scheme']
+            . '://'
+            . $target['host']
+            . ':'
+            . $target['port'];
+        $pull = $this->runCli([
+            'pull-files',
+            $bareTargetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+
+        $this->targetUrl = $bareTargetUrl . '?site-export-api';
+        $this->assertFileExists($this->localIndexPath());
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(
+            0,
+            $this->filesDiffRecords($diff['stdout'])[0][
+                'local_paths_to_push'
+            ]
+        );
+    }
+
+    public function testPullUrlAuthenticationAndFilesDiffUseTheSameLocalIndex(): void
+    {
+        $targetUrlWithoutAuthentication = $this->targetUrl;
+        $authenticatedTargetUrl = preg_replace(
+            '~^(https?://)~',
+            '$1user:password@',
+            $this->targetUrl
+        );
+        $this->assertIsString($authenticatedTargetUrl);
+        $this->targetUrl =
+            $authenticatedTargetUrl . '&SECRET_KEY=one';
+        $this->completeFilesPull();
+
+        $this->targetUrl = $targetUrlWithoutAuthentication;
+        $this->assertFileExists($this->localIndexPath());
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(
+            0,
+            $this->filesDiffRecords($diff['stdout'])[0][
+                'local_paths_to_push'
+            ]
+        );
+    }
+
+    public function testFilesPullRejectsAnUnfinishedFilesPush(): void
+    {
+        if (PHP_VERSION_ID < 80100 || !function_exists('curl_init')) {
+            $this->markTestSkipped(
+                'Starting files-push requires PHP 8.1+ with curl.'
+            );
+        }
+        mkdir($this->localTree, 0700, true);
+        $context = \ImportClient::prepare_files_command_context(
+            $this->targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-push'
+        );
+        $processLock = new \ReprintProcessLock($this->stateDirectory);
+        try {
+            $sender = \PushFilesSender::start([
+                'docroot' => $this->localTree,
+                'push_state_directory' =>
+                    $context['push_state_directory'],
+                'local_index_path' => $context['local_index_path'],
+                'base_url' => $context['target_url'],
+                'hmac_client' => new \Site_Export_HMAC_Client('secret'),
+                'allow_http' => true,
+            ], $processLock);
+            $sender->close();
+        } finally {
+            $processLock->close();
+        }
+
+        $pull = $this->runFilesPull();
+
+        $this->assertSame(1, $pull['exit'], $pull['output']);
+        $this->assertStringContainsString(
+            'Finish the unfinished files-push before running files-pull.',
+            $pull['output']
+        );
+    }
+
+    public function testDeltaPullUpdatesOnlyThePathsItChanges(): void
+    {
+        $this->completeFilesPull();
+        file_put_contents($this->localTree . '/edited.txt', 'longer local edit');
+        unlink($this->localTree . '/deleted.txt');
+        $pulledContents = 'remote change delivered by the second pull';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+            'removed_paths' => ['unchanged.txt'],
+        ]);
+
+        $this->abortFilesPull();
+        $delta = $this->runFilesPull();
+
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        $this->assertSame('longer local edit', file_get_contents($this->localTree . '/edited.txt'));
+        $this->assertSame($pulledContents, file_get_contents($this->localTree . '/' . self::PULLED_PATH));
+        $this->assertFileDoesNotExist($this->localTree . '/unchanged.txt');
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $records = $this->filesDiffRecords($diff['stdout']);
+        $complete = array_pop($records);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 1,
+            'local_paths_to_delete' => 1,
+        ], $complete);
+        $this->assertSame([
+            $this->expectedPushRecord('edited.txt'),
+            [
+                'command' => 'files-diff',
+                'action' => 'delete',
+                'path_b64' => base64_encode('deleted.txt'),
+            ],
+        ], $records);
+    }
+
+    public function testResumeReplaysTheWALIntoTheLocalIndex(): void
+    {
+        $this->completeFilesPull();
+        $pulledContents = 'complete file retained in the WAL before interruption';
+        $this->interruptPullAfterFile($pulledContents);
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+
+        $this->assertFileExists($walPath);
+        $blockedDiff = $this->runFilesDiff();
+        $this->assertSame(1, $blockedDiff['exit'], $blockedDiff['output']);
+        $this->assertStringContainsString(
+            'Finish or abort the interrupted files-pull',
+            $blockedDiff['output']
+        );
+
+        $resumed = $this->runFilesPull();
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $this->assertLocalIndexMatches(self::PULLED_PATH);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0]['local_paths_to_push']);
+    }
+
+    public function testAbortReplaysTheWALAndKeepsTheLocalIndexUsable(): void
+    {
+        $this->completeFilesPull();
+        $this->interruptPullAfterFile('complete file retained before abort');
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $this->assertFileExists($walPath);
+
+        $abort = $this->runFilesPull(['--abort']);
+
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $this->assertLocalIndexMatches(self::PULLED_PATH);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    /**
+     * @dataProvider partialPullProvider
+     * @param list<string> $arguments
+     */
+    public function testFilesPullKeepsIndexEntriesForPathsItDoesNotChange(
+        array $arguments
+    ): void {
+        $this->completeFilesPull();
+        $before = $this->readIndex($this->localIndexPath());
+        $pulledContents = 'partial pull change';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+        ]);
+
+        $this->abortFilesPull();
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $after = $this->readIndex($this->localIndexPath());
+        $this->assertSame(
+            $before['unchanged.txt'],
+            $after['unchanged.txt']
+        );
+        $this->assertSame(
+            $pulledContents,
+            file_get_contents(
+                $this->localTree . '/' . self::PULLED_PATH
+            )
+        );
+        $this->assertLocalIndexMatches(self::PULLED_PATH);
+    }
+
+    /** @return iterable<string,array{list<string>}> */
+    public static function partialPullProvider(): iterable
+    {
+        yield 'selected directory' => [[
+            '--only=/var/www/html/selected',
+        ]];
+        yield 'filtered files' => [[
+            '--filter=essential-files',
+        ]];
+        yield 'preserve local files' => [[
+            '--on-fs-root-nonempty=preserve-local',
+        ]];
+    }
+
+    public function testRemappedPullKeepsUnrelatedLocalIndexEntries(): void
+    {
+        $arguments = [
+            '--remap',
+            '/var/www/html',
+            ':fs-root:/var/www/html/remapped',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $before = $this->readIndex($this->localIndexPath())['remapped/unchanged.txt'];
+        $pulledContents = 'remapped pull change';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+        ]);
+
+        $this->abortFilesPull();
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertSame(
+            $pulledContents,
+            file_get_contents($this->localTree . '/remapped/' . self::PULLED_PATH)
+        );
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertSame($before, $index['remapped/unchanged.txt']);
+        $this->assertArrayHasKey('remapped/' . self::PULLED_PATH, $index);
+    }
+
+    public function testPulledDeletionDoesNotHideAnUntrackedSibling(): void
+    {
+        $this->completeFilesPull();
+        file_put_contents($this->localTree . '/folder/local-added.txt', 'local addition');
+        $this->writeRemoteOverrides([
+            'removed_paths' => ['folder/remote-deleted.txt'],
+        ]);
+
+        $this->abortFilesPull();
+        $pull = $this->runFilesPull([
+            '--only=/var/www/html/folder',
+        ]);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertFileDoesNotExist($this->localTree . '/folder/remote-deleted.txt');
+        $this->assertFileExists($this->localTree . '/folder/local-added.txt');
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertTrue($index['folder']['empty'] ?? false);
+        $this->assertArrayNotHasKey('folder/remote-deleted.txt', $index);
+        $this->assertArrayNotHasKey('folder/local-added.txt', $index);
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([
+            $this->expectedPushRecord('folder/local-added.txt'),
+            [
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => 1,
+                'local_paths_to_delete' => 0,
+            ],
+        ], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testPulledDirectoryDeletionRemovesItsLocalIndexSubtree(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_directories' => ['removed-tree'],
+            'added_files' => [
+                'removed-tree/child.txt' => 'remote child',
+            ],
+        ]);
+        $this->completeFilesPull();
+        $this->assertFileExists($this->localTree . '/removed-tree/child.txt');
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([]);
+        $pull = $this->runFilesPull();
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertDirectoryDoesNotExist($this->localTree . '/removed-tree');
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayNotHasKey('removed-tree', $index);
+        $this->assertArrayNotHasKey('removed-tree/child.txt', $index);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0]['local_paths_to_push']);
+    }
+
+    private function completeFilesPull(): void
+    {
+        $result = $this->runFilesPull();
+        $this->assertSame(0, $result['exit'], $result['output']);
+    }
+
+    private function abortFilesPull(): void
+    {
+        $result = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $result['exit'], $result['output']);
+    }
+
+    private function interruptPullAfterFile(string $contents): void
+    {
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($contents),
+            'pause_before_response_end' => true,
+        ]);
+        [$process, $pipes] = $this->startCliProcess([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+        $readyPath = $this->root . '/remote-overrides.json.pause-ready';
+        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $deadline = microtime(true) + 10;
+        while (
+            ( !is_file($readyPath) || !is_file($walPath) || filesize($walPath) === 0 )
+            && microtime(true) < $deadline
+        ) {
+            clearstatcache(true, $walPath);
+            usleep(20000);
+        }
+        $this->assertFileExists($readyPath);
+        $this->assertFileExists($walPath);
+        $this->assertGreaterThan(0, filesize($walPath));
+
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+        file_put_contents($this->root . '/remote-overrides.json.pause-release', '');
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($contents),
+        ]);
+    }
+
+    private function assertLocalIndexMatches(string $path): void
+    {
+        $stat = lstat($this->localTree . '/' . $path);
+        $this->assertIsArray($stat);
+        $entry = $this->readIndex($this->localIndexPath())[$path];
+        $this->assertSame( (int) $stat['ctime'], $entry['ctime']);
+        $this->assertSame( (int) $stat['size'], $entry['size']);
+    }
+
+    /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
+    private function expectedPushRecord(string $path): array
+    {
+        $stat = lstat($this->localTree . '/' . $path);
+        $this->assertIsArray($stat);
+        return [
+            'command' => 'files-diff',
+            'action' => 'push',
+            'path_b64' => base64_encode($path),
+            'type' => 'file',
+            'size' => (int) $stat['size'],
+            'ctime' => (int) $stat['ctime'],
+        ];
+    }
+
+    /** @param array<string,mixed> $overrides */
+    private function writeRemoteOverrides(array $overrides): void
+    {
+        file_put_contents(
+            $this->root . '/remote-overrides.json',
+            json_encode($overrides, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+    }
+
+    /** @param list<string> $extraArguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesPull(array $extraArguments = []): array
+    {
+        return $this->runCli(array_merge([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ], $extraArguments));
+    }
+
+    /** @return array{exit:int,stdout:string,stderr:string,output:string} */
+    private function runFilesDiff(): array
+    {
+        return $this->runCli([
+            'files-diff',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->localTree,
+        ]);
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $arguments): array
+    {
+        [$process, $pipes] = $this->startCliProcess($arguments);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{0:resource,1:array<int,resource>}
+     */
+    private function startCliProcess(array $arguments): array
+    {
+        $process = proc_open(
+            array_merge([PHP_BINARY, __DIR__ . '/../../importer/import.php'], $arguments),
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function filesDiffRecords(string $output): array
+    {
+        $records = [];
+        foreach (preg_split('/\R/', trim($output)) ?: [] as $line) {
+            $record = json_decode($line, true);
+            if (is_array($record) && ( $record['command'] ?? null ) === 'files-diff') {
+                $records[] = $record;
+            }
+        }
+        return $records;
+    }
+
+    /** @return array<string,array{path:string,type:string,size:int,ctime:int,empty?:bool}> */
+    private function readIndex(string $path): array
+    {
+        $entries = [];
+        $lines = file(
+            $path,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($lines);
+        foreach ($lines as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $decodedPath = base64_decode($entry['path']);
+            $entries[$decodedPath] = [
+                'path' => $decodedPath,
+                'type' => $entry['type'],
+                'size' => $entry['size'],
+                'ctime' => $entry['ctime'],
+            ];
+            if (array_key_exists('empty', $entry)) {
+                $entries[$decodedPath]['empty'] = $entry['empty'];
+            }
+        }
+        return $entries;
+    }
+
+    private function localIndexPath(): string
+    {
+        $context = \ImportClient::prepare_files_command_context(
+            $this->targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        return $context['local_index_path'];
+    }
+
+    private function writePullState(): void
+    {
+        file_put_contents(
+            $this->stateDirectory . '/.import-state.json',
+            json_encode([
+                'preflight' => [
+                    'http_code' => 200,
+                    'data' => [
+                        'ok' => true,
+                        'runtime' => [
+                            'document_root' => '/var/www/html',
+                        ],
+                        'wp_detect' => [
+                            'roots' => [[
+                                'path' => '/var/www/html',
+                            ]],
+                        ],
+                        'database' => [
+                            'wp' => [
+                                'paths_urls' => [
+                                    'content_dir' => '/var/www/html/wp-content',
+                                    'uploads' => [
+                                        'basedir' => '/var/www/html/wp-content/uploads',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+        file_put_contents($this->stateDirectory . '/.import-index.jsonl', '');
+    }
+
+    private function startIndexServer(): string
+    {
+        $remoteFiles = $this->remoteFiles;
+        $remoteFiles[self::PULLED_PATH] = self::PULLED_CONTENTS;
+        $router = $this->root . '/index-server.php';
+        file_put_contents($router, sprintf(<<<'PHP'
+<?php
+$base_remote_files = json_decode(base64_decode('%s'), true);
+$pulled_path = base64_decode('%s');
+$overrides_path = base64_decode('%s');
+$overrides = is_file($overrides_path)
+    ? json_decode((string) file_get_contents($overrides_path), true)
+    : array();
+$remote_files = $base_remote_files;
+$pulled_ctime = 41;
+if (isset($overrides['pulled_contents_b64'])) {
+    $remote_files[$pulled_path] = base64_decode($overrides['pulled_contents_b64']);
+}
+if (isset($overrides['pulled_ctime'])) {
+    $pulled_ctime = (int) $overrides['pulled_ctime'];
+}
+foreach (($overrides['removed_paths'] ?? array()) as $removed_path) {
+    unset($remote_files[$removed_path]);
+}
+foreach (($overrides['added_files'] ?? array()) as $path => $contents) {
+    $remote_files[$path] = $contents;
+}
+$added_directories = array_fill_keys(
+    $overrides['added_directories'] ?? array(),
+    true
+);
+$added_files = array_fill_keys(
+    array_keys($overrides['added_files'] ?? array()),
+    true
+);
+$remote_index = array();
+foreach ($remote_files as $path => $contents) {
+    $remote_index['/var/www/html/' . $path] = array(
+        'path' => base64_encode('/var/www/html/' . $path),
+        'ctime' => $path === $pulled_path
+            ? $pulled_ctime
+            : (isset($added_files[$path]) ? 43 : 41),
+        'size' => strlen($contents),
+        'type' => 'file',
+    );
+}
+foreach ($added_directories as $path => $_) {
+    $remote_index['/var/www/html/' . $path] = array(
+        'path' => base64_encode('/var/www/html/' . $path),
+        'ctime' => 43,
+        'size' => 0,
+        'type' => 'dir',
+    );
+}
+uksort($remote_index, static function (string $left, string $right): int {
+    return strcmp(
+        str_replace('/', "\0", $left),
+        str_replace('/', "\0", $right)
+    );
+});
+
+$endpoint = $_GET['endpoint'] ?? null;
+$request_cursor = $_GET['cursor'] ?? null;
+$selected_directories = $_GET['directory'] ?? array();
+if ($endpoint === 'file_index' && count($selected_directories) > 0) {
+    $remote_index = array_filter(
+        $remote_index,
+        static function (array $entry) use ($selected_directories): bool {
+            $path = base64_decode($entry['path']);
+            foreach ($selected_directories as $directory) {
+                $directory = rtrim($directory, '/');
+                if ($path === $directory || strpos($path, $directory . '/') === 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    );
+}
+
+if ($endpoint === 'preflight') {
+    header('Content-Type: application/json');
+    echo json_encode(array(
+        'ok' => true,
+        'runtime' => array(
+            'document_root' => '/var/www/html',
+            'ini_get_all' => array(),
+        ),
+        'wp_detect' => array(
+            'roots' => array(array('path' => '/var/www/html')),
+        ),
+        'database' => array(
+            'wp' => array(
+                'wp_version' => '6.0-test',
+                'table_prefix' => 'wp_',
+                'paths_urls' => array(
+                    'abspath' => '/var/www/html',
+                    'content_dir' => '/var/www/html/wp-content',
+                    'uploads' => array(
+                        'basedir' => '/var/www/html/wp-content/uploads',
+                    ),
+                ),
+            ),
+        ),
+        'limits' => array('max_request_bytes' => 4194304),
+    ), JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$boundary = 'reprint-files-pull-local-index-test';
+header('Content-Type: multipart/mixed; boundary=' . $boundary);
+$write_part = static function (array $headers, string $body = '') use ($boundary): void {
+    echo "--{$boundary}\r\n";
+    foreach ($headers as $name => $value) {
+        echo $name . ': ' . $value . "\r\n";
+    }
+    echo 'Content-Length: ' . strlen($body) . "\r\n\r\n";
+    echo $body . "\r\n";
+};
+
+if ($endpoint === 'file_index') {
+    $write_part(
+        array('X-Chunk-Type' => 'index_batch'),
+        json_encode(array_values($remote_index), JSON_UNESCAPED_SLASHES)
+    );
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Total-Entries' => count($remote_index),
+    ));
+} elseif ($endpoint === 'file_fetch') {
+    $requested_paths = null;
+    if (
+        isset($_FILES['file_list']['tmp_name'])
+        && is_file($_FILES['file_list']['tmp_name'])
+    ) {
+        $requested_paths = array_fill_keys(
+            json_decode((string) file_get_contents($_FILES['file_list']['tmp_name']), true),
+            true
+        );
+    }
+    $parts = array();
+    foreach ($remote_index as $path => $entry) {
+        if ($requested_paths !== null && !isset($requested_paths[$path])) {
+            continue;
+        }
+        $relative_path = substr($path, strlen('/var/www/html/'));
+        $parts[] = array(
+            'path' => $path,
+            'entry' => $entry,
+            'contents' => $entry['type'] === 'file' ? $remote_files[$relative_path] : '',
+            'cursor' => 'path-' . sha1($path),
+        );
+    }
+    $cursor_reached = $request_cursor === null;
+    $files_completed = 0;
+    $bytes_processed = 0;
+    foreach ($parts as $part) {
+        if (!$cursor_reached) {
+            if ($part['cursor'] === $request_cursor) {
+                $cursor_reached = true;
+            }
+            continue;
+        }
+        if ($part['entry']['type'] === 'dir') {
+            $write_part(array(
+                'X-Chunk-Type' => 'directory',
+                'X-Directory-Path' => $part['entry']['path'],
+                'X-Directory-Ctime' => $part['entry']['ctime'],
+                'X-Cursor' => $part['cursor'],
+            ));
+        } else {
+            $write_part(array(
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => $part['entry']['path'],
+                'X-File-Ctime' => $part['entry']['ctime'],
+                'X-File-Size' => strlen($part['contents']),
+                'X-First-Chunk' => 1,
+                'X-Last-Chunk' => 1,
+                'X-Cursor' => $part['cursor'],
+            ), $part['contents']);
+            $bytes_processed += strlen($part['contents']);
+        }
+        ++$files_completed;
+    }
+    $completion_body = !empty($overrides['pause_before_response_end'])
+        ? str_repeat(' ', 65536)
+        : '';
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Files-Completed' => $files_completed,
+        'X-Bytes-Processed' => $bytes_processed,
+    ), $completion_body);
+    if (!empty($overrides['pause_before_response_end'])) {
+        if (ob_get_level() > 0) {
+            ob_flush();
+        }
+        flush();
+        file_put_contents($overrides_path . '.pause-ready', '');
+        while (!is_file($overrides_path . '.pause-release')) {
+            usleep(20000);
+        }
+    }
+} else {
+    $write_part(array(
+        'X-Chunk-Type' => 'error',
+        'X-Status' => 'failed',
+    ), json_encode(array('message' => 'Unexpected endpoint')));
+}
+echo "--{$boundary}--\r\n";
+PHP,
+            base64_encode( (string) json_encode($remoteFiles)),
+            base64_encode(self::PULLED_PATH),
+            base64_encode($this->root . '/remote-overrides.json')
+        ));
+
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $this->serverPipes,
+            $this->root
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen('127.0.0.1', $port, $errorNumber, $errorMessage, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('Local index server did not start.');
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -43,7 +43,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertNull(ImportClient::files_push_stop_cause(1000.0, PHP_INT_MAX, 0, -1, $chunkBytes));
     }
 
-    public function testPairContextUsesTheTrimmedTargetAndCanonicalLocalTree(): void
+    public function testCommandContextUsesTheTrimmedTargetAndCanonicalLocalTree(): void
     {
         $targetUrl = 'https://example.test/?reprint-api=1&&';
         $context = ImportClient::prepare_files_push_context(
@@ -55,14 +55,23 @@ final class FilesPushCommandTest extends TestCase
         $canonicalLocalTree = realpath($this->localTree);
         $this->assertIsString($canonicalLocalTree);
         $trimmedTargetUrl = rtrim($targetUrl, '?&');
-        $expectedPair = hash('sha256', $trimmedTargetUrl . "\0" . $canonicalLocalTree);
+        $expectedTargetLocalTreeHash = hash(
+            'sha256',
+            $trimmedTargetUrl . "\0" . $canonicalLocalTree
+        );
 
         $this->assertSame($trimmedTargetUrl, $context['target_url']);
         $this->assertSame($canonicalLocalTree, $context['local_tree']);
-        $this->assertSame($expectedPair, $context['pair']);
         $this->assertSame(
-            realpath($this->stateDirectory) . '/push/' . $expectedPair,
+            realpath($this->stateDirectory) . '/push/' . $expectedTargetLocalTreeHash,
             $context['push_state_directory']
+        );
+        $this->assertSame(
+            realpath($this->stateDirectory)
+                . '/local-index/'
+                . $expectedTargetLocalTreeHash
+                . '.jsonl',
+            $context['local_index_path']
         );
 
         $differentQuery = ImportClient::prepare_files_push_context(
@@ -80,8 +89,40 @@ final class FilesPushCommandTest extends TestCase
             ['secret' => 'token', 'force_http' => false]
         );
 
-        $this->assertNotSame($context['pair'], $differentQuery['pair']);
-        $this->assertNotSame($context['pair'], $differentTree['pair']);
+        $this->assertNotSame(
+            $context['push_state_directory'],
+            $differentQuery['push_state_directory']
+        );
+        $this->assertNotSame(
+            $context['local_index_path'],
+            $differentTree['local_index_path']
+        );
+    }
+
+    public function testPullSecretDoesNotChangeTheLocalIndexPath(): void
+    {
+        $targetUrl = 'https://example.test/?site-export-api';
+        $withoutSecret = ImportClient::prepare_files_command_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        $withSecret = ImportClient::prepare_files_command_context(
+            $targetUrl . '&SECRET_KEY=pull-token',
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+
+        $this->assertSame(
+            $withoutSecret['push_state_directory'],
+            $withSecret['push_state_directory']
+        );
+        $this->assertSame(
+            $withoutSecret['local_index_path'],
+            $withSecret['local_index_path']
+        );
     }
 
     public function testFilesPushRejectsOptionsOutsideItsExactAllowlist(): void
@@ -111,7 +152,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $olderCommand['exit'], $olderCommand['output']);
         $this->assertStringContainsString('--force-http is accepted only by files-push.', $olderCommand['output']);
 
-        $existingPairValue = $this->runCli([
+        $dbApplyResult = $this->runCli([
             'db-apply',
             '-',
             '--state-dir=' . $this->stateDirectory,
@@ -122,7 +163,7 @@ final class FilesPushCommandTest extends TestCase
         ]);
         $this->assertStringNotContainsString(
             '--force-http is accepted only by files-push.',
-            $existingPairValue['output']
+            $dbApplyResult['output']
         );
     }
 
@@ -134,7 +175,6 @@ final class FilesPushCommandTest extends TestCase
         $missingSecretError = $this->lastJsonLine($missingSecret['stderr']);
         $this->assertArrayHasKey('error', $missingSecretError);
         $this->assertArrayNotHasKey('command', $missingSecretError);
-        $this->assertArrayNotHasKey('pair', $missingSecretError);
         $this->assertArrayNotHasKey('phase', $missingSecretError);
 
         $querySecret = $this->runFilesPush(
@@ -269,7 +309,6 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $result['exit'], $result['output']);
         $finalLine = $this->lastJsonLine($result['stdout']);
         $this->assertSame('files-push', $finalLine['command'] ?? null);
-        $this->assertSame($context['pair'], $finalLine['pair'] ?? null);
         $this->assertSame('error', $finalLine['status'] ?? null);
         $this->assertSame('starting_plan', $finalLine['phase'] ?? null);
         $this->assertSame('unexpected_error', $finalLine['reason'] ?? null);
@@ -283,13 +322,20 @@ final class FilesPushCommandTest extends TestCase
             JSON_THROW_ON_ERROR
         );
         $this->assertSame(
-            ['command', 'pair', 'status', 'phase', 'reason', 'detail', 'ts'],
+            [
+                'command',
+                'status',
+                'phase',
+                'reason',
+                'detail',
+                'ts',
+            ],
             array_keys($status)
         );
         $this->assertSame('error', $status['status']);
         $audit = (string) file_get_contents($this->stateDirectory . '/.import-audit.log');
         $this->assertSame(1, substr_count($audit, 'ERROR files-push'));
-        $this->assertStringContainsString('pair=' . $context['pair'], $audit);
+        $this->assertStringContainsString('ERROR files-push | phase=starting_plan', $audit);
     }
 
     /** @param list<string> $extraOptions */

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -43,7 +43,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertNull(ImportClient::files_push_stop_cause(1000.0, PHP_INT_MAX, 0, -1, $chunkBytes));
     }
 
-    public function testCommandContextUsesTheTrimmedTargetAndCanonicalLocalTree(): void
+    public function testCommandContextUsesTheTargetStateDirectoryAndCanonicalLocalTree(): void
     {
         $targetUrl = 'https://example.test/?reprint-api=1&&';
         $context = ImportClient::prepare_files_push_context(
@@ -55,22 +55,22 @@ final class FilesPushCommandTest extends TestCase
         $canonicalLocalTree = realpath($this->localTree);
         $this->assertIsString($canonicalLocalTree);
         $trimmedTargetUrl = rtrim($targetUrl, '?&');
-        $expectedTargetLocalTreeHash = hash(
-            'sha256',
-            $trimmedTargetUrl . "\0" . $canonicalLocalTree
-        );
+        $expectedTargetHash = hash('sha256', $trimmedTargetUrl);
 
         $this->assertSame($trimmedTargetUrl, $context['target_url']);
         $this->assertSame($canonicalLocalTree, $context['local_tree']);
         $this->assertSame(
-            realpath($this->stateDirectory) . '/push/' . $expectedTargetLocalTreeHash,
+            realpath($this->stateDirectory)
+                . '/remote-'
+                . $expectedTargetHash,
+            $context['remote_state_directory']
+        );
+        $this->assertSame(
+            $context['remote_state_directory'] . '/push',
             $context['push_state_directory']
         );
         $this->assertSame(
-            realpath($this->stateDirectory)
-                . '/local-index/'
-                . $expectedTargetLocalTreeHash
-                . '.jsonl',
+            $context['remote_state_directory'] . '/.local-index.jsonl',
             $context['local_index_path']
         );
 
@@ -93,7 +93,7 @@ final class FilesPushCommandTest extends TestCase
             $context['push_state_directory'],
             $differentQuery['push_state_directory']
         );
-        $this->assertNotSame(
+        $this->assertSame(
             $context['local_index_path'],
             $differentTree['local_index_path']
         );

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -74,7 +74,15 @@ class FilesSyncStateTest extends TestCase
                 "current_stage" => null,
                 "remote_cursor" => null,
             ],
-            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "preflight" => [
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "document_root" => "",
+                    ],
+                ],
+                "http_code" => 200,
+            ],
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
             "version" => null,
@@ -115,7 +123,7 @@ class FilesSyncStateTest extends TestCase
      */
     private function readDownloadList(): array
     {
-        $file = $this->stateDir . '/.import-download-list.jsonl';
+        $file = $this->remoteStateDirectory() . '/pull-plan.jsonl';
         if (!file_exists($file)) {
             return [];
         }
@@ -129,6 +137,21 @@ class FilesSyncStateTest extends TestCase
         return $paths;
     }
 
+    private function remoteStateDirectory(): string
+    {
+        $context = \ImportClient::prepare_files_command_context(
+            'http://fake.url',
+            $this->stateDir,
+            $this->fs_root,
+            'files-diff'
+        );
+        $remoteStateDirectory = $context['remote_state_directory'];
+        if (!is_dir($remoteStateDirectory)) {
+            mkdir($remoteStateDirectory);
+        }
+        return $remoteStateDirectory;
+    }
+
     /**
      * Set up a client with state loaded and preserve-local mode.
      */
@@ -140,6 +163,10 @@ class FilesSyncStateTest extends TestCase
         $stateProperty = $reflection->getProperty('state');
         $loadState = $reflection->getMethod('load_state');
         $stateProperty->setValue($client, $loadState->invoke($client));
+        $reflection->getMethod('configure_remote_state_directory')->invoke(
+            $client,
+            $this->fs_root
+        );
 
         $ttyProperty = $reflection->getProperty('is_tty');
         $ttyProperty->setValue($client, false);
@@ -191,7 +218,7 @@ class FilesSyncStateTest extends TestCase
             "filter" => "essential-files",
         ]);
         file_put_contents(
-            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->remoteStateDirectory() . '/pull-plan.skipped.jsonl',
             json_encode([
                 "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
             ], JSON_UNESCAPED_SLASHES) . "\n",
@@ -215,7 +242,9 @@ class FilesSyncStateTest extends TestCase
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
         $this->assertNull($state["active_resumable_command"]["current_stage"]);
         $this->assertEquals("skipped-earlier", $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+        $this->assertFileDoesNotExist(
+            $this->remoteStateDirectory() . '/pull-plan.skipped.jsonl'
+        );
     }
 
     /**
@@ -223,7 +252,7 @@ class FilesSyncStateTest extends TestCase
      */
     public function testAbortClearsCompletedStatus()
     {
-        $indexFile = $this->stateDir . '/.import-index.jsonl';
+        $indexFile = $this->remoteStateDirectory() . '/.remote-index.jsonl';
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
@@ -253,7 +282,7 @@ class FilesSyncStateTest extends TestCase
      */
     public function testAbortThenRerunStartsFresh()
     {
-        $indexFile = $this->stateDir . '/.import-index.jsonl';
+        $indexFile = $this->remoteStateDirectory() . '/.remote-index.jsonl';
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
@@ -295,7 +324,7 @@ class FilesSyncStateTest extends TestCase
     public function testSkippedEarlierAfterCompositePullAdoptsFilesPullState(): void
     {
         file_put_contents(
-            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->remoteStateDirectory() . '/pull-plan.skipped.jsonl',
             $this->indexLine('/wp-content/uploads/2024/01/photo.jpg', 1000, 100),
         );
         $this->writeState([
@@ -346,11 +375,12 @@ class FilesSyncStateTest extends TestCase
     public function testDeltaDiffRedownloadsChangedIndexedFile()
     {
         // Local index: file synced at ctime 1000
-        $localIndex = $this->stateDir . '/.import-index.jsonl';
+        $localIndex = $this->remoteStateDirectory() . '/.remote-index.jsonl';
         file_put_contents($localIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 1000, 200));
 
         // Remote index: same file at ctime 2000 (changed)
-        $remoteIndex = $this->stateDir . '/.import-remote-index.jsonl';
+        $remoteIndex =
+            $this->remoteStateDirectory() . '/.remote-index.next.jsonl';
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
@@ -386,11 +416,12 @@ class FilesSyncStateTest extends TestCase
     public function testDeltaDiffSkipsPreExistingLocalFile()
     {
         // Local index: empty (file was never synced by us)
-        $localIndex = $this->stateDir . '/.import-index.jsonl';
+        $localIndex = $this->remoteStateDirectory() . '/.remote-index.jsonl';
         file_put_contents($localIndex, '');
 
         // Remote index: file exists on remote
-        $remoteIndex = $this->stateDir . '/.import-remote-index.jsonl';
+        $remoteIndex =
+            $this->remoteStateDirectory() . '/.remote-index.next.jsonl';
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)

--- a/tests/Import/IndexUpdateFunctionsTest.php
+++ b/tests/Import/IndexUpdateFunctionsTest.php
@@ -1,0 +1,277 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use function Reprint\Importer\apply_local_index_updates;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+final class IndexUpdateFunctionsTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir()
+            . '/index-update-functions-'
+            . bin2hex(random_bytes(6));
+        mkdir($this->root, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider localIndexDescendantProvider
+     */
+    public function testLocalIndexUpdateDeterminesWhetherDescendantsRemain(
+        array $operations,
+        array $expected
+    ): void {
+        $baseIndex = $this->root . '/base.jsonl';
+        $updatesPath = $this->root . '/updates.jsonl';
+        $this->writeJsonLines($baseIndex, [
+            [
+                'path' => base64_encode('directory'),
+                'ctime' => 1,
+                'size' => 0,
+                'type' => 'dir',
+                'empty' => false,
+            ],
+            [
+                'path' => base64_encode('directory/old.txt'),
+                'ctime' => 1,
+                'size' => 3,
+                'type' => 'file',
+            ],
+        ]);
+        $updates = [];
+        foreach ($operations as [$op, $type]) {
+            $update = [
+                'op' => $op,
+                'path' => base64_encode('directory'),
+            ];
+            if ($type !== null) {
+                $update['ctime'] = 2;
+                $update['size'] = $type === 'dir' ? 0 : 4;
+                $update['type'] = $type;
+            }
+            $updates[] = $update;
+        }
+        $this->writeJsonLines($updatesPath, $updates);
+
+        apply_local_index_updates($baseIndex, $updatesPath);
+
+        $actual = [];
+        foreach (file($baseIndex, FILE_IGNORE_NEW_LINES) as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $actual[] = [
+                'path' => base64_decode($entry['path']),
+                'type' => $entry['type'],
+                'empty' => $entry['empty'] ?? null,
+            ];
+        }
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testLocalIndexUpdateAddsParentDirectories(): void
+    {
+        $localIndex = $this->root . '/local-index.jsonl';
+        $updatesPath = $this->root . '/updates.jsonl';
+        $this->writeJsonLines($updatesPath, [[
+            'op' => 'F',
+            'path' => base64_encode('first/second/file.txt'),
+            'ctime' => 7,
+            'size' => 4,
+            'type' => 'file',
+        ]]);
+
+        apply_local_index_updates($localIndex, $updatesPath);
+
+        $entries = [];
+        foreach (file($localIndex, FILE_IGNORE_NEW_LINES) as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $entries[ (string) base64_decode($entry['path']) ] = [
+                'type' => $entry['type'],
+                'empty' => $entry['empty'] ?? null,
+            ];
+        }
+        $this->assertSame([
+            'first' => ['type' => 'dir', 'empty' => false],
+            'first/second' => ['type' => 'dir', 'empty' => false],
+            'first/second/file.txt' => [
+                'type' => 'file',
+                'empty' => null,
+            ],
+        ], $entries);
+    }
+
+    /**
+     * @dataProvider localIndexOperationOrderProvider
+     */
+    public function testLaterOperationsReplaceEarlierSubtrees(
+        array $operations,
+        array $expected
+    ): void {
+        $localIndex = $this->root . '/local-index.jsonl';
+        $updatesPath = $this->root . '/updates.jsonl';
+        $updates = [];
+        foreach ($operations as [$op, $path, $type]) {
+            $update = [
+                'op' => $op,
+                'path' => base64_encode($path),
+            ];
+            if ($type !== null) {
+                $update['ctime'] = 2;
+                $update['size'] = $type === 'dir' ? 0 : 4;
+                $update['type'] = $type;
+            }
+            $updates[] = $update;
+        }
+        $this->writeJsonLines($updatesPath, $updates);
+
+        apply_local_index_updates($localIndex, $updatesPath);
+
+        $actual = [];
+        foreach (file($localIndex, FILE_IGNORE_NEW_LINES) as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $actual[] = [
+                'path' => base64_decode($entry['path']),
+                'type' => $entry['type'],
+                'empty' => $entry['empty'] ?? null,
+            ];
+        }
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function localIndexDescendantProvider(): array
+    {
+        return [
+            'deletion removes descendants' => [
+                [['D', null]],
+                [],
+            ],
+            'file replaces descendants' => [
+                [['F', 'file']],
+                [[
+                    'path' => 'directory',
+                    'type' => 'file',
+                    'empty' => null,
+                ]],
+            ],
+            'directory retains descendants' => [
+                [['F', 'dir']],
+                [
+                    [
+                        'path' => 'directory',
+                        'type' => 'dir',
+                        'empty' => false,
+                    ],
+                    [
+                        'path' => 'directory/old.txt',
+                        'type' => 'file',
+                        'empty' => null,
+                    ],
+                ],
+            ],
+            'deletion followed by directory still removes old descendants' => [
+                [['D', null], ['F', 'dir']],
+                [[
+                    'path' => 'directory',
+                    'type' => 'dir',
+                    'empty' => true,
+                ]],
+            ],
+        ];
+    }
+
+    public static function localIndexOperationOrderProvider(): array
+    {
+        $directoryAndChild = [
+            [
+                'path' => 'directory',
+                'type' => 'dir',
+                'empty' => false,
+            ],
+            [
+                'path' => 'directory/child.txt',
+                'type' => 'file',
+                'empty' => null,
+            ],
+        ];
+        return [
+            'later file replaces earlier child' => [
+                [
+                    ['F', 'directory/child.txt', 'file'],
+                    ['F', 'directory', 'file'],
+                ],
+                [[
+                    'path' => 'directory',
+                    'type' => 'file',
+                    'empty' => null,
+                ]],
+            ],
+            'later child replaces earlier file with a directory' => [
+                [
+                    ['F', 'directory', 'file'],
+                    ['F', 'directory/child.txt', 'file'],
+                ],
+                $directoryAndChild,
+            ],
+            'later deletion removes earlier child' => [
+                [
+                    ['F', 'directory/child.txt', 'file'],
+                    ['D', 'directory', null],
+                ],
+                [],
+            ],
+            'later child recreates an earlier deleted directory' => [
+                [
+                    ['D', 'directory', null],
+                    ['F', 'directory/child.txt', 'file'],
+                ],
+                $directoryAndChild,
+            ],
+        ];
+    }
+
+    private function writeJsonLines(string $path, array $entries): void
+    {
+        file_put_contents(
+            $path,
+            implode('', array_map(
+                static fn(array $entry): string =>
+                    json_encode(
+                        $entry,
+                        JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                    ) . "\n",
+                $entries
+            ))
+        );
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) ?: [] as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+            rmdir($path);
+            return;
+        }
+        unlink($path);
+    }
+}

--- a/tests/Import/IndexUpdateWalTest.php
+++ b/tests/Import/IndexUpdateWalTest.php
@@ -31,32 +31,76 @@ final class IndexUpdateWalTest extends TestCase
         $this->removeTree($this->root);
     }
 
-    public function testAppliedBatchLeavesTheWalMarkerUntilCompletion(): void
+    public function testOneWalRecordUpdatesBothIndexes(): void
     {
+        mkdir($this->fileRoot . '/site');
+        file_put_contents($this->fileRoot . '/site/file.txt', 'hello');
+
         $client = $this->client();
+        $client->get_import_state()->preflight = [
+            'http_code' => 200,
+            'data' => [
+                'ok' => true,
+                'runtime' => [
+                    'document_root' => '/site',
+                ],
+            ],
+        ];
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('record_index_update_file')->invoke(
+        $reflection->getMethod('record_pulled_path')->invoke(
             $client,
             '/site/file.txt',
+            realpath($this->fileRoot . '/site/file.txt'),
             42,
             5,
             'file'
         );
+        $walHandle = $reflection->getProperty('index_update_wal_handle')
+            ->getValue($client);
+        $this->assertIsResource($walHandle);
+        $this->assertTrue(fflush($walHandle));
+        $walLines = file(
+            $this->stateDirectory . '/.import-index-updates.wal',
+            FILE_IGNORE_NEW_LINES
+        );
+        $this->assertIsArray($walLines);
+        $this->assertCount(1, $walLines);
+        $walRecord = json_decode(
+            $walLines[0],
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame(
+            '/site/file.txt',
+            base64_decode($walRecord['path'])
+        );
+        $this->assertSame(
+            'file.txt',
+            base64_decode($walRecord['local_path_b64'])
+        );
+
         $reflection->getMethod('apply_index_update_wal')->invoke($client);
 
         $walPath = $this->stateDirectory . '/.import-index-updates.wal';
         $this->assertFileExists($walPath);
         $this->assertSame('', file_get_contents($walPath));
+        $this->assertSame('/site/file.txt', $this->firstIndexPath());
+        $localIndexPaths = glob(
+            $this->stateDirectory . '/local-index/*.jsonl'
+        );
+        $this->assertIsArray($localIndexPaths);
+        $this->assertCount(1, $localIndexPaths);
         $this->assertSame(
-            '/site/file.txt',
-            $this->firstIndexPath()
+            'file.txt',
+            $this->firstIndexPath($localIndexPaths[0])
         );
 
         $reflection->getMethod('remove_index_update_wal')->invoke($client);
         $this->assertFileDoesNotExist($walPath);
     }
 
-    public function testReplayDiscardsAnUnterminatedFinalRecord(): void
+    public function testApplyingWalDiscardsACorruptUnterminatedFinalRecord(): void
     {
         $completeRecord = json_encode([
             'op' => 'F',
@@ -72,7 +116,7 @@ final class IndexUpdateWalTest extends TestCase
 
         $client = $this->client();
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('replay_index_update_wal')->invoke($client);
+        $reflection->getMethod('apply_index_update_wal')->invoke($client);
 
         $this->assertSame('/site/complete.txt', $this->firstIndexPath());
         $this->assertSame(
@@ -137,17 +181,18 @@ final class IndexUpdateWalTest extends TestCase
         );
     }
 
-    private function firstIndexPath(): string
+    private function firstIndexPath(?string $indexPath = null): string
     {
         $lines = file(
-            $this->stateDirectory . '/.import-index.jsonl',
+            $indexPath ?? $this->stateDirectory . '/.import-index.jsonl',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($lines);
         $line = $lines[0] ?? null;
         $this->assertIsString($line);
         $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-        $path = base64_decode((string) $entry['path']);
+        $encodedPath = (string) $entry['path'];
+        $path = base64_decode($encodedPath);
         $this->assertIsString($path);
         return $path;
     }

--- a/tests/Import/IndexUpdateWalTest.php
+++ b/tests/Import/IndexUpdateWalTest.php
@@ -24,6 +24,7 @@ final class IndexUpdateWalTest extends TestCase
         $this->fileRoot = $this->root . '/files';
         mkdir($this->stateDirectory, 0700, true);
         mkdir($this->fileRoot, 0700, true);
+        mkdir($this->fileRoot . '/site');
     }
 
     protected function tearDown(): void
@@ -33,7 +34,6 @@ final class IndexUpdateWalTest extends TestCase
 
     public function testOneWalRecordUpdatesBothIndexes(): void
     {
-        mkdir($this->fileRoot . '/site');
         file_put_contents($this->fileRoot . '/site/file.txt', 'hello');
 
         $client = $this->client();
@@ -46,6 +46,7 @@ final class IndexUpdateWalTest extends TestCase
                 ],
             ],
         ];
+        $client->prepare_files_pull_options([]);
         $reflection = new \ReflectionClass(\ImportClient::class);
         $reflection->getMethod('record_pulled_path')->invoke(
             $client,
@@ -60,7 +61,7 @@ final class IndexUpdateWalTest extends TestCase
         $this->assertIsResource($walHandle);
         $this->assertTrue(fflush($walHandle));
         $walLines = file(
-            $this->stateDirectory . '/.import-index-updates.wal',
+            $this->remoteStateDirectory() . '/pull-index-updates.wal',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($walLines);
@@ -73,7 +74,7 @@ final class IndexUpdateWalTest extends TestCase
         );
         $this->assertSame(
             '/site/file.txt',
-            base64_decode($walRecord['path'])
+            base64_decode($walRecord['remote_path_b64'])
         );
         $this->assertSame(
             'file.txt',
@@ -82,18 +83,16 @@ final class IndexUpdateWalTest extends TestCase
 
         $reflection->getMethod('apply_index_update_wal')->invoke($client);
 
-        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
+        $walPath =
+            $this->remoteStateDirectory() . '/pull-index-updates.wal';
         $this->assertFileExists($walPath);
         $this->assertSame('', file_get_contents($walPath));
         $this->assertSame('/site/file.txt', $this->firstIndexPath());
-        $localIndexPaths = glob(
-            $this->stateDirectory . '/local-index/*.jsonl'
-        );
-        $this->assertIsArray($localIndexPaths);
-        $this->assertCount(1, $localIndexPaths);
         $this->assertSame(
             'file.txt',
-            $this->firstIndexPath($localIndexPaths[0])
+            $this->firstIndexPath(
+                $this->remoteStateDirectory() . '/.local-index.jsonl'
+            )
         );
 
         $reflection->getMethod('remove_index_update_wal')->invoke($client);
@@ -104,17 +103,27 @@ final class IndexUpdateWalTest extends TestCase
     {
         $completeRecord = json_encode([
             'op' => 'F',
-            'path' => base64_encode('/site/complete.txt'),
-            'ctime' => 42,
-            'size' => 5,
-            'type' => 'file',
+            'remote_path_b64' => base64_encode('/site/complete.txt'),
+            'remote_ctime' => 42,
+            'remote_size' => 5,
+            'remote_type' => 'file',
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        $remoteStateDirectory = $this->remoteStateDirectory();
+        mkdir($remoteStateDirectory);
         file_put_contents(
-            $this->stateDirectory . '/.import-index-updates.wal',
-            $completeRecord . '{"op":"F","path":"'
+            $remoteStateDirectory . '/pull-index-updates.wal',
+            $completeRecord . '{"op":"F","remote_path_b64":"'
         );
 
         $client = $this->client();
+        $client->get_import_state()->preflight = [
+            'data' => [
+                'runtime' => [
+                    'document_root' => '/site',
+                ],
+            ],
+        ];
+        $client->prepare_files_pull_options([]);
         $reflection = new \ReflectionClass(\ImportClient::class);
         $reflection->getMethod('apply_index_update_wal')->invoke($client);
 
@@ -122,7 +131,7 @@ final class IndexUpdateWalTest extends TestCase
         $this->assertSame(
             '',
             file_get_contents(
-                $this->stateDirectory . '/.import-index-updates.wal'
+                $remoteStateDirectory . '/pull-index-updates.wal'
             )
         );
     }
@@ -132,21 +141,28 @@ final class IndexUpdateWalTest extends TestCase
      */
     public function testAbortReplaysAndRemovesTheWal(string $command): void
     {
+        $remoteStateDirectory = $this->remoteStateDirectory();
+        mkdir($remoteStateDirectory);
         file_put_contents(
-            $this->stateDirectory . '/.import-index-updates.wal',
+            $remoteStateDirectory . '/pull-index-updates.wal',
             json_encode([
                 'op' => 'F',
-                'path' => base64_encode('/site/aborted.txt'),
-                'ctime' => 42,
-                'size' => 5,
-                'type' => 'file',
+                'remote_path_b64' => base64_encode('/site/aborted.txt'),
+                'remote_ctime' => 42,
+                'remote_size' => 5,
+                'remote_type' => 'file',
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
         );
         file_put_contents(
             $this->stateDirectory . '/.import-state.json',
             json_encode([
                 'preflight' => [
-                    'data' => ['ok' => true],
+                    'data' => [
+                        'ok' => true,
+                        'runtime' => [
+                            'document_root' => '/site',
+                        ],
+                    ],
                     'http_code' => 200,
                 ],
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
@@ -159,7 +175,127 @@ final class IndexUpdateWalTest extends TestCase
 
         $this->assertSame('/site/aborted.txt', $this->firstIndexPath());
         $this->assertFileDoesNotExist(
-            $this->stateDirectory . '/.import-index-updates.wal'
+            $remoteStateDirectory . '/pull-index-updates.wal'
+        );
+    }
+
+    /**
+     * @dataProvider retainedWalBoundaryProvider
+     */
+    public function testRetainedWalReplaysAfterIndexReplacement(
+        bool $localIndexWasReplaced
+    ): void {
+        file_put_contents($this->fileRoot . '/site/file.txt', 'hello');
+        $client = $this->client();
+        $client->get_import_state()->preflight = [
+            'data' => [
+                'runtime' => [
+                    'document_root' => '/site',
+                ],
+            ],
+        ];
+        $client->prepare_files_pull_options([]);
+        $remoteStateDirectory = $client->remote_state_directory;
+        $remoteIndexLine = $this->indexLine(
+            '/site/file.txt',
+            42,
+            5,
+            'file'
+        );
+        $localIndexLine = $this->indexLine(
+            'file.txt',
+            52,
+            5,
+            'file'
+        );
+        file_put_contents(
+            $remoteStateDirectory . '/.remote-index.jsonl',
+            $remoteIndexLine
+        );
+        if ($localIndexWasReplaced) {
+            file_put_contents(
+                $remoteStateDirectory . '/.local-index.jsonl',
+                $localIndexLine
+            );
+        }
+        file_put_contents(
+            $remoteStateDirectory . '/pull-index-updates.wal',
+            json_encode([
+                'op' => 'F',
+                'remote_path_b64' => base64_encode('/site/file.txt'),
+                'remote_ctime' => 42,
+                'remote_size' => 5,
+                'remote_type' => 'file',
+                'local_path_b64' => base64_encode('file.txt'),
+                'local_ctime' => 52,
+                'local_size' => 5,
+                'local_type' => 'file',
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+        );
+
+        (new \ReflectionClass(\ImportClient::class))
+            ->getMethod('apply_index_update_wal')
+            ->invoke($client);
+
+        $this->assertSame(
+            $remoteIndexLine,
+            file_get_contents(
+                $remoteStateDirectory . '/.remote-index.jsonl'
+            )
+        );
+        $this->assertSame(
+            $localIndexLine,
+            file_get_contents(
+                $remoteStateDirectory . '/.local-index.jsonl'
+            )
+        );
+        $this->assertSame(
+            '',
+            file_get_contents(
+                $remoteStateDirectory . '/pull-index-updates.wal'
+            )
+        );
+    }
+
+    /** @return array<string,array{bool}> */
+    public static function retainedWalBoundaryProvider(): array
+    {
+        return [
+            'remote index replaced' => [false],
+            'both indexes replaced' => [true],
+        ];
+    }
+
+    public function testTargetsKeepSeparateRemoteStateDirectories(): void
+    {
+        $firstClient = $this->client();
+        $secondClient = new \ImportClient(
+            'https://other.example/?site-export-api',
+            $this->stateDirectory,
+            $this->fileRoot
+        );
+        foreach ([$firstClient, $secondClient] as $client) {
+            $client->get_import_state()->preflight = [
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '/site',
+                    ],
+                ],
+            ];
+            $client->prepare_files_pull_options([]);
+        }
+
+        $this->assertNotSame(
+            $firstClient->remote_state_directory,
+            $secondClient->remote_state_directory
+        );
+        $this->assertStringStartsWith(
+            realpath($this->stateDirectory) . '/remote-',
+            $firstClient->remote_state_directory
+        );
+        $this->assertStringStartsWith(
+            realpath($this->stateDirectory) . '/remote-',
+            $secondClient->remote_state_directory
         );
     }
 
@@ -181,10 +317,22 @@ final class IndexUpdateWalTest extends TestCase
         );
     }
 
+    private function remoteStateDirectory(): string
+    {
+        $context = \ImportClient::prepare_files_command_context(
+            'https://example.com/?site-export-api',
+            $this->stateDirectory,
+            $this->fileRoot . '/site',
+            'files-diff'
+        );
+        return $context['remote_state_directory'];
+    }
+
     private function firstIndexPath(?string $indexPath = null): string
     {
         $lines = file(
-            $indexPath ?? $this->stateDirectory . '/.import-index.jsonl',
+            $indexPath
+                ?? $this->remoteStateDirectory() . '/.remote-index.jsonl',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($lines);
@@ -195,6 +343,20 @@ final class IndexUpdateWalTest extends TestCase
         $path = base64_decode($encodedPath);
         $this->assertIsString($path);
         return $path;
+    }
+
+    private function indexLine(
+        string $path,
+        int $ctime,
+        int $size,
+        string $type
+    ): string {
+        return json_encode([
+            'path' => base64_encode($path),
+            'ctime' => $ctime,
+            'size' => $size,
+            'type' => $type,
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
     }
 
     private function removeTree(string $path): void

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -155,6 +155,9 @@ PHP, var_export($requestsLog, true)));
     {
         $data = array(
             'ok' => true,
+            'runtime' => array(
+                'document_root' => '/var/www/html',
+            ),
             'database' => array(
                 'wp' => array(
                     'paths_urls' => array(

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -79,12 +79,15 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
     private function writeIndex(string $name, string $contents): void
     {
-        file_put_contents($this->stateDir . '/' . $name, $contents);
+        file_put_contents(
+            $this->remoteStateDirectory() . '/' . $name,
+            $contents
+        );
     }
 
     private function readLocalIndexPaths(): array
     {
-        $file = $this->stateDir . '/.import-index.jsonl';
+        $file = $this->remoteStateDirectory() . '/.remote-index.jsonl';
         if (!file_exists($file)) {
             return [];
         }
@@ -98,6 +101,21 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         return $paths;
     }
 
+    private function remoteStateDirectory(): string
+    {
+        $context = \ImportClient::prepare_files_command_context(
+            'http://fake.url',
+            $this->stateDir,
+            $this->fs_root,
+            'files-diff'
+        );
+        $remoteStateDirectory = $context['remote_state_directory'];
+        if (!is_dir($remoteStateDirectory)) {
+            mkdir($remoteStateDirectory);
+        }
+        return $remoteStateDirectory;
+    }
+
     /** Mirror FilesSyncStateTest: load state + preserve-local, then set the --only file path prefixes. */
     private function prepareClient(array $pull_only_files_with_path_prefixes): array
     {
@@ -107,7 +125,15 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
                 "completion_state" => "in_progress",
                 "current_stage" => "diff",
             ],
-            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "preflight" => [
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "document_root" => "",
+                    ],
+                ],
+                "http_code" => 200,
+            ],
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
         ];
@@ -119,6 +145,10 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $client = new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
         $r = new \ReflectionClass($client);
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
+        $r->getMethod('configure_remote_state_directory')->invoke(
+            $client,
+            $this->fs_root
+        );
         $r->getProperty('is_tty')->setValue($client, false);
         $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
         $r->getProperty('pull_only_files_with_path_prefixes')->setValue($client, $pull_only_files_with_path_prefixes);
@@ -131,12 +161,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // and a selected orphan absent from the --only remote index. The
         // delete drains must reconcile only within the --only file prefixes, so the local index
         // accumulates as a union across files-pull --only runs.
-        $this->writeIndex('.import-index.jsonl',
+        $this->writeIndex('.remote-index.jsonl',
             $this->indexLine('/wp-config.php', 1000, 10)               // unselected
             . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
             . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // selected orphan
         );
-        $this->writeIndex('.import-remote-index.jsonl',
+        $this->writeIndex('.remote-index.next.jsonl',
             $this->indexLine('/wp-content/keep.txt', 1000, 10)
         );
 
@@ -163,12 +193,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // delete them: that would recursively remove the very directories
         // the user asked to pull, while the matched children keep the
         // download list empty — silent data loss.
-        $this->writeIndex('.import-index.jsonl',
+        $this->writeIndex('.remote-index.jsonl',
             $this->indexLine('/wp-content/themes', 1000, 0, 'dir')
             . $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
             . $this->indexLine('/wp-content/themes/old/orphan.css', 1000, 10)
         );
-        $this->writeIndex('.import-remote-index.jsonl',
+        $this->writeIndex('.remote-index.next.jsonl',
             $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
         );
 

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -92,6 +92,9 @@ class OnlyFilesPathPrefixTest extends TestCase
             ),
             'preflight' => array(
                 'data' => array(
+                    'runtime' => array(
+                        'document_root' => '/var/www/html',
+                    ),
                     'database' => array(
                         'wp' => array(
                             'paths_urls' => array(
@@ -139,6 +142,20 @@ class OnlyFilesPathPrefixTest extends TestCase
     private function readState(): array
     {
         return json_decode(file_get_contents($this->stateDir . '/.import-state.json'), true);
+    }
+
+    private function remoteStateDirectory(): string
+    {
+        $hash = hash(
+            'sha256',
+            'https://src.example/export.php'
+        );
+        $remoteStateDirectory =
+            realpath($this->stateDir) . '/remote-' . $hash;
+        if (!is_dir($remoteStateDirectory)) {
+            mkdir($remoteStateDirectory);
+        }
+        return $remoteStateDirectory;
     }
 
     public function testResolvePullOnlyFilesPrefixAddsDirectoriesOutsideWpContent(): void
@@ -267,7 +284,10 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
-        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
+        file_put_contents(
+            $this->remoteStateDirectory() . '/.remote-index.next.jsonl',
+            ''
+        );
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
@@ -284,7 +304,10 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunRecordsOnlyFingerprintForInProgressFilesPullState(): void
     {
-        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
+        file_put_contents(
+            $this->remoteStateDirectory() . '/.remote-index.next.jsonl',
+            ''
+        );
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => null,
         ));

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -29,7 +29,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
 
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
         $this->stateFile = $stateDir . '/.import-state.json';
-        $this->skippedFile = $stateDir . '/.import-download-list-skipped.jsonl';
+        $this->skippedFile = $stateDir . '/pull-plan.skipped.jsonl';
         file_put_contents($this->stateFile, "{\"command\":\"files-pull\",\"status\":\"partial\"}\n");
         file_put_contents($this->skippedFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
     }
@@ -95,7 +95,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
             $runtime,
         );
         $this->assertStringContainsString(
-            "/tmp/reprint/.import-download-list-skipped.jsonl",
+            "/tmp/reprint/pull-plan.skipped.jsonl",
             $runtime,
         );
         $this->assertStringNotContainsString($this->stateFile, $runtime);
@@ -104,7 +104,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
             $startSh,
         );
         $this->assertStringContainsString(
-            "--mount='" . $this->skippedFile . ":/tmp/reprint/.import-download-list-skipped.jsonl'",
+            "--mount='" . $this->skippedFile . ":/tmp/reprint/pull-plan.skipped.jsonl'",
             $startSh,
         );
 
@@ -117,6 +117,6 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $this->assertContains($this->stateFile, $mount_sources);
         $this->assertContains($this->skippedFile, $mount_sources);
         $this->assertContains('/tmp/reprint/.import-state.json', $mount_targets);
-        $this->assertContains('/tmp/reprint/.import-download-list-skipped.jsonl', $mount_targets);
+        $this->assertContains('/tmp/reprint/pull-plan.skipped.jsonl', $mount_targets);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -83,6 +83,7 @@ class PullFilterFakeClient extends \ImportClient
                 ],
                 "runtime" => [
                     "phpversion" => "8.2",
+                    "document_root" => "",
                 ],
             ],
         ];
@@ -103,11 +104,13 @@ class PullFilterFakeClient extends \ImportClient
         $this->files_sync_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
-                $this->state_dir . '/.import-download-list-skipped.jsonl',
+                $this->remote_state_directory . '/pull-plan.skipped.jsonl',
                 "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
             );
         } else {
-            @unlink($this->state_dir . '/.import-download-list-skipped.jsonl');
+            @unlink(
+                $this->remote_state_directory . '/pull-plan.skipped.jsonl'
+            );
         }
 
         $state = $this->get_import_state();
@@ -817,7 +820,9 @@ class PullFilterOptionTest extends TestCase
         $this->assertTrue($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
-        $this->assertFileExists($this->stateDir . '/.import-download-list-skipped.jsonl');
+        $this->assertFileExists(
+            $client->remote_state_directory . '/pull-plan.skipped.jsonl'
+        );
     }
 
     public function testPullWithoutFilterRecordsFullDownloadMode(): void
@@ -837,7 +842,9 @@ class PullFilterOptionTest extends TestCase
         $this->assertFalse($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+        $this->assertFileDoesNotExist(
+            $client->remote_state_directory . '/pull-plan.skipped.jsonl'
+        );
     }
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void

--- a/tests/Import/PushClientPhpCompatibilityTest.php
+++ b/tests/Import/PushClientPhpCompatibilityTest.php
@@ -20,10 +20,14 @@ class PushClientPhpCompatibilityTest extends TestCase
         $process_lock_path = realpath(
             __DIR__ . '/../../packages/reprint-importer/src/lib/class-reprint-process-lock.php'
         );
+        $index_update_functions_path = realpath(
+            __DIR__ . '/../../packages/reprint-importer/src/lib/index-update-functions.php'
+        );
         $upload_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/upload');
         $push_lib_path = realpath(__DIR__ . '/../../packages/reprint-importer/src/lib/push');
         $this->assertNotFalse($phpcs_path, 'vendor/bin/phpcs is missing; run composer install');
         $this->assertNotFalse($process_lock_path);
+        $this->assertNotFalse($index_update_functions_path);
         $this->assertNotFalse($upload_lib_path);
         $this->assertNotFalse($push_lib_path);
 
@@ -31,6 +35,7 @@ class PushClientPhpCompatibilityTest extends TestCase
             escapeshellarg($phpcs_path)
                 . ' --standard=PHPCompatibility --runtime-set testVersion 7.4- -q '
                 . escapeshellarg($process_lock_path) . ' '
+                . escapeshellarg($index_update_functions_path) . ' '
                 . escapeshellarg($upload_lib_path) . ' '
                 . escapeshellarg($push_lib_path) . ' 2>&1',
             $scan_output,

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/index-update-functions.php';
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-plan.php';
 
 /**
- * Coverage for PushPlan's previous local index and bounded steps.
+ * Coverage for PushPlan's local index and bounded steps.
  *
  * The plan diffs the fresh local index, whose directory entries carry an
- * `empty` boolean from the indexer, against the previous local index.
+ * `empty` boolean from the indexer, against the local index.
  * The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
  * local paths to delete, cursor replay, and every transition among files,
  * symlinks, empty directories, and non-empty directories.
@@ -39,32 +40,8 @@ final class PushPlanTest extends TestCase
     }
 
     // ------------------------------------------------------------------
-    //  Site keys
+    //  Local index
     // ------------------------------------------------------------------
-
-    // ------------------------------------------------------------------
-    //  Previous local index
-    // ------------------------------------------------------------------
-
-    public function testSavedIndexCanBeUsedByTheNextPlan(): void
-    {
-        $this->assertFileDoesNotExist($this->previousLocalIndexPath());
-
-        $this->savePreviousLocalIndex($this->writeIndex([
-            'a.txt' => [100, 5, 'file'],
-        ]));
-        $this->assertFileExists($this->previousLocalIndexPath());
-        $this->assertFileDoesNotExist($this->previousLocalIndexPath() . '.tmp');
-        $this->assertDirectoryDoesNotExist($this->planDirectory());
-
-        // A second successful push replaces the first. Comparing that same index
-        // again produces no paths to push or delete.
-        $second = $this->writeIndex(['b.txt' => [200, 9, 'file']]);
-        $this->savePreviousLocalIndex($second);
-        $plan = $this->startPlan($second);
-        $this->planToCompletion($plan);
-        $this->assertPathCounts(0, 0);
-    }
 
     public function testStartRequiresTheCallerToCreateThePlanDirectory(): void
     {
@@ -73,12 +50,12 @@ final class PushPlanTest extends TestCase
         PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
-            $this->previousLocalIndexPath(),
+            $this->localIndexPath(),
             $this->excludedPathsPath()
         );
     }
 
-    public function testRemovingThePlanDirectoryAllowsANewPlanWithoutSavingTheOldIndex(): void
+    public function testRemovingThePlanDirectoryAllowsANewPlanWithoutChangingTheLocalIndex(): void
     {
         $firstIndex = $this->writeIndex(['first.txt' => [100, 5, 'file']]);
         $plan = $this->startPlan($firstIndex);
@@ -86,7 +63,7 @@ final class PushPlanTest extends TestCase
         $this->removePlanDirectory();
 
         $this->assertDirectoryDoesNotExist($this->planDirectory());
-        $this->assertFileDoesNotExist($this->previousLocalIndexPath());
+        $this->assertFileDoesNotExist($this->localIndexPath());
 
         $secondIndex = $this->writeIndex(['second.txt' => [200, 6, 'file']]);
         $secondPlan = $this->startPlan($secondIndex);
@@ -109,7 +86,9 @@ final class PushPlanTest extends TestCase
     public function testFirstPushSelectsFilesSymlinksAndEmptyDirectories(): void
     {
         $index = $this->writeIndex([
+            'empty-directory' => [100, 0, 'dir', true],
             'index.php' => [100, 5, 'file'],
+            'link' => [100, 0, 'link'],
             'wp-content' => [100, 0, 'dir', false],
             'wp-content/themes/foo/style.css' => [150, 5, 'file'],
         ]);
@@ -117,9 +96,14 @@ final class PushPlanTest extends TestCase
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
 
-        $this->assertPathCounts(2, 0);
+        $this->assertPathCounts(4, 0);
         $this->assertSame(
-            ['index.php', 'wp-content/themes/foo/style.css'],
+            [
+                'empty-directory',
+                'index.php',
+                'link',
+                'wp-content/themes/foo/style.css',
+            ],
             $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
         );
         $this->assertSame('', file_get_contents($this->planPath('local_paths_to_delete')));
@@ -129,15 +113,38 @@ final class PushPlanTest extends TestCase
         $this->assertIsString($pathsToPush);
         $firstLine = strtok($pathsToPush, "\n");
         $firstPath = json_decode($firstLine, true, 512, JSON_THROW_ON_ERROR);
-        $this->assertSame(base64_encode('index.php'), $firstPath['path']);
-        $this->assertSame('file', $firstPath['type']);
-        $this->assertSame(5, $firstPath['size']);
+        $this->assertSame(
+            base64_encode('empty-directory'),
+            $firstPath['path_b64']
+        );
+        $this->assertSame('dir', $firstPath['type']);
+        $this->assertSame(0, $firstPath['size']);
         $this->assertIsInt($firstPath['ctime']);
+        $plannedLines = file(
+            $this->planPath('local_paths_to_push.jsonl'),
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($plannedLines);
+        $plannedEntries = array_map(
+            static function (string $line): array {
+                return json_decode(
+                    $line,
+                    true,
+                    512,
+                    JSON_THROW_ON_ERROR
+                );
+            },
+            $plannedLines
+        );
+        $this->assertSame(
+            ['dir', 'file', 'link', 'file'],
+            array_column($plannedEntries, 'type')
+        );
     }
 
-    public function testPlanCopiesEveryFreshLocalIndexEntryAndExcludesOnlyPushAndDeletePaths(): void
+    public function testFreshLocalIndexIncludesPathsExcludedFromTheOperationLists(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
             'private' => [1, 0, 'dir', false],
             'private/gone.txt' => [1, 1, 'file'],
@@ -175,7 +182,7 @@ final class PushPlanTest extends TestCase
             'a.txt' => [100, 5, 'file'],
             'b/c.txt' => [200, 7, 'file'],
         ]);
-        $this->savePreviousLocalIndex($index);
+        $this->saveLocalIndex($index);
 
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
@@ -187,7 +194,7 @@ final class PushPlanTest extends TestCase
 
     public function testCtimeSizeOrTypeChangeEachMarksThePathChanged(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'ctime-bump.txt' => [100, 5, 'file'],
             'size-bump.txt' => [100, 5, 'file'],
             'type-swap' => [100, 5, 'file'],
@@ -247,7 +254,7 @@ final class PushPlanTest extends TestCase
 
         foreach ($matrix as $previousType => $transitions) {
             foreach ($transitions as $currentType => [$expectedPushes, $expectedDeletes]) {
-                $this->savePreviousLocalIndex($this->writeLogicalIndex($previousType, 1));
+                $this->saveLocalIndex($this->writeLogicalIndex($previousType, 1));
                 $current = $this->writeLogicalIndex($currentType, 2);
 
                 $plan = $this->startPlan($current);
@@ -264,7 +271,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedSubtreeEmitsOnlyItsRootAsALocalPathToDelete(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'gone' => [1, 0, 'dir', false],
             'gone/child.txt' => [1, 1, 'file'],
             'gone/nested' => [1, 0, 'dir', false],
@@ -281,65 +288,73 @@ final class PushPlanTest extends TestCase
         $this->assertSame("gone\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testDeletedDirectoryStackAppendsWithoutGrowingTheCursor(): void
+    public function testDeletedDirectoryPathCoversOnlyItsDescendants(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
-            'a' => [1, 0, 'dir', false],
-            'a/child.txt' => [1, 1, 'file'],
-            'b.txt' => [1, 1, 'file'],
+        $this->saveLocalIndex($this->writeIndex([
+            'directory' => [1, 0, 'dir', false],
+            'directory/child.txt' => [1, 1, 'file'],
+            'directory-sibling.txt' => [1, 1, 'file'],
         ]));
         $plan = $this->startPlan();
 
         $this->assertTrue($this->nextPlanStep($plan));
-        $stack_bytes = filesize($this->planPath('deleted_directories_stack.jsonl'));
-        $this->assertIsInt($stack_bytes);
-        $this->assertGreaterThan(0, $stack_bytes);
         $first_cursor = $this->planCursor();
-        $this->assertSame(0, $first_cursor['deleted_directory_stack_top_byte_offset']);
+        $this->assertSame(
+            base64_encode('directory'),
+            $first_cursor['deleted_directory_path_b64']
+        );
 
         $this->assertTrue($this->nextPlanStep($plan));
         $this->assertFalse($this->nextPlanStep($plan));
         $complete_cursor = $this->planCursor();
         $this->assertSame(['phase' => 'complete'], $complete_cursor);
-        $this->assertSame($stack_bytes, filesize($this->planPath('deleted_directories_stack.jsonl')));
         $plan->close();
 
-        $this->assertSame("a\0b.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame(
+            "directory\0directory-sibling.txt\0",
+            file_get_contents($this->planPath('local_paths_to_delete'))
+        );
     }
 
-    public function testSeenDeletedDirectorySurvivesAnInterleavedSiblingCursor(): void
+    public function testDeletedDirectoryPathSurvivesResumeBeforeItsDescendant(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
-            'a' => [1, 0, 'dir', false],
-            'a/child.txt' => [1, 1, 'file'],
+        $this->saveLocalIndex($this->writeIndex([
+            'directory' => [1, 0, 'dir', false],
+            'directory/child.txt' => [1, 1, 'file'],
         ]));
         $entries = [];
         for ($index = 0; $index < 3; ++$index) {
-            // `-` sorts before `/`, placing these siblings between a and a/child.txt.
-            $entries[sprintf('a-%04d.txt', $index)] = [2, 1, 'file'];
+            $entries[sprintf('directory-sibling-%04d.txt', $index)] =
+                [2, 1, 'file'];
         }
         $current = $this->writeIndex($entries);
         $plan = $this->startPlan($current);
 
         $this->assertTrue($this->nextPlanStep($plan));
+        $this->assertSame(
+            base64_encode('directory'),
+            $this->planCursor()['deleted_directory_path_b64']
+        );
         $plan->close();
         $resumedPlan = $this->resumePlan();
         $this->planToCompletion($resumedPlan);
 
         $this->assertPathCounts(3, 1);
-        $this->assertSame("a\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame(
+            "directory\0",
+            file_get_contents($this->planPath('local_paths_to_delete'))
+        );
         $this->assertCount(3, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
     }
 
-    public function testReplacementRootSurvivesLexicallyInterleavedSiblingPaths(): void
+    public function testReplacementRootSurvivesSiblingPaths(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
         $current = $this->writeIndex([
             'a' => [2, 1, 'file'],
-            // `-` sorts before `/`, so this sibling appears before a/child.txt.
             'a-other' => [2, 1, 'file'],
         ]);
 
@@ -351,9 +366,30 @@ final class PushPlanTest extends TestCase
         $this->assertSame("a\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
+    public function testDescendantChangesDoNotReplanAnUnchangedSibling(): void
+    {
+        $this->saveLocalIndex($this->writeIndex([
+            'a' => [1, 0, 'dir', false],
+            'a/child.txt' => [1, 1, 'file'],
+            'a-other' => [1, 1, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'a' => [2, 0, 'dir', false],
+            'a/new-child.txt' => [2, 1, 'file'],
+            'a-other' => [1, 1, 'file'],
+        ]);
+
+        $plan = $this->startPlan($current);
+        $this->planToCompletion($plan);
+
+        $this->assertPathCounts(1, 1);
+        $this->assertSame(['a/new-child.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
+        $this->assertSame("a/child.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
+    }
+
     public function testNewChangedDeletedAndUnchangedPathsArePlannedTogether(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'changed.txt' => [100, 5, 'file'],
             'deleted.txt' => [100, 5, 'file'],
             'unchanged.txt' => [100, 5, 'file'],
@@ -373,31 +409,12 @@ final class PushPlanTest extends TestCase
         $this->assertSame("deleted.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testSavingTheFreshIndexAsThePreviousLocalIndexClearsPlanOutput(): void
-    {
-        $index = $this->writeIndex(['a.txt' => [100, 5, 'file']]);
-        $plan = $this->startPlan($index);
-
-        $this->planToCompletion($plan);
-        $this->assertSame(['a.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-
-        copy($this->planPath('fresh_local_index.jsonl'), $this->previousLocalIndexPath());
-        $this->removePlanDirectory();
-        $this->assertDirectoryDoesNotExist($this->planDirectory());
-        $plan = $this->startPlan($index);
-        $this->planToCompletion($plan);
-
-        $this->assertPathCounts(0, 0);
-        $this->assertSame([], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame('', file_get_contents($this->planPath('local_paths_to_delete')));
-    }
-
     public function testPathsThatNeedBase64SurvivePushAndDeletePlans(): void
     {
         // Newlines and non-ASCII bytes are why JSONL indexes encode paths.
         $newPath = "wp-content/uploads/line\nbreak.png";
         $deletedPath = 'wp-content/uploads/naïve-café.jpg';
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             $deletedPath => [100, 6, 'file'],
         ]));
         $current = $this->writeIndex([
@@ -418,7 +435,7 @@ final class PushPlanTest extends TestCase
 
     public function testIndexingFinishesBeforeDiffingAndClearsOldOutput(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
         ]));
         $oldIndex = $this->writeIndex(['old.txt' => [1, 1, 'file']]);
@@ -517,36 +534,27 @@ final class PushPlanTest extends TestCase
         $this->assertFalse($this->nextPlanStep($resumed_plan));
     }
 
-    public function testCursorContainsResumePathsOffsetsAndCompletionState(): void
+    public function testCursorContainsOffsetsAndCompletionState(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));
         $this->assertTrue($this->nextPlanStep($plan));
 
         $cursor = $plan->get_cursor();
         $this->assertSame([
-            'plan_directory',
-            'local_tree_root',
-            'previous_local_index',
-            'position',
-        ], array_keys($cursor));
-        $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
-        $this->assertSame(realpath($this->localTreeRoot()), $cursor['local_tree_root']);
-        $this->assertSame($this->previousLocalIndexPath(), $cursor['previous_local_index']);
-        $this->assertSame([
             'phase',
             'byte_offset_in_fresh_index',
-            'byte_offset_in_previous_local_index',
+            'byte_offset_in_local_index',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
-            'deleted_directory_stack_top_byte_offset',
-        ], array_keys($cursor['position']));
+            'deleted_directory_path_b64',
+        ], array_keys($cursor));
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
-            $cursor['position']['byte_offset_in_local_paths_to_push']
+            $cursor['byte_offset_in_local_paths_to_push']
         );
         $this->assertSame(
             filesize($this->planPath('local_paths_to_delete')),
-            $cursor['position']['byte_offset_in_local_paths_to_delete']
+            $cursor['byte_offset_in_local_paths_to_delete']
         );
         $this->assertFileDoesNotExist($this->planPath('cursor.json'));
         $plan->close();
@@ -555,15 +563,15 @@ final class PushPlanTest extends TestCase
     public function testNewInstanceResumesFromTheRetainedCursor(): void
     {
         $currentEntries = [];
-        $previousLocalIndexEntries = [];
+        $localIndexEntries = [];
         for ($index = 0; $index < 3; ++$index) {
             // The current and deleted names alternate in decoded sort order,
             // so every batch appends to both path files.
             $currentEntries[sprintf('item-%04d-current.txt', $index)] = [$index + 1, 1, 'file'];
-            $previousLocalIndexEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
+            $localIndexEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
         }
         $current = $this->writeIndex($currentEntries);
-        $this->savePreviousLocalIndex($this->writeIndex($previousLocalIndexEntries));
+        $this->saveLocalIndex($this->writeIndex($localIndexEntries));
         $plan = $this->startPlan($current);
 
         $this->assertTrue($this->nextPlanStep($plan));
@@ -586,7 +594,7 @@ final class PushPlanTest extends TestCase
 
         $this->assertPathCounts(3, 3);
         $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(array_keys($previousLocalIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
+        $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
@@ -614,17 +622,12 @@ final class PushPlanTest extends TestCase
         $this->assertSame($localPathsToDelete, file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testResumeUsesTheExcludedPathsSavedByStart(): void
+    public function testResumeUsesTheSuppliedExcludedPaths(): void
     {
         $entries = $this->manyFileEntries(2);
         $entries['private/value.txt'] = [2000, 1, 'file'];
         $current = $this->writeIndex($entries);
         $plan = $this->startPlan($current, ['private']);
-        $this->assertSame(
-            file_get_contents($this->excludedPathsPath()),
-            file_get_contents($this->planPath('excluded_paths.json'))
-        );
-        unlink($this->excludedPathsPath());
 
         $this->assertTrue($this->nextPlanStep($plan));
         $plan->close();
@@ -666,7 +669,7 @@ final class PushPlanTest extends TestCase
         $plan = PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
-            $this->previousLocalIndexPath(),
+            $this->localIndexPath(),
             $this->excludedPathsPath()
         );
         $this->cursor = $plan->get_cursor();
@@ -681,14 +684,26 @@ final class PushPlanTest extends TestCase
 
     private function resumePlan(): PushPlan
     {
-        return PushPlan::resume($this->cursor);
+        return PushPlan::resume(
+            $this->planDirectory(),
+            $this->localTreeRoot(),
+            $this->localIndexPath(),
+            $this->excludedPathsPath(),
+            $this->cursor
+        );
     }
 
-    private function savePreviousLocalIndex(string $treeDescriptionPath): void
+    /**
+     * Builds a local-index fixture with the same indexer used by PushPlan.
+     */
+    private function saveLocalIndex(string $treeDescriptionPath): void
     {
         $plan = $this->startPlan($treeDescriptionPath);
         $this->planToCompletion($plan);
-        copy($this->planPath('fresh_local_index.jsonl'), $this->previousLocalIndexPath());
+        if (!is_dir(dirname($this->localIndexPath()))) {
+            mkdir(dirname($this->localIndexPath()), 0755, true);
+        }
+        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexPath());
         $this->removePlanDirectory();
     }
 
@@ -720,7 +735,7 @@ final class PushPlanTest extends TestCase
     /** @return array<string,mixed> */
     private function planCursor(): array
     {
-        return $this->cursor['position'];
+        return $this->cursor;
     }
 
     private function assertPathCounts(
@@ -753,9 +768,9 @@ final class PushPlanTest extends TestCase
         return $this->tempDir . '/state/push/example.com';
     }
 
-    private function previousLocalIndexPath(): string
+    private function localIndexPath(): string
     {
-        return $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        return $this->tempDir . '/state/local-index/example.com.jsonl';
     }
 
     private function excludedPathsPath(): string
@@ -889,7 +904,13 @@ final class PushPlanTest extends TestCase
      */
     private function writeIndex(array $entries): string
     {
-        uksort($entries, 'strcmp');
+        uksort(
+            $entries,
+            static fn(string $left, string $right): int => strcmp(
+                str_replace('/', "\0", $left),
+                str_replace('/', "\0", $right)
+            )
+        );
         $lines = '';
         foreach ($entries as $path => $entry) {
             $lines .= $this->indexLine(
@@ -932,7 +953,7 @@ final class PushPlanTest extends TestCase
         $paths = [];
         foreach ($lines as $line) {
             $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-            $path = base64_decode($data['path'], true);
+            $path = base64_decode($data['path_b64'], true);
             $this->assertIsString($path);
             $paths[] = $path;
         }

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -765,12 +765,13 @@ final class PushPlanTest extends TestCase
 
     private function pushStateDirectory(): string
     {
-        return $this->tempDir . '/state/push/example.com';
+        return $this->tempDir . '/state/remote-example.com/push';
     }
 
     private function localIndexPath(): string
     {
-        return $this->tempDir . '/state/local-index/example.com.jsonl';
+        return $this->tempDir
+            . '/state/remote-example.com/.local-index.jsonl';
     }
 
     private function excludedPathsPath(): string

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -67,8 +67,10 @@ class RemapResolveTest extends TestCase
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
         $this->set($c, 'state', array('preflight' => array('data' => array(
+            'runtime' => array('document_root' => ''),
             'database' => array('wp' => array('paths_urls' => $pathsUrls)),
         ))));
+        $this->call($c, 'configure_remote_state_directory', array($this->fsRoot));
         return $c;
     }
 
@@ -82,9 +84,12 @@ class RemapResolveTest extends TestCase
         $this->call($c, 'assert_files_remap_consistent');
     }
 
-    private function writeLocalIndex(): void
+    private function writeLocalIndex(\ImportClient $client): void
     {
-        file_put_contents($this->stateDir . '/.import-index.jsonl', "{}\n");
+        file_put_contents(
+            $client->remote_state_directory . '/.remote-index.jsonl',
+            "{}\n"
+        );
     }
 
     // --- resolution: SOURCE TARGET → one source => target rule -------------
@@ -225,8 +230,8 @@ class RemapResolveTest extends TestCase
 
     public function testRejectsRemapWithUntrackedExistingFilesIndex(): void
     {
-        $this->writeLocalIndex();
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $this->writeLocalIndex($c);
         $this->set($c, 'remap_rules', array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -124,6 +124,26 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     {
         $state = $this->callPrivate($client, 'load_state');
         $this->setPrivate($client, 'state', $state);
+        $this->callPrivate(
+            $client,
+            'configure_remote_state_directory',
+            [$this->fsRoot]
+        );
+    }
+
+    private function skippedFile(): string
+    {
+        $context = \ImportClient::prepare_files_command_context(
+            'https://source.example/export.php',
+            $this->stateDir,
+            $this->fsRoot,
+            'files-diff'
+        );
+        $remoteStateDirectory = $context['remote_state_directory'];
+        if (!is_dir($remoteStateDirectory)) {
+            mkdir($remoteStateDirectory);
+        }
+        return $remoteStateDirectory . '/pull-plan.skipped.jsonl';
     }
 
     private function runApplyRuntime(\ImportClient $client): string
@@ -152,7 +172,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'filter' => 'essential-files',
         ]);
         file_put_contents(
-            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->skippedFile(),
             json_encode(['path' => '/wp-content/uploads/2024/01/photo.jpg']) . "\n",
         );
 

--- a/tests/Import/SymlinkBundleTest.php
+++ b/tests/Import/SymlinkBundleTest.php
@@ -268,6 +268,10 @@ class SymlinkBundleTest extends TestCase
         // fs-root/opt/data; it must be repointed to the bundle placement.
         $c = $this->newClient();
         $rc = new \ReflectionClass($c);
+        $rc->getMethod('configure_remote_state_directory')->invoke(
+            $c,
+            $this->root
+        );
         $rc->getProperty('symlink_bundle_directory')->setValue($c, $this->root . '/.symlinks-bundle');
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, ['/src/wp-content']);
         $rc->getProperty('follow_symlinks')->setValue($c, true);
@@ -279,7 +283,10 @@ class SymlinkBundleTest extends TestCase
             'type' => 'link',
             'intermediate' => true,
         ]);
-        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', $entry . "\n");
+        file_put_contents(
+            $c->remote_state_directory . '/.remote-index.next.jsonl',
+            $entry . "\n"
+        );
 
         $rc->getMethod('recreate_intermediate_symlinks')->invoke($c);
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1350,15 +1350,15 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/replace-directory/old.txt', 'old');
         file_put_contents($local_docroot . '/replace-directory', 'replacement');
 
-        $previous_local_index_path = $this->root . '/previous-local-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture = $this->root . '/local-index-fixture.jsonl';
+        $this->writeIndex($local_index_fixture, [
             'remove.txt' => [1, 3, 'file'],
             'replace-directory' => [1, 0, 'dir', false],
             'replace-directory/old.txt' => [1, 3, 'file'],
             'same-size.txt' => [1, 4, 'file'],
         ]);
         $push_state_directory = $this->root . '/sender-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
 
         $commit_advances = 0;
         $saw_completing = false;
@@ -1392,7 +1392,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
-        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileExists($this->localIndexPath($push_state_directory));
     }
 
     /**
@@ -1440,14 +1440,14 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/retained-deleted-paths-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $previous_local_index_path = $this->root . '/retained-deleted-paths-previous-index.jsonl';
-        $previous_entries = [];
+        $local_index_fixture = $this->root . '/retained-deleted-paths-index.jsonl';
+        $local_index_entries = [];
         for ($index = 0; $index < 60; ++$index) {
-            $previous_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
+            $local_index_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
         }
-        $this->writeIndex($previous_local_index_path, $previous_entries);
+        $this->writeIndex($local_index_fixture, $local_index_entries);
         $push_state_directory = $this->root . '/retained-deleted-paths-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
         $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
@@ -1469,14 +1469,14 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/single-delete-part-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $previous_local_index_path = $this->root . '/single-delete-part-previous-index.jsonl';
-        $previous_entries = [];
+        $local_index_fixture = $this->root . '/single-delete-part-index.jsonl';
+        $local_index_entries = [];
         for ($index = 0; $index < 20; ++$index) {
-            $previous_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
+            $local_index_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
         }
-        $this->writeIndex($previous_local_index_path, $previous_entries);
+        $this->writeIndex($local_index_fixture, $local_index_entries);
         $push_state_directory = $this->root . '/single-delete-part-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
 
         for ($step = 0; $step < 30; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -1519,12 +1519,12 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/reappeared-delete-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($this->docroot . '/returned.txt', 'old');
-        $previous_local_index_path = $this->root . '/reappeared-delete-previous-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture = $this->root . '/reappeared-delete-index.jsonl';
+        $this->writeIndex($local_index_fixture, [
             'returned.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/reappeared-delete-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
         $sender = $this->startSender($options);
@@ -1551,13 +1551,13 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/replace.txt', 'new');
         mkdir($this->docroot . '/replace.txt');
         file_put_contents($this->docroot . '/replace.txt/old.txt', 'old');
-        $previous_local_index_path = $this->root . '/disappeared-replacement-previous-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture = $this->root . '/disappeared-replacement-index.jsonl';
+        $this->writeIndex($local_index_fixture, [
             'replace.txt' => [1, 0, 'dir', false],
             'replace.txt/old.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/disappeared-replacement-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
 
         for ($step = 0; $step < 30; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -1606,14 +1606,14 @@ final class PushEndpointsTest extends TestCase {
             $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
             $this->assertIsResource($fresh_local_index_handle);
 
-            $cursor_before_step = $this->loadPlanPosition($push_state_directory);
+            $cursor_before_step = $this->loadPlanCursor($push_state_directory);
 
             $sender->next_step();
 
             $first_plan_result = $this->senderResult($sender);
             $this->assertSame('planning', $first_plan_result['phase']);
             $this->assertSame($plan, $plan_property->getValue($sender));
-            $cursor_after_first_step = $this->loadPlanPosition($push_state_directory);
+            $cursor_after_first_step = $this->loadPlanCursor($push_state_directory);
             $this->assertNotSame($cursor_before_step, $cursor_after_first_step);
 
             $sender->next_step();
@@ -1623,7 +1623,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($plan, $plan_property->getValue($sender));
             $this->assertNotSame(
                 $cursor_after_first_step,
-                $this->loadPlanPosition($push_state_directory)
+                $this->loadPlanCursor($push_state_directory)
             );
         } finally {
             $this->closeSender($sender);
@@ -1656,12 +1656,13 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('creating', $sender->get_phase());
             $this->takeSenderStepsUntilPhase($sender, 'planning');
             $this->assertFileExists($fresh_local_index_path);
-            $this->assertFileExists($push_state_directory . '/plan/excluded_paths.json');
-            $this->assertFileDoesNotExist($push_state_directory . '/plan/cursor.json');
-            $this->assertSame(
-                file_get_contents($push_state_directory . '/excluded_paths.json'),
-                file_get_contents($push_state_directory . '/plan/excluded_paths.json')
+            $this->assertFileExists(
+                $push_state_directory . '/excluded_paths.json'
             );
+            $this->assertFileDoesNotExist(
+                $push_state_directory . '/plan/excluded_paths.json'
+            );
+            $this->assertFileDoesNotExist($push_state_directory . '/plan/cursor.json');
             $plan = $plan_property->getValue($sender);
             $this->assertInstanceOf(PushPlan::class, $plan);
             $file_index_processor = $file_index_processor_property->getValue($plan);
@@ -1674,7 +1675,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($plan, $plan_property->getValue($sender));
             $this->assertSame($file_index_processor, $file_index_processor_property->getValue($plan));
             $this->assertSame($fresh_local_index_handle, $fresh_local_index_handle_property->getValue($plan));
-            $plan_cursor = $this->loadPlanPosition($push_state_directory);
+            $plan_cursor = $this->loadPlanCursor($push_state_directory);
             $this->assertSame('indexing', $plan_cursor['phase']);
             $this->assertSame(ftell($fresh_local_index_handle), $plan_cursor['fresh_local_index_byte_offset']);
             $this->assertNotEmpty($plan_cursor['file_index_cursor']['stack']);
@@ -1697,7 +1698,7 @@ final class PushEndpointsTest extends TestCase {
 
             $this->assertTrue($sender->next_step());
             $this->assertSame('planning', $sender->get_phase());
-            $plan_cursor = $this->loadPlanPosition($push_state_directory);
+            $plan_cursor = $this->loadPlanCursor($push_state_directory);
             $this->assertSame('diffing', $plan_cursor['phase']);
             $this->assertFileExists($fresh_local_index_path);
             $state = $this->loadActiveState($push_state_directory);
@@ -1750,7 +1751,7 @@ final class PushEndpointsTest extends TestCase {
         $state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state);
         $this->assertSame('planning', $state['phase']);
-        $plan_cursor = $this->loadPlanPosition($push_state_directory);
+        $plan_cursor = $this->loadPlanCursor($push_state_directory);
         $this->assertSame('indexing', $plan_cursor['phase']);
         $this->assertGreaterThan(0, $plan_cursor['fresh_local_index_byte_offset']);
 
@@ -1758,7 +1759,7 @@ final class PushEndpointsTest extends TestCase {
 
         $this->assertSame('complete', $result['status']);
         $index_lines = file(
-            $push_state_directory . '/previous_local_index.jsonl',
+            $this->localIndexPath($push_state_directory),
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($index_lines);
@@ -1773,14 +1774,14 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/retained-handles-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/file.bin', str_repeat('A', 130));
-        $previous_local_index_path = $this->root . '/retained-handles-previous-index.jsonl';
-        $previous_entries = [];
+        $local_index_fixture = $this->root . '/retained-handles-index.jsonl';
+        $local_index_entries = [];
         for ($index = 0; $index < 20; ++$index) {
-            $previous_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
+            $local_index_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
         }
-        $this->writeIndex($previous_local_index_path, $previous_entries);
+        $this->writeIndex($local_index_fixture, $local_index_entries);
         $push_state_directory = $this->root . '/retained-handles-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
 
         $local_paths_to_push_handle_property = new ReflectionProperty(
             PushFilesSender::class,
@@ -2173,9 +2174,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($result['detail']);
     }
 
-    /**
-     * Applies receiver exclusions without maintaining a second baseline model.
-     */
+    /** Keeps receiver-excluded paths out of the committed local-index update. */
     public function testHighLevelSenderUsesReceiverExclusionsInPushPlan(): void
     {
         $local_docroot = $this->root . '/excluded-local-docroot';
@@ -2190,12 +2189,15 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertSame('public-change', file_get_contents($this->docroot . '/public.txt'));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $saved_local_index = file_get_contents($push_state_directory . '/previous_local_index.jsonl');
+        $saved_local_index = file_get_contents($this->localIndexPath($push_state_directory));
         $this->assertIsString($saved_local_index);
-        $this->assertStringContainsString(
+        $this->assertStringNotContainsString(
             '"path":"' . base64_encode('preserved/value.txt') . '"',
-            $saved_local_index,
-            'Exclusions suppress remote work but remain in the local index saved after the push.'
+            $saved_local_index
+        );
+        $this->assertStringContainsString(
+            '"path":"' . base64_encode('public.txt') . '"',
+            $saved_local_index
         );
     }
 
@@ -2427,6 +2429,7 @@ final class PushEndpointsTest extends TestCase {
         $sender = $this->startSender([
             'docroot' => $local_docroot,
             'push_state_directory' => $push_state_directory,
+            'local_index_path' => $this->localIndexPath($push_state_directory),
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -2459,12 +2462,12 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/delete-after-lost-response.txt', 'old');
         $local_docroot = $this->root . '/lost-response-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $previous_local_index_path = $this->root . '/lost-response-previous-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture = $this->root . '/lost-response-index.jsonl';
+        $this->writeIndex($local_index_fixture, [
             'delete-after-lost-response.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/lost-response-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture);
 
         for ($step = 0; $step < 30; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -2524,7 +2527,106 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
     }
 
-    public function testCompletedFilesPushPublishesThePreviousLocalIndexForFilesDiff(): void
+    public function testFilesPushUsesTheLocalIndexCreatedByFilesPull(): void
+    {
+        $state_directory = $this->root . '/pull-then-push-state';
+        $raw_file_root = $this->root . '/pull-then-push-files';
+        mkdir($state_directory, 0700, true);
+        mkdir($raw_file_root, 0700, true);
+        $remote_docroot = realpath($this->docroot);
+        $this->assertIsString($remote_docroot);
+        file_put_contents($this->docroot . '/edited-after-pull.txt', 'pulled edit');
+        file_put_contents(
+            $this->docroot . '/unchanged-after-pull.txt',
+            'pulled unchanged'
+        );
+        file_put_contents(
+            $state_directory . '/.import-state.json',
+            json_encode([
+                'preflight' => [
+                    'http_code' => 200,
+                    'data' => [
+                        'ok' => true,
+                        'runtime' => [
+                            'document_root' => $remote_docroot,
+                        ],
+                        'wp_detect' => [
+                            'roots' => [[
+                                'path' => $remote_docroot,
+                            ]],
+                        ],
+                        'database' => [
+                            'wp' => [
+                                'paths_urls' => [
+                                    'content_dir' =>
+                                        $remote_docroot . '/wp-content',
+                                    'uploads' => [
+                                        'basedir' =>
+                                            $remote_docroot
+                                            . '/wp-content/uploads',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+
+        $pull_process = proc_open(
+            [
+                PHP_BINARY,
+                __DIR__ . '/../importer/import.php',
+                'files-pull',
+                $this->base_url,
+                '--state-dir=' . $state_directory,
+                '--fs-root=' . $raw_file_root,
+                '--secret=' . self::SECRET,
+            ],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pull_pipes,
+            $this->root
+        );
+        $this->assertIsResource($pull_process);
+        fclose($pull_pipes[0]);
+        $pull_stdout = stream_get_contents($pull_pipes[1]);
+        $pull_stderr = stream_get_contents($pull_pipes[2]);
+        fclose($pull_pipes[1]);
+        fclose($pull_pipes[2]);
+        $pull_exit = proc_close($pull_process);
+        $this->assertIsString($pull_stdout);
+        $this->assertIsString($pull_stderr);
+        $this->assertSame(
+            0,
+            $pull_exit,
+            $pull_stdout . $pull_stderr
+        );
+
+        $local_docroot = $raw_file_root . $remote_docroot;
+        $local_edited_path = $local_docroot . '/edited-after-pull.txt';
+        $remote_unchanged_path =
+            $this->docroot . '/unchanged-after-pull.txt';
+        $remote_unchanged_before = lstat($remote_unchanged_path);
+        $this->assertIsArray($remote_unchanged_before);
+        file_put_contents($local_edited_path, 'local edit after pull');
+
+        $push = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(0, $push['exit'], $push['output']);
+        $this->assertSame(
+            'local edit after pull',
+            file_get_contents($this->docroot . '/edited-after-pull.txt')
+        );
+        $remote_unchanged_after = lstat($remote_unchanged_path);
+        $this->assertIsArray($remote_unchanged_after);
+        $this->assertSame(
+            $remote_unchanged_before['ino'],
+            $remote_unchanged_after['ino'],
+            'files-push replaced a path which still matched the pull-created local index.'
+        );
+    }
+
+    public function testCompletedFilesPushUpdatesTheLocalIndexForFilesDiff(): void
     {
         $local_docroot = $this->root . '/push-diff-local-docroot';
         $state_directory = $this->root . '/push-diff-state';
@@ -2573,7 +2675,7 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Runs the production files-diff CLI for the same pair a push CLI used.
+     * Runs files-diff for the target and local tree used by files-push.
      *
      * @return array{exit:int,stdout:string,stderr:string,output:string}
      */
@@ -2638,7 +2740,8 @@ final class PushEndpointsTest extends TestCase {
         $this->assertTrue(is_link($this->docroot . '/file-link'));
         $this->assertSame('nested/multi-chunk.bin', readlink($this->docroot . '/file-link'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
-        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $local_index = $this->filesLocalIndexPath($push_state_directory);
+        $this->assertFileExists($local_index);
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileDoesNotExist($state_directory . '/.import-state.json');
@@ -2650,7 +2753,7 @@ final class PushEndpointsTest extends TestCase {
             JSON_THROW_ON_ERROR
         );
         $this->assertSame(
-            ['command', 'pair', 'status', 'phase', 'reason', 'detail', 'ts'],
+            ['command', 'status', 'phase', 'reason', 'detail', 'ts'],
             array_keys($status)
         );
         $this->assertSame('complete', $status['status']);
@@ -2664,9 +2767,6 @@ final class PushEndpointsTest extends TestCase {
             }
         ));
         $this->assertNotEmpty($files_push_lines);
-        foreach ($files_push_lines as $line) {
-            $this->assertStringContainsString('pair=' . $initial_result['pair'], $line);
-        }
         preg_match_all('/PHASE files-push .* from=([^ ]+) \| to=([^ ]+)/', $audit, $phase_matches);
         $phase_transitions = array_map(
             static function (string $from, string $to): string {
@@ -2690,7 +2790,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileDoesNotExist($this->docroot . '/delete-later.txt');
         $this->assertSame('added', file_get_contents($this->docroot . '/added.txt'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
-        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileExists($local_index);
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
     }
@@ -2723,8 +2823,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $this->countEndpointRequests('push_upload'));
         $partial_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
-            'PARTIAL files-push | pair=' . $partial_result['pair']
-                . ' | phase=starting_plan | cause=time_limit',
+            'PARTIAL files-push | phase=starting_plan | cause=time_limit',
             $partial_audit
         );
 
@@ -2766,8 +2865,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('starting_plan', $interrupted_result['phase'] ?? null);
         $interrupted_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
-            'INTERRUPTED files-push | pair=' . $interrupted_result['pair']
-                . ' | phase=starting_plan | signal=' . SIGTERM,
+            'INTERRUPTED files-push | phase=starting_plan | signal=' . SIGTERM,
             $interrupted_audit
         );
 
@@ -2872,7 +2970,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($push_state_directory . '/sender.json');
         $failed_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
-            'FAILED files-push | pair=' . $failed_result['pair'],
+            'FAILED files-push | phase=pushing_paths | reason=lock_acquisition_failure',
             $failed_audit
         );
 
@@ -2913,7 +3011,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $restart_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
-            'RESTART files-push | pair=' . $restart_result['pair'],
+            'RESTART files-push | phase=discarding_plan | reason=local_path_changed',
             $restart_audit
         );
 
@@ -3022,8 +3120,19 @@ final class PushEndpointsTest extends TestCase {
     ): string {
         $canonical_local_docroot = realpath($local_docroot);
         $this->assertIsString($canonical_local_docroot);
-        $pair = hash('sha256', rtrim($this->base_url, '?&') . "\0" . $canonical_local_docroot);
-        return $state_directory . '/push/' . $pair;
+        $target_local_tree_hash = hash(
+            'sha256',
+            rtrim($this->base_url, '?&') . "\0" . $canonical_local_docroot
+        );
+        return $state_directory . '/push/' . $target_local_tree_hash;
+    }
+
+    private function filesLocalIndexPath(string $push_state_directory): string
+    {
+        return dirname(dirname($push_state_directory))
+            . '/local-index/'
+            . basename($push_state_directory)
+            . '.jsonl';
     }
 
     /** @return array<string,mixed> */
@@ -3034,6 +3143,7 @@ final class PushEndpointsTest extends TestCase {
         return [
             'docroot' => $local_docroot,
             'push_state_directory' => $push_state_directory,
+            'local_index_path' => $this->filesLocalIndexPath($push_state_directory),
             'base_url' => $this->base_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -3287,6 +3397,7 @@ final class PushEndpointsTest extends TestCase {
         return [
             'docroot' => $local_docroot,
             'push_state_directory' => $push_state_directory,
+            'local_index_path' => $this->localIndexPath($push_state_directory),
             'base_url' => $this->base_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -3440,7 +3551,7 @@ final class PushEndpointsTest extends TestCase {
         string $phase
     ): void {
         for ($step = 0; $step < 300; ++$step) {
-            $cursor = $this->loadPlanPosition($push_state_directory);
+            $cursor = $this->loadPlanCursor($push_state_directory);
             if ($cursor['phase'] === $phase) {
                 return;
             }
@@ -3452,15 +3563,13 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /** @return array<string,mixed> */
-    private function loadPlanPosition(string $push_state_directory): array
+    private function loadPlanCursor(string $push_state_directory): array
     {
         $state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state);
         $cursor = $state['push_plan_cursor'];
         $this->assertIsArray($cursor);
-        $position = $cursor['position'];
-        $this->assertIsArray($position);
-        return $position;
+        return $cursor;
     }
 
     /**
@@ -3534,15 +3643,24 @@ final class PushEndpointsTest extends TestCase {
         return $state;
     }
 
-    /**
-     * Seeds the pair's previous local index.
-     */
-    private function seedPreviousLocalIndex(string $push_state_directory, string $index_path): void
+    private function localIndexPath(string $push_state_directory): string
     {
-        if (!is_dir($push_state_directory)) {
-            mkdir($push_state_directory, 0700, true);
+        return $this->root
+            . '/local-index/'
+            . hash('sha256', $push_state_directory)
+            . '.jsonl';
+    }
+
+    /**
+     * Seeds the local index used by one direct sender test.
+     */
+    private function seedLocalIndex(string $push_state_directory, string $index_path): void
+    {
+        $local_index = $this->localIndexPath($push_state_directory);
+        if (!is_dir(dirname($local_index))) {
+            mkdir(dirname($local_index), 0700, true);
         }
-        $this->assertTrue(copy($index_path, $push_state_directory . '/previous_local_index.jsonl'));
+        $this->assertTrue(copy($index_path, $local_index));
     }
 
     /**
@@ -3771,7 +3889,7 @@ final class PushEndpointsTest extends TestCase {
         @rmdir($path);
     }
     /**
-     * Writes a path-sorted current index or enriched baseline JSONL.
+     * Writes a path-sorted local index JSONL file.
      *
      * @param array<string,array{0:int,1:int,2:'file'|'dir'|'link',3?:bool}> $entries
      *     Path to `[ctime, size, type, optional directory emptiness]` records.

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2733,7 +2733,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $initial['exit'], $initial['output']);
         $initial_result = $this->lastCliJsonLine($initial['stdout']);
         $this->assertSame('complete', $initial_result['status'] ?? null);
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $this->assertSame($initial_contents, file_get_contents($this->docroot . '/nested/multi-chunk.bin'));
         $this->assertSame('delete me later', file_get_contents($this->docroot . '/delete-later.txt'));
         $this->assertDirectoryExists($this->docroot . '/empty-directory');
@@ -2918,7 +2918,7 @@ final class PushEndpointsTest extends TestCase {
         }
 
         $this->assertNotSame(0, $killed['exit']);
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $active_state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($active_state);
         $this->waitForPushLockRelease($active_state['push_session_id']);
@@ -2937,7 +2937,7 @@ final class PushEndpointsTest extends TestCase {
         $state_directory = $this->root . '/cli-failed-state';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'value after failure');
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
@@ -2987,7 +2987,7 @@ final class PushEndpointsTest extends TestCase {
         $state_directory = $this->root . '/cli-restart-state';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/value.txt', 'before');
-        $push_state_directory = $this->filesPushStateDirectory($local_docroot, $state_directory);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $sender = $this->startSender(
             $this->filesPushSenderOptions($local_docroot, $push_state_directory)
         );
@@ -3114,25 +3114,17 @@ final class PushEndpointsTest extends TestCase {
         $this->fail('No JSON line was found in CLI output: ' . $output);
     }
 
-    private function filesPushStateDirectory(
-        string $local_docroot,
-        string $state_directory
-    ): string {
-        $canonical_local_docroot = realpath($local_docroot);
-        $this->assertIsString($canonical_local_docroot);
-        $target_local_tree_hash = hash(
-            'sha256',
-            rtrim($this->base_url, '?&') . "\0" . $canonical_local_docroot
-        );
-        return $state_directory . '/push/' . $target_local_tree_hash;
+    private function filesPushStateDirectory(string $state_directory): string {
+        $target_url_hash = hash('sha256', rtrim($this->base_url, '?&'));
+        return $state_directory
+            . '/remote-'
+            . $target_url_hash
+            . '/push';
     }
 
     private function filesLocalIndexPath(string $push_state_directory): string
     {
-        return dirname(dirname($push_state_directory))
-            . '/local-index/'
-            . basename($push_state_directory)
-            . '.jsonl';
+        return dirname($push_state_directory) . '/.local-index.jsonl';
     }
 
     /** @return array<string,mixed> */
@@ -3646,9 +3638,9 @@ final class PushEndpointsTest extends TestCase {
     private function localIndexPath(string $push_state_directory): string
     {
         return $this->root
-            . '/local-index/'
+            . '/remote-'
             . hash('sha256', $push_state_directory)
-            . '.jsonl';
+            . '/.local-index.jsonl';
     }
 
     /**

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -220,6 +220,23 @@ export function fsRootDir(outputDir) {
 }
 
 /**
+ * Return the target relationship state directory containing one state file.
+ */
+export function getRemoteStateDirectory(outputDir, stateFileName) {
+    const relationshipDirectories = readdirSync(outputDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory() && entry.name.startsWith('remote-'));
+    const matchingDirectories = relationshipDirectories.filter(
+        entry => existsSync(join(outputDir, entry.name, stateFileName)),
+    );
+    assert.equal(
+        matchingDirectories.length,
+        1,
+        `Expected one target relationship state directory containing ${stateFileName} in ${outputDir}`,
+    );
+    return join(outputDir, matchingDirectories[0].name);
+}
+
+/**
  * Run the importer CLI.
  * @param {string} url - Export URL
  * @param {string} outputDir - Local output directory (state files live here; fs-root is outputDir/fs-root)
@@ -685,10 +702,13 @@ export function readAuditLog(outputDir) {
 
 /**
  * Assert that the import indexed at least minCount files.
- * Checks .import-index.jsonl line count.
+ * Checks the target-observed index line count.
  */
 export function assertFileCount(outputDir, minCount = 3000) {
-    const indexPath = join(outputDir, '.import-index.jsonl');
+    const indexPath = join(
+        getRemoteStateDirectory(outputDir, '.remote-index.jsonl'),
+        '.remote-index.jsonl',
+    );
     assert.ok(existsSync(indexPath), `Expected ${indexPath} to exist`);
     const count = countJsonlLines(indexPath);
     assert.ok(count >= minCount,

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -56,9 +56,12 @@ describe('Import: Basic File Sync', () => {
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
-    it('.import-index.jsonl has entries', () => {
-        const indexFile = join(tempDir, '.import-index.jsonl');
-        assert.ok(existsSync(indexFile), 'Expected .import-index.jsonl to exist');
+    it('.remote-index.jsonl has entries', () => {
+        const indexFile = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.jsonl'),
+            '.remote-index.jsonl',
+        );
+        assert.ok(existsSync(indexFile), 'Expected .remote-index.jsonl to exist');
         const lines = readFileSync(indexFile, 'utf-8').trim().split('\n').filter(l => l);
         assert.ok(lines.length > 0, 'Expected at least one index entry');
     });
@@ -92,13 +95,16 @@ describe('Import: Basic File Sync', () => {
         });
         assert.equal(restart.exitCode, 0, `Expected restart exit 0, got ${restart.exitCode}\nstderr: ${restart.stderr}\nstdout: ${restart.stdout}`);
 
-        // Local index should still exist (restart preserves it)
-        const indexFile = join(tempDir, '.import-index.jsonl');
-        assert.ok(existsSync(indexFile), 'Expected local index to be preserved after --abort');
+        const remoteStateDirectory =
+            getRemoteStateDirectory(tempDir, '.remote-index.jsonl');
+
+        // The target-observed index should still exist (restart preserves it)
+        const indexFile = join(remoteStateDirectory, '.remote-index.jsonl');
+        assert.ok(existsSync(indexFile), 'Expected target-observed index to be preserved after --abort');
 
         // Transient files should be cleaned up
-        assert.ok(!existsSync(join(tempDir, '.import-remote-index.jsonl')), 'Expected remote index to be deleted');
-        assert.ok(!existsSync(join(tempDir, '.import-download-list.jsonl')), 'Expected download list to be deleted');
+        assert.ok(!existsSync(join(remoteStateDirectory, '.remote-index.next.jsonl')), 'Expected next target index to be deleted');
+        assert.ok(!existsSync(join(remoteStateDirectory, 'pull-plan.jsonl')), 'Expected pull plan to be deleted');
     });
 
     it('running after --abort performs a delta sync', () => {

--- a/tests/e2e/tests/import-04-files-index.test.js
+++ b/tests/e2e/tests/import-04-files-index.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 04: Files Index via import.php
- * Tests files-index command produces .import-remote-index.jsonl.
+ * Tests files-index command produces .remote-index.next.jsonl.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    countJsonlLines,
+    countJsonlLines, getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -30,14 +30,17 @@ describe('Import: Files Index', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-index produces .import-remote-index.jsonl', () => {
+    it('files-index produces .remote-index.next.jsonl', () => {
         const result = runImporter(importUrl(), tempDir, 'files-index', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const indexFile = join(tempDir, '.import-remote-index.jsonl');
-        assert.ok(existsSync(indexFile), 'Expected .import-remote-index.jsonl to exist');
+        const indexFile = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.next.jsonl'),
+            '.remote-index.next.jsonl',
+        );
+        assert.ok(existsSync(indexFile), 'Expected .remote-index.next.jsonl to exist');
 
         const lines = readFileSync(indexFile, 'utf-8').trim().split('\n').filter(l => l);
         assert.ok(lines.length > 0, 'Expected at least one index entry');
@@ -62,7 +65,10 @@ describe('Import: Files Index', () => {
     });
 
     it('remote index has at least 3000 entries', () => {
-        const indexFile = join(tempDir, '.import-remote-index.jsonl');
+        const indexFile = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.next.jsonl'),
+            '.remote-index.next.jsonl',
+        );
         const count = countJsonlLines(indexFile);
         assert.ok(count >= 3000,
             `Expected at least 3000 entries in remote index, got ${count}`);

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -12,7 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
-    fsRootDir,
+    fsRootDir, getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -83,7 +83,10 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('download list includes deleted files', () => {
-        const dlPath = join(tempDir, '.import-download-list.jsonl');
+        const dlPath = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.jsonl'),
+            'pull-plan.jsonl',
+        );
         if (existsSync(dlPath)) {
             const content = readFileSync(dlPath, 'utf-8');
             // The download list should reference the deleted files

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -25,7 +25,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
-    fsRootDir,
+    fsRootDir, getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -328,7 +328,10 @@ describe('Import: Follow Symlinks', () => {
 
     it('multiple symlinks to same target do not create duplicate index entries', () => {
         // After sort+dedup, each path should appear at most once
-        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
+        const remoteIndex = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.next.jsonl'),
+            '.remote-index.next.jsonl',
+        );
         if (!existsSync(remoteIndex)) return;
 
         const lines = readFileSync(remoteIndex, 'utf-8').split('\n').filter(l => l.trim());

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -17,7 +17,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    fsRootDir,
+    fsRootDir, getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -105,7 +105,10 @@ describe('Import: --filter', () => {
         });
 
         it('skipped download list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
+            assert.ok(existsSync(join(
+                getRemoteStateDirectory(tempDir, 'pull-plan.skipped.jsonl'),
+                'pull-plan.skipped.jsonl',
+            )),
                 'Expected skipped download list to remain on disk');
         });
 
@@ -134,7 +137,10 @@ describe('Import: --filter', () => {
         });
 
         it('skipped download list was cleaned up', () => {
-            assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
+            assert.ok(!existsSync(join(
+                getRemoteStateDirectory(tempDir, '.remote-index.jsonl'),
+                'pull-plan.skipped.jsonl',
+            )),
                 'Expected skipped download list to be cleaned up');
         });
 
@@ -206,7 +212,10 @@ describe('Import: --filter', () => {
         });
 
         it('skipped list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
+            assert.ok(existsSync(join(
+                getRemoteStateDirectory(tempDir, 'pull-plan.skipped.jsonl'),
+                'pull-plan.skipped.jsonl',
+            )),
                 'Expected skipped download list to remain');
         });
     });
@@ -234,7 +243,10 @@ describe('Import: --filter', () => {
         });
 
         it('no skipped download list was created', () => {
-            assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
+            assert.ok(!existsSync(join(
+                getRemoteStateDirectory(tempDir, '.remote-index.jsonl'),
+                'pull-plan.skipped.jsonl',
+            )),
                 'Expected no skipped download list without --filter');
         });
 

--- a/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
+++ b/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
@@ -29,7 +29,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     countJsonlLines,
-    fsRootDir,
+    fsRootDir, getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -79,7 +79,10 @@ describe('Import: Symlink cycle detection', () => {
         // A WordPress site has ~4000-6000 files.  Without cycle detection
         // the self-symlink would double that on every depth level.  With
         // cycle detection the total should stay in the normal range.
-        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
+        const remoteIndex = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.next.jsonl'),
+            '.remote-index.next.jsonl',
+        );
         assert.ok(existsSync(remoteIndex), 'Remote index should exist');
 
         const count = countJsonlLines(remoteIndex);
@@ -93,7 +96,10 @@ describe('Import: Symlink cycle detection', () => {
     });
 
     it('the marker file is indexed exactly once per reachable path', () => {
-        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
+        const remoteIndex = join(
+            getRemoteStateDirectory(tempDir, '.remote-index.next.jsonl'),
+            '.remote-index.next.jsonl',
+        );
         const content = readFileSync(remoteIndex, 'utf-8');
         const lines = content.split('\n').filter(l => l.trim());
 

--- a/tests/e2e/tests/import-48-pull-crash-resume.test.js
+++ b/tests/e2e/tests/import-48-pull-crash-resume.test.js
@@ -23,6 +23,7 @@ import {
     assertTreesMatch, assertSiteMirror,
     fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
+    getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -88,9 +89,12 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(state.pull_pipeline.last_completed_stage, null,
             'Expected pull_pipeline.last_completed_stage to be null after abort');
 
-        // Local index should be preserved (for delta sync)
-        assert.ok(existsSync(join(tempDir, '.import-index.jsonl')),
-            'Expected local index to be preserved after abort');
+        // The target-observed index should be preserved for the delta sync.
+        assert.ok(existsSync(join(
+            getRemoteStateDirectory(tempDir, '.remote-index.jsonl'),
+            '.remote-index.jsonl',
+        )),
+            'Expected target-observed index to be preserved after abort');
     });
 
     it('re-pull after abort performs delta sync', () => {

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -14,6 +14,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
+    getRemoteStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -93,7 +94,10 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
     });
 
     it('skipped download list remains on disk', () => {
-        const skippedList = join(tempDir, '.import-download-list-skipped.jsonl');
+        const skippedList = join(
+            getRemoteStateDirectory(tempDir, 'pull-plan.skipped.jsonl'),
+            'pull-plan.skipped.jsonl',
+        );
         assert.ok(existsSync(skippedList), 'Expected skipped download list to exist');
         assert.ok(readFileSync(skippedList, 'utf-8').trim().length > 0,
             'Expected skipped download list to be non-empty');


### PR DESCRIPTION
This puts each target URL in its own `remote-<hash>/` directory, so files-pull, files-diff, and files-push share one relationship-local index without colliding with another target.

The hash uses the target URL after removing URL user-info, `SECRET_KEY`, and the `site-export-api` endpoint alias. It does not include the local tree. A caller which uses another local document root must use another `--state-dir`.

The pull files now use `.remote-index.jsonl`, `.remote-index.next.jsonl`, `.local-index.jsonl`, `pull-plan.jsonl`, and `pull-index-updates.wal`. WAL records carry explicit remote and local fields; replay updates the remote projection first, then the local projection, and clears the WAL only after both replacements complete.

The relationship directory owns the file indexes and push state. Old index filenames are removed rather than kept as aliases.

Stacked on #406.