### PR TITLE
[Push] Persist target path mappings with pull state

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,12 +714,13 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 URL in a state directory:
 
 ```text
-<state-dir>/remote-<sha256(target URL with user-info and SECRET_KEY removed)>/.local-index.jsonl
+<state-dir>/remote-<sha256(target URL with user-info, SECRET_KEY, and site-export-api removed)>/.local-index.jsonl
 ```
 
-URL user-info and `SECRET_KEY` do not affect the hash; changing any other query
-parameter selects a different local index and push-state directory. Use a
-different state directory for a different local document root.
+URL user-info, `SECRET_KEY`, and the `site-export-api` endpoint alias do not
+affect the hash; changing any other query parameter selects a different local
+index and push-state directory. Use a different state directory for a different
+local document root.
 
 files-pull records each local path it changes through
 `remote-<hash>/pull-index-updates.wal`, except paths skipped by the local

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -84,13 +84,14 @@ previously pushed rows.
 The local index lives at:
 
 ```text
-<state-dir>/remote-<sha256(target URL with user-info and SECRET_KEY removed)>/.local-index.jsonl
+<state-dir>/remote-<sha256(target URL with user-info, SECRET_KEY, and site-export-api removed)>/.local-index.jsonl
 ```
 
-The hash omits URL user-info and `SECRET_KEY`, so pull URL authentication and
-push's `--secret` select the same local index. Changing any other query
-parameter selects a different local index and push-state directory. A different
-local document root uses a different state directory.
+The hash omits URL user-info, `SECRET_KEY`, and the `site-export-api` endpoint
+alias, so pull URL authentication, pull's bare-URL normalization, and push's
+`--secret` select the same local index. Changing any other query parameter
+selects a different local index and push-state directory. A different local
+document root uses a different state directory.
 
 Entries for actual pulled or pushed paths record the locally observed type,
 size, and ctime. Remote values cannot stand in for these fields because ctime
@@ -462,10 +463,11 @@ The local index is
 `<state-dir>/remote-<hash>/.local-index.jsonl`; sender state lives at
 `<state-dir>/remote-<hash>/push/`. A different target query selects a different
 remote state directory. A different local tree uses a different state
-directory. The hash omits URL user-info and `SECRET_KEY`; files-push rejects
-both and receives its secret through `--secret`. Fragments are rejected. The
-local push state directory must be outside the local tree so planning cannot
-index its own changing files.
+directory. The hash omits URL user-info, `SECRET_KEY`, and the
+`site-export-api` endpoint alias; files-push rejects authentication in its
+target URL and receives its secret through `--secret`. Fragments are rejected.
+The local push state directory must be outside the local tree so planning
+cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -125,7 +125,7 @@ succeed.
 One target URL in a state directory uses:
 
 ```text
-<state-dir>/remote-<sha256(target URL with user-info and SECRET_KEY removed)>/
+<state-dir>/remote-<sha256(target URL with user-info, SECRET_KEY, and site-export-api removed)>/
   .remote-index.jsonl
   .remote-index.next.jsonl
   .local-index.jsonl
@@ -134,9 +134,9 @@ One target URL in a state directory uses:
   push/
 ```
 
-The hash omits URL user-info and `SECRET_KEY`; changing any other query
-parameter selects a different remote state directory. A different local
-document root uses a different state directory.
+The hash omits URL user-info, `SECRET_KEY`, and the `site-export-api` endpoint
+alias; changing any other query parameter selects a different remote state
+directory. A different local document root uses a different state directory.
 
 Use `remote_state_directory`, `$remote_state_directory`, and `remote state
 directory` for `remote-<hash>/`. Use `local_index_path`, `$local_index_path`,
@@ -285,8 +285,9 @@ sha256(<target-url-without-authentication>)
 The local index is `<state-dir>/remote-<hash>/.local-index.jsonl`, and the
 `local push state directory` is `<state-dir>/remote-<hash>/push/`. `files-push`
 chooses `start` or `resume` only from whether `sender.json` exists there. The
-hash omits URL user-info and `SECRET_KEY`; files-push receives its secret
-through `--secret`. A different local tree uses a different state directory.
+hash omits URL user-info, `SECRET_KEY`, and the `site-export-api` endpoint
+alias; files-push receives its secret through `--secret`. A different local
+tree uses a different state directory.
 receiver-confirmed upload positions remain receiver-owned; they are not a
 files-push cursor and are not copied into `.import-state.json` or
 `.import-status.json`.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -277,8 +277,14 @@ class ImportClient
     /** @var string State directory for one target URL. */
     public $remote_state_directory;
 
-    /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
+    /** @var string Root bootstrap state used until preflight identifies the local tree. */
+    private $bootstrap_state_file;
+
+    /** @var string Path to pull-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
+
+    /** @var string Path to the immutable resolved path mapping. */
+    private $path_mapping_file;
 
     /**
      * @var float Monotonic timestamp of last progress JSON line emitted.
@@ -554,7 +560,11 @@ class ImportClient
             }
         }
         $this->remote_state_directory = $this->state_dir;
-        $this->state_file = $this->state_dir . "/.import-state.json";
+        $this->bootstrap_state_file =
+            $this->state_dir . "/.import-state.json";
+        $this->state_file = $this->bootstrap_state_file;
+        $this->path_mapping_file =
+            $this->state_dir . "/path-mapping.json";
         $this->remote_index_file =
             $this->state_dir . "/.remote-index.jsonl";
         $this->index_update_wal_path =
@@ -570,6 +580,28 @@ class ImportClient
             $this->state_dir . "/pull-volatile-files.json";
         $this->status_file = $this->state_dir . "/.import-status.json";
 
+        if ($signal_handling_command === 'import-metadata') {
+            $existing_remote_state_directory =
+                $this->find_only_pull_state_directory();
+        } else {
+            $existing_remote_state_directory =
+                $this->find_remote_state_directory(
+                    $signal_handling_command !== 'apply-runtime'
+                );
+            if (
+                $signal_handling_command === 'apply-runtime'
+                && $existing_remote_state_directory === null
+            ) {
+                $existing_remote_state_directory =
+                    $this->find_only_pull_state_directory();
+            }
+        }
+        if ($existing_remote_state_directory !== null) {
+            $this->select_remote_state_directory(
+                $existing_remote_state_directory
+            );
+        }
+
         // Detect TTY for progress display. In stdout mode this is re-evaluated
         // against STDERR in run() once we know the output mode.
         $this->is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
@@ -581,19 +613,39 @@ class ImportClient
     }
 
     /** Selects the per-target files state directory. */
-    private function configure_remote_state_directory(): void
+    private function configure_remote_state_directory(
+        bool $select_pull_state = true
+    ): void
     {
-        $this->remote_state_directory = self::remote_state_directory(
+        $remote_state_directory = self::remote_state_directory(
             $this->remote_url,
             $this->state_dir
         );
         if (
-            !is_dir($this->remote_state_directory)
-            && !mkdir($this->remote_state_directory, 0755, true)
+            !is_dir($remote_state_directory)
+            && !mkdir($remote_state_directory, 0755, true)
         ) {
             throw new RuntimeException(
-                "Failed to create directory: {$this->remote_state_directory}"
+                "Failed to create directory: {$remote_state_directory}"
             );
+        }
+        $this->select_remote_state_directory(
+            $remote_state_directory,
+            $select_pull_state
+        );
+    }
+
+    /** Selects paths owned by one existing target relationship. */
+    private function select_remote_state_directory(
+        string $remote_state_directory,
+        bool $select_pull_state = true
+    ): void {
+        $this->remote_state_directory = $remote_state_directory;
+        if ($select_pull_state) {
+            $this->state_file =
+                $this->remote_state_directory . "/pull-state.json";
+            $this->path_mapping_file =
+                $this->remote_state_directory . "/path-mapping.json";
         }
         $this->remote_index_file =
             $this->remote_state_directory . "/.remote-index.jsonl";
@@ -607,6 +659,92 @@ class ImportClient
             $this->remote_state_directory . "/pull-plan.skipped.jsonl";
         $this->volatile_files_file =
             $this->remote_state_directory . "/pull-volatile-files.json";
+    }
+
+    /**
+     * Finds a persisted relationship by pull filesystem root and, normally,
+     * target URL.
+     */
+    private function find_remote_state_directory(
+        bool $match_target_url = true
+    ): ?string
+    {
+        $canonical_filesystem_root =
+            self::canonicalize_path_with_missing_components($this->fs_root);
+        if ($canonical_filesystem_root === null) {
+            return null;
+        }
+        $target_url_fingerprint = hash(
+            'sha256',
+            self::target_url_for_relationship($this->remote_url)
+        );
+        $mapping_files = glob(
+            $this->state_dir . '/remote-*/path-mapping.json'
+        );
+        if (!is_array($mapping_files)) {
+            return null;
+        }
+        $matching_directories = [];
+        foreach ($mapping_files as $mapping_file) {
+            $mapping = self::read_path_mapping($mapping_file);
+            if (
+                $match_target_url
+                &&
+                $mapping['target_url_fingerprint']
+                    !== $target_url_fingerprint
+            ) {
+                continue;
+            }
+            $filesystem_root = base64_decode(
+                $mapping['filesystem_root_b64'],
+                true
+            );
+            $local_tree = base64_decode(
+                $mapping['local_tree_b64'],
+                true
+            );
+            if (
+                $filesystem_root === $canonical_filesystem_root
+                || $local_tree === $canonical_filesystem_root
+            ) {
+                $matching_directory = realpath(dirname($mapping_file));
+                $matching_directories[] = $matching_directory === false
+                    ? dirname($mapping_file)
+                    : $matching_directory;
+            }
+        }
+        if (count($matching_directories) > 1) {
+            throw new RuntimeException(
+                'More than one target relationship uses the local tree '
+                . $canonical_filesystem_root
+                . ' in '
+                . $this->state_dir
+                . '. Use a state directory containing one matching relationship.'
+            );
+        }
+        return $matching_directories[0] ?? null;
+    }
+
+    /** Finds the only persisted pull state for a local-only command. */
+    private function find_only_pull_state_directory(): ?string
+    {
+        $pull_state_files = glob(
+            $this->state_dir . '/remote-*/pull-state.json'
+        );
+        if (!is_array($pull_state_files) || $pull_state_files === []) {
+            return null;
+        }
+        if (count($pull_state_files) > 1) {
+            throw new RuntimeException(
+                'A local-only command cannot select one pull state because '
+                . $this->state_dir
+                . ' contains more than one target relationship.'
+            );
+        }
+        $pull_state_directory = realpath(dirname($pull_state_files[0]));
+        return $pull_state_directory === false
+            ? dirname($pull_state_files[0])
+            : $pull_state_directory;
     }
 
     /**
@@ -805,9 +943,12 @@ class ImportClient
     /**
      * Resolve file-selection options after preflight is available.
      */
-    public function prepare_files_pull_options(array $options, bool $assert_remap = true): void
+    public function prepare_files_pull_options(
+        array $options,
+        bool $persist_path_mapping = true
+    ): void
     {
-        $this->configure_remote_state_directory();
+        $this->configure_remote_state_directory($persist_path_mapping);
         $remap_raw = $options["remap"] ?? [];
         if (!empty($remap_raw)) {
             $this->remap_rules = $this->resolve_remap($remap_raw);
@@ -821,8 +962,8 @@ class ImportClient
             $this->pull_only_files_with_path_prefixes = $this->resolve_pull_only_files_with_path_prefixes($only_raw);
         }
 
-        if ($assert_remap) {
-            $this->assert_files_remap_consistent();
+        if ($persist_path_mapping) {
+            $this->persist_path_mapping();
         }
     }
 
@@ -1066,9 +1207,9 @@ class ImportClient
         }
 
         // files-diff and files-push use local push state and must not load
-        // or write the pull command's .import-state.json file.
+        // or write the pull command's pull-state.json file.
         if ($command === "files-diff") {
-            $this->configure_remote_state_directory();
+            $this->configure_remote_state_directory(false);
             if (is_file($this->index_update_wal_path)) {
                 throw new RuntimeException(
                     'Finish or abort the interrupted files-pull before running files-diff.'
@@ -1078,7 +1219,7 @@ class ImportClient
             return;
         }
         if ($command === "files-push") {
-            $this->configure_remote_state_directory();
+            $this->configure_remote_state_directory(false);
             if (is_file($this->index_update_wal_path)) {
                 throw new RuntimeException(
                     'Finish or abort the interrupted files-pull before running files-push.'
@@ -1096,9 +1237,6 @@ class ImportClient
         }
 
         $this->state = ImportState::from_array($this->load_state());
-        if (($this->import_state()->preflight ?? null) !== null) {
-            $this->configure_remote_state_directory();
-        }
 
         if ($command === "import-metadata") {
             $this->run_import_metadata();
@@ -1851,6 +1989,20 @@ class ImportClient
                 . '. Pass --force-http only for a target you trust.'
             );
         }
+        $path_mapping_file =
+            $context['remote_state_directory'] . '/path-mapping.json';
+        if (is_file($path_mapping_file)) {
+            $path_mapping = self::read_path_mapping($path_mapping_file);
+            foreach ($path_mapping['prefix_rules'] as $prefix_rule) {
+                if ($prefix_rule['kind'] === 'remap') {
+                    throw new RuntimeException(
+                        'files-push cannot use this local index because '
+                        . $path_mapping_file
+                        . ' contains remapped paths.'
+                    );
+                }
+            }
+        }
         return $context;
     }
 
@@ -1935,6 +2087,26 @@ class ImportClient
                 . ' must be outside the local tree ' . $canonical_local_tree . '.'
             );
         }
+        $path_mapping_file = $remote_state_directory . '/path-mapping.json';
+        if (is_file($path_mapping_file)) {
+            $path_mapping = self::read_path_mapping($path_mapping_file);
+            /** @var string $mapped_local_tree */
+            $mapped_local_tree = base64_decode(
+                $path_mapping['local_tree_b64'],
+                true
+            );
+            if ($mapped_local_tree !== $canonical_local_tree) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $path_mapping_file
+                    . ' records local tree '
+                    . $mapped_local_tree
+                    . ', not '
+                    . $canonical_local_tree
+                    . '. Use a different --state-dir for this local tree.'
+                );
+            }
+        }
 
         return [
             'target_url' => $target_url,
@@ -1945,7 +2117,114 @@ class ImportClient
         ];
     }
 
-    /** Removes authentication inputs which do not identify a target. */
+    /**
+     * Reads and validates one resolved path mapping.
+     *
+     * @return array {
+     *     @type string $target_url_fingerprint    Target URL fingerprint.
+     *     @type string $filesystem_root_b64       Pull filesystem root.
+     *     @type string $local_tree_b64            Canonical local tree.
+     *     @type string $target_document_root_b64  Target document root.
+     *     @type array  $prefix_rules              Resolved prefix rules.
+     * }
+     * @phpstan-return array{target_url_fingerprint:string,filesystem_root_b64:string,local_tree_b64:string,target_document_root_b64:string,prefix_rules:list<array{kind:'default'|'remap',remote_prefix_b64:string,local_prefix_b64:string}>}
+     */
+    private static function read_path_mapping(string $mapping_file): array
+    {
+        $json = file_get_contents($mapping_file);
+        if (!is_string($json)) {
+            throw new RuntimeException(
+                'Failed to read the path mapping: ' . $mapping_file . '.'
+            );
+        }
+        $mapping = json_decode(
+            $json,
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        if (!is_array($mapping)) {
+            throw new RuntimeException(
+                'The path mapping is not a JSON object: '
+                . $mapping_file
+                . '.'
+            );
+        }
+        foreach ([
+            'target_url_fingerprint',
+            'filesystem_root_b64',
+            'local_tree_b64',
+            'target_document_root_b64',
+        ] as $key) {
+            if (!isset($mapping[$key]) || !is_string($mapping[$key])) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $mapping_file
+                    . ' has no string '
+                    . $key
+                    . '.'
+                );
+            }
+        }
+        foreach ([
+            'filesystem_root_b64',
+            'local_tree_b64',
+            'target_document_root_b64',
+        ] as $key) {
+            if (base64_decode($mapping[$key], true) === false) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $mapping_file
+                    . ' has invalid base64 in '
+                    . $key
+                    . '.'
+                );
+            }
+        }
+        if (!isset($mapping['prefix_rules']) || !is_array($mapping['prefix_rules'])) {
+            throw new RuntimeException(
+                'The path mapping '
+                . $mapping_file
+                . ' has no prefix_rules array.'
+            );
+        }
+        foreach ($mapping['prefix_rules'] as $position => $prefix_rule) {
+            if (
+                !is_array($prefix_rule)
+                || !in_array(
+                    $prefix_rule['kind'] ?? null,
+                    ['default', 'remap'],
+                    true
+                )
+                || !isset(
+                    $prefix_rule['remote_prefix_b64'],
+                    $prefix_rule['local_prefix_b64']
+                )
+                || !is_string($prefix_rule['remote_prefix_b64'])
+                || !is_string($prefix_rule['local_prefix_b64'])
+                || base64_decode(
+                    $prefix_rule['remote_prefix_b64'],
+                    true
+                ) === false
+                || base64_decode(
+                    $prefix_rule['local_prefix_b64'],
+                    true
+                ) === false
+            ) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $mapping_file
+                    . ' has an invalid prefix rule at position '
+                    . $position
+                    . '.'
+                );
+            }
+        }
+        /** @var array{target_url_fingerprint:string,filesystem_root_b64:string,local_tree_b64:string,target_document_root_b64:string,prefix_rules:list<array{kind:'default'|'remap',remote_prefix_b64:string,local_prefix_b64:string}>} $mapping */
+        return $mapping;
+    }
+
+    /** Removes endpoint aliases and authentication inputs which do not identify a target. */
     private static function target_url_for_relationship(
         string $target_url
     ): string {
@@ -1965,7 +2244,11 @@ class ImportClient
                 $query_name = explode('=', $query_part, 2)[0];
                 if (
                     $query_part !== ''
-                    && rawurldecode($query_name) !== 'SECRET_KEY'
+                    && !in_array(
+                        rawurldecode($query_name),
+                        ['SECRET_KEY', 'site-export-api'],
+                        true
+                    )
                 ) {
                     $query_parts[] = $query_part;
                 }
@@ -4514,9 +4797,8 @@ class ImportClient
         }
 
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL"] = $base_url;
-        $state_dir = realpath($this->state_dir) ?: $this->state_dir;
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
-            rtrim($state_dir, "/") . "/.import-state.json";
+            $this->state_file;
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
             $this->skipped_download_list_file;
         $manifest->routes[] = [
@@ -8560,51 +8842,117 @@ class ImportClient
     }
 
     /**
-     * Refuse to reuse a files index with different --remap rules.
+     * Stores the resolved mapping once for the target relationship.
      *
-     * The files index stores remote paths. Local writes/deletes derive their
-     * targets from the current remap rules, so changing those rules while the
-     * same index is still in use can point future updates at the wrong path.
+     * The local index stores paths after pull remapping, while later push work
+     * needs their original target coordinates. Changing the resolved rules
+     * while reusing that index could address a different target path, so the
+     * first mapping is immutable. Rule order is normalized because matching
+     * chooses the deepest remote prefix rather than the first listed rule.
      */
-    private function assert_files_remap_consistent(): void
+    private function persist_path_mapping(): void
     {
-        $fingerprint = $this->files_remap_fingerprint();
-        $previous = $this->import_state()->files_remap_fingerprint ?? null;
-
-        $has_existing_index =
-            file_exists($this->remote_index_file)
-            && filesize($this->remote_index_file) > 0;
-        if ($previous === null && $has_existing_index && !empty($this->remap_rules)) {
+        $filesystem_root = $this->get_filesystem_root_path();
+        $local_tree =
+            self::canonicalize_path_with_missing_components(
+                $this->local_tree()
+            );
+        if ($local_tree === null) {
             throw new RuntimeException(
-                "Cannot use --remap with an existing files index that was created before remap tracking. " .
-                    "Use a new --state-dir or clear the existing files index first.",
+                'Failed to resolve the local tree for the path mapping.'
             );
         }
-
-        if ($previous !== null && $previous !== $fingerprint) {
+        $target_document_root =
+            $this->import_state()->preflight['data']['runtime'][
+                'document_root'
+            ] ?? null;
+        if (!is_string($target_document_root)) {
             throw new RuntimeException(
-                "Cannot change --remap rules while reusing the same files index. " .
-                    "Use the original --remap rules, or use a new --state-dir for a fresh files-pull.",
+                'Preflight did not report a target document root for the path mapping.'
             );
         }
-
-        if ($previous === null) {
-            $this->import_state()->files_remap_fingerprint = $fingerprint;
-            $this->save_state($this->state);
+        $target_document_root =
+            rtrim(normalize_path($target_document_root), '/') ?: '/';
+        $resolved_prefix_rules = $this->remap_rules;
+        if (!array_key_exists($target_document_root, $resolved_prefix_rules)) {
+            $resolved_prefix_rules[$target_document_root] = $local_tree;
         }
-    }
+        ksort($resolved_prefix_rules, SORT_STRING);
+        $prefix_rules = [];
+        foreach (
+            $resolved_prefix_rules
+            as $remote_prefix => $local_prefix
+        ) {
+            $prefix_rules[] = [
+                'kind' => array_key_exists(
+                    $remote_prefix,
+                    $this->remap_rules
+                )
+                    ? 'remap'
+                    : 'default',
+                'remote_prefix_b64' => base64_encode($remote_prefix),
+                'local_prefix_b64' => base64_encode($local_prefix),
+            ];
+        }
+        $mapping = [
+            'target_url_fingerprint' => hash(
+                'sha256',
+                self::target_url_for_relationship($this->remote_url)
+            ),
+            'filesystem_root_b64' => base64_encode($filesystem_root),
+            'local_tree_b64' => base64_encode($local_tree),
+            'target_document_root_b64' =>
+                base64_encode($target_document_root),
+            'prefix_rules' => $prefix_rules,
+        ];
 
-    /**
-     * Stable fingerprint for the resolved remap rule set.
-     *
-     * Rule order does not matter: remap matching chooses the deepest source
-     * path, not the first matching rule.
-     */
-    private function files_remap_fingerprint(): string
-    {
-        $rules = $this->remap_rules;
-        ksort($rules, SORT_STRING);
-        return hash("sha256", json_encode($rules, JSON_UNESCAPED_SLASHES));
+        if (is_file($this->path_mapping_file)) {
+            if (self::read_path_mapping($this->path_mapping_file) !== $mapping) {
+                throw new RuntimeException(
+                    'Cannot change the resolved path mapping in '
+                    . $this->remote_state_directory
+                    . '. Use the original --remap rules, or use a new '
+                    . '--state-dir for a fresh files-pull.'
+                );
+            }
+        } else {
+            $temporary_mapping_file = $this->path_mapping_file . '.tmp';
+            $json = json_encode(
+                $mapping,
+                JSON_PRETTY_PRINT
+                    | JSON_UNESCAPED_SLASHES
+                    | JSON_THROW_ON_ERROR
+            );
+            if (
+                file_put_contents($temporary_mapping_file, $json) === false
+            ) {
+                throw new RuntimeException(
+                    'Failed to write the path mapping: '
+                    . $temporary_mapping_file
+                    . '.'
+                );
+            }
+            if (!rename($temporary_mapping_file, $this->path_mapping_file)) {
+                throw new RuntimeException(
+                    'Failed to replace the path mapping: '
+                    . $this->path_mapping_file
+                    . '.'
+                );
+            }
+        }
+
+        $this->save_state($this->state);
+        if (
+            $this->bootstrap_state_file !== $this->state_file
+            && is_file($this->bootstrap_state_file)
+            && !unlink($this->bootstrap_state_file)
+        ) {
+            throw new RuntimeException(
+                'Failed to remove the bootstrap pull state: '
+                . $this->bootstrap_state_file
+                . '.'
+            );
+        }
     }
 
     /**
@@ -11030,7 +11378,6 @@ class ImportClient
         $follow = $this->import_state()->follow_symlinks ?? false;
         $nonempty = $this->import_state()->fs_root_nonempty_behavior ?? "error";
         $max_packet = $this->import_state()->max_allowed_packet ?? null;
-        $files_remap_fingerprint = $this->import_state()->files_remap_fingerprint ?? null;
         $pull = $this->import_state()->pull_pipeline ?? null;
         $this->state = ImportState::from_array($this->default_state());
         $this->import_state()->preflight = $preflight;
@@ -11039,7 +11386,6 @@ class ImportClient
         $this->import_state()->follow_symlinks = $follow;
         $this->import_state()->fs_root_nonempty_behavior = $nonempty;
         $this->import_state()->max_allowed_packet = $max_packet;
-        $this->import_state()->files_remap_fingerprint = $files_remap_fingerprint;
         if ($pull !== null) {
             $this->import_state()->pull_pipeline = $pull;
         }
@@ -11067,7 +11413,6 @@ class ImportClient
             "filter" => "none",
             "user_agent" => null,
             "max_allowed_packet" => null,
-            "files_remap_fingerprint" => null,
             "files_pull_only_fingerprint" => null,
             "files_pull_summary" => [
                 "files_pulled" => 0,
@@ -12847,7 +13192,8 @@ if (
                 "  remote-<hash>/pull-index-updates.wal    Active files-pull WAL\n" .
                 "  remote-<hash>/pull-plan.jsonl           Files pending download\n" .
                 "  remote-<hash>/pull-plan.skipped.jsonl   Skipped files (when --filter=essential-files)\n" .
-                "  .import-state.json                      Resumable state\n" .
+                "  remote-<hash>/pull-state.json           Resumable pull state\n" .
+                "  remote-<hash>/path-mapping.json         Immutable resolved path mapping\n" .
                 "  .import-audit.log                       Audit log\n",
         ],
         "files-diff" => [
@@ -12861,8 +13207,8 @@ if (
                 "updates entries for paths committed by the target.\n" .
                 "The local tree at --fs-root must be the exact document root later\n" .
                 "passed to files-push. Use the same exporter endpoint as pull but\n" .
-                "omit URL user-info and SECRET_KEY. After pull-files received a bare\n" .
-                "site URL, include the site-export-api query which it added.\n" .
+                "omit URL user-info, SECRET_KEY, and the site-export-api marker\n" .
+                "which pull-files may add to a bare site URL.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .
@@ -12976,8 +13322,9 @@ if (
             "short" => "Print local import lifecycle metadata as JSON",
             "usage" => "reprint import-metadata --state-dir=DIR",
             "description" =>
-                "Reads --state-dir/.import-state.json and prints metadata for\n" .
-                "host integrations. No network calls are made.\n",
+                "Reads the only remote-<hash>/pull-state.json in --state-dir\n" .
+                "and prints metadata for host integrations. No network calls\n" .
+                "are made. Refuses an ambiguous state directory.\n",
             "extra" =>
                 "Example:\n" .
                 "  reprint import-metadata --state-dir=./state | jq '.hasCompletedOnce'\n",

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -353,7 +353,6 @@ class ImportState
     /** @var string|null User-Agent that worked during preflight. */
     public ?string $user_agent = null;
     public ?int $max_allowed_packet = null;
-    public ?string $files_remap_fingerprint = null;
     public ?string $files_pull_only_fingerprint = null;
     public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;
@@ -405,7 +404,6 @@ class ImportState
         $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
         $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
         $state->max_allowed_packet = isset($data['max_allowed_packet']) ? (int) $data['max_allowed_packet'] : null;
-        $state->files_remap_fingerprint = isset($data['files_remap_fingerprint']) ? (string) $data['files_remap_fingerprint'] : null;
         $state->files_pull_only_fingerprint = isset($data['files_pull_only_fingerprint']) ? (string) $data['files_pull_only_fingerprint'] : null;
         $state->files_pull_summary = self::files_pull_summary_from($data['files_pull_summary'] ?? []);
         $state->db_index = self::database_table_index_from($data['db_index'] ?? []);
@@ -447,7 +445,6 @@ class ImportState
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,
             'max_allowed_packet' => $this->max_allowed_packet,
-            'files_remap_fingerprint' => $this->files_remap_fingerprint,
             'files_pull_only_fingerprint' => $this->files_pull_only_fingerprint,
             'files_pull_summary' => $this->files_pull_summary->to_array(),
             'db_index' => $this->db_index->to_array(),

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -154,7 +154,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         $mounts = [];
         $runtime_file_mounts = [
             'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE'
-                => '/tmp/reprint/.import-state.json',
+                => '/tmp/reprint/pull-state.json',
             'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'
                 => '/tmp/reprint/pull-plan.skipped.jsonl',
         ];

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -67,7 +67,10 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('update entries for paths they change', $output);
         $this->assertStringContainsString('paths committed by the target', $output);
         $this->assertStringContainsString('Complete files-pull, pull-files, or files-push once', $output);
-        $this->assertStringContainsString('omit URL user-info and SECRET_KEY', $output);
+        $this->assertStringContainsString(
+            'omit URL user-info, SECRET_KEY, and the site-export-api marker',
+            $output
+        );
         $this->assertStringContainsString('same files-pull with --abort', $output);
         $this->assertStringContainsString('push operation plan', $output);
         $this->assertStringContainsString('default-skipped paths', $output);

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -125,6 +125,80 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testPullAliasMarkerDoesNotChangeTheLocalIndexPath(): void
+    {
+        $targetUrl = 'https://example.test/?reprint-api=1';
+        $beforePullNormalization = ImportClient::prepare_files_command_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        $afterPullNormalization = ImportClient::prepare_files_command_context(
+            $targetUrl . '&site-export-api',
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+
+        $this->assertSame(
+            $beforePullNormalization['remote_state_directory'],
+            $afterPullNormalization['remote_state_directory']
+        );
+    }
+
+    public function testCommandContextRejectsMappingForAnotherLocalTree(): void
+    {
+        $targetUrl = 'https://example.test/?reprint-api=1';
+        $context = ImportClient::prepare_files_command_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-push'
+        );
+        mkdir($context['remote_state_directory'], 0700, true);
+        file_put_contents(
+            $context['remote_state_directory'] . '/path-mapping.json',
+            json_encode([
+                'target_url_fingerprint' => hash('sha256', $targetUrl),
+                'filesystem_root_b64' => base64_encode($context['local_tree']),
+                'local_tree_b64' => base64_encode($context['local_tree']),
+                'target_document_root_b64' => base64_encode('/var/www/html'),
+                'prefix_rules' => [[
+                    'kind' => 'default',
+                    'remote_prefix_b64' => base64_encode('/var/www/html'),
+                    'local_prefix_b64' => base64_encode($context['local_tree']),
+                ]],
+            ], JSON_THROW_ON_ERROR)
+        );
+        $otherTree = $this->root . '/other-tree';
+        mkdir($otherTree);
+        $canonicalOtherTree = realpath($otherTree);
+        $this->assertIsString($canonicalOtherTree);
+
+        try {
+            ImportClient::prepare_files_command_context(
+                $targetUrl,
+                $this->stateDirectory,
+                $otherTree,
+                'files-push'
+            );
+            $this->fail('Expected the state directory to reject another local tree.');
+        } catch (\RuntimeException $error) {
+            $this->assertStringContainsString(
+                'records local tree '
+                    . $context['local_tree']
+                    . ', not '
+                    . $canonicalOtherTree,
+                $error->getMessage()
+            );
+            $this->assertStringContainsString(
+                'Use a different --state-dir for this local tree.',
+                $error->getMessage()
+            );
+        }
+    }
+
     public function testFilesPushRejectsOptionsOutsideItsExactAllowlist(): void
     {
         foreach (['--abort', '--filter=none', '--docroot=' . $this->localTree, '--duty=0.5'] as $rejectedOption) {
@@ -260,6 +334,53 @@ final class FilesPushCommandTest extends TestCase
 
         $this->assertNoSenderState($this->stateDirectory);
         $this->assertFileDoesNotExist($this->stateDirectory . '/.import-state.json');
+    }
+
+    public function testFilesPushRefusesPersistedRemapsBeforeStartingSender(): void
+    {
+        $targetUrl = 'https://example.test/?reprint-api=1';
+        $context = ImportClient::prepare_files_command_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-push'
+        );
+        mkdir($context['remote_state_directory'], 0700, true);
+        file_put_contents(
+            $context['remote_state_directory'] . '/path-mapping.json',
+            json_encode([
+                'target_url_fingerprint' => hash('sha256', $targetUrl),
+                'filesystem_root_b64' => base64_encode($context['local_tree']),
+                'local_tree_b64' => base64_encode($context['local_tree']),
+                'target_document_root_b64' => base64_encode('/var/www/html'),
+                'prefix_rules' => [[
+                    'kind' => 'remap',
+                    'remote_prefix_b64' =>
+                        base64_encode('/var/www/html/wp-content'),
+                    'local_prefix_b64' =>
+                        base64_encode($context['local_tree'] . '/content'),
+                ]],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        try {
+            ImportClient::prepare_files_push_context(
+                $targetUrl,
+                $this->stateDirectory,
+                $this->localTree,
+                ['secret' => 'token', 'force_http' => false]
+            );
+            $this->fail('Expected files-push to reject the persisted remap.');
+        } catch (\RuntimeException $error) {
+            $this->assertStringContainsString(
+                'contains remapped paths',
+                $error->getMessage()
+            );
+        }
+
+        $this->assertDirectoryDoesNotExist(
+            $context['push_state_directory']
+        );
     }
 
     public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -101,7 +101,17 @@ class FilesSyncStateTest extends TestCase
      */
     private function readState(): array
     {
-        $contents = file_get_contents($this->stateDir . '/.import-state.json');
+        $stateFile = $this->stateDir . '/.import-state.json';
+        $relationshipStateFiles = glob(
+            $this->stateDir . '/remote-*/pull-state.json'
+        );
+        if (
+            is_array($relationshipStateFiles)
+            && count($relationshipStateFiles) === 1
+        ) {
+            $stateFile = $relationshipStateFiles[0];
+        }
+        $contents = file_get_contents($stateFile);
         return json_decode($contents, true);
     }
 
@@ -163,10 +173,7 @@ class FilesSyncStateTest extends TestCase
         $stateProperty = $reflection->getProperty('state');
         $loadState = $reflection->getMethod('load_state');
         $stateProperty->setValue($client, $loadState->invoke($client));
-        $reflection->getMethod('configure_remote_state_directory')->invoke(
-            $client,
-            $this->fs_root
-        );
+        $client->prepare_files_pull_options([]);
 
         $ttyProperty = $reflection->getProperty('is_tty');
         $ttyProperty->setValue($client, false);

--- a/tests/Import/ImportMetadataTest.php
+++ b/tests/Import/ImportMetadataTest.php
@@ -74,7 +74,12 @@ class ImportMetadataTest extends TestCase
      */
     private function readMetadata(): array
     {
-        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client = new \ImportClient(
+            'http://example.invalid',
+            $this->stateDir,
+            $this->fsRoot,
+            'import-metadata'
+        );
 
         ob_start();
         $client->run(['command' => 'import-metadata']);
@@ -138,6 +143,28 @@ class ImportMetadataTest extends TestCase
 
         $this->assertTrue($metadata['hasCompletedOnce']);
         $this->assertSame('db-apply', $metadata['pullStage']);
+    }
+
+    public function testImportMetadataReadsTheOnlyRelationshipPullState(): void
+    {
+        $this->writeState([
+            'pull_pipeline' => [
+                'stage_sequence' => ['preflight', 'files-pull'],
+                'last_completed_stage' => 'files-pull',
+                'has_completed_once' => true,
+            ],
+        ]);
+        $remoteStateDirectory = $this->stateDir . '/remote-one';
+        mkdir($remoteStateDirectory);
+        rename(
+            $this->stateDir . '/.import-state.json',
+            $remoteStateDirectory . '/pull-state.json'
+        );
+
+        $metadata = $this->readMetadata();
+
+        $this->assertTrue($metadata['hasCompletedOnce']);
+        $this->assertSame('files-pull', $metadata['pullStage']);
     }
 
     /**

--- a/tests/Import/IndexUpdateWalTest.php
+++ b/tests/Import/IndexUpdateWalTest.php
@@ -154,7 +154,7 @@ final class IndexUpdateWalTest extends TestCase
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
         );
         file_put_contents(
-            $this->stateDirectory . '/.import-state.json',
+            $remoteStateDirectory . '/pull-state.json',
             json_encode([
                 'preflight' => [
                     'data' => [
@@ -165,6 +165,27 @@ final class IndexUpdateWalTest extends TestCase
                     ],
                     'http_code' => 200,
                 ],
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+        $filesystemRoot = realpath($this->fileRoot);
+        $localTree = realpath($this->fileRoot . '/site');
+        $this->assertIsString($filesystemRoot);
+        $this->assertIsString($localTree);
+        file_put_contents(
+            $remoteStateDirectory . '/path-mapping.json',
+            json_encode([
+                'target_url_fingerprint' => hash(
+                    'sha256',
+                    'https://example.com/'
+                ),
+                'filesystem_root_b64' => base64_encode($filesystemRoot),
+                'local_tree_b64' => base64_encode($localTree),
+                'target_document_root_b64' => base64_encode('/site'),
+                'prefix_rules' => [[
+                    'kind' => 'default',
+                    'remote_prefix_b64' => base64_encode('/site'),
+                    'local_prefix_b64' => base64_encode($localTree),
+                ]],
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
         );
 

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -141,7 +141,17 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     private function readState(): array
     {
-        return json_decode(file_get_contents($this->stateDir . '/.import-state.json'), true);
+        $stateFile = $this->stateDir . '/.import-state.json';
+        $relationshipStateFiles = glob(
+            $this->stateDir . '/remote-*/pull-state.json'
+        );
+        if (
+            is_array($relationshipStateFiles)
+            && count($relationshipStateFiles) === 1
+        ) {
+            $stateFile = $relationshipStateFiles[0];
+        }
+        return json_decode(file_get_contents($stateFile), true);
     }
 
     private function remoteStateDirectory(): string

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -28,7 +28,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         mkdir($stateDir, 0755, true);
 
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
-        $this->stateFile = $stateDir . '/.import-state.json';
+        $this->stateFile = $stateDir . '/pull-state.json';
         $this->skippedFile = $stateDir . '/pull-plan.skipped.jsonl';
         file_put_contents($this->stateFile, "{\"command\":\"files-pull\",\"status\":\"partial\"}\n");
         file_put_contents($this->skippedFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
@@ -91,7 +91,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $startSh = file_get_contents($this->outputDir . '/start.sh');
 
         $this->assertStringContainsString(
-            "/tmp/reprint/.import-state.json",
+            "/tmp/reprint/pull-state.json",
             $runtime,
         );
         $this->assertStringContainsString(
@@ -100,7 +100,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         );
         $this->assertStringNotContainsString($this->stateFile, $runtime);
         $this->assertStringContainsString(
-            "--mount='" . $this->stateFile . ":/tmp/reprint/.import-state.json'",
+            "--mount='" . $this->stateFile . ":/tmp/reprint/pull-state.json'",
             $startSh,
         );
         $this->assertStringContainsString(
@@ -116,7 +116,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $mount_targets = array_column($startJson['mounts'], 'target');
         $this->assertContains($this->stateFile, $mount_sources);
         $this->assertContains($this->skippedFile, $mount_sources);
-        $this->assertContains('/tmp/reprint/.import-state.json', $mount_targets);
+        $this->assertContains('/tmp/reprint/pull-state.json', $mount_targets);
         $this->assertContains('/tmp/reprint/pull-plan.skipped.jsonl', $mount_targets);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -232,8 +232,18 @@ class PullFilterOptionTest extends TestCase
 
     private function readState(): array
     {
+        $stateFile = $this->stateDir . '/.import-state.json';
+        $relationshipStateFiles = glob(
+            $this->stateDir . '/remote-*/pull-state.json'
+        );
+        if (
+            is_array($relationshipStateFiles)
+            && count($relationshipStateFiles) === 1
+        ) {
+            $stateFile = $relationshipStateFiles[0];
+        }
         return json_decode(
-            file_get_contents($this->stateDir . '/.import-state.json'),
+            file_get_contents($stateFile),
             true,
         );
     }
@@ -312,7 +322,10 @@ class PullFilterOptionTest extends TestCase
                     "started_by_command" => "pull",
                     "last_completed_stage" => "preflight",
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -346,7 +359,10 @@ class PullFilterOptionTest extends TestCase
                     "started_by_command" => "pull",
                     "last_completed_stage" => "preflight",
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -379,7 +395,10 @@ class PullFilterOptionTest extends TestCase
                     "started_by_command" => "pull-db",
                     "last_completed_stage" => null,
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
         file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
@@ -540,7 +559,10 @@ class PullFilterOptionTest extends TestCase
                     "stage_sequence" => ["preflight", "files-pull"],
                     "last_completed_stage" => "preflight",
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -566,7 +588,10 @@ class PullFilterOptionTest extends TestCase
                     "completion_state" => "complete",
                     "current_stage" => null,
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -597,7 +622,10 @@ class PullFilterOptionTest extends TestCase
                     "stage_sequence" => ["preflight", "files-pull"],
                     "last_completed_stage" => "preflight",
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -691,7 +719,10 @@ class PullFilterOptionTest extends TestCase
                     "stage_sequence" => ["preflight", "files-pull"],
                     "last_completed_stage" => "preflight",
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -730,7 +761,10 @@ class PullFilterOptionTest extends TestCase
                     "stage_sequence" => ["preflight", "db-pull", "db-apply"],
                     "last_completed_stage" => "preflight",
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -761,7 +795,10 @@ class PullFilterOptionTest extends TestCase
                     "completion_state" => "complete",
                     "current_stage" => null,
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -890,7 +927,10 @@ class PullFilterOptionTest extends TestCase
                     "files_filter" => "essential-files",
                     "skipped_pending" => true,
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 
@@ -931,7 +971,10 @@ class PullFilterOptionTest extends TestCase
                     "files_filter" => "essential-files",
                     "skipped_pending" => true,
                 ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+                "preflight" => ["http_code" => 200, "data" => [
+                    "ok" => true,
+                    "runtime" => ["document_root" => ""],
+                ]],
             ]),
         );
 

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -63,9 +63,12 @@ class RemapResolveTest extends TestCase
         (new \ReflectionClass($c))->getProperty($p)->setValue($c, $v);
     }
 
-    private function client(array $pathsUrls): \ImportClient
+    private function client(
+        array $pathsUrls,
+        string $targetUrl = 'https://src.example/export.php'
+    ): \ImportClient
     {
-        $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
+        $c = new \ImportClient($targetUrl, $this->stateDir, $this->fsRoot);
         $this->set($c, 'state', array('preflight' => array('data' => array(
             'runtime' => array('document_root' => ''),
             'database' => array('wp' => array('paths_urls' => $pathsUrls)),
@@ -79,16 +82,20 @@ class RemapResolveTest extends TestCase
         return $this->call($c, 'resolve_remap', array($pairs));
     }
 
-    private function assertRemapConsistent($c): void
+    private function persistPathMapping($c): void
     {
-        $this->call($c, 'assert_files_remap_consistent');
+        $this->call($c, 'persist_path_mapping');
     }
 
-    private function writeLocalIndex(\ImportClient $client): void
+    private function readPathMapping(\ImportClient $client): array
     {
-        file_put_contents(
-            $client->remote_state_directory . '/.remote-index.jsonl',
-            "{}\n"
+        return json_decode(
+            file_get_contents(
+                $client->remote_state_directory . '/path-mapping.json'
+            ),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
         );
     }
 
@@ -210,7 +217,39 @@ class RemapResolveTest extends TestCase
         $this->assertSame($this->root . '/special-plugins', $rules['/detached/plugins']);
     }
 
-    // --- state consistency -------------------------------------------------
+    // --- persisted path mapping -------------------------------------------
+
+    public function testPersistsResolvedTargetAndLocalPrefixes(): void
+    {
+        $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
+        $this->set($c, 'remap_rules', array(
+            '/var/www/html/wp-content' => $this->root . '/content',
+        ));
+
+        $this->persistPathMapping($c);
+
+        $mapping = $this->readPathMapping($c);
+        $this->assertSame(realpath($this->fsRoot), base64_decode($mapping['filesystem_root_b64']));
+        $this->assertSame(realpath($this->fsRoot), base64_decode($mapping['local_tree_b64']));
+        $this->assertSame('/', base64_decode($mapping['target_document_root_b64']));
+        $this->assertSame(
+            [
+                [
+                    'kind' => 'default',
+                    'remote_prefix_b64' => base64_encode('/'),
+                    'local_prefix_b64' => base64_encode(realpath($this->fsRoot)),
+                ],
+                [
+                    'kind' => 'remap',
+                    'remote_prefix_b64' => base64_encode('/var/www/html/wp-content'),
+                    'local_prefix_b64' => base64_encode($this->root . '/content'),
+                ],
+            ],
+            $mapping['prefix_rules']
+        );
+        $this->assertFileExists($c->remote_state_directory . '/pull-state.json');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+    }
 
     public function testRejectsChangedRemapRulesForSameState(): void
     {
@@ -218,27 +257,60 @@ class RemapResolveTest extends TestCase
         $this->set($c, 'remap_rules', array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $this->assertRemapConsistent($c);
+        $this->persistPathMapping($c);
 
         $this->set($c, 'remap_rules', array(
             '/var/www/html/wp-content' => $this->root . '/content',
         ));
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --remap rules');
-        $this->assertRemapConsistent($c);
+        $this->expectExceptionMessage(
+            'Cannot change the resolved path mapping'
+        );
+        $this->persistPathMapping($c);
     }
 
-    public function testRejectsRemapWithUntrackedExistingFilesIndex(): void
+    public function testReloadsTheRelationshipStateForTheSameTargetAndLocalTree(): void
     {
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-        $this->writeLocalIndex($c);
-        $this->set($c, 'remap_rules', array(
-            '/var/www/html/wp-content' => $this->root . '/wp-content',
-        ));
+        $this->persistPathMapping($c);
+        $remoteStateDirectory = $c->remote_state_directory;
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('existing files index');
-        $this->assertRemapConsistent($c);
+        $resumed = new \ImportClient(
+            'https://src.example/export.php',
+            $this->stateDir,
+            $this->fsRoot
+        );
+
+        $this->assertSame(
+            $remoteStateDirectory,
+            $resumed->remote_state_directory
+        );
+    }
+
+    public function testKeepsPullStateSeparateForTwoTargets(): void
+    {
+        $first = $this->client(
+            array('content_dir' => '/var/www/html/wp-content'),
+            'https://first.example/export.php'
+        );
+        $this->persistPathMapping($first);
+
+        $second = $this->client(
+            array('content_dir' => '/var/www/html/wp-content'),
+            'https://second.example/export.php'
+        );
+        $this->persistPathMapping($second);
+
+        $this->assertNotSame(
+            $first->remote_state_directory,
+            $second->remote_state_directory
+        );
+        $this->assertFileExists(
+            $first->remote_state_directory . '/pull-state.json'
+        );
+        $this->assertFileExists(
+            $second->remote_state_directory . '/pull-state.json'
+        );
     }
 
     // --- errors ------------------------------------------------------------

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -129,6 +129,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'configure_remote_state_directory',
             [$this->fsRoot]
         );
+        $client->save_import_state();
     }
 
     private function skippedFile(): string
@@ -198,6 +199,34 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         );
         $this->assertStringContainsString(
             "Remote upload proxy failed.",
+            $runtime,
+        );
+    }
+
+    public function testApplyRuntimeSelectsTheOnlyPullStateForAFlattenedRoot(): void
+    {
+        $this->writeState([]);
+        $remoteStateDirectory = dirname($this->skippedFile());
+        rename(
+            $this->stateDir . '/.import-state.json',
+            $remoteStateDirectory . '/pull-state.json'
+        );
+        $flattenedRoot = $this->tempDir . '/flattened';
+        mkdir($flattenedRoot);
+        file_put_contents($flattenedRoot . '/index.php', "<?php echo 'ok';\n");
+
+        $client = new \ImportClient(
+            '-',
+            $this->stateDir,
+            $flattenedRoot,
+            'apply-runtime'
+        );
+        $state = $this->callPrivate($client, 'load_state');
+        $this->setPrivate($client, 'state', $state);
+        $runtime = $this->runApplyRuntime($client);
+
+        $this->assertStringContainsString(
+            $this->fsRoot . '/index.php',
             $runtime,
         );
     }

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -237,6 +237,30 @@ export function getRemoteStateDirectory(outputDir, stateFileName) {
 }
 
 /**
+ * Return the persisted pull state path for an E2E import.
+ */
+export function getPullStatePath(outputDir) {
+    const bootstrapStatePath = join(outputDir, '.import-state.json');
+    if (existsSync(bootstrapStatePath)) {
+        return bootstrapStatePath;
+    }
+    const hasRelationshipPullState = readdirSync(outputDir, { withFileTypes: true })
+        .some(
+            entry =>
+                entry.isDirectory()
+                && entry.name.startsWith('remote-')
+                && existsSync(join(outputDir, entry.name, 'pull-state.json')),
+        );
+    if (!hasRelationshipPullState) {
+        return bootstrapStatePath;
+    }
+    return join(
+        getRemoteStateDirectory(outputDir, 'pull-state.json'),
+        'pull-state.json',
+    );
+}
+
+/**
  * Run the importer CLI.
  * @param {string} url - Export URL
  * @param {string} outputDir - Local output directory (state files live here; fs-root is outputDir/fs-root)
@@ -290,7 +314,7 @@ export function runImporter(url, outputDir, command, options = {}) {
     // Non-preflight commands require a prior preflight run.
     // Automatically run one if the state file doesn't already have preflight data.
     if (command !== 'preflight' && command !== 'preflight-assert' && options.skipPreflight !== true) {
-        const stateFile = join(outputDir, '.import-state.json');
+        const stateFile = getPullStatePath(outputDir);
         let needsPreflight = true;
         try {
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -12,6 +12,7 @@ import {
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
     fsRootDir, getRemoteStateDirectory,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -40,8 +41,8 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('state file shows complete', () => {
-        const stateFile = join(tempDir, '.import-state.json');
-        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
+        const stateFile = getPullStatePath(tempDir);
+        assert.ok(existsSync(stateFile), 'Expected pull-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.command_name, 'files-pull');
         assert.equal(state.active_resumable_command.completion_state, 'complete');
@@ -113,7 +114,7 @@ describe('Import: Basic File Sync', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -13,6 +13,7 @@ import {
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -66,8 +67,8 @@ describe('Import: Symlinks', () => {
         });
 
         it('sync completed without error despite symlinks', () => {
-            const stateFile = join(tempDir, '.import-state.json');
-            assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
+            const stateFile = getPullStatePath(tempDir);
+            assert.ok(existsSync(stateFile), 'Expected pull-state.json to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
         });

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -13,6 +13,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -116,7 +117,7 @@ INSERT INTO wp_secret_table VALUES (1, 'top secret');
         });
 
         it('state shows complete', () => {
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-09-resume-sql.test.js
+++ b/tests/e2e/tests/import-09-resume-sql.test.js
@@ -11,6 +11,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -47,7 +48,7 @@ describe('Import: Resume SQL', { timeout: 120000 }, () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
     });

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -13,6 +13,7 @@ import {
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -56,7 +57,7 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
     });
 
     it('state shows complete', () => {
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         assert.ok(existsSync(stateFile), 'Expected state file to exist');
 
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));

--- a/tests/e2e/tests/import-12-gzip-corruption.test.js
+++ b/tests/e2e/tests/import-12-gzip-corruption.test.js
@@ -11,6 +11,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     writeTestHooks, removeTestHooks, readAuditLog,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -87,7 +88,7 @@ describe('Import: Gzip Corruption', () => {
             // Same as above: must not hang. Either succeeds (partial data OK)
             // or fails with a clear error.
             if (result.exitCode === 0) {
-                const stateFile = join(tempDir, '.import-state.json');
+                const stateFile = getPullStatePath(tempDir);
                 if (existsSync(stateFile)) {
                     const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
                     assert.ok(

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -15,6 +15,7 @@ import {
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -154,7 +155,7 @@ describe('Import: Volatile Files', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -16,6 +16,7 @@ import {
     assertSiteMirror, createMysqlConnection,
     compareDatabases, getDbName,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -53,7 +54,7 @@ describe('Import: Full Round-Trip', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -16,6 +16,7 @@ import {
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -66,7 +67,7 @@ describe('Import: Request Cutoff', () => {
             `Expected exit 2 after the interrupted file index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
         );
 
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(
             state.active_resumable_command.completion_state,
@@ -98,7 +99,7 @@ describe('Import: Request Cutoff', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0 on resume\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected complete status, got ${state.active_resumable_command.completion_state}`);
     });

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -13,6 +13,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
     fsRootDir, getRemoteStateDirectory,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -97,7 +98,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('state shows complete after delta', () => {
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 25: State File Corruption via import.php
- * Tests importer behavior when .import-state.json is corrupted or contains
+ * Tests importer behavior when bootstrap state is corrupted or contains
  * unexpected data. Verifies the importer recovers gracefully.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -12,6 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -46,7 +47,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 (graceful recovery)\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
@@ -96,7 +97,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.command_name, 'files-pull', 'Expected command to be updated');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
@@ -129,7 +130,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 with --abort\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.notEqual(state.active_resumable_command.completion_state, 'in_progress', 'Expected status to be cleared');
             assert.ok(!state.active_resumable_command.remote_cursor, 'Expected cursor to be cleared');
@@ -141,7 +142,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -26,6 +26,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
     fsRootDir, getRemoteStateDirectory,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -213,7 +214,7 @@ describe('Import: Follow Symlinks', () => {
     });
 
     it('state shows complete', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
         assert.equal(state.follow_symlinks, true, 'follow_symlinks should be persisted in state');
     });

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -16,6 +16,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -221,7 +222,7 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
     });
 
     it('state stores path fields in base64 form', () => {
-        const statePath = join(tempDir, '.import-state.json');
+        const statePath = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(statePath, 'utf-8'));
 
         assert.equal(typeof state.diff.local_after, 'string', 'Expected diff.local_after to be persisted');

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -7,10 +7,10 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -42,7 +42,7 @@ describe('Import: Preflight state path encoding', () => {
     });
 
     it('stores requested preflight path fields as base64 in state file', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const data = state.preflight?.data;
         assert.ok(data, 'Expected preflight.data in state');
 

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -9,24 +9,23 @@
 import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
-import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
 describe('Import: Protocol Version Mismatch', () => {
     const site = 'basic';
     let tempDir;
-    const stateFileName = '.import-state.json';
 
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
     function stateFilePath() {
-        return join(tempDir, stateFileName);
+        return getPullStatePath(tempDir);
     }
 
     function readState() {

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -10,6 +10,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -114,7 +115,7 @@ describe('Import: SQL Output Modes', () => {
         });
 
         it('state file records sql_output mode', () => {
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             assert.ok(existsSync(stateFile), 'Expected state file to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.sql_output, 'mysql',

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -41,6 +41,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { buildAtomicHostingFixture, unlockSharedDir } from '../lib/atomic-hosting-fixture.js';
@@ -161,7 +162,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('state shows complete with preserve_local persisted', () => {
-            const stateFile = join(tempDir, '.import-state.json');
+            const stateFile = getPullStatePath(tempDir);
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
@@ -334,7 +335,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('state preserves preserve_local across resume cycles', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
     });

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -25,6 +25,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -113,7 +114,7 @@ require_once ABSPATH . 'wp-settings.php';
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
@@ -151,7 +152,7 @@ require_once ABSPATH . 'wp-settings.php';
     });
 
     it('wp-admin files exist at the resolved core path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const wpAdminPath = state.preflight?.data?.database?.wp?.paths_urls?.wp_admin_path;
         assert.ok(wpAdminPath, 'wp_admin_path not found in state');
 
@@ -167,7 +168,7 @@ require_once ABSPATH . 'wp-settings.php';
     });
 
     it('wp-content files exist at the separate content path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const contentDir = state.preflight?.data?.database?.wp?.paths_urls?.content_dir;
         assert.ok(contentDir, 'content_dir not found in state');
 

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir, readAuditLog,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -39,7 +40,7 @@ describe('Import: Runtime files', () => {
     });
 
     it('preflight state contains ini_get_all with core PHP directives', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
         assert.ok(iniAll && typeof iniAll === 'object', 'runtime.ini_get_all should be an object');
 
@@ -55,7 +56,7 @@ describe('Import: Runtime files', () => {
     });
 
     it('ini_get_all includes auto_prepend_file and auto_append_file directives', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
 
         // These directives should always be present in ini_get_all,

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -18,6 +18,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
     fsRootDir, getRemoteStateDirectory,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -80,7 +81,7 @@ describe('Import: --filter', () => {
         });
 
         it('state shows complete with filter persisted', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
             assert.equal(state.active_resumable_command.command_name, 'files-pull');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.filter, 'essential-files');
@@ -148,7 +149,7 @@ describe('Import: --filter', () => {
             // Regression: the skipped-earlier fetch must mark the sync
             // complete. If it leaves status="in_progress", the filter-change
             // guard blocks the next delta re-pull below.
-            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete',
                 `Expected completion_state=complete after skipped-earlier, got ${state.active_resumable_command?.completion_state}`);
         });
@@ -198,7 +199,7 @@ describe('Import: --filter', () => {
         });
 
         it('state preserves filter across resume cycles', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
             assert.equal(state.filter, 'essential-files');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -16,6 +16,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir, PHP_BINARY,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -71,7 +72,7 @@ describe('Import: Playground CLI runtime', () => {
         assert.equal(result.exitCode, 0,
             `files-sync failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -30,6 +30,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -77,7 +78,7 @@ require ABSPATH . 'wp-blog-header.php';
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
@@ -104,7 +105,7 @@ require ABSPATH . 'wp-blog-header.php';
     });
 
     it('WP core files exist at the resolved path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const abspath = state.preflight?.data?.database?.wp?.paths_urls?.abspath;
         assert.ok(abspath, 'abspath not found in state');
 

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -18,6 +18,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -181,7 +182,7 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     }
                 }
 
-                const stateFile = join(tempDir, '.import-state.json');
+                const stateFile = getPullStatePath(tempDir);
                 assert.ok(existsSync(stateFile), 'Expected state file to exist');
                 const state = JSON.parse(readFileSync(stateFile, 'utf8'));
                 assert.equal(state.active_resumable_command.completion_state, 'complete',

--- a/tests/e2e/tests/import-45-runtime-file-download.test.js
+++ b/tests/e2e/tests/import-45-runtime-file-download.test.js
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir, readAuditLog,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite, SITE_ROOT } from '../lib/site-setup.js';
 import { writeFileSync, mkdirSync } from 'node:fs';
@@ -70,7 +71,7 @@ describe('Import: Runtime file download', () => {
             assert.equal(preflightResult.exitCode, 0,
                 `Expected exit 0\nstderr: ${preflightResult.stderr}\nstdout: ${preflightResult.stdout}`);
 
-            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
             const prepend = state.preflight?.data?.runtime?.ini_get_all?.auto_prepend_file ?? '';
             if (prepend.includes('scripts/env.php')) {
                 break;
@@ -93,7 +94,7 @@ describe('Import: Runtime file download', () => {
     });
 
     it('preflight state reports auto_prepend_file path', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
         const prepend = iniAll?.auto_prepend_file ?? '';
         assert.ok(

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -18,6 +18,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir, getDbName, createMysqlConnection,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -111,7 +112,7 @@ describe('Import: SiteGround plugin stripping', () => {
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assert.equal(state.webhost, 'siteground',
             `Expected webhost 'siteground', got '${state.webhost}'`);
     });

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -15,6 +15,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, assertSiteMirror,
     fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -64,8 +65,8 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
     });
 
     it('state shows pull complete', () => {
-        const stateFile = join(tempDir, '.import-state.json');
-        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
+        const stateFile = getPullStatePath(tempDir);
+        assert.ok(existsSync(stateFile), 'Expected pull-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
     });
@@ -98,7 +99,7 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0 on re-pull, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-47-pull-multi-request.test.js
+++ b/tests/e2e/tests/import-47-pull-multi-request.test.js
@@ -17,6 +17,7 @@ import {
     assertTreesMatch, assertSiteMirror,
     fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -74,7 +75,7 @@ describe('Import: Pull Multi-Request', { timeout: 300000 }, () => {
     });
 
     it('state shows pull complete', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 

--- a/tests/e2e/tests/import-48-pull-crash-resume.test.js
+++ b/tests/e2e/tests/import-48-pull-crash-resume.test.js
@@ -24,6 +24,7 @@ import {
     fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
     getRemoteStateDirectory,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -71,7 +72,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 
@@ -85,7 +86,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
             `Expected abort exit 0, got ${result.exitCode}`);
 
         // The completed-stage marker should be cleared.
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assert.equal(state.pull_pipeline.last_completed_stage, null,
             'Expected pull_pipeline.last_completed_stage to be null after abort');
 
@@ -108,7 +109,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 
@@ -142,7 +143,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected auto re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -15,6 +15,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
     getRemoteStateDirectory,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -85,8 +86,8 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
     });
 
     it('state records deferred files in the pull metadata', () => {
-        const stateFile = join(tempDir, '.import-state.json');
-        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
+        const stateFile = getPullStatePath(tempDir);
+        assert.ok(existsSync(stateFile), 'Expected pull-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
         assert.equal(state.pull_pipeline.files_filter, 'essential-files');

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -32,6 +32,7 @@ import {
     writeTestHooks, removeTestHooks,
     writeHookState, clearHookState,
     fsRootDir,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -143,7 +144,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const localPath = join(importedRoot, fileRel);
         const serializedLocalPath = `base64:${Buffer.from(localPath).toString('base64')}`;
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         assert.ok(existsSync(stateFile), 'Expected import state file to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.notEqual(
@@ -166,7 +167,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected resume to complete\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
 
-        const stateFile = join(tempDir, '.import-state.json');
+        const stateFile = getPullStatePath(tempDir);
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected status=complete after resume, got ${state.active_resumable_command.completion_state}`);
     });

--- a/tests/e2e/tests/import-50-pull-manual-start.test.js
+++ b/tests/e2e/tests/import-50-pull-manual-start.test.js
@@ -13,6 +13,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertPullPipelineComplete,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -61,7 +62,7 @@ describe('Import: Pull start-runtime none', { timeout: 180000 }, () => {
     });
 
     it('marks the pull complete and generates playground runtime files', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(getPullStatePath(tempDir), 'utf-8'));
         assertPullPipelineComplete(state);
         assert.equal(state.active_resumable_command.completion_state, 'complete');
 

--- a/tests/e2e/tests/import-53-adversarial-database-pull.test.js
+++ b/tests/e2e/tests/import-53-adversarial-database-pull.test.js
@@ -9,13 +9,13 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir, getDbName,
     compareDatabases, createMysqlConnection, assertPullPipelineComplete,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -91,7 +91,7 @@ describe('Import: Adversarial database pull', { timeout: 300000 }, () => {
                 `${result.stdout.slice(-4000)}`,
         );
         const importState = JSON.parse(
-            readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
+            readFileSync(getPullStatePath(tempDir), 'utf-8'),
         );
         assertPullPipelineComplete(importState, 'pull-db');
 

--- a/tests/e2e/tests/import-54-db-index-interruption.test.js
+++ b/tests/e2e/tests/import-54-db-index-interruption.test.js
@@ -14,6 +14,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     writeTestHooks, removeTestHooks,
     readHookState, clearHookState,
+    getPullStatePath,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -64,7 +65,7 @@ describe('Import: Database Index Response Interruption', () => {
         );
 
         const state = JSON.parse(
-            readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
+            readFileSync(getPullStatePath(tempDir), 'utf-8'),
         );
         assert.equal(
             state.active_resumable_command.completion_state,


### PR DESCRIPTION
This stores the resolved pull path mapping with each target relationship, so later commands can address the same local tree without repeating preflight.

`path-mapping.json` records the target document root, canonical local tree, and resolved remote/local prefix rules. The first mapping is immutable: reusing the same target and state directory with another local tree fails with an instruction to use another `--state-dir`.

Relationship discovery reads the mapping file. The relationship directory remains keyed only by the target URL after URL user-info, `SECRET_KEY`, and the `site-export-api` endpoint alias are removed. Before file work begins, the old root-level pull state moves into the relationship directory after preflight identifies the target and local tree. When `apply-runtime` receives a flattened root which no longer matches the original local tree, it selects the sole persisted pull state or refuses an ambiguous state directory.

Stacked on #413.