### PR TITLE
Require the complete current importer state schema

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -356,13 +356,8 @@ class ImportClient
      *  that consumers should display as "files done". */
     private $fetch_list_done = null;
 
-    /**
-     * @var ImportState Persistent import state loaded from / saved to $state_file.
-     *
-     * The on-disk schema remains JSON, but in-process code gets documented
-     * state objects and typed nested properties.
-     */
-    public $state;
+    /** @var ImportState Persistent import state loaded from / saved to $state_file. */
+    private ImportState $state;
 
     /** @var bool Set to true by SIGTERM/SIGINT handler to finish the current chunk and exit cleanly. */
     private $shutdown_requested = false;
@@ -6828,6 +6823,7 @@ class ImportClient
             "offset" => $next_offset,
             "next_offset" => $next_offset,
             "batch_file" => null,
+            "batch_entries" => 0,
             "cursor" => null,
         ]));
         $this->save_state($this->state);
@@ -11016,48 +11012,26 @@ class ImportClient
     }
 
     /**
-     * Reset state to defaults while preserving cross-command data like
-     * preflight results, version, and follow_symlinks.
+     * Reset command state while preserving data shared across commands.
      */
     private function reset_state(): void
     {
-        $preflight = $this->import_state()->preflight ?? null;
-        $version = $this->import_state()->version ?? null;
-        $webhost = $this->import_state()->webhost ?? null;
-        $follow = $this->import_state()->follow_symlinks ?? false;
-        $nonempty = $this->import_state()->fs_root_nonempty_behavior ?? "error";
-        $max_packet = $this->import_state()->max_allowed_packet ?? null;
-        $resolved_path_mappings_fingerprint = $this->import_state()->resolved_path_mappings_fingerprint ?? null;
-        $pull = $this->import_state()->pull_pipeline ?? null;
+        $previous_state = $this->state;
         $this->state = new ImportState();
-        $this->import_state()->preflight = $preflight;
-        $this->import_state()->version = $version;
-        $this->import_state()->webhost = $webhost;
-        $this->import_state()->follow_symlinks = $follow;
-        $this->import_state()->fs_root_nonempty_behavior = $nonempty;
-        $this->import_state()->max_allowed_packet = $max_packet;
-        $this->import_state()->resolved_path_mappings_fingerprint = $resolved_path_mappings_fingerprint;
-        if ($pull !== null) {
-            $this->import_state()->pull_pipeline = $pull;
-        }
+        $this->state->preflight = $previous_state->preflight;
+        $this->state->version = $previous_state->version;
+        $this->state->webhost = $previous_state->webhost;
+        $this->state->follow_symlinks = $previous_state->follow_symlinks;
+        $this->state->fs_root_nonempty_behavior = $previous_state->fs_root_nonempty_behavior;
+        $this->state->max_allowed_packet = $previous_state->max_allowed_packet;
+        $this->state->resolved_path_mappings_fingerprint = $previous_state->resolved_path_mappings_fingerprint;
+        $this->state->pull_pipeline = $previous_state->pull_pipeline;
     }
 
-    /** Return the in-process typed state, hydrating legacy arrays at the boundary. */
+    /** Return the in-process import state. */
     private function import_state(): ImportState
     {
-        if (!$this->state instanceof ImportState) {
-            $this->state = ImportState::from_array($this->state_to_array($this->state));
-        }
         return $this->state;
-    }
-
-    /** Convert either the typed state object or a legacy array to the persisted schema. */
-    private function state_to_array($state): array
-    {
-        if ($state instanceof ImportState) {
-            return $state->to_array();
-        }
-        return ImportState::from_array(is_array($state) ? $state : [])->to_array();
     }
 
     /**
@@ -11094,8 +11068,6 @@ class ImportClient
 
     /**
      * Decode base64-encoded path fields in state after loading.
-     *
-     * Supports legacy plain-string fields for backward compatibility.
      */
     private function decode_state_paths(array $state): array
     {
@@ -11280,16 +11252,16 @@ class ImportClient
             return $value;
         }
         if (!str_starts_with($value, self::STATE_PATH_ENCODING_PREFIX)) {
-            return $value;
+            throw new UnexpectedValueException(
+                "Import state path is missing the base64: encoding prefix."
+            );
         }
         $encoded = substr($value, strlen(self::STATE_PATH_ENCODING_PREFIX));
         $decoded = base64_decode($encoded, true);
         if ($decoded === false) {
-            $this->audit_log(
-                "Warning: invalid base64-encoded state path; resetting field",
-                true,
+            throw new UnexpectedValueException(
+                "Import state path contains invalid base64 after the base64: encoding prefix."
             );
-            return null;
         }
         return $decoded;
     }
@@ -11319,7 +11291,6 @@ class ImportClient
             return new ImportState();
         }
 
-        $state = $this->state_to_array($state);
         $state = $this->decode_state_paths($state);
 
         return ImportState::from_array($state);
@@ -11331,14 +11302,14 @@ class ImportClient
      * Uses atomic write (temp file + rename) to prevent corruption if
      * the process is killed mid-write.
      */
-    private function save_state($state): void
+    private function save_state(ImportState $state): void
     {
         // Keep the spinner alive between curl requests. save_state is
         // called frequently during streaming operations, so this fills
         // the gaps where curl's progress callback doesn't fire.
         $this->progress->tick_spinner();
 
-        $state = $this->state_to_array($state);
+        $state = $state->to_array();
         if ($this->tuner instanceof AdaptiveTuner) {
             $state["tuning"] = [
                 "config" => $this->tuner->get_config(),
@@ -11391,9 +11362,7 @@ class ImportClient
      */
     public function write_status_file(?string $error = null): void
     {
-        $state = $this->state instanceof ImportState
-            ? $this->state
-            : ImportState::from_array($this->state_to_array($this->state));
+        $state = $this->state;
         $command = $state->active_resumable_command->command_name;
         $status = $error !== null ? "error" : ($state->active_resumable_command->completion_state ?? "in_progress");
 

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -441,7 +441,7 @@ class Pull
                     $options['filter'] === 'essential-files' &&
                     $this->client->has_skipped_files_pending();
                 $this->client->set_pull_files_state($options['filter'], $skipped_pending);
-                $files_pulled = $this->client->state->files_pull_summary->files_pulled;
+                $files_pulled = $this->client->get_import_state()->files_pull_summary->files_pulled;
                 $pulled_label = $files_pulled === 1 ? 'file' : 'files';
                 $summary = sprintf(
                     '%s changed %s pulled',

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -1,9 +1,11 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Typed import-state objects.
  *
  * The importer persists state as JSON, so these objects keep explicit
- * in-process property names while to_array()/from_array() preserve the stable
+ * in-process property names while to_array()/from_array() define the current
  * on-disk schema.
  */
 
@@ -24,10 +26,11 @@ class ResumableCommandCheckpointState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->command_name = isset($data['command_name']) ? (string) $data['command_name'] : null;
-        $state->completion_state = isset($data['completion_state']) ? (string) $data['completion_state'] : null;
-        $state->current_stage = isset($data['current_stage']) ? (string) $data['current_stage'] : null;
-        $state->remote_cursor = isset($data['remote_cursor']) ? (string) $data['remote_cursor'] : null;
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->command_name = $data['command_name'];
+        $state->completion_state = $data['completion_state'];
+        $state->current_stage = $data['current_stage'];
+        $state->remote_cursor = $data['remote_cursor'];
         return $state;
     }
 
@@ -62,11 +65,12 @@ class DatabaseTableIndexState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->file = isset($data['file']) ? (string) $data['file'] : null;
-        $state->tables = (int) ($data['tables'] ?? 0);
-        $state->rows_estimated = (int) ($data['rows_estimated'] ?? 0);
-        $state->bytes = (int) ($data['bytes'] ?? 0);
-        $state->updated_at = isset($data['updated_at']) ? (string) $data['updated_at'] : null;
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->file = $data['file'];
+        $state->tables = $data['tables'];
+        $state->rows_estimated = $data['rows_estimated'];
+        $state->bytes = $data['bytes'];
+        $state->updated_at = $data['updated_at'];
         return $state;
     }
 
@@ -93,8 +97,9 @@ class FileDiffProgressState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->remote_offset = (int) ($data['remote_offset'] ?? 0);
-        $state->local_after = isset($data['local_after']) ? (string) $data['local_after'] : null;
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->remote_offset = $data['remote_offset'];
+        $state->local_after = $data['local_after'];
         return $state;
     }
 
@@ -115,7 +120,8 @@ class RemoteFileIndexCursorState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->cursor = isset($data['cursor']) ? (string) $data['cursor'] : null;
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->cursor = $data['cursor'];
         return $state;
     }
 
@@ -145,11 +151,12 @@ class FetchListProgressState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->offset = (int) ($data['offset'] ?? 0);
-        $state->next_offset = (int) ($data['next_offset'] ?? 0);
-        $state->batch_file = isset($data['batch_file']) ? (string) $data['batch_file'] : null;
-        $state->cursor = isset($data['cursor']) ? (string) $data['cursor'] : null;
-        $state->batch_entries = (int) ($data['batch_entries'] ?? 0);
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->offset = $data['offset'];
+        $state->next_offset = $data['next_offset'];
+        $state->batch_file = $data['batch_file'];
+        $state->cursor = $data['cursor'];
+        $state->batch_entries = $data['batch_entries'];
         return $state;
     }
 
@@ -173,7 +180,8 @@ class FilesPullSummaryState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->files_pulled = (int) ($data['files_pulled'] ?? 0);
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->files_pulled = $data['files_pulled'];
         return $state;
     }
 
@@ -225,19 +233,18 @@ class DatabaseApplyCommandState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->statements_executed = (int) ($data['statements_executed'] ?? 0);
-        $state->bytes_read = (int) ($data['bytes_read'] ?? 0);
-        $state->rewrite_url = isset($data['rewrite_url']) && is_array($data['rewrite_url']) ? $data['rewrite_url'] : null;
-        $state->target_engine = isset($data['target_engine']) ? (string) $data['target_engine'] : null;
-        $state->target_db = isset($data['target_db']) ? (string) $data['target_db'] : null;
-        $state->target_host = isset($data['target_host']) ? (string) $data['target_host'] : null;
-        $state->target_port = isset($data['target_port']) ? (int) $data['target_port'] : null;
-        $state->target_user = isset($data['target_user']) ? (string) $data['target_user'] : null;
-        $state->target_pass = isset($data['target_pass']) ? (string) $data['target_pass'] : null;
-        $state->target_sqlite_path = isset($data['target_sqlite_path']) ? (string) $data['target_sqlite_path'] : null;
-        $state->remote_paths_removed_from_local_site = isset($data['remote_paths_removed_from_local_site']) && is_array($data['remote_paths_removed_from_local_site'])
-            ? array_values($data['remote_paths_removed_from_local_site'])
-            : [];
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->statements_executed = $data['statements_executed'];
+        $state->bytes_read = $data['bytes_read'];
+        $state->rewrite_url = $data['rewrite_url'];
+        $state->target_engine = $data['target_engine'];
+        $state->target_db = $data['target_db'];
+        $state->target_host = $data['target_host'];
+        $state->target_port = $data['target_port'];
+        $state->target_user = $data['target_user'];
+        $state->target_pass = $data['target_pass'];
+        $state->target_sqlite_path = $data['target_sqlite_path'];
+        $state->remote_paths_removed_from_local_site = array_values($data['remote_paths_removed_from_local_site']);
         return $state;
     }
 
@@ -270,8 +277,9 @@ class AdaptiveTuningState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->config = isset($data['config']) && is_array($data['config']) ? $data['config'] : [];
-        $state->state = isset($data['state']) && is_array($data['state']) ? $data['state'] : [];
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->config = $data['config'];
+        $state->state = $data['state'];
         return $state;
     }
 
@@ -307,14 +315,13 @@ class PullPipelineCheckpointState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->started_by_command = isset($data['started_by_command']) ? (string) $data['started_by_command'] : null;
-        $state->stage_sequence = isset($data['stage_sequence']) && is_array($data['stage_sequence'])
-            ? array_values($data['stage_sequence'])
-            : [];
-        $state->last_completed_stage = isset($data['last_completed_stage']) ? (string) $data['last_completed_stage'] : null;
-        $state->files_filter = isset($data['files_filter']) ? (string) $data['files_filter'] : null;
-        $state->skipped_pending = (bool) ($data['skipped_pending'] ?? false);
-        $state->has_completed_once = (bool) ($data['has_completed_once'] ?? false);
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->started_by_command = $data['started_by_command'];
+        $state->stage_sequence = array_values($data['stage_sequence']);
+        $state->last_completed_stage = $data['last_completed_stage'];
+        $state->files_filter = $data['files_filter'];
+        $state->skipped_pending = $data['skipped_pending'];
+        $state->has_completed_once = $data['has_completed_once'];
         return $state;
     }
 
@@ -335,8 +342,7 @@ class PullPipelineCheckpointState
  * In-process import state with typed properties for each persisted field.
  *
  * This object mirrors .import-state.json. Add new persistent state here first;
- * from_array() accepts missing legacy fields and to_array() keeps the JSON
- * schema stable for existing installations.
+ * from_array() requires the complete current schema.
  */
 class ImportState
 {
@@ -414,42 +420,40 @@ class ImportState
     public static function from_array(array $data): self
     {
         $state = new self();
-        $state->active_resumable_command = self::resumable_command_checkpoint_from($data['active_resumable_command'] ?? []);
-        $state->preflight = isset($data['preflight']) && is_array($data['preflight']) ? $data['preflight'] : null;
-        $state->remote_protocol_version = isset($data['remote_protocol_version']) ? (int) $data['remote_protocol_version'] : null;
-        $state->remote_protocol_min_version = isset($data['remote_protocol_min_version']) ? (int) $data['remote_protocol_min_version'] : null;
-        $state->version = isset($data['version']) ? (string) $data['version'] : null;
-        $state->webhost = isset($data['webhost']) ? (string) $data['webhost'] : null;
-        $state->follow_symlinks = (bool) ($data['follow_symlinks'] ?? true);
-        $state->local_followed_symlinks_root_fingerprint = isset($data['local_followed_symlinks_root_fingerprint']) ? (string) $data['local_followed_symlinks_root_fingerprint'] : null;
-        $state->fs_root_nonempty_behavior = isset($data['fs_root_nonempty_behavior']) ? (string) $data['fs_root_nonempty_behavior'] : 'error';
-        $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
-        $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
-        $state->max_allowed_packet = isset($data['max_allowed_packet']) ? (int) $data['max_allowed_packet'] : null;
-        $state->resolved_path_mappings_fingerprint = isset($data['resolved_path_mappings_fingerprint']) ? (string) $data['resolved_path_mappings_fingerprint'] : null;
-        $state->files_pull_only_fingerprint = isset($data['files_pull_only_fingerprint']) ? (string) $data['files_pull_only_fingerprint'] : null;
-        $state->files_pull_summary = self::files_pull_summary_from($data['files_pull_summary'] ?? []);
-        $state->db_index = self::database_table_index_from($data['db_index'] ?? []);
-        $state->diff = self::file_diff_progress_from($data['diff'] ?? []);
-        $state->index = self::remote_file_index_cursor_from($data['index'] ?? []);
-        $state->fetch = self::fetch_list_progress_from($data['fetch'] ?? []);
-        $state->fetch_skipped = self::fetch_list_progress_from($data['fetch_skipped'] ?? []);
-        $state->current_file = isset($data['current_file']) ? (string) $data['current_file'] : null;
-        $state->current_file_bytes = isset($data['current_file_bytes']) ? (int) $data['current_file_bytes'] : null;
-        $state->sql_bytes = isset($data['sql_bytes']) ? (int) $data['sql_bytes'] : null;
-        $state->sql_statements_counted = (int) ($data['sql_statements_counted'] ?? 0);
-        $state->apply = self::database_apply_command_from($data['apply'] ?? []);
-        $state->sql_output = isset($data['sql_output']) ? (string) $data['sql_output'] : null;
-        $state->mysql_host = isset($data['mysql_host']) ? (string) $data['mysql_host'] : null;
-        $state->mysql_port = isset($data['mysql_port']) ? (int) $data['mysql_port'] : null;
-        $state->mysql_user = isset($data['mysql_user']) ? (string) $data['mysql_user'] : null;
-        $state->mysql_database = isset($data['mysql_database']) ? (string) $data['mysql_database'] : null;
-        $state->consecutive_interrupted_responses = (int) (
-            $data['consecutive_interrupted_responses']
-            ?? 0
-        );
-        $state->tuning = self::adaptive_tuning_from($data['tuning'] ?? []);
-        $state->pull_pipeline = self::pull_pipeline_checkpoint_from($data['pull_pipeline'] ?? []);
+        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->active_resumable_command = ResumableCommandCheckpointState::from_array($data['active_resumable_command']);
+        $state->preflight = $data['preflight'];
+        $state->remote_protocol_version = $data['remote_protocol_version'];
+        $state->remote_protocol_min_version = $data['remote_protocol_min_version'];
+        $state->version = $data['version'];
+        $state->webhost = $data['webhost'];
+        $state->follow_symlinks = $data['follow_symlinks'];
+        $state->local_followed_symlinks_root_fingerprint = $data['local_followed_symlinks_root_fingerprint'];
+        $state->fs_root_nonempty_behavior = $data['fs_root_nonempty_behavior'];
+        $state->filter = $data['filter'];
+        $state->user_agent = $data['user_agent'];
+        $state->max_allowed_packet = $data['max_allowed_packet'];
+        $state->resolved_path_mappings_fingerprint = $data['resolved_path_mappings_fingerprint'];
+        $state->files_pull_only_fingerprint = $data['files_pull_only_fingerprint'];
+        $state->files_pull_summary = FilesPullSummaryState::from_array($data['files_pull_summary']);
+        $state->db_index = DatabaseTableIndexState::from_array($data['db_index']);
+        $state->diff = FileDiffProgressState::from_array($data['diff']);
+        $state->index = RemoteFileIndexCursorState::from_array($data['index']);
+        $state->fetch = FetchListProgressState::from_array($data['fetch']);
+        $state->fetch_skipped = FetchListProgressState::from_array($data['fetch_skipped']);
+        $state->current_file = $data['current_file'];
+        $state->current_file_bytes = $data['current_file_bytes'];
+        $state->sql_bytes = $data['sql_bytes'];
+        $state->sql_statements_counted = $data['sql_statements_counted'];
+        $state->apply = DatabaseApplyCommandState::from_array($data['apply']);
+        $state->sql_output = $data['sql_output'];
+        $state->mysql_host = $data['mysql_host'];
+        $state->mysql_port = $data['mysql_port'];
+        $state->mysql_user = $data['mysql_user'];
+        $state->mysql_database = $data['mysql_database'];
+        $state->consecutive_interrupted_responses = $data['consecutive_interrupted_responses'];
+        $state->tuning = AdaptiveTuningState::from_array($data['tuning']);
+        $state->pull_pipeline = PullPipelineCheckpointState::from_array($data['pull_pipeline']);
         return $state;
     }
 
@@ -491,49 +495,34 @@ class ImportState
             'pull_pipeline' => $this->pull_pipeline->to_array(),
         ];
     }
+}
 
-    private static function resumable_command_checkpoint_from($value): ResumableCommandCheckpointState
-    {
-        return $value instanceof ResumableCommandCheckpointState ? $value : ResumableCommandCheckpointState::from_array(is_array($value) ? $value : []);
+/**
+ * Reject import-state shapes other than the one written by the current code.
+ *
+ * @param array<string,mixed> $data          Observed state data.
+ * @param string[]            $expected_keys Current field names.
+ */
+function reprint_assert_import_state_keys(array $data, array $expected_keys, string $state_name): void
+{
+    $actual_keys = array_keys($data);
+    sort($actual_keys);
+    sort($expected_keys);
+    if ($actual_keys === $expected_keys) {
+        return;
     }
 
-    private static function files_pull_summary_from($value): FilesPullSummaryState
-    {
-        return $value instanceof FilesPullSummaryState ? $value : FilesPullSummaryState::from_array(is_array($value) ? $value : []);
+    $missing_keys = array_values(array_diff($expected_keys, $actual_keys));
+    $unexpected_keys = array_values(array_diff($actual_keys, $expected_keys));
+    $details = [];
+    if ($missing_keys !== []) {
+        $details[] = 'missing ' . implode(', ', $missing_keys);
+    }
+    if ($unexpected_keys !== []) {
+        $details[] = 'unexpected ' . implode(', ', $unexpected_keys);
     }
 
-    private static function database_table_index_from($value): DatabaseTableIndexState
-    {
-        return $value instanceof DatabaseTableIndexState ? $value : DatabaseTableIndexState::from_array(is_array($value) ? $value : []);
-    }
-
-    private static function file_diff_progress_from($value): FileDiffProgressState
-    {
-        return $value instanceof FileDiffProgressState ? $value : FileDiffProgressState::from_array(is_array($value) ? $value : []);
-    }
-
-    private static function remote_file_index_cursor_from($value): RemoteFileIndexCursorState
-    {
-        return $value instanceof RemoteFileIndexCursorState ? $value : RemoteFileIndexCursorState::from_array(is_array($value) ? $value : []);
-    }
-
-    private static function fetch_list_progress_from($value): FetchListProgressState
-    {
-        return $value instanceof FetchListProgressState ? $value : FetchListProgressState::from_array(is_array($value) ? $value : []);
-    }
-
-    private static function database_apply_command_from($value): DatabaseApplyCommandState
-    {
-        return $value instanceof DatabaseApplyCommandState ? $value : DatabaseApplyCommandState::from_array(is_array($value) ? $value : []);
-    }
-
-    private static function adaptive_tuning_from($value): AdaptiveTuningState
-    {
-        return $value instanceof AdaptiveTuningState ? $value : AdaptiveTuningState::from_array(is_array($value) ? $value : []);
-    }
-
-    private static function pull_pipeline_checkpoint_from($value): PullPipelineCheckpointState
-    {
-        return $value instanceof PullPipelineCheckpointState ? $value : PullPipelineCheckpointState::from_array(is_array($value) ? $value : []);
-    }
+    throw new UnexpectedValueException(
+        $state_name . ' does not match the current state schema: ' . implode('; ', $details)
+    );
 }

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -61,25 +61,16 @@ class CurlTimeoutRecoveryTest extends TestCase
 
     private function writeState(array $state): void
     {
-        $defaults = [
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
+        \write_current_import_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
-            "max_allowed_packet" => null,
-        ];
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        ], $state));
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root);
     }
 
     private function readState(): array
@@ -354,7 +345,7 @@ class CurlTimeoutRecoveryTest extends TestCase
                 "tables" => 3,
                 "rows_estimated" => 1000,
                 "bytes" => 256,
-                "updated_at" => time(),
+                "updated_at" => (string) time(),
             ],
         ]);
 

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -307,10 +307,7 @@ class DeactivateHostPluginsTest extends TestCase
 
     private function writeState(array $state): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode($state, JSON_PRETTY_PRINT),
-        );
+        \write_current_import_state($this->makeClient(), $state);
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -62,10 +62,6 @@ class ExportDirectoryAutoDetectTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            'command' => null,
-            'status' => null,
-            'cursor' => null,
-            'stage' => null,
             'preflight' => [
                 'http_code' => 200,
                 'data' => [
@@ -102,10 +98,7 @@ class ExportDirectoryAutoDetectTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        \write_current_import_state($this->makeClient(), array_replace_recursive($defaults, $state));
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -76,27 +76,10 @@ class FetchListProgressTest extends TestCase
 
     private function writeState(array $state): void
     {
-        $defaults = [
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
+        \write_current_import_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
             "follow_symlinks" => false,
-            "fs_root_nonempty_behavior" => "error",
-            "max_allowed_packet" => null,
-            "fetch" => ["offset" => 0, "next_offset" => 0, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
-            "fetch_skipped" => ["offset" => 0, "next_offset" => 0, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
-        ];
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        ], $state));
     }
 
     private function prepareClient(string $filter = "none"): array

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -35,7 +35,6 @@ class FileBodyStreamingTest extends TestCase
         );
         $reflection = new \ReflectionClass($client);
         $reflection->getProperty('is_tty')->setValue($client, true);
-        $reflection->getProperty('state')->setValue($client, []);
 
         $handleFileChunk = $reflection->getMethod('handle_file_chunk');
         $context = new \StreamingContext();
@@ -107,7 +106,6 @@ class FileBodyStreamingTest extends TestCase
         );
         $reflection = new \ReflectionClass($client);
         $reflection->getProperty('is_tty')->setValue($client, true);
-        $reflection->getProperty('state')->setValue($client, []);
 
         $body = str_repeat('0123456789abcdef', 64 * 1024); // 1 MiB
         $halfwayPoint = (int) (strlen($body) / 2);

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -67,25 +67,11 @@ class FilesPullStateTest extends TestCase
      */
     private function writeState(array $state): void
     {
-        $defaults = [
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
+        \write_current_import_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
-            "max_allowed_packet" => null,
-        ];
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        ], $state));
     }
 
     /**

--- a/tests/Import/FlatDocrootWpConfigTest.php
+++ b/tests/Import/FlatDocrootWpConfigTest.php
@@ -139,10 +139,7 @@ class FlatDocrootWpConfigTest extends TestCase
 
     private function writeState(array $state): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode($state, JSON_PRETTY_PRINT),
-        );
+        \write_current_import_state($this->makeClient(), $state);
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/ImportMetadataTest.php
+++ b/tests/Import/ImportMetadataTest.php
@@ -63,9 +63,9 @@ class ImportMetadataTest extends TestCase
      */
     private function writeState(array $state): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+        \write_current_import_state(
+            new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot),
+            $state
         );
     }
 

--- a/tests/Import/ImportStateTest.php
+++ b/tests/Import/ImportStateTest.php
@@ -10,27 +10,25 @@ class ImportStateTest extends TestCase
 {
     public function testStateHydratesDocumentedNestedObjects(): void
     {
-        $state = \ImportState::from_array([
-            'active_resumable_command' => [
-                'command_name' => 'files-pull',
-                'completion_state' => 'partial',
-                'current_stage' => 'fetch',
-                'remote_cursor' => 'cursor-1',
-            ],
-            'pull_pipeline' => [
-                'started_by_command' => 'pull',
-                'stage_sequence' => ['preflight', 'files-pull'],
-                'last_completed_stage' => 'preflight',
-                'files_filter' => 'essential-files',
-                'skipped_pending' => true,
-                'has_completed_once' => false,
-            ],
-            'apply' => [
-                'statements_executed' => 12,
-                'bytes_read' => 34,
-                'target_engine' => 'sqlite',
-            ],
-        ]);
+        $data = (new \ImportState())->to_array();
+        $data['active_resumable_command'] = [
+            'command_name' => 'files-pull',
+            'completion_state' => 'partial',
+            'current_stage' => 'fetch',
+            'remote_cursor' => 'cursor-1',
+        ];
+        $data['pull_pipeline'] = [
+            'started_by_command' => 'pull',
+            'stage_sequence' => ['preflight', 'files-pull'],
+            'last_completed_stage' => 'preflight',
+            'files_filter' => 'essential-files',
+            'skipped_pending' => true,
+            'has_completed_once' => false,
+        ];
+        $data['apply']['statements_executed'] = 12;
+        $data['apply']['bytes_read'] = 34;
+        $data['apply']['target_engine'] = 'sqlite';
+        $state = \ImportState::from_array($data);
 
         $this->assertSame('files-pull', $state->active_resumable_command->command_name);
         $this->assertSame('partial', $state->active_resumable_command->completion_state);
@@ -41,7 +39,7 @@ class ImportStateTest extends TestCase
 
     public function testStateRoundTripsToPersistedArraySchema(): void
     {
-        $state = \ImportState::from_array([]);
+        $state = new \ImportState();
         $state->active_resumable_command->command_name = 'db-pull';
         $state->active_resumable_command->completion_state = 'complete';
         $state->pull_pipeline->started_by_command = 'pull';
@@ -57,9 +55,63 @@ class ImportStateTest extends TestCase
 
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void
     {
-        $state = \ImportState::from_array([]);
+        $state = new \ImportState();
 
         $this->assertNotInstanceOf(\ArrayAccess::class, $state);
         $this->assertNotInstanceOf(\ArrayAccess::class, $state->active_resumable_command);
+    }
+
+    public function testStateRejectsAnIncompleteSchema(): void
+    {
+        $data = (new \ImportState())->to_array();
+        unset($data['webhost']);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('missing webhost');
+
+        \ImportState::from_array($data);
+    }
+
+    public function testStateRejectsUnexpectedFields(): void
+    {
+        $data = (new \ImportState())->to_array();
+        $data['status'] = 'complete';
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('unexpected status');
+
+        \ImportState::from_array($data);
+    }
+
+    public function testStatePathRejectsInvalidBase64(): void
+    {
+        $decode = $this->statePathDecoder();
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('contains invalid base64');
+
+        $decode('base64:not base64');
+    }
+
+    public function testStatePathRejectsAnUnprefixedString(): void
+    {
+        $decode = $this->statePathDecoder();
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('missing the base64: encoding prefix');
+
+        $decode('/srv/htdocs/wp-config.php');
+    }
+
+    private function statePathDecoder(): \Closure
+    {
+        $client = new \ImportClient(
+            'https://source.example/',
+            sys_get_temp_dir(),
+            sys_get_temp_dir(),
+        );
+        $method = (new \ReflectionClass($client))->getMethod('decode_state_path_value');
+        $method->setAccessible(true);
+        return $method->getClosure($client);
     }
 }

--- a/tests/Import/LegacyCommandAliasTest.php
+++ b/tests/Import/LegacyCommandAliasTest.php
@@ -99,7 +99,7 @@ class LegacyCommandAliasTest extends TestCase
         ];
     }
 
-    public function testLegacyStateFieldsAreIgnored(): void
+    public function testRetiredStateShapeIsRejected(): void
     {
         file_put_contents(
             $this->stateDir . '/.import-state.json',
@@ -118,27 +118,12 @@ class LegacyCommandAliasTest extends TestCase
         $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->filesystem_root);
         $reflection = new \ReflectionClass($client);
         $loadState = $reflection->getMethod('load_state');
-        $state = $loadState->invoke($client)->to_array();
+        $loadState->setAccessible(true);
 
-        $this->assertArrayNotHasKey('command', $state);
-        $this->assertArrayNotHasKey('status', $state);
-        $this->assertArrayNotHasKey('cursor', $state);
-        $this->assertArrayNotHasKey('stage', $state);
-        $this->assertArrayNotHasKey('pull', $state);
-        $this->assertSame([
-            "command_name" => null,
-            "completion_state" => null,
-            "current_stage" => null,
-            "remote_cursor" => null,
-        ], $state["active_resumable_command"]);
-        $this->assertSame([
-            "started_by_command" => null,
-            "stage_sequence" => [],
-            "last_completed_stage" => null,
-            "files_filter" => null,
-            "skipped_pending" => false,
-            "has_completed_once" => false,
-        ], $state["pull_pipeline"]);
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('does not match the current state schema');
+
+        $loadState->invoke($client);
     }
 
 }

--- a/tests/Import/LocalIndexWalTest.php
+++ b/tests/Import/LocalIndexWalTest.php
@@ -98,15 +98,12 @@ final class LocalIndexWalTest extends TestCase
                 'type' => 'file',
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
         );
-        file_put_contents(
-            $this->stateDirectory . '/.import-state.json',
-            json_encode([
-                'preflight' => [
-                    'data' => ['ok' => true],
-                    'http_code' => 200,
-                ],
-            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
-        );
+        \write_current_import_state($this->client(), [
+            'preflight' => [
+                'data' => ['ok' => true],
+                'http_code' => 200,
+            ],
+        ]);
 
         $this->client()->run([
             'command' => $command,

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -103,14 +103,9 @@ class NewSiteUrlSqliteTest extends TestCase
      */
     private function writeState(array $extra = []): void
     {
-        $state = array_merge([
-            'command' => null,
-            'status' => null,
-            'apply' => [],
-        ], $extra);
-        file_put_contents(
-            $this->tempDir . '/.import-state.json',
-            json_encode($state, JSON_PRETTY_PRINT),
+        \write_current_import_state(
+            new \ImportClient('http://example.invalid', $this->tempDir, $this->tempDir),
+            $extra
         );
     }
 

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -172,12 +172,19 @@ PHP, var_export($requestsLog, true)));
             );
         }
 
-        file_put_contents($this->tempDir . '/state/.import-state.json', json_encode(array(
-            'preflight' => array(
-                'data' => $data,
-                'http_code' => 200,
+        \write_current_import_state(
+            new \ImportClient(
+                'http://fake.invalid/',
+                $this->tempDir . '/state',
+                $this->tempDir . '/fs'
             ),
-        ), JSON_PRETTY_PRINT));
+            array(
+                'preflight' => array(
+                    'data' => $data,
+                    'http_code' => 200,
+                ),
+            )
+        );
     }
 
     public function testOnlyOptionIsRecognizedAsRepeatableInBothForms(): void

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -101,7 +101,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     /** Mirror FilesPullStateTest: load state + preserve-local, then set the --only file path prefixes. */
     private function prepareClient(array $pull_only_files_with_path_prefixes): array
     {
-        $defaults = [
+        $state = [
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "in_progress",
@@ -111,9 +111,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
         ];
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode($defaults, JSON_PRETTY_PRINT),
+        \write_current_import_state(
+            new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root),
+            $state
         );
 
         $client = new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root);

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -65,7 +65,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     private function client(array $preflightData): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $this->set($c, 'state', array('preflight' => array('data' => $preflightData)));
+        $c->get_import_state()->preflight = array('data' => $preflightData);
         $this->set($c, 'audit_log', $this->tempDir . '/audit.log');
         return $c;
     }
@@ -111,9 +111,9 @@ class OnlyFilesPathPrefixTest extends TestCase
             'filter' => 'none',
         );
 
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT)
+        \write_current_import_state(
+            new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot),
+            array_replace_recursive($defaults, $state)
         );
     }
 
@@ -234,7 +234,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
         $original_fingerprint = $this->call($c, 'files_pull_only_fingerprint');
 
-        $this->set($c, 'state', array('files_pull_only_fingerprint' => $original_fingerprint));
+        $c->get_import_state()->files_pull_only_fingerprint = $original_fingerprint;
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->expectException(\RuntimeException::class);
@@ -246,7 +246,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
 
-        $this->set($c, 'state', array('files_pull_only_fingerprint' => 'different'));
+        $c->get_import_state()->files_pull_only_fingerprint = 'different';
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->call($c, 'assert_files_pull_only_unchanged_while_resuming', array(false));

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -65,10 +65,12 @@ class ProductionDropInRemovalTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            'command' => null,
-            'status' => null,
-            'cursor' => null,
-            'stage' => null,
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'complete',
+                'current_stage' => null,
+                'remote_cursor' => null,
+            ],
             'preflight' => [
                 'http_code' => 200,
                 'data' => [
@@ -113,10 +115,7 @@ class ProductionDropInRemovalTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        \write_current_import_state($this->makeClient(), array_replace_recursive($defaults, $state));
     }
 
     private function makeClient(): \ImportClient
@@ -188,7 +187,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesObjectCacheFile(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $objectCachePath = $this->fsRoot . '/wp-content/object-cache.php';
@@ -203,7 +202,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesAdvancedCacheFile(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $advancedCachePath = $this->fsRoot . '/wp-content/advanced-cache.php';
@@ -218,7 +217,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesWpcomshDirectory(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $wpcomshDir = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh';
@@ -233,7 +232,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesWpcomshDevDirectory(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $wpcomshDevDir = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh-dev';
@@ -248,7 +247,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesWpcomshLoaderFile(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $loaderPath = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh-loader.php';
@@ -265,7 +264,7 @@ class ProductionDropInRemovalTest extends TestCase
     {
         // Don't create any drop-in files. The removal loop should skip
         // them gracefully without errors.
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         mkdir($this->fsRoot . '/wp-content', 0755, true);
 
         $client = $this->makeClient();
@@ -278,7 +277,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimePreservesUnrelatedFiles(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         // Create a legitimate mu-plugin that should NOT be removed.
@@ -294,7 +293,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeLogsRemovalsToAuditLog(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $client = $this->makeClient();
@@ -324,7 +323,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimePersistsPathsRemovedToState(): void
     {
-        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
+        $this->writeState([]);
         $this->createProductionDropIns();
 
         $client = $this->makeClient();
@@ -350,8 +349,6 @@ class ProductionDropInRemovalTest extends TestCase
         // Override webhost to 'other' — the DefaultHostAnalyzer should
         // produce an empty paths_to_remove.
         $this->writeState([
-            'command' => 'files-pull',
-            'status' => 'complete',
             'webhost' => 'other',
             'preflight' => [
                 'data' => [
@@ -383,8 +380,6 @@ class ProductionDropInRemovalTest extends TestCase
     private function writeSitegroundState(array $overrides = []): void
     {
         $this->writeState(array_replace_recursive([
-            'command' => 'files-sync',
-            'status' => 'complete',
             'webhost' => 'siteground',
             'preflight' => [
                 'data' => [

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -235,6 +235,11 @@ class PullFilterOptionTest extends TestCase
         );
     }
 
+    private function writeState(array $state): void
+    {
+        \write_current_import_state($this->makeClient(false), $state);
+    }
+
     public function testPullRejectsSkippedEarlierFilterBeforePersistingIt(): void
     {
         $client = $this->makeClient(false);
@@ -297,21 +302,18 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull",
-                    "last_completed_stage" => "preflight",
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull",
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -331,21 +333,18 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullResumesSameUnfinishedPipelineWithoutConflict(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "in_progress",
-                    "current_stage" => "fetch",
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull",
-                    "last_completed_stage" => "preflight",
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull",
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -364,21 +363,18 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullRefusesToClearCompletedCommandOwnedByDifferentUnfinishedPipeline(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "db-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull-db",
-                    "last_completed_stage" => null,
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull-db",
+                "last_completed_stage" => null,
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
         file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
 
         $client = $this->makeClient(false);
@@ -524,22 +520,19 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullFilesResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull-files",
-                    "stage_sequence" => ["preflight", "files-pull"],
-                    "last_completed_stage" => "preflight",
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull-files",
+                "stage_sequence" => ["preflight", "files-pull"],
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -555,17 +548,14 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullFilesAfterStandaloneFilesPullStartsFreshDelta(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -581,22 +571,19 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullAfterFilesPullCompletedBeforePipelineStageWasMarkedDoesNotStealIt(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull-files",
-                    "stage_sequence" => ["preflight", "files-pull"],
-                    "last_completed_stage" => "preflight",
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull-files",
+                "stage_sequence" => ["preflight", "files-pull"],
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -675,22 +662,19 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDbRejectsConflictingInProgressPullFiles(): void
     {
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "partial",
-                    "current_stage" => "fetch",
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull-files",
-                    "stage_sequence" => ["preflight", "files-pull"],
-                    "last_completed_stage" => "preflight",
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "partial",
+                "current_stage" => "fetch",
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull-files",
+                "stage_sequence" => ["preflight", "files-pull"],
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -714,22 +698,19 @@ class PullFilterOptionTest extends TestCase
     public function testPullDbResumesAfterDbPullCompletedBeforePipelineStageWasMarked(): void
     {
         file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "db-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "pull_pipeline" => [
-                    "started_by_command" => "pull-db",
-                    "stage_sequence" => ["preflight", "db-pull", "db-apply"],
-                    "last_completed_stage" => "preflight",
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull-db",
+                "stage_sequence" => ["preflight", "db-pull", "db-apply"],
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -750,17 +731,14 @@ class PullFilterOptionTest extends TestCase
     public function testPullDbAfterStandaloneDbPullDownloadsFreshDump(): void
     {
         file_put_contents($this->stateDir . '/db.sql', "SELECT stale;\n");
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "db-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -867,25 +845,22 @@ class PullFilterOptionTest extends TestCase
         // The deferred "skipped-earlier" tail belongs to a files-pull that
         // has finished. Once that lifecycle state is truthful, a completed
         // pull can delta re-pull without bypassing the mid-flight guard.
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "complete",
-                    "current_stage" => null,
-                ],
-                "filter" => "skipped-earlier",
-                "pull_pipeline" => [
-                    "started_by_command" => "pull",
-                    "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
-                    "last_completed_stage" => "db-apply",
-                    "files_filter" => "essential-files",
-                    "skipped_pending" => true,
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "complete",
+                "current_stage" => null,
+            ],
+            "filter" => "skipped-earlier",
+            "pull_pipeline" => [
+                "started_by_command" => "pull",
+                "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
+                "last_completed_stage" => "db-apply",
+                "files_filter" => "essential-files",
+                "skipped_pending" => true,
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 
@@ -908,25 +883,22 @@ class PullFilterOptionTest extends TestCase
         // with filter=skipped-earlier. A new essential-files pull must still be
         // allowed: the filter-change guard must not treat the terminal tail as
         // a mid-flight sync.
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode([
-                "active_resumable_command" => [
-                    "command_name" => "files-pull",
-                    "completion_state" => "partial",
-                    "current_stage" => "fetch-skipped",
-                ],
-                "filter" => "skipped-earlier",
-                "pull_pipeline" => [
-                    "started_by_command" => "pull",
-                    "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
-                    "last_completed_stage" => "db-apply",
-                    "files_filter" => "essential-files",
-                    "skipped_pending" => true,
-                ],
-                "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-            ]),
-        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "partial",
+                "current_stage" => "fetch-skipped",
+            ],
+            "filter" => "skipped-earlier",
+            "pull_pipeline" => [
+                "started_by_command" => "pull",
+                "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
+                "last_completed_stage" => "db-apply",
+                "files_filter" => "essential-files",
+                "skipped_pending" => true,
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
 
         $client = $this->makeClient(false);
 

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -66,9 +66,9 @@ class RemapResolveTest extends TestCase
     private function client(array $pathsUrls): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $this->set($c, 'state', array('preflight' => array('data' => array(
+        $c->get_import_state()->preflight = array('data' => array(
             'database' => array('wp' => array('paths_urls' => $pathsUrls)),
-        ))));
+        ));
         return $c;
     }
 

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -95,10 +95,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        \write_current_import_state($this->makeClient(), array_replace_recursive($defaults, $state));
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -68,25 +68,10 @@ class RuntimeFilesTest extends TestCase
 
     private function writeState(array $state): void
     {
-        $defaults = [
-            "active_resumable_command" => [
-                "command_name" => null,
-                "completion_state" => null,
-                "current_stage" => null,
-                "remote_cursor" => null,
-            ],
+        \write_current_import_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
-            "remote_protocol_version" => null,
-            "remote_protocol_min_version" => null,
-            "version" => null,
             "follow_symlinks" => false,
-            "fs_root_nonempty_behavior" => "error",
-            "max_allowed_packet" => null,
-        ];
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
-        );
+        ], $state));
     }
 
     private function callPrivate(\ImportClient $client, string $method, array $args = [])

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -61,8 +61,6 @@ class SqliteRuntimeConfigTest extends TestCase
     private function writeState(array $state): void
     {
         $defaults = [
-            'command' => 'db-apply',
-            'status' => 'complete',
             'preflight' => [
                 'http_code' => 200,
                 'data' => [
@@ -94,9 +92,9 @@ class SqliteRuntimeConfigTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        file_put_contents(
-            $this->stateDir . '/.import-state.json',
-            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
+        \write_current_import_state(
+            new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot),
+            array_replace_recursive($defaults, $state)
         );
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,5 +44,21 @@ if (!class_exists('Site_Export_Push_Session', false)) {
     require_once __DIR__ . '/../packages/reprint-exporter/src/class-push-session.php';
 }
 
+/**
+ * Persist a complete current import-state schema for tests.
+ *
+ * @param ImportClient         $client  Client whose state directory receives the file.
+ * @param array<string, mixed> $changes Values to apply to a new ImportState.
+ */
+function write_current_import_state(ImportClient $client, array $changes): void
+{
+    $data = array_replace_recursive((new ImportState())->to_array(), $changes);
+    $state = ImportState::from_array($data);
+    $property = (new ReflectionClass(ImportClient::class))->getProperty('state');
+    $property->setAccessible(true);
+    $property->setValue($client, $state);
+    $client->save_import_state();
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -76,13 +76,15 @@ describe('Import: State Corruption', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-state-wrong-cmd');
-            // Write valid state but for a different command
-            writeFileSync(join(tempDir, '.import-state.json'), JSON.stringify({
-                active_resumable_command: {
-                    command_name: 'db-pull',
-                    completion_state: 'complete',
-                },
-            }));
+            const result = runImporter(importUrl(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(result.exitCode, 0, `Preflight failed:\n${result.stderr}`);
+            const statePath = join(tempDir, '.import-state.json');
+            const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+            state.active_resumable_command.command_name = 'db-pull';
+            state.active_resumable_command.completion_state = 'complete';
+            writeFileSync(statePath, JSON.stringify(state));
         });
 
         afterAll(() => {
@@ -108,14 +110,16 @@ describe('Import: State Corruption', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-state-restart');
-            // Write a partial state to simulate interrupted transfer
-            writeFileSync(join(tempDir, '.import-state.json'), JSON.stringify({
-                active_resumable_command: {
-                    command_name: 'files-pull',
-                    completion_state: 'in_progress',
-                    remote_cursor: 'some-old-cursor',
-                },
-            }));
+            const result = runImporter(importUrl(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(result.exitCode, 0, `Preflight failed:\n${result.stderr}`);
+            const statePath = join(tempDir, '.import-state.json');
+            const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+            state.active_resumable_command.command_name = 'files-pull';
+            state.active_resumable_command.completion_state = 'in_progress';
+            state.active_resumable_command.remote_cursor = 'some-old-cursor';
+            writeFileSync(statePath, JSON.stringify(state));
         });
 
         afterAll(() => {

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -98,8 +98,8 @@ describe('Import: Protocol Version Mismatch', () => {
 
     it('fails when remote does not report a protocol version', () => {
         const state = readState();
-        delete state.remote_protocol_version;
-        delete state.remote_protocol_min_version;
+        state.remote_protocol_version = null;
+        state.remote_protocol_min_version = null;
         writeState(state);
 
         const result = runImporter(importUrl(), tempDir, 'preflight-assert', {


### PR DESCRIPTION
The importer now rejects persisted state that does not match the complete current schema instead of reshaping older or partial arrays at load time.

`ImportState` and its nested objects are the single state model. State paths must use the current `base64:` representation, unknown fields fail closed, and tests construct complete state explicitly rather than relying on defaults hidden in `normalize_state()`.

This is PR 1 of 7 in the cleanup stack. The stack deliberately leaves `?site-export-api`, `secret.php`, and the top-level `importer/import.php` entry point unchanged.

Stack order: #416 → #418 → #419 → #420 → #421 → #422 → #423.

## Testing

`../vendor/bin/phpunit --no-progress Import` passes with 459 tests and 3,463 assertions at the stack tip. PHPStan and `git diff --check` pass.
