### PR TITLE
[Push] Carry local and target paths through file pushes

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -130,6 +130,15 @@ files-pull also refuses to start while the same target and local tree have an
 unfinished files-push, so the local index cannot change while PushPlan is
 between processes.
 
+Each remote state directory stores its target document root and resolved
+remote-to-local prefix rules in `path-mapping.json`. The first mapping is
+immutable. Push validates that the inverse mapping is addressable before it
+opens a push request. Push plans use `local_path_b64` for local index, stat,
+and read work, and `target_path_b64` for target exclusions, status, upload,
+and deletion work. A symlink target which pull rewrote into local coordinates
+is rewritten into target coordinates before upload. A relative target outside
+the local tree is rejected when its symlink path itself is remapped.
+
 `PushPlan` builds a path-sorted fresh local index and diffs it against the
 local index at the path supplied by its caller. The indexer marks physical
 emptiness while it observes each directory, so a completed index distinguishes
@@ -141,9 +150,9 @@ revalidating the same serialized record.
 A push plan is an internal part of the sender lifecycle:
 
 1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
-   100 target exclusions, which the sender stores in `excluded_paths.json`.
+   100 target exclusions, which the sender stores in `excluded-paths.json`.
 2. The sender starts PushPlan with the local index path and sender-owned
-   exclusions, opens `plan/fresh_local_index.jsonl`, and starts one
+   exclusions, opens `plan/.local-index.next.jsonl`, and starts one
    `FileIndexProcessor`.
 3. Each `indexing` step advances one traversal event, appends its JSONL entry
    when applicable, flushes those bytes, and updates the traversal cursor and
@@ -151,11 +160,12 @@ A push plan is an internal part of the sender lifecycle:
    index diff.
 4. Each `diffing` step compares at most one path from the fresh index or local
    index. It writes files, symlinks, and empty directories to
-   `plan/local_paths_to_push.jsonl` and raw NUL-delimited paths to
-   `plan/local_paths_to_delete`.
+   `plan/paths-to-push.jsonl`, raw NUL-delimited target paths to
+   `plan/paths-to-delete`, and the paired local paths to
+   `plan/local-paths-to-delete`.
 5. The sender closes the completed plan before it consumes those two files.
 6. After the receiver commit succeeds, the sender writes
-   `plan/local_index_updates.jsonl` from the committed push and delete lists and
+   `plan/local-index-updates.jsonl` from the committed push and delete lists and
    applies those updates to the local index. The merge adds directory ancestors
    for each F update and removes the path and its descendants for each D update.
    If the index does not exist, the same atomic merge creates it. Finally the
@@ -312,7 +322,7 @@ none. The one state-directory-wide Reprint process lock prevents concurrent
 pull, push, diff, and other local Reprint processes from using that site state,
 regardless of their target URL or local tree.
 
-The local index and active push files use the same target/local-tree hash:
+The local index and active push files use the same target hash:
 
 ```text
 <state-dir>/remote-<hash>/
@@ -322,13 +332,14 @@ The local index and active push files use the same target/local-tree hash:
   pull-plan.jsonl                     files pending download
   pull-index-updates.wal              completed pull operations
   push/
-  excluded_paths.json                 sender-owned target exclusions
-  sender.json                         active push state
-  plan/
-    fresh_local_index.jsonl           plan-owned fresh local index
-    local_paths_to_push.jsonl         local paths to push
-    local_paths_to_delete             raw NUL-delimited local paths to delete
-    local_index_updates.jsonl         committed updates, created after commit
+    excluded-paths.json               sender-owned target exclusions
+    sender.json                       active push state
+    plan/
+      .local-index.next.jsonl         plan-owned fresh local index
+      paths-to-push.jsonl             paired local and target paths to push
+      paths-to-delete                 raw NUL-delimited target paths to delete
+      local-paths-to-delete           paired local paths for index updates
+      local-index-updates.jsonl       committed updates, created after commit
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.
@@ -351,7 +362,7 @@ During PushPlan's internal `indexing` phase, the plan retains one
 `FileIndexProcessor` and the open fresh local index across steps. A
 newly opened plan truncates that file to the byte offset stored with the
 processor cursor before continuing. The sender lazily opens
-`local_paths_to_push.jsonl`, `local_paths_to_delete`, and the current local file.
+`paths-to-push.jsonl`, `paths-to-delete`, and the current local file.
 It retains those handles across `next_step()` calls, lets each handle advance
 with the work, and seeks only when a newly opened or receiver-confirmed offset
 differs. It closes each handle when its phase or file ends and closes any
@@ -368,7 +379,7 @@ stable.
 
 `sender.json` contains no copied receiver cursor. It stores the push session
 and phase, the PushPlan cursor, the next byte offset in
-`local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
+`paths-to-push.jsonl`, the receiver part limit, and learned request-body
 sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
 `updating_local_index`, `completing`, `removing`, and
@@ -396,7 +407,7 @@ After all local paths are pushed, a newly opened sender reads
 `work_deletes_bytes` and `work_deletes_complete` from `push_status`. Successful
 uploads retain those values in memory for later deletion steps. Those
 receiver-owned values are the only work-delete cursor; `sender.json` does not
-duplicate it. Each uploaded deletion-list part contains one complete local path.
+duplicate it. Each uploaded deletion-list part contains one complete target path.
 The sender trusts this completed, immutable plan without consulting the fresh
 local index or live local tree again. If a deleted path reappears after planning,
 the current push may delete it on the target and the next push will send it.
@@ -411,7 +422,7 @@ the live tree at commit time.
 
 Repeated `push_commit` calls drive the receiver to `complete`. Only then does
 the sender enter `updating_local_index`. It writes F/D updates from the
-committed push and delete lists to `plan/local_index_updates.jsonl`, then
+committed push and delete lists to `plan/local-index-updates.jsonl`, then
 applies them to the local index. The merge adds directory ancestors for
 each F update and removes the path and its descendants for each D update.
 Other branches remain unchanged. Target-excluded paths do not enter the local
@@ -519,14 +530,15 @@ it is missing. Each applied WAL batch updates only the paths that pull changed,
 so local additions, edits, and deletions left elsewhere stay in the diff.
 
 Output is JSONL. Each selected current file, symlink, or empty directory has
-`action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,
-`dir`, or `link`. Each selected local deletion has `action: "delete"` and
-`path_b64`. Type transitions may emit both actions for one path. This is a
-local minimized push operation plan before target exclusions, not a
-path-for-path filesystem log: descendants represent a new non-empty directory,
-one deleted subtree root covers its descendants, and metadata-only changes to
-non-empty directories select no operation. Base64 keeps arbitrary filesystem
-path bytes representable. The final record carries `status: "complete"` with
+`action: "push"`, `local_path_b64`, `target_path_b64`, `type`, `size`, and
+`ctime`; its type is `file`, `dir`, or `link`. Each selected local deletion has
+`action: "delete"`, `local_path_b64`, and `target_path_b64`. Type transitions
+may emit both actions for one local path. This is a local minimized push
+operation plan before target exclusions, not a path-for-path filesystem log:
+descendants represent a new non-empty directory, one deleted subtree root
+covers its descendants, and metadata-only changes to non-empty directories
+select no operation. Base64 keeps arbitrary filesystem path bytes
+representable. The final record carries `status: "complete"` with
 `local_paths_to_push` and `local_paths_to_delete` counts.
 
 files-diff persists nothing between runs. The whole plan runs in one process,

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -150,25 +150,36 @@ Use these names verbatim:
 | --- | --- |
 | Local index path | `local_index_path`, `$local_index_path` |
 | Active plan directory | `plan`, `$plan_directory` |
-| Plan-owned fresh local index | `fresh_local_index.jsonl`, `$fresh_local_index` |
+| Plan-owned fresh local index | `.local-index.next.jsonl`, `$fresh_local_index` |
 | Byte offset in the local index | `byte_offset_in_local_index`, `$byte_offset_in_local_index` |
-| Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
-| Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
+| Paths to push | `paths-to-push.jsonl`, `$local_paths_to_push` |
+| Target paths to delete | `paths-to-delete`, `$target_paths_to_delete` |
+| Local paths to delete | `local-paths-to-delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
 | PushPlan cursor | `push_plan_cursor`, `$push_plan_cursor`, `get_cursor()` |
-| Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
+| Sender-owned excluded paths | `excluded-paths.json`, `$excluded_paths_path` |
 | Deleted directory path | `deleted_directory_path_b64`, `$deleted_directory_path` |
 | Active state | `sender.json`, `$state_path` |
-| Plan-owned committed local-index updates | `plan/local_index_updates.jsonl` |
+| Plan-owned committed local-index updates | `plan/local-index-updates.jsonl` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`sender.json` and `excluded_paths.json` live directly under the local push
+`sender.json` and `excluded-paths.json` live directly under the local push
 state directory. The sender creates `plan/` for one active plan and starts
 PushPlan with the local index path and sender-owned excluded paths.
-`fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
-`local_paths_to_delete`, and the post-commit `local_index_updates.jsonl` live
-inside `plan/`.
+`.local-index.next.jsonl`, `paths-to-push.jsonl`, `paths-to-delete`,
+`local-paths-to-delete`, and the post-commit `local-index-updates.jsonl` live
+inside `plan/`. Each paths-to-push record stores both `local_path_b64` and
+`target_path_b64`. `paths-to-delete` stores target paths for the request;
+`local-paths-to-delete` stores the paired local paths for the committed
+local-index update.
+
+`path-mapping.json` stores the target document root and the resolved remote and
+local prefix rules for one remote state directory. The first mapping is
+immutable. Push validates it before opening a push request, reads and stats
+`local_path_b64`, addresses the receiver with `target_path_b64`, and rewrites
+pulled symlink targets back into target coordinates. A relative symlink target
+outside the local tree is rejected when the symlink path itself is remapped.
 
 Completing files-pull creates the local index when it is missing. Each actual
 local mutation is recorded in `pull-index-updates.wal` with the local path and,
@@ -196,7 +207,7 @@ current local-index lookahead entry again after resume.
 
 The PushPlan cursor is stored in `sender.json`. During `indexing`, it contains
 the FileIndexProcessor cursor and the committed byte offset in
-`fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
+`.local-index.next.jsonl`. During `diffing`, it contains the index offsets,
 output offsets, and `deleted_directory_path_b64` while descendants of one
 deleted directory need no separate deletion. The exclusions have a maximum of
 100 paths. `sender.json` phases are `creating`, `starting_plan`,
@@ -205,7 +216,7 @@ deleted directory need no separate deletion. The exclusions have a maximum of
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
 completes before local paths are sent. After a successful commit, the sender
-writes `plan/local_index_updates.jsonl` from the committed path lists and
+writes `plan/local-index-updates.jsonl` from the committed path lists and
 applies it to the local index. The merge adds directory ancestors for each F
 update and removes the path and its descendants for each D update. If the local
 index does not exist, the same atomic merge creates it. Paths excluded by the
@@ -255,13 +266,13 @@ endpoint path and query as the file-only pull but omits URL user-info and
 to a bare site URL.
 
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
-`delete`, and `path_b64`. A push record also has the local path `type`, `size`,
-and `ctime`; its type is `file`, `dir`, or `link`. These records form a local
-minimized push operation plan before target exclusions: descendants represent
-a new non-empty directory, one deleted subtree root covers its descendants,
-and metadata-only changes to non-empty directories select no operation. The
-final record has `status: "complete"`, `local_paths_to_push`, and
-`local_paths_to_delete`.
+`delete`, `local_path_b64`, and `target_path_b64`. A push record also has the
+local path `type`, `size`, and `ctime`; its type is `file`, `dir`, or `link`.
+These records form a local minimized push operation plan before target
+exclusions: descendants represent a new non-empty directory, one deleted
+subtree root covers its descendants, and metadata-only changes to non-empty
+directories select no operation. The final record has `status: "complete"`,
+`local_paths_to_push`, and `local_paths_to_delete`.
 
 files-diff persists nothing between runs. It runs one complete PushPlan in
 `files-diff-plan/` while its command holds the state-directory-wide Reprint
@@ -334,11 +345,11 @@ Use these names verbatim inside `PushFilesSender`:
 | Maximum file payload bytes | `$maximum_file_payload_bytes` |
 | Maximum delete-list payload bytes | `$maximum_delete_list_payload_bytes` |
 | Local I/O failure detail | `$local_io_failure_detail` |
-| Whether the local delete list is complete | `$local_delete_list_complete` |
+| Whether the target delete list is complete | `$target_delete_list_complete` |
 | Copy through a swap file | `copy_through_swap_file()`, `$source_path`, `$target_path` |
 | Open directory handle | `$directory_handle` |
 | Open local paths-to-push handle | `$local_paths_to_push_handle` |
-| Open local paths-to-delete handle | `$local_paths_to_delete_handle` |
+| Open target paths-to-delete handle | `$target_paths_to_delete_handle` |
 | Open local file handle | `$local_file_handle` |
 | Local path stat result | `$path_stat` |
 | File type bits | `$file_type_bits` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -80,6 +80,7 @@ require_once __DIR__ . '/lib/state/class-import-state.php';
 // Adaptive sizing for push request bodies
 require_once __DIR__ . '/lib/upload/class-push-request-sizer.php';
 require_once __DIR__ . '/lib/upload/class-multipart-push-stream-client.php';
+require_once __DIR__ . '/lib/push/class-push-path-mapping.php';
 require_once __DIR__ . '/lib/push/class-push-plan.php';
 require_once __DIR__ . '/lib/push/class-push-files-sender.php';
 
@@ -686,7 +687,7 @@ class ImportClient
         }
         $matching_directories = [];
         foreach ($mapping_files as $mapping_file) {
-            $mapping = self::read_path_mapping($mapping_file);
+            $mapping = PushPathMapping::read_file($mapping_file);
             if (
                 $match_target_url
                 &&
@@ -1619,7 +1620,13 @@ class ImportClient
                 $plan_directory,
                 $context['local_tree'],
                 $local_index_path,
-                $excluded_paths_path
+                $excluded_paths_path,
+                $context['path_mapping_path'] === null
+                    ? PushPathMapping::identity($context['local_tree'])
+                    : PushPathMapping::from_file(
+                        $context['path_mapping_path'],
+                        $context['local_tree']
+                    )
             );
             try {
                 while ($plan->next_step()) {
@@ -1631,13 +1638,14 @@ class ImportClient
 
             $local_paths_to_push_count = 0;
             foreach (
-                $plan->read_planned_local_paths_to_push()
+                $plan->read_planned_paths_to_push()
                 as $entry
             ) {
                 $line = json_encode([
                     'command' => 'files-diff',
                     'action' => 'push',
-                    'path_b64' => $entry['path_b64'],
+                    'local_path_b64' => $entry['local_path_b64'],
+                    'target_path_b64' => $entry['target_path_b64'],
                     'type' => $entry['type'],
                     'size' => $entry['size'],
                     'ctime' => $entry['ctime'],
@@ -1650,13 +1658,16 @@ class ImportClient
 
             $local_paths_to_delete_count = 0;
             foreach (
-                $plan->read_planned_local_paths_to_delete()
-                as $local_path_to_delete
+                $plan->read_planned_paths_to_delete()
+                as $path_to_delete
             ) {
                 $line = json_encode([
                     'command' => 'files-diff',
                     'action' => 'delete',
-                    'path_b64' => base64_encode($local_path_to_delete),
+                    'local_path_b64' =>
+                        base64_encode($path_to_delete['local_path']),
+                    'target_path_b64' =>
+                        base64_encode($path_to_delete['target_path']),
                 ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
                 if (fwrite($this->progress_fd, $line) !== strlen($line)) {
                     throw new RuntimeException('Failed to write the files-diff result.');
@@ -1759,6 +1770,7 @@ class ImportClient
             'docroot' => $context['local_tree'],
             'push_state_directory' => $context['push_state_directory'],
             'local_index_path' => $context['local_index_path'],
+            'path_mapping_path' => $context['path_mapping_path'],
             'base_url' => $context['target_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
@@ -1955,8 +1967,9 @@ class ImportClient
      *     @type string $remote_state_directory State directory for the target relationship.
      *     @type string $push_state_directory   Local push state directory.
      *     @type string $local_index_path        Local index used by pull and push.
+     *     @type string|null $path_mapping_path   Persisted pull path mapping, when present.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,remote_state_directory:string,push_state_directory:string,local_index_path:string}
+     * @phpstan-return array{target_url:string,local_tree:string,remote_state_directory:string,push_state_directory:string,local_index_path:string,path_mapping_path:string|null}
      */
     public static function prepare_files_push_context(
         string $target_url,
@@ -1989,19 +2002,12 @@ class ImportClient
                 . '. Pass --force-http only for a target you trust.'
             );
         }
-        $path_mapping_file =
-            $context['remote_state_directory'] . '/path-mapping.json';
-        if (is_file($path_mapping_file)) {
-            $path_mapping = self::read_path_mapping($path_mapping_file);
-            foreach ($path_mapping['prefix_rules'] as $prefix_rule) {
-                if ($prefix_rule['kind'] === 'remap') {
-                    throw new RuntimeException(
-                        'files-push cannot use this local index because '
-                        . $path_mapping_file
-                        . ' contains remapped paths.'
-                    );
-                }
-            }
+        $path_mapping_file = $context['path_mapping_path'];
+        if ($path_mapping_file !== null) {
+            PushPathMapping::from_file(
+                $path_mapping_file,
+                $context['local_tree']
+            );
         }
         return $context;
     }
@@ -2021,8 +2027,9 @@ class ImportClient
      *     @type string $remote_state_directory State directory for the target relationship.
      *     @type string $push_state_directory   Local push state directory.
      *     @type string $local_index_path        Local index used by pull and push.
+     *     @type string|null $path_mapping_path   Persisted pull path mapping, when present.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,remote_state_directory:string,push_state_directory:string,local_index_path:string}
+     * @phpstan-return array{target_url:string,local_tree:string,remote_state_directory:string,push_state_directory:string,local_index_path:string,path_mapping_path:string|null}
      */
     public static function prepare_files_command_context(
         string $target_url,
@@ -2089,7 +2096,7 @@ class ImportClient
         }
         $path_mapping_file = $remote_state_directory . '/path-mapping.json';
         if (is_file($path_mapping_file)) {
-            $path_mapping = self::read_path_mapping($path_mapping_file);
+            $path_mapping = PushPathMapping::read_file($path_mapping_file);
             /** @var string $mapped_local_tree */
             $mapped_local_tree = base64_decode(
                 $path_mapping['local_tree_b64'],
@@ -2108,120 +2115,18 @@ class ImportClient
             }
         }
 
+        $path_mapping_path =
+            $remote_state_directory . '/path-mapping.json';
         return [
             'target_url' => $target_url,
             'local_tree' => $canonical_local_tree,
             'remote_state_directory' => $remote_state_directory,
             'push_state_directory' => $push_state_directory,
             'local_index_path' => $remote_state_directory . '/.local-index.jsonl',
+            'path_mapping_path' => is_file($path_mapping_path)
+                ? $path_mapping_path
+                : null,
         ];
-    }
-
-    /**
-     * Reads and validates one resolved path mapping.
-     *
-     * @return array {
-     *     @type string $target_url_fingerprint    Target URL fingerprint.
-     *     @type string $filesystem_root_b64       Pull filesystem root.
-     *     @type string $local_tree_b64            Canonical local tree.
-     *     @type string $target_document_root_b64  Target document root.
-     *     @type array  $prefix_rules              Resolved prefix rules.
-     * }
-     * @phpstan-return array{target_url_fingerprint:string,filesystem_root_b64:string,local_tree_b64:string,target_document_root_b64:string,prefix_rules:list<array{kind:'default'|'remap',remote_prefix_b64:string,local_prefix_b64:string}>}
-     */
-    private static function read_path_mapping(string $mapping_file): array
-    {
-        $json = file_get_contents($mapping_file);
-        if (!is_string($json)) {
-            throw new RuntimeException(
-                'Failed to read the path mapping: ' . $mapping_file . '.'
-            );
-        }
-        $mapping = json_decode(
-            $json,
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
-        if (!is_array($mapping)) {
-            throw new RuntimeException(
-                'The path mapping is not a JSON object: '
-                . $mapping_file
-                . '.'
-            );
-        }
-        foreach ([
-            'target_url_fingerprint',
-            'filesystem_root_b64',
-            'local_tree_b64',
-            'target_document_root_b64',
-        ] as $key) {
-            if (!isset($mapping[$key]) || !is_string($mapping[$key])) {
-                throw new RuntimeException(
-                    'The path mapping '
-                    . $mapping_file
-                    . ' has no string '
-                    . $key
-                    . '.'
-                );
-            }
-        }
-        foreach ([
-            'filesystem_root_b64',
-            'local_tree_b64',
-            'target_document_root_b64',
-        ] as $key) {
-            if (base64_decode($mapping[$key], true) === false) {
-                throw new RuntimeException(
-                    'The path mapping '
-                    . $mapping_file
-                    . ' has invalid base64 in '
-                    . $key
-                    . '.'
-                );
-            }
-        }
-        if (!isset($mapping['prefix_rules']) || !is_array($mapping['prefix_rules'])) {
-            throw new RuntimeException(
-                'The path mapping '
-                . $mapping_file
-                . ' has no prefix_rules array.'
-            );
-        }
-        foreach ($mapping['prefix_rules'] as $position => $prefix_rule) {
-            if (
-                !is_array($prefix_rule)
-                || !in_array(
-                    $prefix_rule['kind'] ?? null,
-                    ['default', 'remap'],
-                    true
-                )
-                || !isset(
-                    $prefix_rule['remote_prefix_b64'],
-                    $prefix_rule['local_prefix_b64']
-                )
-                || !is_string($prefix_rule['remote_prefix_b64'])
-                || !is_string($prefix_rule['local_prefix_b64'])
-                || base64_decode(
-                    $prefix_rule['remote_prefix_b64'],
-                    true
-                ) === false
-                || base64_decode(
-                    $prefix_rule['local_prefix_b64'],
-                    true
-                ) === false
-            ) {
-                throw new RuntimeException(
-                    'The path mapping '
-                    . $mapping_file
-                    . ' has an invalid prefix rule at position '
-                    . $position
-                    . '.'
-                );
-            }
-        }
-        /** @var array{target_url_fingerprint:string,filesystem_root_b64:string,local_tree_b64:string,target_document_root_b64:string,prefix_rules:list<array{kind:'default'|'remap',remote_prefix_b64:string,local_prefix_b64:string}>} $mapping */
-        return $mapping;
     }
 
     /** Removes endpoint aliases and authentication inputs which do not identify a target. */
@@ -8907,7 +8812,7 @@ class ImportClient
         ];
 
         if (is_file($this->path_mapping_file)) {
-            if (self::read_path_mapping($this->path_mapping_file) !== $mapping) {
+            if (PushPathMapping::read_file($this->path_mapping_file) !== $mapping) {
                 throw new RuntimeException(
                     'Cannot change the resolved path mapping in '
                     . $this->remote_state_directory
@@ -13214,7 +13119,9 @@ if (
                 "default-skipped paths include generated wp-content caches, version-\n" .
                 "control data, node_modules, package-manager caches, OS metadata, and\n" .
                 "editor scratch files.\n" .
-                "Paths remain base64 text in JSONL output so\n" .
+                "Each change reports local_path_b64 for local filesystem work and\n" .
+                "target_path_b64 for the corresponding target path. Paths remain\n" .
+                "base64 text in JSONL output so\n" .
                 "arbitrary filesystem names are preserved. No network calls are made\n" .
                 "and no secret is required. The state directory's .reprint.lock is\n" .
                 "held for the entire command.\n",
@@ -13236,6 +13143,8 @@ if (
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It does not require pull preflight.\n" .
+                "When files-pull stored a path mapping for this target and local tree,\n" .
+                "files-push reads local paths and addresses their mapped target paths.\n" .
                 "\n" .
                 "Each process runs one sender until it completes, reaches a caller time or\n" .
                 "memory boundary, or receives a signal handled by this PHP runtime.\n" .

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -123,8 +123,8 @@ use function Reprint\Importer\write_local_index_update;
  *
  * @phpstan-type LocalPathTypeSizeAndCtime array{type:'file'|'dir'|'link',size:int,ctime:int}
  * @phpstan-type LocalPathStat array{type:'file'|'dir'|'link'|'unsupported',size:int,ctime:int}
- * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
- * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
+ * @phpstan-type LocalPathToPush array{local_path:string,target_path:string,target_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
+ * @phpstan-type TargetPathToDelete array{target_path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
  * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'updating_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
@@ -140,6 +140,9 @@ final class PushFilesSender
 
     /** @var string Local index updated by successful pulls and pushes. */
     private string $local_index_path;
+
+    /** @var PushPathMapping Validated local-to-target path mapping. */
+    private PushPathMapping $path_mapping;
 
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
@@ -159,17 +162,17 @@ final class PushFilesSender
     /** @var int|null Current byte offset of the retained local paths-to-push handle. */
     private ?int $local_paths_to_push_byte_offset = null;
 
-    /** @var resource|null Open local_paths_to_delete list retained while pushing deleted paths. */
-    private $local_paths_to_delete_handle = null;
+    /** @var resource|null Open target deletion list retained while pushing deleted paths. */
+    private $target_paths_to_delete_handle = null;
 
     /** @var int|null Current byte offset of the retained deletion-list handle. */
-    private ?int $local_paths_to_delete_byte_offset = null;
+    private ?int $target_paths_to_delete_byte_offset = null;
 
-    /** @var LocalPathToDelete|null Current local path to delete retained until it is sent. */
-    private ?array $local_path_to_delete = null;
+    /** @var TargetPathToDelete|null Current target path to delete retained until it is sent. */
+    private ?array $target_path_to_delete = null;
 
     /** @var bool Whether the retained deletion-list handle reached EOF. */
-    private bool $local_delete_list_complete = false;
+    private bool $target_delete_list_complete = false;
 
     /** @var resource|null Open local file retained while pushing its chunks. */
     private $local_file_handle = null;
@@ -237,6 +240,7 @@ final class PushFilesSender
      *     @type string                  $docroot                Required local document-root directory.
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $local_index_path        Required local index used by pull and push.
+     *     @type string|null             $path_mapping_path       Persisted pull path mapping, when present.
      *     @type string                  $base_url                Required exporter API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
@@ -319,6 +323,7 @@ final class PushFilesSender
                     $sender->docroot,
                     $sender->local_index_path,
                     $sender->excluded_paths_path,
+                    $sender->path_mapping,
                     $state['push_plan_cursor']
                 );
             }
@@ -379,8 +384,20 @@ final class PushFilesSender
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
         $this->local_index_path = $local_index_path;
+        $path_mapping_path = $options['path_mapping_path'] ?? null;
+        if ($path_mapping_path !== null && !is_string($path_mapping_path)) {
+            throw new InvalidArgumentException(
+                'path_mapping_path must be a string or null.'
+            );
+        }
+        $this->path_mapping = $path_mapping_path === null
+            ? PushPathMapping::identity($this->docroot)
+            : PushPathMapping::from_file(
+                $path_mapping_path,
+                $this->docroot
+            );
         $this->state_path = $this->push_state_directory . '/sender.json';
-        $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
+        $this->excluded_paths_path = $this->push_state_directory . '/excluded-paths.json';
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
     }
@@ -510,12 +527,12 @@ final class PushFilesSender
         $this->receiver_confirmed_file_byte_offset = null;
         $this->receiver_confirmed_deleted_paths_byte_offset = null;
         $this->receiver_confirmed_deleted_paths_complete = null;
-        $this->local_delete_list_complete = false;
+        $this->target_delete_list_complete = false;
         $this->local_path_to_push = null;
-        $this->local_path_to_delete = null;
+        $this->target_path_to_delete = null;
         $this->close_local_file_handle();
         $this->close_local_paths_to_push_handle();
-        $this->close_local_paths_to_delete_handle();
+        $this->close_target_paths_to_delete_handle();
     }
 
     /**
@@ -532,7 +549,7 @@ final class PushFilesSender
         }
         $this->close_local_file_handle();
         $this->close_local_paths_to_push_handle();
-        $this->close_local_paths_to_delete_handle();
+        $this->close_target_paths_to_delete_handle();
         if (isset($this->push_stream_client)) {
             $this->push_stream_client->close();
         }
@@ -605,7 +622,8 @@ final class PushFilesSender
             $this->plan_directory,
             $this->docroot,
             $this->local_index_path,
-            $this->excluded_paths_path
+            $this->excluded_paths_path,
+            $this->path_mapping
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         $this->state['phase'] = 'planning';
@@ -650,8 +668,8 @@ final class PushFilesSender
 
         // Keep the planned-path list open across calls while this phase is active.
         if (!is_resource($this->local_paths_to_push_handle)) {
-            $local_paths_to_push_path = $this->plan->get_local_paths_to_push_path();
-            $this->local_paths_to_push_handle = fopen($local_paths_to_push_path, 'rb');
+            $paths_to_push_path = $this->plan->get_paths_to_push_path();
+            $this->local_paths_to_push_handle = fopen($paths_to_push_path, 'rb');
             if (!is_resource($this->local_paths_to_push_handle)) {
                 $this->fail('local_io_error', 'Could not open the local paths to push.');
                 return;
@@ -694,7 +712,9 @@ final class PushFilesSender
         }
 
         $planned_local_path_type_size_and_ctime = $local_path_to_push['planned_local_path_type_size_and_ctime'];
-        $local_path_type_size_and_ctime = $this->stat_local_path($local_path_to_push['path']);
+        $local_path_type_size_and_ctime = $this->stat_local_path(
+            $local_path_to_push['local_path']
+        );
 
         // A path which disappeared belongs in a newly generated plan, not this upload-only session.
         if ($local_path_type_size_and_ctime === null) {
@@ -740,7 +760,7 @@ final class PushFilesSender
         } else {
             $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                 'push_session_id' => $this->state['push_session_id'],
-                'path_b64' => $local_path_to_push['path_b64'],
+                'path_b64' => $local_path_to_push['target_path_b64'],
             ], ['accepted']);
             if ($this->handle_request_failure($request_result)) {
                 return;
@@ -775,12 +795,16 @@ final class PushFilesSender
 
         // Directory and symlink values each fit in one MIME part and need no byte cursor.
         if ($local_path_type_size_and_ctime['type'] === 'dir') {
-            $directory_is_empty = $this->directory_is_empty($local_path_to_push['path']);
+            $directory_is_empty = $this->directory_is_empty(
+                $local_path_to_push['local_path']
+            );
             if ($directory_is_empty === null) {
-                $this->fail('local_io_error', 'Could not read the local directory to push: ' . base64_encode($local_path_to_push['path']) . '.');
+                $this->fail('local_io_error', 'Could not read the local directory to push: ' . base64_encode($local_path_to_push['local_path']) . '.');
                 return;
             }
-            $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
+            $local_path_type_size_and_ctime_after_read = $this->stat_local_path(
+                $local_path_to_push['local_path']
+            );
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
                 $this->start_removing_push_session_after_local_change();
@@ -798,13 +822,17 @@ final class PushFilesSender
             }
             $upload_part = [
                 'type' => $multipart_part_type,
-                'path' => $local_path_to_push['path'],
+                'path' => $local_path_to_push['target_path'],
                 'payload' => '',
             ];
             $upload_completes_local_path = true;
         } elseif ($local_path_type_size_and_ctime['type'] === 'link') {
-            $symlink_target = @readlink($this->docroot . '/' . $local_path_to_push['path']);
-            $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
+            $symlink_target = @readlink(
+                $this->docroot . '/' . $local_path_to_push['local_path']
+            );
+            $local_path_type_size_and_ctime_after_read = $this->stat_local_path(
+                $local_path_to_push['local_path']
+            );
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
                 $this->start_removing_push_session_after_local_change();
@@ -816,13 +844,26 @@ final class PushFilesSender
                 return;
             }
             if ($symlink_target === false) {
-                $this->fail('local_io_error', 'Could not read the local symlink target to push: ' . base64_encode($local_path_to_push['path']) . '.');
+                $this->fail('local_io_error', 'Could not read the local symlink target to push: ' . base64_encode($local_path_to_push['local_path']) . '.');
+                return;
+            }
+            try {
+                $target_symlink_target = $this->path_mapping
+                    ->local_symlink_target_to_target(
+                        $local_path_to_push['local_path'],
+                        $symlink_target
+                    );
+            } catch (RuntimeException $exception) {
+                $this->fail(
+                    'unaddressable_symlink_target',
+                    $exception->getMessage()
+                );
                 return;
             }
             $upload_part = [
                 'type' => $multipart_part_type,
-                'path' => $local_path_to_push['path'],
-                'target' => $symlink_target,
+                'path' => $local_path_to_push['target_path'],
+                'target' => $target_symlink_target,
                 'payload' => '',
             ];
             $upload_completes_local_path = true;
@@ -831,7 +872,7 @@ final class PushFilesSender
         // A file contributes at most one bounded chunk during this call and remains open for the next.
         if ($local_path_type_size_and_ctime['type'] === 'file') {
             $maximum_file_payload_bytes = $this->push_stream_client->next_file_body_bytes(
-                $local_path_to_push['path'],
+                $local_path_to_push['target_path'],
                 $local_path_type_size_and_ctime['size'],
                 $file_byte_offset
             );
@@ -840,7 +881,7 @@ final class PushFilesSender
                     $this->upload_request_stage = 'finishing';
                     return;
                 }
-                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($local_path_to_push['path']) . '.');
+                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for target path ' . base64_encode($local_path_to_push['target_path']) . '.');
                 return;
             }
 
@@ -849,18 +890,18 @@ final class PushFilesSender
                 $local_io_failure_detail = null;
                 if (!is_resource($this->local_file_handle)) {
                     $this->local_file_handle = fopen(
-                        $this->docroot . '/' . $local_path_to_push['path'],
+                        $this->docroot . '/' . $local_path_to_push['local_path'],
                         'rb'
                     );
                 }
 
                 if (!is_resource($this->local_file_handle)) {
-                    $local_io_failure_detail = 'Could not open the local file to push: ' . base64_encode($local_path_to_push['path']) . '.';
+                    $local_io_failure_detail = 'Could not open the local file to push: ' . base64_encode($local_path_to_push['local_path']) . '.';
                 } else {
                     if ($this->local_file_byte_offset !== $file_byte_offset) {
                         if (fseek($this->local_file_handle, $file_byte_offset) !== 0) {
                             $this->close_local_file_handle();
-                            $local_io_failure_detail = 'Could not seek to the receiver-confirmed cursor in the local file to push: ' . base64_encode($local_path_to_push['path']) . '.';
+                            $local_io_failure_detail = 'Could not seek to the receiver-confirmed cursor in the local file to push: ' . base64_encode($local_path_to_push['local_path']) . '.';
                         } else {
                             $this->local_file_byte_offset = $file_byte_offset;
                         }
@@ -873,7 +914,9 @@ final class PushFilesSender
                     }
                 }
 
-                $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
+                $local_path_type_size_and_ctime_after_read = $this->stat_local_path(
+                    $local_path_to_push['local_path']
+                );
                 if ($local_path_type_size_and_ctime_after_read === null) {
                     $this->close_local_file_handle();
                     $this->close_local_paths_to_push_handle();
@@ -892,14 +935,14 @@ final class PushFilesSender
                 }
                 if (!is_string($payload) || ( $payload === '' && $file_byte_offset < $local_path_type_size_and_ctime['size'] )) {
                     $this->close_local_file_handle();
-                    $this->fail('local_io_error', 'Could not read the local file to push at its receiver-confirmed cursor: ' . base64_encode($local_path_to_push['path']) . '.');
+                    $this->fail('local_io_error', 'Could not read the local file to push at its receiver-confirmed cursor: ' . base64_encode($local_path_to_push['local_path']) . '.');
                     return;
                 }
             }
 
             $upload_part = [
                 'type' => $multipart_part_type,
-                'path' => $local_path_to_push['path'],
+                'path' => $local_path_to_push['target_path'],
                 'total_bytes' => $local_path_type_size_and_ctime['size'],
                 'offset' => $file_byte_offset,
                 'payload' => $payload,
@@ -933,7 +976,7 @@ final class PushFilesSender
             if ($this->status !== 'continue') {
                 return;
             }
-            $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($local_path_to_push['path']) . '.');
+            $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for target path ' . base64_encode($local_path_to_push['target_path']) . '.');
             return;
         }
 
@@ -964,7 +1007,7 @@ final class PushFilesSender
         }
 
         // Select one complete path at the tentative or target-confirmed list position.
-        if ($this->local_path_to_delete === null && !$this->local_delete_list_complete) {
+        if ($this->target_path_to_delete === null && !$this->target_delete_list_complete) {
             if ($this->upload_request_stage !== 'closed') {
                 $delete_list_byte_offset = $this->next_delete_list_byte_offset ?? 0;
             } else {
@@ -984,7 +1027,7 @@ final class PushFilesSender
                 }
                 $delete_list_byte_offset = $this->receiver_confirmed_deleted_paths_byte_offset;
                 if ($this->receiver_confirmed_deleted_paths_complete) {
-                    $this->close_local_paths_to_delete_handle();
+                    $this->close_target_paths_to_delete_handle();
                     $this->receiver_confirmed_deleted_paths_byte_offset = null;
                     $this->receiver_confirmed_deleted_paths_complete = null;
                     $this->state['phase'] = 'committing';
@@ -1003,31 +1046,35 @@ final class PushFilesSender
                     $this->upload_request_stage = 'finishing';
                     return;
                 }
-                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one local path to delete.');
+                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one target path to delete.');
                 return;
             }
 
             // Keep the completed deletion plan open while successive calls consume it.
-            if (!is_resource($this->local_paths_to_delete_handle)) {
-                $local_paths_to_delete_path = $this->plan->get_local_paths_to_delete_path();
-                $this->local_paths_to_delete_handle = fopen($local_paths_to_delete_path, 'rb');
-                if (!is_resource($this->local_paths_to_delete_handle)) {
-                    $this->fail('local_io_error', 'Could not open the local paths to delete.');
+            if (!is_resource($this->target_paths_to_delete_handle)) {
+                $target_paths_to_delete_path =
+                    $this->plan->get_target_paths_to_delete_path();
+                $this->target_paths_to_delete_handle = fopen(
+                    $target_paths_to_delete_path,
+                    'rb'
+                );
+                if (!is_resource($this->target_paths_to_delete_handle)) {
+                    $this->fail('local_io_error', 'Could not open the target paths to delete.');
                     return;
                 }
             }
-            if ($this->local_paths_to_delete_byte_offset !== $delete_list_byte_offset) {
-                if (fseek($this->local_paths_to_delete_handle, $delete_list_byte_offset) !== 0) {
-                    $this->close_local_paths_to_delete_handle();
-                    $this->fail('local_io_error', 'Could not seek to the receiver-confirmed cursor in the local paths to delete.');
+            if ($this->target_paths_to_delete_byte_offset !== $delete_list_byte_offset) {
+                if (fseek($this->target_paths_to_delete_handle, $delete_list_byte_offset) !== 0) {
+                    $this->close_target_paths_to_delete_handle();
+                    $this->fail('local_io_error', 'Could not seek to the receiver-confirmed cursor in the target paths to delete.');
                     return;
                 }
-                $this->local_paths_to_delete_byte_offset = $delete_list_byte_offset;
+                $this->target_paths_to_delete_byte_offset = $delete_list_byte_offset;
             }
 
             try {
-                $this->local_path_to_delete = $this->read_next_local_path_to_delete(
-                    $this->local_paths_to_delete_handle,
+                $this->target_path_to_delete = $this->read_next_target_path_to_delete(
+                    $this->target_paths_to_delete_handle,
                     $delete_list_byte_offset,
                     $maximum_delete_list_payload_bytes
                 );
@@ -1038,20 +1085,21 @@ final class PushFilesSender
                 $this->fail('local_io_error', $exception->getMessage());
                 return;
             }
-            if ($this->local_path_to_delete === null) {
-                $this->local_delete_list_complete = true;
+            if ($this->target_path_to_delete === null) {
+                $this->target_delete_list_complete = true;
             } else {
-                $this->local_paths_to_delete_byte_offset = $this->local_path_to_delete['next_delete_list_byte_offset'];
+                $this->target_paths_to_delete_byte_offset = $this->target_path_to_delete['next_delete_list_byte_offset'];
             }
         }
 
         // EOF becomes the empty part which marks the deletion list complete.
-        if ($this->local_path_to_delete === null) {
+        if ($this->target_path_to_delete === null) {
             $delete_list_byte_offset = $this->next_delete_list_byte_offset ?? 0;
             $payload = '';
         } else {
-            $delete_list_byte_offset = $this->local_path_to_delete['delete_list_byte_offset'];
-            $payload = $this->local_path_to_delete['path'] . "\0";
+            $delete_list_byte_offset = $this->target_path_to_delete['delete_list_byte_offset'];
+            $payload =
+                $this->target_path_to_delete['target_path'] . "\0";
             $maximum_delete_list_payload_bytes = $this->push_stream_client->next_delete_body_bytes(
                 $delete_list_byte_offset
             );
@@ -1060,7 +1108,7 @@ final class PushFilesSender
                     $this->upload_request_stage = 'finishing';
                     return;
                 }
-                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one local path to delete.');
+                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one target path to delete.');
                 return;
             }
         }
@@ -1079,7 +1127,7 @@ final class PushFilesSender
         $part_sent = $this->push_stream_client->send_part([
             'type' => 'delete-list',
             'offset' => $delete_list_byte_offset,
-            'complete' => $this->local_delete_list_complete,
+            'complete' => $this->target_delete_list_complete,
             'payload' => $payload,
         ]);
 
@@ -1087,7 +1135,7 @@ final class PushFilesSender
         // An empty request which cannot fit the part cannot make progress.
         if (!$part_sent) {
             if ($this->push_stream_client->has_sent_parts()) {
-                $this->local_path_to_delete = null;
+                $this->target_path_to_delete = null;
                 $this->upload_request_stage = 'finishing';
                 return;
             }
@@ -1101,8 +1149,8 @@ final class PushFilesSender
 
         // Keep the next list position tentative until the target confirms the request.
         $this->next_delete_list_byte_offset = $delete_list_byte_offset + strlen($payload);
-        $this->local_path_to_delete = null;
-        if ($this->local_delete_list_complete || $this->push_stream_client->should_finish_request()) {
+        $this->target_path_to_delete = null;
+        if ($this->target_delete_list_complete || $this->push_stream_client->should_finish_request()) {
             $this->upload_request_stage = 'finishing';
         }
     }
@@ -1128,12 +1176,12 @@ final class PushFilesSender
             $this->receiver_confirmed_file_byte_offset = $this->next_file_byte_offset ?? 0;
         } elseif ($request_had_parts && $request_phase === 'pushing_deletes') {
             $this->receiver_confirmed_deleted_paths_byte_offset = $this->next_delete_list_byte_offset ?? 0;
-            $this->receiver_confirmed_deleted_paths_complete = $this->local_delete_list_complete;
+            $this->receiver_confirmed_deleted_paths_complete = $this->target_delete_list_complete;
         }
         $this->upload_request_stage = 'closed';
         $this->next_file_byte_offset = null;
         $this->next_delete_list_byte_offset = null;
-        $this->local_delete_list_complete = false;
+        $this->target_delete_list_complete = false;
         if (!$request_failed) {
             $this->state['request_sizer_state'] = $this->push_stream_client->get_request_sizer_state();
             if ($this->state !== $this->state_before_upload_request) {
@@ -1180,15 +1228,15 @@ final class PushFilesSender
     /**
      * Closes the deleted-path list when that phase or this lifecycle ends.
      */
-    private function close_local_paths_to_delete_handle(): void
+    private function close_target_paths_to_delete_handle(): void
     {
-        if (is_resource($this->local_paths_to_delete_handle)) {
-            fclose($this->local_paths_to_delete_handle);
+        if (is_resource($this->target_paths_to_delete_handle)) {
+            fclose($this->target_paths_to_delete_handle);
         }
-        $this->local_paths_to_delete_handle = null;
-        $this->local_paths_to_delete_byte_offset = null;
-        $this->local_path_to_delete = null;
-        $this->local_delete_list_complete = false;
+        $this->target_paths_to_delete_handle = null;
+        $this->target_paths_to_delete_byte_offset = null;
+        $this->target_path_to_delete = null;
+        $this->target_delete_list_complete = false;
     }
 
     /**
@@ -1223,7 +1271,7 @@ final class PushFilesSender
     {
         try {
             $local_index_updates_path =
-                $this->plan_directory . '/local_index_updates.jsonl';
+                $this->plan_directory . '/local-index-updates.jsonl';
             $local_index_updates_handle =
                 fopen($local_index_updates_path, 'wb');
             if (!is_resource($local_index_updates_handle)) {
@@ -1239,22 +1287,24 @@ final class PushFilesSender
                  * directories and derives their empty state.
                  */
                 foreach (
-                    $this->plan->read_planned_local_paths_to_delete()
-                    as $local_path_to_delete
+                    $this->plan->read_planned_paths_to_delete()
+                    as $path_to_delete
                 ) {
                     write_local_index_update($local_index_updates_handle, [
                         'op' => 'D',
-                        'path' => base64_encode($local_path_to_delete),
+                        'path' => base64_encode(
+                            $path_to_delete['local_path']
+                        ),
                     ]);
                 }
 
                 foreach (
-                    $this->plan->read_planned_local_paths_to_push()
+                    $this->plan->read_planned_paths_to_push()
                     as $local_path_to_push
                 ) {
                     write_local_index_update($local_index_updates_handle, [
                         'op' => 'F',
-                        'path' => $local_path_to_push['path_b64'],
+                        'path' => $local_path_to_push['local_path_b64'],
                         'ctime' => $local_path_to_push['ctime'],
                         'size' => $local_path_to_push['size'],
                         'type' => $local_path_to_push['type'],
@@ -1406,19 +1456,23 @@ final class PushFilesSender
         if (!is_int($next_local_paths_to_push_byte_offset)) {
             throw new RuntimeException('Failed to determine the next byte offset in the local paths to push.');
         }
-        /** @var array{path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int} $decoded_local_path */
+        /** @var array{local_path_b64:string,target_path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int} $decoded_local_path */
         $decoded_local_path = json_decode(
             $line,
             true,
             512,
             JSON_THROW_ON_ERROR
         );
-        $path_b64 = $decoded_local_path['path_b64'];
-        /** @var string $path */
-        $path = base64_decode($path_b64);
+        $local_path_b64 = $decoded_local_path['local_path_b64'];
+        $target_path_b64 = $decoded_local_path['target_path_b64'];
+        /** @var string $local_path */
+        $local_path = base64_decode($local_path_b64);
+        /** @var string $target_path */
+        $target_path = base64_decode($target_path_b64);
         return [
-            'path' => $path,
-            'path_b64' => $path_b64,
+            'local_path' => $local_path,
+            'target_path' => $target_path,
+            'target_path_b64' => $target_path_b64,
             'next_local_paths_to_push_byte_offset' => $next_local_paths_to_push_byte_offset,
             'planned_local_path_type_size_and_ctime' => [
                 'type' => $decoded_local_path['type'],
@@ -1429,37 +1483,37 @@ final class PushFilesSender
     }
 
     /**
-     * Reads one complete local path to delete within the next part limit.
+     * Reads one complete target path to delete within the next part limit.
      *
-     * @param resource $local_paths_to_delete_handle Open local paths-to-delete file.
+     * @param resource $target_paths_to_delete_handle Open target paths-to-delete file.
      * @param int      $delete_list_byte_offset      Byte offset at the start of the path.
      * @param int      $maximum_delete_list_payload_bytes Maximum bytes available for the path and NUL delimiter.
-     * @return LocalPathToDelete|null One local path to delete, or null at EOF.
+     * @return TargetPathToDelete|null One target path to delete, or null at EOF.
      *
      * @throws LengthException When the next complete path does not fit.
      * @throws RuntimeException When the deletion list cannot be read.
      */
-    private function read_next_local_path_to_delete(
-        $local_paths_to_delete_handle,
+    private function read_next_target_path_to_delete(
+        $target_paths_to_delete_handle,
         int $delete_list_byte_offset,
         int $maximum_delete_list_payload_bytes
     ): ?array {
-        $path = stream_get_line($local_paths_to_delete_handle, $maximum_delete_list_payload_bytes, "\0");
-        if ($path === false) {
-            if (feof($local_paths_to_delete_handle)) {
+        $target_path = stream_get_line($target_paths_to_delete_handle, $maximum_delete_list_payload_bytes, "\0");
+        if ($target_path === false) {
+            if (feof($target_paths_to_delete_handle)) {
                 return null;
             }
-            throw new RuntimeException('Could not read the next local path to delete.');
+            throw new RuntimeException('Could not read the next target path to delete.');
         }
-        $next_delete_list_byte_offset = ftell($local_paths_to_delete_handle);
+        $next_delete_list_byte_offset = ftell($target_paths_to_delete_handle);
         if (!is_int($next_delete_list_byte_offset)) {
-            throw new RuntimeException('Could not determine the next byte offset in the local paths to delete.');
+            throw new RuntimeException('Could not determine the next byte offset in the target paths to delete.');
         }
-        if ($next_delete_list_byte_offset !== $delete_list_byte_offset + strlen($path) + 1) {
-            throw new LengthException('The current request-body budget cannot fit one complete local path to delete.');
+        if ($next_delete_list_byte_offset !== $delete_list_byte_offset + strlen($target_path) + 1) {
+            throw new LengthException('The current request-body budget cannot fit one complete target path to delete.');
         }
         return [
-            'path' => $path,
+            'target_path' => $target_path,
             'delete_list_byte_offset' => $delete_list_byte_offset,
             'next_delete_list_byte_offset' => $next_delete_list_byte_offset,
         ];

--- a/packages/reprint-importer/src/lib/push/class-push-path-mapping.php
+++ b/packages/reprint-importer/src/lib/push/class-push-path-mapping.php
@@ -1,0 +1,567 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Mapping failures are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Maps local-index paths back to the target document-root coordinate system.
+ *
+ * A pull relationship stores absolute remote and local prefixes. Push plans
+ * use local document-root-relative paths for filesystem work and target
+ * document-root-relative paths for protocol work. An absent mapping means the
+ * two relative coordinate systems are identical.
+ *
+ * @phpstan-type StoredPrefixRule array{kind:'default'|'remap',remote_prefix_b64:string,local_prefix_b64:string}
+ * @phpstan-type StoredPathMapping array{target_url_fingerprint:string,filesystem_root_b64:string,local_tree_b64:string,target_document_root_b64:string,prefix_rules:list<StoredPrefixRule>}
+ * @phpstan-type DecodedPrefixRule array{remote_prefix:string,local_prefix:string}
+ */
+final class PushPathMapping
+{
+    /** @var string Canonical local document root. */
+    private string $local_tree;
+
+    /** @var string|null Absolute target document root, or null for identity. */
+    private ?string $target_document_root;
+
+    /** @var list<DecodedPrefixRule> Rules sorted by descending local-prefix length. */
+    private array $prefix_rules;
+
+    /**
+     * Uses identical local and target relative paths.
+     */
+    public static function identity(string $local_tree): self
+    {
+        return new self($local_tree, null, []);
+    }
+
+    /**
+     * Loads and validates the immutable mapping used by one push relationship.
+     */
+    public static function from_file(
+        string $mapping_file,
+        string $local_tree
+    ): self {
+        $mapping = self::read_file($mapping_file);
+        $stored_local_tree = base64_decode(
+            $mapping['local_tree_b64'],
+            true
+        );
+        $target_document_root = base64_decode(
+            $mapping['target_document_root_b64'],
+            true
+        );
+        /** @var string $stored_local_tree */
+        /** @var string $target_document_root */
+        $canonical_local_tree = realpath($local_tree);
+        if (
+            $canonical_local_tree === false
+            || self::normalize_path($stored_local_tree)
+                !== self::normalize_path($canonical_local_tree)
+        ) {
+            throw new RuntimeException(
+                'path-mapping.json belongs to a different local tree.'
+            );
+        }
+        $decoded_prefix_rules = [];
+        foreach ($mapping['prefix_rules'] as $prefix_rule) {
+            $remote_prefix = base64_decode(
+                $prefix_rule['remote_prefix_b64'],
+                true
+            );
+            $local_prefix = base64_decode(
+                $prefix_rule['local_prefix_b64'],
+                true
+            );
+            /** @var string $remote_prefix */
+            /** @var string $local_prefix */
+            $decoded_prefix_rules[] = [
+                'remote_prefix' => $remote_prefix,
+                'local_prefix' => $local_prefix,
+            ];
+        }
+        return new self(
+            $local_tree,
+            $target_document_root,
+            $decoded_prefix_rules
+        );
+    }
+
+    /**
+     * Reads the persisted representation used for relationship discovery.
+     *
+     * @return array {
+     *     @type string $target_url_fingerprint    Target URL fingerprint.
+     *     @type string $filesystem_root_b64       Pull filesystem root.
+     *     @type string $local_tree_b64            Canonical local tree.
+     *     @type string $target_document_root_b64  Target document root.
+     *     @type array  $prefix_rules              Resolved prefix rules.
+     * }
+     * @phpstan-return StoredPathMapping
+     */
+    public static function read_file(string $mapping_file): array
+    {
+        $json = file_get_contents($mapping_file);
+        if (!is_string($json)) {
+            throw new RuntimeException(
+                'Failed to read the path mapping: ' . $mapping_file . '.'
+            );
+        }
+        $mapping = json_decode(
+            $json,
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        if (!is_array($mapping)) {
+            throw new RuntimeException(
+                'The path mapping is not a JSON object: '
+                . $mapping_file
+                . '.'
+            );
+        }
+        foreach ([
+            'target_url_fingerprint',
+            'filesystem_root_b64',
+            'local_tree_b64',
+            'target_document_root_b64',
+        ] as $key) {
+            if (!isset($mapping[$key]) || !is_string($mapping[$key])) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $mapping_file
+                    . ' has no string '
+                    . $key
+                    . '.'
+                );
+            }
+        }
+        foreach ([
+            'filesystem_root_b64',
+            'local_tree_b64',
+            'target_document_root_b64',
+        ] as $key) {
+            if (base64_decode($mapping[$key], true) === false) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $mapping_file
+                    . ' has invalid base64 in '
+                    . $key
+                    . '.'
+                );
+            }
+        }
+        if (!isset($mapping['prefix_rules']) || !is_array($mapping['prefix_rules'])) {
+            throw new RuntimeException(
+                'The path mapping '
+                . $mapping_file
+                . ' has no prefix_rules array.'
+            );
+        }
+        foreach ($mapping['prefix_rules'] as $position => $prefix_rule) {
+            if (
+                !is_array($prefix_rule)
+                || !in_array(
+                    $prefix_rule['kind'] ?? null,
+                    ['default', 'remap'],
+                    true
+                )
+                || !isset(
+                    $prefix_rule['remote_prefix_b64'],
+                    $prefix_rule['local_prefix_b64']
+                )
+                || !is_string($prefix_rule['remote_prefix_b64'])
+                || !is_string($prefix_rule['local_prefix_b64'])
+                || base64_decode(
+                    $prefix_rule['remote_prefix_b64'],
+                    true
+                ) === false
+                || base64_decode(
+                    $prefix_rule['local_prefix_b64'],
+                    true
+                ) === false
+            ) {
+                throw new RuntimeException(
+                    'The path mapping '
+                    . $mapping_file
+                    . ' has an invalid prefix rule at position '
+                    . $position
+                    . '.'
+                );
+            }
+        }
+        /** @var StoredPathMapping $mapping */
+        return $mapping;
+    }
+
+    /**
+     * Returns the target document-root-relative coordinate for a local path.
+     */
+    public function local_path_to_target_path(string $local_path): string
+    {
+        self::assert_relative_path($local_path, 'local-index path');
+        if ($this->target_document_root === null) {
+            return $local_path;
+        }
+        $local_absolute_path =
+            $this->local_tree . '/' . $local_path;
+        foreach ($this->prefix_rules as $prefix_rule) {
+            $remainder = self::path_remainder_under(
+                $local_absolute_path,
+                $prefix_rule['local_prefix']
+            );
+            if ($remainder === null) {
+                continue;
+            }
+            $target_absolute_path = self::join_paths(
+                $prefix_rule['remote_prefix'],
+                $remainder
+            );
+            $target_path = self::path_remainder_under(
+                $target_absolute_path,
+                $this->target_document_root
+            );
+            if ($target_path === null || $target_path === '') {
+                throw new RuntimeException(
+                    'The local-index path '
+                    . base64_encode($local_path)
+                    . ' does not map to a path below the target document root.'
+                );
+            }
+            return $target_path;
+        }
+        throw new RuntimeException(
+            'The local-index path '
+            . base64_encode($local_path)
+            . ' is not covered by path-mapping.json.'
+        );
+    }
+
+    /**
+     * Rewrites a local symlink target into the target path coordinates.
+     *
+     * Absolute targets and relative targets from an unchanged link coordinate
+     * keep their spelling when they resolve outside the local tree. A relative
+     * target from a remapped link cannot be reconstructed without a mapped
+     * local target, so it is rejected instead of changing its destination.
+     */
+    public function local_symlink_target_to_target(
+        string $local_path,
+        string $symlink_target
+    ): string {
+        if ($this->target_document_root === null) {
+            return $symlink_target;
+        }
+        $local_symlink_absolute_path =
+            $this->local_tree . '/' . $local_path;
+        $local_target_absolute_path = $symlink_target !== ''
+            && $symlink_target[0] === '/'
+                ? self::normalize_path($symlink_target)
+                : self::normalize_path(
+                    dirname($local_symlink_absolute_path)
+                    . '/'
+                    . $symlink_target
+                );
+        $local_target_path = self::path_remainder_under(
+            $local_target_absolute_path,
+            $this->local_tree
+        );
+        $target_link_path =
+            $this->local_path_to_target_path($local_path);
+        if ($local_target_path === null) {
+            if (
+                $symlink_target !== ''
+                && $symlink_target[0] !== '/'
+                && $target_link_path !== $local_path
+            ) {
+                throw new RuntimeException(
+                    'The remapped local symlink '
+                    . base64_encode($local_path)
+                    . ' has a relative target outside the local tree: '
+                    . base64_encode($symlink_target)
+                    . '.'
+                );
+            }
+            return $symlink_target;
+        }
+        $target_path = $local_target_path === ''
+            ? ''
+            : $this->local_path_to_target_path($local_target_path);
+        return self::relative_path(
+            dirname('/' . $target_link_path),
+            '/' . $target_path
+        );
+    }
+
+    /**
+     * Validates and stores one decoded mapping.
+     *
+     * @param list<DecodedPrefixRule> $prefix_rules
+     */
+    private function __construct(
+        string $local_tree,
+        ?string $target_document_root,
+        array $prefix_rules
+    ) {
+        $canonical_local_tree = realpath($local_tree);
+        if (
+            $canonical_local_tree === false
+            || !is_dir($canonical_local_tree)
+            || is_link($local_tree)
+        ) {
+            throw new InvalidArgumentException(
+                'Push path mapping requires a real local tree directory.'
+            );
+        }
+        $this->local_tree =
+            rtrim(self::normalize_path($canonical_local_tree), '/') ?: '/';
+        if ($target_document_root === null) {
+            $this->target_document_root = null;
+            $this->prefix_rules = [];
+            return;
+        }
+        $target_document_root =
+            rtrim(self::normalize_path($target_document_root), '/') ?: '/';
+        self::assert_absolute_normalized_path(
+            $target_document_root,
+            'target document root'
+        );
+        $decoded_rules = [];
+        $covers_local_tree = false;
+        $remote_prefix_by_local_prefix = [];
+        foreach ($prefix_rules as $prefix_rule) {
+            $remote_prefix =
+                rtrim(
+                    self::normalize_path($prefix_rule['remote_prefix']),
+                    '/'
+                ) ?: '/';
+            $local_prefix =
+                rtrim(
+                    self::normalize_path($prefix_rule['local_prefix']),
+                    '/'
+                ) ?: '/';
+            self::assert_absolute_normalized_path(
+                $remote_prefix,
+                'remote prefix'
+            );
+            self::assert_absolute_normalized_path(
+                $local_prefix,
+                'local prefix'
+            );
+            if (
+                self::path_remainder_under(
+                    $remote_prefix,
+                    $target_document_root
+                ) === null
+            ) {
+                throw new RuntimeException(
+                    'The remote prefix '
+                    . base64_encode($remote_prefix)
+                    . ' is outside the target document root '
+                    . base64_encode($target_document_root)
+                    . '.'
+                );
+            }
+            if (
+                self::path_remainder_under(
+                    $local_prefix,
+                    $this->local_tree
+                ) === null
+            ) {
+                throw new RuntimeException(
+                    'The local prefix '
+                    . base64_encode($local_prefix)
+                    . ' is outside the local tree '
+                    . base64_encode($this->local_tree)
+                    . '.'
+                );
+            }
+            self::assert_no_symlink_component(
+                $local_prefix,
+                $this->local_tree
+            );
+            if (
+                isset($remote_prefix_by_local_prefix[$local_prefix])
+                && $remote_prefix_by_local_prefix[$local_prefix]
+                    !== $remote_prefix
+            ) {
+                throw new RuntimeException(
+                    'The local prefix '
+                    . base64_encode($local_prefix)
+                    . ' maps to more than one remote prefix.'
+                );
+            }
+            $remote_prefix_by_local_prefix[$local_prefix] = $remote_prefix;
+            if ($local_prefix === $this->local_tree) {
+                $covers_local_tree = true;
+            }
+            $decoded_rules[] = [
+                'remote_prefix' => $remote_prefix,
+                'local_prefix' => $local_prefix,
+            ];
+        }
+        usort(
+            $decoded_rules,
+            static function (array $left, array $right): int {
+                return strlen($right['local_prefix'])
+                    <=> strlen($left['local_prefix']);
+            }
+        );
+        if ($decoded_rules === []) {
+            throw new RuntimeException(
+                'path-mapping.json contains no prefix rules.'
+            );
+        }
+        if (!$covers_local_tree) {
+            throw new RuntimeException(
+                'path-mapping.json does not cover the local tree.'
+            );
+        }
+        $this->target_document_root = $target_document_root;
+        $this->prefix_rules = $decoded_rules;
+    }
+
+    /** Validates one document-root-relative path. */
+    private static function assert_relative_path(
+        string $path,
+        string $description
+    ): void {
+        if (
+            $path === ''
+            || $path[0] === '/'
+            || strpos($path, "\0") !== false
+            || self::normalize_path('/' . $path) !== '/' . $path
+        ) {
+            throw new RuntimeException(
+                'The '
+                . $description
+                . ' is not a normalized relative path: '
+                . base64_encode($path)
+                . '.'
+            );
+        }
+    }
+
+    /** Validates one absolute normalized prefix. */
+    private static function assert_absolute_normalized_path(
+        string $path,
+        string $description
+    ): void {
+        if (
+            $path === ''
+            || $path[0] !== '/'
+            || strpos($path, "\0") !== false
+            || self::normalize_path($path) !== $path
+        ) {
+            throw new RuntimeException(
+                'The '
+                . $description
+                . ' is not a normalized absolute path: '
+                . base64_encode($path)
+                . '.'
+            );
+        }
+    }
+
+    /** Rejects a mapping prefix which traverses an existing symlink. */
+    private static function assert_no_symlink_component(
+        string $path,
+        string $root
+    ): void {
+        $remainder = self::path_remainder_under($path, $root);
+        if ($remainder === null || $remainder === '') {
+            return;
+        }
+        $current_path = $root;
+        foreach (explode('/', $remainder) as $component) {
+            $current_path .= '/' . $component;
+            if (is_link($current_path)) {
+                throw new RuntimeException(
+                    'The local mapping prefix traverses the symlink '
+                    . base64_encode($current_path)
+                    . '.'
+                );
+            }
+            if (!file_exists($current_path)) {
+                return;
+            }
+        }
+    }
+
+    /** Returns a normalized path without filesystem access. */
+    private static function normalize_path(string $path): string
+    {
+        $absolute = $path !== '' && $path[0] === '/';
+        $components = [];
+        foreach (explode('/', $path) as $component) {
+            if ($component === '' || $component === '.') {
+                continue;
+            }
+            if ($component === '..') {
+                array_pop($components);
+                continue;
+            }
+            $components[] = $component;
+        }
+        return ( $absolute ? '/' : '' ) . implode('/', $components);
+    }
+
+    /** Returns the remainder below a prefix, including an empty remainder. */
+    private static function path_remainder_under(
+        string $path,
+        string $prefix
+    ): ?string {
+        $path = rtrim($path, '/') ?: '/';
+        $prefix = rtrim($prefix, '/') ?: '/';
+        if ($path === $prefix) {
+            return '';
+        }
+        $prefix_with_separator =
+            $prefix === '/' ? '/' : $prefix . '/';
+        if (strpos($path, $prefix_with_separator) !== 0) {
+            return null;
+        }
+        return substr($path, strlen($prefix_with_separator));
+    }
+
+    /** Joins an absolute prefix and a relative remainder. */
+    private static function join_paths(
+        string $prefix,
+        string $remainder
+    ): string {
+        return rtrim($prefix, '/')
+            . ( $remainder === '' ? '' : '/' . ltrim($remainder, '/') );
+    }
+
+    /** Computes one relative path between two absolute logical paths. */
+    private static function relative_path(
+        string $from_directory,
+        string $to_path
+    ): string {
+        $from_components =
+            explode('/', trim(self::normalize_path($from_directory), '/'));
+        $to_components =
+            explode('/', trim(self::normalize_path($to_path), '/'));
+        if ($from_components === ['']) {
+            $from_components = [];
+        }
+        if ($to_components === ['']) {
+            $to_components = [];
+        }
+        while (
+            $from_components !== []
+            && $to_components !== []
+            && $from_components[0] === $to_components[0]
+        ) {
+            array_shift($from_components);
+            array_shift($to_components);
+        }
+        $relative_components = array_merge(
+            array_fill(0, count($from_components), '..'),
+            $to_components
+        );
+        return $relative_components === []
+            ? '.'
+            : implode('/', $relative_components);
+    }
+}

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -10,9 +10,8 @@ use function Reprint\Importer\write_index_entry;
  * Internal bounded local-index and change planner.
  *
  * PushPlan builds a path-sorted fresh local index, then diffs it against the
- * local index at the caller-supplied path. It writes durable lists of local
- * paths to push and local paths to delete without accumulating an index or
- * path list in memory.
+ * local index at the caller-supplied path. It writes durable local and target
+ * path coordinates without accumulating an index or path list in memory.
  *
  * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
  * lock, top-level phase, result, and terminal behavior. PushPlan owns
@@ -61,7 +60,7 @@ use function Reprint\Importer\write_index_entry;
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_path_b64:string|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,byte_offset_in_target_paths_to_delete:int,deleted_directory_path_b64:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
  * @phpstan-type PushPlanCursor IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  */
@@ -82,6 +81,9 @@ class PushPlan
     /** @var string Raw NUL-delimited local paths to delete. */
     private string $local_paths_to_delete;
 
+    /** @var string Raw NUL-delimited target paths to delete. */
+    private string $target_paths_to_delete;
+
     /** @var string Plan-owned fresh local index. */
     private string $fresh_local_index;
 
@@ -90,6 +92,9 @@ class PushPlan
 
     /** @var list<string> Decoded excluded paths. */
     private array $excluded_paths = [];
+
+    /** @var PushPathMapping Local-to-target path mapping for this relationship. */
+    private PushPathMapping $path_mapping;
 
     /** @var PushPlanCursor Current cursor returned to the caller. */
     private array $cursor;
@@ -123,6 +128,8 @@ class PushPlan
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
     private $local_paths_to_delete_handle = null;
+    /** @var resource|null */
+    private $target_paths_to_delete_handle = null;
     /**
      * Starts a push plan by opening a fresh local index traversal.
      *
@@ -130,19 +137,22 @@ class PushPlan
      * @param string $local_tree_root              Canonical local tree root.
      * @param string $local_index_path             Local index this plan diffs against.
      * @param string $excluded_paths_path          Excluded paths file.
+     * @param PushPathMapping $path_mapping        Validated local-to-target mapping.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $local_tree_root,
         string $local_index_path,
-        string $excluded_paths_path
+        string $excluded_paths_path,
+        PushPathMapping $path_mapping
     ): self {
         $plan = new self(
             $plan_directory,
             $local_tree_root,
             $local_index_path,
-            $excluded_paths_path
+            $excluded_paths_path,
+            $path_mapping
         );
         $plan->excluded_paths = $plan->load_excluded_paths();
         $plan->fresh_local_index_handle = fopen($plan->fresh_local_index, "w+b");
@@ -174,6 +184,7 @@ class PushPlan
      * @param string $local_tree_root     Canonical local tree root.
      * @param string $local_index_path    Local index this plan diffs against.
      * @param string $excluded_paths_path Excluded paths file.
+     * @param PushPathMapping $path_mapping Validated local-to-target mapping.
      * @phpstan-param PushPlanCursor $cursor Cursor previously returned by get_cursor().
      * @return self Open plan positioned at its last durable cursor.
      */
@@ -182,13 +193,15 @@ class PushPlan
         string $local_tree_root,
         string $local_index_path,
         string $excluded_paths_path,
+        PushPathMapping $path_mapping,
         array $cursor
     ): self {
         $plan = new self(
             $plan_directory,
             $local_tree_root,
             $local_index_path,
-            $excluded_paths_path
+            $excluded_paths_path,
+            $path_mapping
         );
         $plan->cursor = $cursor;
         if ($cursor["phase"] !== "complete") {
@@ -215,26 +228,24 @@ class PushPlan
     /**
      * Returns the JSONL local paths to push list.
      */
-    public function get_local_paths_to_push_path(): string
+    public function get_paths_to_push_path(): string
     {
         return $this->local_paths_to_push;
     }
 
-    /**
-     * Returns the raw NUL-delimited path list produced for local deletions.
-     */
-    public function get_local_paths_to_delete_path(): string
+    /** Returns the raw NUL-delimited target deletion list. */
+    public function get_target_paths_to_delete_path(): string
     {
-        return $this->local_paths_to_delete;
+        return $this->target_paths_to_delete;
     }
 
     /**
-     * Reads the completed local paths-to-push list.
+     * Reads the completed paths-to-push list.
      *
      * @return Generator Completed plan entries.
-     * @phpstan-return Generator<int,array{path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int},mixed,void>
+     * @phpstan-return Generator<int,array{local_path_b64:string,target_path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int},mixed,void>
      */
-    public function read_planned_local_paths_to_push(): Generator
+    public function read_planned_paths_to_push(): Generator
     {
         $local_paths_to_push_handle = fopen($this->local_paths_to_push, 'rb');
         if (!is_resource($local_paths_to_push_handle)) {
@@ -249,7 +260,7 @@ class PushPlan
                     }
                     return;
                 }
-                /** @var array{path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int} $entry */
+                /** @var array{local_path_b64:string,target_path_b64:string,type:'file'|'dir'|'link',size:int,ctime:int} $entry */
                 $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
                 yield $entry;
             }
@@ -259,30 +270,49 @@ class PushPlan
     }
 
     /**
-     * Reads the completed local paths-to-delete list.
+     * Reads the completed local and target deletion coordinates together.
      *
-     * @return Generator Completed local paths to delete.
-     * @phpstan-return Generator<int,string,mixed,void>
+     * @phpstan-return Generator<int,array{local_path:string,target_path:string},mixed,void>
      */
-    public function read_planned_local_paths_to_delete(): Generator
+    public function read_planned_paths_to_delete(): Generator
     {
         $local_paths_to_delete_handle = fopen($this->local_paths_to_delete, 'rb');
         if (!is_resource($local_paths_to_delete_handle)) {
             throw new RuntimeException('Failed to open the completed local paths-to-delete list.');
         }
+        $target_paths_to_delete_handle = fopen($this->target_paths_to_delete, 'rb');
+        if (!is_resource($target_paths_to_delete_handle)) {
+            fclose($local_paths_to_delete_handle);
+            throw new RuntimeException('Failed to open the completed target paths-to-delete list.');
+        }
         try {
             while (true) {
                 $local_path_to_delete = stream_get_line($local_paths_to_delete_handle, 1048576, "\0");
-                if ($local_path_to_delete === false) {
-                    if (!feof($local_paths_to_delete_handle)) {
-                        throw new RuntimeException('Failed to read the completed local paths-to-delete list.');
-                    }
+                $target_path_to_delete = stream_get_line($target_paths_to_delete_handle, 1048576, "\0");
+                if (
+                    $local_path_to_delete === false
+                    && $target_path_to_delete === false
+                    && feof($local_paths_to_delete_handle)
+                    && feof($target_paths_to_delete_handle)
+                ) {
                     return;
                 }
-                yield $local_path_to_delete;
+                if (
+                    $local_path_to_delete === false
+                    || $target_path_to_delete === false
+                ) {
+                    throw new RuntimeException(
+                        'The completed local and target deletion lists have different lengths.'
+                    );
+                }
+                yield [
+                    'local_path' => $local_path_to_delete,
+                    'target_path' => $target_path_to_delete,
+                ];
             }
         } finally {
             fclose($local_paths_to_delete_handle);
+            fclose($target_paths_to_delete_handle);
         }
     }
 
@@ -293,12 +323,14 @@ class PushPlan
      * @param string $local_tree_root              Canonical local tree root.
      * @param string $local_index_path    Local index this plan diffs against.
      * @param string $excluded_paths_path Excluded paths file.
+     * @param PushPathMapping $path_mapping Validated local-to-target mapping.
      */
     private function __construct(
         string $plan_directory,
         string $local_tree_root,
         string $local_index_path,
-        string $excluded_paths_path
+        string $excluded_paths_path,
+        PushPathMapping $path_mapping
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -307,10 +339,12 @@ class PushPlan
         $this->plan_directory = $plan_directory;
         $this->set_local_tree_root($local_tree_root);
         $this->local_index_path = $local_index_path;
-        $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
-        $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
-        $this->fresh_local_index = $plan_directory . "/fresh_local_index.jsonl";
+        $this->local_paths_to_push = $plan_directory . "/paths-to-push.jsonl";
+        $this->local_paths_to_delete = $plan_directory . "/local-paths-to-delete";
+        $this->target_paths_to_delete = $plan_directory . "/paths-to-delete";
+        $this->fresh_local_index = $plan_directory . "/.local-index.next.jsonl";
         $this->excluded_paths_path = $excluded_paths_path;
+        $this->path_mapping = $path_mapping;
     }
 
     /**
@@ -382,6 +416,10 @@ class PushPlan
         $this->local_paths_to_delete_handle = $this->open_and_truncate_and_seek(
             $this->local_paths_to_delete,
             $cursor["byte_offset_in_local_paths_to_delete"]
+        );
+        $this->target_paths_to_delete_handle = $this->open_and_truncate_and_seek(
+            $this->target_paths_to_delete,
+            $cursor["byte_offset_in_target_paths_to_delete"]
         );
         $this->fresh_local_index_handle = fopen($this->fresh_local_index, "rb");
         if (!is_resource($this->fresh_local_index_handle)) {
@@ -500,6 +538,7 @@ class PushPlan
             "byte_offset_in_local_index" => 0,
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
+            "byte_offset_in_target_paths_to_delete" => 0,
             "deleted_directory_path_b64" => null,
         ];
         $this->open_plan_files();
@@ -724,7 +763,13 @@ class PushPlan
 
         if (
             ( $local_paths_to_push_changed && !fflush($this->local_paths_to_push_handle) )
-            || ( $local_paths_to_delete_changed && !fflush($this->local_paths_to_delete_handle) )
+            || (
+                $local_paths_to_delete_changed
+                && (
+                    !fflush($this->local_paths_to_delete_handle)
+                    || !fflush($this->target_paths_to_delete_handle)
+                )
+            )
         ) {
             throw new RuntimeException("Failed to flush a push-plan output.");
         }
@@ -742,6 +787,7 @@ class PushPlan
                 "byte_offset_in_local_index" => $byte_offset_in_local_index,
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
+                "byte_offset_in_target_paths_to_delete" => ftell($this->target_paths_to_delete_handle),
                 "deleted_directory_path_b64" =>
                     $this->deleted_directory_path === null
                         ? null
@@ -772,9 +818,13 @@ class PushPlan
         if (is_resource($this->local_paths_to_delete_handle)) {
             fclose($this->local_paths_to_delete_handle);
         }
+        if (is_resource($this->target_paths_to_delete_handle)) {
+            fclose($this->target_paths_to_delete_handle);
+        }
         $this->local_index_handle = null;
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
+        $this->target_paths_to_delete_handle = null;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
         $this->local_index_lookahead_entry = null;
@@ -853,9 +903,12 @@ class PushPlan
      */
     private function append_local_path_to_push(array $entry): void
     {
+        $target_path = $this->path_mapping
+            ->local_path_to_target_path($entry["path"]);
         $line = json_encode(
             [
-                "path_b64" => base64_encode($entry["path"]),
+                "local_path_b64" => base64_encode($entry["path"]),
+                "target_path_b64" => base64_encode($target_path),
                 "type" => $entry["type"],
                 "size" => $entry["size"],
                 "ctime" => $entry["ctime"],
@@ -868,15 +921,30 @@ class PushPlan
     }
 
     /**
-     * Appends one path to the NUL-delimited list of local paths to delete.
+     * Appends one local path and its target coordinate to their deletion lists.
      *
      * @param string $path Raw filesystem path selected for deletion.
      */
     private function append_local_path_to_delete(string $path): void
     {
-        $path_with_nul = $path . "\0";
-        if (fwrite($this->local_paths_to_delete_handle, $path_with_nul) !== strlen($path_with_nul)) {
+        $local_path_with_nul = $path . "\0";
+        if (
+            fwrite(
+                $this->local_paths_to_delete_handle,
+                $local_path_with_nul
+            ) !== strlen($local_path_with_nul)
+        ) {
             throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
+        }
+        $target_path_with_nul = $this->path_mapping
+            ->local_path_to_target_path($path) . "\0";
+        if (
+            fwrite(
+                $this->target_paths_to_delete_handle,
+                $target_path_with_nul
+            ) !== strlen($target_path_with_nul)
+        ) {
+            throw new RuntimeException("Short write on target paths to delete {$this->target_paths_to_delete}, is the disk full?");
         }
     }
 
@@ -888,16 +956,18 @@ class PushPlan
      * or contains an excluded descendant. The last case prevents deleting or
      * replacing a directory from removing an excluded descendant with it.
      *
-     * @param string $path Raw filesystem path considered for push or deletion.
+     * @param string $path Local path considered for push or deletion.
      * @return bool Whether operating on the path could change an excluded path.
      */
     private function path_conflicts_with_excluded_paths(string $path): bool
     {
+        $target_path =
+            $this->path_mapping->local_path_to_target_path($path);
         foreach ($this->excluded_paths as $excluded_path) {
             if (
-                $path === $excluded_path
-                || strpos($path, $excluded_path . "/") === 0
-                || strpos($excluded_path, $path . "/") === 0
+                $target_path === $excluded_path
+                || strpos($target_path, $excluded_path . "/") === 0
+                || strpos($excluded_path, $target_path . "/") === 0
             ) {
                 return true;
             }

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -104,8 +104,9 @@ final class FilesDiffCommandTest extends TestCase
 
         $recordsByActionAndPath = [];
         foreach ($records as $record) {
-            $path = base64_decode($record['path_b64'] ?? '', true);
+            $path = base64_decode($record['local_path_b64'] ?? '', true);
             $this->assertIsString($path);
+            $this->assertSame($record['local_path_b64'], $record['target_path_b64']);
             $recordsByActionAndPath[( $record['action'] ?? '' ) . ':' . $path] = $record;
         }
         $this->assertCount(6, $recordsByActionAndPath);
@@ -144,12 +145,14 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertSame([
             'command' => 'files-diff',
             'action' => 'delete',
-            'path_b64' => base64_encode('deleted.txt'),
+            'local_path_b64' => base64_encode('deleted.txt'),
+            'target_path_b64' => base64_encode('deleted.txt'),
         ], $recordsByActionAndPath['delete:deleted.txt']);
         $this->assertSame([
             'command' => 'files-diff',
             'action' => 'delete',
-            'path_b64' => base64_encode('swap'),
+            'local_path_b64' => base64_encode('swap'),
+            'target_path_b64' => base64_encode('swap'),
         ], $recordsByActionAndPath['delete:swap']);
         $this->assertSame('', $result['stderr']);
         $this->assertSame(
@@ -191,7 +194,8 @@ final class FilesDiffCommandTest extends TestCase
             [
                 'command' => 'files-diff',
                 'action' => 'delete',
-                'path_b64' => base64_encode($this->invalidBytePathInIndex),
+                'local_path_b64' => base64_encode($this->invalidBytePathInIndex),
+                'target_path_b64' => base64_encode($this->invalidBytePathInIndex),
             ],
         ], $records);
         $this->assertStringNotContainsString($invalidBytePathToPush, $result['stdout']);
@@ -364,7 +368,7 @@ final class FilesDiffCommandTest extends TestCase
         file_put_contents($localIndex, $lines);
     }
 
-    /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
+    /** @return array{command:string,action:string,local_path_b64:string,target_path_b64:string,type:string,size:int,ctime:int} */
     private function expectedPushRecord(string $path, string $type): array
     {
         $stat = lstat($this->localTree . '/' . $path);
@@ -372,7 +376,8 @@ final class FilesDiffCommandTest extends TestCase
         return [
             'command' => 'files-diff',
             'action' => 'push',
-            'path_b64' => base64_encode($path),
+            'local_path_b64' => base64_encode($path),
+            'target_path_b64' => base64_encode($path),
             'type' => $type,
             'size' => $type === 'dir' ? 0 : (int) $stat['size'],
             'ctime' => (int) $stat['ctime'],

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -293,7 +293,8 @@ final class FilesPullLocalIndexTest extends TestCase
             [
                 'command' => 'files-diff',
                 'action' => 'delete',
-                'path_b64' => base64_encode('deleted.txt'),
+                'local_path_b64' => base64_encode('deleted.txt'),
+                'target_path_b64' => base64_encode('deleted.txt'),
             ],
         ], $records);
     }
@@ -543,7 +544,7 @@ final class FilesPullLocalIndexTest extends TestCase
         $this->assertSame( (int) $stat['size'], $entry['size']);
     }
 
-    /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
+    /** @return array{command:string,action:string,local_path_b64:string,target_path_b64:string,type:string,size:int,ctime:int} */
     private function expectedPushRecord(string $path): array
     {
         $stat = lstat($this->localTree . '/' . $path);
@@ -551,7 +552,8 @@ final class FilesPullLocalIndexTest extends TestCase
         return [
             'command' => 'files-diff',
             'action' => 'push',
-            'path_b64' => base64_encode($path),
+            'local_path_b64' => base64_encode($path),
+            'target_path_b64' => base64_encode($path),
             'type' => 'file',
             'size' => (int) $stat['size'],
             'ctime' => (int) $stat['ctime'],

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -336,9 +336,11 @@ final class FilesPushCommandTest extends TestCase
         $this->assertFileDoesNotExist($this->stateDirectory . '/.import-state.json');
     }
 
-    public function testFilesPushRefusesPersistedRemapsBeforeStartingSender(): void
+    public function testFilesPushAcceptsAValidatedPersistedRemap(): void
     {
         $targetUrl = 'https://example.test/?reprint-api=1';
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
         $context = ImportClient::prepare_files_command_context(
             $targetUrl,
             $this->stateDirectory,
@@ -350,15 +352,68 @@ final class FilesPushCommandTest extends TestCase
             $context['remote_state_directory'] . '/path-mapping.json',
             json_encode([
                 'target_url_fingerprint' => hash('sha256', $targetUrl),
-                'filesystem_root_b64' => base64_encode($context['local_tree']),
-                'local_tree_b64' => base64_encode($context['local_tree']),
+                'filesystem_root_b64' => base64_encode($canonicalLocalTree),
+                'local_tree_b64' => base64_encode($canonicalLocalTree),
+                'target_document_root_b64' => base64_encode('/var/www/html'),
+                'prefix_rules' => [
+                    [
+                        'kind' => 'default',
+                        'remote_prefix_b64' =>
+                            base64_encode('/var/www/html'),
+                        'local_prefix_b64' =>
+                            base64_encode($canonicalLocalTree),
+                    ],
+                    [
+                        'kind' => 'remap',
+                        'remote_prefix_b64' =>
+                            base64_encode('/var/www/html/wp-content'),
+                        'local_prefix_b64' =>
+                            base64_encode($canonicalLocalTree . '/content'),
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        $pushContext = ImportClient::prepare_files_push_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            ['secret' => 'token', 'force_http' => false]
+        );
+
+        $this->assertSame(
+            $context['remote_state_directory'] . '/path-mapping.json',
+            $pushContext['path_mapping_path']
+        );
+        $this->assertDirectoryDoesNotExist(
+            $context['push_state_directory']
+        );
+    }
+
+    public function testFilesPushRejectsAnUnaddressableMappingBeforeStartingSender(): void
+    {
+        $targetUrl = 'https://example.test/?reprint-api=1';
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
+        $context = ImportClient::prepare_files_command_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-push'
+        );
+        mkdir($context['remote_state_directory'], 0700, true);
+        file_put_contents(
+            $context['remote_state_directory'] . '/path-mapping.json',
+            json_encode([
+                'target_url_fingerprint' => hash('sha256', $targetUrl),
+                'filesystem_root_b64' => base64_encode($canonicalLocalTree),
+                'local_tree_b64' => base64_encode($canonicalLocalTree),
                 'target_document_root_b64' => base64_encode('/var/www/html'),
                 'prefix_rules' => [[
                     'kind' => 'remap',
-                    'remote_prefix_b64' =>
-                        base64_encode('/var/www/html/wp-content'),
+                    'remote_prefix_b64' => base64_encode('/opt/plugins'),
                     'local_prefix_b64' =>
-                        base64_encode($context['local_tree'] . '/content'),
+                        base64_encode($canonicalLocalTree . '/plugins'),
                 ]],
             ], JSON_THROW_ON_ERROR)
         );
@@ -370,10 +425,75 @@ final class FilesPushCommandTest extends TestCase
                 $this->localTree,
                 ['secret' => 'token', 'force_http' => false]
             );
-            $this->fail('Expected files-push to reject the persisted remap.');
+            $this->fail(
+                'Expected files-push to reject the unaddressable mapping.'
+            );
         } catch (\RuntimeException $error) {
             $this->assertStringContainsString(
-                'contains remapped paths',
+                'outside the target document root',
+                $error->getMessage()
+            );
+        }
+
+        $this->assertDirectoryDoesNotExist(
+            $context['push_state_directory']
+        );
+    }
+
+    public function testFilesPushRejectsAnAmbiguousMappingBeforeStartingSender(): void
+    {
+        $targetUrl = 'https://example.test/?reprint-api=1';
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
+        $context = ImportClient::prepare_files_command_context(
+            $targetUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            'files-push'
+        );
+        mkdir($context['remote_state_directory'], 0700, true);
+        file_put_contents(
+            $context['remote_state_directory'] . '/path-mapping.json',
+            json_encode([
+                'target_url_fingerprint' => hash('sha256', $targetUrl),
+                'filesystem_root_b64' => base64_encode($canonicalLocalTree),
+                'local_tree_b64' => base64_encode($canonicalLocalTree),
+                'target_document_root_b64' =>
+                    base64_encode('/var/www/html'),
+                'prefix_rules' => [
+                    [
+                        'kind' => 'remap',
+                        'remote_prefix_b64' =>
+                            base64_encode('/var/www/html/plugins'),
+                        'local_prefix_b64' => base64_encode(
+                            $canonicalLocalTree . '/plugins'
+                        ),
+                    ],
+                    [
+                        'kind' => 'remap',
+                        'remote_prefix_b64' =>
+                            base64_encode('/var/www/html/mu-plugins'),
+                        'local_prefix_b64' => base64_encode(
+                            $canonicalLocalTree . '/plugins'
+                        ),
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        try {
+            ImportClient::prepare_files_push_context(
+                $targetUrl,
+                $this->stateDirectory,
+                $this->localTree,
+                ['secret' => 'token', 'force_http' => false]
+            );
+            $this->fail(
+                'Expected files-push to reject the ambiguous mapping.'
+            );
+        } catch (\RuntimeException $error) {
+            $this->assertStringContainsString(
+                'maps to more than one remote prefix',
                 $error->getMessage()
             );
         }

--- a/tests/Import/PushPathMappingTest.php
+++ b/tests/Import/PushPathMappingTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-path-mapping.php';
+
+final class PushPathMappingTest extends TestCase
+{
+    private string $tempDirectory;
+    private string $localTree;
+    private string $mappingFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDirectory =
+            sys_get_temp_dir() . '/push-path-mapping-' . uniqid();
+        $this->localTree = $this->tempDirectory . '/local-tree';
+        $this->mappingFile = $this->tempDirectory . '/path-mapping.json';
+        mkdir($this->localTree, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->tempDirectory);
+        parent::tearDown();
+    }
+
+    public function testMapsLocalPathsBackToTheirTargetCoordinates(): void
+    {
+        $mapping = $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+
+        $this->assertSame(
+            'wp-content/plugins/example/plugin.php',
+            $mapping->local_path_to_target_path(
+                'plugins/example/plugin.php'
+            )
+        );
+        $this->assertSame(
+            'index.php',
+            $mapping->local_path_to_target_path('index.php')
+        );
+        $this->assertSame(
+            'wp-content/plugins/example\\plugin.php',
+            $mapping->local_path_to_target_path(
+                'plugins/example\\plugin.php'
+            )
+        );
+    }
+
+    public function testRewritesAPulledSymlinkTargetIntoTargetCoordinates(): void
+    {
+        $mapping = $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+
+        $this->assertSame(
+            '../../themes/example',
+            $mapping->local_symlink_target_to_target(
+                'plugins/current',
+                '../themes/example'
+            )
+        );
+    }
+
+    public function testRewritesASymlinkTargetingTheLocalTreeRoot(): void
+    {
+        $mapping = $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+
+        $this->assertSame(
+            '../../..',
+            $mapping->local_symlink_target_to_target(
+                'plugins/example/current',
+                '../..'
+            )
+        );
+    }
+
+    public function testRejectsARelativeTargetOutsideTheRemappedLocalTree(): void
+    {
+        $mapping = $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'has a relative target outside the local tree'
+        );
+
+        $mapping->local_symlink_target_to_target(
+            'plugins/current',
+            '../../outside'
+        );
+    }
+
+    public function testRejectsARemotePrefixOutsideTheTargetDocumentRoot(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('outside the target document root');
+
+        $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            ['/opt/plugins', $this->localTree . '/plugins', 'remap'],
+        ]);
+    }
+
+    public function testRejectsOneLocalPrefixForTwoRemotePrefixes(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'maps to more than one remote prefix'
+        );
+
+        $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+            [
+                '/var/www/html/wp-content/mu-plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+    }
+
+    public function testRejectsAMappingWhichDoesNotCoverTheLocalTree(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not cover the local tree');
+
+        $this->writeMapping([
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+    }
+
+    public function testRejectsALocalPrefixWhichTraversesASymlink(): void
+    {
+        mkdir($this->localTree . '/real-plugins');
+        symlink(
+            $this->localTree . '/real-plugins',
+            $this->localTree . '/plugins'
+        );
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('traverses the symlink');
+
+        $this->writeMapping([
+            ['/var/www/html', $this->localTree, 'default'],
+            [
+                '/var/www/html/wp-content/plugins',
+                $this->localTree . '/plugins',
+                'remap',
+            ],
+        ]);
+    }
+
+    /**
+     * @param list<array{string,string,'default'|'remap'}> $rules
+     */
+    private function writeMapping(array $rules): PushPathMapping
+    {
+        $canonicalLocalTree = realpath($this->localTree);
+        $this->assertIsString($canonicalLocalTree);
+        $prefixRules = [];
+        foreach ($rules as [$remotePrefix, $localPrefix, $kind]) {
+            $prefixRules[] = [
+                'kind' => $kind,
+                'remote_prefix_b64' => base64_encode($remotePrefix),
+                'local_prefix_b64' => base64_encode(
+                    str_replace($this->localTree, $canonicalLocalTree, $localPrefix)
+                ),
+            ];
+        }
+        file_put_contents(
+            $this->mappingFile,
+            json_encode([
+                'target_url_fingerprint' => str_repeat('1', 64),
+                'filesystem_root_b64' => base64_encode($canonicalLocalTree),
+                'local_tree_b64' => base64_encode($canonicalLocalTree),
+                'target_document_root_b64' =>
+                    base64_encode('/var/www/html'),
+                'prefix_rules' => $prefixRules,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+        return PushPathMapping::from_file(
+            $this->mappingFile,
+            $this->localTree
+        );
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) ?: [] as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+            rmdir($path);
+            return;
+        }
+        unlink($path);
+    }
+}

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/index-update-functions.php';
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-path-mapping.php';
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-plan.php';
 
 /**
@@ -12,8 +13,8 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push
  *
  * The plan diffs the fresh local index, whose directory entries carry an
  * `empty` boolean from the indexer, against the local index.
- * The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
- * local paths to delete, cursor replay, and every transition among files,
+ * The tests pin the resulting paths-to-push JSONL, raw NUL-delimited local
+ * and target paths to delete, cursor replay, and every transition among files,
  * symlinks, empty directories, and non-empty directories.
  */
 final class PushPlanTest extends TestCase
@@ -25,6 +26,8 @@ final class PushPlanTest extends TestCase
 
     /** @var array<string,array<string,mixed>> Last tree shape created by materializeLocalTree(). */
     private array $materializedIndexEntries = [];
+
+    private PushPathMapping $pathMapping;
 
     protected function setUp(): void
     {
@@ -45,13 +48,15 @@ final class PushPlanTest extends TestCase
 
     public function testStartRequiresTheCallerToCreateThePlanDirectory(): void
     {
+        mkdir($this->localTreeRoot());
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('without its directory');
         PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
             $this->localIndexPath(),
-            $this->excludedPathsPath()
+            $this->excludedPathsPath(),
+            PushPathMapping::identity($this->localTreeRoot())
         );
     }
 
@@ -71,11 +76,11 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(1, 0);
         $this->assertSame(
             ['second.txt'],
-            $this->listPaths($secondPlan->get_local_paths_to_push_path())
+            $this->listPaths($secondPlan->get_paths_to_push_path())
         );
         $this->assertSame(
             [],
-            $this->localPathsToDelete($secondPlan->get_local_paths_to_delete_path())
+            $this->localPathsToDelete($secondPlan->get_target_paths_to_delete_path())
         );
     }
 
@@ -104,24 +109,44 @@ final class PushPlanTest extends TestCase
                 'link',
                 'wp-content/themes/foo/style.css',
             ],
-            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+            $this->listPaths($this->planPath('paths-to-push.jsonl'))
         );
-        $this->assertSame('', file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame('', file_get_contents($this->planPath('local-paths-to-delete')));
+        $this->assertSame(
+            '',
+            file_get_contents($this->planPath('paths-to-delete'))
+        );
+        $this->assertFileExists(
+            $this->planPath('.local-index.next.jsonl')
+        );
+        $this->assertFileExists(
+            $this->planPath('paths-to-push.jsonl')
+        );
+        $this->assertFileExists(
+            $this->planPath('local-paths-to-delete')
+        );
+        $this->assertFileExists(
+            $this->planPath('paths-to-delete')
+        );
 
-        // Pin the local_paths_to_push representation: paths remain base64 in JSONL.
-        $pathsToPush = file_get_contents($this->planPath('local_paths_to_push.jsonl'));
+        // Pin the paths-to-push representation: both coordinates remain base64 in JSONL.
+        $pathsToPush = file_get_contents($this->planPath('paths-to-push.jsonl'));
         $this->assertIsString($pathsToPush);
         $firstLine = strtok($pathsToPush, "\n");
         $firstPath = json_decode($firstLine, true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame(
             base64_encode('empty-directory'),
-            $firstPath['path_b64']
+            $firstPath['local_path_b64']
+        );
+        $this->assertSame(
+            base64_encode('empty-directory'),
+            $firstPath['target_path_b64']
         );
         $this->assertSame('dir', $firstPath['type']);
         $this->assertSame(0, $firstPath['size']);
         $this->assertIsInt($firstPath['ctime']);
         $plannedLines = file(
-            $this->planPath('local_paths_to_push.jsonl'),
+            $this->planPath('paths-to-push.jsonl'),
             FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
         );
         $this->assertIsArray($plannedLines);
@@ -162,10 +187,10 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(3, 1);
-        $this->assertSame(['empty', 'full/child.txt', 'public.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame("gone.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame(['empty', 'full/child.txt', 'public.txt'], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame("gone.txt\0", file_get_contents($this->planPath('local-paths-to-delete')));
 
-        $freshLocalIndexEntries = $this->indexEntries($this->planPath('fresh_local_index.jsonl'));
+        $freshLocalIndexEntries = $this->indexEntries($this->planPath('.local-index.next.jsonl'));
         $this->assertSame(
             ['empty', 'full', 'full/child.txt', 'private', 'private/current.txt', 'public.txt'],
             array_keys($freshLocalIndexEntries)
@@ -174,6 +199,49 @@ final class PushPlanTest extends TestCase
         $this->assertFalse($freshLocalIndexEntries['full']['empty']);
         $this->assertFalse($freshLocalIndexEntries['private']['empty']);
         $this->assertArrayNotHasKey('empty', $freshLocalIndexEntries['public.txt']);
+    }
+
+    public function testRemappedPlansUseTargetPathsForOperationsAndExclusions(): void
+    {
+        $this->saveLocalIndex($this->writeIndex([
+            'plugins/deleted.php' => [1, 3, 'file'],
+            'plugins/private/value.php' => [1, 3, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'plugins/added.php' => [2, 4, 'file'],
+            'plugins/private/value.php' => [2, 5, 'file'],
+        ]);
+        $mapping = $this->remappedPluginsPathMapping();
+
+        $plan = $this->startPlan(
+            $current,
+            ['wp-content/plugins/private'],
+            $mapping
+        );
+        $this->planToCompletion($plan);
+
+        $this->assertSame(
+            ['plugins/added.php'],
+            $this->listPaths($this->planPath('paths-to-push.jsonl'))
+        );
+        $this->assertSame(
+            ['wp-content/plugins/added.php'],
+            $this->listTargetPaths(
+                $this->planPath('paths-to-push.jsonl')
+            )
+        );
+        $this->assertSame(
+            ['plugins/deleted.php'],
+            $this->localPathsToDelete(
+                $this->planPath('local-paths-to-delete')
+            )
+        );
+        $this->assertSame(
+            ['wp-content/plugins/deleted.php'],
+            $this->localPathsToDelete(
+                $this->planPath('paths-to-delete')
+            )
+        );
     }
 
     public function testUnchangedIndexProducesEmptyPlans(): void
@@ -188,8 +256,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(0, 0);
-        $this->assertSame([], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame('', file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame([], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame('', file_get_contents($this->planPath('local-paths-to-delete')));
     }
 
     public function testCtimeSizeOrTypeChangeEachMarksThePathChanged(): void
@@ -219,7 +287,7 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(3, 0);
         $this->assertSame(
             ['ctime-bump.txt', 'size-bump.txt', 'type-swap'],
-            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+            $this->listPaths($this->planPath('paths-to-push.jsonl'))
         );
     }
 
@@ -261,8 +329,8 @@ final class PushPlanTest extends TestCase
                 $this->planToCompletion($plan);
                 $message = $previousType . ' to ' . $currentType;
 
-                $this->assertSame($expectedPushes, $this->listPaths($this->planPath('local_paths_to_push.jsonl')), $message);
-                $this->assertSame($expectedDeletes, $this->localPathsToDelete($this->planPath('local_paths_to_delete')), $message);
+                $this->assertSame($expectedPushes, $this->listPaths($this->planPath('paths-to-push.jsonl')), $message);
+                $this->assertSame($expectedDeletes, $this->localPathsToDelete($this->planPath('local-paths-to-delete')), $message);
                 $this->assertPathCounts(count($expectedPushes), count($expectedDeletes), $message);
                 $this->removePlanDirectory();
             }
@@ -284,8 +352,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(0, 1);
-        $this->assertSame([], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame("gone\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame([], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame("gone\0", file_get_contents($this->planPath('local-paths-to-delete')));
     }
 
     public function testDeletedDirectoryPathCoversOnlyItsDescendants(): void
@@ -312,7 +380,7 @@ final class PushPlanTest extends TestCase
 
         $this->assertSame(
             "directory\0directory-sibling.txt\0",
-            file_get_contents($this->planPath('local_paths_to_delete'))
+            file_get_contents($this->planPath('local-paths-to-delete'))
         );
     }
 
@@ -342,9 +410,9 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(3, 1);
         $this->assertSame(
             "directory\0",
-            file_get_contents($this->planPath('local_paths_to_delete'))
+            file_get_contents($this->planPath('local-paths-to-delete'))
         );
-        $this->assertCount(3, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
+        $this->assertCount(3, $this->listPaths($this->planPath('paths-to-push.jsonl')));
     }
 
     public function testReplacementRootSurvivesSiblingPaths(): void
@@ -362,8 +430,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(2, 1);
-        $this->assertSame(['a', 'a-other'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame("a\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame(['a', 'a-other'], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame("a\0", file_get_contents($this->planPath('local-paths-to-delete')));
     }
 
     public function testDescendantChangesDoNotReplanAnUnchangedSibling(): void
@@ -383,8 +451,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(1, 1);
-        $this->assertSame(['a/new-child.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame("a/child.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame(['a/new-child.txt'], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame("a/child.txt\0", file_get_contents($this->planPath('local-paths-to-delete')));
     }
 
     public function testNewChangedDeletedAndUnchangedPathsArePlannedTogether(): void
@@ -405,8 +473,8 @@ final class PushPlanTest extends TestCase
 
         $this->assertPathCounts(2, 1);
         // Output order follows decoded path order from the indexes.
-        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame("deleted.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame(['added.txt', 'changed.txt'], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame("deleted.txt\0", file_get_contents($this->planPath('local-paths-to-delete')));
     }
 
     public function testPathsThatNeedBase64SurvivePushAndDeletePlans(): void
@@ -425,8 +493,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(1, 1);
-        $this->assertSame([$newPath], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame($deletedPath . "\0", file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame([$newPath], $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame($deletedPath . "\0", file_get_contents($this->planPath('local-paths-to-delete')));
     }
 
     // ------------------------------------------------------------------
@@ -441,18 +509,18 @@ final class PushPlanTest extends TestCase
         $oldIndex = $this->writeIndex(['old.txt' => [1, 1, 'file']]);
         $plan = $this->startPlan($oldIndex);
         $this->planToCompletion($plan);
-        $this->assertGreaterThan(0, filesize($this->planPath('fresh_local_index.jsonl')));
-        $this->assertGreaterThan(0, filesize($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertGreaterThan(0, filesize($this->planPath('local_paths_to_delete')));
+        $this->assertGreaterThan(0, filesize($this->planPath('.local-index.next.jsonl')));
+        $this->assertGreaterThan(0, filesize($this->planPath('paths-to-push.jsonl')));
+        $this->assertGreaterThan(0, filesize($this->planPath('local-paths-to-delete')));
         $this->removePlanDirectory();
 
         $current = $this->writeIndex($this->manyFileEntries(2));
         $plan = $this->startPlan($current);
-        $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
+        $this->assertCount(2, $this->indexEntries($this->planPath('.local-index.next.jsonl')));
         $this->assertSame('diffing', $this->planCursor()['phase']);
         $this->assertFileDoesNotExist($this->planPath('cursor.json'));
-        $this->assertSame(0, filesize($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(0, filesize($this->planPath('local_paths_to_delete')));
+        $this->assertSame(0, filesize($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame(0, filesize($this->planPath('local-paths-to-delete')));
         $plan->close();
     }
 
@@ -465,16 +533,16 @@ final class PushPlanTest extends TestCase
         $this->assertTrue($this->nextPlanStep($plan));
 
         $this->assertPathCounts(1, 0);
-        $this->assertCount(1, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(0, filesize($this->planPath('local_paths_to_delete')));
+        $this->assertCount(1, $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame(0, filesize($this->planPath('local-paths-to-delete')));
         $plan->close();
 
         $resumedPlan = $this->resumePlan();
         $this->planToCompletion($resumedPlan);
 
         $this->assertPathCounts(2, 0);
-        $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
+        $this->assertCount(2, $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertCount(2, $this->indexEntries($this->planPath('.local-index.next.jsonl')));
     }
 
     public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
@@ -494,7 +562,7 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(2, 0);
         $this->assertSame(
             ['file-0000.txt', 'file-0001.txt'],
-            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+            $this->listPaths($this->planPath('paths-to-push.jsonl'))
         );
     }
 
@@ -546,15 +614,20 @@ final class PushPlanTest extends TestCase
             'byte_offset_in_local_index',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
+            'byte_offset_in_target_paths_to_delete',
             'deleted_directory_path_b64',
         ], array_keys($cursor));
         $this->assertSame(
-            filesize($this->planPath('local_paths_to_push.jsonl')),
+            filesize($this->planPath('paths-to-push.jsonl')),
             $cursor['byte_offset_in_local_paths_to_push']
         );
         $this->assertSame(
-            filesize($this->planPath('local_paths_to_delete')),
+            filesize($this->planPath('local-paths-to-delete')),
             $cursor['byte_offset_in_local_paths_to_delete']
+        );
+        $this->assertSame(
+            filesize($this->planPath('paths-to-delete')),
+            $cursor['byte_offset_in_target_paths_to_delete']
         );
         $this->assertFileDoesNotExist($this->planPath('cursor.json'));
         $plan->close();
@@ -575,27 +648,27 @@ final class PushPlanTest extends TestCase
         $plan = $this->startPlan($current);
 
         $this->assertTrue($this->nextPlanStep($plan));
-        $firstPushBytes = filesize($this->planPath('local_paths_to_push.jsonl'));
-        $firstDeleteBytes = filesize($this->planPath('local_paths_to_delete'));
+        $firstPushBytes = filesize($this->planPath('paths-to-push.jsonl'));
+        $firstDeleteBytes = filesize($this->planPath('local-paths-to-delete'));
         $plan->close();
 
         $reopened = $this->resumePlan();
         $this->assertTrue($this->nextPlanStep($reopened));
         $this->assertSame(
             $firstPushBytes,
-            filesize($this->planPath('local_paths_to_push.jsonl'))
+            filesize($this->planPath('paths-to-push.jsonl'))
         );
         $this->assertGreaterThan(
             $firstDeleteBytes,
-            filesize($this->planPath('local_paths_to_delete'))
+            filesize($this->planPath('local-paths-to-delete'))
         );
 
         $this->planToCompletion($reopened);
 
         $this->assertPathCounts(3, 3);
-        $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
-        $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
+        $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local-paths-to-delete')));
+        $this->assertCount(3, $this->indexEntries($this->planPath('.local-index.next.jsonl')));
     }
 
     public function testSavedOffsetsAndCompletedEofAreIdempotentAfterRestart(): void
@@ -607,9 +680,12 @@ final class PushPlanTest extends TestCase
 
         $reopened = $this->resumePlan();
         $this->assertFalse($this->nextPlanStep($reopened));
-        $freshLocalIndex = file_get_contents($this->planPath('fresh_local_index.jsonl'));
-        $pathsToPush = file_get_contents($this->planPath('local_paths_to_push.jsonl'));
-        $localPathsToDelete = file_get_contents($this->planPath('local_paths_to_delete'));
+        $freshLocalIndex = file_get_contents($this->planPath('.local-index.next.jsonl'));
+        $pathsToPush = file_get_contents($this->planPath('paths-to-push.jsonl'));
+        $localPathsToDelete = file_get_contents($this->planPath('local-paths-to-delete'));
+        $targetPathsToDelete = file_get_contents(
+            $this->planPath('paths-to-delete')
+        );
         $reopened->close();
 
         $replayedPlan = $this->resumePlan();
@@ -617,9 +693,13 @@ final class PushPlanTest extends TestCase
         $replayedPlan->close();
 
         $this->assertFalse($replayedEof);
-        $this->assertSame($freshLocalIndex, file_get_contents($this->planPath('fresh_local_index.jsonl')));
-        $this->assertSame($pathsToPush, file_get_contents($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame($localPathsToDelete, file_get_contents($this->planPath('local_paths_to_delete')));
+        $this->assertSame($freshLocalIndex, file_get_contents($this->planPath('.local-index.next.jsonl')));
+        $this->assertSame($pathsToPush, file_get_contents($this->planPath('paths-to-push.jsonl')));
+        $this->assertSame($localPathsToDelete, file_get_contents($this->planPath('local-paths-to-delete')));
+        $this->assertSame(
+            $targetPathsToDelete,
+            file_get_contents($this->planPath('paths-to-delete'))
+        );
     }
 
     public function testResumeUsesTheSuppliedExcludedPaths(): void
@@ -638,7 +718,7 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(2, 0);
         $this->assertNotContains(
             'private/value.txt',
-            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+            $this->listPaths($this->planPath('paths-to-push.jsonl'))
         );
     }
 
@@ -647,7 +727,11 @@ final class PushPlanTest extends TestCase
     // ------------------------------------------------------------------
 
     /** @param list<string> $excludedPaths */
-    private function startPlan(?string $treeDescriptionPath = null, array $excludedPaths = []): PushPlan
+    private function startPlan(
+        ?string $treeDescriptionPath = null,
+        array $excludedPaths = [],
+        ?PushPathMapping $pathMapping = null
+    ): PushPlan
     {
         if ($treeDescriptionPath === null) {
             $treeDescriptionPath = $this->tempDir . '/empty-tree.jsonl';
@@ -666,11 +750,14 @@ final class PushPlanTest extends TestCase
                 JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
             )
         );
+        $this->pathMapping = $pathMapping
+            ?? PushPathMapping::identity($this->localTreeRoot());
         $plan = PushPlan::start(
             $this->planDirectory(),
             $this->localTreeRoot(),
             $this->localIndexPath(),
-            $this->excludedPathsPath()
+            $this->excludedPathsPath(),
+            $this->pathMapping
         );
         $this->cursor = $plan->get_cursor();
         for ($step = 0; $step < 100; ++$step) {
@@ -689,6 +776,7 @@ final class PushPlanTest extends TestCase
             $this->localTreeRoot(),
             $this->localIndexPath(),
             $this->excludedPathsPath(),
+            $this->pathMapping,
             $this->cursor
         );
     }
@@ -703,7 +791,7 @@ final class PushPlanTest extends TestCase
         if (!is_dir(dirname($this->localIndexPath()))) {
             mkdir(dirname($this->localIndexPath()), 0755, true);
         }
-        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexPath());
+        copy($this->planPath('.local-index.next.jsonl'), $this->localIndexPath());
         $this->removePlanDirectory();
     }
 
@@ -745,12 +833,21 @@ final class PushPlanTest extends TestCase
     ): void {
         $this->assertCount(
             $localPathsToPushCount,
-            $this->listPaths($this->planPath('local_paths_to_push.jsonl')),
+            $this->listPaths($this->planPath('paths-to-push.jsonl')),
             $message
         );
-        $localPathsToDelete = file_get_contents($this->planPath('local_paths_to_delete'));
+        $localPathsToDelete = file_get_contents($this->planPath('local-paths-to-delete'));
         $this->assertIsString($localPathsToDelete);
         $this->assertSame($localPathsToDeleteCount, substr_count($localPathsToDelete, "\0"), $message);
+        $targetPathsToDelete = file_get_contents(
+            $this->planPath('paths-to-delete')
+        );
+        $this->assertIsString($targetPathsToDelete);
+        $this->assertSame(
+            $localPathsToDeleteCount,
+            substr_count($targetPathsToDelete, "\0"),
+            $message
+        );
     }
 
     private function planDirectory(): string
@@ -776,7 +873,7 @@ final class PushPlanTest extends TestCase
 
     private function excludedPathsPath(): string
     {
-        return $this->pushStateDirectory() . '/excluded_paths.json';
+        return $this->pushStateDirectory() . '/excluded-paths.json';
     }
 
     private function removePlanDirectory(): void
@@ -787,6 +884,45 @@ final class PushPlanTest extends TestCase
     private function localTreeRoot(): string
     {
         return $this->tempDir . '/local-tree-root';
+    }
+
+    private function remappedPluginsPathMapping(): PushPathMapping
+    {
+        $canonicalLocalTree = realpath($this->localTreeRoot());
+        $this->assertIsString($canonicalLocalTree);
+        $mappingFile = $this->tempDir . '/path-mapping.json';
+        file_put_contents(
+            $mappingFile,
+            json_encode([
+                'target_url_fingerprint' => str_repeat('1', 64),
+                'filesystem_root_b64' => base64_encode($canonicalLocalTree),
+                'local_tree_b64' => base64_encode($canonicalLocalTree),
+                'target_document_root_b64' =>
+                    base64_encode('/var/www/html'),
+                'prefix_rules' => [
+                    [
+                        'kind' => 'default',
+                        'remote_prefix_b64' =>
+                            base64_encode('/var/www/html'),
+                        'local_prefix_b64' =>
+                            base64_encode($canonicalLocalTree),
+                    ],
+                    [
+                        'kind' => 'remap',
+                        'remote_prefix_b64' => base64_encode(
+                            '/var/www/html/wp-content/plugins'
+                        ),
+                        'local_prefix_b64' => base64_encode(
+                            $canonicalLocalTree . '/plugins'
+                        ),
+                    ],
+                ],
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+        return PushPathMapping::from_file(
+            $mappingFile,
+            $this->localTreeRoot()
+        );
     }
 
     /**
@@ -954,7 +1090,23 @@ final class PushPlanTest extends TestCase
         $paths = [];
         foreach ($lines as $line) {
             $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-            $path = base64_decode($data['path_b64'], true);
+            $path = base64_decode($data['local_path_b64'], true);
+            $this->assertIsString($path);
+            $paths[] = $path;
+        }
+        return $paths;
+    }
+
+    /** @return list<string> */
+    private function listTargetPaths(string $file): array
+    {
+        $this->assertFileExists($file);
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertIsArray($lines);
+        $paths = [];
+        foreach ($lines as $line) {
+            $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $path = base64_decode($data['target_path_b64'], true);
             $this->assertIsString($path);
             $paths[] = $path;
         }
@@ -971,7 +1123,7 @@ final class PushPlanTest extends TestCase
             return [];
         }
         $paths = explode("\0", $bytes);
-        $this->assertSame('', array_pop($paths), 'The local_paths_to_delete file must end after a NUL-terminated path.');
+        $this->assertSame('', array_pop($paths), 'The local-paths-to-delete file must end after a NUL-terminated path.');
         return $paths;
     }
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1391,7 +1391,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
+        $this->assertFileDoesNotExist($push_state_directory . '/excluded-paths.json');
         $this->assertFileExists($this->localIndexPath($push_state_directory));
     }
 
@@ -1463,7 +1463,7 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Sends one local path to delete and returns before reading the next one.
+     * Sends one target path to delete and returns before reading the next one.
      */
     public function testHighLevelSenderSendsOneDeletionListPartPerStep(): void
     {
@@ -1488,21 +1488,21 @@ final class PushEndpointsTest extends TestCase {
         }
         $this->assertIsArray($state);
 
-        $local_paths_to_delete_handle_property = new ReflectionProperty(
+        $target_paths_to_delete_handle_property = new ReflectionProperty(
             PushFilesSender::class,
-            'local_paths_to_delete_handle'
+            'target_paths_to_delete_handle'
         );
         $sender = $this->resumeSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
         try {
             $this->assertTrue($sender->next_step());
-            $local_paths_to_delete_handle = $local_paths_to_delete_handle_property->getValue($sender);
-            $this->assertIsResource($local_paths_to_delete_handle);
-            $this->assertSame(14, ftell($local_paths_to_delete_handle));
+            $target_paths_to_delete_handle = $target_paths_to_delete_handle_property->getValue($sender);
+            $this->assertIsResource($target_paths_to_delete_handle);
+            $this->assertSame(14, ftell($target_paths_to_delete_handle));
 
             $this->assertTrue($sender->next_step());
-            $this->assertSame(28, ftell($local_paths_to_delete_handle));
+            $this->assertSame(28, ftell($target_paths_to_delete_handle));
         } finally {
             if ($sender->get_status() === 'continue') {
                 $sender->cancel();
@@ -1642,7 +1642,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/a.txt', 'a');
         file_put_contents($local_docroot . '/b.txt', 'bb');
         $push_state_directory = $this->root . '/bounded-index-state';
-        $fresh_local_index_path = $push_state_directory . '/plan/fresh_local_index.jsonl';
+        $fresh_local_index_path = $push_state_directory . '/plan/.local-index.next.jsonl';
         $options = $this->senderOptions($local_docroot, $push_state_directory);
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
         $file_index_processor_property = new ReflectionProperty(PushPlan::class, 'file_index_processor');
@@ -1657,10 +1657,10 @@ final class PushEndpointsTest extends TestCase {
             $this->takeSenderStepsUntilPhase($sender, 'planning');
             $this->assertFileExists($fresh_local_index_path);
             $this->assertFileExists(
-                $push_state_directory . '/excluded_paths.json'
+                $push_state_directory . '/excluded-paths.json'
             );
             $this->assertFileDoesNotExist(
-                $push_state_directory . '/plan/excluded_paths.json'
+                $push_state_directory . '/plan/excluded-paths.json'
             );
             $this->assertFileDoesNotExist($push_state_directory . '/plan/cursor.json');
             $plan = $plan_property->getValue($sender);
@@ -1788,9 +1788,9 @@ final class PushEndpointsTest extends TestCase {
             'local_paths_to_push_handle'
         );
         $local_file_handle_property = new ReflectionProperty(PushFilesSender::class, 'local_file_handle');
-        $local_paths_to_delete_handle_property = new ReflectionProperty(
+        $target_paths_to_delete_handle_property = new ReflectionProperty(
             PushFilesSender::class,
-            'local_paths_to_delete_handle'
+            'target_paths_to_delete_handle'
         );
         $push_stream_client_property = new ReflectionProperty(PushFilesSender::class, 'push_stream_client');
         $curl_handle_property = new ReflectionProperty(MultipartPushStreamClient::class, 'curl_handle');
@@ -1852,28 +1852,28 @@ final class PushEndpointsTest extends TestCase {
             $sender->next_step();
             $first_delete_chunk = $this->senderResult($sender);
             $this->assertSame('pushing_deletes', $first_delete_chunk['phase']);
-            $local_paths_to_delete_handle = $local_paths_to_delete_handle_property->getValue($sender);
-            $this->assertIsResource($local_paths_to_delete_handle);
-            $local_paths_to_delete_position = ftell($local_paths_to_delete_handle);
-            $this->assertIsInt($local_paths_to_delete_position);
+            $target_paths_to_delete_handle = $target_paths_to_delete_handle_property->getValue($sender);
+            $this->assertIsResource($target_paths_to_delete_handle);
+            $target_paths_to_delete_position = ftell($target_paths_to_delete_handle);
+            $this->assertIsInt($target_paths_to_delete_position);
 
             $sender->next_step();
 
             $second_delete_chunk = $this->senderResult($sender);
             $this->assertSame('pushing_deletes', $second_delete_chunk['phase']);
             $this->assertSame(
-                $local_paths_to_delete_handle,
-                $local_paths_to_delete_handle_property->getValue($sender)
+                $target_paths_to_delete_handle,
+                $target_paths_to_delete_handle_property->getValue($sender)
             );
             $this->assertGreaterThan(
-                $local_paths_to_delete_position,
-                ftell($local_paths_to_delete_handle)
+                $target_paths_to_delete_position,
+                ftell($target_paths_to_delete_handle)
             );
         } finally {
             $this->closeSender($sender);
         }
-        $this->assertNull($local_paths_to_delete_handle_property->getValue($sender));
-        $this->assertFalse(is_resource($local_paths_to_delete_handle));
+        $this->assertNull($target_paths_to_delete_handle_property->getValue($sender));
+        $this->assertFalse(is_resource($target_paths_to_delete_handle));
     }
 
     /**
@@ -2061,7 +2061,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
+        $this->assertFileDoesNotExist($push_state_directory . '/excluded-paths.json');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
@@ -2107,7 +2107,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('local_path_changed', $result['reason']);
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
+        $this->assertFileDoesNotExist($push_state_directory . '/excluded-paths.json');
         $this->assertDirectoryDoesNotExist($this->reprint_directory . '/.reprint/push/' . $push_session_id);
     }
 
@@ -2478,7 +2478,7 @@ final class PushEndpointsTest extends TestCase {
             }
         }
         $this->assertIsArray($state);
-        $deletions = (string) file_get_contents($push_state_directory . '/plan/local_paths_to_delete');
+        $deletions = (string) file_get_contents($push_state_directory . '/plan/paths-to-delete');
         $this->assertSame("delete-after-lost-response.txt\0", $deletions);
         $boundary = 'reprint-lost-delete-response';
         $delete_body = '--' . $boundary . "\r\n"
@@ -2626,6 +2626,133 @@ final class PushEndpointsTest extends TestCase {
         );
     }
 
+    public function testHighLevelSenderPushesRemappedPathsInTargetCoordinates(): void
+    {
+        $local_docroot = $this->root . '/remapped-push-local-docroot';
+        $local_plugins = $local_docroot . '/plugins/example';
+        $target_plugins = $this->docroot . '/wp-content/plugins/example';
+        mkdir($local_plugins, 0700, true);
+        mkdir($target_plugins, 0700, true);
+        file_put_contents($local_plugins . '/plugin.php', 'edited plugin');
+        file_put_contents($local_plugins . '/added.php', 'added plugin');
+        file_put_contents($local_docroot . '/theme.txt', 'target-root file');
+        symlink('../../theme.txt', $local_plugins . '/theme-link');
+        file_put_contents($target_plugins . '/plugin.php', 'old plugin');
+        file_put_contents($target_plugins . '/deleted.php', 'deleted plugin');
+
+        $push_state_directory = $this->root . '/remapped-push-state';
+        $local_index_fixture = $this->root . '/remapped-push-index.jsonl';
+        $this->writeIndex($local_index_fixture, [
+            'plugins/example/deleted.php' => [1, 14, 'file'],
+            'plugins/example/plugin.php' => [1, 10, 'file'],
+        ]);
+        $this->seedLocalIndex(
+            $push_state_directory,
+            $local_index_fixture
+        );
+        $canonical_local_docroot = realpath($local_docroot);
+        $canonical_target_docroot = realpath($this->docroot);
+        $this->assertIsString($canonical_local_docroot);
+        $this->assertIsString($canonical_target_docroot);
+        $path_mapping_path =
+            $this->root . '/remapped-push-path-mapping.json';
+        file_put_contents(
+            $path_mapping_path,
+            json_encode([
+                'target_url_fingerprint' => str_repeat('1', 64),
+                'filesystem_root_b64' => base64_encode(
+                    $canonical_local_docroot
+                ),
+                'local_tree_b64' => base64_encode(
+                    $canonical_local_docroot
+                ),
+                'target_document_root_b64' => base64_encode(
+                    $canonical_target_docroot
+                ),
+                'prefix_rules' => [
+                    [
+                        'kind' => 'default',
+                        'remote_prefix_b64' => base64_encode(
+                            $canonical_target_docroot
+                        ),
+                        'local_prefix_b64' => base64_encode(
+                            $canonical_local_docroot
+                        ),
+                    ],
+                    [
+                        'kind' => 'remap',
+                        'remote_prefix_b64' => base64_encode(
+                            $canonical_target_docroot
+                            . '/wp-content/plugins'
+                        ),
+                        'local_prefix_b64' => base64_encode(
+                            $canonical_local_docroot . '/plugins'
+                        ),
+                    ],
+                ],
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+
+        $options = $this->senderOptions(
+            $local_docroot,
+            $push_state_directory
+        );
+        $options['path_mapping_path'] = $path_mapping_path;
+        $sender = $this->startSender($options);
+        try {
+            for ($step = 0; $step < 200; ++$step) {
+                $has_more_steps = $sender->next_step();
+                $result = $this->senderResult($sender);
+                $this->assertNotSame(
+                    'failed',
+                    $result['status'],
+                    (string) json_encode($result)
+                );
+                if (!$has_more_steps) {
+                    break;
+                }
+            }
+        } finally {
+            $this->closeSender($sender);
+        }
+
+        $this->assertSame(
+            'complete',
+            $result['status'],
+            (string) json_encode($result)
+        );
+        $this->assertSame(
+            'edited plugin',
+            file_get_contents($target_plugins . '/plugin.php')
+        );
+        $this->assertSame(
+            'added plugin',
+            file_get_contents($target_plugins . '/added.php')
+        );
+        $this->assertFileDoesNotExist(
+            $target_plugins . '/deleted.php'
+        );
+        $this->assertSame(
+            '../../../theme.txt',
+            readlink($target_plugins . '/theme-link')
+        );
+        $this->assertSame(
+            'target-root file',
+            file_get_contents($this->docroot . '/theme.txt')
+        );
+        $local_index = (string) file_get_contents(
+            $this->localIndexPath($push_state_directory)
+        );
+        $this->assertStringContainsString(
+            base64_encode('plugins/example/plugin.php'),
+            $local_index
+        );
+        $this->assertStringNotContainsString(
+            base64_encode('wp-content/plugins/example/plugin.php'),
+            $local_index
+        );
+    }
+
     public function testCompletedFilesPushUpdatesTheLocalIndexForFilesDiff(): void
     {
         $local_docroot = $this->root . '/push-diff-local-docroot';
@@ -2659,7 +2786,8 @@ final class PushEndpointsTest extends TestCase {
             json_encode([
                 'command' => 'files-diff',
                 'action' => 'push',
-                'path_b64' => base64_encode('pushed.txt'),
+                'local_path_b64' => base64_encode('pushed.txt'),
+                'target_path_b64' => base64_encode('pushed.txt'),
                 'type' => 'file',
                 'size' => (int) $changed_stat['size'],
                 'ctime' => (int) $changed_stat['ctime'],


### PR DESCRIPTION
This sends remapped local edits, additions, deletions, and symlinks back to their original target paths while keeping \`.local-index.jsonl\` in local coordinates.

Push plans write both \`local_path_b64\` and \`target_path_b64\`. Local stat, read, and index updates use the local path; target exclusions, status checks, multipart uploads, and deletion parts use the target path. Separate local and target deletion lists keep receiver byte offsets independent from the committed local-index update.

Mapping validation runs before sender startup and rejects paths outside the target document root, ambiguous inverses, uncovered local trees, and mapping prefixes which traverse symlinks. The real endpoint test covers remapped edits, additions, deletions, and a rewritten symlink target.

Focused importer and endpoint tests pass, PHPStan reports no errors, PHP 7.4 compatibility passes, and PHPCS counts do not increase. The complete local PHPUnit run was limited only by 158 MySQL-dependent cases and one MySQL connection assertion because no MySQL server is listening in this workspace.

Stacked on #414.