### PR TITLE
Use explicit remote and local path coordinates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ Inside a class, omit the class name when context already supplies it: use
 - Classify remote rejections by the protocol's own design: `busy` and
   `offset_gap` are recoverable (retry with the returned cursor); auth
   failures and redirects fail permanently with pointed messages ("The target
-  redirected to X. Use that address as the push base_url."). "Retry" must
+  redirected to X. Use that address as the remote Reprint API URL."). "Retry" must
   never be a final status — exhausted retries become `failed`.
 - Cursors and status responses report only what the store has confirmed —
   never echo a sender's claimed offset back as truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the i
 
 ### Progress Tracking
 
-During the file fetch phase, progress and heartbeat records include `files_done` (cumulative across restarts, derived from download list byte offset + current batch count) and `files_total` (total download list entries, fixed after the diff phase). Both are emitted together only when the download list exists. The `files_imported` field is still emitted for backward compatibility.
+During the file fetch phase, progress and heartbeat records include `files_done` (cumulative across restarts, derived from fetch list byte offset + current batch count) and `files_total` (total fetch list entries, fixed after the diff phase). Both are emitted together only when the fetch list exists. The `files_imported` field is still emitted for backward compatibility.
 
 ## File Organization
 
@@ -243,7 +243,7 @@ Progress is computed client-side by reading state files (all in `--state-dir`):
 - `.import-state.json`: Current command, status, cursor, stage
 - `.import-index.jsonl`: Local file index (line count = files indexed)
 - `.import-remote-index.jsonl`: Remote file index (for delta comparison)
-- `.import-download-list.jsonl`: Files pending download
+- `.import-fetch-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
 
 And from `--fs-root`:

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 The pipeline proceeds as usual through indexing and diffing, but skips uploads. When the essential
 files are done, the sync marks itself **complete**. The skipped file list stays on disk at
-`.import-download-list-skipped.jsonl`. At this point you can apply the database and bring the site online.
+`.import-fetch-list-skipped.jsonl`. At this point you can apply the database and bring the site online.
 
 ```bash
 # Step 2: download the uploads
@@ -562,10 +562,10 @@ structured file counters:
 
 | Field         | Type           | Description |
 |---------------|----------------|-------------|
-| `files_done`  | `int`          | Files already processed (cumulative across restarts). Derived from the download list byte offset plus the current batch's `files_imported`. |
-| `files_total` | `int`          | Total non-empty entries in the download list. Fixed once the diff phase completes. |
+| `files_done`  | `int`          | Files already processed (cumulative across restarts). Derived from the fetch list byte offset plus the current batch's `files_imported`. |
+| `files_total` | `int`          | Total non-empty entries in the fetch list. Fixed once the diff phase completes. |
 
-Both fields are emitted together only when the download list exists — they
+Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
@@ -608,7 +608,7 @@ If the JSON is invalid on load, the importer renames it to
   },
   "filter": "none",               // "none" | "essential-files" | "skipped-earlier"
   "fetch": {
-    "offset": 512,                // byte offset into download list
+    "offset": 512,                // byte offset into fetch list
     "next_offset": 1024,
     "batch_file": null,
     "cursor": "..."               // file_fetch cursor

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -81,8 +81,8 @@ one. It only answers "what changed locally since my last successful push to
 this remote" by comparing the current local paths and rows against the pair's
 previous local index and the previously pushed rows.
 
-The local machine keeps these files **per target URL and resolved local
-tree**, overwritten after each successful commit:
+The local machine keeps these files **per remote Reprint API URL and resolved
+filesystem root**, overwritten after each successful commit:
 
     <state-dir>/push/<pair-key>/previous_local_index.jsonl
     <state-dir>/push/<pair-key>/previously_pushed_rows.jsonl   (phase two)
@@ -406,7 +406,7 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 
 ## Low-level files-push command
 
-`reprint files-push <target-url>` is the production CLI caller for one
+`reprint files-push <remote-reprint-api-url>` is the production CLI caller for one
 `PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
 It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
 the operator passes `--force-http`. It does not run pull preflight, read or
@@ -417,7 +417,7 @@ database, retry a failed request, or start a replacement sender after a
 The command derives one pair key without general URL normalization:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-filesystem-root>)
+sha256(rtrim(<remote-reprint-api-url>, "?&") + "\0" + <resolved-filesystem-root>)
 ```
 
 Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
@@ -451,7 +451,7 @@ neither file copies receiver cursors or tentative upload positions.
 
 ## Local files-diff command
 
-`reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR` reports a local
+`reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR` reports a local
 minimized push operation plan before target exclusions: the local paths a
 files-push would send or delete, compared against the pair's previous local
 index published by a completed files-push. It uses the files-push pair-key

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -81,7 +81,7 @@ one. It only answers "what changed locally since my last successful push to
 this remote" by comparing the current local paths and rows against the pair's
 previous local index and the previously pushed rows.
 
-The local machine keeps these files **per target URL and canonical local
+The local machine keeps these files **per target URL and resolved local
 tree**, overwritten after each successful commit:
 
     <state-dir>/push/<pair-key>/previous_local_index.jsonl
@@ -149,7 +149,7 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, local tree root, previous local
+The cursor contains the plan directory, local document root, previous local
 index, and current planning position. During indexing, that
 position contains the `FileIndexProcessor` cursor and committed fresh-index byte
 offset. During diffing, each step flushes only the path list or append-only
@@ -260,7 +260,7 @@ direct embedder passes the same array to `_site_export_handle_api_request()`.
 The document-root path must resolve to an existing directory. `ABSPATH` remains
 the default only for pull endpoints because it may point at a separate shared
 WordPress core tree. Push work lives in a document-root-specific private
-directory beside the canonical document root unless server configuration
+directory beside the resolved absolute document root unless server configuration
 supplies `reprint_directory`.
 Configured reprint directories must remain outside the document root; the HTTP
 endpoints reject an inside path because they do not yet apply the indexing and
@@ -362,7 +362,7 @@ uploads retain those values in memory for later deletion steps. Those
 receiver-owned values are the only work-delete cursor; `sender.json` does not
 duplicate it. Each uploaded deletion-list part contains one complete local path.
 The sender trusts this completed, immutable plan without consulting the fresh
-local index or live local tree again. If a deleted path reappears after planning,
+local index or live local document root again. If a deleted path reappears after planning,
 the current push may delete it on the target and the next push will send it.
 
 A changed local path to push, a vanished path to push, or a directory to push
@@ -407,7 +407,7 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 ## Low-level files-push command
 
 `reprint files-push <target-url>` is the production CLI caller for one
-`PushFilesSender`. It sends only the canonical local tree named by `--fs-root`.
+`PushFilesSender`. It sends only the resolved local document root named by `--fs-root`.
 It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
 the operator passes `--force-http`. It does not run pull preflight, read or
 write `.import-state.json`, show a plan, ask for confirmation, transfer a
@@ -417,13 +417,13 @@ database, retry a failed request, or start a replacement sender after a
 The command derives one pair key without general URL normalization:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
+sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-local-document-root>)
 ```
 
 Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
-query or canonical local tree therefore selects a different retained local
+query or resolved local document root therefore selects a different retained local
 index. Fragments, URL user-info, and `SECRET_KEY` target parameters are
-rejected. The local push state directory must be outside the local tree so
+rejected. The local push state directory must be outside the local document root so
 planning cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
@@ -456,7 +456,7 @@ minimized push operation plan before target exclusions: the local paths a
 files-push would send or delete, compared against the pair's previous local
 index published by a completed files-push. It uses the files-push pair-key
 formula, including its trailing `?` and `&` trim, so another URL query or
-local tree cannot reuse the index. It accepts only `--state-dir` and
+local document root cannot reuse the index. It accepts only `--state-dir` and
 `--fs-root`; it needs no secret, performs no preflight, and makes no network
 request. It runs one complete PushPlan against `previous_local_index.jsonl` in
 `files-diff-plan/` while the command holds the state-directory-wide Reprint

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -149,7 +149,7 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, local document root, previous local
+The cursor contains the plan directory, filesystem root, previous local
 index, and current planning position. During indexing, that
 position contains the `FileIndexProcessor` cursor and committed fresh-index byte
 offset. During diffing, each step flushes only the path list or append-only
@@ -362,7 +362,7 @@ uploads retain those values in memory for later deletion steps. Those
 receiver-owned values are the only work-delete cursor; `sender.json` does not
 duplicate it. Each uploaded deletion-list part contains one complete local path.
 The sender trusts this completed, immutable plan without consulting the fresh
-local index or live local document root again. If a deleted path reappears after planning,
+local index or live filesystem root again. If a deleted path reappears after planning,
 the current push may delete it on the target and the next push will send it.
 
 A changed local path to push, a vanished path to push, or a directory to push
@@ -407,7 +407,7 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 ## Low-level files-push command
 
 `reprint files-push <target-url>` is the production CLI caller for one
-`PushFilesSender`. It sends only the resolved local document root named by `--fs-root`.
+`PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
 It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
 the operator passes `--force-http`. It does not run pull preflight, read or
 write `.import-state.json`, show a plan, ask for confirmation, transfer a
@@ -417,13 +417,13 @@ database, retry a failed request, or start a replacement sender after a
 The command derives one pair key without general URL normalization:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-local-document-root>)
+sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-filesystem-root>)
 ```
 
 Its sender state lives at `<state-dir>/push/<pair-key>/`. A different target
-query or resolved local document root therefore selects a different retained local
+query or resolved filesystem root therefore selects a different retained local
 index. Fragments, URL user-info, and `SECRET_KEY` target parameters are
-rejected. The local push state directory must be outside the local document root so
+rejected. The local push state directory must be outside the filesystem root so
 planning cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
@@ -456,7 +456,7 @@ minimized push operation plan before target exclusions: the local paths a
 files-push would send or delete, compared against the pair's previous local
 index published by a completed files-push. It uses the files-push pair-key
 formula, including its trailing `?` and `&` trim, so another URL query or
-local document root cannot reuse the index. It accepts only `--state-dir` and
+filesystem root cannot reuse the index. It accepts only `--state-dir` and
 `--fs-root`; it needs no secret, performs no preflight, and makes no network
 request. It runs one complete PushPlan against `previous_local_index.jsonl` in
 `files-diff-plan/` while the command holds the state-directory-wide Reprint

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -15,11 +15,9 @@ is filesystem-absolute, filesystem-root-relative, or document-root-relative.
   filesystem is reconstructed and whose contents are compared, pulled, and
   pushed. Use `$filesystem_root`.
 - A **target** is the site addressed by the configured exporter API URL. It is
-  the source during pull and the destination during push. Use `$target_url`.
-- The **target base URL** removes URL user-info, `SECRET_KEY`, and the
-  `site-export-api` alias from the target URL. Use `$target_base_url`.
-- The **target fingerprint** is the SHA-256 of the target base URL and is
-  only a directory-safe identifier. Use `$target_fingerprint`.
+  the source during pull and the destination during push.
+- The **remote Reprint API URL** is the configured URL used for Reprint
+  requests. Use `$remote_reprint_api_url`.
 - The **target document root** is the absolute document root on the target
   machine. Use `$target_document_root`.
 
@@ -74,11 +72,10 @@ maps every relevant filesystem-root-relative path to exactly one target document
 target document root; an **ambiguous mapping** has more than one target path,
 and an **unaddressable mapping** has none. An **identity mapping** leaves local
 and target document paths identical. `path-mapping.json` stores the resolved
-path mapping for its target.
+path mapping.
 
-A state directory belongs to one filesystem root and may contain several
-targets. Target-specific state is keyed by target fingerprint. Reusing mapped
-target state with another filesystem root is rejected.
+A state directory belongs to one filesystem root. Reusing its mapping state
+with another filesystem root is rejected.
 
 ## Core nouns
 
@@ -269,7 +266,7 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `target URL`, `filesystem root`, `pair
+The local-only command is `files-diff`. Its `remote Reprint API URL`, `filesystem root`, `pair
 key`, and `local push state directory` have the same meanings and pair-key
 formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
 which a completed files-push publishes, and never changes it.
@@ -291,15 +288,15 @@ running the command again prints the complete report.
 
 ## Files-push CLI names
 
-The low-level, files-only command is `files-push`. Its `target URL` is the
+The low-level, files-only command is `files-push`. Its `remote Reprint API URL` is the
 exporter API URL, and its `filesystem root` is the resolved absolute directory supplied by
 `--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
 plain-HTTP opt-in.
 
-The `pair key` identifies exactly one target URL and resolved filesystem root:
+The `pair key` identifies exactly one remote Reprint API URL and resolved filesystem root:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-filesystem-root>)
+sha256(rtrim(<remote-reprint-api-url>, "?&") + "\0" + <resolved-filesystem-root>)
 ```
 
 The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -56,8 +56,8 @@ local relative path to a push-root-relative path.
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
-- The **index-update WAL** records completed pull mutations awaiting application
-  to the remote and local indexes.
+- The **local index WAL** records completed pull mutations awaiting application
+  to the local index.
 - A **pull plan** lists remote absolute paths still scheduled for download or
   deletion. A **push plan** pairs local relative paths with push-root-relative
   paths.
@@ -171,11 +171,11 @@ none. `PushFilesSender::start()` and `PushFilesSender::resume()` receive that
 open lock from the caller; sender `close()` does not release it. This local
 lock is separate from the receiver's push-session and commit locks.
 
-## Pull index-update WAL
+## Pull local index WAL
 
-Call the single pull-side write-ahead log the **index-update WAL**. It lives at
-`<state-dir>/.import-index-updates.wal`; use `.import-index-updates.wal`,
-`$index_update_wal_path`, and `$index_update_wal_handle`.
+Call the single pull-side write-ahead log the **local index WAL**. It lives at
+`<state-dir>/.import-local-index.wal`; use `.import-local-index.wal`,
+`$local_index_wal_path`, and `$local_index_wal_handle`.
 Applied batch records are cleared, but the empty WAL remains as a marker until
 files-pull completes. A retained WAL is consumed only while resuming or
 aborting the interrupted files-pull, including through a high-level pull

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -7,30 +7,28 @@ commit messages, or pull-request descriptions.
 ## Coordinate systems and relationship state
 
 Every path name states the machine whose coordinates it uses and whether it
-is filesystem-absolute, filesystem-root-relative, or document-root-relative.
+is absolute or relative to a named root.
 
 - A **state directory** is the caller-selected local directory containing
   Reprint state for one filesystem root. Use `$state_dir`.
-- The **filesystem root** is the local directory under which a pulled target
+- The **filesystem root** is the local directory under which a pulled remote
   filesystem is reconstructed and whose contents are compared, pulled, and
   pushed. Use `$filesystem_root`.
-- A **target** is the site addressed by the configured exporter API URL. It is
-  the source during pull and the destination during push.
 - The **remote Reprint API URL** is the configured URL used for Reprint
   requests. Use `$remote_reprint_api_url`.
-- The **target document root** is the absolute document root on the target
-  machine. Use `$target_document_root`.
+- The **push root** is the remote root selected by the receiving push session.
+  Use `$push_root`.
 
-The four domain path terms are:
+The domain path terms are:
 
 | Term | Meaning | Preferred name |
 | --- | --- | --- |
-| Target filesystem path | Absolute path on the target machine. | `$target_filesystem_path` |
-| Local filesystem path | Absolute path on the local machine. | `$local_filesystem_path` |
-| Target document path | Path relative to the target document root. | `$target_document_path` |
-| Filesystem-root-relative path | Path relative to the filesystem root. | `$filesystem_relative_path` |
+| Remote absolute path | Absolute path on the remote machine. | `$remote_absolute_path` |
+| Local absolute path | Absolute path on the local machine. | `$local_absolute_path` |
+| Local relative path | Path relative to the filesystem root. | `$local_relative_path` |
+| Push-root-relative path | Path relative to the push root. | `$push_root_relative_path` |
 
-An **absolute path** begins at `/`. A **document path** has no leading slash.
+An **absolute path** begins at `/`. A **relative path** has no leading slash.
 A **normalized path** has repeated separators and `.` or `..` segments removed
 lexically; it does not inspect the filesystem. A **resolved absolute path** is
 an absolute path whose existing symlinks `realpath()` resolved. An
@@ -42,36 +40,36 @@ retains a missing suffix. Do not call this a canonical path. Do not use a bare
 `$path`, `$local_path`, or `$remote_path` when more than one coordinate system
 is present.
 
-The pull conversion flow is target filesystem path → local filesystem path →
-filesystem-root-relative path. Push applies the reverse mapping from a
-filesystem-root-relative path to a target document path.
+The pull conversion flow is remote absolute path → local absolute path →
+local relative path. Push applies the reverse mapping from a
+local relative path to a push-root-relative path.
 
 ## Indexes and mappings
 
-- A **target index** is the last target filesystem state accepted by pull.
-  Its entries use target filesystem paths and target-observed metadata. Use
-  `$target_index_file`.
+- A **remote index** is the last remote filesystem state accepted by pull.
+  Its entries use remote absolute paths and remote-observed metadata. Use
+  `$remote_index_file`.
 - A **local index** is the locally accounted baseline. Its entries use
-  filesystem-root-relative paths and locally observed metadata. Use
+  local relative paths and locally observed metadata. Use
   `$local_index_file`.
 - A **fresh local index** is the current filesystem-root scan created while
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
 - The **index-update WAL** records completed pull mutations awaiting application
-  to the target and local indexes.
-- A **pull plan** lists target filesystem paths still scheduled for download or
-  deletion. A **push plan** pairs filesystem-root-relative paths with target
-  document paths.
+  to the remote and local indexes.
+- A **pull plan** lists remote absolute paths still scheduled for download or
+  deletion. A **push plan** pairs local relative paths with push-root-relative
+  paths.
 
-A **resolved path mapping** is an immutable mapping between target filesystem
-prefixes and local filesystem prefixes. A **pull mapping** converts a target
-filesystem path to a local filesystem path. A **push mapping** converts a
-filesystem-root-relative path to a target document path. An **addressable mapping**
-maps every relevant filesystem-root-relative path to exactly one target document path below the
-target document root; an **ambiguous mapping** has more than one target path,
+A **resolved path mapping** is an immutable mapping between remote absolute
+prefixes and local absolute prefixes. A **pull mapping** converts a remote
+absolute path to a local absolute path. A **push mapping** converts a
+local relative path to a push-root-relative path. An **addressable mapping**
+maps every relevant local relative path to exactly one push-root-relative path below the
+push root; an **ambiguous mapping** has more than one push-root-relative path,
 and an **unaddressable mapping** has none. An **identity mapping** leaves local
-and target document paths identical. `path-mapping.json` stores the resolved
+and push-root-relative paths identical. `path-mapping.json` stores the resolved
 path mapping.
 
 A state directory belongs to one filesystem root. Reusing its mapping state
@@ -163,7 +161,7 @@ Every local Reprint command workflow runs under the **Reprint process lock** at
 `<state-dir>/.reprint.lock`. Use `.reprint.lock` and `$process_lock`. The lock
 is non-blocking and state-directory-wide: pull, push, diff, and other local
 Reprint processes cannot run concurrently against the same state directory,
-even when their target or local-tree pairs differ.
+even when their remote Reprint API URL or filesystem-root pairs differ.
 
 The production CLI acquires the Reprint process lock before it prepares pair
 context, constructs `ImportClient`, or writes the command audit entry. It
@@ -232,7 +230,7 @@ paths. `sender.json` phases are `creating`, `starting_plan`,
 path-list cursor, receiver part limit, and request-sizing state. The index diff
 completes before local paths are sent. The index copy after a successful commit
 has no separate copy cursor and is repeated after interruption. After the index
-is saved or the target confirms removal, the sender clears the PushPlan
+is saved or the remote confirms removal, the sender clears the PushPlan
 cursor, then removes the entire plan directory and its exclusions file. It
 does not ask PushPlan to manage terminal cleanup; PushPlan only closes its open
 handles.
@@ -274,7 +272,7 @@ which a completed files-push publishes, and never changes it.
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
 `delete`, and `path_b64`. A push record also has the local path `type`, `size`,
 and `ctime`; its type is `file`, `dir`, or `link`. These records form a local
-minimized push operation plan before target exclusions: descendants represent
+minimized push operation plan before remote exclusions: descendants represent
 a new non-empty directory, one deleted subtree root covers its descendants,
 and metadata-only changes to non-empty directories select no operation. The
 final record has `status: "complete"`, `local_paths_to_push`, and

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -10,21 +10,16 @@ Every path name states the machine whose coordinates it uses and whether it
 is filesystem-absolute, filesystem-root-relative, or document-root-relative.
 
 - A **state directory** is the caller-selected local directory containing
-  Reprint state for one filesystem root. Use `$state_directory`.
+  Reprint state for one filesystem root. Use `$state_dir`.
 - The **filesystem root** is the local directory under which a pulled target
   filesystem is reconstructed and whose contents are compared, pulled, and
   pushed. Use `$filesystem_root`.
 - A **target** is the site addressed by the configured exporter API URL. It is
   the source during pull and the destination during push. Use `$target_url`.
-- The **target identity URL** removes URL user-info, `SECRET_KEY`, and the
-  `site-export-api` alias from the target URL. Use `$target_identity_url`.
-- The **target fingerprint** is the SHA-256 of the target identity URL and is
+- The **target base URL** removes URL user-info, `SECRET_KEY`, and the
+  `site-export-api` alias from the target URL. Use `$target_base_url`.
+- The **target fingerprint** is the SHA-256 of the target base URL and is
   only a directory-safe identifier. Use `$target_fingerprint`.
-- A **target relationship** is the synchronization relationship between the
-  state directory's filesystem root and one target.
-- A **target relationship directory** is the local
-  `remote-<target-fingerprint>/` directory containing one target
-  relationship's state. Use `$target_relationship_directory`.
 - The **target document root** is the absolute document root on the target
   machine. Use `$target_document_root`.
 
@@ -79,12 +74,11 @@ maps every relevant filesystem-root-relative path to exactly one target document
 target document root; an **ambiguous mapping** has more than one target path,
 and an **unaddressable mapping** has none. An **identity mapping** leaves local
 and target document paths identical. `path-mapping.json` stores the resolved
-path mapping for a target relationship.
+path mapping for its target.
 
 A state directory belongs to one filesystem root and may contain several
-target relationships. Each target relationship directory is keyed only by its
-target fingerprint. Reusing a mapped relationship with another filesystem root
-is rejected.
+targets. Target-specific state is keyed by target fingerprint. Reusing mapped
+target state with another filesystem root is rejected.
 
 ## Core nouns
 

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -49,8 +49,8 @@ local relative path to a push-root-relative path.
 - A **remote index** is the last remote filesystem state accepted by pull.
   Its entries use remote absolute paths and remote-observed metadata. Use
   `$remote_index_file`.
-- A **local index** is the locally accounted baseline. Its entries use
-  local relative paths and locally observed metadata. Use
+- A **local index** is the locally accounted pull baseline. Its entries use
+  remote absolute paths as the merge key and locally observed metadata. Use
   `$local_index_file`.
 - A **fresh local index** is the current filesystem-root scan created while
   planning a push. Use `$fresh_local_index_file`.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -7,15 +7,13 @@ commit messages, or pull-request descriptions.
 ## Coordinate systems and relationship state
 
 Every path name states the machine whose coordinates it uses and whether it
-is filesystem-absolute or document-root-relative.
+is filesystem-absolute, filesystem-root-relative, or document-root-relative.
 
 - A **state directory** is the caller-selected local directory containing
-  Reprint state for one local document root. Use `$state_directory`.
-- The **local document root** is the local directory whose contents are
-  compared, pulled, and pushed. Use `$local_document_root`.
-- The **import root** is the local directory under which a pulled target
-  filesystem is reconstructed. The local document root may be nested inside
-  it. Use `$import_root`.
+  Reprint state for one filesystem root. Use `$state_directory`.
+- The **filesystem root** is the local directory under which a pulled target
+  filesystem is reconstructed and whose contents are compared, pulled, and
+  pushed. Use `$filesystem_root`.
 - A **target** is the site addressed by the configured exporter API URL. It is
   the source during pull and the destination during push. Use `$target_url`.
 - The **target identity URL** removes URL user-info, `SECRET_KEY`, and the
@@ -23,7 +21,7 @@ is filesystem-absolute or document-root-relative.
 - The **target fingerprint** is the SHA-256 of the target identity URL and is
   only a directory-safe identifier. Use `$target_fingerprint`.
 - A **target relationship** is the synchronization relationship between the
-  state directory's local document root and one target.
+  state directory's filesystem root and one target.
 - A **target relationship directory** is the local
   `remote-<target-fingerprint>/` directory containing one target
   relationship's state. Use `$target_relationship_directory`.
@@ -37,7 +35,7 @@ The four domain path terms are:
 | Target filesystem path | Absolute path on the target machine. | `$target_filesystem_path` |
 | Local filesystem path | Absolute path on the local machine. | `$local_filesystem_path` |
 | Target document path | Path relative to the target document root. | `$target_document_path` |
-| Local document path | Path relative to the local document root. | `$local_document_path` |
+| Filesystem-root-relative path | Path relative to the filesystem root. | `$filesystem_relative_path` |
 
 An **absolute path** begins at `/`. A **document path** has no leading slash.
 A **normalized path** has repeated separators and `.` or `..` segments removed
@@ -52,40 +50,41 @@ retains a missing suffix. Do not call this a canonical path. Do not use a bare
 is present.
 
 The pull conversion flow is target filesystem path → local filesystem path →
-local document path. Push applies the reverse mapping from local document path
-to target document path.
+filesystem-root-relative path. Push applies the reverse mapping from a
+filesystem-root-relative path to a target document path.
 
 ## Indexes and mappings
 
 - A **target index** is the last target filesystem state accepted by pull.
   Its entries use target filesystem paths and target-observed metadata. Use
   `$target_index_file`.
-- A **local index** is the locally accounted baseline. Its entries use local
-  document paths and locally observed metadata. Use `$local_index_file`.
-- A **fresh local index** is the current local-document-root scan created while
+- A **local index** is the locally accounted baseline. Its entries use
+  filesystem-root-relative paths and locally observed metadata. Use
+  `$local_index_file`.
+- A **fresh local index** is the current filesystem-root scan created while
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
 - The **index-update WAL** records completed pull mutations awaiting application
   to the target and local indexes.
 - A **pull plan** lists target filesystem paths still scheduled for download or
-  deletion. A **push plan** pairs local document paths with target document
-  paths.
+  deletion. A **push plan** pairs filesystem-root-relative paths with target
+  document paths.
 
 A **resolved path mapping** is an immutable mapping between target filesystem
 prefixes and local filesystem prefixes. A **pull mapping** converts a target
-filesystem path to a local filesystem path. A **push mapping** converts a local
-document path to a target document path. An **addressable mapping** maps every
-relevant local document path to exactly one target document path below the
+filesystem path to a local filesystem path. A **push mapping** converts a
+filesystem-root-relative path to a target document path. An **addressable mapping**
+maps every relevant filesystem-root-relative path to exactly one target document path below the
 target document root; an **ambiguous mapping** has more than one target path,
 and an **unaddressable mapping** has none. An **identity mapping** leaves local
 and target document paths identical. `path-mapping.json` stores the resolved
 path mapping for a target relationship.
 
-A state directory belongs to one local document root and may contain several
+A state directory belongs to one filesystem root and may contain several
 target relationships. Each target relationship directory is keyed only by its
-target fingerprint. Reusing a mapped relationship with another local document
-root is rejected.
+target fingerprint. Reusing a mapped relationship with another filesystem root
+is rejected.
 
 ## Core nouns
 
@@ -221,14 +220,14 @@ sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
-The **previous local index** describes the local document root as the pair's last
+The **previous local index** describes the filesystem root as the pair's last
 completed push observed it. The sender saves it after a successful commit, and
 `files-diff` reads it. PushPlan diffs its fresh local index against the copy
 its caller supplies. `byte_offset_in_previous_local_index` is the position
 from which its current lookahead entry is read again after resume.
 
 The PushPlan cursor is stored in `sender.json`. It contains the plan
-directory, local document root, previous local index, and current
+directory, filesystem root, previous local index, and current
 planning position. During `indexing`, that position contains the
 FileIndexProcessor cursor and the committed byte offset in
 `fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
@@ -253,7 +252,7 @@ an explicit `request_too_large` failure lowers future request sizes.
 
 When a local path to push changes, the sender reports `local_path_changed` and
 moves to `removing`. After removal a new sender builds a fresh local index. The
-sender trusts the completed deletion plan without checking the live local document root;
+sender trusts the completed deletion plan without checking the live filesystem root;
 changes after planning belong to the next push.
 
 Receiver-confirmed file and work-delete cursors remain receiver state. A newly
@@ -276,7 +275,7 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `target URL`, `local document root`, `pair
+The local-only command is `files-diff`. Its `target URL`, `filesystem root`, `pair
 key`, and `local push state directory` have the same meanings and pair-key
 formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
 which a completed files-push publishes, and never changes it.
@@ -299,14 +298,14 @@ running the command again prints the complete report.
 ## Files-push CLI names
 
 The low-level, files-only command is `files-push`. Its `target URL` is the
-exporter API URL, and its `local document root` is the resolved absolute directory supplied by
+exporter API URL, and its `filesystem root` is the resolved absolute directory supplied by
 `--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
 plain-HTTP opt-in.
 
-The `pair key` identifies exactly one target URL and resolved local document root:
+The `pair key` identifies exactly one target URL and resolved filesystem root:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-local-document-root>)
+sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-filesystem-root>)
 ```
 
 The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
@@ -374,7 +373,7 @@ Use these names verbatim inside `PushPlan`:
 | Meaning | Name |
 | --- | --- |
 | Active plan directory | `$plan_directory` |
-| Local tree root | `$local_document_root`, `set_local_document_root()` |
+| Filesystem root | `$filesystem_root`, `set_filesystem_root()` |
 | Previous local index | `$previous_local_index` |
 | Open previous local index | `$previous_local_index_handle` |
 | Previous local index lookahead entry | `$previous_local_index_lookahead_entry`, `$previous_local_index_lookahead_entry_loaded` |

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -1,8 +1,91 @@
-# Push terminology
+# Reprint terminology
 
-This is the vocabulary contract for every push surface. Read it before
-changing push code, tests, documentation, plans, review replies, commit
-messages, or pull-request descriptions.
+This is the vocabulary contract for every Reprint surface. Read it before
+changing pull or push code, tests, documentation, plans, review replies,
+commit messages, or pull-request descriptions.
+
+## Coordinate systems and relationship state
+
+Every path name states the machine whose coordinates it uses and whether it
+is filesystem-absolute or document-root-relative.
+
+- A **state directory** is the caller-selected local directory containing
+  Reprint state for one local document root. Use `$state_directory`.
+- The **local document root** is the local directory whose contents are
+  compared, pulled, and pushed. Use `$local_document_root`.
+- The **import root** is the local directory under which a pulled target
+  filesystem is reconstructed. The local document root may be nested inside
+  it. Use `$import_root`.
+- A **target** is the site addressed by the configured exporter API URL. It is
+  the source during pull and the destination during push. Use `$target_url`.
+- The **target identity URL** removes URL user-info, `SECRET_KEY`, and the
+  `site-export-api` alias from the target URL. Use `$target_identity_url`.
+- The **target fingerprint** is the SHA-256 of the target identity URL and is
+  only a directory-safe identifier. Use `$target_fingerprint`.
+- A **target relationship** is the synchronization relationship between the
+  state directory's local document root and one target.
+- A **target relationship directory** is the local
+  `remote-<target-fingerprint>/` directory containing one target
+  relationship's state. Use `$target_relationship_directory`.
+- The **target document root** is the absolute document root on the target
+  machine. Use `$target_document_root`.
+
+The four domain path terms are:
+
+| Term | Meaning | Preferred name |
+| --- | --- | --- |
+| Target filesystem path | Absolute path on the target machine. | `$target_filesystem_path` |
+| Local filesystem path | Absolute path on the local machine. | `$local_filesystem_path` |
+| Target document path | Path relative to the target document root. | `$target_document_path` |
+| Local document path | Path relative to the local document root. | `$local_document_path` |
+
+An **absolute path** begins at `/`. A **document path** has no leading slash.
+A **normalized path** has repeated separators and `.` or `..` segments removed
+lexically; it does not inspect the filesystem. A **resolved absolute path** is
+an absolute path whose existing symlinks `realpath()` resolved. An
+**uncreated suffix** is the final sequence of segments that does not yet
+exist. A **base64 path** describes transport encoding, not coordinates.
+
+Use `resolve_absolute_path_with_uncreated_suffix()` for a path resolver that
+retains a missing suffix. Do not call this a canonical path. Do not use a bare
+`$path`, `$local_path`, or `$remote_path` when more than one coordinate system
+is present.
+
+The pull conversion flow is target filesystem path → local filesystem path →
+local document path. Push applies the reverse mapping from local document path
+to target document path.
+
+## Indexes and mappings
+
+- A **target index** is the last target filesystem state accepted by pull.
+  Its entries use target filesystem paths and target-observed metadata. Use
+  `$target_index_file`.
+- A **local index** is the locally accounted baseline. Its entries use local
+  document paths and locally observed metadata. Use `$local_index_file`.
+- A **fresh local index** is the current local-document-root scan created while
+  planning a push. Use `$fresh_local_index_file`.
+- An **index entry** records one path, type, size, and ctime. Use
+  `$index_entry`.
+- The **index-update WAL** records completed pull mutations awaiting application
+  to the target and local indexes.
+- A **pull plan** lists target filesystem paths still scheduled for download or
+  deletion. A **push plan** pairs local document paths with target document
+  paths.
+
+A **resolved path mapping** is an immutable mapping between target filesystem
+prefixes and local filesystem prefixes. A **pull mapping** converts a target
+filesystem path to a local filesystem path. A **push mapping** converts a local
+document path to a target document path. An **addressable mapping** maps every
+relevant local document path to exactly one target document path below the
+target document root; an **ambiguous mapping** has more than one target path,
+and an **unaddressable mapping** has none. An **identity mapping** leaves local
+and target document paths identical. `path-mapping.json` stores the resolved
+path mapping for a target relationship.
+
+A state directory belongs to one local document root and may contain several
+target relationships. Each target relationship directory is keyed only by its
+target fingerprint. Reusing a mapped relationship with another local document
+root is rejected.
 
 ## Core nouns
 
@@ -138,14 +221,14 @@ sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
-The **previous local index** describes the local tree as the pair's last
+The **previous local index** describes the local document root as the pair's last
 completed push observed it. The sender saves it after a successful commit, and
 `files-diff` reads it. PushPlan diffs its fresh local index against the copy
 its caller supplies. `byte_offset_in_previous_local_index` is the position
 from which its current lookahead entry is read again after resume.
 
 The PushPlan cursor is stored in `sender.json`. It contains the plan
-directory, local tree root, previous local index, and current
+directory, local document root, previous local index, and current
 planning position. During `indexing`, that position contains the
 FileIndexProcessor cursor and the committed byte offset in
 `fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
@@ -170,7 +253,7 @@ an explicit `request_too_large` failure lowers future request sizes.
 
 When a local path to push changes, the sender reports `local_path_changed` and
 moves to `removing`. After removal a new sender builds a fresh local index. The
-sender trusts the completed deletion plan without checking the live local tree;
+sender trusts the completed deletion plan without checking the live local document root;
 changes after planning belong to the next push.
 
 Receiver-confirmed file and work-delete cursors remain receiver state. A newly
@@ -193,7 +276,7 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `target URL`, `local tree`, `pair
+The local-only command is `files-diff`. Its `target URL`, `local document root`, `pair
 key`, and `local push state directory` have the same meanings and pair-key
 formula as `files-push`. It reads the pair's `previous_local_index.jsonl`,
 which a completed files-push publishes, and never changes it.
@@ -216,14 +299,14 @@ running the command again prints the complete report.
 ## Files-push CLI names
 
 The low-level, files-only command is `files-push`. Its `target URL` is the
-exporter API URL, and its `local tree` is the canonical directory supplied by
+exporter API URL, and its `local document root` is the resolved absolute directory supplied by
 `--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
 plain-HTTP opt-in.
 
-The `pair key` identifies exactly one target URL and canonical local tree:
+The `pair key` identifies exactly one target URL and resolved local document root:
 
 ```text
-sha256(rtrim(<target-url>, "?&") + "\0" + <canonical-local-tree-path>)
+sha256(rtrim(<target-url>, "?&") + "\0" + <resolved-local-document-root>)
 ```
 
 The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
@@ -291,7 +374,7 @@ Use these names verbatim inside `PushPlan`:
 | Meaning | Name |
 | --- | --- |
 | Active plan directory | `$plan_directory` |
-| Local tree root | `$local_tree_root`, `set_local_tree_root()` |
+| Local tree root | `$local_document_root`, `set_local_document_root()` |
 | Previous local index | `$previous_local_index` |
 | Open previous local index | `$previous_local_index_handle` |
 | Previous local index lookahead entry | `$previous_local_index_lookahead_entry`, `$previous_local_index_lookahead_entry_loaded` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -745,7 +745,7 @@ class ImportClient
         if (isset($masked[2]) && $command !== 'apply-runtime') {
             $masked[2] = preg_replace('/SECRET_KEY=[^&\s]+/', 'SECRET_KEY=***', $masked[2]);
             if ($command === 'files-push') {
-                $masked[2] = self::mask_url_user_info($masked[2]);
+                $masked[2] = self::mask_url_credentials($masked[2]);
             }
         }
         foreach ($masked as $argument_index => $argument) {
@@ -1790,7 +1790,7 @@ class ImportClient
             'files-push'
         );
         $masked_remote_reprint_api_url =
-            self::mask_url_user_info($remote_reprint_api_url);
+            self::mask_url_credentials($remote_reprint_api_url);
         $force_http = $options['force_http'] ?? false;
         $scheme = strtolower( (string) parse_url($remote_reprint_api_url, PHP_URL_SCHEME) );
         if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
@@ -1826,7 +1826,7 @@ class ImportClient
         string $command
     ): array {
         $masked_remote_reprint_api_url =
-            self::mask_url_user_info($remote_reprint_api_url);
+            self::mask_url_credentials($remote_reprint_api_url);
         if (strpos($remote_reprint_api_url, '#') !== false) {
             throw new InvalidArgumentException(
                 'The ' . $command . ' remote Reprint API URL must not contain a fragment: ' . $masked_remote_reprint_api_url . '.'
@@ -1951,7 +1951,7 @@ class ImportClient
     }
 
     /** Masks URL authority credentials without changing the pair-key input. */
-    private static function mask_url_user_info(string $url): string
+    private static function mask_url_credentials(string $url): string
     {
         $masked = preg_replace(
             '~^([a-z][a-z0-9+.-]*://)[^/?#]*@~i',

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -325,11 +325,11 @@ class ImportClient
      */
     private $remote_index_file;
 
-    /** @var string Path to .import-download-list.jsonl — files to download, computed by diffing remote vs local index. */
-    private $download_list_file;
+    /** @var string Path to .import-fetch-list.jsonl — files to download, computed by diffing remote vs local index. */
+    private $fetch_list_file;
 
-    /** @var string Path to .import-download-list-skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
-    private $skipped_download_list_file;
+    /** @var string Path to .import-fetch-list-skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
+    private $skipped_fetch_list_file;
 
     /** @var string Path to .import-audit.log — append-only log of every operation for debugging. */
     private $audit_log;
@@ -346,15 +346,15 @@ class ImportClient
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
-    /** @var int|null Total entries in the current download list.  Set once
-     *  at the start of download_files_from_list() by counting newlines. */
-    private $download_list_total = null;
+    /** @var int|null Total entries in the current fetch list.  Set once
+     *  at the start of fetch_files_from_list() by counting newlines. */
+    private $fetch_list_total = null;
 
     /** @var int|null Entries already processed (before the current offset)
-     *  in the download list.  Computed at list start and incremented after
+     *  in the fetch list.  Computed at list start and incremented after
      *  each batch completes.  This is the cumulative, restart-safe counter
      *  that consumers should display as "files done". */
-    private $download_list_done = null;
+    private $fetch_list_done = null;
 
     /**
      * @var ImportState Persistent import state loaded from / saved to $state_file.
@@ -560,10 +560,10 @@ class ImportClient
             $this->state_dir . "/.import-index-updates.wal";
         $this->remote_index_file =
             $this->state_dir . "/.import-remote-index.jsonl";
-        $this->download_list_file =
-            $this->state_dir . "/.import-download-list.jsonl";
-        $this->skipped_download_list_file =
-            $this->state_dir . "/.import-download-list-skipped.jsonl";
+        $this->fetch_list_file =
+            $this->state_dir . "/.import-fetch-list.jsonl";
+        $this->skipped_fetch_list_file =
+            $this->state_dir . "/.import-fetch-list-skipped.jsonl";
         $this->audit_log = $this->state_dir . "/.import-audit.log";
         $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
         $this->status_file = $this->state_dir . "/.import-status.json";
@@ -721,12 +721,12 @@ class ImportClient
         }
     }
 
-    /** True when the skipped-download list exists and still has entries. */
+    /** True when the skipped-fetch list exists and still has entries. */
     public function has_skipped_files_pending(): bool
     {
         return
-            file_exists($this->skipped_download_list_file) &&
-            filesize($this->skipped_download_list_file) > 0;
+            file_exists($this->skipped_fetch_list_file) &&
+            filesize($this->skipped_fetch_list_file) > 0;
     }
 
     /**
@@ -2077,21 +2077,21 @@ class ImportClient
             @unlink($this->remote_index_file);
             $this->audit_log("FILE DELETE | {$this->remote_index_file}");
         }
-        if (file_exists($this->download_list_file)) {
-            @unlink($this->download_list_file);
-            $this->audit_log("FILE DELETE | {$this->download_list_file}");
+        if (file_exists($this->fetch_list_file)) {
+            @unlink($this->fetch_list_file);
+            $this->audit_log("FILE DELETE | {$this->fetch_list_file}");
         }
-        if (file_exists($this->skipped_download_list_file)) {
-            @unlink($this->skipped_download_list_file);
-            $this->audit_log("FILE DELETE | {$this->skipped_download_list_file}");
+        if (file_exists($this->skipped_fetch_list_file)) {
+            @unlink($this->skipped_fetch_list_file);
+            $this->audit_log("FILE DELETE | {$this->skipped_fetch_list_file}");
         }
         if (file_exists($this->volatile_files_file)) {
             @unlink($this->volatile_files_file);
             $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
         }
         $this->import_state()->index = new RemoteFileIndexCursorState();
-        $this->import_state()->fetch = new DownloadListFetchProgressState();
-        $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+        $this->import_state()->fetch = new FetchListProgressState();
+        $this->import_state()->fetch_skipped = new FetchListProgressState();
 
         $this->save_state($this->state);
     }
@@ -2219,7 +2219,7 @@ class ImportClient
             }
         }
 
-        $this->download_runtime_files();
+        $this->fetch_runtime_files();
     }
 
     /**
@@ -2231,7 +2231,7 @@ class ImportClient
      * failures are tolerated since the scripts may live on paths not
      * accessible to the web server process.
      */
-    private function download_runtime_files(): void
+    private function fetch_runtime_files(): void
     {
         $runtime_dir = $this->state_dir . "/runtime_files";
 
@@ -2739,8 +2739,8 @@ class ImportClient
         if ($current_status === "complete") {
             $this->remove_index_update_wal();
             $has_skipped =
-                file_exists($this->skipped_download_list_file) &&
-                filesize($this->skipped_download_list_file) > 0;
+                file_exists($this->skipped_fetch_list_file) &&
+                filesize($this->skipped_fetch_list_file) > 0;
 
             // --filter=skipped-earlier: download only the files that a prior
             // --filter=essential-files run skipped.  This is the only way to
@@ -2845,7 +2845,7 @@ class ImportClient
         if ($has_progress) {
             // Don't reset files_imported here — it counts files within
             // the current batch and is only reset when a batch completes
-            // (in download_files_from_list). Resetting it on entry would
+            // (in fetch_files_from_list). Resetting it on entry would
             // cause the progress counter to dip between pull retries.
             $index_size = $this->index_count();
 
@@ -2888,8 +2888,8 @@ class ImportClient
             $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
             $this->import_state()->diff = new FileDiffProgressState();
             $this->import_state()->index = new RemoteFileIndexCursorState();
-            $this->import_state()->fetch = new DownloadListFetchProgressState();
-            $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+            $this->import_state()->fetch = new FetchListProgressState();
+            $this->import_state()->fetch_skipped = new FetchListProgressState();
             $this->import_state()->files_pull_summary = new FilesPullSummaryState();
             $this->save_state($this->state);
 
@@ -2980,7 +2980,7 @@ class ImportClient
         $stage = $this->import_state()->active_resumable_command->current_stage ?? "index";
 
         if ($stage === "index") {
-            $complete = $this->download_remote_index();
+            $complete = $this->fetch_remote_index();
             if (!$complete) {
                 $this->import_state()->active_resumable_command->completion_state = "partial";
                 $this->save_state($this->state);
@@ -2997,16 +2997,16 @@ class ImportClient
             $this->sort_index_file($this->remote_index_file);
             $this->import_state()->active_resumable_command->current_stage = "diff";
             $this->import_state()->diff = new FileDiffProgressState();
-            if (file_exists($this->download_list_file)) {
-                @unlink($this->download_list_file);
+            if (file_exists($this->fetch_list_file)) {
+                @unlink($this->fetch_list_file);
                 $this->audit_log(
-                    "FILE DELETE | {$this->download_list_file} | clearing before diff stage",
+                    "FILE DELETE | {$this->fetch_list_file} | clearing before diff stage",
                 );
             }
-            if (file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
+            if (file_exists($this->skipped_fetch_list_file)) {
+                @unlink($this->skipped_fetch_list_file);
                 $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | clearing before diff stage",
+                    "FILE DELETE | {$this->skipped_fetch_list_file} | clearing before diff stage",
                 );
             }
             $this->save_state($this->state);
@@ -3021,15 +3021,15 @@ class ImportClient
                 return;
             }
 
-            $has_downloads =
-                file_exists($this->download_list_file) &&
-                filesize($this->download_list_file) > 0;
+            $has_files_to_fetch =
+                file_exists($this->fetch_list_file) &&
+                filesize($this->fetch_list_file) > 0;
             $has_skipped =
-                file_exists($this->skipped_download_list_file) &&
-                filesize($this->skipped_download_list_file) > 0;
+                file_exists($this->skipped_fetch_list_file) &&
+                filesize($this->skipped_fetch_list_file) > 0;
 
             // Determine the first fetch stage to run.
-            if ($has_downloads) {
+            if ($has_files_to_fetch) {
                 $stage = "fetch";
             } elseif ($has_skipped) {
                 $stage = "fetch-skipped";
@@ -3041,14 +3041,14 @@ class ImportClient
 
             // In pull mode, finalize the scanning line with a checkmark
             // and start the download progress on a fresh line.
-            if ($has_downloads && $this->progress->is_mode('pipeline')) {
+            if ($has_files_to_fetch && $this->progress->is_mode('pipeline')) {
                 $green = "\033[32m";
                 $dim = "\033[2m";
                 $r = "\033[0m";
                 $scanned = number_format($this->index_entries_counted);
                 $this->progress->clear_progress_line();
                 $this->progress->print_line("  {$green}✓{$r} Scanned {$dim}— {$scanned} entries{$r}\n");
-                $total = $this->count_newlines($this->download_list_file);
+                $total = $this->count_newlines($this->fetch_list_file);
                 $this->progress->set_active_label(null);
                 $this->progress->show_progress_line(
                     "Downloading — 0 / " . number_format($total) . " files",
@@ -3056,23 +3056,23 @@ class ImportClient
                 );
             }
 
-            if (!$has_downloads && file_exists($this->download_list_file)) {
-                @unlink($this->download_list_file);
+            if (!$has_files_to_fetch && file_exists($this->fetch_list_file)) {
+                @unlink($this->fetch_list_file);
                 $this->audit_log(
-                    "FILE DELETE | {$this->download_list_file} | no files to fetch",
+                    "FILE DELETE | {$this->fetch_list_file} | no files to fetch",
                 );
             }
-            if (!$has_skipped && file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
+            if (!$has_skipped && file_exists($this->skipped_fetch_list_file)) {
+                @unlink($this->skipped_fetch_list_file);
                 $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | no skipped files to fetch",
+                    "FILE DELETE | {$this->skipped_fetch_list_file} | no skipped files to fetch",
                 );
             }
         }
 
         if ($stage === "fetch") {
-            $complete = $this->download_files_from_list(
-                $this->download_list_file,
+            $complete = $this->fetch_files_from_list(
+                $this->fetch_list_file,
                 "fetch",
             );
             if (!$complete) {
@@ -3080,18 +3080,18 @@ class ImportClient
                 $this->save_state($this->state);
                 return;
             }
-            $this->import_state()->fetch = new DownloadListFetchProgressState();
+            $this->import_state()->fetch = new FetchListProgressState();
 
-            if (file_exists($this->download_list_file)) {
-                @unlink($this->download_list_file);
+            if (file_exists($this->fetch_list_file)) {
+                @unlink($this->fetch_list_file);
                 $this->audit_log(
-                    "FILE DELETE | {$this->download_list_file} | fetch complete",
+                    "FILE DELETE | {$this->fetch_list_file} | fetch complete",
                 );
             }
 
             $has_skipped =
-                file_exists($this->skipped_download_list_file) &&
-                filesize($this->skipped_download_list_file) > 0;
+                file_exists($this->skipped_fetch_list_file) &&
+                filesize($this->skipped_fetch_list_file) > 0;
 
             if ($has_skipped && $this->filter === "essential-files") {
                 // Essential files are done — mark the sync as complete.
@@ -3100,7 +3100,7 @@ class ImportClient
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->save_state($this->state);
                 $this->audit_log(
-                    "ESSENTIAL FILES COMPLETE | skipped files listed in {$this->skipped_download_list_file} — run with --filter=skipped-earlier to download them",
+                    "ESSENTIAL FILES COMPLETE | skipped files listed in {$this->skipped_fetch_list_file} — run with --filter=skipped-earlier to download them",
                     true,
                 );
                 $stage = null;
@@ -3122,8 +3122,8 @@ class ImportClient
         }
 
         if ($stage === "fetch-skipped") {
-            $complete = $this->download_files_from_list(
-                $this->skipped_download_list_file,
+            $complete = $this->fetch_files_from_list(
+                $this->skipped_fetch_list_file,
                 "fetch_skipped",
             );
             if (!$complete) {
@@ -3132,16 +3132,16 @@ class ImportClient
                 return;
             }
             $this->import_state()->active_resumable_command->current_stage = null;
-            $this->import_state()->fetch_skipped = new DownloadListFetchProgressState();
+            $this->import_state()->fetch_skipped = new FetchListProgressState();
             // Tail fully fetched; clear the flag so a later skipped-earlier run
             // doesn't treat the now-empty tail as pending.
             $this->import_state()->pull_pipeline->skipped_pending = false;
             $this->save_state($this->state);
 
-            if (file_exists($this->skipped_download_list_file)) {
-                @unlink($this->skipped_download_list_file);
+            if (file_exists($this->skipped_fetch_list_file)) {
+                @unlink($this->skipped_fetch_list_file);
                 $this->audit_log(
-                    "FILE DELETE | {$this->skipped_download_list_file} | skipped files fetch complete",
+                    "FILE DELETE | {$this->skipped_fetch_list_file} | skipped files fetch complete",
                 );
             }
         }
@@ -3213,7 +3213,7 @@ class ImportClient
         $attempts = 0;
         $last_cursor = $this->import_state()->index->cursor ?? null;
         while (true) {
-            $complete = $this->download_remote_index();
+            $complete = $this->fetch_remote_index();
             if ($complete) {
                 break;
             }
@@ -3338,7 +3338,7 @@ class ImportClient
                 "message" => "Following symlink target: {$dir}",
             ], true);
 
-            // Reset the index cursor so download_remote_index starts fresh
+            // Reset the index cursor so fetch_remote_index starts fresh
             // for this directory, but appends to the existing index file.
             // Note we are not losing the previous cursor position. This code
             // runs only after the previous directory was fully indexed so
@@ -3350,7 +3350,7 @@ class ImportClient
             $last_cursor = null;
             while (true) {
                 try {
-                    $complete = $this->download_remote_index($dir);
+                $complete = $this->fetch_remote_index($dir);
                 } catch (RuntimeException $e) {
                     // We won't be able to follow every symlink. If
                     // the response seems like the remote server rejecting
@@ -3732,7 +3732,7 @@ class ImportClient
                 "message" => "Downloading table metadata",
             ]);
 
-            $this->download_db_index();
+            $this->fetch_database_index();
 
             // Interrupted response during db-index — state already saved, exit partial.
             if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
@@ -3757,7 +3757,7 @@ class ImportClient
             "message" => "Downloading SQL dump",
         ]);
 
-        $this->download_sql();
+        $this->fetch_sql();
 
         // Interrupted response during SQL download — state already saved, exit partial.
         if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
@@ -3874,12 +3874,12 @@ class ImportClient
      * plus pending downloads and their size.
      *
      * Reads .import-remote-index.jsonl for all indexed files and
-     * .import-download-list.jsonl for files not yet downloaded.
+     * .import-fetch-list.jsonl for files not yet downloaded.
      */
     private function run_files_stats(): void
     {
         $remote_index = $this->remote_index_file;
-        $download_list = $this->download_list_file;
+        $fetch_list = $this->fetch_list_file;
 
         // Single pass over the remote index to build a path→size map.
         // Duplicates (from overlapping symlink targets) are collapsed
@@ -3904,7 +3904,7 @@ class ImportClient
         $indexed_count = count($size_by_path);
         $indexed_bytes = array_sum($size_by_path);
 
-        // Walk the download list(s) to count pending files. The download
+        // Walk the fetch list(s) to count pending files. The download
         // list only stores paths, so look up sizes from the map above.
         // Files before the fetch byte offset have already been downloaded.
         $pending_count = 0;
@@ -3912,10 +3912,10 @@ class ImportClient
         $skipped_pending_count = 0;
         $skipped_pending_bytes = 0;
 
-        // Count pending in the main download list
+        // Count pending in the main fetch list
         $fetch_offset = $this->import_state()->fetch->offset ?? 0;
-        if (is_file($download_list)) {
-            $handle = fopen($download_list, "r");
+        if (is_file($fetch_list)) {
+            $handle = fopen($fetch_list, "r");
             if ($handle) {
                 // Seek past already-downloaded entries. The fetch offset
                 // is the byte position where the next batch starts, so
@@ -3944,9 +3944,9 @@ class ImportClient
             }
         }
 
-        // Count pending in the skipped download list (uploads filtered out by --filter=essential-files)
+        // Count pending in the skipped fetch list (uploads filtered out by --filter=essential-files)
         $skipped_offset = $this->import_state()->fetch_skipped->offset ?? 0;
-        $skipped_list = $this->skipped_download_list_file;
+        $skipped_list = $this->skipped_fetch_list_file;
         if (is_file($skipped_list)) {
             $handle = fopen($skipped_list, "r");
             if ($handle) {
@@ -4214,7 +4214,7 @@ class ImportClient
         // Resolve the path to WordPress's index.php. On standard hosts it
         // lives in the filesystem root. On WPCloud the ABSPATH is a different
         // directory (e.g. /wordpress/core/X.Y.Z) which maps to
-        // download_root + abspath when using --fs-root.
+        // filesystem root + ABSPATH when using --fs-root.
         $paths_urls = $preflight_data["database"]["wp"]["paths_urls"] ?? [];
         $abspath = rtrim($paths_urls["abspath"] ?? "", "/");
         if (!empty($flat_document_root)) {
@@ -4222,7 +4222,7 @@ class ImportClient
             $wordpress_index_php = $local_document_root . '/index.php';
         } elseif ($abspath !== "") {
             // Raw download: ABSPATH is relative to the download root,
-            // not the local document root (which is download_root + document_root).
+            // not the local document root (which is filesystem root + document root).
             $wordpress_index_php = realpath($this->filesystem_root . $abspath . '/index.php') ?: '';
         } else {
             $wordpress_index_php = $local_document_root . '/index.php';
@@ -4356,7 +4356,7 @@ class ImportClient
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
             rtrim($state_dir, "/") . "/.import-state.json";
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
-            rtrim($state_dir, "/") . "/.import-download-list-skipped.jsonl";
+            rtrim($state_dir, "/") . "/.import-fetch-list-skipped.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -4378,8 +4378,8 @@ class ImportClient
     private function should_enable_remote_upload_proxy(): bool
     {
         if (
-            file_exists($this->skipped_download_list_file) &&
-            filesize($this->skipped_download_list_file) > 0
+            file_exists($this->skipped_fetch_list_file) &&
+            filesize($this->skipped_fetch_list_file) > 0
         ) {
             return true;
         }
@@ -5935,7 +5935,7 @@ class ImportClient
         $this->import_state()->active_resumable_command->command_name = "db-index";
         $this->save_state($this->state);
 
-        $this->download_db_index();
+        $this->fetch_database_index();
         if (
             $this->import_state()->active_resumable_command->completion_state ===
             "partial"
@@ -5972,12 +5972,12 @@ class ImportClient
      * @param array|null $post_data Optional POST data
      * @param string|null $cursor Cursor for resumption within the current batch
      */
-    private function download_file_fetch(
+    private function fetch_file_batch(
         ?array $post_data,
         ?string $cursor,
         string $state_key = "fetch"
     ): bool {
-        $fetch_state = $this->get_download_list_fetch_state($state_key);
+        $fetch_state = $this->get_fetch_list_progress_state($state_key);
         $cursor = $cursor ?? $fetch_state->cursor;
         $complete = false;
         $chunks_since_save = 0;
@@ -6008,7 +6008,7 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
-        // Always send directory[] – see comment in download_remote_index().
+        // Always send directory[] – see comment in fetch_remote_index().
         $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
@@ -6185,7 +6185,7 @@ class ImportClient
                     ) {
                         throw new RuntimeException('Failed to flush the index-update WAL.');
                     }
-                    $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
+                    $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
                     $this->save_state($this->state);
                     $chunks_since_save = 0;
                 }
@@ -6208,7 +6208,7 @@ class ImportClient
             // the last complete part; the next invocation truncates any later
             // bytes before resuming.
             $durable_cursor =
-                $this->get_download_list_fetch_state($state_key)->cursor;
+                $this->get_fetch_list_progress_state($state_key)->cursor;
             $this->assert_can_resume_after_interrupted_response(
                 "file_fetch",
                 $cursor_before,
@@ -6233,7 +6233,7 @@ class ImportClient
             $wall_time,
             $context->response_stats ?? [],
         );
-        $this->get_download_list_fetch_state($state_key)->cursor = $cursor;
+        $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
         $this->apply_index_update_wal();
         // Update file tracking: track in-progress file, or clear if complete/no active file
         if ($context->file_handle && $context->file_path) {
@@ -6256,7 +6256,7 @@ class ImportClient
     /**
      * Download the remote index stream and write to disk.
      */
-    private function download_remote_index(?string $list_dir_override = null): bool
+    private function fetch_remote_index(?string $list_dir_override = null): bool
     {
         $cursor = $this->import_state()->index->cursor;
 
@@ -6498,7 +6498,7 @@ class ImportClient
     }
 
     /**
-     * Diff local index against remote index and build download list.
+     * Diff local index against remote index and build fetch list.
      */
     private function diff_indexes_and_build_fetch_list(): bool
     {
@@ -6509,19 +6509,19 @@ class ImportClient
         $diff = $this->import_state()->diff;
         $remote_offset = $diff->remote_offset;
         $last_local_index_entry_path = $diff->local_after;
-        $download_mode = $remote_offset > 0 ? "a" : "w";
-        if ($download_mode === "w") {
+        $fetch_list_mode = $remote_offset > 0 ? "a" : "w";
+        if ($fetch_list_mode === "w") {
             $this->audit_log(
-                "FILE CREATE | {$this->download_list_file} | building download list",
+                "FILE CREATE | {$this->fetch_list_file} | building fetch list",
             );
         } else {
             $this->audit_log(
-                "FILE APPEND | {$this->download_list_file} | resuming download list build",
+                "FILE APPEND | {$this->fetch_list_file} | resuming fetch list build",
             );
         }
-        $download_handle = fopen($this->download_list_file, $download_mode);
-        if (!$download_handle) {
-            throw new RuntimeException("Failed to open download list file");
+        $fetch_list_handle = fopen($this->fetch_list_file, $fetch_list_mode);
+        if (!$fetch_list_handle) {
+            throw new RuntimeException("Failed to open fetch list file");
         }
 
         // When --filter=essential-files is active, uploads go to a separate
@@ -6529,19 +6529,19 @@ class ImportClient
         $skipped_handle = null;
         $uploads_basedir = null;
         if ($this->filter === "essential-files") {
-            if ($download_mode === "w") {
+            if ($fetch_list_mode === "w") {
                 $this->audit_log(
-                    "FILE CREATE | {$this->skipped_download_list_file} | building skipped download list (uploads)",
+                    "FILE CREATE | {$this->skipped_fetch_list_file} | building skipped fetch list (uploads)",
                 );
             } else {
                 $this->audit_log(
-                    "FILE APPEND | {$this->skipped_download_list_file} | resuming skipped download list build",
+                    "FILE APPEND | {$this->skipped_fetch_list_file} | resuming skipped fetch list build",
                 );
             }
-            $skipped_handle = fopen($this->skipped_download_list_file, $download_mode);
+            $skipped_handle = fopen($this->skipped_fetch_list_file, $fetch_list_mode);
             if (!$skipped_handle) {
-                fclose($download_handle);
-                throw new RuntimeException("Failed to open skipped download list file");
+                fclose($fetch_list_handle);
+                throw new RuntimeException("Failed to open skipped fetch list file");
             }
             $uploads_basedir = $this->get_uploads_basedir();
             $this->audit_log(
@@ -6551,7 +6551,7 @@ class ImportClient
 
         $remote_index_handle = fopen($this->remote_index_file, "r");
         if (!$remote_index_handle) {
-            fclose($download_handle);
+            fclose($fetch_list_handle);
             throw new RuntimeException("Failed to open remote index file");
         }
         if ($remote_offset > 0) {
@@ -6614,7 +6614,7 @@ class ImportClient
                     // Always re-download — this file is in our local index,
                     // meaning we synced it before; preserve-local does not
                     // protect files we own.
-                    $download_list_handle = (
+                    $fetch_list_handle = (
                         $skipped_handle !== null &&
                         $this->is_remote_absolute_path_in_uploads_directory(
                             $remote_index_entry["path"],
@@ -6622,10 +6622,10 @@ class ImportClient
                         )
                     )
                         ? $skipped_handle
-                        : $download_handle;
-                    $this->append_download_list(
+                        : $fetch_list_handle;
+                    $this->append_fetch_list(
                         $remote_index_entry["path"],
-                        $download_list_handle,
+                        $fetch_list_handle,
                     );
                 }
                 $last_local_index_entry_path = $local_index_entry["path"];
@@ -6639,7 +6639,7 @@ class ImportClient
                     $this->audit_log($skip_reason, true);
                     $this->emit_skip_progress($remote_index_entry["path"]);
                 } else {
-                    $download_list_handle = (
+                    $fetch_list_handle = (
                         $skipped_handle !== null &&
                         $this->is_remote_absolute_path_in_uploads_directory(
                             $remote_index_entry["path"],
@@ -6647,8 +6647,8 @@ class ImportClient
                         )
                     )
                         ? $skipped_handle
-                        : $download_handle;
-                    $this->append_download_list($remote_index_entry["path"], $download_list_handle);
+                        : $fetch_list_handle;
+                    $this->append_fetch_list($remote_index_entry["path"], $fetch_list_handle);
                 }
             }
 
@@ -6681,7 +6681,7 @@ class ImportClient
             fclose($local_index_handle);
         }
         fclose($remote_index_handle);
-        fclose($download_handle);
+        fclose($fetch_list_handle);
         if ($skipped_handle !== null) {
             fclose($skipped_handle);
         }
@@ -6697,7 +6697,7 @@ class ImportClient
     /**
      * Download files from a prepared list.
      *
-     * @param string $list_file   Path to the JSONL download list to process.
+     * @param string $list_file   Path to the JSONL fetch list to process.
      * @param string $state_key   Key in $this->state that holds fetch progress
      *                            (e.g. "fetch" or "fetch_skipped").
      */
@@ -6733,7 +6733,7 @@ class ImportClient
         return $count;
     }
 
-    private function download_files_from_list(
+    private function fetch_files_from_list(
         string $list_file,
         string $state_key
     ): bool {
@@ -6745,17 +6745,17 @@ class ImportClient
             return true;
         }
 
-        // Compute download list counters once at the start of each list.
+        // Compute fetch list counters once at the start of each list.
         // These survive across batches within one invocation and are
         // recomputed on restart from the state file's byte offset.
-        if ($this->download_list_total === null) {
-            $offset = $this->get_download_list_fetch_state($state_key)->offset;
-            $this->download_list_total = $this->count_newlines($list_file);
-            $this->download_list_done = $offset > 0
+        if ($this->fetch_list_total === null) {
+            $offset = $this->get_fetch_list_progress_state($state_key)->offset;
+            $this->fetch_list_total = $this->count_newlines($list_file);
+            $this->fetch_list_done = $offset > 0
                 ? $this->count_newlines($list_file, $offset)
                 : 0;
         }
-        $fetch_state = $this->get_download_list_fetch_state($state_key);
+        $fetch_state = $this->get_fetch_list_progress_state($state_key);
         $batch_file = $fetch_state->batch_file;
         $batch_offset = $fetch_state->offset;
         $next_offset = $fetch_state->next_offset;
@@ -6773,7 +6773,7 @@ class ImportClient
             $next_offset = $batch["next_offset"];
             $batch_entries = $batch["entries"];
             $cursor = null;
-            $this->set_download_list_fetch_state($state_key, DownloadListFetchProgressState::from_array([
+            $this->set_fetch_list_progress_state($state_key, FetchListProgressState::from_array([
                 "offset" => $batch_offset,
                 "next_offset" => $next_offset,
                 "batch_file" => $batch_file,
@@ -6791,7 +6791,7 @@ class ImportClient
             ),
         ];
 
-        $complete = $this->download_file_fetch($post_data, $cursor, $state_key);
+        $complete = $this->fetch_file_batch($post_data, $cursor, $state_key);
         if (!$complete) {
             return false;
         }
@@ -6804,14 +6804,14 @@ class ImportClient
         // Advance the done counter by the known batch size and reset
         // the per-batch file counter. files_imported counted files within
         // this batch; now that the batch is complete, those files are
-        // accounted for in download_list_done.
-        if ($this->download_list_done !== null) {
-            $this->download_list_done += $batch_entries;
+        // accounted for in fetch_list_done.
+        if ($this->fetch_list_done !== null) {
+            $this->fetch_list_done += $batch_entries;
         }
         $this->import_state()->files_pull_summary->files_pulled += $batch_entries;
         $this->files_imported = 0;
 
-        $this->set_download_list_fetch_state($state_key, DownloadListFetchProgressState::from_array([
+        $this->set_fetch_list_progress_state($state_key, FetchListProgressState::from_array([
             "offset" => $next_offset,
             "next_offset" => $next_offset,
             "batch_file" => null,
@@ -6822,7 +6822,7 @@ class ImportClient
         return $next_offset >= filesize($list_file);
     }
 
-    private function get_download_list_fetch_state(string $state_key): DownloadListFetchProgressState
+    private function get_fetch_list_progress_state(string $state_key): FetchListProgressState
     {
         if ($state_key === "fetch") {
             return $this->import_state()->fetch;
@@ -6833,7 +6833,7 @@ class ImportClient
         throw new InvalidArgumentException("Unknown fetch state key: {$state_key}");
     }
 
-    private function set_download_list_fetch_state(string $state_key, DownloadListFetchProgressState $state): void
+    private function set_fetch_list_progress_state(string $state_key, FetchListProgressState $state): void
     {
         if ($state_key === "fetch") {
             $this->import_state()->fetch = $state;
@@ -6849,7 +6849,7 @@ class ImportClient
     /**
      * Builds a JSON batch file listing the next set of paths to download.
      *
-     * Reads from the download list (.import-download-list.jsonl) starting at
+     * Reads from the fetch list (.import-fetch-list.jsonl) starting at
      * $offset, accumulating paths into a JSON array until the batch approaches
      * 80% of the server's max request size.  Always includes at least one path,
      * even if it alone exceeds the limit.
@@ -6857,8 +6857,8 @@ class ImportClient
      * The batch file is written to a temp file and intended to be uploaded as
      * the request body for the file_fetch endpoint.
      *
-     * @param string $list_file Path to the JSONL download list.
-     * @param int    $offset    Byte offset into the download list file.
+     * @param string $list_file Path to the JSONL fetch list.
+     * @param int    $offset    Byte offset into the fetch list file.
      * @return array|null {
      *     Prepared fetch batch, or null if no paths remain.
      *
@@ -6877,10 +6877,10 @@ class ImportClient
         $max_request = $this->get_max_request_bytes();
         $limit = (int) max(256 * 1024, $max_request * 0.8);
 
-        // Open the download list and seek to where the previous batch left off.
+        // Open the fetch list and seek to where the previous batch left off.
         $handle = fopen($list_file, "r");
         if (!$handle) {
-            throw new RuntimeException("Failed to open download list file");
+            throw new RuntimeException("Failed to open fetch list file");
         }
 
         if ($offset > 0) {
@@ -6902,9 +6902,9 @@ class ImportClient
             throw new RuntimeException("Failed to open fetch batch file");
         }
 
-        // Read lines from the download list (one JSON entry per line) and
+        // Read lines from the fetch list (one JSON entry per line) and
         // accumulate them into the JSON array until we approach the size limit.
-        // The download list supports two formats:
+        // The fetch list supports two formats:
         //   - A bare JSON string:   "/path/to/file"
         //   - A JSON object:        {"path": "<base64-encoded path>"}
         $bytes = 0;
@@ -6978,7 +6978,7 @@ class ImportClient
         fclose($handle);
         fclose($out);
 
-        // An empty batch (just "[]") means we've exhausted the download list.
+        // An empty batch (just "[]") means we've exhausted the fetch list.
         if ($bytes <= 2) {
             @unlink($tmp);
             return null;
@@ -7048,9 +7048,9 @@ class ImportClient
     }
 
     /**
-     * Append a path to the download list file.
+     * Append a path to the fetch list file.
      */
-    private function append_download_list(string $path, $handle): void
+    private function append_fetch_list(string $path, $handle): void
     {
         $line = json_encode(
             ["path" => base64_encode($path)],
@@ -7059,7 +7059,7 @@ class ImportClient
         if ($line !== false) {
             fwrite($handle, $line . "\n");
         }
-        $this->audit_log("Added to the download list: {$path}", false);
+        $this->audit_log("Added to the fetch list: {$path}", false);
     }
 
     /**
@@ -7519,7 +7519,7 @@ class ImportClient
     /**
      * Download SQL from remote.
      */
-    private function download_sql(): void
+    private function fetch_sql(): void
     {
         $cursor = $this->import_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
@@ -8225,7 +8225,7 @@ class ImportClient
     /**
      * Download table stats from the db_index endpoint.
      */
-    private function download_db_index(): void
+    private function fetch_database_index(): void
     {
         $cursor = $this->import_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
@@ -9141,8 +9141,8 @@ class ImportClient
                 false,
             );
 
-            $files_done = ($this->download_list_done ?? 0) + $this->files_imported;
-            $files_total = $this->download_list_total;
+            $files_done = ($this->fetch_list_done ?? 0) + $this->files_imported;
+            $files_total = $this->fetch_list_total;
             $file_fraction = ($files_total !== null && $files_total > 0)
                 ? $files_done / $files_total
                 : null;
@@ -9157,8 +9157,8 @@ class ImportClient
                 "size" => $file_size,
                 "message" => $file_progress_message,
             ];
-            if ($this->download_list_total !== null) {
-                $progress_record["files_total"] = $this->download_list_total;
+            if ($this->fetch_list_total !== null) {
+                $progress_record["files_total"] = $this->fetch_list_total;
             }
             $this->output_progress($progress_record);
         }
@@ -10925,14 +10925,14 @@ class ImportClient
                             "heartbeat" => true,
                             "bytes_received" => $bytes_received,
                         ];
-                        // Only emit file counters when the download list has
+                        // Only emit file counters when the fetch list has
                         // been counted (fetch phase).  During indexing the
                         // list doesn't exist yet and emitting files_done:0
                         // without files_total confuses consumers.
-                        if ($this->download_list_total !== null) {
+                        if ($this->fetch_list_total !== null) {
                             $heartbeat["files_done"] =
-                                ($this->download_list_done ?? 0) + $this->files_imported;
-                            $heartbeat["files_total"] = $this->download_list_total;
+                                ($this->fetch_list_done ?? 0) + $this->files_imported;
+                            $heartbeat["files_total"] = $this->fetch_list_total;
                         }
                         fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
                     }
@@ -12644,8 +12644,8 @@ if (
                 "  (filesystem root)/                              Downloaded files\n" .
                 "  .import-index.jsonl                     Local file index\n" .
                 "  .import-remote-index.jsonl              Remote index snapshot\n" .
-                "  .import-download-list.jsonl             Files pending download\n" .
-                "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
+                "  .import-fetch-list.jsonl             Files pending download\n" .
+                "  .import-fetch-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
                 "  .import-state.json                      Resumable state\n" .
                 "  .import-audit.log                       Audit log\n",
         ],
@@ -12700,7 +12700,7 @@ if (
                 "\n" .
                 "On the first run, builds the complete index. On subsequent runs,\n" .
                 "re-indexes and diffs against the prior snapshot to produce a\n" .
-                "download list of changed files.\n" .
+                "fetch list of changed files.\n" .
                 "\n" .
                 "When symlink-following is enabled, recursively discovers and indexes\n" .
                 "additional directories outside the primary roots.\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6613,7 +6613,7 @@ class ImportClient
                     // Always re-download — this file is in our local index,
                     // meaning we synced it before; preserve-local does not
                     // protect files we own.
-                    $fetch_list_handle = (
+                    $selected_fetch_list_handle = (
                         $skipped_handle !== null &&
                         (
                             $uploads_basedir !== null
@@ -6631,7 +6631,7 @@ class ImportClient
                         : $fetch_list_handle;
                     $this->append_to_fetch_list(
                         $remote_index_entry["path"],
-                        $fetch_list_handle,
+                        $selected_fetch_list_handle,
                     );
                 }
                 $last_local_index_entry_path = $local_index_entry["path"];
@@ -6645,7 +6645,7 @@ class ImportClient
                     $this->audit_log($skip_reason, true);
                     $this->emit_skip_progress($remote_index_entry["path"]);
                 } else {
-                    $fetch_list_handle = (
+                    $selected_fetch_list_handle = (
                         $skipped_handle !== null &&
                         (
                             $uploads_basedir !== null
@@ -6661,7 +6661,7 @@ class ImportClient
                     )
                         ? $skipped_handle
                         : $fetch_list_handle;
-                    $this->append_to_fetch_list($remote_index_entry["path"], $fetch_list_handle);
+                    $this->append_to_fetch_list($remote_index_entry["path"], $selected_fetch_list_handle);
                 }
             }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2318,7 +2318,7 @@ class ImportClient
 
                     $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
                     $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
-                    $local_absolute_path = $path . $remote_absolute_path;
+                    $local_absolute_path = wp_join_unix_paths($path, $remote_absolute_path);
 
                     if ($is_first) {
                         if ($context->file_handle) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -287,37 +287,37 @@ class ImportClient
     private $local_index_file;
 
     /**
-     * @var string Path to .import-index-updates.wal — the append-only write-ahead
+     * @var string Path to .import-local-index.wal — the append-only write-ahead
      * log for the current files-pull. Applied batches are cleared, but the file
      * remains until the lifecycle completes or is aborted.
      */
-    private $index_update_wal_path;
+    private $local_index_wal_path;
 
-    /** @var resource|null Open file handle for $index_update_wal_path while writing. */
-    private $index_update_wal_handle;
+    /** @var resource|null Open file handle for $local_index_wal_path while writing. */
+    private $local_index_wal_handle;
 
-    /** @var int Number of entries written to the open WAL batch. */
-    private $index_update_wal_record_count = 0;
+    /** @var int Number of entries written to the open local index WAL batch. */
+    private $local_index_wal_record_count = 0;
 
     /**
-     * Deduplication state for index updates. Consecutive upsert_index_entry() or
-     * delete_index_entry() calls for the same path are collapsed into one WAL write.
+     * Deduplication state for local index WAL records. Consecutive upsert_index_entry() or
+     * delete_index_entry() calls for the same path are collapsed into one local index WAL write.
      *
-     * @var string|null Last path written to the index-update WAL.
+     * @var string|null Last path written to the local index WAL.
      */
-    private $last_update_path = null;
+    private $last_local_index_wal_path = null;
 
-    /** @var bool|null Whether the last index update was a deletion (true) or upsert (false). */
-    private $last_update_delete = null;
+    /** @var bool|null Whether the last local index WAL record was a deletion (true) or upsert (false). */
+    private $last_local_index_wal_deletion = null;
 
-    /** @var int|null ctime of the last upserted index entry. */
-    private $last_update_ctime = null;
+    /** @var int|null ctime of the last local index WAL file record. */
+    private $last_local_index_wal_ctime = null;
 
     /** @var int|null Size in bytes of the last upserted index entry. */
-    private $last_update_size = null;
+    private $last_local_index_wal_size = null;
 
     /** @var string|null Type ("file", "link", "dir") of the last upserted index entry. */
-    private $last_update_type = null;
+    private $last_local_index_wal_type = null;
 
     /**
      * @var string Remote index file .import-remote-index.jsonl, including
@@ -556,8 +556,8 @@ class ImportClient
         $this->filesystem_root = rtrim($filesystem_root, "/");
         $this->state_file = $this->state_dir . "/.import-state.json";
         $this->local_index_file = $this->state_dir . "/.import-index.jsonl";
-        $this->index_update_wal_path =
-            $this->state_dir . "/.import-index-updates.wal";
+        $this->local_index_wal_path =
+            $this->state_dir . "/.import-local-index.wal";
         $this->remote_index_file =
             $this->state_dir . "/.import-remote-index.jsonl";
         $this->fetch_list_file =
@@ -619,7 +619,7 @@ class ImportClient
         int $size,
         string $type
     ): void {
-        $this->record_index_update_file($path, $ctime, $size, $type);
+        $this->record_local_index_wal_file($path, $ctime, $size, $type);
     }
 
     /**
@@ -627,14 +627,14 @@ class ImportClient
      */
     private function delete_index_entry(string $path): void
     {
-        $this->record_index_update_deletion($path);
+        $this->record_local_index_wal_deletion($path);
     }
 
-    /** Replays a WAL left by an interrupted batch. */
-    private function replay_index_update_wal(): void
+    /** Replays a local index WAL left by an interrupted batch. */
+    private function replay_local_index_wal(): void
     {
-        if (is_file($this->index_update_wal_path)) {
-            $this->apply_index_update_wal();
+        if (is_file($this->local_index_wal_path)) {
+            $this->apply_local_index_wal();
         }
     }
 
@@ -2066,12 +2066,12 @@ class ImportClient
             "RESTART | Clearing files-pull progress (keeping local index and files)",
             true,
         );
-        // Replay the WAL before clearing the cursor which made its records durable.
-        $this->replay_index_update_wal();
-        $this->remove_index_update_wal();
+        // Replay the local index WAL before clearing the cursor which made its records durable.
+        $this->replay_local_index_wal();
+        $this->remove_local_index_wal();
         $this->reset_state();
-        $this->index_update_wal_handle = null;
-        $this->index_update_wal_record_count = 0;
+        $this->local_index_wal_handle = null;
+        $this->local_index_wal_record_count = 0;
 
         if (file_exists($this->remote_index_file)) {
             @unlink($this->remote_index_file);
@@ -2731,13 +2731,13 @@ class ImportClient
             $current_status !== null &&
             $current_status !== "complete";
 
-        $this->replay_index_update_wal();
+        $this->replay_local_index_wal();
         $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
         $this->assert_symlink_bundle_directory_unchanged();
 
         // Already completed.
         if ($current_status === "complete") {
-            $this->remove_index_update_wal();
+            $this->remove_local_index_wal();
             $has_skipped =
                 file_exists($this->skipped_fetch_list_file) &&
                 filesize($this->skipped_fetch_list_file) > 0;
@@ -2769,7 +2769,7 @@ class ImportClient
                 $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
                 $this->import_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state($this->state);
-                $this->open_index_update_wal();
+                $this->open_local_index_wal();
                 $this->run_files_sync_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
                 // tail finishes, restore the completed status so later filter
@@ -2779,7 +2779,7 @@ class ImportClient
                 }
                 $this->import_state()->active_resumable_command->completion_state = "complete";
                 $this->save_state($this->state);
-                $this->remove_index_update_wal();
+                $this->remove_local_index_wal();
                 return;
             }
 
@@ -2933,7 +2933,7 @@ class ImportClient
         $this->import_state()->active_resumable_command->completion_state = "in_progress";
         $this->save_state($this->state);
 
-        $this->open_index_update_wal();
+        $this->open_local_index_wal();
         $this->run_files_sync_pipeline();
 
         // Pipeline returns early with partial status if interrupted
@@ -2943,7 +2943,7 @@ class ImportClient
 
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->save_state($this->state);
-        $this->remove_index_update_wal();
+        $this->remove_local_index_wal();
 
         $this->progress->clear_progress_line();
         $index_size = $this->index_count();
@@ -6148,7 +6148,7 @@ class ImportClient
              * chunk. The part cursor points past the complete chunk, so saving it
              * early would make resume skip the missing suffix.
              *
-             * On the closing callback, flush the file and index-update WAL
+             * On the closing callback, flush the file and local index WAL
              * before storing the cursor in .import-state.json. If the response
              * stops first, state retains the preceding cursor; resume truncates
              * the later bytes and requests the multipart part again.
@@ -6180,10 +6180,10 @@ class ImportClient
                         $this->import_state()->current_file_bytes = null;
                     }
                     if (
-                        $this->index_update_wal_handle
-                        && !fflush($this->index_update_wal_handle)
+                        $this->local_index_wal_handle
+                        && !fflush($this->local_index_wal_handle)
                     ) {
-                        throw new RuntimeException('Failed to flush the index-update WAL.');
+                        throw new RuntimeException('Failed to flush the local index WAL.');
                     }
                     $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
                     $this->save_state($this->state);
@@ -6220,7 +6220,7 @@ class ImportClient
                 fclose($context->file_handle);
                 $context->file_handle = null;
             }
-            $this->apply_index_update_wal();
+            $this->apply_local_index_wal();
             $this->import_state()->active_resumable_command->completion_state = "partial";
             $this->save_state($this->state);
             return false;
@@ -6234,7 +6234,7 @@ class ImportClient
             $context->response_stats ?? [],
         );
         $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
-        $this->apply_index_update_wal();
+        $this->apply_local_index_wal();
         // Update file tracking: track in-progress file, or clear if complete/no active file
         if ($context->file_handle && $context->file_path) {
             if (!fflush($context->file_handle)) {
@@ -6571,7 +6571,7 @@ class ImportClient
                 $local_index_entry = $this->read_index_line($local_index_handle);
             }
         }
-        $this->open_index_update_wal();
+        $this->open_local_index_wal();
         $processed = 0;
 
         while (($line = fgets($remote_index_handle)) !== false) {
@@ -6670,10 +6670,10 @@ class ImportClient
                 $this->import_state()->diff->remote_offset = $remote_offset;
                 $this->import_state()->diff->local_after = $last_local_index_entry_path;
                 if (
-                    $this->index_update_wal_handle
-                    && !fflush($this->index_update_wal_handle)
+                    $this->local_index_wal_handle
+                    && !fflush($this->local_index_wal_handle)
                 ) {
-                    throw new RuntimeException('Failed to flush the index-update WAL.');
+                    throw new RuntimeException('Failed to flush the local index WAL.');
                 }
                 $this->save_state($this->state);
                 $this->progress->tick_spinner();
@@ -6701,7 +6701,7 @@ class ImportClient
 
         $this->import_state()->diff->remote_offset = $remote_offset;
         $this->import_state()->diff->local_after = $last_local_index_entry_path;
-        $this->apply_index_update_wal();
+        $this->apply_local_index_wal();
         $this->save_state($this->state);
 
         return !$this->shutdown_requested;
@@ -7156,48 +7156,48 @@ class ImportClient
         ];
     }
 
-    /** Opens the current index-update WAL for append. */
-    private function open_index_update_wal(): void
+    /** Opens the current local index WAL for append. */
+    private function open_local_index_wal(): void
     {
-        if ($this->index_update_wal_handle) {
+        if ($this->local_index_wal_handle) {
             return;
         }
-        $is_new = !is_file($this->index_update_wal_path);
-        $this->index_update_wal_handle = fopen($this->index_update_wal_path, "a");
-        if (!$this->index_update_wal_handle) {
-            throw new RuntimeException("Failed to open the index-update WAL.");
+        $is_new = !is_file($this->local_index_wal_path);
+        $this->local_index_wal_handle = fopen($this->local_index_wal_path, "a");
+        if (!$this->local_index_wal_handle) {
+            throw new RuntimeException("Failed to open the local index WAL.");
         }
         if ($is_new) {
             $this->audit_log(
-                "FILE CREATE | {$this->index_update_wal_path} | index-update WAL",
+                "FILE CREATE | {$this->local_index_wal_path} | local index WAL",
             );
         }
-        $this->index_update_wal_record_count = 0;
-        $this->last_update_path = null;
-        $this->last_update_delete = null;
-        $this->last_update_ctime = null;
-        $this->last_update_size = null;
-        $this->last_update_type = null;
+        $this->local_index_wal_record_count = 0;
+        $this->last_local_index_wal_path = null;
+        $this->last_local_index_wal_deletion = null;
+        $this->last_local_index_wal_ctime = null;
+        $this->last_local_index_wal_size = null;
+        $this->last_local_index_wal_type = null;
     }
 
     /**
-     * Record a file upsert in the index-update WAL.
+     * Record a file upsert in the local index WAL.
      */
-    private function record_index_update_file(
+    private function record_local_index_wal_file(
         string $path,
         int $ctime,
         int $size,
         string $type
     ): void {
-        if (!$this->index_update_wal_handle) {
-            $this->open_index_update_wal();
+        if (!$this->local_index_wal_handle) {
+            $this->open_local_index_wal();
         }
         if (
-            $this->last_update_path === $path &&
-            $this->last_update_delete === false &&
-            $this->last_update_ctime === $ctime &&
-            $this->last_update_size === $size &&
-            $this->last_update_type === $type
+            $this->last_local_index_wal_path === $path &&
+            $this->last_local_index_wal_deletion === false &&
+            $this->last_local_index_wal_ctime === $ctime &&
+            $this->last_local_index_wal_size === $size &&
+            $this->last_local_index_wal_type === $type
         ) {
             return;
         }
@@ -7213,30 +7213,30 @@ class ImportClient
         );
         if ($line !== false) {
             $line .= "\n";
-            $bytes = fwrite($this->index_update_wal_handle, $line);
+            $bytes = fwrite($this->local_index_wal_handle, $line);
             if ($bytes !== strlen($line)) {
-                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
+                throw new RuntimeException("Failed to write to the local index WAL (disk full?).");
             }
         }
-        $this->index_update_wal_record_count++;
-        $this->last_update_path = $path;
-        $this->last_update_delete = false;
-        $this->last_update_ctime = $ctime;
-        $this->last_update_size = $size;
-        $this->last_update_type = $type;
+        $this->local_index_wal_record_count++;
+        $this->last_local_index_wal_path = $path;
+        $this->last_local_index_wal_deletion = false;
+        $this->last_local_index_wal_ctime = $ctime;
+        $this->last_local_index_wal_size = $size;
+        $this->last_local_index_wal_type = $type;
     }
 
     /**
-     * Record a deletion in the index-update WAL.
+     * Record a deletion in the local index WAL.
      */
-    private function record_index_update_deletion(string $path): void
+    private function record_local_index_wal_deletion(string $path): void
     {
-        if (!$this->index_update_wal_handle) {
-            $this->open_index_update_wal();
+        if (!$this->local_index_wal_handle) {
+            $this->open_local_index_wal();
         }
         if (
-            $this->last_update_path === $path &&
-            $this->last_update_delete === true
+            $this->last_local_index_wal_path === $path &&
+            $this->last_local_index_wal_deletion === true
         ) {
             return;
         }
@@ -7249,59 +7249,59 @@ class ImportClient
         );
         if ($line !== false) {
             $line .= "\n";
-            $bytes = fwrite($this->index_update_wal_handle, $line);
+            $bytes = fwrite($this->local_index_wal_handle, $line);
             if ($bytes !== strlen($line)) {
-                throw new RuntimeException("Failed to write to the index-update WAL (disk full?).");
+                throw new RuntimeException("Failed to write to the local index WAL (disk full?).");
             }
         }
-        $this->index_update_wal_record_count++;
-        $this->last_update_path = $path;
-        $this->last_update_delete = true;
-        $this->last_update_ctime = null;
-        $this->last_update_size = null;
-        $this->last_update_type = null;
+        $this->local_index_wal_record_count++;
+        $this->last_local_index_wal_path = $path;
+        $this->last_local_index_wal_deletion = true;
+        $this->last_local_index_wal_ctime = null;
+        $this->last_local_index_wal_size = null;
+        $this->last_local_index_wal_type = null;
     }
 
-    /** Applies the current WAL to the import index. */
-    private function apply_index_update_wal(): void
+    /** Applies the current local index WAL to the local index. */
+    private function apply_local_index_wal(): void
     {
-        if ($this->index_update_wal_handle) {
-            $closed = fclose($this->index_update_wal_handle);
-            $this->index_update_wal_handle = null;
+        if ($this->local_index_wal_handle) {
+            $closed = fclose($this->local_index_wal_handle);
+            $this->local_index_wal_handle = null;
             if (!$closed) {
-                throw new RuntimeException("Failed to flush the index-update WAL.");
+                throw new RuntimeException("Failed to flush the local index WAL.");
             }
         }
-        $this->last_update_path = null;
-        $this->last_update_delete = null;
-        $this->last_update_ctime = null;
-        $this->last_update_size = null;
-        $this->last_update_type = null;
+        $this->last_local_index_wal_path = null;
+        $this->last_local_index_wal_deletion = null;
+        $this->last_local_index_wal_ctime = null;
+        $this->last_local_index_wal_size = null;
+        $this->last_local_index_wal_type = null;
 
-        $has_updates =
-            $this->index_update_wal_record_count > 0 ||
-            (is_file($this->index_update_wal_path) &&
-                filesize($this->index_update_wal_path) > 0);
+        $has_local_index_wal_records =
+            $this->local_index_wal_record_count > 0 ||
+            (is_file($this->local_index_wal_path) &&
+                filesize($this->local_index_wal_path) > 0);
 
-        if (!$has_updates) {
-            $this->index_update_wal_record_count = 0;
+        if (!$has_local_index_wal_records) {
+            $this->local_index_wal_record_count = 0;
             return;
         }
 
         $new_index = $this->local_index_file . ".new";
 
         $this->audit_log(
-            "INDEX MERGE START | merging updates into {$this->local_index_file}",
+            "INDEX MERGE START | merging local index WAL into {$this->local_index_file}",
         );
 
         $old_handle = file_exists($this->local_index_file)
             ? fopen($this->local_index_file, "r")
             : null;
-        $upd_handle = fopen($this->index_update_wal_path, "r");
+        $local_index_wal_read_handle = fopen($this->local_index_wal_path, "r");
         $new_handle = fopen($new_index, "w");
 
-        if (!$upd_handle || !$new_handle) {
-            throw new RuntimeException("Failed to merge index updates");
+        if (!$local_index_wal_read_handle || !$new_handle) {
+            throw new RuntimeException("Failed to merge local index WAL records");
         }
 
         $write_line = function ($handle, array $entry): void {
@@ -7320,12 +7320,15 @@ class ImportClient
         };
 
         $old = $this->read_index_line($old_handle);
-        $carry = null;
-        $upd = $this->read_update_line($upd_handle, $carry);
+        $local_index_wal_lookahead_entry = null;
+        $local_index_wal_entry = $this->read_local_index_wal_line(
+            $local_index_wal_read_handle,
+            $local_index_wal_lookahead_entry
+        );
         $last_written_path = null;
 
-        while ($old !== null || $upd !== null) {
-            if ($upd === null) {
+        while ($old !== null || $local_index_wal_entry !== null) {
+            if ($local_index_wal_entry === null) {
                 if ($last_written_path !== $old["path"]) {
                     $write_line($new_handle, $old);
                     $last_written_path = $old["path"];
@@ -7335,22 +7338,34 @@ class ImportClient
             }
 
             if ($old === null) {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
+                if (
+                    !$local_index_wal_entry["delete"] &&
+                    $last_written_path !== $local_index_wal_entry["path"]
+                ) {
+                    $write_line($new_handle, $local_index_wal_entry);
+                    $last_written_path = $local_index_wal_entry["path"];
                 }
-                $upd = $this->read_update_line($upd_handle, $carry);
+                $local_index_wal_entry = $this->read_local_index_wal_line(
+                    $local_index_wal_read_handle,
+                    $local_index_wal_lookahead_entry
+                );
                 continue;
             }
 
-            $cmp = strcmp($old["path"], $upd["path"]);
+            $cmp = strcmp($old["path"], $local_index_wal_entry["path"]);
             if ($cmp === 0) {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
+                if (
+                    !$local_index_wal_entry["delete"] &&
+                    $last_written_path !== $local_index_wal_entry["path"]
+                ) {
+                    $write_line($new_handle, $local_index_wal_entry);
+                    $last_written_path = $local_index_wal_entry["path"];
                 }
                 $old = $this->read_index_line($old_handle);
-                $upd = $this->read_update_line($upd_handle, $carry);
+                $local_index_wal_entry = $this->read_local_index_wal_line(
+                    $local_index_wal_read_handle,
+                    $local_index_wal_lookahead_entry
+                );
             } elseif ($cmp < 0) {
                 if ($last_written_path !== $old["path"]) {
                     $write_line($new_handle, $old);
@@ -7358,18 +7373,24 @@ class ImportClient
                 }
                 $old = $this->read_index_line($old_handle);
             } else {
-                if (!$upd["delete"] && $last_written_path !== $upd["path"]) {
-                    $write_line($new_handle, $upd);
-                    $last_written_path = $upd["path"];
+                if (
+                    !$local_index_wal_entry["delete"] &&
+                    $last_written_path !== $local_index_wal_entry["path"]
+                ) {
+                    $write_line($new_handle, $local_index_wal_entry);
+                    $last_written_path = $local_index_wal_entry["path"];
                 }
-                $upd = $this->read_update_line($upd_handle, $carry);
+                $local_index_wal_entry = $this->read_local_index_wal_line(
+                    $local_index_wal_read_handle,
+                    $local_index_wal_lookahead_entry
+                );
             }
         }
 
         if ($old_handle) {
             fclose($old_handle);
         }
-        fclose($upd_handle);
+        fclose($local_index_wal_read_handle);
         fclose($new_handle);
 
         if (!rename($new_index, $this->local_index_file)) {
@@ -7377,38 +7398,38 @@ class ImportClient
         }
         $this->audit_log("INDEX MERGE COMPLETE | {$this->local_index_file} updated");
 
-        if (file_put_contents($this->index_update_wal_path, '') === false) {
-            throw new RuntimeException("Failed to clear the applied index-update WAL.");
+        if (file_put_contents($this->local_index_wal_path, '') === false) {
+            throw new RuntimeException("Failed to clear the applied local index WAL.");
         }
         $this->audit_log(
-            "FILE TRUNCATE | {$this->index_update_wal_path} | WAL batch applied"
+            "FILE TRUNCATE | {$this->local_index_wal_path} | local index WAL batch applied"
         );
-        $this->index_update_wal_record_count = 0;
+        $this->local_index_wal_record_count = 0;
     }
 
-    /** Removes the WAL marker after files-pull completes or is aborted. */
-    private function remove_index_update_wal(): void
+    /** Removes the local index WAL marker after files-pull completes or is aborted. */
+    private function remove_local_index_wal(): void
     {
-        if (is_resource($this->index_update_wal_handle)) {
-            if (!fclose($this->index_update_wal_handle)) {
-                throw new RuntimeException("Failed to flush the index-update WAL.");
+        if (is_resource($this->local_index_wal_handle)) {
+            if (!fclose($this->local_index_wal_handle)) {
+                throw new RuntimeException("Failed to flush the local index WAL.");
             }
-            $this->index_update_wal_handle = null;
+            $this->local_index_wal_handle = null;
         }
-        clearstatcache(true, $this->index_update_wal_path);
+        clearstatcache(true, $this->local_index_wal_path);
         if (
-            is_file($this->index_update_wal_path)
-            && filesize($this->index_update_wal_path) > 0
+            is_file($this->local_index_wal_path)
+            && filesize($this->local_index_wal_path) > 0
         ) {
-            throw new RuntimeException("Cannot remove an unapplied index-update WAL.");
+            throw new RuntimeException("Cannot remove an unapplied local index WAL.");
         }
         if (
-            is_file($this->index_update_wal_path)
-            && !unlink($this->index_update_wal_path)
+            is_file($this->local_index_wal_path)
+            && !unlink($this->local_index_wal_path)
         ) {
-            throw new RuntimeException("Failed to remove the index-update WAL.");
+            throw new RuntimeException("Failed to remove the local index WAL.");
         }
-        $this->index_update_wal_record_count = 0;
+        $this->local_index_wal_record_count = 0;
     }
 
     /**
@@ -7429,9 +7450,9 @@ class ImportClient
     }
 
     /**
-     * Read one raw update record (F/D) from the updates file.
+     * Read one raw local index WAL record (F/D).
      */
-    private function read_update_line_raw($handle): ?array
+    private function read_local_index_wal_line_raw($handle): ?array
     {
         if (!$handle) {
             return null;
@@ -7446,16 +7467,16 @@ class ImportClient
             }
             $data = json_decode($line, true);
             if (!is_array($data)) {
-                throw new RuntimeException("Invalid index update line format");
+                throw new RuntimeException("Invalid local index WAL line format");
             }
             $op = $data["op"] ?? null;
             $path_encoded = $data["path"] ?? null;
             if (!is_string($path_encoded) || $path_encoded === "") {
-                throw new RuntimeException("Invalid index update path");
+                throw new RuntimeException("Invalid local index WAL path");
             }
             $path = base64_decode($path_encoded);
             if ($path === false || $path === "") {
-                throw new RuntimeException("Invalid index update path (base64 decode failed)");
+                throw new RuntimeException("Invalid local index WAL path (base64 decode failed)");
             }
             if ($op === "D") {
                 return [
@@ -7480,24 +7501,24 @@ class ImportClient
     }
 
     /**
-     * Read one update record, coalescing consecutive updates to the same path.
+     * Read one local index WAL record, coalescing consecutive records for the same path.
      *
-     * @param mixed $handle Update file handle
-     * @param array|null $carry Read-ahead buffer for the next record
+     * @param mixed $handle Local index WAL file handle
+     * @param array|null $carry Local index WAL lookahead entry
      */
-    private function read_update_line($handle, ?array &$carry = null): ?array
+    private function read_local_index_wal_line($handle, ?array &$carry = null): ?array
     {
         if (!$handle) {
             return null;
         }
-        $current = $carry ?? $this->read_update_line_raw($handle);
+        $current = $carry ?? $this->read_local_index_wal_line_raw($handle);
         $carry = null;
         if ($current === null) {
             return null;
         }
 
         while (true) {
-            $next = $this->read_update_line_raw($handle);
+            $next = $this->read_local_index_wal_line_raw($handle);
             if ($next === null) {
                 return $current;
             }
@@ -7505,7 +7526,7 @@ class ImportClient
                 $carry = $next;
                 return $current;
             }
-            // Same path: keep the latest update.
+            // Same path: keep the latest local index WAL record.
             $current = $next;
         }
     }
@@ -11443,12 +11464,12 @@ class ImportClient
         $this->shutdown_requested = true;
         $this->progress->clear_progress_line();
 
-        if (is_resource($this->index_update_wal_handle)) {
+        if (is_resource($this->local_index_wal_handle)) {
             try {
-                $this->apply_index_update_wal();
+                $this->apply_local_index_wal();
             } catch (Exception $e) {
                 $this->audit_log(
-                    "Failed to apply the index-update WAL on shutdown: " .
+                    "Failed to apply the local index WAL on shutdown: " .
                         $e->getMessage(),
                     true,
                 );

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1847,15 +1847,15 @@ class ImportClient
                 'The filesystem root does not exist or is not a directory: ' . $filesystem_root . '.'
             );
         }
-        $resolved_filesystem_root = realpath($filesystem_root);
-        if ($resolved_filesystem_root === false) {
+        $resolved_local_filesystem_root = realpath($filesystem_root);
+        if ($resolved_local_filesystem_root === false) {
             throw new InvalidArgumentException(
                 'The filesystem root does not exist or is not a directory: ' . $filesystem_root . '.'
             );
         }
-        $resolved_filesystem_root = rtrim($resolved_filesystem_root, '/') ?: '/';
+        $resolved_local_filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
         $remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
-        $pair = hash('sha256', $remote_reprint_api_url . "\0" . $resolved_filesystem_root);
+        $pair = hash('sha256', $remote_reprint_api_url . "\0" . $resolved_local_filesystem_root);
         // Resolve an absolute physical path even when its final components do not exist.
         $push_state_directory = $state_dir . '/push/' . $pair;
         if (strpos($push_state_directory, '/') !== 0) {
@@ -1886,18 +1886,18 @@ class ImportClient
             );
         }
         if (
-            $resolved_filesystem_root === '/'
-            || path_is_within_root($push_state_directory, $resolved_filesystem_root)
+            $resolved_local_filesystem_root === '/'
+            || path_is_within_root($push_state_directory, $resolved_local_filesystem_root)
         ) {
             throw new InvalidArgumentException(
                 'The local push state directory ' . $push_state_directory
-                . ' must be outside the filesystem root ' . $resolved_filesystem_root . '.'
+                . ' must be outside the filesystem root ' . $resolved_local_filesystem_root . '.'
             );
         }
 
         return [
             'remote_reprint_api_url' => $remote_reprint_api_url,
-            'filesystem_root' => $resolved_filesystem_root,
+            'filesystem_root' => $resolved_local_filesystem_root,
             'pair' => $pair,
             'push_state_directory' => $push_state_directory,
         ];

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -263,7 +263,7 @@ class ImportClient
     public $target_url;
 
     /** @var string State directory for this filesystem root (.import-state.json, db.sql, etc.). */
-    public $state_directory;
+    public $state_dir;
 
     /** @var string Filesystem root where the target filesystem is reconstructed. */
     public $filesystem_root;
@@ -529,7 +529,7 @@ class ImportClient
 
     public function __construct(
         string $target_url,
-        string $state_directory,
+        string $state_dir,
         string $filesystem_root,
         ?string $signal_handling_command = null
     )
@@ -552,21 +552,21 @@ class ImportClient
         }
 
         $this->target_url = rtrim($target_url, "?&");
-        $this->state_directory = rtrim($state_directory, "/");
+        $this->state_dir = rtrim($state_dir, "/");
         $this->filesystem_root = rtrim($filesystem_root, "/");
-        $this->state_file = $this->state_directory . "/.import-state.json";
-        $this->local_index_file = $this->state_directory . "/.import-index.jsonl";
+        $this->state_file = $this->state_dir . "/.import-state.json";
+        $this->local_index_file = $this->state_dir . "/.import-index.jsonl";
         $this->index_update_wal_path =
-            $this->state_directory . "/.import-index-updates.wal";
+            $this->state_dir . "/.import-index-updates.wal";
         $this->target_index_file =
-            $this->state_directory . "/.import-remote-index.jsonl";
+            $this->state_dir . "/.import-remote-index.jsonl";
         $this->download_list_file =
-            $this->state_directory . "/.import-download-list.jsonl";
+            $this->state_dir . "/.import-download-list.jsonl";
         $this->skipped_download_list_file =
-            $this->state_directory . "/.import-download-list-skipped.jsonl";
-        $this->audit_log = $this->state_directory . "/.import-audit.log";
-        $this->volatile_files_file = $this->state_directory . "/.import-volatile-files.json";
-        $this->status_file = $this->state_directory . "/.import-status.json";
+            $this->state_dir . "/.import-download-list-skipped.jsonl";
+        $this->audit_log = $this->state_dir . "/.import-audit.log";
+        $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
+        $this->status_file = $this->state_dir . "/.import-status.json";
 
         // Detect TTY for progress display. In stdout mode this is re-evaluated
         // against STDERR in run() once we know the output mode.
@@ -576,9 +576,9 @@ class ImportClient
         $this->pull = new Pull($this, $this->progress);
 
         // Create directories
-        if (!is_dir($this->state_directory)) {
-            if (!mkdir($this->state_directory, 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->state_directory}");
+        if (!is_dir($this->state_dir)) {
+            if (!mkdir($this->state_dir, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->state_dir}");
             }
         }
         if (!is_dir($this->filesystem_root)) {
@@ -890,7 +890,7 @@ class ImportClient
         ?ReprintProcessLock $process_lock = null
     ): void
     {
-        $process_lock = $process_lock ?? new ReprintProcessLock($this->state_directory);
+        $process_lock = $process_lock ?? new ReprintProcessLock($this->state_dir);
         if (!$process_lock->is_held()) {
             throw new InvalidArgumentException(
                 'ImportClient requires a held Reprint process lock.'
@@ -1324,7 +1324,7 @@ class ImportClient
     {
         $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
             $this->target_url,
-            $this->state_directory,
+            $this->state_dir,
             $this->filesystem_root,
             'files-diff'
         );
@@ -1542,7 +1542,7 @@ class ImportClient
         $started_at = hrtime(true) / 1000000000;
         $context = $options['files_push_context'] ?? self::prepare_files_push_context(
             $this->target_url,
-            $this->state_directory,
+            $this->state_dir,
             $this->filesystem_root,
             $options
         );
@@ -1769,7 +1769,7 @@ class ImportClient
      */
     public static function prepare_files_push_context(
         string $target_url,
-        string $state_directory,
+        string $state_dir,
         string $filesystem_root,
         array $options
     ): array {
@@ -1785,7 +1785,7 @@ class ImportClient
 
         $context = self::prepare_files_pair_context(
             $target_url,
-            $state_directory,
+            $state_dir,
             $filesystem_root,
             'files-push'
         );
@@ -1820,7 +1820,7 @@ class ImportClient
      */
     public static function prepare_files_pair_context(
         string $target_url,
-        string $state_directory,
+        string $state_dir,
         string $filesystem_root,
         string $command
     ): array {
@@ -1855,7 +1855,7 @@ class ImportClient
         $target_url = rtrim($target_url, '?&');
         $pair = hash('sha256', $target_url . "\0" . $resolved_filesystem_root);
         // Resolve an absolute physical path even when its final components do not exist.
-        $push_state_directory = $state_directory . '/push/' . $pair;
+        $push_state_directory = $state_dir . '/push/' . $pair;
         if (strpos($push_state_directory, '/') !== 0) {
             $working_directory = getcwd();
             if ($working_directory === false) {
@@ -1998,7 +1998,7 @@ class ImportClient
                 $this->save_state($this->state);
 
                 if ($this->sql_output_mode === "file") {
-                    $sql_file = $this->state_directory . "/db.sql";
+                    $sql_file = $this->state_dir . "/db.sql";
                     if (file_exists($sql_file)) {
                         unlink($sql_file);
                         $this->audit_log(
@@ -2006,14 +2006,14 @@ class ImportClient
                         );
                     }
                 }
-                $tables_file = $this->state_directory . "/db-tables.jsonl";
+                $tables_file = $this->state_dir . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
                         "FILE DELETE | {$tables_file} | abort db-pull",
                     );
                 }
-                $domains_file = $this->state_directory . "/.import-domains.json";
+                $domains_file = $this->state_dir . "/.import-domains.json";
                 if (file_exists($domains_file)) {
                     unlink($domains_file);
                     $this->audit_log(
@@ -2030,7 +2030,7 @@ class ImportClient
                 $this->reset_state();
                 $this->save_state($this->state);
 
-                $tables_file = $this->state_directory . "/db-tables.jsonl";
+                $tables_file = $this->state_dir . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
@@ -2231,7 +2231,7 @@ class ImportClient
      */
     private function download_runtime_files(): void
     {
-        $runtime_dir = $this->state_directory . "/runtime_files";
+        $runtime_dir = $this->state_dir . "/runtime_files";
 
         // Always wipe and recreate so the directory reflects current state.
         if (is_dir($runtime_dir)) {
@@ -3640,7 +3640,7 @@ class ImportClient
     public function run_db_sync(): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
-        $sql_file = $this->state_directory . "/db.sql";
+        $sql_file = $this->state_dir . "/db.sql";
 
         $has_progress =
             $state_command === "db-pull" &&
@@ -3798,8 +3798,8 @@ class ImportClient
      */
     private function run_db_domains(): void
     {
-        $domains_file = $this->state_directory . "/.import-domains.json";
-        $sql_file = $this->state_directory . "/db.sql";
+        $domains_file = $this->state_dir . "/.import-domains.json";
+        $sql_file = $this->state_dir . "/db.sql";
 
         if (file_exists($domains_file)) {
             // Fast path: domains were already discovered during db-pull
@@ -3851,7 +3851,7 @@ class ImportClient
             );
         } else {
             throw new RuntimeException(
-                "No domain data found. Run db-pull first, or place a db.sql file in {$this->state_directory}.",
+                "No domain data found. Run db-pull first, or place a db.sql file in {$this->state_dir}.",
             );
         }
 
@@ -4344,11 +4344,11 @@ class ImportClient
         }
 
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL"] = $base_url;
-        $state_directory = realpath($this->state_directory) ?: $this->state_directory;
+        $state_dir = realpath($this->state_dir) ?: $this->state_dir;
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
-            rtrim($state_directory, "/") . "/.import-state.json";
+            rtrim($state_dir, "/") . "/.import-state.json";
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
-            rtrim($state_directory, "/") . "/.import-download-list-skipped.jsonl";
+            rtrim($state_dir, "/") . "/.import-download-list-skipped.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -5215,10 +5215,10 @@ class ImportClient
 
     public function run_db_apply(array $options): void
     {
-        $sql_file = $this->state_directory . "/db.sql";
+        $sql_file = $this->state_dir . "/db.sql";
         if (!file_exists($sql_file)) {
             throw new RuntimeException(
-                "db.sql not found in {$this->state_directory}. Run db-pull first.",
+                "db.sql not found in {$this->state_dir}. Run db-pull first.",
             );
         }
 
@@ -5235,7 +5235,7 @@ class ImportClient
         }
 
         // Show discovered domains if available
-        $domains_file = $this->state_directory . "/.import-domains.json";
+        $domains_file = $this->state_dir . "/.import-domains.json";
         if (file_exists($domains_file)) {
             $domains = json_decode(file_get_contents($domains_file), true);
             if (is_array($domains) && !empty($domains)) {
@@ -5403,7 +5403,7 @@ class ImportClient
         $stmts_since_save = 0;
 
         // Load pre-computed statement count from db-pull for progress reporting
-        $sql_stats_file = $this->state_directory . "/.import-sql-stats.json";
+        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
         $statements_total = null;
         if (file_exists($sql_stats_file)) {
             $stats = json_decode(file_get_contents($sql_stats_file), true);
@@ -5867,7 +5867,7 @@ class ImportClient
     private function run_db_index(): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
-        $tables_file = $this->state_directory . "/db-tables.jsonl";
+        $tables_file = $this->state_dir . "/db-tables.jsonl";
 
         $has_cursor =
             $state_command === "db-index" &&
@@ -7506,7 +7506,7 @@ class ImportClient
         $sql_buffer = "";
 
         if ($mode === "file") {
-            $sql_file = $this->state_directory . "/db.sql";
+            $sql_file = $this->state_dir . "/db.sql";
 
             // Crash recovery: if SQL file is larger than expected, truncate it.
             // This happens if we crashed after writing but before saving the new cursor.
@@ -7578,7 +7578,7 @@ class ImportClient
             // Each SQL chunk is appended to this file as it arrives; when the
             // query completes and executes, the file is truncated. If the process
             // dies at any point, the next run reloads whatever was accumulated.
-            $buffer_file = $this->state_directory . "/.sql-buffer";
+            $buffer_file = $this->state_dir . "/.sql-buffer";
             if (file_exists($buffer_file)) {
                 $sql_buffer = file_get_contents($buffer_file);
                 $this->audit_log(
@@ -7601,8 +7601,8 @@ class ImportClient
         $domain_collector = class_exists('DomainCollector')
             ? new \DomainCollector()
             : null;
-        $domains_file = $this->state_directory . "/.import-domains.json";
-        $sql_stats_file = $this->state_directory . "/.import-sql-stats.json";
+        $domains_file = $this->state_dir . "/.import-domains.json";
+        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
         $sql_statements_counted = (int) ($this->import_state()->sql_statements_counted ?? 0);
 
         // Auto-detect the source site domain from the export URL so it
@@ -7941,7 +7941,7 @@ class ImportClient
                 $mysql_conn = null;
                 // Clean up buffer file — if we got here with an empty buffer,
                 // all queries were executed successfully.
-                $buffer_file = $this->state_directory . "/.sql-buffer";
+                $buffer_file = $this->state_dir . "/.sql-buffer";
                 if ($pending === "" && file_exists($buffer_file)) {
                     unlink($buffer_file);
                 }
@@ -8201,7 +8201,7 @@ class ImportClient
     {
         $cursor = $this->import_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
-        $tables_file = $this->state_directory . "/db-tables.jsonl";
+        $tables_file = $this->state_dir . "/db-tables.jsonl";
 
         $stats = $this->import_state()->db_index;
         $tables_written = $stats->tables;
@@ -11633,7 +11633,7 @@ if (
     //                  'value-or-next' --name=VAL or --name VAL
     //                  'pair'          --name A B (repeatable, takes 2 args)
     //   target         Where to store the parsed value:
-    //                  'state_directory' | 'filesystem_root' → special local variables
+    //                  'state_dir' | 'filesystem_root' → special local variables
     //                  'key'                   → $options['key']
     //                  'tuning_config.key'     → $options['tuning_config']['key']
     //   help           Description for --help output (null = hidden)
@@ -11654,7 +11654,7 @@ if (
         [
             'name' => 'state-dir',
             'type' => 'value',
-            'target' => 'state_directory',
+            'target' => 'state_dir',
             'placeholder' => 'DIR',
             'help' => 'Directory for import state files and SQL dumps',
             'help_section' => 'required',
@@ -12084,7 +12084,7 @@ if (
      */
     function _cli_parse_options(array $argv, int $argc, int $start, array $option_defs): array
     {
-        $state_directory = null;
+        $state_dir = null;
         $filesystem_root = null;
         $options = [
             "abort" => false,
@@ -12114,7 +12114,7 @@ if (
                                     fwrite(STDERR, "Invalid --{$def['name']} value: {$raw}. Valid values: " . implode(", ", $def['valid_values']) . "\n");
                                     exit(1);
                                 }
-                                _cli_store($def, $value, $state_directory, $filesystem_root, $options);
+                                _cli_store($def, $value, $state_dir, $filesystem_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12122,7 +12122,7 @@ if (
 
                         case 'flag':
                             if ($arg === "--{$cli_name}" || (isset($def['short']) && $arg === "-{$def['short']}")) {
-                                _cli_store($def, $def['flag_value'] ?? true, $state_directory, $filesystem_root, $options);
+                                _cli_store($def, $def['flag_value'] ?? true, $state_dir, $filesystem_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12132,7 +12132,7 @@ if (
                             $prefix = "--{$cli_name}=";
                             if (strpos($arg, $prefix) === 0) {
                                 $raw = substr($arg, strlen($prefix));
-                                _cli_store($def, $raw, $state_directory, $filesystem_root, $options);
+                                _cli_store($def, $raw, $state_dir, $filesystem_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12141,7 +12141,7 @@ if (
                                     fwrite(STDERR, "--{$def['name']} requires one argument: " . ($def['placeholder'] ?? 'VALUE') . "\n");
                                     exit(1);
                                 }
-                                _cli_store($def, $argv[$i + 1], $state_directory, $filesystem_root, $options);
+                                _cli_store($def, $argv[$i + 1], $state_dir, $filesystem_root, $options);
                                 $i += 1;
                                 $matched = true;
                                 break 3;
@@ -12174,7 +12174,7 @@ if (
             }
         }
 
-        return [$state_directory, $filesystem_root, $options];
+        return [$state_dir, $filesystem_root, $options];
     }
 
     /** @internal */
@@ -12189,10 +12189,10 @@ if (
     }
 
     /** @internal */
-    function _cli_store(array $def, $value, ?string &$state_directory, ?string &$filesystem_root, array &$options): void
+    function _cli_store(array $def, $value, ?string &$state_dir, ?string &$filesystem_root, array &$options): void
     {
         $target = $def['target'];
-        if ($target === 'state_directory') { $state_directory = $value; return; }
+        if ($target === 'state_dir') { $state_dir = $value; return; }
         if ($target === 'filesystem_root')      { $filesystem_root = $value; return; }
         if (strpos($target, 'tuning_config.') === 0) {
             $options['tuning_config'][substr($target, strlen('tuning_config.'))] = $value;
@@ -12885,7 +12885,7 @@ if (
         $option_start_index = 3;
     }
 
-    [$state_directory, $filesystem_root, $options] = _cli_parse_options(
+    [$state_dir, $filesystem_root, $options] = _cli_parse_options(
         $argv, $argc, $option_start_index, $option_defs
     );
     $options["command"] = $command;
@@ -12923,7 +12923,7 @@ if (
         exit(1);
     }
 
-    if (!$state_directory) {
+    if (!$state_dir) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
@@ -12947,31 +12947,31 @@ if (
         // import-metadata reads only state, but ImportClient still expects
         // a filesystem root path. Point it at state-dir rather than requiring an
         // otherwise-unused CLI option.
-        $filesystem_root = $flat_document_root ?: $state_directory;
+        $filesystem_root = $flat_document_root ?: $state_dir;
     }
 
     try {
         // Acquire the lock before pair setup and audit writes so each command
         // owns every local state transition for its complete invocation.
-        $reprint_process_lock = new ReprintProcessLock($state_directory);
+        $reprint_process_lock = new ReprintProcessLock($state_dir);
         $reprint_files_push_context = null;
         $reprint_files_diff_context = null;
         if ($command === 'files-push') {
             $reprint_files_push_context = ImportClient::prepare_files_push_context(
                 $target_url,
-                $state_directory,
+                $state_dir,
                 $filesystem_root,
                 $options
             );
         } elseif ($command === 'files-diff') {
             $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
                 $target_url,
-                $state_directory,
+                $state_dir,
                 $filesystem_root,
                 'files-diff'
             );
         }
-        $client = new ImportClient($target_url, $state_directory, $filesystem_root, $command);
+        $client = new ImportClient($target_url, $state_dir, $filesystem_root, $command);
         $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
         $client->audit_log_argv($command, $argv, $reprint_files_pair);
         $client->run(

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4099,7 +4099,7 @@ class ImportClient
 
         if (!empty($flat_document_root)) {
             // --flat-document-root: used directly as the web root.
-            $local_document_root = rtrim($flat_document_root, "/");
+            $raw_local_document_root = rtrim($flat_document_root, "/");
         } else {
             // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
@@ -4114,14 +4114,14 @@ class ImportClient
             }
 
             if ($remote_doc_root !== "") {
-                $local_document_root = $this->filesystem_root . $remote_doc_root;
+                $raw_local_document_root = $this->filesystem_root . $remote_doc_root;
             } else {
-                $local_document_root = $this->filesystem_root;
+                $raw_local_document_root = $this->filesystem_root;
             }
 
-            if (!is_dir($local_document_root)) {
+            if (!is_dir($raw_local_document_root)) {
                 throw new RuntimeException(
-                    "Local document root does not exist: {$local_document_root}\n" .
+                    "Local document root does not exist: {$raw_local_document_root}\n" .
                     "The remote document_root was: {$remote_doc_root}\n" .
                     "If you used flat-docroot, pass the flattened directory " .
                     "with --flat-document-root instead of --fs-root."
@@ -4131,7 +4131,7 @@ class ImportClient
 
         // Resolve to absolute paths so generated files work from any cwd.
         $abs_output_dir = realpath($output_dir) ?: $output_dir;
-        $resolved_local_document_root = realpath($local_document_root) ?: $local_document_root;
+        $local_document_root = realpath($raw_local_document_root) ?: $raw_local_document_root;
 
         if (!is_dir($abs_output_dir)) {
             if (!mkdir($abs_output_dir, 0755, true)) {
@@ -4219,13 +4219,13 @@ class ImportClient
         $abspath = rtrim($paths_urls["abspath"] ?? "", "/");
         if (!empty($flat_document_root)) {
             // Flattened layout: index.php is at the top level.
-            $wordpress_index_php = $resolved_local_document_root . '/index.php';
+            $wordpress_index_php = $local_document_root . '/index.php';
         } elseif ($abspath !== "") {
             // Raw download: ABSPATH is relative to the download root,
             // not the local document root (which is download_root + document_root).
             $wordpress_index_php = realpath($this->filesystem_root . $abspath . '/index.php') ?: '';
         } else {
-            $wordpress_index_php = $resolved_local_document_root . '/index.php';
+            $wordpress_index_php = $local_document_root . '/index.php';
         }
 
         // Step 2: Runtime applier writes server-specific config files.
@@ -4254,11 +4254,11 @@ class ImportClient
             // Resolve {fs-root} in db_dir now that we have the real path.
             $manifest->sqlite['db_dir'] = resolve_runtime_placeholders(
                 $manifest->sqlite['db_dir'],
-                $resolved_local_document_root,
+                $local_document_root,
             );
         }
 
-        $summary = $applier->apply($manifest, $resolved_local_document_root, $abs_output_dir, $applier_options);
+        $summary = $applier->apply($manifest, $local_document_root, $abs_output_dir, $applier_options);
 
         if ($manifest->sqlite !== null) {
             $summary[] = "Copied sqlite-database-integration to {$abs_output_dir}/sqlite-database-integration";
@@ -4269,7 +4269,7 @@ class ImportClient
         // depend on infrastructure (Memcached servers, multisite APIs)
         // not available outside the original hosting environment.
         foreach ($manifest->paths_to_remove as $rel_path) {
-            $full_path = $resolved_local_document_root . '/' . ltrim($rel_path, '/');
+            $full_path = $local_document_root . '/' . ltrim($rel_path, '/');
             if (!file_exists($full_path) && !is_link($full_path)) {
                 continue;
             }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -717,7 +717,7 @@ class ImportClient
         }
 
         if ($assert_remap) {
-            $this->assert_files_remap_consistent();
+            $this->assert_resolved_path_mappings_consistent();
         }
     }
 
@@ -3555,7 +3555,7 @@ class ImportClient
             // Repoint through the same seam regular symlink chunks use, so the
             // link targets wherever the content actually landed (filesystem root,
             // remapped, or bundled) instead of the raw source spelling.
-            $symlink_target = $this->map_symlink_target_for_local_mirror(
+            $symlink_target = $this->rewrite_symlink_target_for_local_filesystem(
                 $remote_absolute_path,
                 $local_absolute_path,
                 $symlink_target
@@ -3570,7 +3570,7 @@ class ImportClient
             $parent = dirname($local_absolute_path);
             if (!is_dir($parent)) {
                 try {
-                    $this->ensure_directory_path($parent);
+                    $this->create_directory_if_missing($parent);
                 } catch (RuntimeException $e) {
                     $this->audit_log(
                         "INTERMEDIATE SYMLINK SKIP: failed to prepare parent for {$remote_absolute_path}: " .
@@ -7056,7 +7056,7 @@ class ImportClient
     }
 
     /**
-     * Remove the local mirror entry for a deletion reported by the remote index.
+     * Remove the local filesystem entry for a deletion reported by the remote index.
      */
     private function apply_remote_deletion_locally(string $remote_absolute_path): void
     {
@@ -8453,7 +8453,7 @@ class ImportClient
     }
 
     /**
-     * Map a remote symlink target to the filesystem root mirror when possible.
+     * Rewrite a remote symlink target for the local filesystem when possible.
      *
      * Handles both absolute and relative targets (relative ones are resolved
      * against the symlink's source directory). In-scope and non-followed targets
@@ -8484,9 +8484,9 @@ class ImportClient
      * Without this mapping, the symlink would point at /tmp/e2e-shared-themes/pub/indice
      * (which does not exist on the local machine, or worse, exists with unrelated content).
      * With this mapping, the symlink is rewritten to a relative path that resolves to the
-     * mirrored local copy under filesystem root.
+     * local copy under filesystem root.
      */
-    private function map_symlink_target_for_local_mirror(
+    private function rewrite_symlink_target_for_local_filesystem(
         string $remote_absolute_path,
         string $local_absolute_path,
         string $target
@@ -8604,10 +8604,10 @@ class ImportClient
      * local absolute paths from the current remap rules, so changing those rules while the
      * same index is still in use can point future updates at the wrong path.
      */
-    private function assert_files_remap_consistent(): void
+    private function assert_resolved_path_mappings_consistent(): void
     {
-        $fingerprint = $this->files_remap_fingerprint();
-        $previous = $this->import_state()->files_remap_fingerprint ?? null;
+        $fingerprint = $this->resolved_path_mappings_fingerprint();
+        $previous = $this->import_state()->resolved_path_mappings_fingerprint ?? null;
 
         $has_existing_index = file_exists($this->local_index_file) && filesize($this->local_index_file) > 0;
         if ($previous === null && $has_existing_index && !empty($this->resolved_path_mappings)) {
@@ -8625,18 +8625,18 @@ class ImportClient
         }
 
         if ($previous === null) {
-            $this->import_state()->files_remap_fingerprint = $fingerprint;
+            $this->import_state()->resolved_path_mappings_fingerprint = $fingerprint;
             $this->save_state($this->state);
         }
     }
 
     /**
-     * Stable fingerprint for the resolved remap rule set.
+     * Stable fingerprint for the resolved path mappings.
      *
      * Rule order does not matter: remap matching chooses the deepest source
      * path, not the first matching rule.
      */
-    private function files_remap_fingerprint(): string
+    private function resolved_path_mappings_fingerprint(): string
     {
         $rules = $this->resolved_path_mappings;
         ksort($rules, SORT_STRING);
@@ -8995,30 +8995,6 @@ class ImportClient
     }
 
     /**
-     * Map a remote absolute path through the resolved path mappings, or
-     * return null when no mapping applies. The deepest remote prefix wins.
-     *
-     * Matching mapping prefixes are nested, so the longest remote prefix is
-     * the most specific match.
-     */
-    private function map_remote_absolute_path_with_resolved_mappings(
-        string $remote_absolute_path
-    ): ?string {
-        $local_absolute_path = null;
-        $longest_remote_prefix_length = -1;
-
-        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
-            $remainder = self::path_remainder_under($remote_absolute_path, $remote_prefix);
-            if ($remainder !== null && strlen($remote_prefix) > $longest_remote_prefix_length) {
-                $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
-                $longest_remote_prefix_length = strlen($remote_prefix);
-            }
-        }
-
-        return $local_absolute_path;
-    }
-
-    /**
      * Map a remote absolute path to a local absolute path under the filesystem
      * root. Symlink traversal checks prevent writes outside the filesystem root.
      *
@@ -9030,13 +9006,17 @@ class ImportClient
         string $remote_absolute_path
     ): string {
         assert_valid_path($remote_absolute_path, "remote absolute path");
-        if (!empty($this->resolved_path_mappings)) {
-            $local_absolute_path = $this->map_remote_absolute_path_with_resolved_mappings(
-                $remote_absolute_path
-            );
-            if ($local_absolute_path !== null) {
-                return $local_absolute_path;
+        $local_absolute_path = null;
+        $longest_remote_prefix_length = -1;
+        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
+            $remainder = self::path_remainder_under($remote_absolute_path, $remote_prefix);
+            if ($remainder !== null && strlen($remote_prefix) > $longest_remote_prefix_length) {
+                $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
+                $longest_remote_prefix_length = strlen($remote_prefix);
             }
+        }
+        if ($local_absolute_path !== null) {
+            return $local_absolute_path;
         }
 
         // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
@@ -9193,7 +9173,7 @@ class ImportClient
             if (!is_dir($dir)) {
                 // Check if any component of the path exists as a file and remove it
                 try {
-                    $this->ensure_directory_path($dir);
+                    $this->create_directory_if_missing($dir);
                 } catch (PreserveLocalSkipException $e) {
                     $context->skip_current_file = true;
                     $this->audit_log($e->getMessage(), true);
@@ -9362,12 +9342,12 @@ class ImportClient
     }
 
     /**
-     * Ensure a directory path exists, removing any files that block it.
+     * Create a directory path when missing, removing blockers.
      *
-     * @param string $dir Directory path to ensure
+     * @param string $dir Directory path to create
      * @throws RuntimeException if directory cannot be created or is outside allowed path
      */
-    private function ensure_directory_path(string $dir): void
+    private function create_directory_if_missing(string $dir): void
     {
         // Security: Ensure path is under the filesystem root
         $real_filesystem_root = $this->get_filesystem_root_path();
@@ -9561,7 +9541,7 @@ class ImportClient
 
         // Create directory, removing any files that block the path
         try {
-            $this->ensure_directory_path($local_absolute_path);
+            $this->create_directory_if_missing($local_absolute_path);
         } catch (PreserveLocalSkipException $e) {
             $this->audit_log($e->getMessage(), true);
             $this->emit_skip_progress($remote_absolute_path);
@@ -9608,7 +9588,7 @@ class ImportClient
         }
 
         $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path($path);
-        $target_for_local = $this->map_symlink_target_for_local_mirror(
+        $target_for_local = $this->rewrite_symlink_target_for_local_filesystem(
             $path,
             $local_absolute_path,
             $target,
@@ -9675,7 +9655,7 @@ class ImportClient
         $dir = dirname($local_absolute_path);
         if (!is_dir($dir)) {
             try {
-                $this->ensure_directory_path($dir);
+                $this->create_directory_if_missing($dir);
             } catch (PreserveLocalSkipException $e) {
                 $this->audit_log($e->getMessage(), true);
                 $this->emit_skip_progress($path);
@@ -11047,7 +11027,7 @@ class ImportClient
         $follow = $this->import_state()->follow_symlinks ?? false;
         $nonempty = $this->import_state()->fs_root_nonempty_behavior ?? "error";
         $max_packet = $this->import_state()->max_allowed_packet ?? null;
-        $files_remap_fingerprint = $this->import_state()->files_remap_fingerprint ?? null;
+        $resolved_path_mappings_fingerprint = $this->import_state()->resolved_path_mappings_fingerprint ?? null;
         $pull = $this->import_state()->pull_pipeline ?? null;
         $this->state = new ImportState();
         $this->import_state()->preflight = $preflight;
@@ -11056,7 +11036,7 @@ class ImportClient
         $this->import_state()->follow_symlinks = $follow;
         $this->import_state()->fs_root_nonempty_behavior = $nonempty;
         $this->import_state()->max_allowed_packet = $max_packet;
-        $this->import_state()->files_remap_fingerprint = $files_remap_fingerprint;
+        $this->import_state()->resolved_path_mappings_fingerprint = $resolved_path_mappings_fingerprint;
         if ($pull !== null) {
             $this->import_state()->pull_pipeline = $pull;
         }
@@ -11593,7 +11573,7 @@ class StreamingContext
 }
 
 /**
- * Thrown by ensure_directory_path() in preserve-local mode when a directory
+ * Thrown by create_directory_if_missing() in preserve-local mode when a directory
  * component is not writable or a symlink blocks directory creation.
  * Callers catch this to skip the current file/directory/symlink gracefully.
  */

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6593,9 +6593,8 @@ class ImportClient
                 $local_index_entry !== null &&
                 strcmp($local_index_entry["path"], $remote_index_entry["path"]) < 0
             ) {
-                // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
-                if ($this->is_file_path_selected_by_pull_only_files($local_index_entry["path"])) {
+                if ($this->is_selected_for_pulling($local_index_entry["path"])) {
                     $remote_absolute_path = $local_index_entry["path"];
                     $this->apply_remote_deletion_locally($remote_absolute_path);
                     $this->delete_index_entry($remote_absolute_path);
@@ -6616,14 +6615,21 @@ class ImportClient
                     // protect files we own.
                     $fetch_list_handle = (
                         $skipped_handle !== null &&
-                        $this->is_remote_absolute_path_in_uploads_directory(
-                            $remote_index_entry["path"],
-                            $uploads_basedir
+                        (
+                            $uploads_basedir !== null
+                                ? path_is_within_root(
+                                    $remote_index_entry["path"],
+                                    $uploads_basedir
+                                )
+                                : strpos(
+                                    $remote_index_entry["path"],
+                                    "wp-content/uploads/"
+                                ) !== false
                         )
                     )
                         ? $skipped_handle
                         : $fetch_list_handle;
-                    $this->append_fetch_list(
+                    $this->append_to_fetch_list(
                         $remote_index_entry["path"],
                         $fetch_list_handle,
                     );
@@ -6641,14 +6647,21 @@ class ImportClient
                 } else {
                     $fetch_list_handle = (
                         $skipped_handle !== null &&
-                        $this->is_remote_absolute_path_in_uploads_directory(
-                            $remote_index_entry["path"],
-                            $uploads_basedir
+                        (
+                            $uploads_basedir !== null
+                                ? path_is_within_root(
+                                    $remote_index_entry["path"],
+                                    $uploads_basedir
+                                )
+                                : strpos(
+                                    $remote_index_entry["path"],
+                                    "wp-content/uploads/"
+                                ) !== false
                         )
                     )
                         ? $skipped_handle
                         : $fetch_list_handle;
-                    $this->append_fetch_list($remote_index_entry["path"], $fetch_list_handle);
+                    $this->append_to_fetch_list($remote_index_entry["path"], $fetch_list_handle);
                 }
             }
 
@@ -6668,7 +6681,7 @@ class ImportClient
         }
 
         while ($local_index_entry !== null) {
-            if ($this->is_file_path_selected_by_pull_only_files($local_index_entry["path"])) {
+            if ($this->is_selected_for_pulling($local_index_entry["path"])) {
                 $remote_absolute_path = $local_index_entry["path"];
                 $this->apply_remote_deletion_locally($remote_absolute_path);
                 $this->delete_index_entry($remote_absolute_path);
@@ -7013,8 +7026,6 @@ class ImportClient
     /**
      * Return the uploads basedir from preflight data (e.g. "/wp-content/uploads").
      *
-     * Falls back to a heuristic pattern match if the preflight doesn't contain
-     * explicit uploads path information.
      */
     private function get_uploads_basedir(): ?string
     {
@@ -7026,31 +7037,13 @@ class ImportClient
         if (!is_string($basedir) || $basedir === "") {
             return null;
         }
-        return rtrim($basedir, "/") . "/";
-    }
-
-    /**
-     * Check whether a remote absolute path belongs to the uploads directory.
-     *
-     * Uses the preflight-reported uploads basedir when available, otherwise
-     * falls back to matching "wp-content/uploads/" anywhere in the path.
-     */
-    private function is_remote_absolute_path_in_uploads_directory(
-        string $remote_absolute_path,
-        ?string $uploads_basedir
-    ): bool
-    {
-        if ($uploads_basedir !== null) {
-            return strpos($remote_absolute_path, $uploads_basedir) !== false;
-        }
-        // Fallback: match the conventional WordPress uploads path
-        return strpos($remote_absolute_path, "wp-content/uploads/") !== false;
+        return rtrim($basedir, "/");
     }
 
     /**
      * Append a path to the fetch list file.
      */
-    private function append_fetch_list(string $path, $handle): void
+    private function append_to_fetch_list(string $path, $handle): void
     {
         $line = json_encode(
             ["path" => base64_encode($path)],
@@ -8869,27 +8862,23 @@ class ImportClient
     }
 
     /**
-     * Whether $path is selected by the active --only file path prefixes. With no
-     * --only flag, every file path is selected (returns true) — this keeps
-     * the diff's delete drains at their default behavior. When --only is set,
-     * true only when $path falls under one of those file path prefixes IF it is
-     * NOT the directory itself (when the path remainder is an empty string): an
-     * --only remote index lists what is inside each selected directory, never
-     * the directory itself, so to the diff the selected directories always
-     * appear deleted-on-remote even though they exist.
+     * Whether a remote absolute path is selected by the active --only file path
+     * prefixes. With no --only flag, every path is selected. A selected root is
+     * excluded because a filtered remote index lists its contents, not the root.
      */
-    private function is_file_path_selected_by_pull_only_files(string $path): bool
+    private function is_selected_for_pulling(string $remote_absolute_path): bool
     {
         if (empty($this->pull_only_files_with_path_prefixes)) {
             return true;
         }
 
-        foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
-            $remainder = self::path_remainder_under($path, $prefix);
-            if ($remainder === "") {
+        $remote_absolute_path = rtrim($remote_absolute_path, "/");
+        foreach ($this->pull_only_files_with_path_prefixes as $pull_only_files_prefix) {
+            $pull_only_files_prefix = rtrim($pull_only_files_prefix, "/");
+            if ($remote_absolute_path === $pull_only_files_prefix) {
                 return false;
             }
-            if ($remainder !== null) {
+            if (path_is_within_root($remote_absolute_path, $pull_only_files_prefix)) {
                 return true;
             }
         }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -7060,7 +7060,7 @@ class ImportClient
     }
 
     /**
-     * Delete the local absolute path mapped from a remote absolute path.
+     * Remove the local mirror entry for a deletion reported by the remote index.
      */
     private function apply_remote_deletion_locally(string $remote_absolute_path): void
     {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1268,7 +1268,7 @@ class ImportClient
                     return;
 
                 case "files-pull":
-                    $this->run_files_sync();
+                    $this->run_files_pull();
                     break;
 
                 case "files-index":
@@ -2699,7 +2699,7 @@ class ImportClient
      *
      * Both modes share the same pipeline: index → diff → fetch.
      */
-    public function run_files_sync(): void
+    public function run_files_pull(): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
 
@@ -2770,7 +2770,7 @@ class ImportClient
                 $this->import_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state($this->state);
                 $this->open_local_index_wal();
-                $this->run_files_sync_pipeline();
+                $this->run_files_pull_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
                 // tail finishes, restore the completed status so later filter
                 // changes are judged against the actual lifecycle state.
@@ -2934,7 +2934,7 @@ class ImportClient
         $this->save_state($this->state);
 
         $this->open_local_index_wal();
-        $this->run_files_sync_pipeline();
+        $this->run_files_pull_pipeline();
 
         // Pipeline returns early with partial status if interrupted
         if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
@@ -2975,7 +2975,7 @@ class ImportClient
      * Reads the current stage from state and runs each stage in sequence.
      * Returns early (with partial status) if any stage doesn't complete.
      */
-    private function run_files_sync_pipeline(): void
+    private function run_files_pull_pipeline(): void
     {
         $stage = $this->import_state()->active_resumable_command->current_stage ?? "index";
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6595,7 +6595,7 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_remote_absolute_path($local["path"]);
+                    $this->apply_remote_deletion_locally($local["path"]);
                     $this->delete_index_entry($local["path"]);
                 }
                 $local_after = $local["path"];
@@ -6667,7 +6667,7 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_remote_absolute_path($local["path"]);
+                $this->apply_remote_deletion_locally($local["path"]);
                 $this->delete_index_entry($local["path"]);
             }
             $local_after = $local["path"];
@@ -7062,7 +7062,7 @@ class ImportClient
     /**
      * Delete the local absolute path mapped from a remote absolute path.
      */
-    private function delete_remote_absolute_path(string $remote_absolute_path): void
+    private function apply_remote_deletion_locally(string $remote_absolute_path): void
     {
         if ($remote_absolute_path === "") {
             return;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3446,8 +3446,8 @@ class ImportClient
             if (!empty($entry["intermediate"])) {
                 continue;
             }
-            $target_encoded = $entry["target"] ?? null;
-            if (!is_string($target_encoded) || $target_encoded === "") {
+            $symlink_target_encoded = $entry["target"] ?? null;
+            if (!is_string($symlink_target_encoded) || $symlink_target_encoded === "") {
                 continue;
             }
             $target = base64_decode($target_encoded);
@@ -3535,8 +3535,8 @@ class ImportClient
              * @see https://www.php.net/base64_decode
              */
             $remote_absolute_path = base64_decode($path_encoded, true);
-            $target = base64_decode($target_encoded, true);
-            if ($remote_absolute_path === false || $remote_absolute_path === "" || $target === false || $target === "") {
+            $symlink_target = base64_decode($symlink_target_encoded, true);
+            if ($remote_absolute_path === false || $remote_absolute_path === "" || $symlink_target === false || $symlink_target === "") {
                 continue;
             }
 
@@ -3555,14 +3555,14 @@ class ImportClient
             // Repoint through the same seam regular symlink chunks use, so the
             // link targets wherever the content actually landed (filesystem root,
             // remapped, or bundled) instead of the raw source spelling.
-            $target = $this->map_symlink_target_for_local_mirror(
+            $symlink_target = $this->map_symlink_target_for_local_mirror(
                 $remote_absolute_path,
                 $local_absolute_path,
-                $target
+                $symlink_target
             );
 
             // Already correct — skip
-            if (is_link($local_absolute_path) && readlink($local_absolute_path) === $target) {
+            if (is_link($local_absolute_path) && readlink($local_absolute_path) === $symlink_target) {
                 continue;
             }
 
@@ -3602,7 +3602,7 @@ class ImportClient
             try {
                 $this->assert_symlink_target_within_root(
                     dirname($local_absolute_path),
-                    $target,
+                    $symlink_target,
                     $root
                 );
             } catch (RuntimeException $e) {
@@ -3613,15 +3613,15 @@ class ImportClient
                 continue;
             }
 
-            if (@symlink($target, $local_absolute_path)) {
+            if (@symlink($symlink_target, $local_absolute_path)) {
                 $created++;
                 $this->audit_log(
-                    "INTERMEDIATE SYMLINK: {$remote_absolute_path} -> {$target}",
+                    "INTERMEDIATE SYMLINK: {$remote_absolute_path} -> {$symlink_target}",
                     false,
                 );
             } else {
                 $this->audit_log(
-                    "Failed to create intermediate symlink: {$remote_absolute_path} -> {$target}",
+                    "Failed to create intermediate symlink: {$remote_absolute_path} -> {$symlink_target}",
                     true,
                 );
             }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -745,7 +745,7 @@ class ImportClient
         if (isset($masked[2]) && $command !== 'apply-runtime') {
             $masked[2] = preg_replace('/SECRET_KEY=[^&\s]+/', 'SECRET_KEY=***', $masked[2]);
             if ($command === 'files-push') {
-                $masked[2] = self::mask_files_push_remote_reprint_api_url_user_info($masked[2]);
+                $masked[2] = self::mask_url_user_info($masked[2]);
             }
         }
         foreach ($masked as $argument_index => $argument) {
@@ -1790,7 +1790,7 @@ class ImportClient
             'files-push'
         );
         $masked_remote_reprint_api_url =
-            self::mask_files_push_remote_reprint_api_url_user_info($remote_reprint_api_url);
+            self::mask_url_user_info($remote_reprint_api_url);
         $force_http = $options['force_http'] ?? false;
         $scheme = strtolower( (string) parse_url($remote_reprint_api_url, PHP_URL_SCHEME) );
         if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
@@ -1826,7 +1826,7 @@ class ImportClient
         string $command
     ): array {
         $masked_remote_reprint_api_url =
-            self::mask_files_push_remote_reprint_api_url_user_info($remote_reprint_api_url);
+            self::mask_url_user_info($remote_reprint_api_url);
         if (strpos($remote_reprint_api_url, '#') !== false) {
             throw new InvalidArgumentException(
                 'The ' . $command . ' remote Reprint API URL must not contain a fragment: ' . $masked_remote_reprint_api_url . '.'
@@ -1951,7 +1951,7 @@ class ImportClient
     }
 
     /** Masks URL authority credentials without changing the pair-key input. */
-    private static function mask_files_push_remote_reprint_api_url_user_info(string $url): string
+    private static function mask_url_user_info(string $url): string
     {
         $masked = preg_replace(
             '~^([a-z][a-z0-9+.-]*://)[^/?#]*@~i',

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3425,14 +3425,14 @@ class ImportClient
      */
     private function extract_symlink_dirs_from_index(array $visited): array
     {
-        $targets = [];
+        $symlink_targets = [];
         if (!file_exists($this->remote_index_file)) {
-            return $targets;
+            return $symlink_targets;
         }
 
         $handle = fopen($this->remote_index_file, "r");
         if (!$handle) {
-            return $targets;
+            return $symlink_targets;
         }
 
         while (($line = fgets($handle)) !== false) {
@@ -3450,21 +3450,21 @@ class ImportClient
             if (!is_string($symlink_target_encoded) || $symlink_target_encoded === "") {
                 continue;
             }
-            $target = base64_decode($target_encoded);
-            if ($target === false || $target === "") {
+            $symlink_target = base64_decode($symlink_target_encoded);
+            if ($symlink_target === false || $symlink_target === "") {
                 continue;
             }
 
-            // If we've seen this target already, we can move on
+            // If we've seen this symlink target already, we can move on
             // to the next one.
-            if (isset($visited[$target])) {
+            if (isset($visited[$symlink_target])) {
                 continue;
             }
 
             // Check containment: skip if already under a visited root
             $contained = false;
             foreach ($visited as $root => $_) {
-                if (str_starts_with($target, $root . "/")) {
+                if (str_starts_with($symlink_target, $root . "/")) {
                     $contained = true;
                     break;
                 }
@@ -3473,11 +3473,11 @@ class ImportClient
                 continue;
             }
 
-            $targets[] = $target;
+            $symlink_targets[] = $symlink_target;
         }
         fclose($handle);
 
-        return array_values(array_unique($targets));
+        return array_values(array_unique($symlink_targets));
     }
 
     /**
@@ -3519,8 +3519,8 @@ class ImportClient
             if (empty($entry["intermediate"])) {
                 continue;
             }
-            $target_encoded = $entry["target"] ?? null;
-            if (!is_string($target_encoded) || $target_encoded === "") {
+            $symlink_target_encoded = $entry["target"] ?? null;
+            if (!is_string($symlink_target_encoded) || $symlink_target_encoded === "") {
                 continue;
             }
             $path_encoded = $entry["path"] ?? null;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -262,11 +262,11 @@ class ImportClient
     /** @var string Target exporter API URL. */
     public $target_url;
 
-    /** @var string State directory for this local document root (.import-state.json, db.sql, etc.). */
+    /** @var string State directory for this filesystem root (.import-state.json, db.sql, etc.). */
     public $state_directory;
 
-    /** @var string Import root where the target filesystem is reconstructed. */
-    public $import_root;
+    /** @var string Filesystem root where the target filesystem is reconstructed. */
+    public $filesystem_root;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
@@ -404,14 +404,14 @@ class ImportClient
     private $include_caches = false;
 
     /**
-     * @var string Controls behavior when the import root is non-empty at import start.
+     * @var string Controls behavior when the filesystem root is non-empty at import start.
      *
-     * 'error' (default): throw an error if the import root is non-empty.
+     * 'error' (default): throw an error if the filesystem root is non-empty.
      * 'preserve-local': preserve existing files, symlinks, and directories in the
-     * import root instead of overwriting them; non-writable directories are skipped
+     * filesystem root instead of overwriting them; non-writable directories are skipped
      * gracefully and logged to the audit log.
      *
-     * On the first sync, existing import root content is left untouched — any file,
+     * On the first sync, existing filesystem root content is left untouched — any file,
      * symlink, or directory that already exists at a path the remote tries to write
      * is skipped and never added to the local index.
      *
@@ -442,7 +442,7 @@ class ImportClient
     /**
      * @var array<string,string> Resolved path mappings from target filesystem
      * paths to local filesystem paths. Both sides are absolute. Empty means
-     * the identity mapping beneath the import root.
+     * the identity mapping beneath the filesystem root.
      */
     private $resolved_path_mappings = [];
 
@@ -530,7 +530,7 @@ class ImportClient
     public function __construct(
         string $target_url,
         string $state_directory,
-        string $import_root,
+        string $filesystem_root,
         ?string $signal_handling_command = null
     )
     {
@@ -553,7 +553,7 @@ class ImportClient
 
         $this->target_url = rtrim($target_url, "?&");
         $this->state_directory = rtrim($state_directory, "/");
-        $this->import_root = rtrim($import_root, "/");
+        $this->filesystem_root = rtrim($filesystem_root, "/");
         $this->state_file = $this->state_directory . "/.import-state.json";
         $this->local_index_file = $this->state_directory . "/.import-index.jsonl";
         $this->index_update_wal_path =
@@ -581,9 +581,9 @@ class ImportClient
                 throw new RuntimeException("Failed to create directory: {$this->state_directory}");
             }
         }
-        if (!is_dir($this->import_root)) {
-            if (!mkdir($this->import_root, 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->import_root}");
+        if (!is_dir($this->filesystem_root)) {
+            if (!mkdir($this->filesystem_root, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->filesystem_root}");
             }
         }
 
@@ -1325,7 +1325,7 @@ class ImportClient
         $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
             $this->target_url,
             $this->state_directory,
-            $this->import_root,
+            $this->filesystem_root,
             'files-diff'
         );
         if (!is_array($context)) {
@@ -1336,7 +1336,7 @@ class ImportClient
         $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
         $missing_previous_local_index_message =
             'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
-            . 'for the same target URL, state directory, and local document root.';
+            . 'for the same target URL, state directory, and filesystem root.';
         if (!is_dir($push_state_directory)) {
             throw new RuntimeException($missing_previous_local_index_message);
         }
@@ -1359,7 +1359,7 @@ class ImportClient
             }
             $plan = PushPlan::start(
                 $plan_directory,
-                $context['local_document_root'],
+                $context['filesystem_root'],
                 $previous_local_index,
                 $excluded_paths_path
             );
@@ -1543,7 +1543,7 @@ class ImportClient
         $context = $options['files_push_context'] ?? self::prepare_files_push_context(
             $this->target_url,
             $this->state_directory,
-            $this->import_root,
+            $this->filesystem_root,
             $options
         );
         if (!is_array($context)) {
@@ -1565,7 +1565,7 @@ class ImportClient
             ? -1
             : parse_size($memory_limit_value);
         $sender_options = [
-            'docroot' => $context['local_document_root'],
+            'filesystem_root' => $context['filesystem_root'],
             'push_state_directory' => $context['push_state_directory'],
             'base_url' => $context['target_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
@@ -1761,16 +1761,16 @@ class ImportClient
      *     Validated files-push command context.
      *
      *     @type string $target_url           Target exporter API URL.
-     *     @type string $local_document_root  Resolved local document root being sent.
-     *     @type string $pair                 Target/local-document-root pair key.
+     *     @type string $filesystem_root  Resolved filesystem root being sent.
+     *     @type string $pair                 Target/filesystem-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{target_url:string,local_document_root:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{target_url:string,filesystem_root:string,pair:string,push_state_directory:string}
      */
     public static function prepare_files_push_context(
         string $target_url,
         string $state_directory,
-        string $local_document_root,
+        string $filesystem_root,
         array $options
     ): array {
         $secret = $options['secret'] ?? null;
@@ -1786,7 +1786,7 @@ class ImportClient
         $context = self::prepare_files_pair_context(
             $target_url,
             $state_directory,
-            $local_document_root,
+            $filesystem_root,
             'files-push'
         );
         $masked_target_url = self::mask_files_push_url_user_info($target_url);
@@ -1812,16 +1812,16 @@ class ImportClient
      *     Validated pair context.
      *
      *     @type string $target_url           Target exporter API URL.
-     *     @type string $local_document_root  Resolved local document root.
-     *     @type string $pair                 Target/local-document-root pair key.
+     *     @type string $filesystem_root  Resolved filesystem root.
+     *     @type string $pair                 Target/filesystem-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{target_url:string,local_document_root:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{target_url:string,filesystem_root:string,pair:string,push_state_directory:string}
      */
     public static function prepare_files_pair_context(
         string $target_url,
         string $state_directory,
-        string $local_document_root,
+        string $filesystem_root,
         string $command
     ): array {
         $masked_target_url = self::mask_files_push_url_user_info($target_url);
@@ -1837,23 +1837,23 @@ class ImportClient
                 'The ' . $command . ' target URL must not contain URL user-info: ' . $masked_target_url . '.'
             );
         }
-        if (is_link($local_document_root)) {
-            throw new InvalidArgumentException('The local document root must not be a symlink: ' . $local_document_root . '.');
+        if (is_link($filesystem_root)) {
+            throw new InvalidArgumentException('The filesystem root must not be a symlink: ' . $filesystem_root . '.');
         }
-        if (!is_dir($local_document_root)) {
+        if (!is_dir($filesystem_root)) {
             throw new InvalidArgumentException(
-                'The local document root does not exist or is not a directory: ' . $local_document_root . '.'
+                'The filesystem root does not exist or is not a directory: ' . $filesystem_root . '.'
             );
         }
-        $resolved_local_document_root = realpath($local_document_root);
-        if ($resolved_local_document_root === false) {
+        $resolved_filesystem_root = realpath($filesystem_root);
+        if ($resolved_filesystem_root === false) {
             throw new InvalidArgumentException(
-                'The local document root does not exist or is not a directory: ' . $local_document_root . '.'
+                'The filesystem root does not exist or is not a directory: ' . $filesystem_root . '.'
             );
         }
-        $resolved_local_document_root = rtrim($resolved_local_document_root, '/') ?: '/';
+        $resolved_filesystem_root = rtrim($resolved_filesystem_root, '/') ?: '/';
         $target_url = rtrim($target_url, '?&');
-        $pair = hash('sha256', $target_url . "\0" . $resolved_local_document_root);
+        $pair = hash('sha256', $target_url . "\0" . $resolved_filesystem_root);
         // Resolve an absolute physical path even when its final components do not exist.
         $push_state_directory = $state_directory . '/push/' . $pair;
         if (strpos($push_state_directory, '/') !== 0) {
@@ -1884,18 +1884,18 @@ class ImportClient
             );
         }
         if (
-            $resolved_local_document_root === '/'
-            || path_is_within_root($push_state_directory, $resolved_local_document_root)
+            $resolved_filesystem_root === '/'
+            || path_is_within_root($push_state_directory, $resolved_filesystem_root)
         ) {
             throw new InvalidArgumentException(
                 'The local push state directory ' . $push_state_directory
-                . ' must be outside the local document root ' . $resolved_local_document_root . '.'
+                . ' must be outside the filesystem root ' . $resolved_filesystem_root . '.'
             );
         }
 
         return [
             'target_url' => $target_url,
-            'local_document_root' => $resolved_local_document_root,
+            'filesystem_root' => $resolved_filesystem_root,
             'pair' => $pair,
             'push_state_directory' => $push_state_directory,
         ];
@@ -2170,10 +2170,10 @@ class ImportClient
 
         // Detect webhost environment from preflight data.
         // The host analyzers score based on preflight signals. We also
-        // check the import root for a __wp__ symlink as a fallback
+        // check the filesystem root for a __wp__ symlink as a fallback
         // when the remote preflight didn't report enough filesystem data.
         $detected_webhost = is_array($payload) ? detect_host($payload) : 'other';
-        if ($detected_webhost === 'other' && is_link($this->import_root . '/__wp__')) {
+        if ($detected_webhost === 'other' && is_link($this->filesystem_root . '/__wp__')) {
             $detected_webhost = 'wpcloud';
         }
         $this->import_state()->webhost = $detected_webhost;
@@ -2828,8 +2828,8 @@ class ImportClient
         // Filter out "." and ".." explicitly: standard PHP scandir() returns them,
         // but WASM PHP (WordPress Playground) does not, so a `count <= 2` shortcut
         // would mis-classify directories with one or two real entries as empty.
-        $is_empty = !is_dir($this->import_root) || count(array_diff(
-            scandir($this->import_root) ?: [],
+        $is_empty = !is_dir($this->filesystem_root) || count(array_diff(
+            scandir($this->filesystem_root) ?: [],
             [".", ".."]
         )) === 0;
 
@@ -2871,7 +2871,7 @@ class ImportClient
             ], true);
         } else {
             // Starting fresh — validate that target directory is empty.
-            // A delta sync ($is_delta) naturally has a non-empty import root
+            // A delta sync ($is_delta) naturally has a non-empty filesystem root
             // because we put those files there during the initial sync.
             if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
                 throw new RuntimeException(
@@ -3490,8 +3490,8 @@ class ImportClient
      *
      * Since the server indexes everything under realpath()-resolved paths,
      * the files are already downloaded to the target location (e.g.
-     * import root/wordpress/...).  We just need to create the symlink
-     * (e.g. import root/srv/wordpress -> /wordpress) so the directory
+     * filesystem root/wordpress/...).  We just need to create the symlink
+     * (e.g. filesystem root/srv/wordpress -> /wordpress) so the directory
      * layout matches the server.
      */
     private function recreate_intermediate_symlinks(): void
@@ -3549,7 +3549,7 @@ class ImportClient
             }
 
             // Repoint through the same seam regular symlink chunks use, so the
-            // link targets wherever the content actually landed (import root,
+            // link targets wherever the content actually landed (filesystem root,
             // remapped, or bundled) instead of the raw source spelling.
             $target = $this->map_symlink_target_for_local_mirror($path, $local_path, $target);
 
@@ -3590,7 +3590,7 @@ class ImportClient
             }
 
             // Validate that the symlink target doesn't escape the filesystem root.
-            $root = $this->get_import_root_path();
+            $root = $this->get_filesystem_root_path();
             try {
                 $this->assert_symlink_target_within_root(
                     dirname($local_path),
@@ -4049,9 +4049,9 @@ class ImportClient
      * the applier writes the files the target server needs to fulfill those
      * requirements.
      *
-     * The effective import root is --fs-root + the remote site's document_root
+     * The effective filesystem root is --fs-root + the remote site's document_root
      * prefix (from preflight). For example, if the remote document_root is
-     * /srv/htdocs and --fs-root is ./files, the effective import root is
+     * /srv/htdocs and --fs-root is ./files, the effective filesystem root is
      * ./files/srv/htdocs. If the site was flattened with flat-docroot,
      * pass the flattened directory as --fs-root directly and the prefix
      * is not applied.
@@ -4084,7 +4084,7 @@ class ImportClient
         $preflight_data = $entry["data"];
         $webhost = $this->import_state()->webhost ?? "other";
 
-        // Resolve the effective import root from either --flat-document-root
+        // Resolve the effective filesystem root from either --flat-document-root
         // (used as-is) or --fs-root (prefixed with the remote document_root).
         // Mutual exclusion is already enforced at the CLI level.
         $flat_document_root = $options["flat_document_root"] ?? null;
@@ -4096,7 +4096,7 @@ class ImportClient
             // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
             // source server. Files are downloaded preserving the full
-            // target filesystem path, so the effective import root is --fs-root +
+            // target filesystem path, so the effective filesystem root is --fs-root +
             // document_root.
             $remote_doc_root = $preflight_data["runtime"]["document_root"] ?? "";
             if (is_string($remote_doc_root)) {
@@ -4106,14 +4106,14 @@ class ImportClient
             }
 
             if ($remote_doc_root !== "") {
-                $effective_fs_root = $this->import_root . $remote_doc_root;
+                $effective_fs_root = $this->filesystem_root . $remote_doc_root;
             } else {
-                $effective_fs_root = $this->import_root;
+                $effective_fs_root = $this->filesystem_root;
             }
 
             if (!is_dir($effective_fs_root)) {
                 throw new RuntimeException(
-                    "Effective import root does not exist: {$effective_fs_root}\n" .
+                    "Effective filesystem root does not exist: {$effective_fs_root}\n" .
                     "The remote document_root was: {$remote_doc_root}\n" .
                     "If you used flat-docroot, pass the flattened directory " .
                     "with --flat-document-root instead of --fs-root."
@@ -4170,7 +4170,7 @@ class ImportClient
                 $db_dir = rtrim(dirname($sqlite_path), '/') . '/';
                 $db_file = basename($sqlite_path);
             } else {
-                $db_dir = '{import root}/wp-content/database/';
+                $db_dir = '{fs-root}/wp-content/database/';
                 $db_file = '.ht.sqlite';
             }
             $manifest->sqlite = [
@@ -4204,7 +4204,7 @@ class ImportClient
         }
 
         // Resolve the path to WordPress's index.php. On standard hosts it
-        // lives in the import root. On WPCloud the ABSPATH is a different
+        // lives in the filesystem root. On WPCloud the ABSPATH is a different
         // directory (e.g. /wordpress/core/X.Y.Z) which maps to
         // download_root + abspath when using --fs-root.
         $paths_urls = $preflight_data["database"]["wp"]["paths_urls"] ?? [];
@@ -4214,8 +4214,8 @@ class ImportClient
             $wordpress_index = $abs_fs_root . '/index.php';
         } elseif ($abspath !== "") {
             // Raw download: ABSPATH is relative to the download root,
-            // not the effective import root (which is download_root + document_root).
-            $wordpress_index = realpath($this->import_root . $abspath . '/index.php') ?: '';
+            // not the effective filesystem root (which is download_root + document_root).
+            $wordpress_index = realpath($this->filesystem_root . $abspath . '/index.php') ?: '';
         } else {
             $wordpress_index = $abs_fs_root . '/index.php';
         }
@@ -4243,7 +4243,7 @@ class ImportClient
             // Replace the source path with the copied-to path so the
             // generated runtime.php points to the output directory.
             $manifest->sqlite['plugin_dir'] = $copied_plugin;
-            // Resolve {import root} in db_dir now that we have the real path.
+            // Resolve {fs-root} in db_dir now that we have the real path.
             $manifest->sqlite['db_dir'] = resolve_runtime_placeholders(
                 $manifest->sqlite['db_dir'],
                 $abs_fs_root,
@@ -4415,9 +4415,9 @@ class ImportClient
      *
      * Creates a directory at the specified --flatten-to path that mirrors
      * a vanilla WordPress installation layout by symlinking entries from
-     * the import root. Uses preflight data (paths_urls) to determine
+     * the filesystem root. Uses preflight data (paths_urls) to determine
      * where each WordPress component actually lives, rather than blindly
-     * scanning import root top-level entries.
+     * scanning filesystem root top-level entries.
      *
      * This is essential when the source site uses a non-standard layout
      * (e.g. WP Cloud with ABSPATH=/srv/htdocs and WP_CONTENT_DIR=/tmp/__wp__/wp-content)
@@ -4440,10 +4440,10 @@ class ImportClient
         $flatten_to = rtrim($flatten_to, "/");
         $force = $options["force"] ?? false;
 
-        // Ensure the import root exists
-        if (!is_dir($this->import_root)) {
+        // Ensure the filesystem root exists
+        if (!is_dir($this->filesystem_root)) {
             throw new RuntimeException(
-                "Fs root does not exist: {$this->import_root}",
+                "Fs root does not exist: {$this->filesystem_root}",
             );
         }
 
@@ -4488,32 +4488,32 @@ class ImportClient
             );
         }
 
-        // Map target filesystem paths to local paths within import root
-        $local_abspath = $this->import_root . $abspath;
+        // Map target filesystem paths to local paths within filesystem root
+        $local_abspath = $this->filesystem_root . $abspath;
         if (!is_dir($local_abspath)) {
             throw new RuntimeException(
-                "WordPress ABSPATH directory not found in import root: {$local_abspath} " .
+                "WordPress ABSPATH directory not found in filesystem root: {$local_abspath} " .
                     "(remote ABSPATH: {$abspath}). Has the file sync completed?",
             );
         }
 
         $local_wp_admin = $wp_admin_path !== null
-            ? $this->import_root . $wp_admin_path
+            ? $this->filesystem_root . $wp_admin_path
             : null;
         $local_wp_includes = $wp_includes_path !== null
-            ? $this->import_root . $wp_includes_path
+            ? $this->filesystem_root . $wp_includes_path
             : null;
         $local_content_dir = $content_dir !== null
-            ? $this->import_root . $content_dir
+            ? $this->filesystem_root . $content_dir
             : null;
         $local_plugins_dir = $plugins_dir !== null
-            ? $this->import_root . $plugins_dir
+            ? $this->filesystem_root . $plugins_dir
             : null;
         $local_mu_plugins_dir = $mu_plugins_dir !== null
-            ? $this->import_root . $mu_plugins_dir
+            ? $this->filesystem_root . $mu_plugins_dir
             : null;
         $local_uploads_basedir = $uploads_basedir !== null
-            ? $this->import_root . $uploads_basedir
+            ? $this->filesystem_root . $uploads_basedir
             : null;
 
         // Determine which components are "detached" — located outside
@@ -4653,7 +4653,7 @@ class ImportClient
         $wp_config_in_flatten = $flatten_to . "/wp-config.php";
         if (!file_exists($wp_config_in_flatten)) {
             $parent_of_abspath = dirname($abspath);
-            $local_parent_wp_config = $this->import_root . $parent_of_abspath . "/wp-config.php";
+            $local_parent_wp_config = $this->filesystem_root . $parent_of_abspath . "/wp-config.php";
             if (file_exists($local_parent_wp_config)) {
                 $this->flatten_place_symlink(
                     $local_parent_wp_config,
@@ -4766,7 +4766,7 @@ class ImportClient
                 );
             } else {
                 $this->audit_log(
-                    "FLAT-DOCUMENT-ROOT | Warning: content_dir not found in import root: " .
+                    "FLAT-DOCUMENT-ROOT | Warning: content_dir not found in filesystem root: " .
                         "{$local_content_dir} (remote: {$content_dir})",
                     true,
                 );
@@ -4786,7 +4786,7 @@ class ImportClient
         $result = [
             "status" => "complete",
             "flatten_to" => $flatten_to,
-            "fs_root" => $this->import_root,
+            "fs_root" => $this->filesystem_root,
             "abspath" => $abspath,
             "wp_admin_path" => $wp_admin_path,
             "wp_includes_path" => $wp_includes_path,
@@ -5146,7 +5146,7 @@ class ImportClient
                         "--target-sqlite-path option is required but was missing.",
                     );
                 }
-                $target_path = $this->get_import_root_path() . $content_dir . '/database/.ht.sqlite';
+                $target_path = $this->get_filesystem_root_path() . $content_dir . '/database/.ht.sqlite';
                 $this->audit_log("DB-APPLY | defaulting SQLite path to: {$target_path}");
                 $this->progress->show_lifecycle_line("SQLite path: {$target_path}\n");
             }
@@ -7037,7 +7037,7 @@ class ImportClient
     }
 
     /**
-     * Delete a local file path safely under the import root.
+     * Delete a local file path safely under the filesystem root.
      */
     private function delete_target_filesystem_path(string $path): void
     {
@@ -8411,7 +8411,7 @@ class ImportClient
     }
 
     /**
-     * Map a remote symlink target to the import root mirror when possible.
+     * Map a remote symlink target to the filesystem root mirror when possible.
      *
      * Handles both absolute and relative targets (relative ones are resolved
      * against the symlink's source directory). In-scope and non-followed targets
@@ -8432,7 +8432,7 @@ class ImportClient
      *
      * Local import state:
      *
-     *   <state-dir>/import root/
+     *   <state-dir>/filesystem root/
      *   |-- tmp/e2e-shared-themes/pub/indice/
      *   |   |-- style.css
      *   |   `-- index.php
@@ -8442,7 +8442,7 @@ class ImportClient
      * Without this mapping, the symlink would point at /tmp/e2e-shared-themes/pub/indice
      * (which does not exist on the local machine, or worse, exists with unrelated content).
      * With this mapping, the symlink is rewritten to a relative path that resolves to the
-     * mirrored local copy under import root.
+     * mirrored local copy under filesystem root.
      */
     private function map_symlink_target_for_local_mirror(
         string $target_filesystem_path,
@@ -8533,22 +8533,22 @@ class ImportClient
     }
 
     /**
-     * Return the resolved absolute import root, creating it if it doesn't exist.
+     * Return the resolved absolute filesystem root, creating it if it doesn't exist.
      */
-    private function get_import_root_path(): string
+    private function get_filesystem_root_path(): string
     {
-        if (!is_dir($this->import_root)) {
-            if (!mkdir($this->import_root, 0755, true) && !is_dir($this->import_root)) {
+        if (!is_dir($this->filesystem_root)) {
+            if (!mkdir($this->filesystem_root, 0755, true) && !is_dir($this->filesystem_root)) {
                 throw new RuntimeException(
-                    "Failed to create import root directory: {$this->import_root}",
+                    "Failed to create filesystem root directory: {$this->filesystem_root}",
                 );
             }
         }
 
-        $real = realpath($this->import_root);
+        $real = realpath($this->filesystem_root);
         if ($real === false) {
             throw new RuntimeException(
-                "Failed to resolve import root path: {$this->import_root}",
+                "Failed to resolve filesystem root path: {$this->filesystem_root}",
             );
         }
 
@@ -8674,12 +8674,12 @@ class ImportClient
 
     /**
      * Fingerprint of the effective bundle placement root. No bundle directory
-     * (and bare --follow-symlinks) fingerprints as import root, which is the
+     * (and bare --follow-symlinks) fingerprints as filesystem root, which is the
      * equivalent placement — so switching between those spellings is allowed.
      */
     private function symlink_bundle_directory_fingerprint(): string
     {
-        $effective = $this->symlink_bundle_directory ?? rtrim($this->get_import_root_path(), "/");
+        $effective = $this->symlink_bundle_directory ?? rtrim($this->get_filesystem_root_path(), "/");
         return hash("sha256", $effective);
     }
 
@@ -8691,12 +8691,12 @@ class ImportClient
      */
     private function resolve_symlink_bundle_directory(string $raw): string
     {
-        $import_root = rtrim($this->get_import_root_path(), "/");
-        $directory = $this->resolve_token_path($raw, ["fs-root" => $import_root]);
+        $filesystem_root = rtrim($this->get_filesystem_root_path(), "/");
+        $directory = $this->resolve_token_path($raw, ["fs-root" => $filesystem_root]);
 
-        if (!path_is_within_root($directory, $import_root)) {
+        if (!path_is_within_root($directory, $filesystem_root)) {
             throw new InvalidArgumentException(
-                "--follow-symlinks bundle directory \"{$directory}\" resolves outside --fs-root ({$import_root}); " .
+                "--follow-symlinks bundle directory \"{$directory}\" resolves outside --fs-root ({$filesystem_root}); " .
                     "it must stay within the destination root",
             );
         }
@@ -8717,10 +8717,10 @@ class ImportClient
      */
     private function resolve_remap(array $remap_raw): array
     {
-        $import_root = rtrim($this->get_import_root_path(), "/");
+        $filesystem_root = rtrim($this->get_filesystem_root_path(), "/");
 
         $source_tokens = $this->wp_source_path_tokens();
-        $target_tokens = ["fs-root" => $import_root];
+        $target_tokens = ["fs-root" => $filesystem_root];
 
         $rules = [];
         $wp_content_target = null;
@@ -8728,9 +8728,9 @@ class ImportClient
             $source = $this->resolve_token_path($source_raw, $source_tokens);
             $target = $this->resolve_token_path($target_raw, $target_tokens);
 
-            if (!path_is_within_root($target, $import_root)) {
+            if (!path_is_within_root($target, $filesystem_root)) {
                 throw new InvalidArgumentException(
-                    "--remap target \"{$target}\" resolves outside --fs-root ({$import_root}); " .
+                    "--remap target \"{$target}\" resolves outside --fs-root ({$filesystem_root}); " .
                         "targets must stay within the destination root",
                 );
             }
@@ -8982,7 +8982,7 @@ class ImportClient
 
     /**
      * Map a target filesystem path to a local filesystem path under the import
-     * root. Symlink traversal checks prevent writes outside the import root.
+     * root. Symlink traversal checks prevent writes outside the filesystem root.
      *
      * With --remap active, a matched target filesystem path is routed to its
      * mapped local filesystem path. An unmatched path remains nested beneath
@@ -9008,7 +9008,7 @@ class ImportClient
             return $this->symlink_bundle_directory . $target_filesystem_path;
         }
 
-        return $this->get_import_root_path() . $target_filesystem_path;
+        return $this->get_filesystem_root_path() . $target_filesystem_path;
     }
 
 
@@ -9299,7 +9299,7 @@ class ImportClient
 
     private function path_traverses_symlink(string $path): bool
     {
-        $root = $this->get_import_root_path();
+        $root = $this->get_filesystem_root_path();
         $relative = ltrim(substr($path, strlen($root)), "/");
         if ($relative === "") {
             return false;
@@ -9329,8 +9329,8 @@ class ImportClient
      */
     private function ensure_directory_path(string $dir): void
     {
-        // Security: Ensure path is under the import root
-        $real_filesystem_root = $this->get_import_root_path();
+        // Security: Ensure path is under the filesystem root
+        $real_filesystem_root = $this->get_filesystem_root_path();
 
         // Resolve the target path (or what it would be)
         // For non-existent paths, resolve the parent and append the final component
@@ -9349,16 +9349,16 @@ class ImportClient
                 !path_is_within_root($real_check, $real_filesystem_root)
             ) {
                 // In preserve-local mode, a path that resolves outside the
-                // import root is expected when a directory like wp-content/plugins
+                // filesystem root is expected when a directory like wp-content/plugins
                 // is symlinked to a shared hosting location.  Skip gracefully
                 // instead of treating it as a security violation.
                 if ($this->fs_root_nonempty_behavior === 'preserve-local') {
                     throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: path resolves outside import root via symlink: {$dir}",
+                        "PRESERVE-LOCAL: path resolves outside filesystem root via symlink: {$dir}",
                     );
                 }
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside import root: {$dir}",
+                    "Security: Refusing to create directory outside filesystem root: {$dir}",
                 );
             }
         }
@@ -9377,7 +9377,7 @@ class ImportClient
             !str_starts_with($dir, $real_filesystem_root . "/")
         ) {
             throw new RuntimeException(
-                "Security: Refusing to create directory outside import root: {$dir}",
+                "Security: Refusing to create directory outside filesystem root: {$dir}",
             );
         }
 
@@ -9452,7 +9452,7 @@ class ImportClient
             $resolved = realpath($current);
             if ($resolved === false || !path_is_within_root($resolved, $real_filesystem_root)) {
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside import root: {$current}",
+                    "Security: Refusing to create directory outside filesystem root: {$current}",
                 );
             }
         }
@@ -9590,7 +9590,7 @@ class ImportClient
         }
 
         // Validate that the symlink target doesn't escape the filesystem root.
-        $root = $this->get_import_root_path();
+        $root = $this->get_filesystem_root_path();
         try {
             $this->assert_symlink_target_within_root(
                 dirname($local_path),
@@ -9726,7 +9726,7 @@ class ImportClient
             true,
         );
         if ($path !== "" && $is_file_error) {
-            $local_path = $this->import_root . $path;
+            $local_path = $this->filesystem_root . $path;
             if ($context->file_handle && $context->file_path === $local_path) {
                 fclose($context->file_handle);
                 $context->file_handle = null;
@@ -11633,7 +11633,7 @@ if (
     //                  'value-or-next' --name=VAL or --name VAL
     //                  'pair'          --name A B (repeatable, takes 2 args)
     //   target         Where to store the parsed value:
-    //                  'state_directory' | 'import_root' → special local variables
+    //                  'state_directory' | 'filesystem_root' → special local variables
     //                  'key'                   → $options['key']
     //                  'tuning_config.key'     → $options['tuning_config']['key']
     //   help           Description for --help output (null = hidden)
@@ -11663,7 +11663,7 @@ if (
         [
             'name' => 'fs-root',
             'type' => 'value',
-            'target' => 'import_root',
+            'target' => 'filesystem_root',
             'placeholder' => 'DIR',
             'help' => 'Local directory read from or written to for site files',
             'help_section' => 'required',
@@ -11737,7 +11737,7 @@ if (
             'type' => 'value',
             'target' => 'fs_root_nonempty_behavior',
             'placeholder' => 'MODE',
-            'help' => 'What to do when import root is non-empty (error|preserve-local)',
+            'help' => 'What to do when filesystem root is non-empty (error|preserve-local)',
             'help_section' => 'global',
             'commands' => ['pull', 'pull-files', 'files-pull'],
             'aliases' => ['on-docroot-nonempty'],
@@ -12085,7 +12085,7 @@ if (
     function _cli_parse_options(array $argv, int $argc, int $start, array $option_defs): array
     {
         $state_directory = null;
-        $import_root = null;
+        $filesystem_root = null;
         $options = [
             "abort" => false,
             "verbose" => false,
@@ -12114,7 +12114,7 @@ if (
                                     fwrite(STDERR, "Invalid --{$def['name']} value: {$raw}. Valid values: " . implode(", ", $def['valid_values']) . "\n");
                                     exit(1);
                                 }
-                                _cli_store($def, $value, $state_directory, $import_root, $options);
+                                _cli_store($def, $value, $state_directory, $filesystem_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12122,7 +12122,7 @@ if (
 
                         case 'flag':
                             if ($arg === "--{$cli_name}" || (isset($def['short']) && $arg === "-{$def['short']}")) {
-                                _cli_store($def, $def['flag_value'] ?? true, $state_directory, $import_root, $options);
+                                _cli_store($def, $def['flag_value'] ?? true, $state_directory, $filesystem_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12132,7 +12132,7 @@ if (
                             $prefix = "--{$cli_name}=";
                             if (strpos($arg, $prefix) === 0) {
                                 $raw = substr($arg, strlen($prefix));
-                                _cli_store($def, $raw, $state_directory, $import_root, $options);
+                                _cli_store($def, $raw, $state_directory, $filesystem_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12141,7 +12141,7 @@ if (
                                     fwrite(STDERR, "--{$def['name']} requires one argument: " . ($def['placeholder'] ?? 'VALUE') . "\n");
                                     exit(1);
                                 }
-                                _cli_store($def, $argv[$i + 1], $state_directory, $import_root, $options);
+                                _cli_store($def, $argv[$i + 1], $state_directory, $filesystem_root, $options);
                                 $i += 1;
                                 $matched = true;
                                 break 3;
@@ -12174,7 +12174,7 @@ if (
             }
         }
 
-        return [$state_directory, $import_root, $options];
+        return [$state_directory, $filesystem_root, $options];
     }
 
     /** @internal */
@@ -12189,11 +12189,11 @@ if (
     }
 
     /** @internal */
-    function _cli_store(array $def, $value, ?string &$state_directory, ?string &$import_root, array &$options): void
+    function _cli_store(array $def, $value, ?string &$state_directory, ?string &$filesystem_root, array &$options): void
     {
         $target = $def['target'];
         if ($target === 'state_directory') { $state_directory = $value; return; }
-        if ($target === 'import_root')      { $import_root = $value; return; }
+        if ($target === 'filesystem_root')      { $filesystem_root = $value; return; }
         if (strpos($target, 'tuning_config.') === 0) {
             $options['tuning_config'][substr($target, strlen('tuning_config.'))] = $value;
             return;
@@ -12609,7 +12609,7 @@ if (
                 "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
                 "\n" .
                 "Output files:\n" .
-                "  (import root)/                              Downloaded files\n" .
+                "  (filesystem root)/                              Downloaded files\n" .
                 "  .import-index.jsonl                     Local file index\n" .
                 "  .import-remote-index.jsonl              Target index snapshot\n" .
                 "  .import-download-list.jsonl             Files pending download\n" .
@@ -12623,9 +12623,9 @@ if (
             "usage" => "reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
                 "Shows which local paths a files-push would send or delete, comparing\n" .
-                "the local document root at --fs-root with the pair's previous local index —\n" .
+                "the filesystem root at --fs-root with the pair's previous local index —\n" .
                 "the index a completed files-push publishes for the same target URL,\n" .
-                "state directory, and local document root.\n" .
+                "state directory, and filesystem root.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .
@@ -12643,7 +12643,7 @@ if (
             "short" => "Push one local file tree without database work",
             "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
             "description" =>
-                "Sends the existing local document root at --fs-root to the target exporter API.\n" .
+                "Sends the existing filesystem root at --fs-root to the target exporter API.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It does not require pull preflight.\n" .
@@ -12804,7 +12804,7 @@ if (
                 "  DB_USER, and DB_PASSWORD. For SQLite targets, the sqlite-database-\n" .
                 "  integration plugin is copied into the output directory and a lazy-\n" .
                 "  loading \$wpdb proxy is generated in runtime.php (Playground-style,\n" .
-                "  no files placed in the import root).\n" .
+                "  no files placed in the filesystem root).\n" .
                 "\n" .
                 "Output files (nginx-fpm):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, route handlers)\n" .
@@ -12853,7 +12853,7 @@ if (
         $command = $command_aliases[$command];
     }
 
-    // install-exporter is a standalone guide — no URL, state-dir, or import root needed.
+    // install-exporter is a standalone guide — no URL, state-dir, or filesystem root needed.
     // Handle it before per-command --help so it always shows the full guide.
     if ($command === "install-exporter") {
         _cli_render_install_exporter();
@@ -12885,7 +12885,7 @@ if (
         $option_start_index = 3;
     }
 
-    [$state_directory, $import_root, $options] = _cli_parse_options(
+    [$state_directory, $filesystem_root, $options] = _cli_parse_options(
         $argv, $argc, $option_start_index, $option_defs
     );
     $options["command"] = $command;
@@ -12931,23 +12931,23 @@ if (
 
     // apply-runtime accepts --flat-document-root as an alternative to --fs-root.
     $flat_document_root = $options["flat_document_root"] ?? null;
-    if ($import_root && $flat_document_root) {
+    if ($filesystem_root && $flat_document_root) {
         fwrite(STDERR, "Error: --fs-root and --flat-document-root are mutually exclusive.\n");
         fwrite(STDERR, "Use --fs-root for the raw download directory, or --flat-document-root for a flattened layout.\n");
         exit(1);
     }
-    if (!$import_root && !$flat_document_root && $command !== "import-metadata") {
+    if (!$filesystem_root && !$flat_document_root && $command !== "import-metadata") {
         fwrite(STDERR, "Error: --fs-root=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
-    if (!$import_root) {
-        // For commands that need an import root in the constructor, use the
-        // flattened import root. run_apply_runtime will resolve it properly.
+    if (!$filesystem_root) {
+        // For commands that need a filesystem root in the constructor, use the
+        // flattened filesystem root. run_apply_runtime will resolve it properly.
         // import-metadata reads only state, but ImportClient still expects
-        // an import root path. Point it at state-dir rather than requiring an
+        // a filesystem root path. Point it at state-dir rather than requiring an
         // otherwise-unused CLI option.
-        $import_root = $flat_document_root ?: $state_directory;
+        $filesystem_root = $flat_document_root ?: $state_directory;
     }
 
     try {
@@ -12960,18 +12960,18 @@ if (
             $reprint_files_push_context = ImportClient::prepare_files_push_context(
                 $target_url,
                 $state_directory,
-                $import_root,
+                $filesystem_root,
                 $options
             );
         } elseif ($command === 'files-diff') {
             $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
                 $target_url,
                 $state_directory,
-                $import_root,
+                $filesystem_root,
                 'files-diff'
             );
         }
-        $client = new ImportClient($target_url, $state_directory, $import_root, $command);
+        $client = new ImportClient($target_url, $state_directory, $filesystem_root, $command);
         $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
         $client->audit_log_argv($command, $argv, $reprint_files_pair);
         $client->run(

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -259,14 +259,14 @@ class ImportClient
      */
     private const MAX_CONSECUTIVE_INTERRUPTED_RESPONSES = 3;
 
-    /** @var string Export server URL. */
-    public $remote_url;
+    /** @var string Target exporter API URL. */
+    public $target_url;
 
-    /** @var string Directory for import state files (.import-state.json, db.sql, etc.). */
-    public $state_dir;
+    /** @var string State directory for this local document root (.import-state.json, db.sql, etc.). */
+    public $state_directory;
 
-    /** @var string Directory where downloaded site files are written (no filesystem-root/ wrapper). */
-    public $fs_root;
+    /** @var string Import root where the target filesystem is reconstructed. */
+    public $import_root;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
@@ -281,11 +281,10 @@ class ImportClient
     private $progress_throttle = 1.0;
 
     /**
-     * @var string Path to .import-index.jsonl — sorted JSON-lines file tracking every
-     * imported file's path, ctime, size, and type. Used for delta detection: on the next
-     * sync we compare this against the remote index to decide what to download or delete.
+     * @var string Local index file .import-index.jsonl. It tracks each accounted
+     * path's ctime, size, and type for the next target-index comparison.
      */
-    private $index_file;
+    private $local_index_file;
 
     /**
      * @var string Path to .import-index-updates.wal — the append-only write-ahead
@@ -321,10 +320,10 @@ class ImportClient
     private $last_update_type = null;
 
     /**
-     * @var string Path to .import-remote-index.jsonl — latest file index received
-     * from the server, including directory `empty` fields when available.
+     * @var string Target index file .import-remote-index.jsonl, including
+     * directory `empty` fields when available.
      */
-    private $remote_index_file;
+    private $target_index_file;
 
     /** @var string Path to .import-download-list.jsonl — files to download, computed by diffing remote vs local index. */
     private $download_list_file;
@@ -405,19 +404,19 @@ class ImportClient
     private $include_caches = false;
 
     /**
-     * @var string Controls behavior when the fs root is non-empty at import start.
+     * @var string Controls behavior when the import root is non-empty at import start.
      *
-     * 'error' (default): throw an error if the fs root is non-empty.
+     * 'error' (default): throw an error if the import root is non-empty.
      * 'preserve-local': preserve existing files, symlinks, and directories in the
-     * fs root instead of overwriting them; non-writable directories are skipped
+     * import root instead of overwriting them; non-writable directories are skipped
      * gracefully and logged to the audit log.
      *
-     * On the first sync, existing fs root content is left untouched — any file,
+     * On the first sync, existing import root content is left untouched — any file,
      * symlink, or directory that already exists at a path the remote tries to write
      * is skipped and never added to the local index.
      *
      * On subsequent delta syncs, preserved paths survive because the importer only
-     * acts on paths listed in the remote index. Local-only hosting infrastructure
+     * acts on paths listed in the target index. Local-only hosting infrastructure
      * (e.g. __wp__ symlinks, drop-in symlinks, shared plugin directories) is simply
      * invisible to the diff and never touched.
      *
@@ -441,11 +440,11 @@ class ImportClient
     private $extra_directory = null;
 
     /**
-     * @var array<string,string> Resolved remap rules: full source path => its
-     * full local target path (both absolute). Empty = no remapping (files land
-     * nested based on their source).
+     * @var array<string,string> Resolved path mappings from target filesystem
+     * paths to local filesystem paths. Both sides are absolute. Empty means
+     * the identity mapping beneath the import root.
      */
-    private $remap_rules = [];
+    private $resolved_path_mappings = [];
 
     /**
      * @var array<int,string> Resolved `--only` file paths: a list of real source
@@ -485,12 +484,12 @@ class ImportClient
     private $index_entries_counted = 0;
 
     /**
-     * Memoized lookups for "does remote index contain this path or any descendant path?"
+     * Memoized lookups for "does target index contain this path or any descendant path?"
      * keyed by normalized absolute path.
      *
      * @var array<string,bool>
      */
-    private $remote_index_prefix_cache = [];
+    private $target_index_prefix_cache = [];
 
     /** @var int|null Current step in a multi-step pipeline (1-indexed). Set via --step. */
     private $pipeline_step = null;
@@ -529,9 +528,9 @@ class ImportClient
     public $exit_code = 0;
 
     public function __construct(
-        string $remote_url,
-        string $state_dir,
-        string $fs_root,
+        string $target_url,
+        string $state_directory,
+        string $import_root,
         ?string $signal_handling_command = null
     )
     {
@@ -552,22 +551,22 @@ class ImportClient
             }
         }
 
-        $this->remote_url = rtrim($remote_url, "?&");
-        $this->state_dir = rtrim($state_dir, "/");
-        $this->fs_root = rtrim($fs_root, "/");
-        $this->state_file = $this->state_dir . "/.import-state.json";
-        $this->index_file = $this->state_dir . "/.import-index.jsonl";
+        $this->target_url = rtrim($target_url, "?&");
+        $this->state_directory = rtrim($state_directory, "/");
+        $this->import_root = rtrim($import_root, "/");
+        $this->state_file = $this->state_directory . "/.import-state.json";
+        $this->local_index_file = $this->state_directory . "/.import-index.jsonl";
         $this->index_update_wal_path =
-            $this->state_dir . "/.import-index-updates.wal";
-        $this->remote_index_file =
-            $this->state_dir . "/.import-remote-index.jsonl";
+            $this->state_directory . "/.import-index-updates.wal";
+        $this->target_index_file =
+            $this->state_directory . "/.import-remote-index.jsonl";
         $this->download_list_file =
-            $this->state_dir . "/.import-download-list.jsonl";
+            $this->state_directory . "/.import-download-list.jsonl";
         $this->skipped_download_list_file =
-            $this->state_dir . "/.import-download-list-skipped.jsonl";
-        $this->audit_log = $this->state_dir . "/.import-audit.log";
-        $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
-        $this->status_file = $this->state_dir . "/.import-status.json";
+            $this->state_directory . "/.import-download-list-skipped.jsonl";
+        $this->audit_log = $this->state_directory . "/.import-audit.log";
+        $this->volatile_files_file = $this->state_directory . "/.import-volatile-files.json";
+        $this->status_file = $this->state_directory . "/.import-status.json";
 
         // Detect TTY for progress display. In stdout mode this is re-evaluated
         // against STDERR in run() once we know the output mode.
@@ -577,14 +576,14 @@ class ImportClient
         $this->pull = new Pull($this, $this->progress);
 
         // Create directories
-        if (!is_dir($this->state_dir)) {
-            if (!mkdir($this->state_dir, 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->state_dir}");
+        if (!is_dir($this->state_directory)) {
+            if (!mkdir($this->state_directory, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->state_directory}");
             }
         }
-        if (!is_dir($this->fs_root)) {
-            if (!mkdir($this->fs_root, 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->fs_root}");
+        if (!is_dir($this->import_root)) {
+            if (!mkdir($this->import_root, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->import_root}");
             }
         }
 
@@ -596,10 +595,10 @@ class ImportClient
      */
     public function index_count(): int
     {
-        if (!is_file($this->index_file)) {
+        if (!is_file($this->local_index_file)) {
             return 0;
         }
-        $handle = fopen($this->index_file, "r");
+        $handle = fopen($this->local_index_file, "r");
         if (!$handle) {
             return 0;
         }
@@ -706,7 +705,7 @@ class ImportClient
     {
         $remap_raw = $options["remap"] ?? [];
         if (!empty($remap_raw)) {
-            $this->remap_rules = $this->resolve_remap($remap_raw);
+            $this->resolved_path_mappings = $this->resolve_remap($remap_raw);
         }
 
         $only_raw = $options["only"] ?? [];
@@ -735,7 +734,7 @@ class ImportClient
      * Called from the CLI entry point before run() so the invocation
      * is captured even if run() throws early.
      *
-     * @param string       $command Canonical CLI command name.
+     * @param string       $command Normalized CLI command name.
      * @param list<string> $argv    Raw command arguments.
      * @param string|null  $pair    Files-diff or files-push pair key, when available.
      */
@@ -891,7 +890,7 @@ class ImportClient
         ?ReprintProcessLock $process_lock = null
     ): void
     {
-        $process_lock = $process_lock ?? new ReprintProcessLock($this->state_dir);
+        $process_lock = $process_lock ?? new ReprintProcessLock($this->state_directory);
         if (!$process_lock->is_held()) {
             throw new InvalidArgumentException(
                 'ImportClient requires a held Reprint process lock.'
@@ -1324,9 +1323,9 @@ class ImportClient
     private function run_files_diff(array $options): void
     {
         $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
-            $this->remote_url,
-            $this->state_dir,
-            $this->fs_root,
+            $this->target_url,
+            $this->state_directory,
+            $this->import_root,
             'files-diff'
         );
         if (!is_array($context)) {
@@ -1337,7 +1336,7 @@ class ImportClient
         $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
         $missing_previous_local_index_message =
             'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
-            . 'for the same target URL, state directory, and local tree.';
+            . 'for the same target URL, state directory, and local document root.';
         if (!is_dir($push_state_directory)) {
             throw new RuntimeException($missing_previous_local_index_message);
         }
@@ -1360,7 +1359,7 @@ class ImportClient
             }
             $plan = PushPlan::start(
                 $plan_directory,
-                $context['local_tree'],
+                $context['local_document_root'],
                 $previous_local_index,
                 $excluded_paths_path
             );
@@ -1542,9 +1541,9 @@ class ImportClient
     {
         $started_at = hrtime(true) / 1000000000;
         $context = $options['files_push_context'] ?? self::prepare_files_push_context(
-            $this->remote_url,
-            $this->state_dir,
-            $this->fs_root,
+            $this->target_url,
+            $this->state_directory,
+            $this->import_root,
             $options
         );
         if (!is_array($context)) {
@@ -1566,7 +1565,7 @@ class ImportClient
             ? -1
             : parse_size($memory_limit_value);
         $sender_options = [
-            'docroot' => $context['local_tree'],
+            'docroot' => $context['local_document_root'],
             'push_state_directory' => $context['push_state_directory'],
             'base_url' => $context['target_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
@@ -1762,16 +1761,16 @@ class ImportClient
      *     Validated files-push command context.
      *
      *     @type string $target_url           Target exporter API URL.
-     *     @type string $local_tree           Canonical local tree being sent.
-     *     @type string $pair                 Target/local-tree pair key.
+     *     @type string $local_document_root  Resolved local document root being sent.
+     *     @type string $pair                 Target/local-document-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{target_url:string,local_document_root:string,pair:string,push_state_directory:string}
      */
     public static function prepare_files_push_context(
         string $target_url,
         string $state_directory,
-        string $local_tree,
+        string $local_document_root,
         array $options
     ): array {
         $secret = $options['secret'] ?? null;
@@ -1787,7 +1786,7 @@ class ImportClient
         $context = self::prepare_files_pair_context(
             $target_url,
             $state_directory,
-            $local_tree,
+            $local_document_root,
             'files-push'
         );
         $masked_target_url = self::mask_files_push_url_user_info($target_url);
@@ -1813,16 +1812,16 @@ class ImportClient
      *     Validated pair context.
      *
      *     @type string $target_url           Target exporter API URL.
-     *     @type string $local_tree           Canonical local tree.
-     *     @type string $pair                 Target/local-tree pair key.
+     *     @type string $local_document_root  Resolved local document root.
+     *     @type string $pair                 Target/local-document-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{target_url:string,local_tree:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{target_url:string,local_document_root:string,pair:string,push_state_directory:string}
      */
     public static function prepare_files_pair_context(
         string $target_url,
         string $state_directory,
-        string $local_tree,
+        string $local_document_root,
         string $command
     ): array {
         $masked_target_url = self::mask_files_push_url_user_info($target_url);
@@ -1838,23 +1837,23 @@ class ImportClient
                 'The ' . $command . ' target URL must not contain URL user-info: ' . $masked_target_url . '.'
             );
         }
-        if (is_link($local_tree)) {
-            throw new InvalidArgumentException('The local tree must not be a symlink: ' . $local_tree . '.');
+        if (is_link($local_document_root)) {
+            throw new InvalidArgumentException('The local document root must not be a symlink: ' . $local_document_root . '.');
         }
-        if (!is_dir($local_tree)) {
+        if (!is_dir($local_document_root)) {
             throw new InvalidArgumentException(
-                'The local tree does not exist or is not a directory: ' . $local_tree . '.'
+                'The local document root does not exist or is not a directory: ' . $local_document_root . '.'
             );
         }
-        $canonical_local_tree = realpath($local_tree);
-        if ($canonical_local_tree === false) {
+        $resolved_local_document_root = realpath($local_document_root);
+        if ($resolved_local_document_root === false) {
             throw new InvalidArgumentException(
-                'The local tree does not exist or is not a directory: ' . $local_tree . '.'
+                'The local document root does not exist or is not a directory: ' . $local_document_root . '.'
             );
         }
-        $canonical_local_tree = rtrim($canonical_local_tree, '/') ?: '/';
+        $resolved_local_document_root = rtrim($resolved_local_document_root, '/') ?: '/';
         $target_url = rtrim($target_url, '?&');
-        $pair = hash('sha256', $target_url . "\0" . $canonical_local_tree);
+        $pair = hash('sha256', $target_url . "\0" . $resolved_local_document_root);
         // Resolve an absolute physical path even when its final components do not exist.
         $push_state_directory = $state_directory . '/push/' . $pair;
         if (strpos($push_state_directory, '/') !== 0) {
@@ -1875,28 +1874,28 @@ class ImportClient
             array_unshift($missing_state_components, basename($existing_state_path));
             $existing_state_path = dirname($existing_state_path);
         }
-        $canonical_existing_state_path = realpath($existing_state_path);
-        if ($canonical_existing_state_path !== false) {
+        $resolved_existing_state_path = realpath($existing_state_path);
+        if ($resolved_existing_state_path !== false) {
             $push_state_directory = normalize_path(
-                $canonical_existing_state_path
+                $resolved_existing_state_path
                     . ( $missing_state_components === []
                         ? ''
                         : '/' . implode('/', $missing_state_components) )
             );
         }
         if (
-            $canonical_local_tree === '/'
-            || path_is_within_root($push_state_directory, $canonical_local_tree)
+            $resolved_local_document_root === '/'
+            || path_is_within_root($push_state_directory, $resolved_local_document_root)
         ) {
             throw new InvalidArgumentException(
                 'The local push state directory ' . $push_state_directory
-                . ' must be outside the local tree ' . $canonical_local_tree . '.'
+                . ' must be outside the local document root ' . $resolved_local_document_root . '.'
             );
         }
 
         return [
             'target_url' => $target_url,
-            'local_tree' => $canonical_local_tree,
+            'local_document_root' => $resolved_local_document_root,
             'pair' => $pair,
             'push_state_directory' => $push_state_directory,
         ];
@@ -1983,9 +1982,9 @@ class ImportClient
                 $this->import_state()->active_resumable_command->completion_state = null;
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->import_state()->index = new RemoteFileIndexCursorState();
-                if (file_exists($this->remote_index_file)) {
-                    @unlink($this->remote_index_file);
-                    $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+                if (file_exists($this->target_index_file)) {
+                    @unlink($this->target_index_file);
+                    $this->audit_log("FILE DELETE | {$this->target_index_file}");
                 }
                 $this->save_state($this->state);
                 break;
@@ -1999,7 +1998,7 @@ class ImportClient
                 $this->save_state($this->state);
 
                 if ($this->sql_output_mode === "file") {
-                    $sql_file = $this->state_dir . "/db.sql";
+                    $sql_file = $this->state_directory . "/db.sql";
                     if (file_exists($sql_file)) {
                         unlink($sql_file);
                         $this->audit_log(
@@ -2007,14 +2006,14 @@ class ImportClient
                         );
                     }
                 }
-                $tables_file = $this->state_dir . "/db-tables.jsonl";
+                $tables_file = $this->state_directory . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
                         "FILE DELETE | {$tables_file} | abort db-pull",
                     );
                 }
-                $domains_file = $this->state_dir . "/.import-domains.json";
+                $domains_file = $this->state_directory . "/.import-domains.json";
                 if (file_exists($domains_file)) {
                     unlink($domains_file);
                     $this->audit_log(
@@ -2031,7 +2030,7 @@ class ImportClient
                 $this->reset_state();
                 $this->save_state($this->state);
 
-                $tables_file = $this->state_dir . "/db-tables.jsonl";
+                $tables_file = $this->state_directory . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
@@ -2072,9 +2071,9 @@ class ImportClient
         $this->index_update_wal_handle = null;
         $this->index_update_wal_record_count = 0;
 
-        if (file_exists($this->remote_index_file)) {
-            @unlink($this->remote_index_file);
-            $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+        if (file_exists($this->target_index_file)) {
+            @unlink($this->target_index_file);
+            $this->audit_log("FILE DELETE | {$this->target_index_file}");
         }
         if (file_exists($this->download_list_file)) {
             @unlink($this->download_list_file);
@@ -2171,10 +2170,10 @@ class ImportClient
 
         // Detect webhost environment from preflight data.
         // The host analyzers score based on preflight signals. We also
-        // check the local fs root for a __wp__ symlink as a fallback
+        // check the import root for a __wp__ symlink as a fallback
         // when the remote preflight didn't report enough filesystem data.
         $detected_webhost = is_array($payload) ? detect_host($payload) : 'other';
-        if ($detected_webhost === 'other' && is_link($this->fs_root . '/__wp__')) {
+        if ($detected_webhost === 'other' && is_link($this->import_root . '/__wp__')) {
             $detected_webhost = 'wpcloud';
         }
         $this->import_state()->webhost = $detected_webhost;
@@ -2232,7 +2231,7 @@ class ImportClient
      */
     private function download_runtime_files(): void
     {
-        $runtime_dir = $this->state_dir . "/runtime_files";
+        $runtime_dir = $this->state_directory . "/runtime_files";
 
         // Always wipe and recreate so the directory reflects current state.
         if (is_dir($runtime_dir)) {
@@ -2267,7 +2266,7 @@ class ImportClient
     }
 
     /**
-     * Download a list of absolute remote paths into $target_dir,
+     * Download a list of absolute target filesystem paths into $target_dir,
      * preserving their directory structure.
      *
      * Issues one file_fetch request per parent directory so that an
@@ -2829,16 +2828,16 @@ class ImportClient
         // Filter out "." and ".." explicitly: standard PHP scandir() returns them,
         // but WASM PHP (WordPress Playground) does not, so a `count <= 2` shortcut
         // would mis-classify directories with one or two real entries as empty.
-        $is_empty = !is_dir($this->fs_root) || count(array_diff(
-            scandir($this->fs_root) ?: [],
+        $is_empty = !is_dir($this->import_root) || count(array_diff(
+            scandir($this->import_root) ?: [],
             [".", ".."]
         )) === 0;
 
         // A local index from a prior completed sync means the next run is a
         // delta: re-index the remote, diff against local, fetch only changes.
         $is_delta =
-            file_exists($this->index_file) &&
-            filesize($this->index_file) > 0;
+            file_exists($this->local_index_file) &&
+            filesize($this->local_index_file) > 0;
 
         // Resuming an in-progress sync
         if ($has_progress) {
@@ -2872,7 +2871,7 @@ class ImportClient
             ], true);
         } else {
             // Starting fresh — validate that target directory is empty.
-            // A delta sync ($is_delta) naturally has a non-empty fs root
+            // A delta sync ($is_delta) naturally has a non-empty import root
             // because we put those files there during the initial sync.
             if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
                 throw new RuntimeException(
@@ -2979,7 +2978,7 @@ class ImportClient
         $stage = $this->import_state()->active_resumable_command->current_stage ?? "index";
 
         if ($stage === "index") {
-            $complete = $this->download_remote_index();
+            $complete = $this->download_target_index();
             if (!$complete) {
                 $this->import_state()->active_resumable_command->completion_state = "partial";
                 $this->save_state($this->state);
@@ -2993,7 +2992,7 @@ class ImportClient
                     return;
                 }
             }
-            $this->sort_index_file($this->remote_index_file);
+            $this->sort_index_file($this->target_index_file);
             $this->import_state()->active_resumable_command->current_stage = "diff";
             $this->import_state()->diff = new FileDiffProgressState();
             if (file_exists($this->download_list_file)) {
@@ -3147,7 +3146,7 @@ class ImportClient
 
         // Recreate intermediate path symlinks so the full symlink chain
         // works locally.  The server discovers these (e.g. /srv/wordpress
-        // -> /wordpress) and includes them in the remote index.
+        // -> /wordpress) and includes them in the target index.
         if ($this->follow_symlinks) {
             $this->recreate_intermediate_symlinks();
         }
@@ -3157,9 +3156,9 @@ class ImportClient
      * Command: files-index
      *
      * Rules:
-     * - Streams the full remote index (DFS across directories) until complete
+     * - Streams the full target index (DFS across directories) until complete
      * - If already completed: require --abort flag
-     * - If abort flag: clear remote index file and index cursor
+     * - If abort flag: clear target index file and index cursor
      */
     private function run_files_index(): void
     {
@@ -3212,7 +3211,7 @@ class ImportClient
         $attempts = 0;
         $last_cursor = $this->import_state()->index->cursor ?? null;
         while (true) {
-            $complete = $this->download_remote_index();
+            $complete = $this->download_target_index();
             if ($complete) {
                 break;
             }
@@ -3246,14 +3245,14 @@ class ImportClient
             $this->discover_symlink_targets();
         }
 
-        $this->sort_index_file($this->remote_index_file);
+        $this->sort_index_file($this->target_index_file);
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->import_state()->active_resumable_command->current_stage = null;
         $this->save_state($this->state);
 
         $count = 0;
-        if (file_exists($this->remote_index_file)) {
-            $h = fopen($this->remote_index_file, "r");
+        if (file_exists($this->target_index_file)) {
+            $h = fopen($this->target_index_file, "r");
             if ($h) {
                 while (fgets($h) !== false) {
                     $count++;
@@ -3267,14 +3266,14 @@ class ImportClient
         );
 
         $this->progress->show_lifecycle_line("files-index complete: {$count} entries indexed\n");
-        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_file}\n");
+        $this->progress->show_lifecycle_line("Target index: {$this->target_index_file}\n");
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
             "command" => "files-index",
             "entries_indexed" => $count,
-            "remote_index" => $this->remote_index_file,
+            "remote_index" => $this->target_index_file,
             "audit_log" => $this->audit_log,
             "message" => "files-index complete: {$count} entries indexed",
         ], true);
@@ -3284,7 +3283,7 @@ class ImportClient
      * Recursively discover directories that need indexing beyond the primary
      * export roots.
      *
-     * Scans the remote index for symlink entries with a "target" field,
+     * Scans the target index for symlink entries with a "target" field,
      * resolves relative targets to absolute paths, and indexes each target
      * directory. Repeats until the queue is drained, with cycle detection.
      */
@@ -3337,7 +3336,7 @@ class ImportClient
                 "message" => "Following symlink target: {$dir}",
             ], true);
 
-            // Reset the index cursor so download_remote_index starts fresh
+            // Reset the index cursor so download_target_index starts fresh
             // for this directory, but appends to the existing index file.
             // Note we are not losing the previous cursor position. This code
             // runs only after the previous directory was fully indexed so
@@ -3349,7 +3348,7 @@ class ImportClient
             $last_cursor = null;
             while (true) {
                 try {
-                    $complete = $this->download_remote_index($dir);
+                    $complete = $this->download_target_index($dir);
                 } catch (RuntimeException $e) {
                     // We won't be able to follow every symlink. If
                     // the response seems like the remote server rejecting
@@ -3415,7 +3414,7 @@ class ImportClient
     }
 
     /**
-     * Scan the remote index file for symlink entries whose targets are
+     * Scan the target index file for symlink entries whose targets are
      * directories not already in $visited.  Returns an array of real paths.
      *
      * Skips entries marked as "intermediate" — those are path-component
@@ -3425,11 +3424,11 @@ class ImportClient
     private function extract_symlink_dirs_from_index(array $visited): array
     {
         $targets = [];
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->target_index_file)) {
             return $targets;
         }
 
-        $handle = fopen($this->remote_index_file, "r");
+        $handle = fopen($this->target_index_file, "r");
         if (!$handle) {
             return $targets;
         }
@@ -3491,17 +3490,17 @@ class ImportClient
      *
      * Since the server indexes everything under realpath()-resolved paths,
      * the files are already downloaded to the target location (e.g.
-     * fs-root/wordpress/...).  We just need to create the symlink
-     * (e.g. fs-root/srv/wordpress -> /wordpress) so the directory
+     * import root/wordpress/...).  We just need to create the symlink
+     * (e.g. import root/srv/wordpress -> /wordpress) so the directory
      * layout matches the server.
      */
     private function recreate_intermediate_symlinks(): void
     {
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->target_index_file)) {
             return;
         }
 
-        $h = fopen($this->remote_index_file, "r");
+        $h = fopen($this->target_index_file, "r");
         if (!$h) {
             return;
         }
@@ -3540,7 +3539,7 @@ class ImportClient
             }
 
             try {
-                $local_path = $this->remote_path_to_local_path_within_import_root($path);
+                $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
             } catch (RuntimeException $e) {
                 $this->audit_log(
                     "INTERMEDIATE SYMLINK SKIP: invalid path {$path}: " . $e->getMessage(),
@@ -3550,7 +3549,7 @@ class ImportClient
             }
 
             // Repoint through the same seam regular symlink chunks use, so the
-            // link targets wherever the content actually landed (fs-root,
+            // link targets wherever the content actually landed (import root,
             // remapped, or bundled) instead of the raw source spelling.
             $target = $this->map_symlink_target_for_local_mirror($path, $local_path, $target);
 
@@ -3591,7 +3590,7 @@ class ImportClient
             }
 
             // Validate that the symlink target doesn't escape the filesystem root.
-            $root = $this->get_filesystem_root_path();
+            $root = $this->get_import_root_path();
             try {
                 $this->assert_symlink_target_within_root(
                     dirname($local_path),
@@ -3641,7 +3640,7 @@ class ImportClient
     public function run_db_sync(): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
-        $sql_file = $this->state_dir . "/db.sql";
+        $sql_file = $this->state_directory . "/db.sql";
 
         $has_progress =
             $state_command === "db-pull" &&
@@ -3799,8 +3798,8 @@ class ImportClient
      */
     private function run_db_domains(): void
     {
-        $domains_file = $this->state_dir . "/.import-domains.json";
-        $sql_file = $this->state_dir . "/db.sql";
+        $domains_file = $this->state_directory . "/.import-domains.json";
+        $sql_file = $this->state_directory . "/db.sql";
 
         if (file_exists($domains_file)) {
             // Fast path: domains were already discovered during db-pull
@@ -3852,7 +3851,7 @@ class ImportClient
             );
         } else {
             throw new RuntimeException(
-                "No domain data found. Run db-pull first, or place a db.sql file in {$this->state_dir}.",
+                "No domain data found. Run db-pull first, or place a db.sql file in {$this->state_directory}.",
             );
         }
 
@@ -3871,17 +3870,17 @@ class ImportClient
      */
     private function run_files_stats(): void
     {
-        $remote_index = $this->remote_index_file;
+        $target_index = $this->target_index_file;
         $download_list = $this->download_list_file;
 
-        // Single pass over the remote index to build a path→size map.
+        // Single pass over the target index to build a path→size map.
         // Duplicates (from overlapping symlink targets) are collapsed
         // automatically because later entries overwrite earlier ones in
         // the map, so the counts we derive are always deduplicated.
         $size_by_path = [];
 
-        if (is_file($remote_index)) {
-            $handle = fopen($remote_index, "r");
+        if (is_file($target_index)) {
+            $handle = fopen($target_index, "r");
             if ($handle) {
                 while (($line = fgets($handle)) !== false) {
                     $entry = $this->parse_index_line($line);
@@ -4050,9 +4049,9 @@ class ImportClient
      * the applier writes the files the target server needs to fulfill those
      * requirements.
      *
-     * The effective fs root is --fs-root + the remote site's document_root
+     * The effective import root is --fs-root + the remote site's document_root
      * prefix (from preflight). For example, if the remote document_root is
-     * /srv/htdocs and --fs-root is ./files, the effective fs root is
+     * /srv/htdocs and --fs-root is ./files, the effective import root is
      * ./files/srv/htdocs. If the site was flattened with flat-docroot,
      * pass the flattened directory as --fs-root directly and the prefix
      * is not applied.
@@ -4085,7 +4084,7 @@ class ImportClient
         $preflight_data = $entry["data"];
         $webhost = $this->import_state()->webhost ?? "other";
 
-        // Resolve the effective fs root from either --flat-document-root
+        // Resolve the effective import root from either --flat-document-root
         // (used as-is) or --fs-root (prefixed with the remote document_root).
         // Mutual exclusion is already enforced at the CLI level.
         $flat_document_root = $options["flat_document_root"] ?? null;
@@ -4097,7 +4096,7 @@ class ImportClient
             // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
             // source server. Files are downloaded preserving the full
-            // remote path, so the effective fs root is --fs-root +
+            // target filesystem path, so the effective import root is --fs-root +
             // document_root.
             $remote_doc_root = $preflight_data["runtime"]["document_root"] ?? "";
             if (is_string($remote_doc_root)) {
@@ -4107,14 +4106,14 @@ class ImportClient
             }
 
             if ($remote_doc_root !== "") {
-                $effective_fs_root = $this->fs_root . $remote_doc_root;
+                $effective_fs_root = $this->import_root . $remote_doc_root;
             } else {
-                $effective_fs_root = $this->fs_root;
+                $effective_fs_root = $this->import_root;
             }
 
             if (!is_dir($effective_fs_root)) {
                 throw new RuntimeException(
-                    "Effective fs root does not exist: {$effective_fs_root}\n" .
+                    "Effective import root does not exist: {$effective_fs_root}\n" .
                     "The remote document_root was: {$remote_doc_root}\n" .
                     "If you used flat-docroot, pass the flattened directory " .
                     "with --flat-document-root instead of --fs-root."
@@ -4171,7 +4170,7 @@ class ImportClient
                 $db_dir = rtrim(dirname($sqlite_path), '/') . '/';
                 $db_file = basename($sqlite_path);
             } else {
-                $db_dir = '{fs-root}/wp-content/database/';
+                $db_dir = '{import root}/wp-content/database/';
                 $db_file = '.ht.sqlite';
             }
             $manifest->sqlite = [
@@ -4205,7 +4204,7 @@ class ImportClient
         }
 
         // Resolve the path to WordPress's index.php. On standard hosts it
-        // lives in the fs root. On WPCloud the ABSPATH is a different
+        // lives in the import root. On WPCloud the ABSPATH is a different
         // directory (e.g. /wordpress/core/X.Y.Z) which maps to
         // download_root + abspath when using --fs-root.
         $paths_urls = $preflight_data["database"]["wp"]["paths_urls"] ?? [];
@@ -4215,8 +4214,8 @@ class ImportClient
             $wordpress_index = $abs_fs_root . '/index.php';
         } elseif ($abspath !== "") {
             // Raw download: ABSPATH is relative to the download root,
-            // not the effective fs root (which is download_root + document_root).
-            $wordpress_index = realpath($this->fs_root . $abspath . '/index.php') ?: '';
+            // not the effective import root (which is download_root + document_root).
+            $wordpress_index = realpath($this->import_root . $abspath . '/index.php') ?: '';
         } else {
             $wordpress_index = $abs_fs_root . '/index.php';
         }
@@ -4244,7 +4243,7 @@ class ImportClient
             // Replace the source path with the copied-to path so the
             // generated runtime.php points to the output directory.
             $manifest->sqlite['plugin_dir'] = $copied_plugin;
-            // Resolve {fs-root} in db_dir now that we have the real path.
+            // Resolve {import root} in db_dir now that we have the real path.
             $manifest->sqlite['db_dir'] = resolve_runtime_placeholders(
                 $manifest->sqlite['db_dir'],
                 $abs_fs_root,
@@ -4345,11 +4344,11 @@ class ImportClient
         }
 
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL"] = $base_url;
-        $state_dir = realpath($this->state_dir) ?: $this->state_dir;
+        $state_directory = realpath($this->state_directory) ?: $this->state_directory;
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
-            rtrim($state_dir, "/") . "/.import-state.json";
+            rtrim($state_directory, "/") . "/.import-state.json";
         $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
-            rtrim($state_dir, "/") . "/.import-download-list-skipped.jsonl";
+            rtrim($state_directory, "/") . "/.import-download-list-skipped.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -4416,9 +4415,9 @@ class ImportClient
      *
      * Creates a directory at the specified --flatten-to path that mirrors
      * a vanilla WordPress installation layout by symlinking entries from
-     * the import fs root. Uses preflight data (paths_urls) to determine
+     * the import root. Uses preflight data (paths_urls) to determine
      * where each WordPress component actually lives, rather than blindly
-     * scanning fs root top-level entries.
+     * scanning import root top-level entries.
      *
      * This is essential when the source site uses a non-standard layout
      * (e.g. WP Cloud with ABSPATH=/srv/htdocs and WP_CONTENT_DIR=/tmp/__wp__/wp-content)
@@ -4441,10 +4440,10 @@ class ImportClient
         $flatten_to = rtrim($flatten_to, "/");
         $force = $options["force"] ?? false;
 
-        // Ensure the fs root exists
-        if (!is_dir($this->fs_root)) {
+        // Ensure the import root exists
+        if (!is_dir($this->import_root)) {
             throw new RuntimeException(
-                "Fs root does not exist: {$this->fs_root}",
+                "Fs root does not exist: {$this->import_root}",
             );
         }
 
@@ -4489,32 +4488,32 @@ class ImportClient
             );
         }
 
-        // Map remote paths to local paths within fs root
-        $local_abspath = $this->fs_root . $abspath;
+        // Map target filesystem paths to local paths within import root
+        $local_abspath = $this->import_root . $abspath;
         if (!is_dir($local_abspath)) {
             throw new RuntimeException(
-                "WordPress ABSPATH directory not found in fs root: {$local_abspath} " .
+                "WordPress ABSPATH directory not found in import root: {$local_abspath} " .
                     "(remote ABSPATH: {$abspath}). Has the file sync completed?",
             );
         }
 
         $local_wp_admin = $wp_admin_path !== null
-            ? $this->fs_root . $wp_admin_path
+            ? $this->import_root . $wp_admin_path
             : null;
         $local_wp_includes = $wp_includes_path !== null
-            ? $this->fs_root . $wp_includes_path
+            ? $this->import_root . $wp_includes_path
             : null;
         $local_content_dir = $content_dir !== null
-            ? $this->fs_root . $content_dir
+            ? $this->import_root . $content_dir
             : null;
         $local_plugins_dir = $plugins_dir !== null
-            ? $this->fs_root . $plugins_dir
+            ? $this->import_root . $plugins_dir
             : null;
         $local_mu_plugins_dir = $mu_plugins_dir !== null
-            ? $this->fs_root . $mu_plugins_dir
+            ? $this->import_root . $mu_plugins_dir
             : null;
         $local_uploads_basedir = $uploads_basedir !== null
-            ? $this->fs_root . $uploads_basedir
+            ? $this->import_root . $uploads_basedir
             : null;
 
         // Determine which components are "detached" — located outside
@@ -4654,7 +4653,7 @@ class ImportClient
         $wp_config_in_flatten = $flatten_to . "/wp-config.php";
         if (!file_exists($wp_config_in_flatten)) {
             $parent_of_abspath = dirname($abspath);
-            $local_parent_wp_config = $this->fs_root . $parent_of_abspath . "/wp-config.php";
+            $local_parent_wp_config = $this->import_root . $parent_of_abspath . "/wp-config.php";
             if (file_exists($local_parent_wp_config)) {
                 $this->flatten_place_symlink(
                     $local_parent_wp_config,
@@ -4767,7 +4766,7 @@ class ImportClient
                 );
             } else {
                 $this->audit_log(
-                    "FLAT-DOCUMENT-ROOT | Warning: content_dir not found in fs root: " .
+                    "FLAT-DOCUMENT-ROOT | Warning: content_dir not found in import root: " .
                         "{$local_content_dir} (remote: {$content_dir})",
                     true,
                 );
@@ -4787,7 +4786,7 @@ class ImportClient
         $result = [
             "status" => "complete",
             "flatten_to" => $flatten_to,
-            "fs_root" => $this->fs_root,
+            "fs_root" => $this->import_root,
             "abspath" => $abspath,
             "wp_admin_path" => $wp_admin_path,
             "wp_includes_path" => $wp_includes_path,
@@ -5020,7 +5019,7 @@ class ImportClient
             return;
         }
 
-        $parsed_url = parse_url($this->remote_url);
+        $parsed_url = parse_url($this->target_url);
         if (!$parsed_url || !isset($parsed_url['scheme'], $parsed_url['host'])) {
             throw new InvalidArgumentException(
                 "--new-site-url requires a valid export URL to derive the source site origin.",
@@ -5147,7 +5146,7 @@ class ImportClient
                         "--target-sqlite-path option is required but was missing.",
                     );
                 }
-                $target_path = $this->get_filesystem_root_path() . $content_dir . '/database/.ht.sqlite';
+                $target_path = $this->get_import_root_path() . $content_dir . '/database/.ht.sqlite';
                 $this->audit_log("DB-APPLY | defaulting SQLite path to: {$target_path}");
                 $this->progress->show_lifecycle_line("SQLite path: {$target_path}\n");
             }
@@ -5216,10 +5215,10 @@ class ImportClient
 
     public function run_db_apply(array $options): void
     {
-        $sql_file = $this->state_dir . "/db.sql";
+        $sql_file = $this->state_directory . "/db.sql";
         if (!file_exists($sql_file)) {
             throw new RuntimeException(
-                "db.sql not found in {$this->state_dir}. Run db-pull first.",
+                "db.sql not found in {$this->state_directory}. Run db-pull first.",
             );
         }
 
@@ -5236,7 +5235,7 @@ class ImportClient
         }
 
         // Show discovered domains if available
-        $domains_file = $this->state_dir . "/.import-domains.json";
+        $domains_file = $this->state_directory . "/.import-domains.json";
         if (file_exists($domains_file)) {
             $domains = json_decode(file_get_contents($domains_file), true);
             if (is_array($domains) && !empty($domains)) {
@@ -5404,7 +5403,7 @@ class ImportClient
         $stmts_since_save = 0;
 
         // Load pre-computed statement count from db-pull for progress reporting
-        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
+        $sql_stats_file = $this->state_directory . "/.import-sql-stats.json";
         $statements_total = null;
         if (file_exists($sql_stats_file)) {
             $stats = json_decode(file_get_contents($sql_stats_file), true);
@@ -5868,7 +5867,7 @@ class ImportClient
     private function run_db_index(): void
     {
         $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
-        $tables_file = $this->state_dir . "/db-tables.jsonl";
+        $tables_file = $this->state_directory . "/db-tables.jsonl";
 
         $has_cursor =
             $state_command === "db-index" &&
@@ -6001,7 +6000,7 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
-        // Always send directory[] – see comment in download_remote_index().
+        // Always send directory[] – see comment in download_target_index().
         $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
@@ -6247,9 +6246,9 @@ class ImportClient
     }
 
     /**
-     * Download the remote index stream and write to disk.
+     * Download the target index stream and write to disk.
      */
-    private function download_remote_index(?string $list_dir_override = null): bool
+    private function download_target_index(?string $list_dir_override = null): bool
     {
         $cursor = $this->import_state()->index->cursor;
 
@@ -6261,24 +6260,24 @@ class ImportClient
             );
         }
 
-        $mode = file_exists($this->remote_index_file) ? "a" : "w";
+        $mode = file_exists($this->target_index_file) ? "a" : "w";
         // Initialize the index counter from the existing file so resume
         // shows a monotonically increasing count.
         if ($mode === "a" && $this->index_entries_counted === 0) {
-            $this->index_entries_counted = $this->count_newlines($this->remote_index_file);
+            $this->index_entries_counted = $this->count_newlines($this->target_index_file);
         }
         if ($mode === "w") {
             $this->audit_log(
-                "FILE CREATE | {$this->remote_index_file} | downloading fresh remote index",
+                "FILE CREATE | {$this->target_index_file} | downloading fresh target index",
             );
         } else {
             $this->audit_log(
-                "FILE APPEND | {$this->remote_index_file} | resuming remote index download",
+                "FILE APPEND | {$this->target_index_file} | resuming target index download",
             );
         }
-        $handle = fopen($this->remote_index_file, $mode);
+        $handle = fopen($this->target_index_file, $mode);
         if (!$handle) {
-            throw new RuntimeException("Failed to open remote index file");
+            throw new RuntimeException("Failed to open target index file");
         }
 
         $complete = false;
@@ -6414,7 +6413,7 @@ class ImportClient
                     }
                     $bytes = fwrite($handle, $line . "\n");
                     if ($bytes === false) {
-                        throw new RuntimeException("Failed to write to remote index file (disk full?)");
+                        throw new RuntimeException("Failed to write to target index file (disk full?)");
                     }
                     $this->index_entries_counted++;
                 }
@@ -6491,12 +6490,12 @@ class ImportClient
     }
 
     /**
-     * Diff local index against remote index and build download list.
+     * Diff local index against target index and build download list.
      */
     private function diff_indexes_and_build_fetch_list(): bool
     {
-        if (!file_exists($this->remote_index_file)) {
-            throw new RuntimeException("Remote index file not found");
+        if (!file_exists($this->target_index_file)) {
+            throw new RuntimeException("Target index file not found");
         }
 
         $diff = $this->import_state()->diff;
@@ -6542,17 +6541,17 @@ class ImportClient
             );
         }
 
-        $remote_handle = fopen($this->remote_index_file, "r");
+        $remote_handle = fopen($this->target_index_file, "r");
         if (!$remote_handle) {
             fclose($download_handle);
-            throw new RuntimeException("Failed to open remote index file");
+            throw new RuntimeException("Failed to open target index file");
         }
         if ($remote_offset > 0) {
             fseek($remote_handle, $remote_offset);
         }
 
-        $local_handle = file_exists($this->index_file)
-            ? fopen($this->index_file, "r")
+        $local_handle = file_exists($this->local_index_file)
+            ? fopen($this->local_index_file, "r")
             : null;
         $local = $this->read_index_line($local_handle);
         if ($local_after) {
@@ -6588,7 +6587,7 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_local_file_path($local["path"]);
+                    $this->delete_target_filesystem_path($local["path"]);
                     $this->delete_index_entry($local["path"]);
                 }
                 $local_after = $local["path"];
@@ -6648,7 +6647,7 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_local_file_path($local["path"]);
+                $this->delete_target_filesystem_path($local["path"]);
                 $this->delete_index_entry($local["path"]);
             }
             $local_after = $local["path"];
@@ -7008,7 +7007,7 @@ class ImportClient
     }
 
     /**
-     * Check whether a remote path belongs to the uploads directory.
+     * Check whether a target filesystem path belongs to the uploads directory.
      *
      * Uses the preflight-reported uploads basedir when available, otherwise
      * falls back to matching "wp-content/uploads/" anywhere in the path.
@@ -7038,15 +7037,15 @@ class ImportClient
     }
 
     /**
-     * Delete a local file path safely under the fs root.
+     * Delete a local file path safely under the import root.
      */
-    private function delete_local_file_path(string $path): void
+    private function delete_target_filesystem_path(string $path): void
     {
         if ($path === "") {
             return;
         }
         try {
-            $local_path = $this->remote_path_to_local_path_within_import_root($path);
+            $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
         } catch (RuntimeException $e) {
             $this->audit_log(
                 "Security: refusing to delete invalid path '{$path}': " . $e->getMessage(),
@@ -7058,7 +7057,7 @@ class ImportClient
             return;
         }
 
-        if ($this->remove_local_path_without_following_symlinks($local_path)) {
+        if ($this->remove_local_filesystem_path_without_following_symlinks($local_path)) {
             $this->audit_log("Deleted: {$path}", false);
             return;
         }
@@ -7072,7 +7071,7 @@ class ImportClient
      * Symlinks are always unlinked as links. Directories are traversed
      * depth-first.
      */
-    private function remove_local_path_without_following_symlinks(
+    private function remove_local_filesystem_path_without_following_symlinks(
         string $local_path
     ): bool {
         if (!file_exists($local_path) && !is_link($local_path)) {
@@ -7093,7 +7092,7 @@ class ImportClient
                     continue;
                 }
                 if (
-                    !$this->remove_local_path_without_following_symlinks(
+                    !$this->remove_local_filesystem_path_without_following_symlinks(
                         $local_path . "/" . $entry
                     )
                 ) {
@@ -7268,14 +7267,14 @@ class ImportClient
             return;
         }
 
-        $new_index = $this->index_file . ".new";
+        $new_index = $this->local_index_file . ".new";
 
         $this->audit_log(
-            "INDEX MERGE START | merging updates into {$this->index_file}",
+            "INDEX MERGE START | merging updates into {$this->local_index_file}",
         );
 
-        $old_handle = file_exists($this->index_file)
-            ? fopen($this->index_file, "r")
+        $old_handle = file_exists($this->local_index_file)
+            ? fopen($this->local_index_file, "r")
             : null;
         $upd_handle = fopen($this->index_update_wal_path, "r");
         $new_handle = fopen($new_index, "w");
@@ -7352,10 +7351,10 @@ class ImportClient
         fclose($upd_handle);
         fclose($new_handle);
 
-        if (!rename($new_index, $this->index_file)) {
+        if (!rename($new_index, $this->local_index_file)) {
             throw new RuntimeException("Failed to replace index file");
         }
-        $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
+        $this->audit_log("INDEX MERGE COMPLETE | {$this->local_index_file} updated");
 
         if (file_put_contents($this->index_update_wal_path, '') === false) {
             throw new RuntimeException("Failed to clear the applied index-update WAL.");
@@ -7507,7 +7506,7 @@ class ImportClient
         $sql_buffer = "";
 
         if ($mode === "file") {
-            $sql_file = $this->state_dir . "/db.sql";
+            $sql_file = $this->state_directory . "/db.sql";
 
             // Crash recovery: if SQL file is larger than expected, truncate it.
             // This happens if we crashed after writing but before saving the new cursor.
@@ -7579,7 +7578,7 @@ class ImportClient
             // Each SQL chunk is appended to this file as it arrives; when the
             // query completes and executes, the file is truncated. If the process
             // dies at any point, the next run reloads whatever was accumulated.
-            $buffer_file = $this->state_dir . "/.sql-buffer";
+            $buffer_file = $this->state_directory . "/.sql-buffer";
             if (file_exists($buffer_file)) {
                 $sql_buffer = file_get_contents($buffer_file);
                 $this->audit_log(
@@ -7602,15 +7601,15 @@ class ImportClient
         $domain_collector = class_exists('DomainCollector')
             ? new \DomainCollector()
             : null;
-        $domains_file = $this->state_dir . "/.import-domains.json";
-        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
+        $domains_file = $this->state_directory . "/.import-domains.json";
+        $sql_stats_file = $this->state_directory . "/.import-sql-stats.json";
         $sql_statements_counted = (int) ($this->import_state()->sql_statements_counted ?? 0);
 
         // Auto-detect the source site domain from the export URL so it
         // always appears in .import-domains.json even if the SQL dump
         // hasn't been fully scanned yet.
         if ($domain_collector) {
-            $parsed_url = parse_url($this->remote_url);
+            $parsed_url = parse_url($this->target_url);
             if ($parsed_url && isset($parsed_url['scheme'], $parsed_url['host'])) {
                 $source_origin = $parsed_url['scheme'] . '://' . $parsed_url['host'];
                 if (!empty($parsed_url['port'])) {
@@ -7942,7 +7941,7 @@ class ImportClient
                 $mysql_conn = null;
                 // Clean up buffer file — if we got here with an empty buffer,
                 // all queries were executed successfully.
-                $buffer_file = $this->state_dir . "/.sql-buffer";
+                $buffer_file = $this->state_directory . "/.sql-buffer";
                 if ($pending === "" && file_exists($buffer_file)) {
                     unlink($buffer_file);
                 }
@@ -8202,7 +8201,7 @@ class ImportClient
     {
         $cursor = $this->import_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
-        $tables_file = $this->state_dir . "/db-tables.jsonl";
+        $tables_file = $this->state_directory . "/db-tables.jsonl";
 
         $stats = $this->import_state()->db_index;
         $tables_written = $stats->tables;
@@ -8412,7 +8411,7 @@ class ImportClient
     }
 
     /**
-     * Map a remote symlink target to the local fs-root mirror when possible.
+     * Map a remote symlink target to the import root mirror when possible.
      *
      * Handles both absolute and relative targets (relative ones are resolved
      * against the symlink's source directory). In-scope and non-followed targets
@@ -8433,7 +8432,7 @@ class ImportClient
      *
      * Local import state:
      *
-     *   <state-dir>/fs-root/
+     *   <state-dir>/import root/
      *   |-- tmp/e2e-shared-themes/pub/indice/
      *   |   |-- style.css
      *   |   `-- index.php
@@ -8443,71 +8442,74 @@ class ImportClient
      * Without this mapping, the symlink would point at /tmp/e2e-shared-themes/pub/indice
      * (which does not exist on the local machine, or worse, exists with unrelated content).
      * With this mapping, the symlink is rewritten to a relative path that resolves to the
-     * mirrored local copy under fs-root.
+     * mirrored local copy under import root.
      */
     private function map_symlink_target_for_local_mirror(
-        string $path,
-        string $local_path,
+        string $target_filesystem_path,
+        string $local_filesystem_path,
         string $target
     ): string {
-        // Resolve to an absolute source path (relative targets against the
-        // symlink's source dir) so both spellings are handled the same way.
-        $source_target = str_starts_with($target, "/")
+        // Resolve to a target filesystem path (relative targets are based on
+        // the source symlink's target filesystem directory).
+        $target_filesystem_target = str_starts_with($target, "/")
             ? normalize_path($target)
-            : normalize_path(dirname($path) . "/" . $target);
+            : normalize_path(dirname($target_filesystem_path) . "/" . $target);
 
         // Only rewrite a target whose subtree was actually followed and indexed;
         // everything else keeps its original (portable) spelling.
         if (
             !$this->follow_symlinks ||
-            !$this->remote_index_contains_path_prefix($source_target)
+            !$this->target_index_contains_target_filesystem_path_prefix($target_filesystem_target)
         ) {
             return $target;
         }
 
-        // Repoint to wherever the target's content is actually placed,
-        // the same seam file chunks use, so that the link never dangles.
-        $mapped_absolute = $this->remote_path_to_local_path_within_import_root($source_target);
-        $mapped_relative = self::compute_relative_path(
-            dirname($local_path),
-            $mapped_absolute
+        // Repoint to where the target's content is placed by the same pull
+        // mapping used for file chunks, so the symlink does not dangle.
+        $local_filesystem_target = $this->map_target_filesystem_path_to_local_filesystem_path(
+            $target_filesystem_target
+        );
+        $local_relative_target = self::compute_relative_path(
+            dirname($local_filesystem_path),
+            $local_filesystem_target
         );
 
         $this->audit_log(
-            "SYMLINK TARGET REMAP | {$path}: {$target} -> {$mapped_relative}",
+            "SYMLINK TARGET REMAP | {$target_filesystem_path}: {$target} -> {$local_relative_target}",
             false,
         );
 
-        return $mapped_relative;
+        return $local_relative_target;
     }
 
     /**
-     * Checks if the remote index contains $path or any descendant under it.
-     * Runs a memoized O(N) scan of .import-remote-index.jsonl.
+     * Checks whether the target index contains a target filesystem path or one
+     * of its descendants. Runs a memoized O(N) scan of .import-remote-index.jsonl.
      */
-    private function remote_index_contains_path_prefix(string $path): bool
-    {
-        $path = rtrim(normalize_path($path), "/");
-        if ($path === "") {
+    private function target_index_contains_target_filesystem_path_prefix(
+        string $target_filesystem_path
+    ): bool {
+        $target_filesystem_path = rtrim(normalize_path($target_filesystem_path), "/");
+        if ($target_filesystem_path === "") {
             return false;
         }
 
-        if (isset($this->remote_index_prefix_cache[$path])) {
-            return $this->remote_index_prefix_cache[$path];
+        if (isset($this->target_index_prefix_cache[$target_filesystem_path])) {
+            return $this->target_index_prefix_cache[$target_filesystem_path];
         }
 
-        if (!file_exists($this->remote_index_file)) {
-            $this->remote_index_prefix_cache[$path] = false;
+        if (!file_exists($this->target_index_file)) {
+            $this->target_index_prefix_cache[$target_filesystem_path] = false;
             return false;
         }
 
-        $h = fopen($this->remote_index_file, "r");
+        $h = fopen($this->target_index_file, "r");
         if (!$h) {
-            $this->remote_index_prefix_cache[$path] = false;
+            $this->target_index_prefix_cache[$target_filesystem_path] = false;
             return false;
         }
 
-        $prefix = $path . "/";
+        $prefix = $target_filesystem_path . "/";
         $found = false;
         while (($line = fgets($h)) !== false) {
             try {
@@ -8519,34 +8521,34 @@ class ImportClient
                 continue;
             }
             $entry_path = $entry["path"];
-            if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
+            if ($entry_path === $target_filesystem_path || str_starts_with($entry_path, $prefix)) {
                 $found = true;
                 break;
             }
         }
         fclose($h);
 
-        $this->remote_index_prefix_cache[$path] = $found;
+        $this->target_index_prefix_cache[$target_filesystem_path] = $found;
         return $found;
     }
 
     /**
-     * Return canonical fs root path, creating it if it doesn't exist.
+     * Return the resolved absolute import root, creating it if it doesn't exist.
      */
-    private function get_filesystem_root_path(): string
+    private function get_import_root_path(): string
     {
-        if (!is_dir($this->fs_root)) {
-            if (!mkdir($this->fs_root, 0755, true) && !is_dir($this->fs_root)) {
+        if (!is_dir($this->import_root)) {
+            if (!mkdir($this->import_root, 0755, true) && !is_dir($this->import_root)) {
                 throw new RuntimeException(
-                    "Failed to create fs root directory: {$this->fs_root}",
+                    "Failed to create import root directory: {$this->import_root}",
                 );
             }
         }
 
-        $real = realpath($this->fs_root);
+        $real = realpath($this->import_root);
         if ($real === false) {
             throw new RuntimeException(
-                "Failed to resolve fs root path: {$this->fs_root}",
+                "Failed to resolve import root path: {$this->import_root}",
             );
         }
 
@@ -8556,7 +8558,7 @@ class ImportClient
     /**
      * Refuse to reuse a files index with different --remap rules.
      *
-     * The files index stores remote paths. Local writes/deletes derive their
+     * The files index stores target filesystem paths. Local writes/deletes derive their
      * targets from the current remap rules, so changing those rules while the
      * same index is still in use can point future updates at the wrong path.
      */
@@ -8565,8 +8567,8 @@ class ImportClient
         $fingerprint = $this->files_remap_fingerprint();
         $previous = $this->import_state()->files_remap_fingerprint ?? null;
 
-        $has_existing_index = file_exists($this->index_file) && filesize($this->index_file) > 0;
-        if ($previous === null && $has_existing_index && !empty($this->remap_rules)) {
+        $has_existing_index = file_exists($this->local_index_file) && filesize($this->local_index_file) > 0;
+        if ($previous === null && $has_existing_index && !empty($this->resolved_path_mappings)) {
             throw new RuntimeException(
                 "Cannot use --remap with an existing files index that was created before remap tracking. " .
                     "Use a new --state-dir or clear the existing files index first.",
@@ -8594,7 +8596,7 @@ class ImportClient
      */
     private function files_remap_fingerprint(): string
     {
-        $rules = $this->remap_rules;
+        $rules = $this->resolved_path_mappings;
         ksort($rules, SORT_STRING);
         return hash("sha256", json_encode($rules, JSON_UNESCAPED_SLASHES));
     }
@@ -8602,7 +8604,7 @@ class ImportClient
     /**
      * Refuse to resume a files-pull after changing --only.
      *
-     * The in-progress remote index cursor/file was built from one directory[]
+     * The in-progress target index cursor/file was built from one directory[]
      * allowlist. Switching the selected source path prefixes mid-resume would
      * mix indexes from different traversals. Completed runs are allowed to use
      * different --only prefixes because the local index is intentionally a union
@@ -8672,12 +8674,12 @@ class ImportClient
 
     /**
      * Fingerprint of the effective bundle placement root. No bundle directory
-     * (and bare --follow-symlinks) fingerprints as fs-root, which is the
+     * (and bare --follow-symlinks) fingerprints as import root, which is the
      * equivalent placement — so switching between those spellings is allowed.
      */
     private function symlink_bundle_directory_fingerprint(): string
     {
-        $effective = $this->symlink_bundle_directory ?? rtrim($this->get_filesystem_root_path(), "/");
+        $effective = $this->symlink_bundle_directory ?? rtrim($this->get_import_root_path(), "/");
         return hash("sha256", $effective);
     }
 
@@ -8689,12 +8691,12 @@ class ImportClient
      */
     private function resolve_symlink_bundle_directory(string $raw): string
     {
-        $fs_root = rtrim($this->get_filesystem_root_path(), "/");
-        $directory = $this->resolve_token_path($raw, ["fs-root" => $fs_root]);
+        $import_root = rtrim($this->get_import_root_path(), "/");
+        $directory = $this->resolve_token_path($raw, ["fs-root" => $import_root]);
 
-        if (!path_is_within_root($directory, $fs_root)) {
+        if (!path_is_within_root($directory, $import_root)) {
             throw new InvalidArgumentException(
-                "--follow-symlinks bundle directory \"{$directory}\" resolves outside --fs-root ({$fs_root}); " .
+                "--follow-symlinks bundle directory \"{$directory}\" resolves outside --fs-root ({$import_root}); " .
                     "it must stay within the destination root",
             );
         }
@@ -8715,10 +8717,10 @@ class ImportClient
      */
     private function resolve_remap(array $remap_raw): array
     {
-        $fs_root = rtrim($this->get_filesystem_root_path(), "/");
+        $import_root = rtrim($this->get_import_root_path(), "/");
 
         $source_tokens = $this->wp_source_path_tokens();
-        $target_tokens = ["fs-root" => $fs_root];
+        $target_tokens = ["fs-root" => $import_root];
 
         $rules = [];
         $wp_content_target = null;
@@ -8726,9 +8728,9 @@ class ImportClient
             $source = $this->resolve_token_path($source_raw, $source_tokens);
             $target = $this->resolve_token_path($target_raw, $target_tokens);
 
-            if (!path_is_within_root($target, $fs_root)) {
+            if (!path_is_within_root($target, $import_root)) {
                 throw new InvalidArgumentException(
-                    "--remap target \"{$target}\" resolves outside --fs-root ({$fs_root}); " .
+                    "--remap target \"{$target}\" resolves outside --fs-root ({$import_root}); " .
                         "targets must stay within the destination root",
                 );
             }
@@ -8844,7 +8846,7 @@ class ImportClient
      * the diff's delete drains at their default behavior. When --only is set,
      * true only when $path falls under one of those file path prefixes IF it is
      * NOT the directory itself (when the path remainder is an empty string): an
-     * --only remote index lists what is inside each selected directory, never
+     * --only target index lists what is inside each selected directory, never
      * the directory itself, so to the diff the selected directories always
      * appear deleted-on-remote even though they exist.
      */
@@ -8955,62 +8957,58 @@ class ImportClient
     }
 
     /**
-     * Map a source absolute path to its absolute local target via the remap
-     * rules (most specific source wins), or null when no rule applies.
+     * Map a target filesystem path through the resolved path mappings, or
+     * return null when no mapping applies. The deepest target prefix wins.
      *
-     * Any rules that match the same path are nested (each is a path-prefix of
-     * it, and prefixes of one string are ordered by length), so the longest
-     * matching source is the deepest — i.e. the most specific — match. Ranking
-     * by source, not target: a rule applies based purely on its source side.
+     * Matching mapping prefixes are nested, so the longest target prefix is
+     * the most specific match.
      */
-    private function remap_source_path_to_target(string $source_path): ?string
-    {
-        $best = null;
-        $best_source_length = -1;
+    private function map_target_filesystem_path_with_resolved_mappings(
+        string $target_filesystem_path
+    ): ?string {
+        $local_filesystem_path = null;
+        $longest_target_prefix_length = -1;
 
-        foreach ($this->remap_rules as $source => $target) {
-            $rest = self::path_remainder_under($source_path, $source);
-            if ($rest !== null && strlen($source) > $best_source_length) {
-                $best = wp_join_unix_paths($target, $rest);
-                $best_source_length = strlen($source);
+        foreach ($this->resolved_path_mappings as $target_prefix => $local_prefix) {
+            $remainder = self::path_remainder_under($target_filesystem_path, $target_prefix);
+            if ($remainder !== null && strlen($target_prefix) > $longest_target_prefix_length) {
+                $local_filesystem_path = wp_join_unix_paths($local_prefix, $remainder);
+                $longest_target_prefix_length = strlen($target_prefix);
             }
         }
 
-        return $best;
+        return $local_filesystem_path;
     }
 
     /**
-     * Resolve a remote absolute path into a local path under the fs root.
+     * Map a target filesystem path to a local filesystem path under the import
+     * root. Symlink traversal checks prevent writes outside the import root.
      *
-     * Maps a remote absolute path (e.g. "/wp-content/uploads/photo.jpg") to a
-     * local path under the import fs root. Performs symlink traversal security
-     * checks to prevent directory traversal attacks that could write files
-     * outside the import root.
-     *
-     * With --remap active, a source path matched by a remap rule is first routed to its
-     * target (e.g. "/var/www/html/wp-content/x" -> "<docroot>/wp-content/x");
-     * paths under no remap rule are still written under --fs-root using their
-     * remote absolute path, exactly as a plain pull.
+     * With --remap active, a matched target filesystem path is routed to its
+     * mapped local filesystem path. An unmatched path remains nested beneath
+     * --fs-root, as in an identity pull mapping.
      */
-    private function remote_path_to_local_path_within_import_root(
-        string $path
+    private function map_target_filesystem_path_to_local_filesystem_path(
+        string $target_filesystem_path
     ): string {
-        assert_valid_path($path, "remote path");
-        if (!empty($this->remap_rules)) {
-            $target = $this->remap_source_path_to_target($path);
-            if ($target !== null) {
-                return $target;
+        assert_valid_path($target_filesystem_path, "target filesystem path");
+        if (!empty($this->resolved_path_mappings)) {
+            $local_filesystem_path = $this->map_target_filesystem_path_with_resolved_mappings(
+                $target_filesystem_path
+            );
+            if ($local_filesystem_path !== null) {
+                return $local_filesystem_path;
             }
         }
 
         // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
         // Use the same bundle mapping for copied content and rewritten symlink targets so the links do not dangle.
         if ($this->symlink_bundle_directory !== null
-            && !$this->path_is_within_original_export_scope($path)) {
-            return $this->symlink_bundle_directory . $path;
+            && !$this->path_is_within_original_export_scope($target_filesystem_path)) {
+            return $this->symlink_bundle_directory . $target_filesystem_path;
         }
 
-        return $this->get_filesystem_root_path() . $path;
+        return $this->get_import_root_path() . $target_filesystem_path;
     }
 
 
@@ -9075,7 +9073,7 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
 
         // Open file on first chunk
         if ($is_first) {
@@ -9087,7 +9085,7 @@ class ImportClient
                 (!is_file($local_path) || is_link($local_path))
             ) {
                 if (
-                    !$this->remove_local_path_without_following_symlinks(
+                    !$this->remove_local_filesystem_path_without_following_symlinks(
                         $local_path
                     )
                 ) {
@@ -9275,7 +9273,7 @@ class ImportClient
             return null;
         }
 
-        $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
 
         // Skip if anything already exists at this path — regular file, symlink
         // (even to a file), or directory.  This preserves hosting symlinks like
@@ -9301,7 +9299,7 @@ class ImportClient
 
     private function path_traverses_symlink(string $path): bool
     {
-        $root = $this->get_filesystem_root_path();
+        $root = $this->get_import_root_path();
         $relative = ltrim(substr($path, strlen($root)), "/");
         if ($relative === "") {
             return false;
@@ -9331,8 +9329,8 @@ class ImportClient
      */
     private function ensure_directory_path(string $dir): void
     {
-        // Security: Ensure path is under the fs root
-        $real_filesystem_root = $this->get_filesystem_root_path();
+        // Security: Ensure path is under the import root
+        $real_filesystem_root = $this->get_import_root_path();
 
         // Resolve the target path (or what it would be)
         // For non-existent paths, resolve the parent and append the final component
@@ -9351,16 +9349,16 @@ class ImportClient
                 !path_is_within_root($real_check, $real_filesystem_root)
             ) {
                 // In preserve-local mode, a path that resolves outside the
-                // fs root is expected when a directory like wp-content/plugins
+                // import root is expected when a directory like wp-content/plugins
                 // is symlinked to a shared hosting location.  Skip gracefully
                 // instead of treating it as a security violation.
                 if ($this->fs_root_nonempty_behavior === 'preserve-local') {
                     throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: path resolves outside fs root via symlink: {$dir}",
+                        "PRESERVE-LOCAL: path resolves outside import root via symlink: {$dir}",
                     );
                 }
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside fs root: {$dir}",
+                    "Security: Refusing to create directory outside import root: {$dir}",
                 );
             }
         }
@@ -9379,7 +9377,7 @@ class ImportClient
             !str_starts_with($dir, $real_filesystem_root . "/")
         ) {
             throw new RuntimeException(
-                "Security: Refusing to create directory outside fs root: {$dir}",
+                "Security: Refusing to create directory outside import root: {$dir}",
             );
         }
 
@@ -9454,7 +9452,7 @@ class ImportClient
             $resolved = realpath($current);
             if ($resolved === false || !path_is_within_root($resolved, $real_filesystem_root)) {
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside fs root: {$current}",
+                    "Security: Refusing to create directory outside import root: {$current}",
                 );
             }
         }
@@ -9481,7 +9479,7 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
 
         // In preserve-local mode, if the directory already exists (as a real
         // directory or via a symlink to a directory), keep it as-is.
@@ -9511,7 +9509,7 @@ class ImportClient
             (!is_dir($local_path) || is_link($local_path))
         ) {
             if (
-                !$this->remove_local_path_without_following_symlinks($local_path)
+                !$this->remove_local_filesystem_path_without_following_symlinks($local_path)
             ) {
                 throw new RuntimeException(
                     "Failed to replace path with directory: {$path}",
@@ -9567,7 +9565,7 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
         $target_for_local = $this->map_symlink_target_for_local_mirror(
             $path,
             $local_path,
@@ -9592,7 +9590,7 @@ class ImportClient
         }
 
         // Validate that the symlink target doesn't escape the filesystem root.
-        $root = $this->get_filesystem_root_path();
+        $root = $this->get_import_root_path();
         try {
             $this->assert_symlink_target_within_root(
                 dirname($local_path),
@@ -9614,7 +9612,7 @@ class ImportClient
         // Remove existing file/symlink if present
         if (file_exists($local_path) || is_link($local_path)) {
             if (
-                !$this->remove_local_path_without_following_symlinks($local_path)
+                !$this->remove_local_filesystem_path_without_following_symlinks($local_path)
             ) {
                 $this->audit_log(
                     "Failed to remove existing path for symlink: {$local_path}",
@@ -9728,7 +9726,7 @@ class ImportClient
             true,
         );
         if ($path !== "" && $is_file_error) {
-            $local_path = $this->fs_root . $path;
+            $local_path = $this->import_root . $path;
             if ($context->file_handle && $context->file_path === $local_path) {
                 fclose($context->file_handle);
                 $context->file_handle = null;
@@ -9784,7 +9782,7 @@ class ImportClient
         ?string $cursor,
         array $params = []
     ): string {
-        $url = $this->remote_url;
+        $url = $this->target_url;
         $separator = strpos($url, "?") === false ? "?" : "&";
 
         $params["endpoint"] = $endpoint;
@@ -9888,7 +9886,7 @@ class ImportClient
         // uploads directories that live outside the WordPress roots and so
         // wouldn't be discovered by traversal alone.
         $remap_index = 0;
-        foreach (array_keys($this->remap_rules) as $source) {
+        foreach (array_keys($this->resolved_path_mappings) as $source) {
             $extra_paths["remap_source_{$remap_index}"] = $source;
             $remap_index++;
         }
@@ -11635,7 +11633,7 @@ if (
     //                  'value-or-next' --name=VAL or --name VAL
     //                  'pair'          --name A B (repeatable, takes 2 args)
     //   target         Where to store the parsed value:
-    //                  'state_dir' | 'fs_root' → special local variables
+    //                  'state_directory' | 'import_root' → special local variables
     //                  'key'                   → $options['key']
     //                  'tuning_config.key'     → $options['tuning_config']['key']
     //   help           Description for --help output (null = hidden)
@@ -11656,7 +11654,7 @@ if (
         [
             'name' => 'state-dir',
             'type' => 'value',
-            'target' => 'state_dir',
+            'target' => 'state_directory',
             'placeholder' => 'DIR',
             'help' => 'Directory for import state files and SQL dumps',
             'help_section' => 'required',
@@ -11665,7 +11663,7 @@ if (
         [
             'name' => 'fs-root',
             'type' => 'value',
-            'target' => 'fs_root',
+            'target' => 'import_root',
             'placeholder' => 'DIR',
             'help' => 'Local directory read from or written to for site files',
             'help_section' => 'required',
@@ -11739,7 +11737,7 @@ if (
             'type' => 'value',
             'target' => 'fs_root_nonempty_behavior',
             'placeholder' => 'MODE',
-            'help' => 'What to do when fs root is non-empty (error|preserve-local)',
+            'help' => 'What to do when import root is non-empty (error|preserve-local)',
             'help_section' => 'global',
             'commands' => ['pull', 'pull-files', 'files-pull'],
             'aliases' => ['on-docroot-nonempty'],
@@ -12086,8 +12084,8 @@ if (
      */
     function _cli_parse_options(array $argv, int $argc, int $start, array $option_defs): array
     {
-        $state_dir = null;
-        $fs_root = null;
+        $state_directory = null;
+        $import_root = null;
         $options = [
             "abort" => false,
             "verbose" => false,
@@ -12116,7 +12114,7 @@ if (
                                     fwrite(STDERR, "Invalid --{$def['name']} value: {$raw}. Valid values: " . implode(", ", $def['valid_values']) . "\n");
                                     exit(1);
                                 }
-                                _cli_store($def, $value, $state_dir, $fs_root, $options);
+                                _cli_store($def, $value, $state_directory, $import_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12124,7 +12122,7 @@ if (
 
                         case 'flag':
                             if ($arg === "--{$cli_name}" || (isset($def['short']) && $arg === "-{$def['short']}")) {
-                                _cli_store($def, $def['flag_value'] ?? true, $state_dir, $fs_root, $options);
+                                _cli_store($def, $def['flag_value'] ?? true, $state_directory, $import_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12134,7 +12132,7 @@ if (
                             $prefix = "--{$cli_name}=";
                             if (strpos($arg, $prefix) === 0) {
                                 $raw = substr($arg, strlen($prefix));
-                                _cli_store($def, $raw, $state_dir, $fs_root, $options);
+                                _cli_store($def, $raw, $state_directory, $import_root, $options);
                                 $matched = true;
                                 break 3;
                             }
@@ -12143,7 +12141,7 @@ if (
                                     fwrite(STDERR, "--{$def['name']} requires one argument: " . ($def['placeholder'] ?? 'VALUE') . "\n");
                                     exit(1);
                                 }
-                                _cli_store($def, $argv[$i + 1], $state_dir, $fs_root, $options);
+                                _cli_store($def, $argv[$i + 1], $state_directory, $import_root, $options);
                                 $i += 1;
                                 $matched = true;
                                 break 3;
@@ -12176,7 +12174,7 @@ if (
             }
         }
 
-        return [$state_dir, $fs_root, $options];
+        return [$state_directory, $import_root, $options];
     }
 
     /** @internal */
@@ -12191,11 +12189,11 @@ if (
     }
 
     /** @internal */
-    function _cli_store(array $def, $value, ?string &$state_dir, ?string &$fs_root, array &$options): void
+    function _cli_store(array $def, $value, ?string &$state_directory, ?string &$import_root, array &$options): void
     {
         $target = $def['target'];
-        if ($target === 'state_dir') { $state_dir = $value; return; }
-        if ($target === 'fs_root')   { $fs_root = $value;   return; }
+        if ($target === 'state_directory') { $state_directory = $value; return; }
+        if ($target === 'import_root')      { $import_root = $value; return; }
         if (strpos($target, 'tuning_config.') === 0) {
             $options['tuning_config'][substr($target, strlen('tuning_config.'))] = $value;
             return;
@@ -12611,9 +12609,9 @@ if (
                 "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
                 "\n" .
                 "Output files:\n" .
-                "  (fs-root)/                              Downloaded files\n" .
+                "  (import root)/                              Downloaded files\n" .
                 "  .import-index.jsonl                     Local file index\n" .
-                "  .import-remote-index.jsonl              Remote index snapshot\n" .
+                "  .import-remote-index.jsonl              Target index snapshot\n" .
                 "  .import-download-list.jsonl             Files pending download\n" .
                 "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
                 "  .import-state.json                      Resumable state\n" .
@@ -12625,9 +12623,9 @@ if (
             "usage" => "reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
                 "Shows which local paths a files-push would send or delete, comparing\n" .
-                "the local tree at --fs-root with the pair's previous local index —\n" .
+                "the local document root at --fs-root with the pair's previous local index —\n" .
                 "the index a completed files-push publishes for the same target URL,\n" .
-                "state directory, and local tree.\n" .
+                "state directory, and local document root.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .
@@ -12645,7 +12643,7 @@ if (
             "short" => "Push one local file tree without database work",
             "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
             "description" =>
-                "Sends the existing local tree at --fs-root to the target exporter API.\n" .
+                "Sends the existing local document root at --fs-root to the target exporter API.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It does not require pull preflight.\n" .
@@ -12806,7 +12804,7 @@ if (
                 "  DB_USER, and DB_PASSWORD. For SQLite targets, the sqlite-database-\n" .
                 "  integration plugin is copied into the output directory and a lazy-\n" .
                 "  loading \$wpdb proxy is generated in runtime.php (Playground-style,\n" .
-                "  no files placed in the fs-root).\n" .
+                "  no files placed in the import root).\n" .
                 "\n" .
                 "Output files (nginx-fpm):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, route handlers)\n" .
@@ -12855,7 +12853,7 @@ if (
         $command = $command_aliases[$command];
     }
 
-    // install-exporter is a standalone guide — no URL, state-dir, or fs-root needed.
+    // install-exporter is a standalone guide — no URL, state-dir, or import root needed.
     // Handle it before per-command --help so it always shows the full guide.
     if ($command === "install-exporter") {
         _cli_render_install_exporter();
@@ -12875,11 +12873,11 @@ if (
     $is_local_only = in_array($command, $local_only_commands, true);
 
     if ($is_local_only) {
-        $remote_url = "-";
+        $target_url = "-";
         $option_start_index = 2; // options start right after the command
     } else {
-        $remote_url = $argv[2] ?? null;
-        if (!$remote_url) {
+        $target_url = $argv[2] ?? null;
+        if (!$target_url) {
             fwrite(STDERR, "Error: <remote-url> is required\n");
             fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
             exit(1);
@@ -12887,7 +12885,7 @@ if (
         $option_start_index = 3;
     }
 
-    [$state_dir, $fs_root, $options] = _cli_parse_options(
+    [$state_directory, $import_root, $options] = _cli_parse_options(
         $argv, $argc, $option_start_index, $option_defs
     );
     $options["command"] = $command;
@@ -12925,7 +12923,7 @@ if (
         exit(1);
     }
 
-    if (!$state_dir) {
+    if (!$state_directory) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
@@ -12933,47 +12931,47 @@ if (
 
     // apply-runtime accepts --flat-document-root as an alternative to --fs-root.
     $flat_document_root = $options["flat_document_root"] ?? null;
-    if ($fs_root && $flat_document_root) {
+    if ($import_root && $flat_document_root) {
         fwrite(STDERR, "Error: --fs-root and --flat-document-root are mutually exclusive.\n");
         fwrite(STDERR, "Use --fs-root for the raw download directory, or --flat-document-root for a flattened layout.\n");
         exit(1);
     }
-    if (!$fs_root && !$flat_document_root && $command !== "import-metadata") {
+    if (!$import_root && !$flat_document_root && $command !== "import-metadata") {
         fwrite(STDERR, "Error: --fs-root=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
-    if (!$fs_root) {
-        // For commands that need an fs root in the constructor, use the
-        // flattened fs root. run_apply_runtime will resolve it properly.
+    if (!$import_root) {
+        // For commands that need an import root in the constructor, use the
+        // flattened import root. run_apply_runtime will resolve it properly.
         // import-metadata reads only state, but ImportClient still expects
-        // an fs root path. Point it at state-dir rather than requiring an
+        // an import root path. Point it at state-dir rather than requiring an
         // otherwise-unused CLI option.
-        $fs_root = $flat_document_root ?: $state_dir;
+        $import_root = $flat_document_root ?: $state_directory;
     }
 
     try {
         // Acquire the lock before pair setup and audit writes so each command
         // owns every local state transition for its complete invocation.
-        $reprint_process_lock = new ReprintProcessLock($state_dir);
+        $reprint_process_lock = new ReprintProcessLock($state_directory);
         $reprint_files_push_context = null;
         $reprint_files_diff_context = null;
         if ($command === 'files-push') {
             $reprint_files_push_context = ImportClient::prepare_files_push_context(
-                $remote_url,
-                $state_dir,
-                $fs_root,
+                $target_url,
+                $state_directory,
+                $import_root,
                 $options
             );
         } elseif ($command === 'files-diff') {
             $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
-                $remote_url,
-                $state_dir,
-                $fs_root,
+                $target_url,
+                $state_directory,
+                $import_root,
                 'files-diff'
             );
         }
-        $client = new ImportClient($remote_url, $state_dir, $fs_root, $command);
+        $client = new ImportClient($target_url, $state_directory, $import_root, $command);
         $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
         $client->audit_log_argv($command, $argv, $reprint_files_pair);
         $client->run(

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -259,8 +259,8 @@ class ImportClient
      */
     private const MAX_CONSECUTIVE_INTERRUPTED_RESPONSES = 3;
 
-    /** @var string Target exporter API URL. */
-    public $target_url;
+    /** @var string Remote Reprint API URL. */
+    public $remote_reprint_api_url;
 
     /** @var string State directory for this filesystem root (.import-state.json, db.sql, etc.). */
     public $state_dir;
@@ -528,7 +528,7 @@ class ImportClient
     public $exit_code = 0;
 
     public function __construct(
-        string $target_url,
+        string $remote_reprint_api_url,
         string $state_dir,
         string $filesystem_root,
         ?string $signal_handling_command = null
@@ -551,7 +551,7 @@ class ImportClient
             }
         }
 
-        $this->target_url = rtrim($target_url, "?&");
+        $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
         $this->filesystem_root = rtrim($filesystem_root, "/");
         $this->state_file = $this->state_dir . "/.import-state.json";
@@ -1323,7 +1323,7 @@ class ImportClient
     private function run_files_diff(array $options): void
     {
         $context = $options['files_diff_context'] ?? self::prepare_files_pair_context(
-            $this->target_url,
+            $this->remote_reprint_api_url,
             $this->state_dir,
             $this->filesystem_root,
             'files-diff'
@@ -1336,7 +1336,7 @@ class ImportClient
         $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
         $missing_previous_local_index_message =
             'files-diff requires the pair\'s previous local index, which a completed files-push publishes '
-            . 'for the same target URL, state directory, and filesystem root.';
+            . 'for the same remote Reprint API URL, state directory, and filesystem root.';
         if (!is_dir($push_state_directory)) {
             throw new RuntimeException($missing_previous_local_index_message);
         }
@@ -1541,7 +1541,7 @@ class ImportClient
     {
         $started_at = hrtime(true) / 1000000000;
         $context = $options['files_push_context'] ?? self::prepare_files_push_context(
-            $this->target_url,
+            $this->remote_reprint_api_url,
             $this->state_dir,
             $this->filesystem_root,
             $options
@@ -1567,7 +1567,7 @@ class ImportClient
         $sender_options = [
             'filesystem_root' => $context['filesystem_root'],
             'push_state_directory' => $context['push_state_directory'],
-            'base_url' => $context['target_url'],
+            'base_url' => $context['remote_reprint_api_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
             'chunk_bytes' => $chunk_bytes,
@@ -1760,15 +1760,15 @@ class ImportClient
      * @return array {
      *     Validated files-push command context.
      *
-     *     @type string $target_url           Target exporter API URL.
+     *     @type string $remote_reprint_api_url Remote Reprint API URL.
      *     @type string $filesystem_root  Resolved filesystem root being sent.
      *     @type string $pair                 Target/filesystem-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{target_url:string,filesystem_root:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{remote_reprint_api_url:string,filesystem_root:string,pair:string,push_state_directory:string}
      */
     public static function prepare_files_push_context(
-        string $target_url,
+        string $remote_reprint_api_url,
         string $state_dir,
         string $filesystem_root,
         array $options
@@ -1777,25 +1777,26 @@ class ImportClient
         if (!is_string($secret) || $secret === '') {
             throw new InvalidArgumentException('files-push requires --secret=TOKEN.');
         }
-        if (preg_match('/(?:\?|&)SECRET_KEY(?:=|&|$)/', $target_url) === 1) {
+        if (preg_match('/(?:\?|&)SECRET_KEY(?:=|&|$)/', $remote_reprint_api_url) === 1) {
             throw new InvalidArgumentException(
-                'files-push does not accept SECRET_KEY in the target URL; pass --secret=TOKEN.'
+                'files-push does not accept SECRET_KEY in the remote Reprint API URL; pass --secret=TOKEN.'
             );
         }
 
         $context = self::prepare_files_pair_context(
-            $target_url,
+            $remote_reprint_api_url,
             $state_dir,
             $filesystem_root,
             'files-push'
         );
-        $masked_target_url = self::mask_files_push_url_user_info($target_url);
+        $masked_remote_reprint_api_url =
+            self::mask_files_push_remote_reprint_api_url_user_info($remote_reprint_api_url);
         $force_http = $options['force_http'] ?? false;
-        $scheme = strtolower( (string) parse_url($target_url, PHP_URL_SCHEME) );
+        $scheme = strtolower( (string) parse_url($remote_reprint_api_url, PHP_URL_SCHEME) );
         if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
             throw new InvalidArgumentException(
-                'The files-push target must use HTTPS: ' . $masked_target_url
-                . '. Pass --force-http only for a target you trust.'
+                'The files-push remote Reprint API URL must use HTTPS: ' . $masked_remote_reprint_api_url
+                . '. Pass --force-http only for a remote Reprint API URL you trust.'
             );
         }
         return $context;
@@ -1811,30 +1812,31 @@ class ImportClient
      * @return array {
      *     Validated pair context.
      *
-     *     @type string $target_url           Target exporter API URL.
+     *     @type string $remote_reprint_api_url Remote Reprint API URL.
      *     @type string $filesystem_root  Resolved filesystem root.
      *     @type string $pair                 Target/filesystem-root pair key.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{target_url:string,filesystem_root:string,pair:string,push_state_directory:string}
+     * @phpstan-return array{remote_reprint_api_url:string,filesystem_root:string,pair:string,push_state_directory:string}
      */
     public static function prepare_files_pair_context(
-        string $target_url,
+        string $remote_reprint_api_url,
         string $state_dir,
         string $filesystem_root,
         string $command
     ): array {
-        $masked_target_url = self::mask_files_push_url_user_info($target_url);
-        if (strpos($target_url, '#') !== false) {
+        $masked_remote_reprint_api_url =
+            self::mask_files_push_remote_reprint_api_url_user_info($remote_reprint_api_url);
+        if (strpos($remote_reprint_api_url, '#') !== false) {
             throw new InvalidArgumentException(
-                'The ' . $command . ' target URL must not contain a fragment: ' . $masked_target_url . '.'
+                'The ' . $command . ' remote Reprint API URL must not contain a fragment: ' . $masked_remote_reprint_api_url . '.'
             );
         }
-        $target_url_user = parse_url($target_url, PHP_URL_USER);
-        $target_url_password = parse_url($target_url, PHP_URL_PASS);
-        if (is_string($target_url_user) || is_string($target_url_password)) {
+        $remote_reprint_api_url_user = parse_url($remote_reprint_api_url, PHP_URL_USER);
+        $remote_reprint_api_url_password = parse_url($remote_reprint_api_url, PHP_URL_PASS);
+        if (is_string($remote_reprint_api_url_user) || is_string($remote_reprint_api_url_password)) {
             throw new InvalidArgumentException(
-                'The ' . $command . ' target URL must not contain URL user-info: ' . $masked_target_url . '.'
+                'The ' . $command . ' remote Reprint API URL must not contain URL user-info: ' . $masked_remote_reprint_api_url . '.'
             );
         }
         if (is_link($filesystem_root)) {
@@ -1852,8 +1854,8 @@ class ImportClient
             );
         }
         $resolved_filesystem_root = rtrim($resolved_filesystem_root, '/') ?: '/';
-        $target_url = rtrim($target_url, '?&');
-        $pair = hash('sha256', $target_url . "\0" . $resolved_filesystem_root);
+        $remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
+        $pair = hash('sha256', $remote_reprint_api_url . "\0" . $resolved_filesystem_root);
         // Resolve an absolute physical path even when its final components do not exist.
         $push_state_directory = $state_dir . '/push/' . $pair;
         if (strpos($push_state_directory, '/') !== 0) {
@@ -1894,7 +1896,7 @@ class ImportClient
         }
 
         return [
-            'target_url' => $target_url,
+            'remote_reprint_api_url' => $remote_reprint_api_url,
             'filesystem_root' => $resolved_filesystem_root,
             'pair' => $pair,
             'push_state_directory' => $push_state_directory,
@@ -1949,7 +1951,7 @@ class ImportClient
     }
 
     /** Masks URL authority credentials without changing the pair-key input. */
-    private static function mask_files_push_url_user_info(string $url): string
+    private static function mask_files_push_remote_reprint_api_url_user_info(string $url): string
     {
         $masked = preg_replace(
             '~^([a-z][a-z0-9+.-]*://)[^/?#]*@~i',
@@ -5019,7 +5021,7 @@ class ImportClient
             return;
         }
 
-        $parsed_url = parse_url($this->target_url);
+        $parsed_url = parse_url($this->remote_reprint_api_url);
         if (!$parsed_url || !isset($parsed_url['scheme'], $parsed_url['host'])) {
             throw new InvalidArgumentException(
                 "--new-site-url requires a valid export URL to derive the source site origin.",
@@ -7609,7 +7611,7 @@ class ImportClient
         // always appears in .import-domains.json even if the SQL dump
         // hasn't been fully scanned yet.
         if ($domain_collector) {
-            $parsed_url = parse_url($this->target_url);
+            $parsed_url = parse_url($this->remote_reprint_api_url);
             if ($parsed_url && isset($parsed_url['scheme'], $parsed_url['host'])) {
                 $source_origin = $parsed_url['scheme'] . '://' . $parsed_url['host'];
                 if (!empty($parsed_url['port'])) {
@@ -9782,7 +9784,7 @@ class ImportClient
         ?string $cursor,
         array $params = []
     ): string {
-        $url = $this->target_url;
+        $url = $this->remote_reprint_api_url;
         $separator = strpos($url, "?") === false ? "?" : "&";
 
         $params["endpoint"] = $endpoint;
@@ -12225,7 +12227,7 @@ if (
         echo "Mirror any WordPress site over HTTP.\n";
         echo "Version " . get_importer_version() . "\n";
         echo "\n";
-        echo "Usage: reprint <command> <remote-url> [options]\n";
+        echo "Usage: reprint <command> <remote-reprint-api-url> [options]\n";
         echo "\n";
 
         $high = array_filter($command_info, fn($i) => ($i['level'] ?? 'low') === 'high');
@@ -12283,7 +12285,7 @@ if (
         }
 
         $info = $command_info[$command];
-        $usage = $info["usage"] ?? "reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]";
+        $usage = $info["usage"] ?? "reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]";
         echo "Usage: {$usage}\n";
         echo "\n";
         echo $info["description"];
@@ -12620,11 +12622,11 @@ if (
         "files-diff" => [
             "level" => "low",
             "short" => "Show local file changes since the last push",
-            "usage" => "reprint files-diff <target-url> --state-dir=DIR --fs-root=DIR",
+            "usage" => "reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
                 "Shows which local paths a files-push would send or delete, comparing\n" .
                 "the filesystem root at --fs-root with the pair's previous local index —\n" .
-                "the index a completed files-push publishes for the same target URL,\n" .
+                "the index a completed files-push publishes for the same remote Reprint API URL,\n" .
                 "state directory, and filesystem root.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
@@ -12641,9 +12643,9 @@ if (
         "files-push" => [
             "level" => "low",
             "short" => "Push one local file tree without database work",
-            "usage" => "reprint files-push <target-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
+            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
             "description" =>
-                "Sends the existing filesystem root at --fs-root to the target exporter API.\n" .
+                "Sends the existing filesystem root at --fs-root to the remote Reprint API.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It does not require pull preflight.\n" .
@@ -12873,13 +12875,13 @@ if (
     $is_local_only = in_array($command, $local_only_commands, true);
 
     if ($is_local_only) {
-        $target_url = "-";
+        $remote_reprint_api_url = "-";
         $option_start_index = 2; // options start right after the command
     } else {
-        $target_url = $argv[2] ?? null;
-        if (!$target_url) {
-            fwrite(STDERR, "Error: <remote-url> is required\n");
-            fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        $remote_reprint_api_url = $argv[2] ?? null;
+        if (!$remote_reprint_api_url) {
+            fwrite(STDERR, "Error: <remote-reprint-api-url> is required\n");
+            fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
             exit(1);
         }
         $option_start_index = 3;
@@ -12925,7 +12927,7 @@ if (
 
     if (!$state_dir) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
-        fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
 
@@ -12938,7 +12940,7 @@ if (
     }
     if (!$filesystem_root && !$flat_document_root && $command !== "import-metadata") {
         fwrite(STDERR, "Error: --fs-root=DIR is required\n");
-        fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
     if (!$filesystem_root) {
@@ -12958,20 +12960,20 @@ if (
         $reprint_files_diff_context = null;
         if ($command === 'files-push') {
             $reprint_files_push_context = ImportClient::prepare_files_push_context(
-                $target_url,
+                $remote_reprint_api_url,
                 $state_dir,
                 $filesystem_root,
                 $options
             );
         } elseif ($command === 'files-diff') {
             $reprint_files_diff_context = ImportClient::prepare_files_pair_context(
-                $target_url,
+                $remote_reprint_api_url,
                 $state_dir,
                 $filesystem_root,
                 'files-diff'
             );
         }
-        $client = new ImportClient($target_url, $state_dir, $filesystem_root, $command);
+        $client = new ImportClient($remote_reprint_api_url, $state_dir, $filesystem_root, $command);
         $reprint_files_pair = $reprint_files_push_context['pair'] ?? ( $reprint_files_diff_context['pair'] ?? null );
         $client->audit_log_argv($command, $argv, $reprint_files_pair);
         $client->run(

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6508,7 +6508,7 @@ class ImportClient
 
         $diff = $this->import_state()->diff;
         $remote_offset = $diff->remote_offset;
-        $local_after = $diff->local_after;
+        $last_local_index_entry_path = $diff->local_after;
         $download_mode = $remote_offset > 0 ? "a" : "w";
         if ($download_mode === "w") {
             $this->audit_log(
@@ -6549,31 +6549,32 @@ class ImportClient
             );
         }
 
-        $remote_handle = fopen($this->remote_index_file, "r");
-        if (!$remote_handle) {
+        $remote_index_handle = fopen($this->remote_index_file, "r");
+        if (!$remote_index_handle) {
             fclose($download_handle);
             throw new RuntimeException("Failed to open remote index file");
         }
         if ($remote_offset > 0) {
-            fseek($remote_handle, $remote_offset);
+            fseek($remote_index_handle, $remote_offset);
         }
 
-        $local_handle = file_exists($this->local_index_file)
+        $local_index_handle = file_exists($this->local_index_file)
             ? fopen($this->local_index_file, "r")
             : null;
-        $local = $this->read_index_line($local_handle);
-        if ($local_after) {
+        // Local index entries retain remote absolute paths as the merge key.
+        $local_index_entry = $this->read_index_line($local_index_handle);
+        if ($last_local_index_entry_path) {
             while (
-                $local !== null &&
-                strcmp($local["path"], $local_after) <= 0
+                $local_index_entry !== null &&
+                strcmp($local_index_entry["path"], $last_local_index_entry_path) <= 0
             ) {
-                $local = $this->read_index_line($local_handle);
+                $local_index_entry = $this->read_index_line($local_index_handle);
             }
         }
         $this->open_index_update_wal();
         $processed = 0;
 
-        while (($line = fgets($remote_handle)) !== false) {
+        while (($line = fgets($remote_index_handle)) !== false) {
             if ($this->shutdown_requested) {
                 break;
             }
@@ -6582,31 +6583,32 @@ class ImportClient
                 pcntl_signal_dispatch();
             }
 
-            $remote_offset = ftell($remote_handle);
-            $remote = $this->parse_index_line($line);
-            if (!$remote) {
+            $remote_offset = ftell($remote_index_handle);
+            $remote_index_entry = $this->parse_index_line($line);
+            if (!$remote_index_entry) {
                 continue;
             }
 
             while (
-                $local !== null &&
-                strcmp($local["path"], $remote["path"]) < 0
+                $local_index_entry !== null &&
+                strcmp($local_index_entry["path"], $remote_index_entry["path"]) < 0
             ) {
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
-                if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->apply_remote_deletion_locally($local["path"]);
-                    $this->delete_index_entry($local["path"]);
+                if ($this->is_file_path_selected_by_pull_only_files($local_index_entry["path"])) {
+                    $remote_absolute_path = $local_index_entry["path"];
+                    $this->apply_remote_deletion_locally($remote_absolute_path);
+                    $this->delete_index_entry($remote_absolute_path);
                 }
-                $local_after = $local["path"];
-                $local = $this->read_index_line($local_handle);
+                $last_local_index_entry_path = $local_index_entry["path"];
+                $local_index_entry = $this->read_index_line($local_index_handle);
             }
 
-            if ($local !== null && $local["path"] === $remote["path"]) {
+            if ($local_index_entry !== null && $local_index_entry["path"] === $remote_index_entry["path"]) {
                 if (
-                    $local["ctime"] !== $remote["ctime"] ||
-                    $local["size"] !== $remote["size"] ||
-                    $local["type"] !== $remote["type"]
+                    $local_index_entry["ctime"] !== $remote_index_entry["ctime"] ||
+                    $local_index_entry["size"] !== $remote_index_entry["size"] ||
+                    $local_index_entry["type"] !== $remote_index_entry["type"]
                 ) {
                     // File is in both indexes but changed on the remote.
                     // Always re-download — this file is in our local index,
@@ -6615,45 +6617,45 @@ class ImportClient
                     $download_list_handle = (
                         $skipped_handle !== null &&
                         $this->is_remote_absolute_path_in_uploads_directory(
-                            $remote["path"],
+                            $remote_index_entry["path"],
                             $uploads_basedir
                         )
                     )
                         ? $skipped_handle
                         : $download_handle;
                     $this->append_download_list(
-                        $remote["path"],
+                        $remote_index_entry["path"],
                         $download_list_handle,
                     );
                 }
-                $local_after = $local["path"];
-                $local = $this->read_index_line($local_handle);
+                $last_local_index_entry_path = $local_index_entry["path"];
+                $local_index_entry = $this->read_index_line($local_index_handle);
             } elseif (
-                $local === null ||
-                strcmp($local["path"], $remote["path"]) > 0
+                $local_index_entry === null ||
+                strcmp($local_index_entry["path"], $remote_index_entry["path"]) > 0
             ) {
-                $skip_reason = $this->should_skip_for_preserve_local($remote["path"]);
+                $skip_reason = $this->should_skip_for_preserve_local($remote_index_entry["path"]);
                 if ($skip_reason) {
                     $this->audit_log($skip_reason, true);
-                    $this->emit_skip_progress($remote["path"]);
+                    $this->emit_skip_progress($remote_index_entry["path"]);
                 } else {
                     $download_list_handle = (
                         $skipped_handle !== null &&
                         $this->is_remote_absolute_path_in_uploads_directory(
-                            $remote["path"],
+                            $remote_index_entry["path"],
                             $uploads_basedir
                         )
                     )
                         ? $skipped_handle
                         : $download_handle;
-                    $this->append_download_list($remote["path"], $download_list_handle);
+                    $this->append_download_list($remote_index_entry["path"], $download_list_handle);
                 }
             }
 
             $processed++;
             if ($processed % 200 === 0) {
                 $this->import_state()->diff->remote_offset = $remote_offset;
-                $this->import_state()->diff->local_after = $local_after;
+                $this->import_state()->diff->local_after = $last_local_index_entry_path;
                 if (
                     $this->index_update_wal_handle
                     && !fflush($this->index_update_wal_handle)
@@ -6665,26 +6667,27 @@ class ImportClient
             }
         }
 
-        while ($local !== null) {
-            if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->apply_remote_deletion_locally($local["path"]);
-                $this->delete_index_entry($local["path"]);
+        while ($local_index_entry !== null) {
+            if ($this->is_file_path_selected_by_pull_only_files($local_index_entry["path"])) {
+                $remote_absolute_path = $local_index_entry["path"];
+                $this->apply_remote_deletion_locally($remote_absolute_path);
+                $this->delete_index_entry($remote_absolute_path);
             }
-            $local_after = $local["path"];
-            $local = $this->read_index_line($local_handle);
+            $last_local_index_entry_path = $local_index_entry["path"];
+            $local_index_entry = $this->read_index_line($local_index_handle);
         }
 
-        if ($local_handle) {
-            fclose($local_handle);
+        if ($local_index_handle) {
+            fclose($local_index_handle);
         }
-        fclose($remote_handle);
+        fclose($remote_index_handle);
         fclose($download_handle);
         if ($skipped_handle !== null) {
             fclose($skipped_handle);
         }
 
         $this->import_state()->diff->remote_offset = $remote_offset;
-        $this->import_state()->diff->local_after = $local_after;
+        $this->import_state()->diff->local_after = $last_local_index_entry_path;
         $this->apply_index_update_wal();
         $this->save_state($this->state);
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2268,7 +2268,7 @@ class ImportClient
     }
 
     /**
-     * Download a list of remote absolute paths into $local_absolute_directory,
+     * Download a list of remote absolute paths into $path,
      * preserving their directory structure.
      *
      * Issues one file_fetch request per parent directory so that an
@@ -2277,7 +2277,7 @@ class ImportClient
      *
      * @return int Number of files successfully downloaded.
      */
-    private function fetch_files_into(string $local_absolute_directory, array $files): int
+    private function fetch_files_into(string $path, array $files): int
     {
         $by_dir = [];
         foreach ($files as $f) {
@@ -2306,19 +2306,19 @@ class ImportClient
             $context->file_path = null;
             $context->file_ctime = null;
 
-            $context->on_chunk = function ($chunk) use ($local_absolute_directory, $context, &$downloaded) {
+            $context->on_chunk = function ($chunk) use ($path, $context, &$downloaded) {
                 $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
                 if ($chunk_type === "file") {
                     $raw = $chunk["headers"]["x-file-path"] ?? "";
-                    $path = base64_decode($raw, true);
-                    if ($path === false || $path === "") {
+                    $remote_absolute_path = base64_decode($raw, true);
+                    if ($remote_absolute_path === false || $remote_absolute_path === "") {
                         return;
                     }
 
                     $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
                     $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
-                    $local_absolute_path = $local_absolute_directory . $path;
+                    $local_absolute_path = $path . $remote_absolute_path;
 
                     if ($is_first) {
                         if ($context->file_handle) {
@@ -2341,7 +2341,7 @@ class ImportClient
                         fclose($context->file_handle);
                         $context->file_handle = null;
                         $downloaded++;
-                        $this->audit_log("Saved {$path} → {$local_absolute_path}");
+                        $this->audit_log("Saved {$remote_absolute_path} → {$local_absolute_path}");
                     }
                 } elseif ($chunk_type === "error") {
                     $body = json_decode($chunk["body"] ?? "{}", true);

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4057,9 +4057,9 @@ class ImportClient
      * the applier writes the files the target server needs to fulfill those
      * requirements.
      *
-     * The effective filesystem root is --fs-root + the remote site's document_root
+     * The local document root is --fs-root + the remote site's document_root
      * prefix (from preflight). For example, if the remote document_root is
-     * /srv/htdocs and --fs-root is ./files, the effective filesystem root is
+     * /srv/htdocs and --fs-root is ./files, the local document root is
      * ./files/srv/htdocs. If the site was flattened with flat-docroot,
      * pass the flattened directory as --fs-root directly and the prefix
      * is not applied.
@@ -4092,19 +4092,19 @@ class ImportClient
         $preflight_data = $entry["data"];
         $webhost = $this->import_state()->webhost ?? "other";
 
-        // Resolve the effective filesystem root from either --flat-document-root
+        // Resolve the local document root from either --flat-document-root
         // (used as-is) or --fs-root (prefixed with the remote document_root).
         // Mutual exclusion is already enforced at the CLI level.
         $flat_document_root = $options["flat_document_root"] ?? null;
 
         if (!empty($flat_document_root)) {
             // --flat-document-root: used directly as the web root.
-            $effective_fs_root = rtrim($flat_document_root, "/");
+            $local_document_root = rtrim($flat_document_root, "/");
         } else {
             // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
             // source server. Files are downloaded preserving the full
-            // remote absolute path, so the effective filesystem root is --fs-root +
+            // remote absolute path, so the local document root is --fs-root +
             // document_root.
             $remote_doc_root = $preflight_data["runtime"]["document_root"] ?? "";
             if (is_string($remote_doc_root)) {
@@ -4114,14 +4114,14 @@ class ImportClient
             }
 
             if ($remote_doc_root !== "") {
-                $effective_fs_root = $this->filesystem_root . $remote_doc_root;
+                $local_document_root = $this->filesystem_root . $remote_doc_root;
             } else {
-                $effective_fs_root = $this->filesystem_root;
+                $local_document_root = $this->filesystem_root;
             }
 
-            if (!is_dir($effective_fs_root)) {
+            if (!is_dir($local_document_root)) {
                 throw new RuntimeException(
-                    "Effective filesystem root does not exist: {$effective_fs_root}\n" .
+                    "Local document root does not exist: {$local_document_root}\n" .
                     "The remote document_root was: {$remote_doc_root}\n" .
                     "If you used flat-docroot, pass the flattened directory " .
                     "with --flat-document-root instead of --fs-root."
@@ -4131,7 +4131,7 @@ class ImportClient
 
         // Resolve to absolute paths so generated files work from any cwd.
         $abs_output_dir = realpath($output_dir) ?: $output_dir;
-        $abs_fs_root = realpath($effective_fs_root) ?: $effective_fs_root;
+        $resolved_local_document_root = realpath($local_document_root) ?: $local_document_root;
 
         if (!is_dir($abs_output_dir)) {
             if (!mkdir($abs_output_dir, 0755, true)) {
@@ -4219,20 +4219,20 @@ class ImportClient
         $abspath = rtrim($paths_urls["abspath"] ?? "", "/");
         if (!empty($flat_document_root)) {
             // Flattened layout: index.php is at the top level.
-            $wordpress_index = $abs_fs_root . '/index.php';
+            $wordpress_index_php = $resolved_local_document_root . '/index.php';
         } elseif ($abspath !== "") {
             // Raw download: ABSPATH is relative to the download root,
-            // not the effective filesystem root (which is download_root + document_root).
-            $wordpress_index = realpath($this->filesystem_root . $abspath . '/index.php') ?: '';
+            // not the local document root (which is download_root + document_root).
+            $wordpress_index_php = realpath($this->filesystem_root . $abspath . '/index.php') ?: '';
         } else {
-            $wordpress_index = $abs_fs_root . '/index.php';
+            $wordpress_index_php = $resolved_local_document_root . '/index.php';
         }
 
         // Step 2: Runtime applier writes server-specific config files.
         $applier = runtime_applier_for($runtime);
         $applier_options = [];
-        if ($wordpress_index !== '') {
-            $applier_options['wordpress_index'] = $wordpress_index;
+        if ($wordpress_index_php !== '') {
+            $applier_options['wordpress_index_php'] = $wordpress_index_php;
         }
         if ($host !== null) {
             $applier_options['host'] = $host;
@@ -4254,11 +4254,11 @@ class ImportClient
             // Resolve {fs-root} in db_dir now that we have the real path.
             $manifest->sqlite['db_dir'] = resolve_runtime_placeholders(
                 $manifest->sqlite['db_dir'],
-                $abs_fs_root,
+                $resolved_local_document_root,
             );
         }
 
-        $summary = $applier->apply($manifest, $abs_fs_root, $abs_output_dir, $applier_options);
+        $summary = $applier->apply($manifest, $resolved_local_document_root, $abs_output_dir, $applier_options);
 
         if ($manifest->sqlite !== null) {
             $summary[] = "Copied sqlite-database-integration to {$abs_output_dir}/sqlite-database-integration";
@@ -4269,7 +4269,7 @@ class ImportClient
         // depend on infrastructure (Memcached servers, multisite APIs)
         // not available outside the original hosting environment.
         foreach ($manifest->paths_to_remove as $rel_path) {
-            $full_path = $abs_fs_root . '/' . ltrim($rel_path, '/');
+            $full_path = $resolved_local_document_root . '/' . ltrim($rel_path, '/');
             if (!file_exists($full_path) && !is_link($full_path)) {
                 continue;
             }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -379,13 +379,13 @@ class ImportClient
     private $follow_symlinks = true;
 
     /**
-     * @var string|null Destination directory for escaping (out-of-scope) symlink targets,
-     * nested by the source path. null keeps the default: each symlink target is
-     * mirrored at its own source path underneath --fs-root.
+     * @var string|null Local root for content reached through escaping symlinks,
+     * nested by the source path. null keeps the default: each followed path is
+     * placed at its source path underneath --fs-root.
      *
      * Usage: --follow-symlinks=<dir>
      */
-    private $symlink_bundle_directory = null;
+    private $local_followed_symlinks_root = null;
 
     /** @var array|null Cached result of get_export_directories(). */
     private $export_directories_cache = null;
@@ -993,8 +993,8 @@ class ImportClient
             $this->follow_symlinks = $this->import_state()->follow_symlinks;
         }
 
-        if (isset($options["symlink_bundle_directory"])) {
-            $this->symlink_bundle_directory = $this->resolve_symlink_bundle_directory($options["symlink_bundle_directory"]);
+        if (isset($options["local_followed_symlinks_root"])) {
+            $this->local_followed_symlinks_root = $this->resolve_local_followed_symlinks_root($options["local_followed_symlinks_root"]);
             $this->follow_symlinks = true;
             $this->import_state()->follow_symlinks = true;
             $this->save_state($this->state);
@@ -2733,7 +2733,7 @@ class ImportClient
 
         $this->replay_local_index_wal();
         $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
-        $this->assert_symlink_bundle_directory_unchanged();
+        $this->assert_local_followed_symlinks_root_unchanged();
 
         // Already completed.
         if ($current_status === "complete") {
@@ -3554,7 +3554,7 @@ class ImportClient
 
             // Repoint through the same seam regular symlink chunks use, so the
             // link targets wherever the content actually landed (filesystem root,
-            // remapped, or bundled) instead of the raw source spelling.
+            // remapped, or placed under the local followed symlinks root) instead of the raw source spelling.
             $symlink_target = $this->rewrite_symlink_target_for_local_filesystem(
                 $remote_absolute_path,
                 $local_absolute_path,
@@ -8691,54 +8691,54 @@ class ImportClient
     }
 
     /**
-     * Refuse to run files-pull after the --follow-symlinks bundle directory
-     * changed. Placement of followed content is bound to it, so changing it
+     * Refuse to run files-pull after the local followed symlinks root changed.
+     * Placement of followed content is bound to it, so changing it
      * mid-state would split content across two layouts. Recorded on the first
      * run, compared on every run after; --abort resets it.
      */
-    private function assert_symlink_bundle_directory_unchanged(): void
+    private function assert_local_followed_symlinks_root_unchanged(): void
     {
-        $fingerprint = $this->symlink_bundle_directory_fingerprint();
-        $previous = $this->import_state()->symlink_bundle_directory_fingerprint ?? null;
+        $fingerprint = $this->local_followed_symlinks_root_fingerprint();
+        $previous = $this->import_state()->local_followed_symlinks_root_fingerprint ?? null;
 
         if ($previous !== null && $previous !== $fingerprint) {
             throw new RuntimeException(
-                "Cannot change the --follow-symlinks bundle directory for an existing files-pull. " .
+                "Cannot change the local followed symlinks root for an existing files-pull. " .
                     "Use the original value, or use --abort to start a new files-pull.",
             );
         }
 
         if ($previous === null) {
-            $this->import_state()->symlink_bundle_directory_fingerprint = $fingerprint;
+            $this->import_state()->local_followed_symlinks_root_fingerprint = $fingerprint;
             $this->save_state($this->state);
         }
     }
 
     /**
-     * Fingerprint of the effective bundle placement root. No bundle directory
+     * Fingerprint of the effective local followed symlinks root. No explicit root
      * (and bare --follow-symlinks) fingerprints as filesystem root, which is the
      * equivalent placement — so switching between those spellings is allowed.
      */
-    private function symlink_bundle_directory_fingerprint(): string
+    private function local_followed_symlinks_root_fingerprint(): string
     {
-        $effective = $this->symlink_bundle_directory ?? rtrim($this->get_filesystem_root_path(), "/");
+        $effective = $this->local_followed_symlinks_root ?? rtrim($this->get_filesystem_root_path(), "/");
         return hash("sha256", $effective);
     }
 
     /**
-     * Resolve the --follow-symlinks=<dir> bundle destination.
+     * Resolve the --follow-symlinks=<dir> local followed symlinks root.
      *
      * Uses the same target grammar as --remap targets: a :fs-root: path or a raw
      * absolute path, which must resolve within --fs-root.
      */
-    private function resolve_symlink_bundle_directory(string $raw): string
+    private function resolve_local_followed_symlinks_root(string $raw): string
     {
         $filesystem_root = rtrim($this->get_filesystem_root_path(), "/");
         $directory = $this->resolve_token_path($raw, ["fs-root" => $filesystem_root]);
 
         if (!path_is_within_root($directory, $filesystem_root)) {
             throw new InvalidArgumentException(
-                "--follow-symlinks bundle directory \"{$directory}\" resolves outside --fs-root ({$filesystem_root}); " .
+                "--follow-symlinks local followed symlinks root \"{$directory}\" resolves outside --fs-root ({$filesystem_root}); " .
                     "it must stay within the destination root",
             );
         }
@@ -9020,10 +9020,10 @@ class ImportClient
         }
 
         // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
-        // Use the same bundle mapping for copied content and rewritten symlink targets so the links do not dangle.
-        if ($this->symlink_bundle_directory !== null
+        // Use the same local followed symlinks root for copied content and rewritten symlink targets so the links do not dangle.
+        if ($this->local_followed_symlinks_root !== null
             && !$this->path_is_within_original_export_scope($remote_absolute_path)) {
-            return $this->symlink_bundle_directory . $remote_absolute_path;
+            return $this->local_followed_symlinks_root . $remote_absolute_path;
         }
 
         return $this->get_filesystem_root_path() . $remote_absolute_path;
@@ -11747,7 +11747,7 @@ if (
         [
             'name' => 'follow-symlinks',
             'type' => 'value',
-            'target' => 'symlink_bundle_directory',
+            'target' => 'local_followed_symlinks_root',
             'placeholder' => 'DIR',
             'help' => 'Follow symlinks, consolidating escaping (out-of-scope) targets into DIR ' .
                 '(a :fs-root: path or an absolute path within --fs-root), nested by source path. ' .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -745,7 +745,7 @@ class ImportClient
         if (isset($masked[2]) && $command !== 'apply-runtime') {
             $masked[2] = preg_replace('/SECRET_KEY=[^&\s]+/', 'SECRET_KEY=***', $masked[2]);
             if ($command === 'files-push') {
-                $masked[2] = self::mask_files_push_url_user_info($masked[2]);
+                $masked[2] = self::mask_files_push_remote_reprint_api_url_user_info($masked[2]);
             }
         }
         foreach ($masked as $argument_index => $argument) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1567,7 +1567,7 @@ class ImportClient
         $sender_options = [
             'filesystem_root' => $context['filesystem_root'],
             'push_state_directory' => $context['push_state_directory'],
-            'base_url' => $context['remote_reprint_api_url'],
+            'remote_reprint_api_url' => $context['remote_reprint_api_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
             'chunk_bytes' => $chunk_bytes,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -265,7 +265,7 @@ class ImportClient
     /** @var string State directory for this filesystem root (.import-state.json, db.sql, etc.). */
     public $state_dir;
 
-    /** @var string Filesystem root where the target filesystem is reconstructed. */
+    /** @var string Filesystem root where the remote filesystem is reconstructed. */
     public $filesystem_root;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
@@ -282,7 +282,7 @@ class ImportClient
 
     /**
      * @var string Local index file .import-index.jsonl. It tracks each accounted
-     * path's ctime, size, and type for the next target-index comparison.
+     * path's ctime, size, and type for the next remote-index comparison.
      */
     private $local_index_file;
 
@@ -320,10 +320,10 @@ class ImportClient
     private $last_update_type = null;
 
     /**
-     * @var string Target index file .import-remote-index.jsonl, including
+     * @var string Remote index file .import-remote-index.jsonl, including
      * directory `empty` fields when available.
      */
-    private $target_index_file;
+    private $remote_index_file;
 
     /** @var string Path to .import-download-list.jsonl — files to download, computed by diffing remote vs local index. */
     private $download_list_file;
@@ -416,7 +416,7 @@ class ImportClient
      * is skipped and never added to the local index.
      *
      * On subsequent delta syncs, preserved paths survive because the importer only
-     * acts on paths listed in the target index. Local-only hosting infrastructure
+     * acts on paths listed in the remote index. Local-only hosting infrastructure
      * (e.g. __wp__ symlinks, drop-in symlinks, shared plugin directories) is simply
      * invisible to the diff and never touched.
      *
@@ -440,8 +440,8 @@ class ImportClient
     private $extra_directory = null;
 
     /**
-     * @var array<string,string> Resolved path mappings from target filesystem
-     * paths to local filesystem paths. Both sides are absolute. Empty means
+     * @var array<string,string> Resolved path mappings from remote absolute
+     * paths to local absolute paths. Both sides are absolute. Empty means
      * the identity mapping beneath the filesystem root.
      */
     private $resolved_path_mappings = [];
@@ -484,12 +484,12 @@ class ImportClient
     private $index_entries_counted = 0;
 
     /**
-     * Memoized lookups for "does target index contain this path or any descendant path?"
+     * Memoized lookups for "does remote index contain this path or any descendant path?"
      * keyed by normalized absolute path.
      *
      * @var array<string,bool>
      */
-    private $target_index_prefix_cache = [];
+    private $remote_index_prefix_cache = [];
 
     /** @var int|null Current step in a multi-step pipeline (1-indexed). Set via --step. */
     private $pipeline_step = null;
@@ -558,7 +558,7 @@ class ImportClient
         $this->local_index_file = $this->state_dir . "/.import-index.jsonl";
         $this->index_update_wal_path =
             $this->state_dir . "/.import-index-updates.wal";
-        $this->target_index_file =
+        $this->remote_index_file =
             $this->state_dir . "/.import-remote-index.jsonl";
         $this->download_list_file =
             $this->state_dir . "/.import-download-list.jsonl";
@@ -1984,9 +1984,9 @@ class ImportClient
                 $this->import_state()->active_resumable_command->completion_state = null;
                 $this->import_state()->active_resumable_command->current_stage = null;
                 $this->import_state()->index = new RemoteFileIndexCursorState();
-                if (file_exists($this->target_index_file)) {
-                    @unlink($this->target_index_file);
-                    $this->audit_log("FILE DELETE | {$this->target_index_file}");
+                if (file_exists($this->remote_index_file)) {
+                    @unlink($this->remote_index_file);
+                    $this->audit_log("FILE DELETE | {$this->remote_index_file}");
                 }
                 $this->save_state($this->state);
                 break;
@@ -2073,9 +2073,9 @@ class ImportClient
         $this->index_update_wal_handle = null;
         $this->index_update_wal_record_count = 0;
 
-        if (file_exists($this->target_index_file)) {
-            @unlink($this->target_index_file);
-            $this->audit_log("FILE DELETE | {$this->target_index_file}");
+        if (file_exists($this->remote_index_file)) {
+            @unlink($this->remote_index_file);
+            $this->audit_log("FILE DELETE | {$this->remote_index_file}");
         }
         if (file_exists($this->download_list_file)) {
             @unlink($this->download_list_file);
@@ -2268,7 +2268,7 @@ class ImportClient
     }
 
     /**
-     * Download a list of absolute target filesystem paths into $target_dir,
+     * Download a list of remote absolute paths into $local_absolute_directory,
      * preserving their directory structure.
      *
      * Issues one file_fetch request per parent directory so that an
@@ -2277,7 +2277,7 @@ class ImportClient
      *
      * @return int Number of files successfully downloaded.
      */
-    private function fetch_files_into(string $target_dir, array $files): int
+    private function fetch_files_into(string $local_absolute_directory, array $files): int
     {
         $by_dir = [];
         foreach ($files as $f) {
@@ -2306,7 +2306,7 @@ class ImportClient
             $context->file_path = null;
             $context->file_ctime = null;
 
-            $context->on_chunk = function ($chunk) use ($target_dir, $context, &$downloaded) {
+            $context->on_chunk = function ($chunk) use ($local_absolute_directory, $context, &$downloaded) {
                 $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
                 if ($chunk_type === "file") {
@@ -2318,19 +2318,19 @@ class ImportClient
 
                     $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
                     $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
-                    $local_path = $target_dir . $path;
+                    $local_absolute_path = $local_absolute_directory . $path;
 
                     if ($is_first) {
                         if ($context->file_handle) {
                             fclose($context->file_handle);
                             $context->file_handle = null;
                         }
-                        $dir = dirname($local_path);
+                        $dir = dirname($local_absolute_path);
                         if (!is_dir($dir)) {
                             @mkdir($dir, 0755, true);
                         }
-                        $context->file_handle = @fopen($local_path, "wb");
-                        $context->file_path = $local_path;
+                        $context->file_handle = @fopen($local_absolute_path, "wb");
+                        $context->file_path = $local_absolute_path;
                     }
 
                     if ($context->file_handle && isset($chunk["body"])) {
@@ -2341,7 +2341,7 @@ class ImportClient
                         fclose($context->file_handle);
                         $context->file_handle = null;
                         $downloaded++;
-                        $this->audit_log("Saved {$path} → {$local_path}");
+                        $this->audit_log("Saved {$path} → {$local_absolute_path}");
                     }
                 } elseif ($chunk_type === "error") {
                     $body = json_decode($chunk["body"] ?? "{}", true);
@@ -2872,13 +2872,13 @@ class ImportClient
                 "message" => "Resuming files-pull (stage: {$stage}, indexed: {$index_size} files)",
             ], true);
         } else {
-            // Starting fresh — validate that target directory is empty.
+            // Starting fresh — validate that the filesystem root is empty.
             // A delta sync ($is_delta) naturally has a non-empty filesystem root
             // because we put those files there during the initial sync.
             if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
                 throw new RuntimeException(
-                    "Target directory is not empty and no cursor found. " .
-                        "Either clear the target directory, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
+                    "Filesystem root is not empty and no cursor found. " .
+                        "Either clear the filesystem root, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
                 );
             }
 
@@ -2980,7 +2980,7 @@ class ImportClient
         $stage = $this->import_state()->active_resumable_command->current_stage ?? "index";
 
         if ($stage === "index") {
-            $complete = $this->download_target_index();
+            $complete = $this->download_remote_index();
             if (!$complete) {
                 $this->import_state()->active_resumable_command->completion_state = "partial";
                 $this->save_state($this->state);
@@ -2994,7 +2994,7 @@ class ImportClient
                     return;
                 }
             }
-            $this->sort_index_file($this->target_index_file);
+            $this->sort_index_file($this->remote_index_file);
             $this->import_state()->active_resumable_command->current_stage = "diff";
             $this->import_state()->diff = new FileDiffProgressState();
             if (file_exists($this->download_list_file)) {
@@ -3148,7 +3148,7 @@ class ImportClient
 
         // Recreate intermediate path symlinks so the full symlink chain
         // works locally.  The server discovers these (e.g. /srv/wordpress
-        // -> /wordpress) and includes them in the target index.
+        // -> /wordpress) and includes them in the remote index.
         if ($this->follow_symlinks) {
             $this->recreate_intermediate_symlinks();
         }
@@ -3158,9 +3158,9 @@ class ImportClient
      * Command: files-index
      *
      * Rules:
-     * - Streams the full target index (DFS across directories) until complete
+     * - Streams the full remote index (DFS across directories) until complete
      * - If already completed: require --abort flag
-     * - If abort flag: clear target index file and index cursor
+     * - If abort flag: clear remote index file and index cursor
      */
     private function run_files_index(): void
     {
@@ -3213,7 +3213,7 @@ class ImportClient
         $attempts = 0;
         $last_cursor = $this->import_state()->index->cursor ?? null;
         while (true) {
-            $complete = $this->download_target_index();
+            $complete = $this->download_remote_index();
             if ($complete) {
                 break;
             }
@@ -3247,14 +3247,14 @@ class ImportClient
             $this->discover_symlink_targets();
         }
 
-        $this->sort_index_file($this->target_index_file);
+        $this->sort_index_file($this->remote_index_file);
         $this->import_state()->active_resumable_command->completion_state = "complete";
         $this->import_state()->active_resumable_command->current_stage = null;
         $this->save_state($this->state);
 
         $count = 0;
-        if (file_exists($this->target_index_file)) {
-            $h = fopen($this->target_index_file, "r");
+        if (file_exists($this->remote_index_file)) {
+            $h = fopen($this->remote_index_file, "r");
             if ($h) {
                 while (fgets($h) !== false) {
                     $count++;
@@ -3268,14 +3268,14 @@ class ImportClient
         );
 
         $this->progress->show_lifecycle_line("files-index complete: {$count} entries indexed\n");
-        $this->progress->show_lifecycle_line("Target index: {$this->target_index_file}\n");
+        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_file}\n");
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
             "command" => "files-index",
             "entries_indexed" => $count,
-            "remote_index" => $this->target_index_file,
+            "remote_index" => $this->remote_index_file,
             "audit_log" => $this->audit_log,
             "message" => "files-index complete: {$count} entries indexed",
         ], true);
@@ -3285,7 +3285,7 @@ class ImportClient
      * Recursively discover directories that need indexing beyond the primary
      * export roots.
      *
-     * Scans the target index for symlink entries with a "target" field,
+     * Scans the remote index for symlink entries with a "target" field,
      * resolves relative targets to absolute paths, and indexes each target
      * directory. Repeats until the queue is drained, with cycle detection.
      */
@@ -3328,7 +3328,7 @@ class ImportClient
             $visited[$dir] = true;
 
             $this->audit_log(
-                "FOLLOW SYMLINK | indexing target directory: {$dir}",
+                "FOLLOW SYMLINK | indexing remote directory: {$dir}",
                 true,
             );
             $this->progress->show_lifecycle_line("Following symlink target: {$dir}\n");
@@ -3338,7 +3338,7 @@ class ImportClient
                 "message" => "Following symlink target: {$dir}",
             ], true);
 
-            // Reset the index cursor so download_target_index starts fresh
+            // Reset the index cursor so download_remote_index starts fresh
             // for this directory, but appends to the existing index file.
             // Note we are not losing the previous cursor position. This code
             // runs only after the previous directory was fully indexed so
@@ -3350,7 +3350,7 @@ class ImportClient
             $last_cursor = null;
             while (true) {
                 try {
-                    $complete = $this->download_target_index($dir);
+                    $complete = $this->download_remote_index($dir);
                 } catch (RuntimeException $e) {
                     // We won't be able to follow every symlink. If
                     // the response seems like the remote server rejecting
@@ -3416,7 +3416,7 @@ class ImportClient
     }
 
     /**
-     * Scan the target index file for symlink entries whose targets are
+     * Scan the remote index file for symlink entries whose targets are
      * directories not already in $visited.  Returns an array of real paths.
      *
      * Skips entries marked as "intermediate" — those are path-component
@@ -3426,11 +3426,11 @@ class ImportClient
     private function extract_symlink_dirs_from_index(array $visited): array
     {
         $targets = [];
-        if (!file_exists($this->target_index_file)) {
+        if (!file_exists($this->remote_index_file)) {
             return $targets;
         }
 
-        $handle = fopen($this->target_index_file, "r");
+        $handle = fopen($this->remote_index_file, "r");
         if (!$handle) {
             return $targets;
         }
@@ -3491,18 +3491,18 @@ class ImportClient
      * type=link, intermediate=true.
      *
      * Since the server indexes everything under realpath()-resolved paths,
-     * the files are already downloaded to the target location (e.g.
+     * the files are already downloaded to the local location (e.g.
      * filesystem root/wordpress/...).  We just need to create the symlink
      * (e.g. filesystem root/srv/wordpress -> /wordpress) so the directory
      * layout matches the server.
      */
     private function recreate_intermediate_symlinks(): void
     {
-        if (!file_exists($this->target_index_file)) {
+        if (!file_exists($this->remote_index_file)) {
             return;
         }
 
-        $h = fopen($this->target_index_file, "r");
+        $h = fopen($this->remote_index_file, "r");
         if (!$h) {
             return;
         }
@@ -3534,17 +3534,19 @@ class ImportClient
              *
              * @see https://www.php.net/base64_decode
              */
-            $path = base64_decode($path_encoded, true);
+            $remote_absolute_path = base64_decode($path_encoded, true);
             $target = base64_decode($target_encoded, true);
-            if ($path === false || $path === "" || $target === false || $target === "") {
+            if ($remote_absolute_path === false || $remote_absolute_path === "" || $target === false || $target === "") {
                 continue;
             }
 
             try {
-                $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
+                $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+                    $remote_absolute_path
+                );
             } catch (RuntimeException $e) {
                 $this->audit_log(
-                    "INTERMEDIATE SYMLINK SKIP: invalid path {$path}: " . $e->getMessage(),
+                    "INTERMEDIATE SYMLINK SKIP: invalid path {$remote_absolute_path}: " . $e->getMessage(),
                     true,
                 );
                 continue;
@@ -3553,21 +3555,25 @@ class ImportClient
             // Repoint through the same seam regular symlink chunks use, so the
             // link targets wherever the content actually landed (filesystem root,
             // remapped, or bundled) instead of the raw source spelling.
-            $target = $this->map_symlink_target_for_local_mirror($path, $local_path, $target);
+            $target = $this->map_symlink_target_for_local_mirror(
+                $remote_absolute_path,
+                $local_absolute_path,
+                $target
+            );
 
             // Already correct — skip
-            if (is_link($local_path) && readlink($local_path) === $target) {
+            if (is_link($local_absolute_path) && readlink($local_absolute_path) === $target) {
                 continue;
             }
 
             // Create parent directory
-            $parent = dirname($local_path);
+            $parent = dirname($local_absolute_path);
             if (!is_dir($parent)) {
                 try {
                     $this->ensure_directory_path($parent);
                 } catch (RuntimeException $e) {
                     $this->audit_log(
-                        "INTERMEDIATE SYMLINK SKIP: failed to prepare parent for {$path}: " .
+                        "INTERMEDIATE SYMLINK SKIP: failed to prepare parent for {$remote_absolute_path}: " .
                             $e->getMessage(),
                         true,
                     );
@@ -3576,16 +3582,16 @@ class ImportClient
             }
 
             // Remove stale symlink if present
-            if (is_link($local_path)) {
-                @unlink($local_path);
+            if (is_link($local_absolute_path)) {
+                @unlink($local_absolute_path);
             }
 
             // Don't overwrite a real directory — that shouldn't exist for
             // an intermediate symlink path, and if it does something else
             // is wrong.
-            if (file_exists($local_path)) {
+            if (file_exists($local_absolute_path)) {
                 $this->audit_log(
-                    "INTERMEDIATE SYMLINK SKIP: {$path} already exists as a real file/dir",
+                    "INTERMEDIATE SYMLINK SKIP: {$remote_absolute_path} already exists as a real file/dir",
                     true,
                 );
                 continue;
@@ -3595,7 +3601,7 @@ class ImportClient
             $root = $this->get_filesystem_root_path();
             try {
                 $this->assert_symlink_target_within_root(
-                    dirname($local_path),
+                    dirname($local_absolute_path),
                     $target,
                     $root
                 );
@@ -3607,15 +3613,15 @@ class ImportClient
                 continue;
             }
 
-            if (@symlink($target, $local_path)) {
+            if (@symlink($target, $local_absolute_path)) {
                 $created++;
                 $this->audit_log(
-                    "INTERMEDIATE SYMLINK: {$path} -> {$target}",
+                    "INTERMEDIATE SYMLINK: {$remote_absolute_path} -> {$target}",
                     false,
                 );
             } else {
                 $this->audit_log(
-                    "Failed to create intermediate symlink: {$path} -> {$target}",
+                    "Failed to create intermediate symlink: {$remote_absolute_path} -> {$target}",
                     true,
                 );
             }
@@ -3872,17 +3878,17 @@ class ImportClient
      */
     private function run_files_stats(): void
     {
-        $target_index = $this->target_index_file;
+        $remote_index = $this->remote_index_file;
         $download_list = $this->download_list_file;
 
-        // Single pass over the target index to build a path→size map.
+        // Single pass over the remote index to build a path→size map.
         // Duplicates (from overlapping symlink targets) are collapsed
         // automatically because later entries overwrite earlier ones in
         // the map, so the counts we derive are always deduplicated.
         $size_by_path = [];
 
-        if (is_file($target_index)) {
-            $handle = fopen($target_index, "r");
+        if (is_file($remote_index)) {
+            $handle = fopen($remote_index, "r");
             if ($handle) {
                 while (($line = fgets($handle)) !== false) {
                     $entry = $this->parse_index_line($line);
@@ -4098,7 +4104,7 @@ class ImportClient
             // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
             // source server. Files are downloaded preserving the full
-            // target filesystem path, so the effective filesystem root is --fs-root +
+            // remote absolute path, so the effective filesystem root is --fs-root +
             // document_root.
             $remote_doc_root = $preflight_data["runtime"]["document_root"] ?? "";
             if (is_string($remote_doc_root)) {
@@ -4490,7 +4496,7 @@ class ImportClient
             );
         }
 
-        // Map target filesystem paths to local paths within filesystem root
+        // Map remote absolute paths to local absolute paths within filesystem root
         $local_abspath = $this->filesystem_root . $abspath;
         if (!is_dir($local_abspath)) {
             throw new RuntimeException(
@@ -6002,7 +6008,7 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
-        // Always send directory[] – see comment in download_target_index().
+        // Always send directory[] – see comment in download_remote_index().
         $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
@@ -6248,9 +6254,9 @@ class ImportClient
     }
 
     /**
-     * Download the target index stream and write to disk.
+     * Download the remote index stream and write to disk.
      */
-    private function download_target_index(?string $list_dir_override = null): bool
+    private function download_remote_index(?string $list_dir_override = null): bool
     {
         $cursor = $this->import_state()->index->cursor;
 
@@ -6262,24 +6268,24 @@ class ImportClient
             );
         }
 
-        $mode = file_exists($this->target_index_file) ? "a" : "w";
+        $mode = file_exists($this->remote_index_file) ? "a" : "w";
         // Initialize the index counter from the existing file so resume
         // shows a monotonically increasing count.
         if ($mode === "a" && $this->index_entries_counted === 0) {
-            $this->index_entries_counted = $this->count_newlines($this->target_index_file);
+            $this->index_entries_counted = $this->count_newlines($this->remote_index_file);
         }
         if ($mode === "w") {
             $this->audit_log(
-                "FILE CREATE | {$this->target_index_file} | downloading fresh target index",
+                "FILE CREATE | {$this->remote_index_file} | downloading fresh remote index",
             );
         } else {
             $this->audit_log(
-                "FILE APPEND | {$this->target_index_file} | resuming target index download",
+                "FILE APPEND | {$this->remote_index_file} | resuming remote index download",
             );
         }
-        $handle = fopen($this->target_index_file, $mode);
+        $handle = fopen($this->remote_index_file, $mode);
         if (!$handle) {
-            throw new RuntimeException("Failed to open target index file");
+            throw new RuntimeException("Failed to open remote index file");
         }
 
         $complete = false;
@@ -6415,7 +6421,7 @@ class ImportClient
                     }
                     $bytes = fwrite($handle, $line . "\n");
                     if ($bytes === false) {
-                        throw new RuntimeException("Failed to write to target index file (disk full?)");
+                        throw new RuntimeException("Failed to write to remote index file (disk full?)");
                     }
                     $this->index_entries_counted++;
                 }
@@ -6492,12 +6498,12 @@ class ImportClient
     }
 
     /**
-     * Diff local index against target index and build download list.
+     * Diff local index against remote index and build download list.
      */
     private function diff_indexes_and_build_fetch_list(): bool
     {
-        if (!file_exists($this->target_index_file)) {
-            throw new RuntimeException("Target index file not found");
+        if (!file_exists($this->remote_index_file)) {
+            throw new RuntimeException("Remote index file not found");
         }
 
         $diff = $this->import_state()->diff;
@@ -6543,10 +6549,10 @@ class ImportClient
             );
         }
 
-        $remote_handle = fopen($this->target_index_file, "r");
+        $remote_handle = fopen($this->remote_index_file, "r");
         if (!$remote_handle) {
             fclose($download_handle);
-            throw new RuntimeException("Failed to open target index file");
+            throw new RuntimeException("Failed to open remote index file");
         }
         if ($remote_offset > 0) {
             fseek($remote_handle, $remote_offset);
@@ -6589,7 +6595,7 @@ class ImportClient
                 // When --only file prefixes are active, only delete local files that fall under those prefixes.
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                    $this->delete_target_filesystem_path($local["path"]);
+                    $this->delete_remote_absolute_path($local["path"]);
                     $this->delete_index_entry($local["path"]);
                 }
                 $local_after = $local["path"];
@@ -6606,12 +6612,18 @@ class ImportClient
                     // Always re-download — this file is in our local index,
                     // meaning we synced it before; preserve-local does not
                     // protect files we own.
-                    $target_handle = ($skipped_handle !== null && $this->is_uploads_path($remote["path"], $uploads_basedir))
+                    $download_list_handle = (
+                        $skipped_handle !== null &&
+                        $this->is_remote_absolute_path_in_uploads_directory(
+                            $remote["path"],
+                            $uploads_basedir
+                        )
+                    )
                         ? $skipped_handle
                         : $download_handle;
                     $this->append_download_list(
                         $remote["path"],
-                        $target_handle,
+                        $download_list_handle,
                     );
                 }
                 $local_after = $local["path"];
@@ -6625,10 +6637,16 @@ class ImportClient
                     $this->audit_log($skip_reason, true);
                     $this->emit_skip_progress($remote["path"]);
                 } else {
-                    $target_handle = ($skipped_handle !== null && $this->is_uploads_path($remote["path"], $uploads_basedir))
+                    $download_list_handle = (
+                        $skipped_handle !== null &&
+                        $this->is_remote_absolute_path_in_uploads_directory(
+                            $remote["path"],
+                            $uploads_basedir
+                        )
+                    )
                         ? $skipped_handle
                         : $download_handle;
-                    $this->append_download_list($remote["path"], $target_handle);
+                    $this->append_download_list($remote["path"], $download_list_handle);
                 }
             }
 
@@ -6649,7 +6667,7 @@ class ImportClient
 
         while ($local !== null) {
             if ($this->is_file_path_selected_by_pull_only_files($local["path"])) {
-                $this->delete_target_filesystem_path($local["path"]);
+                $this->delete_remote_absolute_path($local["path"]);
                 $this->delete_index_entry($local["path"]);
             }
             $local_after = $local["path"];
@@ -7009,18 +7027,21 @@ class ImportClient
     }
 
     /**
-     * Check whether a target filesystem path belongs to the uploads directory.
+     * Check whether a remote absolute path belongs to the uploads directory.
      *
      * Uses the preflight-reported uploads basedir when available, otherwise
      * falls back to matching "wp-content/uploads/" anywhere in the path.
      */
-    private function is_uploads_path(string $path, ?string $uploads_basedir): bool
+    private function is_remote_absolute_path_in_uploads_directory(
+        string $remote_absolute_path,
+        ?string $uploads_basedir
+    ): bool
     {
         if ($uploads_basedir !== null) {
-            return strpos($path, $uploads_basedir) !== false;
+            return strpos($remote_absolute_path, $uploads_basedir) !== false;
         }
         // Fallback: match the conventional WordPress uploads path
-        return strpos($path, "wp-content/uploads/") !== false;
+        return strpos($remote_absolute_path, "wp-content/uploads/") !== false;
     }
 
     /**
@@ -7039,53 +7060,55 @@ class ImportClient
     }
 
     /**
-     * Delete a local file path safely under the filesystem root.
+     * Delete the local absolute path mapped from a remote absolute path.
      */
-    private function delete_target_filesystem_path(string $path): void
+    private function delete_remote_absolute_path(string $remote_absolute_path): void
     {
-        if ($path === "") {
+        if ($remote_absolute_path === "") {
             return;
         }
         try {
-            $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
+            $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+                $remote_absolute_path
+            );
         } catch (RuntimeException $e) {
             $this->audit_log(
-                "Security: refusing to delete invalid path '{$path}': " . $e->getMessage(),
+                "Security: refusing to delete invalid path '{$remote_absolute_path}': " . $e->getMessage(),
                 true,
             );
             return;
         }
-        if (!file_exists($local_path) && !is_link($local_path)) {
+        if (!file_exists($local_absolute_path) && !is_link($local_absolute_path)) {
             return;
         }
 
-        if ($this->remove_local_filesystem_path_without_following_symlinks($local_path)) {
-            $this->audit_log("Deleted: {$path}", false);
+        if ($this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)) {
+            $this->audit_log("Deleted: {$remote_absolute_path}", false);
             return;
         }
 
-        $this->audit_log("Failed to delete: {$path}", true);
+        $this->audit_log("Failed to delete: {$remote_absolute_path}", true);
     }
 
     /**
-     * Remove a local path recursively without traversing symlink targets.
+     * Remove a local absolute path recursively without traversing symlink targets.
      *
      * Symlinks are always unlinked as links. Directories are traversed
      * depth-first.
      */
-    private function remove_local_filesystem_path_without_following_symlinks(
-        string $local_path
+    private function remove_local_absolute_path_without_following_symlinks(
+        string $local_absolute_path
     ): bool {
-        if (!file_exists($local_path) && !is_link($local_path)) {
+        if (!file_exists($local_absolute_path) && !is_link($local_absolute_path)) {
             return true;
         }
 
-        if (is_link($local_path) || is_file($local_path)) {
-            return true === @unlink($local_path);
+        if (is_link($local_absolute_path) || is_file($local_absolute_path)) {
+            return true === @unlink($local_absolute_path);
         }
 
-        if (is_dir($local_path)) {
-            $entries = @scandir($local_path);
+        if (is_dir($local_absolute_path)) {
+            $entries = @scandir($local_absolute_path);
             if ($entries === false) {
                 return false;
             }
@@ -7094,17 +7117,17 @@ class ImportClient
                     continue;
                 }
                 if (
-                    !$this->remove_local_filesystem_path_without_following_symlinks(
-                        $local_path . "/" . $entry
+                    !$this->remove_local_absolute_path_without_following_symlinks(
+                        $local_absolute_path . "/" . $entry
                     )
                 ) {
                     return false;
                 }
             }
-            return true === @rmdir($local_path);
+            return true === @rmdir($local_absolute_path);
         }
 
-        return true === @unlink($local_path);
+        return true === @unlink($local_absolute_path);
     }
 
     /**
@@ -8447,37 +8470,37 @@ class ImportClient
      * mirrored local copy under filesystem root.
      */
     private function map_symlink_target_for_local_mirror(
-        string $target_filesystem_path,
-        string $local_filesystem_path,
+        string $remote_absolute_path,
+        string $local_absolute_path,
         string $target
     ): string {
-        // Resolve to a target filesystem path (relative targets are based on
-        // the source symlink's target filesystem directory).
-        $target_filesystem_target = str_starts_with($target, "/")
+        // Resolve to a remote absolute path (relative targets are based on
+        // the source symlink's remote directory).
+        $remote_absolute_target = str_starts_with($target, "/")
             ? normalize_path($target)
-            : normalize_path(dirname($target_filesystem_path) . "/" . $target);
+            : normalize_path(dirname($remote_absolute_path) . "/" . $target);
 
         // Only rewrite a target whose subtree was actually followed and indexed;
         // everything else keeps its original (portable) spelling.
         if (
             !$this->follow_symlinks ||
-            !$this->target_index_contains_target_filesystem_path_prefix($target_filesystem_target)
+            !$this->remote_index_contains_remote_absolute_path_prefix($remote_absolute_target)
         ) {
             return $target;
         }
 
         // Repoint to where the target's content is placed by the same pull
         // mapping used for file chunks, so the symlink does not dangle.
-        $local_filesystem_target = $this->map_target_filesystem_path_to_local_filesystem_path(
-            $target_filesystem_target
+        $local_absolute_target = $this->map_remote_absolute_path_to_local_absolute_path(
+            $remote_absolute_target
         );
         $local_relative_target = self::compute_relative_path(
-            dirname($local_filesystem_path),
-            $local_filesystem_target
+            dirname($local_absolute_path),
+            $local_absolute_target
         );
 
         $this->audit_log(
-            "SYMLINK TARGET REMAP | {$target_filesystem_path}: {$target} -> {$local_relative_target}",
+            "SYMLINK TARGET REMAP | {$remote_absolute_path}: {$target} -> {$local_relative_target}",
             false,
         );
 
@@ -8485,33 +8508,33 @@ class ImportClient
     }
 
     /**
-     * Checks whether the target index contains a target filesystem path or one
+     * Checks whether the remote index contains a remote absolute path or one
      * of its descendants. Runs a memoized O(N) scan of .import-remote-index.jsonl.
      */
-    private function target_index_contains_target_filesystem_path_prefix(
-        string $target_filesystem_path
+    private function remote_index_contains_remote_absolute_path_prefix(
+        string $remote_absolute_path
     ): bool {
-        $target_filesystem_path = rtrim(normalize_path($target_filesystem_path), "/");
-        if ($target_filesystem_path === "") {
+        $remote_absolute_path = rtrim(normalize_path($remote_absolute_path), "/");
+        if ($remote_absolute_path === "") {
             return false;
         }
 
-        if (isset($this->target_index_prefix_cache[$target_filesystem_path])) {
-            return $this->target_index_prefix_cache[$target_filesystem_path];
+        if (isset($this->remote_index_prefix_cache[$remote_absolute_path])) {
+            return $this->remote_index_prefix_cache[$remote_absolute_path];
         }
 
-        if (!file_exists($this->target_index_file)) {
-            $this->target_index_prefix_cache[$target_filesystem_path] = false;
+        if (!file_exists($this->remote_index_file)) {
+            $this->remote_index_prefix_cache[$remote_absolute_path] = false;
             return false;
         }
 
-        $h = fopen($this->target_index_file, "r");
+        $h = fopen($this->remote_index_file, "r");
         if (!$h) {
-            $this->target_index_prefix_cache[$target_filesystem_path] = false;
+            $this->remote_index_prefix_cache[$remote_absolute_path] = false;
             return false;
         }
 
-        $prefix = $target_filesystem_path . "/";
+        $prefix = $remote_absolute_path . "/";
         $found = false;
         while (($line = fgets($h)) !== false) {
             try {
@@ -8523,14 +8546,14 @@ class ImportClient
                 continue;
             }
             $entry_path = $entry["path"];
-            if ($entry_path === $target_filesystem_path || str_starts_with($entry_path, $prefix)) {
+            if ($entry_path === $remote_absolute_path || str_starts_with($entry_path, $prefix)) {
                 $found = true;
                 break;
             }
         }
         fclose($h);
 
-        $this->target_index_prefix_cache[$target_filesystem_path] = $found;
+        $this->remote_index_prefix_cache[$remote_absolute_path] = $found;
         return $found;
     }
 
@@ -8560,8 +8583,8 @@ class ImportClient
     /**
      * Refuse to reuse a files index with different --remap rules.
      *
-     * The files index stores target filesystem paths. Local writes/deletes derive their
-     * targets from the current remap rules, so changing those rules while the
+     * The files index stores remote absolute paths. Local writes/deletes derive their
+     * local absolute paths from the current remap rules, so changing those rules while the
      * same index is still in use can point future updates at the wrong path.
      */
     private function assert_files_remap_consistent(): void
@@ -8606,7 +8629,7 @@ class ImportClient
     /**
      * Refuse to resume a files-pull after changing --only.
      *
-     * The in-progress target index cursor/file was built from one directory[]
+     * The in-progress remote index cursor/file was built from one directory[]
      * allowlist. Switching the selected source path prefixes mid-resume would
      * mix indexes from different traversals. Completed runs are allowed to use
      * different --only prefixes because the local index is intentionally a union
@@ -8848,7 +8871,7 @@ class ImportClient
      * the diff's delete drains at their default behavior. When --only is set,
      * true only when $path falls under one of those file path prefixes IF it is
      * NOT the directory itself (when the path remainder is an empty string): an
-     * --only target index lists what is inside each selected directory, never
+     * --only remote index lists what is inside each selected directory, never
      * the directory itself, so to the diff the selected directories always
      * appear deleted-on-remote even though they exist.
      */
@@ -8959,58 +8982,58 @@ class ImportClient
     }
 
     /**
-     * Map a target filesystem path through the resolved path mappings, or
-     * return null when no mapping applies. The deepest target prefix wins.
+     * Map a remote absolute path through the resolved path mappings, or
+     * return null when no mapping applies. The deepest remote prefix wins.
      *
-     * Matching mapping prefixes are nested, so the longest target prefix is
+     * Matching mapping prefixes are nested, so the longest remote prefix is
      * the most specific match.
      */
-    private function map_target_filesystem_path_with_resolved_mappings(
-        string $target_filesystem_path
+    private function map_remote_absolute_path_with_resolved_mappings(
+        string $remote_absolute_path
     ): ?string {
-        $local_filesystem_path = null;
-        $longest_target_prefix_length = -1;
+        $local_absolute_path = null;
+        $longest_remote_prefix_length = -1;
 
-        foreach ($this->resolved_path_mappings as $target_prefix => $local_prefix) {
-            $remainder = self::path_remainder_under($target_filesystem_path, $target_prefix);
-            if ($remainder !== null && strlen($target_prefix) > $longest_target_prefix_length) {
-                $local_filesystem_path = wp_join_unix_paths($local_prefix, $remainder);
-                $longest_target_prefix_length = strlen($target_prefix);
+        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
+            $remainder = self::path_remainder_under($remote_absolute_path, $remote_prefix);
+            if ($remainder !== null && strlen($remote_prefix) > $longest_remote_prefix_length) {
+                $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
+                $longest_remote_prefix_length = strlen($remote_prefix);
             }
         }
 
-        return $local_filesystem_path;
+        return $local_absolute_path;
     }
 
     /**
-     * Map a target filesystem path to a local filesystem path under the import
+     * Map a remote absolute path to a local absolute path under the filesystem
      * root. Symlink traversal checks prevent writes outside the filesystem root.
      *
-     * With --remap active, a matched target filesystem path is routed to its
-     * mapped local filesystem path. An unmatched path remains nested beneath
+     * With --remap active, a matched remote absolute path is routed to its
+     * mapped local absolute path. An unmatched path remains nested beneath
      * --fs-root, as in an identity pull mapping.
      */
-    private function map_target_filesystem_path_to_local_filesystem_path(
-        string $target_filesystem_path
+    private function map_remote_absolute_path_to_local_absolute_path(
+        string $remote_absolute_path
     ): string {
-        assert_valid_path($target_filesystem_path, "target filesystem path");
+        assert_valid_path($remote_absolute_path, "remote absolute path");
         if (!empty($this->resolved_path_mappings)) {
-            $local_filesystem_path = $this->map_target_filesystem_path_with_resolved_mappings(
-                $target_filesystem_path
+            $local_absolute_path = $this->map_remote_absolute_path_with_resolved_mappings(
+                $remote_absolute_path
             );
-            if ($local_filesystem_path !== null) {
-                return $local_filesystem_path;
+            if ($local_absolute_path !== null) {
+                return $local_absolute_path;
             }
         }
 
         // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
         // Use the same bundle mapping for copied content and rewritten symlink targets so the links do not dangle.
         if ($this->symlink_bundle_directory !== null
-            && !$this->path_is_within_original_export_scope($target_filesystem_path)) {
-            return $this->symlink_bundle_directory . $target_filesystem_path;
+            && !$this->path_is_within_original_export_scope($remote_absolute_path)) {
+            return $this->symlink_bundle_directory . $remote_absolute_path;
         }
 
-        return $this->get_filesystem_root_path() . $target_filesystem_path;
+        return $this->get_filesystem_root_path() . $remote_absolute_path;
     }
 
 
@@ -9075,7 +9098,7 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
+        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path($path);
 
         // Open file on first chunk
         if ($is_first) {
@@ -9083,12 +9106,12 @@ class ImportClient
             $context->skip_current_file = false;
 
             if (
-                (file_exists($local_path) || is_link($local_path)) &&
-                (!is_file($local_path) || is_link($local_path))
+                (file_exists($local_absolute_path) || is_link($local_absolute_path)) &&
+                (!is_file($local_absolute_path) || is_link($local_absolute_path))
             ) {
                 if (
-                    !$this->remove_local_filesystem_path_without_following_symlinks(
-                        $local_path
+                    !$this->remove_local_absolute_path_without_following_symlinks(
+                        $local_absolute_path
                     )
                 ) {
                     throw new RuntimeException(
@@ -9098,8 +9121,8 @@ class ImportClient
             }
 
             // Check if file exists locally
-            $exists_locally = file_exists($local_path);
-            $local_size = $exists_locally ? filesize($local_path) : 0;
+            $exists_locally = file_exists($local_absolute_path);
+            $local_size = $exists_locally ? filesize($local_absolute_path) : 0;
             $file_size = (int) ($headers["x-file-size"] ?? 0);
 
             // Log file import with useful context
@@ -9153,7 +9176,7 @@ class ImportClient
             }
 
             // Create parent directory if needed
-            $dir = dirname($local_path);
+            $dir = dirname($local_absolute_path);
             if (!is_dir($dir)) {
                 // Check if any component of the path exists as a file and remove it
                 try {
@@ -9167,11 +9190,11 @@ class ImportClient
             }
 
             // Open new file
-            $context->file_handle = fopen($local_path, "wb");
+            $context->file_handle = fopen($local_absolute_path, "wb");
             if (!$context->file_handle) {
                 $error = error_get_last();
                 throw new RuntimeException(
-                    "Failed to open file for writing: {$local_path}\n" .
+                    "Failed to open file for writing: {$local_absolute_path}\n" .
                         "Parent directory: {$dir}\n" .
                         "Directory exists: " .
                         (is_dir($dir) ? "yes" : "no") .
@@ -9180,7 +9203,7 @@ class ImportClient
                         ($error["message"] ?? "unknown"),
                 );
             }
-            $context->file_path = $local_path;
+            $context->file_path = $local_absolute_path;
             $context->file_ctime = (int) ($headers["x-file-ctime"] ?? 0);
             $context->file_bytes_written = 0;  // Reset byte counter for new file
         }
@@ -9264,36 +9287,38 @@ class ImportClient
 
     /**
      * Check whether any component of the path (between the filesystem root
-     * and the target) is a symlink.  In preserve-local mode this is used
+     * and the remote absolute path) is a symlink. In preserve-local mode this is used
      * to prevent creating new content through symlinked directories — their
      * contents belong to shared hosting infrastructure and must not be
      * modified.
      */
-    private function should_skip_for_preserve_local(string $path): ?string
+    private function should_skip_for_preserve_local(string $remote_absolute_path): ?string
     {
         if ($this->fs_root_nonempty_behavior !== 'preserve-local') {
             return null;
         }
 
-        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
+        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+            $remote_absolute_path
+        );
 
         // Skip if anything already exists at this path — regular file, symlink
         // (even to a file), or directory.  This preserves hosting symlinks like
         // wp-load.php -> __wp__/wp-load.php and drop-in symlinks like
         // object-cache.php -> ../../wordpress/drop-ins/...
-        if (file_exists($local_path) || is_link($local_path)) {
-            return "PRESERVE-LOCAL skip file (exists): {$path}";
+        if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
+            return "PRESERVE-LOCAL skip file (exists): {$remote_absolute_path}";
         }
 
         // Skip if parent directory is not writable or if any directory component
         // in the path is a symlink.  We never create new files through symlinks —
         // the symlink and its target contents are shared hosting infrastructure.
-        $dir = dirname($local_path);
+        $dir = dirname($local_absolute_path);
         if (is_dir($dir) && !is_writable($dir)) {
-            return "PRESERVE-LOCAL skip file (dir not writable): {$path}";
+            return "PRESERVE-LOCAL skip file (dir not writable): {$remote_absolute_path}";
         }
         if ($this->path_traverses_symlink($dir)) {
-            return "PRESERVE-LOCAL skip file (symlink in path): {$path}";
+            return "PRESERVE-LOCAL skip file (symlink in path): {$remote_absolute_path}";
         }
 
         return null;
@@ -9467,10 +9492,10 @@ class ImportClient
     {
         $headers = $chunk["headers"];
         $raw_header = $headers["x-directory-path"] ?? "";
-        $path = base64_decode($raw_header, true);
+        $remote_absolute_path = base64_decode($raw_header, true);
         $ctime = (int) ($headers["x-directory-ctime"] ?? 0);
 
-        if ($path === false || $path === "") {
+        if ($remote_absolute_path === false || $remote_absolute_path === "") {
             if ($raw_header !== "") {
                 $this->audit_log(
                     "Warning: base64_decode failed for x-directory-path header: " .
@@ -9481,57 +9506,59 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
+        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+            $remote_absolute_path
+        );
 
         // In preserve-local mode, if the directory already exists (as a real
         // directory or via a symlink to a directory), keep it as-is.
         // Also skip if any parent component is a symlink — we never create
         // new directories through symlinked paths.
         if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-            if (is_dir($local_path)) {
-                $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$path}", true);
-                $this->emit_skip_progress($path);
+            if (is_dir($local_absolute_path)) {
+                $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$remote_absolute_path}", true);
+                $this->emit_skip_progress($remote_absolute_path);
                 if ($ctime > 0) {
-                    $this->upsert_index_entry($path, $ctime, 0, "dir");
+                    $this->upsert_index_entry($remote_absolute_path, $ctime, 0, "dir");
                 }
                 return;
             }
-            if ($this->path_traverses_symlink($local_path)) {
-                $this->audit_log("PRESERVE-LOCAL skip directory (symlink in path): {$path}", true);
-                $this->emit_skip_progress($path);
+            if ($this->path_traverses_symlink($local_absolute_path)) {
+                $this->audit_log("PRESERVE-LOCAL skip directory (symlink in path): {$remote_absolute_path}", true);
+                $this->emit_skip_progress($remote_absolute_path);
                 if ($ctime > 0) {
-                    $this->upsert_index_entry($path, $ctime, 0, "dir");
+                    $this->upsert_index_entry($remote_absolute_path, $ctime, 0, "dir");
                 }
                 return;
             }
         }
 
         if (
-            (file_exists($local_path) || is_link($local_path)) &&
-            (!is_dir($local_path) || is_link($local_path))
+            (file_exists($local_absolute_path) || is_link($local_absolute_path)) &&
+            (!is_dir($local_absolute_path) || is_link($local_absolute_path))
         ) {
             if (
-                !$this->remove_local_filesystem_path_without_following_symlinks($local_path)
+                !$this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)
             ) {
                 throw new RuntimeException(
-                    "Failed to replace path with directory: {$path}",
+                    "Failed to replace path with directory: {$remote_absolute_path}",
                 );
             }
         }
 
         // Create directory, removing any files that block the path
         try {
-            $this->ensure_directory_path($local_path);
+            $this->ensure_directory_path($local_absolute_path);
         } catch (PreserveLocalSkipException $e) {
             $this->audit_log($e->getMessage(), true);
-            $this->emit_skip_progress($path);
+            $this->emit_skip_progress($remote_absolute_path);
             return;
         }
 
-        $this->audit_log("Directory: {$path}", false);
+        $this->audit_log("Directory: {$remote_absolute_path}", false);
 
         if ($ctime > 0) {
-            $this->upsert_index_entry($path, $ctime, 0, "dir");
+            $this->upsert_index_entry($remote_absolute_path, $ctime, 0, "dir");
         }
     }
 
@@ -9567,10 +9594,10 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->map_target_filesystem_path_to_local_filesystem_path($path);
+        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path($path);
         $target_for_local = $this->map_symlink_target_for_local_mirror(
             $path,
-            $local_path,
+            $local_absolute_path,
             $target,
         );
 
@@ -9579,12 +9606,12 @@ class ImportClient
         // Also skip if any parent component is a symlink — we never create
         // new content through symlinked directories.
         if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-            if (file_exists($local_path) || is_link($local_path)) {
+            if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
                 $this->audit_log("PRESERVE-LOCAL skip symlink (path exists): {$path} -> {$target}", true);
                 $this->emit_skip_progress($path);
                 return;
             }
-            if ($this->path_traverses_symlink(dirname($local_path))) {
+            if ($this->path_traverses_symlink(dirname($local_absolute_path))) {
                 $this->audit_log("PRESERVE-LOCAL skip symlink (symlink in path): {$path} -> {$target}", true);
                 $this->emit_skip_progress($path);
                 return;
@@ -9595,7 +9622,7 @@ class ImportClient
         $root = $this->get_filesystem_root_path();
         try {
             $this->assert_symlink_target_within_root(
-                dirname($local_path),
+                dirname($local_absolute_path),
                 $target_for_local,
                 $root
             );
@@ -9612,12 +9639,12 @@ class ImportClient
         }
 
         // Remove existing file/symlink if present
-        if (file_exists($local_path) || is_link($local_path)) {
+        if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
             if (
-                !$this->remove_local_filesystem_path_without_following_symlinks($local_path)
+                !$this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)
             ) {
                 $this->audit_log(
-                    "Failed to remove existing path for symlink: {$local_path}",
+                    "Failed to remove existing path for symlink: {$local_absolute_path}",
                     true,
                 );
                 $this->output_progress([
@@ -9632,7 +9659,7 @@ class ImportClient
         }
 
         // Create parent directory
-        $dir = dirname($local_path);
+        $dir = dirname($local_absolute_path);
         if (!is_dir($dir)) {
             try {
                 $this->ensure_directory_path($dir);
@@ -9658,11 +9685,11 @@ class ImportClient
         }
 
         // Create symlink
-        $symlink_result = symlink($target_for_local, $local_path);
-        if (true !== $symlink_result || !is_link($local_path)) {
+        $symlink_result = symlink($target_for_local, $local_absolute_path);
+        if (true !== $symlink_result || !is_link($local_absolute_path)) {
             // Log error and skip this symlink
             $this->audit_log(
-                "Failed to create symlink: {$local_path} -> {$target_for_local}",
+                "Failed to create symlink: {$local_absolute_path} -> {$target_for_local}",
                 true,
             );
             $this->output_progress([
@@ -9677,7 +9704,7 @@ class ImportClient
 
         // Try to set the ctime (may not work on all systems)
         if ($ctime > 0) {
-            @touch($local_path, $ctime);
+            @touch($local_absolute_path, $ctime);
         }
 
         $this->audit_log("Symlink: {$path} -> {$target_for_local}", false);
@@ -9728,8 +9755,8 @@ class ImportClient
             true,
         );
         if ($path !== "" && $is_file_error) {
-            $local_path = $this->filesystem_root . $path;
-            if ($context->file_handle && $context->file_path === $local_path) {
+            $local_absolute_path = $this->filesystem_root . $path;
+            if ($context->file_handle && $context->file_path === $local_absolute_path) {
                 fclose($context->file_handle);
                 $context->file_handle = null;
                 $context->file_path = null;
@@ -9737,8 +9764,8 @@ class ImportClient
                 $context->file_bytes_written = 0;
             }
 
-            if (file_exists($local_path)) {
-                @unlink($local_path);
+            if (file_exists($local_absolute_path)) {
+                @unlink($local_absolute_path);
             }
             $this->delete_index_entry($path);
 
@@ -12613,7 +12640,7 @@ if (
                 "Output files:\n" .
                 "  (filesystem root)/                              Downloaded files\n" .
                 "  .import-index.jsonl                     Local file index\n" .
-                "  .import-remote-index.jsonl              Target index snapshot\n" .
+                "  .import-remote-index.jsonl              Remote index snapshot\n" .
                 "  .import-download-list.jsonl             Files pending download\n" .
                 "  .import-download-list-skipped.jsonl     Skipped files (when --filter=essential-files)\n" .
                 "  .import-state.json                      Resumable state\n" .

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -972,9 +972,9 @@ class Pull
         $bold = "\033[1m";
         $dim = "\033[2m";
         $r = "\033[0m";
-        $import_root = $this->client->import_root;
+        $filesystem_root = $this->client->filesystem_root;
         $this->progress->print_line(
-            "\n{$green}{$bold}Done.{$r} {$dim}Files in {$import_root}{$r}\n"
+            "\n{$green}{$bold}Done.{$r} {$dim}Files in {$filesystem_root}{$r}\n"
         );
         if ($this->client->get_import_state()->pull_pipeline->skipped_pending) {
             $this->progress->print_line(

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -338,7 +338,7 @@ class Pull
             }
         }
 
-        $host = parse_url($this->client->target_url, PHP_URL_HOST) ?? $this->client->target_url;
+        $host = parse_url($this->client->remote_reprint_api_url, PHP_URL_HOST) ?? $this->client->remote_reprint_api_url;
         $bold = "\033[1m";
         $r = "\033[0m";
         $this->progress->print_line("\n{$bold}{$title} {$host}{$r}\n");
@@ -750,10 +750,10 @@ class Pull
      */
     private function normalize_url(): void
     {
-        $url = $this->client->target_url;
+        $url = $this->client->remote_reprint_api_url;
         if (strpos($url, 'site-export-api') === false) {
             $separator = strpos($url, '?') === false ? '?' : '&';
-            $this->client->target_url = $url . $separator . 'site-export-api';
+            $this->client->remote_reprint_api_url = $url . $separator . 'site-export-api';
         }
     }
 

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -292,15 +292,15 @@ class Pull
                 $state->current_file_bytes = null;
                 $state->diff = new FileDiffProgressState();
                 $state->index = new RemoteFileIndexCursorState();
-                $state->fetch = new DownloadListFetchProgressState();
-                $state->fetch_skipped = new DownloadListFetchProgressState();
+                $state->fetch = new FetchListProgressState();
+                $state->fetch_skipped = new FetchListProgressState();
                 $state->files_pull_summary = new FilesPullSummaryState();
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_import_state();
                 foreach ([
                     "{$state_dir}/.import-remote-index.jsonl",
-                    "{$state_dir}/.import-download-list.jsonl",
-                    "{$state_dir}/.import-download-list-skipped.jsonl",
+                    "{$state_dir}/.import-fetch-list.jsonl",
+                    "{$state_dir}/.import-fetch-list-skipped.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -808,8 +808,8 @@ class Pull
             $state->current_file = null;
             $state->current_file_bytes = null;
             $state->diff = new FileDiffProgressState();
-            $state->fetch = new DownloadListFetchProgressState();
-            $state->fetch_skipped = new DownloadListFetchProgressState();
+            $state->fetch = new FetchListProgressState();
+            $state->fetch_skipped = new FetchListProgressState();
             $state->files_pull_summary = new FilesPullSummaryState();
         }
         if ($reset_file_selection_state) {
@@ -827,8 +827,8 @@ class Pull
         $paths = [];
         if ($reset_file_transfer_state) {
             $paths[] = $state_dir . "/.import-remote-index.jsonl";
-            $paths[] = $state_dir . "/.import-download-list.jsonl";
-            $paths[] = $state_dir . "/.import-download-list-skipped.jsonl";
+            $paths[] = $state_dir . "/.import-fetch-list.jsonl";
+            $paths[] = $state_dir . "/.import-fetch-list-skipped.jsonl";
         }
         if ($reset_db_state) {
             $paths[] = $state_dir . "/db.sql";
@@ -978,7 +978,7 @@ class Pull
         );
         if ($this->client->get_import_state()->pull_pipeline->skipped_pending) {
             $this->progress->print_line(
-                "{$dim}Deferred files remain. The skipped download list was preserved on disk for a follow-up sync.{$r}\n"
+                "{$dim}Deferred files remain. The skipped fetch list was preserved on disk for a follow-up sync.{$r}\n"
             );
         }
     }

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -277,7 +277,7 @@ class Pull
             // high-level command skip its matching stage: the pipeline has not
             // recorded that stage as complete. Clear the direct command
             // checkpoint first so the stage computes a fresh delta.
-            $state_directory = $this->client->state_directory;
+            $state_dir = $this->client->state_dir;
             if ($state_command === 'files-pull' && in_array('files-pull', $stages, true)) {
                 // Keep the local file index, but clear transient files-pull
                 // download state so this pipeline computes a fresh
@@ -298,9 +298,9 @@ class Pull
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_import_state();
                 foreach ([
-                    "{$state_directory}/.import-remote-index.jsonl",
-                    "{$state_directory}/.import-download-list.jsonl",
-                    "{$state_directory}/.import-download-list-skipped.jsonl",
+                    "{$state_dir}/.import-remote-index.jsonl",
+                    "{$state_dir}/.import-download-list.jsonl",
+                    "{$state_dir}/.import-download-list-skipped.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -318,9 +318,9 @@ class Pull
                 $state->db_index = new DatabaseTableIndexState();
                 $this->client->save_import_state();
                 foreach ([
-                    "{$state_directory}/db.sql",
-                    "{$state_directory}/db-tables.jsonl",
-                    "{$state_directory}/.import-domains.json",
+                    "{$state_dir}/db.sql",
+                    "{$state_dir}/db-tables.jsonl",
+                    "{$state_dir}/.import-domains.json",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -462,13 +462,13 @@ class Pull
                 if (
                     $state->active_resumable_command->command_name !== 'db-pull' ||
                     $state->active_resumable_command->completion_state !== 'complete' ||
-                    !file_exists($this->client->state_directory . '/db.sql')
+                    !file_exists($this->client->state_dir . '/db.sql')
                 ) {
                     $this->run_until_complete('db-pull', function () {
                         $this->client->run_db_sync();
                     });
                 }
-                $sql_file = $this->client->state_directory . "/db.sql";
+                $sql_file = $this->client->state_dir . "/db.sql";
                 $size = null;
                 if (file_exists($sql_file)) {
                     $bytes = filesize($sql_file);
@@ -566,7 +566,7 @@ class Pull
         $options = $this->validate_database_target_options($options);
 
         if (empty($options['output_dir'])) {
-            $options['output_dir'] = $this->client->state_directory . '/runtime';
+            $options['output_dir'] = $this->client->state_dir . '/runtime';
         }
 
         if (!isset($options['filter'])) {
@@ -767,7 +767,7 @@ class Pull
      */
     private function prepare_repull(string $command): void
     {
-        $state_directory = $this->client->state_directory;
+        $state_dir = $this->client->state_dir;
         switch ($command) {
             case 'pull':
                 $reset_file_transfer_state = true;
@@ -826,14 +826,14 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $state_directory . "/.import-remote-index.jsonl";
-            $paths[] = $state_directory . "/.import-download-list.jsonl";
-            $paths[] = $state_directory . "/.import-download-list-skipped.jsonl";
+            $paths[] = $state_dir . "/.import-remote-index.jsonl";
+            $paths[] = $state_dir . "/.import-download-list.jsonl";
+            $paths[] = $state_dir . "/.import-download-list-skipped.jsonl";
         }
         if ($reset_db_state) {
-            $paths[] = $state_directory . "/db.sql";
-            $paths[] = $state_directory . "/db-tables.jsonl";
-            $paths[] = $state_directory . "/.import-domains.json";
+            $paths[] = $state_dir . "/db.sql";
+            $paths[] = $state_dir . "/db-tables.jsonl";
+            $paths[] = $state_dir . "/.import-domains.json";
         }
 
         foreach ($paths as $path) {
@@ -878,7 +878,7 @@ class Pull
      */
     private function start_server(array $options): void
     {
-        $output_dir = $options['output_dir'] ?? $this->client->state_directory . '/runtime';
+        $output_dir = $options['output_dir'] ?? $this->client->state_dir . '/runtime';
         $start_sh = $output_dir . '/start.sh';
 
         if (!file_exists($start_sh)) {

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -277,7 +277,7 @@ class Pull
             // high-level command skip its matching stage: the pipeline has not
             // recorded that stage as complete. Clear the direct command
             // checkpoint first so the stage computes a fresh delta.
-            $state_dir = $this->client->state_dir;
+            $state_directory = $this->client->state_directory;
             if ($state_command === 'files-pull' && in_array('files-pull', $stages, true)) {
                 // Keep the local file index, but clear transient files-pull
                 // download state so this pipeline computes a fresh
@@ -298,9 +298,9 @@ class Pull
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_import_state();
                 foreach ([
-                    "{$state_dir}/.import-remote-index.jsonl",
-                    "{$state_dir}/.import-download-list.jsonl",
-                    "{$state_dir}/.import-download-list-skipped.jsonl",
+                    "{$state_directory}/.import-remote-index.jsonl",
+                    "{$state_directory}/.import-download-list.jsonl",
+                    "{$state_directory}/.import-download-list-skipped.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -318,9 +318,9 @@ class Pull
                 $state->db_index = new DatabaseTableIndexState();
                 $this->client->save_import_state();
                 foreach ([
-                    "{$state_dir}/db.sql",
-                    "{$state_dir}/db-tables.jsonl",
-                    "{$state_dir}/.import-domains.json",
+                    "{$state_directory}/db.sql",
+                    "{$state_directory}/db-tables.jsonl",
+                    "{$state_directory}/.import-domains.json",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -338,7 +338,7 @@ class Pull
             }
         }
 
-        $host = parse_url($this->client->remote_url, PHP_URL_HOST) ?? $this->client->remote_url;
+        $host = parse_url($this->client->target_url, PHP_URL_HOST) ?? $this->client->target_url;
         $bold = "\033[1m";
         $r = "\033[0m";
         $this->progress->print_line("\n{$bold}{$title} {$host}{$r}\n");
@@ -462,13 +462,13 @@ class Pull
                 if (
                     $state->active_resumable_command->command_name !== 'db-pull' ||
                     $state->active_resumable_command->completion_state !== 'complete' ||
-                    !file_exists($this->client->state_dir . '/db.sql')
+                    !file_exists($this->client->state_directory . '/db.sql')
                 ) {
                     $this->run_until_complete('db-pull', function () {
                         $this->client->run_db_sync();
                     });
                 }
-                $sql_file = $this->client->state_dir . "/db.sql";
+                $sql_file = $this->client->state_directory . "/db.sql";
                 $size = null;
                 if (file_exists($sql_file)) {
                     $bytes = filesize($sql_file);
@@ -566,7 +566,7 @@ class Pull
         $options = $this->validate_database_target_options($options);
 
         if (empty($options['output_dir'])) {
-            $options['output_dir'] = $this->client->state_dir . '/runtime';
+            $options['output_dir'] = $this->client->state_directory . '/runtime';
         }
 
         if (!isset($options['filter'])) {
@@ -750,10 +750,10 @@ class Pull
      */
     private function normalize_url(): void
     {
-        $url = $this->client->remote_url;
+        $url = $this->client->target_url;
         if (strpos($url, 'site-export-api') === false) {
             $separator = strpos($url, '?') === false ? '?' : '&';
-            $this->client->remote_url = $url . $separator . 'site-export-api';
+            $this->client->target_url = $url . $separator . 'site-export-api';
         }
     }
 
@@ -767,7 +767,7 @@ class Pull
      */
     private function prepare_repull(string $command): void
     {
-        $state_dir = $this->client->state_dir;
+        $state_directory = $this->client->state_directory;
         switch ($command) {
             case 'pull':
                 $reset_file_transfer_state = true;
@@ -826,14 +826,14 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $state_dir . "/.import-remote-index.jsonl";
-            $paths[] = $state_dir . "/.import-download-list.jsonl";
-            $paths[] = $state_dir . "/.import-download-list-skipped.jsonl";
+            $paths[] = $state_directory . "/.import-remote-index.jsonl";
+            $paths[] = $state_directory . "/.import-download-list.jsonl";
+            $paths[] = $state_directory . "/.import-download-list-skipped.jsonl";
         }
         if ($reset_db_state) {
-            $paths[] = $state_dir . "/db.sql";
-            $paths[] = $state_dir . "/db-tables.jsonl";
-            $paths[] = $state_dir . "/.import-domains.json";
+            $paths[] = $state_directory . "/db.sql";
+            $paths[] = $state_directory . "/db-tables.jsonl";
+            $paths[] = $state_directory . "/.import-domains.json";
         }
 
         foreach ($paths as $path) {
@@ -878,7 +878,7 @@ class Pull
      */
     private function start_server(array $options): void
     {
-        $output_dir = $options['output_dir'] ?? $this->client->state_dir . '/runtime';
+        $output_dir = $options['output_dir'] ?? $this->client->state_directory . '/runtime';
         $start_sh = $output_dir . '/start.sh';
 
         if (!file_exists($start_sh)) {
@@ -972,9 +972,9 @@ class Pull
         $bold = "\033[1m";
         $dim = "\033[2m";
         $r = "\033[0m";
-        $fs_root = $this->client->fs_root;
+        $import_root = $this->client->import_root;
         $this->progress->print_line(
-            "\n{$green}{$bold}Done.{$r} {$dim}Files in {$fs_root}{$r}\n"
+            "\n{$green}{$bold}Done.{$r} {$dim}Files in {$import_root}{$r}\n"
         );
         if ($this->client->get_import_state()->pull_pipeline->skipped_pending) {
             $this->progress->print_line(

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -18,7 +18,7 @@ class PullFailureReportedException extends RuntimeException
  * subset, and `pull-db` runs the database subset.
  *
  * The class holds a reference to ImportClient because each stage
- * delegates to an ImportClient method (run_preflight, run_files_sync,
+ * delegates to an ImportClient method (run_preflight, run_files_pull,
  * etc.). The orchestration logic (pipeline state, retry loop, stage
  * framing) lives here; the actual transfer logic stays in ImportClient.
  */
@@ -435,7 +435,7 @@ class Pull
             case 'files-pull':
                 $this->client->prepare_files_pull_options($options);
                 $this->run_until_complete('files-pull', function () {
-                    $this->client->run_files_sync();
+                    $this->client->run_files_pull();
                 });
                 $skipped_pending =
                     $options['filter'] === 'essential-files' &&

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -82,7 +82,7 @@
  * local index used for planning. The sender compares the live path with those
  * values before sending and again after each read. A difference removes the
  * upload-only push session, because its work and the planned local index no
- * longer describe the same local document root.
+ * longer describe the same filesystem root.
  *
  * Receiver-confirmed file and deletion-list positions are never copied into
  * active state. A newly opened sender reads them from `push_status`; a
@@ -126,8 +126,8 @@
  */
 final class PushFilesSender
 {
-    /** @var string Local document root whose local paths to push are sent. */
-    private string $docroot;
+    /** @var string Filesystem root whose local paths to push are sent. */
+    private string $filesystem_root;
 
     /** @var string Local push state directory owned by this sender. */
     private string $push_state_directory;
@@ -231,7 +231,7 @@ final class PushFilesSender
      * @param array $options {
      *     Push, push stream client, and local-file options.
      *
-     *     @type string                  $docroot                Required local document-root directory.
+     *     @type string                  $filesystem_root                Required filesystem root directory.
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $base_url                Required exporter API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
@@ -329,10 +329,10 @@ final class PushFilesSender
      */
     private function __construct(array $options, ReprintProcessLock $process_lock)
     {
-        $docroot = $options['docroot'] ?? null;
+        $filesystem_root = $options['filesystem_root'] ?? null;
         $push_state_directory = $options['push_state_directory'] ?? null;
-        if (!is_string($docroot) || !is_dir($docroot) || is_link($docroot)) {
-            throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
+        if (!is_string($filesystem_root) || !is_dir($filesystem_root) || is_link($filesystem_root)) {
+            throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
         if (!is_string($push_state_directory) || $push_state_directory === '') {
             throw new InvalidArgumentException('PushFilesSender requires a push_state_directory.');
@@ -356,11 +356,11 @@ final class PushFilesSender
             }
         }
 
-        $resolved_local_document_root = realpath($docroot);
-        if ($resolved_local_document_root === false) {
-            throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
+        $resolved_filesystem_root = realpath($filesystem_root);
+        if ($resolved_filesystem_root === false) {
+            throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
-        $this->docroot = rtrim($resolved_local_document_root, '/');
+        $this->filesystem_root = rtrim($resolved_filesystem_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
@@ -586,7 +586,7 @@ final class PushFilesSender
     {
         $this->plan = PushPlan::start(
             $this->plan_directory,
-            $this->docroot,
+            $this->filesystem_root,
             $this->previous_local_index,
             $this->excluded_paths_path
         );
@@ -778,7 +778,7 @@ final class PushFilesSender
             ];
             $upload_completes_local_path = true;
         } elseif ($local_path_type_size_and_ctime['type'] === 'symlink') {
-            $symlink_target = @readlink($this->docroot . '/' . $local_path_to_push['path']);
+            $symlink_target = @readlink($this->filesystem_root . '/' . $local_path_to_push['path']);
             $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
@@ -824,7 +824,7 @@ final class PushFilesSender
                 $local_io_failure_detail = null;
                 if (!is_resource($this->local_file_handle)) {
                     $this->local_file_handle = fopen(
-                        $this->docroot . '/' . $local_path_to_push['path'],
+                        $this->filesystem_root . '/' . $local_path_to_push['path'],
                         'rb'
                     );
                 }
@@ -1119,7 +1119,7 @@ final class PushFilesSender
     }
 
     /**
-     * Moves a changed local document root to push-session removal.
+     * Moves a changed filesystem root to push-session removal.
      */
     private function start_removing_push_session_after_local_change(): void
     {
@@ -1424,7 +1424,7 @@ final class PushFilesSender
      */
     private function directory_is_empty(string $path): ?bool
     {
-        $directory_handle = @opendir($this->docroot . '/' . $path);
+        $directory_handle = @opendir($this->filesystem_root . '/' . $path);
         if ($directory_handle === false) {
             return null;
         }
@@ -1456,7 +1456,7 @@ final class PushFilesSender
      */
     private function stat_local_path(string $path): ?array
     {
-        $absolute_path = $this->docroot . '/' . $path;
+        $absolute_path = $this->filesystem_root . '/' . $path;
         clearstatcache(true, $absolute_path);
         $path_stat = @lstat($absolute_path);
         if (!is_array($path_stat)) {

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -356,11 +356,11 @@ final class PushFilesSender
             }
         }
 
-        $resolved_filesystem_root = realpath($filesystem_root);
-        if ($resolved_filesystem_root === false) {
+        $resolved_local_filesystem_root = realpath($filesystem_root);
+        if ($resolved_local_filesystem_root === false) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
-        $this->filesystem_root = rtrim($resolved_filesystem_root, '/');
+        $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -82,7 +82,7 @@
  * local index used for planning. The sender compares the live path with those
  * values before sending and again after each read. A difference removes the
  * upload-only push session, because its work and the planned local index no
- * longer describe the same local tree.
+ * longer describe the same local document root.
  *
  * Receiver-confirmed file and deletion-list positions are never copied into
  * active state. A newly opened sender reads them from `push_status`; a
@@ -356,11 +356,11 @@ final class PushFilesSender
             }
         }
 
-        $canonical_docroot = realpath($docroot);
-        if ($canonical_docroot === false) {
+        $resolved_local_document_root = realpath($docroot);
+        if ($resolved_local_document_root === false) {
             throw new InvalidArgumentException('PushFilesSender requires a real docroot directory.');
         }
-        $this->docroot = rtrim($canonical_docroot, '/');
+        $this->docroot = rtrim($resolved_local_document_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
@@ -1119,7 +1119,7 @@ final class PushFilesSender
     }
 
     /**
-     * Moves a changed local tree to push-session removal.
+     * Moves a changed local document root to push-session removal.
      */
     private function start_removing_push_session_after_local_change(): void
     {

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -233,7 +233,7 @@ final class PushFilesSender
      *
      *     @type string                  $filesystem_root                Required filesystem root directory.
      *     @type string                  $push_state_directory    Required local push state directory.
-     *     @type string                  $base_url                Required exporter API URL.
+     *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
      *     @type int|float|string        $chunk_bytes             Maximum bytes read from one local file. Default 4 MiB.
@@ -346,7 +346,7 @@ final class PushFilesSender
         }
 
         $push_stream_client_options = [
-            'base_url' => $options['base_url'] ?? null,
+            'remote_reprint_api_url' => $options['remote_reprint_api_url'] ?? null,
             'hmac_client' => $options['hmac_client'] ?? null,
             'allow_http' => $options['allow_http'] ?? false,
         ];

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -273,11 +273,11 @@ class PushPlan
     private function set_filesystem_root(string $filesystem_root): void
     {
         clearstatcache(true, $filesystem_root);
-        $resolved_filesystem_root = realpath($filesystem_root);
-        if ($resolved_filesystem_root === false || !is_dir($resolved_filesystem_root) || is_link($filesystem_root)) {
+        $resolved_local_filesystem_root = realpath($filesystem_root);
+        if ($resolved_local_filesystem_root === false || !is_dir($resolved_local_filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException("PushPlan requires the filesystem root to be a real directory.");
         }
-        $this->filesystem_root = rtrim($resolved_filesystem_root, "/");
+        $this->filesystem_root = rtrim($resolved_local_filesystem_root, "/");
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -66,8 +66,8 @@
  */
 class PushPlan
 {
-    /** @var string Resolved local document root inspected while building the fresh local index. */
-    private string $local_document_root;
+    /** @var string Resolved filesystem root inspected while building the fresh local index. */
+    private string $filesystem_root;
 
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
@@ -136,18 +136,18 @@ class PushPlan
      * an interrupted start is repeated and overwrites these initial plan files.
      *
      * @param string $plan_directory              Caller-owned active plan directory.
-     * @param string $local_document_root              Resolved local document root.
+     * @param string $filesystem_root              Resolved filesystem root.
      * @param string $previous_local_index Previous local index this plan diffs against.
      * @param string $excluded_paths_path          Caller-owned target exclusions file.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
-        string $local_document_root,
+        string $filesystem_root,
         string $previous_local_index,
         string $excluded_paths_path
     ): self {
-        $plan = new self($plan_directory, $local_document_root, $previous_local_index);
+        $plan = new self($plan_directory, $filesystem_root, $previous_local_index);
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -157,15 +157,15 @@ class PushPlan
             throw new RuntimeException("Failed to open the fresh local index: {$plan->fresh_local_index}");
         }
         $plan->file_index_processor = FileIndexProcessor::start(
-            [$plan->local_document_root],
-            $plan->local_document_root,
+            [$plan->filesystem_root],
+            $plan->filesystem_root,
             false,
             false,
             $plan->plan_directory
         );
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
-            "local_tree_root" => $plan->local_document_root,
+            "local_tree_root" => $plan->filesystem_root,
             "previous_local_index" => $plan->previous_local_index,
             "position" => [
                 "phase" => "indexing",
@@ -243,12 +243,12 @@ class PushPlan
      * Initializes paths in the caller-owned active plan directory.
      *
      * @param string $plan_directory              Caller-owned active plan directory.
-     * @param string $local_document_root              Resolved local document root.
+     * @param string $filesystem_root              Resolved filesystem root.
      * @param string $previous_local_index Previous local index this plan diffs against.
      */
     private function __construct(
         string $plan_directory,
-        string $local_document_root,
+        string $filesystem_root,
         string $previous_local_index
     ) {
         $plan_directory = rtrim($plan_directory, "/");
@@ -256,7 +256,7 @@ class PushPlan
             throw new LogicException("Cannot open a push plan without its directory: {$plan_directory}");
         }
         $this->plan_directory = $plan_directory;
-        $this->set_local_document_root($local_document_root);
+        $this->set_filesystem_root($filesystem_root);
         $this->previous_local_index = $previous_local_index;
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
@@ -266,18 +266,18 @@ class PushPlan
     }
 
     /**
-     * Stores the resolved local document root represented by this plan.
+     * Stores the resolved filesystem root represented by this plan.
      *
-     * @param string $local_document_root Local tree root selected by the caller.
+     * @param string $filesystem_root Filesystem root selected by the caller.
      */
-    private function set_local_document_root(string $local_document_root): void
+    private function set_filesystem_root(string $filesystem_root): void
     {
-        clearstatcache(true, $local_document_root);
-        $resolved_local_document_root = realpath($local_document_root);
-        if ($resolved_local_document_root === false || !is_dir($resolved_local_document_root) || is_link($local_document_root)) {
-            throw new InvalidArgumentException("PushPlan requires the local document root to be a real directory.");
+        clearstatcache(true, $filesystem_root);
+        $resolved_filesystem_root = realpath($filesystem_root);
+        if ($resolved_filesystem_root === false || !is_dir($resolved_filesystem_root) || is_link($filesystem_root)) {
+            throw new InvalidArgumentException("PushPlan requires the filesystem root to be a real directory.");
         }
-        $this->local_document_root = rtrim($resolved_local_document_root, "/");
+        $this->filesystem_root = rtrim($resolved_filesystem_root, "/");
     }
 
     /**
@@ -301,7 +301,7 @@ class PushPlan
             throw new RuntimeException("Failed to seek to the fresh local index byte offset.");
         }
         $this->file_index_processor = FileIndexProcessor::resume(
-            [$this->local_document_root],
+            [$this->filesystem_root],
             json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
             false,
             false,
@@ -484,7 +484,7 @@ class PushPlan
             );
         }
 
-        $local_path = substr($index_entry["path"], strlen($this->local_document_root) + 1);
+        $local_path = substr($index_entry["path"], strlen($this->filesystem_root) + 1);
         $fresh_local_index_entry = [
             "path" => base64_encode($local_path),
             "ctime" => $index_entry["ctime"],

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -66,8 +66,8 @@
  */
 class PushPlan
 {
-    /** @var string Canonical local tree root inspected while building the fresh local index. */
-    private string $local_tree_root;
+    /** @var string Resolved local document root inspected while building the fresh local index. */
+    private string $local_document_root;
 
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
@@ -136,18 +136,18 @@ class PushPlan
      * an interrupted start is repeated and overwrites these initial plan files.
      *
      * @param string $plan_directory              Caller-owned active plan directory.
-     * @param string $local_tree_root              Canonical local tree root.
+     * @param string $local_document_root              Resolved local document root.
      * @param string $previous_local_index Previous local index this plan diffs against.
      * @param string $excluded_paths_path          Caller-owned target exclusions file.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
-        string $local_tree_root,
+        string $local_document_root,
         string $previous_local_index,
         string $excluded_paths_path
     ): self {
-        $plan = new self($plan_directory, $local_tree_root, $previous_local_index);
+        $plan = new self($plan_directory, $local_document_root, $previous_local_index);
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -157,15 +157,15 @@ class PushPlan
             throw new RuntimeException("Failed to open the fresh local index: {$plan->fresh_local_index}");
         }
         $plan->file_index_processor = FileIndexProcessor::start(
-            [$plan->local_tree_root],
-            $plan->local_tree_root,
+            [$plan->local_document_root],
+            $plan->local_document_root,
             false,
             false,
             $plan->plan_directory
         );
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
-            "local_tree_root" => $plan->local_tree_root,
+            "local_tree_root" => $plan->local_document_root,
             "previous_local_index" => $plan->previous_local_index,
             "position" => [
                 "phase" => "indexing",
@@ -243,12 +243,12 @@ class PushPlan
      * Initializes paths in the caller-owned active plan directory.
      *
      * @param string $plan_directory              Caller-owned active plan directory.
-     * @param string $local_tree_root              Canonical local tree root.
+     * @param string $local_document_root              Resolved local document root.
      * @param string $previous_local_index Previous local index this plan diffs against.
      */
     private function __construct(
         string $plan_directory,
-        string $local_tree_root,
+        string $local_document_root,
         string $previous_local_index
     ) {
         $plan_directory = rtrim($plan_directory, "/");
@@ -256,7 +256,7 @@ class PushPlan
             throw new LogicException("Cannot open a push plan without its directory: {$plan_directory}");
         }
         $this->plan_directory = $plan_directory;
-        $this->set_local_tree_root($local_tree_root);
+        $this->set_local_document_root($local_document_root);
         $this->previous_local_index = $previous_local_index;
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
@@ -266,18 +266,18 @@ class PushPlan
     }
 
     /**
-     * Stores the canonical root of the local tree represented by this plan.
+     * Stores the resolved local document root represented by this plan.
      *
-     * @param string $local_tree_root Local tree root selected by the caller.
+     * @param string $local_document_root Local tree root selected by the caller.
      */
-    private function set_local_tree_root(string $local_tree_root): void
+    private function set_local_document_root(string $local_document_root): void
     {
-        clearstatcache(true, $local_tree_root);
-        $canonical_local_tree_root = realpath($local_tree_root);
-        if ($canonical_local_tree_root === false || !is_dir($canonical_local_tree_root) || is_link($local_tree_root)) {
-            throw new InvalidArgumentException("PushPlan requires the local tree root to be a real directory.");
+        clearstatcache(true, $local_document_root);
+        $resolved_local_document_root = realpath($local_document_root);
+        if ($resolved_local_document_root === false || !is_dir($resolved_local_document_root) || is_link($local_document_root)) {
+            throw new InvalidArgumentException("PushPlan requires the local document root to be a real directory.");
         }
-        $this->local_tree_root = rtrim($canonical_local_tree_root, "/");
+        $this->local_document_root = rtrim($resolved_local_document_root, "/");
     }
 
     /**
@@ -301,7 +301,7 @@ class PushPlan
             throw new RuntimeException("Failed to seek to the fresh local index byte offset.");
         }
         $this->file_index_processor = FileIndexProcessor::resume(
-            [$this->local_tree_root],
+            [$this->local_document_root],
             json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
             false,
             false,
@@ -484,7 +484,7 @@ class PushPlan
             );
         }
 
-        $local_path = substr($index_entry["path"], strlen($this->local_tree_root) + 1);
+        $local_path = substr($index_entry["path"], strlen($this->local_document_root) + 1);
         $fresh_local_index_entry = [
             "path" => base64_encode($local_path),
             "ctime" => $index_entry["ctime"],

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -125,9 +125,9 @@ class RemoteFileIndexCursorState
     }
 }
 
-class DownloadListFetchProgressState
+class FetchListProgressState
 {
-    /** @var int Current byte offset into the download-list file. */
+    /** @var int Current byte offset into the fetch-list file. */
     public int $offset = 0;
 
     /** @var int Next byte offset after the current batch. */
@@ -364,8 +364,8 @@ class ImportState
     public DatabaseTableIndexState $db_index;
     public FileDiffProgressState $diff;
     public RemoteFileIndexCursorState $index;
-    public DownloadListFetchProgressState $fetch;
-    public DownloadListFetchProgressState $fetch_skipped;
+    public FetchListProgressState $fetch;
+    public FetchListProgressState $fetch_skipped;
     /** @var string|null Path to the file being written for crash recovery. */
     public ?string $current_file = null;
     /** @var int|null Expected bytes written to the current file. */
@@ -402,8 +402,8 @@ class ImportState
         $this->db_index = new DatabaseTableIndexState();
         $this->diff = new FileDiffProgressState();
         $this->index = new RemoteFileIndexCursorState();
-        $this->fetch = new DownloadListFetchProgressState();
-        $this->fetch_skipped = new DownloadListFetchProgressState();
+        $this->fetch = new FetchListProgressState();
+        $this->fetch_skipped = new FetchListProgressState();
         $this->files_pull_summary = new FilesPullSummaryState();
         $this->apply = new DatabaseApplyCommandState();
         $this->tuning = new AdaptiveTuningState();
@@ -431,8 +431,8 @@ class ImportState
         $state->db_index = self::database_table_index_from($data['db_index'] ?? []);
         $state->diff = self::file_diff_progress_from($data['diff'] ?? []);
         $state->index = self::remote_file_index_cursor_from($data['index'] ?? []);
-        $state->fetch = self::download_list_fetch_progress_from($data['fetch'] ?? []);
-        $state->fetch_skipped = self::download_list_fetch_progress_from($data['fetch_skipped'] ?? []);
+        $state->fetch = self::fetch_list_progress_from($data['fetch'] ?? []);
+        $state->fetch_skipped = self::fetch_list_progress_from($data['fetch_skipped'] ?? []);
         $state->current_file = isset($data['current_file']) ? (string) $data['current_file'] : null;
         $state->current_file_bytes = isset($data['current_file_bytes']) ? (int) $data['current_file_bytes'] : null;
         $state->sql_bytes = isset($data['sql_bytes']) ? (int) $data['sql_bytes'] : null;
@@ -516,9 +516,9 @@ class ImportState
         return $value instanceof RemoteFileIndexCursorState ? $value : RemoteFileIndexCursorState::from_array(is_array($value) ? $value : []);
     }
 
-    private static function download_list_fetch_progress_from($value): DownloadListFetchProgressState
+    private static function fetch_list_progress_from($value): FetchListProgressState
     {
-        return $value instanceof DownloadListFetchProgressState ? $value : DownloadListFetchProgressState::from_array(is_array($value) ? $value : []);
+        return $value instanceof FetchListProgressState ? $value : FetchListProgressState::from_array(is_array($value) ? $value : []);
     }
 
     private static function database_apply_command_from($value): DatabaseApplyCommandState

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -351,8 +351,8 @@ class ImportState
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
     public bool $follow_symlinks = true;
-    /** @var string|null Fingerprint of the --follow-symlinks bundle directory; guards resume. */
-    public ?string $symlink_bundle_directory_fingerprint = null;
+    /** @var string|null Fingerprint of the local followed symlinks root; guards resume. */
+    public ?string $local_followed_symlinks_root_fingerprint = null;
     public string $fs_root_nonempty_behavior = 'error';
     public string $filter = 'none';
     /** @var string|null User-Agent that worked during preflight. */
@@ -421,7 +421,7 @@ class ImportState
         $state->version = isset($data['version']) ? (string) $data['version'] : null;
         $state->webhost = isset($data['webhost']) ? (string) $data['webhost'] : null;
         $state->follow_symlinks = (bool) ($data['follow_symlinks'] ?? true);
-        $state->symlink_bundle_directory_fingerprint = isset($data['symlink_bundle_directory_fingerprint']) ? (string) $data['symlink_bundle_directory_fingerprint'] : null;
+        $state->local_followed_symlinks_root_fingerprint = isset($data['local_followed_symlinks_root_fingerprint']) ? (string) $data['local_followed_symlinks_root_fingerprint'] : null;
         $state->fs_root_nonempty_behavior = isset($data['fs_root_nonempty_behavior']) ? (string) $data['fs_root_nonempty_behavior'] : 'error';
         $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
         $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
@@ -463,7 +463,7 @@ class ImportState
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
-            'symlink_bundle_directory_fingerprint' => $this->symlink_bundle_directory_fingerprint,
+            'local_followed_symlinks_root_fingerprint' => $this->local_followed_symlinks_root_fingerprint,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -358,7 +358,8 @@ class ImportState
     /** @var string|null User-Agent that worked during preflight. */
     public ?string $user_agent = null;
     public ?int $max_allowed_packet = null;
-    public ?string $files_remap_fingerprint = null;
+    /** @var string|null Fingerprint of resolved path mappings; guards files-pull reuse. */
+    public ?string $resolved_path_mappings_fingerprint = null;
     public ?string $files_pull_only_fingerprint = null;
     public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;
@@ -425,7 +426,7 @@ class ImportState
         $state->filter = isset($data['filter']) ? (string) $data['filter'] : 'none';
         $state->user_agent = isset($data['user_agent']) ? (string) $data['user_agent'] : null;
         $state->max_allowed_packet = isset($data['max_allowed_packet']) ? (int) $data['max_allowed_packet'] : null;
-        $state->files_remap_fingerprint = isset($data['files_remap_fingerprint']) ? (string) $data['files_remap_fingerprint'] : null;
+        $state->resolved_path_mappings_fingerprint = isset($data['resolved_path_mappings_fingerprint']) ? (string) $data['resolved_path_mappings_fingerprint'] : null;
         $state->files_pull_only_fingerprint = isset($data['files_pull_only_fingerprint']) ? (string) $data['files_pull_only_fingerprint'] : null;
         $state->files_pull_summary = self::files_pull_summary_from($data['files_pull_summary'] ?? []);
         $state->db_index = self::database_table_index_from($data['db_index'] ?? []);
@@ -467,7 +468,7 @@ class ImportState
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,
             'max_allowed_packet' => $this->max_allowed_packet,
-            'files_remap_fingerprint' => $this->files_remap_fingerprint,
+            'resolved_path_mappings_fingerprint' => $this->resolved_path_mappings_fingerprint,
             'files_pull_only_fingerprint' => $this->files_pull_only_fingerprint,
             'files_pull_summary' => $this->files_pull_summary->to_array(),
             'db_index' => $this->db_index->to_array(),

--- a/packages/reprint-importer/src/lib/target-runtime/class-nginx-fpm-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-nginx-fpm-applier.php
@@ -14,7 +14,7 @@
  */
 class NginxFpmApplier implements RuntimeApplier
 {
-    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $filesystem_root, string $output_dir, array $options = []): array
     {
         $host = $options['host'] ?? 'localhost';
         $port = (int) ($options['port'] ?? 80);
@@ -23,13 +23,13 @@ class NginxFpmApplier implements RuntimeApplier
 
         // 1. Write runtime.php
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $import_root);
+        $runtime = generate_runtime_php($manifest, $filesystem_root);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write nginx.conf (includes auto_prepend_file + INI directives)
         $nginx_conf_path = $output_dir . '/nginx.conf';
-        $nginx_conf = $this->generate_nginx_conf($manifest, $import_root, $runtime_path, $host, $port);
+        $nginx_conf = $this->generate_nginx_conf($manifest, $filesystem_root, $runtime_path, $host, $port);
         write_runtime_file($nginx_conf_path, $nginx_conf);
         $summary[] = "Wrote {$nginx_conf_path}";
 
@@ -51,7 +51,7 @@ class NginxFpmApplier implements RuntimeApplier
      */
     private function generate_nginx_conf(
         RuntimeManifest $manifest,
-        string $import_root,
+        string $filesystem_root,
         string $runtime_path,
         string $host,
         int $port
@@ -63,7 +63,7 @@ class NginxFpmApplier implements RuntimeApplier
         $lines[] = 'server {';
         $lines[] = "    listen {$port};";
         $lines[] = "    server_name {$host};";
-        $lines[] = "    root {$import_root};";
+        $lines[] = "    root {$filesystem_root};";
         $lines[] = '    index index.php index.html;';
         $lines[] = '';
         $lines[] = '    # Static files served directly by nginx — no PHP involved.';

--- a/packages/reprint-importer/src/lib/target-runtime/class-nginx-fpm-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-nginx-fpm-applier.php
@@ -14,7 +14,7 @@
  */
 class NginxFpmApplier implements RuntimeApplier
 {
-    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array
     {
         $host = $options['host'] ?? 'localhost';
         $port = (int) ($options['port'] ?? 80);
@@ -23,13 +23,13 @@ class NginxFpmApplier implements RuntimeApplier
 
         // 1. Write runtime.php
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $fs_root);
+        $runtime = generate_runtime_php($manifest, $import_root);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write nginx.conf (includes auto_prepend_file + INI directives)
         $nginx_conf_path = $output_dir . '/nginx.conf';
-        $nginx_conf = $this->generate_nginx_conf($manifest, $fs_root, $runtime_path, $host, $port);
+        $nginx_conf = $this->generate_nginx_conf($manifest, $import_root, $runtime_path, $host, $port);
         write_runtime_file($nginx_conf_path, $nginx_conf);
         $summary[] = "Wrote {$nginx_conf_path}";
 
@@ -51,7 +51,7 @@ class NginxFpmApplier implements RuntimeApplier
      */
     private function generate_nginx_conf(
         RuntimeManifest $manifest,
-        string $fs_root,
+        string $import_root,
         string $runtime_path,
         string $host,
         int $port
@@ -63,7 +63,7 @@ class NginxFpmApplier implements RuntimeApplier
         $lines[] = 'server {';
         $lines[] = "    listen {$port};";
         $lines[] = "    server_name {$host};";
-        $lines[] = "    root {$fs_root};";
+        $lines[] = "    root {$import_root};";
         $lines[] = '    index index.php index.html;';
         $lines[] = '';
         $lines[] = '    # Static files served directly by nginx — no PHP involved.';

--- a/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
@@ -56,13 +56,13 @@ class PhpBuiltinApplier implements RuntimeApplier
      */
     private function generate_cli_server_routing(array $options): string
     {
-        $wp_index = $options['wordpress_index'] ?? '';
+        $wordpress_index_php = $options['wordpress_index_php'] ?? '';
         $wp_core_dir = '';
-        if ($wp_index !== '') {
-            $real_wp_index = realpath($wp_index);
-            $wp_core_dir = dirname($real_wp_index !== false ? $real_wp_index : $wp_index);
+        if ($wordpress_index_php !== '') {
+            $real_wp_index = realpath($wordpress_index_php);
+            $wp_core_dir = dirname($real_wp_index !== false ? $real_wp_index : $wordpress_index_php);
         }
-        $escaped_wp_index = addslashes($wp_index);
+        $escaped_wp_index = addslashes($wordpress_index_php);
         $escaped_wp_core_dir = addslashes($wp_core_dir);
 
         $lines = [];

--- a/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
@@ -16,7 +16,7 @@
  */
 class PhpBuiltinApplier implements RuntimeApplier
 {
-    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $filesystem_root, string $output_dir, array $options = []): array
     {
         $host = $options['host'] ?? 'localhost';
         $port = (int) ($options['port'] ?? 8881);
@@ -25,14 +25,14 @@ class PhpBuiltinApplier implements RuntimeApplier
 
         // 1. Write runtime.php (base layers + CLI-server routing)
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $import_root);
+        $runtime = generate_runtime_php($manifest, $filesystem_root);
         $runtime .= $this->generate_cli_server_routing($options);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write start.sh
         $start_path = $output_dir . '/start.sh';
-        $start_script = $this->generate_start_script($manifest, $import_root, $runtime_path, $host, $port);
+        $start_script = $this->generate_start_script($manifest, $filesystem_root, $runtime_path, $host, $port);
         write_runtime_file($start_path, $start_script);
         chmod($start_path, 0755);
         $summary[] = "Wrote {$start_path}";
@@ -227,7 +227,7 @@ class PhpBuiltinApplier implements RuntimeApplier
      */
     private function generate_start_script(
         RuntimeManifest $manifest,
-        string $import_root,
+        string $filesystem_root,
         string $runtime_path,
         string $host,
         int $port
@@ -250,7 +250,7 @@ class PhpBuiltinApplier implements RuntimeApplier
         }
 
         $php_args[] = '-S ' . $host . ':' . $port;
-        $php_args[] = '-t ' . escapeshellarg($import_root);
+        $php_args[] = '-t ' . escapeshellarg($filesystem_root);
         $php_args[] = escapeshellarg($runtime_path);
 
         $lines[] = 'echo "Starting PHP built-in server..."';

--- a/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-php-builtin-applier.php
@@ -16,7 +16,7 @@
  */
 class PhpBuiltinApplier implements RuntimeApplier
 {
-    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array
     {
         $host = $options['host'] ?? 'localhost';
         $port = (int) ($options['port'] ?? 8881);
@@ -25,14 +25,14 @@ class PhpBuiltinApplier implements RuntimeApplier
 
         // 1. Write runtime.php (base layers + CLI-server routing)
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $fs_root);
+        $runtime = generate_runtime_php($manifest, $import_root);
         $runtime .= $this->generate_cli_server_routing($options);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write start.sh
         $start_path = $output_dir . '/start.sh';
-        $start_script = $this->generate_start_script($manifest, $fs_root, $runtime_path, $host, $port);
+        $start_script = $this->generate_start_script($manifest, $import_root, $runtime_path, $host, $port);
         write_runtime_file($start_path, $start_script);
         chmod($start_path, 0755);
         $summary[] = "Wrote {$start_path}";
@@ -227,7 +227,7 @@ class PhpBuiltinApplier implements RuntimeApplier
      */
     private function generate_start_script(
         RuntimeManifest $manifest,
-        string $fs_root,
+        string $import_root,
         string $runtime_path,
         string $host,
         int $port
@@ -250,7 +250,7 @@ class PhpBuiltinApplier implements RuntimeApplier
         }
 
         $php_args[] = '-S ' . $host . ':' . $port;
-        $php_args[] = '-t ' . escapeshellarg($fs_root);
+        $php_args[] = '-t ' . escapeshellarg($import_root);
         $php_args[] = escapeshellarg($runtime_path);
 
         $lines[] = 'echo "Starting PHP built-in server..."';

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -198,12 +198,12 @@ class PlaygroundCliApplier implements RuntimeApplier
     {
         $mounts = [];
 
-        $wordpress_index = $options['wordpress_index'] ?? '';
+        $wordpress_index_php = $options['wordpress_index_php'] ?? '';
         $wordpress_core_dir = '';
 
-        if ($wordpress_index !== '') {
+        if ($wordpress_index_php !== '') {
             // Resolve through any symlinks to get the real path.
-            $real_index = realpath($wordpress_index);
+            $real_index = realpath($wordpress_index_php);
             if ($real_index !== false) {
                 $wordpress_core_dir = dirname($real_index);
             }

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -36,7 +36,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      */
     private const VFS_ROOT = '/wordpress';
 
-    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array
     {
         $port = (int) ($options['port'] ?? 9400);
 
@@ -88,7 +88,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         $start_path = $output_dir . '/start.sh';
         $start_script = $this->generate_start_script(
             $manifest,
-            $fs_root,
+            $import_root,
             $output_dir,
             $runtime_path,
             $port,
@@ -104,7 +104,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         // callers running inside a VFS must map them to host paths.
         $config_path = $output_dir . '/start.json';
         $config = $this->generate_start_config(
-            $fs_root,
+            $import_root,
             $output_dir,
             $runtime_path,
             $port,
@@ -194,7 +194,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      * to shared host directories) are resolved by Playground's
      * --follow-symlinks flag — no per-symlink mounts needed.
      */
-    private function build_mounts(string $fs_root, array $options): array
+    private function build_mounts(string $import_root, array $options): array
     {
         $mounts = [];
 
@@ -209,7 +209,7 @@ class PlaygroundCliApplier implements RuntimeApplier
             }
         }
 
-        $real_fs_root = realpath($fs_root) ?: $fs_root;
+        $real_fs_root = realpath($import_root) ?: $import_root;
 
         if ($wordpress_core_dir !== '' && $wordpress_core_dir !== $real_fs_root) {
             // WPCloud-style layout: WordPress core is separate from the
@@ -242,7 +242,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      * importer ran on to the actual host paths.
      */
     private function generate_start_config(
-        string $fs_root,
+        string $import_root,
         string $output_dir,
         string $runtime_path,
         int $port,
@@ -262,7 +262,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         // WordPress layout mounts. For standard sites this is a single
         // mount. For WPCloud-style sites, three mounts assemble a standard
         // layout from separate directories.
-        foreach ($this->build_mounts($fs_root, $options) as $mount) {
+        foreach ($this->build_mounts($import_root, $options) as $mount) {
             [$source, $target] = explode(':', $mount, 2);
             $config['mounts_before_install'][] = [
                 'source' => $source,
@@ -299,14 +299,14 @@ class PlaygroundCliApplier implements RuntimeApplier
      */
     private function generate_start_script(
         RuntimeManifest $manifest,
-        string $fs_root,
+        string $import_root,
         string $output_dir,
         string $runtime_path,
         int $port,
         array $options,
         array $extra_mounts = []
     ): string {
-        $config = $this->generate_start_config($fs_root, $output_dir, $runtime_path, $port, $options, $extra_mounts);
+        $config = $this->generate_start_config($import_root, $output_dir, $runtime_path, $port, $options, $extra_mounts);
 
         $lines = [];
         $lines[] = '#!/usr/bin/env bash';

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -156,7 +156,7 @@ class PlaygroundCliApplier implements RuntimeApplier
             'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE'
                 => '/tmp/reprint/.import-state.json',
             'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'
-                => '/tmp/reprint/.import-download-list-skipped.jsonl',
+                => '/tmp/reprint/.import-fetch-list-skipped.jsonl',
         ];
 
         foreach ($runtime_file_mounts as $constant_name => $vfs_path) {

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -36,7 +36,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      */
     private const VFS_ROOT = '/wordpress';
 
-    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $filesystem_root, string $output_dir, array $options = []): array
     {
         $port = (int) ($options['port'] ?? 9400);
 
@@ -88,7 +88,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         $start_path = $output_dir . '/start.sh';
         $start_script = $this->generate_start_script(
             $manifest,
-            $import_root,
+            $filesystem_root,
             $output_dir,
             $runtime_path,
             $port,
@@ -104,7 +104,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         // callers running inside a VFS must map them to host paths.
         $config_path = $output_dir . '/start.json';
         $config = $this->generate_start_config(
-            $import_root,
+            $filesystem_root,
             $output_dir,
             $runtime_path,
             $port,
@@ -194,7 +194,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      * to shared host directories) are resolved by Playground's
      * --follow-symlinks flag — no per-symlink mounts needed.
      */
-    private function build_mounts(string $import_root, array $options): array
+    private function build_mounts(string $filesystem_root, array $options): array
     {
         $mounts = [];
 
@@ -209,7 +209,7 @@ class PlaygroundCliApplier implements RuntimeApplier
             }
         }
 
-        $real_fs_root = realpath($import_root) ?: $import_root;
+        $real_fs_root = realpath($filesystem_root) ?: $filesystem_root;
 
         if ($wordpress_core_dir !== '' && $wordpress_core_dir !== $real_fs_root) {
             // WPCloud-style layout: WordPress core is separate from the
@@ -242,7 +242,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      * importer ran on to the actual host paths.
      */
     private function generate_start_config(
-        string $import_root,
+        string $filesystem_root,
         string $output_dir,
         string $runtime_path,
         int $port,
@@ -262,7 +262,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         // WordPress layout mounts. For standard sites this is a single
         // mount. For WPCloud-style sites, three mounts assemble a standard
         // layout from separate directories.
-        foreach ($this->build_mounts($import_root, $options) as $mount) {
+        foreach ($this->build_mounts($filesystem_root, $options) as $mount) {
             [$source, $target] = explode(':', $mount, 2);
             $config['mounts_before_install'][] = [
                 'source' => $source,
@@ -299,14 +299,14 @@ class PlaygroundCliApplier implements RuntimeApplier
      */
     private function generate_start_script(
         RuntimeManifest $manifest,
-        string $import_root,
+        string $filesystem_root,
         string $output_dir,
         string $runtime_path,
         int $port,
         array $options,
         array $extra_mounts = []
     ): string {
-        $config = $this->generate_start_config($import_root, $output_dir, $runtime_path, $port, $options, $extra_mounts);
+        $config = $this->generate_start_config($filesystem_root, $output_dir, $runtime_path, $port, $options, $extra_mounts);
 
         $lines = [];
         $lines[] = '#!/usr/bin/env bash';

--- a/packages/reprint-importer/src/lib/target-runtime/functions.php
+++ b/packages/reprint-importer/src/lib/target-runtime/functions.php
@@ -42,7 +42,7 @@ function runtime_applier_for(string $runtime): RuntimeApplier
  * Appliers may append platform-specific code to the result (e.g. the
  * php-builtin applier adds CLI-server routing).
  */
-function generate_runtime_php(RuntimeManifest $manifest, string $fs_root): string
+function generate_runtime_php(RuntimeManifest $manifest, string $import_root): string
 {
     $lines = [];
     $lines[] = '<?php';
@@ -72,7 +72,7 @@ function generate_runtime_php(RuntimeManifest $manifest, string $fs_root): strin
     // Constants
     if (!empty($manifest->constants)) {
         foreach ($manifest->constants as $name => $value) {
-            $resolved = resolve_runtime_placeholders($value, $fs_root);
+            $resolved = resolve_runtime_placeholders($value, $import_root);
             $escaped = addslashes($resolved);
             $lines[] = "if (!defined('{$name}')) {";
             $lines[] = "    define('{$name}', '{$escaped}');";
@@ -84,7 +84,7 @@ function generate_runtime_php(RuntimeManifest $manifest, string $fs_root): strin
     // Server variables
     if (!empty($manifest->server_vars)) {
         foreach ($manifest->server_vars as $name => $value) {
-            $resolved = resolve_runtime_placeholders($value, $fs_root);
+            $resolved = resolve_runtime_placeholders($value, $import_root);
             $escaped = addslashes($resolved);
             $lines[] = "\$_SERVER['{$name}'] = '{$escaped}';";
         }
@@ -354,9 +354,9 @@ function generate_route_handler_code(RuntimeManifest $manifest): string
 /**
  * Replace {fs-root} placeholders with the actual fs-root path.
  */
-function resolve_runtime_placeholders(string $value, string $fs_root): string
+function resolve_runtime_placeholders(string $value, string $import_root): string
 {
-    return str_replace('{fs-root}', rtrim($fs_root, '/'), $value);
+    return str_replace('{fs-root}', rtrim($import_root, '/'), $value);
 }
 
 /**

--- a/packages/reprint-importer/src/lib/target-runtime/functions.php
+++ b/packages/reprint-importer/src/lib/target-runtime/functions.php
@@ -42,7 +42,7 @@ function runtime_applier_for(string $runtime): RuntimeApplier
  * Appliers may append platform-specific code to the result (e.g. the
  * php-builtin applier adds CLI-server routing).
  */
-function generate_runtime_php(RuntimeManifest $manifest, string $import_root): string
+function generate_runtime_php(RuntimeManifest $manifest, string $filesystem_root): string
 {
     $lines = [];
     $lines[] = '<?php';
@@ -72,7 +72,7 @@ function generate_runtime_php(RuntimeManifest $manifest, string $import_root): s
     // Constants
     if (!empty($manifest->constants)) {
         foreach ($manifest->constants as $name => $value) {
-            $resolved = resolve_runtime_placeholders($value, $import_root);
+            $resolved = resolve_runtime_placeholders($value, $filesystem_root);
             $escaped = addslashes($resolved);
             $lines[] = "if (!defined('{$name}')) {";
             $lines[] = "    define('{$name}', '{$escaped}');";
@@ -84,7 +84,7 @@ function generate_runtime_php(RuntimeManifest $manifest, string $import_root): s
     // Server variables
     if (!empty($manifest->server_vars)) {
         foreach ($manifest->server_vars as $name => $value) {
-            $resolved = resolve_runtime_placeholders($value, $import_root);
+            $resolved = resolve_runtime_placeholders($value, $filesystem_root);
             $escaped = addslashes($resolved);
             $lines[] = "\$_SERVER['{$name}'] = '{$escaped}';";
         }
@@ -354,9 +354,9 @@ function generate_route_handler_code(RuntimeManifest $manifest): string
 /**
  * Replace {fs-root} placeholders with the actual fs-root path.
  */
-function resolve_runtime_placeholders(string $value, string $import_root): string
+function resolve_runtime_placeholders(string $value, string $filesystem_root): string
 {
-    return str_replace('{fs-root}', rtrim($import_root, '/'), $value);
+    return str_replace('{fs-root}', rtrim($filesystem_root, '/'), $value);
 }
 
 /**

--- a/packages/reprint-importer/src/lib/target-runtime/interface-runtime-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/interface-runtime-applier.php
@@ -16,7 +16,7 @@ interface RuntimeApplier
      * @param string          $filesystem_root    Absolute path to the site fs-root.
      * @param string          $output_dir Absolute path to the output directory.
      * @param array           $options    Runtime-specific options (e.g. host, port,
-     *                                    wordpress_index).
+     *                                    wordpress_index_php).
      * @return string[] Human-readable summary lines (printed to the user).
      */
     public function apply(RuntimeManifest $manifest, string $filesystem_root, string $output_dir, array $options = []): array;

--- a/packages/reprint-importer/src/lib/target-runtime/interface-runtime-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/interface-runtime-applier.php
@@ -13,11 +13,11 @@ interface RuntimeApplier
      * Apply a manifest to the target fs-root.
      *
      * @param RuntimeManifest $manifest   The manifest to apply.
-     * @param string          $fs_root    Absolute path to the site fs-root.
+     * @param string          $import_root    Absolute path to the site fs-root.
      * @param string          $output_dir Absolute path to the output directory.
      * @param array           $options    Runtime-specific options (e.g. host, port,
      *                                    wordpress_index).
      * @return string[] Human-readable summary lines (printed to the user).
      */
-    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array;
+    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array;
 }

--- a/packages/reprint-importer/src/lib/target-runtime/interface-runtime-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/interface-runtime-applier.php
@@ -13,11 +13,11 @@ interface RuntimeApplier
      * Apply a manifest to the target fs-root.
      *
      * @param RuntimeManifest $manifest   The manifest to apply.
-     * @param string          $import_root    Absolute path to the site fs-root.
+     * @param string          $filesystem_root    Absolute path to the site fs-root.
      * @param string          $output_dir Absolute path to the output directory.
      * @param array           $options    Runtime-specific options (e.g. host, port,
      *                                    wordpress_index).
      * @return string[] Human-readable summary lines (printed to the user).
      */
-    public function apply(RuntimeManifest $manifest, string $import_root, string $output_dir, array $options = []): array;
+    public function apply(RuntimeManifest $manifest, string $filesystem_root, string $output_dir, array $options = []): array;
 }

--- a/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -66,10 +66,10 @@ function remote_upload_proxy_code(): string
 	$local_path = $content_dir . '/uploads/' . ltrim($matches[1], '/');
 	if (file_exists($local_path)) return;
 
-	$remote_url = rtrim(STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL, '/') . '/' . ltrim($matches[1], '/');
+	$target_url = rtrim(STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL, '/') . '/' . ltrim($matches[1], '/');
 	$query = parse_url($uri, PHP_URL_QUERY);
 	if (is_string($query) && $query !== '') {
-		$remote_url .= '?' . $query;
+		$target_url .= '?' . $query;
 	}
 
 	$request_headers = ['Accept-Encoding: identity'];
@@ -107,7 +107,7 @@ function remote_upload_proxy_code(): string
 		}
 	};
 
-	$curl = curl_init($remote_url);
+	$curl = curl_init($target_url);
 	if ($curl === false) {
 		return;
 	}

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -61,8 +61,8 @@ class MultipartPushStreamClient
     /** Maximum JSON response bytes retained from the target. */
     private const MAX_RESPONSE_BYTES = 1024 * 1024;
 
-    /** @var string Exporter API URL used as the base of every signed request target. */
-    private string $base_url;
+    /** @var string Remote Reprint API URL used for every signed request target. */
+    private string $remote_reprint_api_url;
 
     /** @var Site_Export_HMAC_Client Signs the exact method and URL before transfer. */
     private Site_Export_HMAC_Client $hmac_client;
@@ -164,11 +164,11 @@ class MultipartPushStreamClient
      * @param array<string,mixed> $options {
      *     Transport, authentication, and limit options.
      *
-     *     @type string $base_url Required exporter API URL. Must use HTTPS
+     *     @type string $remote_reprint_api_url Required remote Reprint API URL. Must use HTTPS
      *         unless `allow_http` is true.
      *     @type Site_Export_HMAC_Client $hmac_client Required signer for the
      *         exact method and request URL.
-     *     @type bool $allow_http Whether to permit an explicit HTTP base URL.
+     *     @type bool $allow_http Whether to permit an explicit HTTP remote Reprint API URL.
      *         Default false.
      *     @type PushRequestSizer $request_sizer Request-body sizing state to
      *         reuse. Defaults to a new sizer.
@@ -196,22 +196,22 @@ class MultipartPushStreamClient
                 . 'which older PHP curl bindings interpret as end-of-body. See https://github.com/WordPress/reprint/issues/327.'
             );
         }
-        $base_url = $options['base_url'] ?? null;
-        if (!is_string($base_url) || $base_url === '') {
-            throw new InvalidArgumentException('MultipartPushStreamClient requires a non-empty base_url option.');
+        $remote_reprint_api_url = $options['remote_reprint_api_url'] ?? null;
+        if (!is_string($remote_reprint_api_url) || $remote_reprint_api_url === '') {
+            throw new InvalidArgumentException('MultipartPushStreamClient requires a non-empty remote_reprint_api_url option.');
         }
-        $scheme = strtolower((string) parse_url($base_url, PHP_URL_SCHEME));
+        $scheme = strtolower((string) parse_url($remote_reprint_api_url, PHP_URL_SCHEME));
         $allow_http = $options['allow_http'] ?? false;
         if (!is_bool($allow_http) || ($scheme !== 'https' && $scheme !== 'http') || ($scheme === 'http' && !$allow_http)) {
             throw new InvalidArgumentException(
-                'Push base_url must be https://, unless allow_http is true for an explicit http:// target.'
+                'Push remote Reprint API URL must be https://, unless allow_http is true for an explicit http:// remote Reprint API URL.'
             );
         }
         $hmac_client = $options['hmac_client'] ?? null;
         if (!$hmac_client instanceof Site_Export_HMAC_Client) {
             throw new InvalidArgumentException('MultipartPushStreamClient requires a Site_Export_HMAC_Client.');
         }
-        $this->base_url = rtrim($base_url, '?&');
+        $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
         $this->hmac_client = $hmac_client;
         $this->request_sizer = $options['request_sizer'] ?? new PushRequestSizer();
         if (!$this->request_sizer instanceof PushRequestSizer) {
@@ -663,8 +663,8 @@ class MultipartPushStreamClient
                 'status' => 'failed',
                 'reason' => 'redirected',
                 'detail' => $redirect_url === ''
-                    ? 'The target redirected the upload. Use its final URL as the push base_url.'
-                    : 'The target redirected to ' . $redirect_url . '. Use that address as the push base_url.',
+                    ? 'The remote redirected the upload. Use its final URL as the remote Reprint API URL.'
+                    : 'The remote redirected to ' . $redirect_url . '. Use that address as the remote Reprint API URL.',
                 'response' => null,
                 'parts_sent' => $this->parts_sent,
                 'body_bytes_sent' => $this->body_bytes_sent,
@@ -860,7 +860,7 @@ class MultipartPushStreamClient
             return [
                 'status' => 'failed',
                 'reason' => 'redirected',
-                'detail' => 'The target redirected to ' . ($redirect_url === '' ? 'another address' : $redirect_url) . '. Use that address as the push base_url.',
+                'detail' => 'The remote redirected to ' . ($redirect_url === '' ? 'another address' : $redirect_url) . '. Use that address as the remote Reprint API URL.',
                 'response' => null,
                 'parts_sent' => 0,
                 'body_bytes_sent' => 0,
@@ -1109,7 +1109,7 @@ class MultipartPushStreamClient
     private function endpoint_url(string $endpoint, array $parameters): string
     {
         $parameters = array_merge(['endpoint' => $endpoint], $parameters);
-        return $this->base_url . (strpos($this->base_url, '?') === false ? '?' : '&') . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
+        return $this->remote_reprint_api_url . (strpos($this->remote_reprint_api_url, '?') === false ? '?' : '&') . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
     }
 
     /**

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -39,7 +39,7 @@ class CliHelpTest extends TestCase
     {
         $output = $this->runHelp('files-push');
 
-        $this->assertStringContainsString('Usage: reprint files-push <target-url>', $output);
+        $this->assertStringContainsString('Usage: reprint files-push <remote-reprint-api-url>', $output);
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('--secret=TOKEN', $output);
@@ -58,7 +58,7 @@ class CliHelpTest extends TestCase
     {
         $output = $this->runHelp('files-diff');
 
-        $this->assertStringContainsString('Usage: reprint files-diff <target-url>', $output);
+        $this->assertStringContainsString('Usage: reprint files-diff <remote-reprint-api-url>', $output);
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('previous local index', $output);

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -46,7 +46,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--force-http', $output);
         $this->assertStringContainsString('--verbose, -v', $output);
         $this->assertStringContainsString('low-level, files-only command', $output);
-        $this->assertStringContainsString('existing local tree at --fs-root', $output);
+        $this->assertStringContainsString('existing local document root at --fs-root', $output);
         $this->assertStringContainsString('read or modify', $output);
         $this->assertStringNotContainsString('--abort', $output);
         $this->assertStringNotContainsString('--filter', $output);

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -46,7 +46,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--force-http', $output);
         $this->assertStringContainsString('--verbose, -v', $output);
         $this->assertStringContainsString('low-level, files-only command', $output);
-        $this->assertStringContainsString('existing local document root at --fs-root', $output);
+        $this->assertStringContainsString('existing filesystem root at --fs-root', $output);
         $this->assertStringContainsString('read or modify', $output);
         $this->assertStringNotContainsString('--abort', $output);
         $this->assertStringNotContainsString('--filter', $output);

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -316,7 +316,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $downloadIndex = $reflection->getMethod('download_target_index');
+        $downloadIndex = $reflection->getMethod('download_remote_index');
         $result = $downloadIndex->invoke($client);
 
         $this->assertFalse(
@@ -558,7 +558,7 @@ class CurlTimeoutRecoveryTest extends TestCase
             SuccessTestClient::class,
         );
 
-        $downloadIndex = $reflection->getMethod('download_target_index');
+        $downloadIndex = $reflection->getMethod('download_remote_index');
         $downloadIndex->invoke($client);
 
         $state = $this->readState();

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -7,10 +7,10 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Verify recovery from cURL timeouts during streaming downloads.
+ * Verify recovery from cURL timeouts during streaming fetches.
  *
- * Each download method (download_sql, download_file_fetch, download_remote_index,
- * download_db_index) is tested by injecting a CurlTimeoutException. SQL retries
+ * Each fetch method (fetch_sql, fetch_file_batch, fetch_remote_index,
+ * fetch_database_index) is tested by injecting a CurlTimeoutException. SQL retries
  * in the same invocation; the other phases save partial state for a later run.
  *
  * Also verifies the no-progress safety net: after repeated interrupted
@@ -140,7 +140,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // download_sql: timeout retries in the same invocation
+    // fetch_sql: timeout retries in the same invocation
     // ---------------------------------------------------------------
 
     public function testSqlDownloadRetriesTimeoutUntilNoProgressLimit()
@@ -163,9 +163,9 @@ class CurlTimeoutRecoveryTest extends TestCase
         $modeProp = $reflection->getProperty('sql_output_mode');
         $modeProp->setValue($client, 'file');
 
-        $downloadSql = $reflection->getMethod('download_sql');
+        $fetchSql = $reflection->getMethod('fetch_sql');
         try {
-            $downloadSql->invoke($client);
+            $fetchSql->invoke($client);
             $this->fail("Expected the no-progress limit to stop SQL retries");
         } catch (\RuntimeException $e) {
             $this->assertStringContainsString(
@@ -177,12 +177,12 @@ class CurlTimeoutRecoveryTest extends TestCase
         $this->assertSame(
             3,
             $client->streaming_requests,
-            "download_sql should retry timeouts until the no-progress limit",
+            "fetch_sql should retry timeouts until the no-progress limit",
         );
     }
 
     // ---------------------------------------------------------------
-    // download_file_fetch: timeout saves state and returns false
+    // fetch_file_batch: timeout saves state and returns false
     // ---------------------------------------------------------------
 
     public function testFileFetchTimeoutSavesPartialState()
@@ -203,8 +203,8 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $downloadFilesFetch = $reflection->getMethod('download_file_fetch');
-        $result = $downloadFilesFetch->invoke(
+        $fetchFileBatch = $reflection->getMethod('fetch_file_batch');
+        $result = $fetchFileBatch->invoke(
             $client,
             null,
             base64_encode('{"path":"/photo.jpg","offset":4096}'),
@@ -213,7 +213,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         $this->assertFalse(
             $result,
-            "download_file_fetch should return false (not complete) on timeout"
+            "fetch_file_batch should return false (not complete) on timeout"
         );
 
         $state = $this->readState();
@@ -250,10 +250,10 @@ class CurlTimeoutRecoveryTest extends TestCase
             InterruptedAfterStreamedPartCloseClient::class,
         );
 
-        $downloadFilesFetch = $reflection->getMethod('download_file_fetch');
+        $fetchFileBatch = $reflection->getMethod('fetch_file_batch');
 
         try {
-            $downloadFilesFetch->invoke(
+            $fetchFileBatch->invoke(
                 $client,
                 null,
                 self::fileCursorForBytes(256),
@@ -287,7 +287,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // download_remote_index: timeout saves state and returns false
+    // fetch_remote_index: timeout saves state and returns false
     // ---------------------------------------------------------------
 
     public function testRemoteIndexTimeoutSavesPartialState()
@@ -316,12 +316,12 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $downloadIndex = $reflection->getMethod('download_remote_index');
-        $result = $downloadIndex->invoke($client);
+        $fetchRemoteIndex = $reflection->getMethod('fetch_remote_index');
+        $result = $fetchRemoteIndex->invoke($client);
 
         $this->assertFalse(
             $result,
-            "download_remote_index should return false on timeout"
+            "fetch_remote_index should return false on timeout"
         );
 
         $state = $this->readState();
@@ -337,7 +337,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // download_db_index: timeout saves state as "partial"
+    // fetch_database_index: timeout saves state as "partial"
     // ---------------------------------------------------------------
 
     public function testDbIndexTimeoutSavesPartialState()
@@ -360,8 +360,8 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $downloadDbIndex = $reflection->getMethod('download_db_index');
-        $downloadDbIndex->invoke($client);
+        $fetchDatabaseIndex = $reflection->getMethod('fetch_database_index');
+        $fetchDatabaseIndex->invoke($client);
 
         $state = $this->readState();
         $this->assertEquals(
@@ -498,7 +498,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     /**
-     * End-to-end: download_sql with counter already at MAX-1 and no
+     * End-to-end: fetch_sql with counter already at MAX-1 and no
      * cursor progress should throw RuntimeException.
      */
     public function testSqlDownloadGivesUpAfterMaxConsecutiveTimeouts()
@@ -525,8 +525,8 @@ class CurlTimeoutRecoveryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('consecutive');
 
-        $downloadSql = $reflection->getMethod('download_sql');
-        $downloadSql->invoke($client);
+        $fetchSql = $reflection->getMethod('fetch_sql');
+        $fetchSql->invoke($client);
     }
 
     public function testSuccessfulRequestResetsCounter()
@@ -558,8 +558,8 @@ class CurlTimeoutRecoveryTest extends TestCase
             SuccessTestClient::class,
         );
 
-        $downloadIndex = $reflection->getMethod('download_remote_index');
-        $downloadIndex->invoke($client);
+        $fetchRemoteIndex = $reflection->getMethod('fetch_remote_index');
+        $fetchRemoteIndex->invoke($client);
 
         $state = $this->readState();
         $this->assertEquals(
@@ -596,7 +596,7 @@ class TimeoutTestClient extends \ImportClient
 
 /**
  * Test double that simulates a process dying immediately after a streamed
- * file part-complete checkpoint. This is a hard crash, so download_file_fetch()
+ * file part-complete checkpoint. This is a hard crash, so fetch_file_batch()
  * must not get a chance to do its normal final save.
  */
 class InterruptedAfterStreamedPartCloseClient extends \ImportClient

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -20,16 +20,16 @@ class CurlTimeoutRecoveryTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/curl-timeout-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -125,7 +125,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         $client = new $clientClass(
             'http://fake.url',
             $this->stateDir,
-            $this->fs_root,
+            $this->import_root,
         );
         $reflection = new \ReflectionClass(\ImportClient::class);
 
@@ -226,7 +226,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
     public function testFileFetchHardCrashCheckpointDoesNotPutCursorBehindBytes()
     {
-        $trackedPath = $this->fs_root . '/uploads/large.bin';
+        $trackedPath = $this->import_root . '/uploads/large.bin';
         mkdir(dirname($trackedPath), 0755, true);
         file_put_contents($trackedPath, str_repeat('a', 256));
 

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -316,7 +316,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $downloadIndex = $reflection->getMethod('download_remote_index');
+        $downloadIndex = $reflection->getMethod('download_target_index');
         $result = $downloadIndex->invoke($client);
 
         $this->assertFalse(
@@ -558,7 +558,7 @@ class CurlTimeoutRecoveryTest extends TestCase
             SuccessTestClient::class,
         );
 
-        $downloadIndex = $reflection->getMethod('download_remote_index');
+        $downloadIndex = $reflection->getMethod('download_target_index');
         $downloadIndex->invoke($client);
 
         $state = $this->readState();

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -20,16 +20,16 @@ class CurlTimeoutRecoveryTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/curl-timeout-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -125,7 +125,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         $client = new $clientClass(
             'http://fake.url',
             $this->stateDir,
-            $this->import_root,
+            $this->filesystem_root,
         );
         $reflection = new \ReflectionClass(\ImportClient::class);
 
@@ -226,7 +226,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
     public function testFileFetchHardCrashCheckpointDoesNotPutCursorBehindBytes()
     {
-        $trackedPath = $this->import_root . '/uploads/large.bin';
+        $trackedPath = $this->filesystem_root . '/uploads/large.bin';
         mkdir(dirname($trackedPath), 0755, true);
         file_put_contents($trackedPath, str_repeat('a', 256));
 

--- a/tests/Import/DownloadListProgressTest.php
+++ b/tests/Import/DownloadListProgressTest.php
@@ -16,16 +16,16 @@ class DownloadListProgressTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/download-list-progress-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -57,7 +57,7 @@ class DownloadListProgressTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
     }
 
     /**

--- a/tests/Import/DownloadListProgressTest.php
+++ b/tests/Import/DownloadListProgressTest.php
@@ -16,16 +16,16 @@ class DownloadListProgressTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/download-list-progress-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -57,7 +57,7 @@ class DownloadListProgressTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root);
     }
 
     /**

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -9,10 +9,10 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
 /**
  * Verify that files_done and files_total progress counters are correct
  * across multiple invocations (exit-code-2 restarts), with and without
- * the essential-files filter (which splits the download list into a
+ * the essential-files filter (which splits the fetch list into a
  * main list and a skipped list).
  */
-class DownloadListProgressTest extends TestCase
+class FetchListProgressTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
@@ -21,7 +21,7 @@ class DownloadListProgressTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/download-list-progress-test-' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/fetch-list-progress-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
@@ -61,11 +61,11 @@ class DownloadListProgressTest extends TestCase
     }
 
     /**
-     * Build a download list JSONL file with N entries.
+     * Build a fetch list JSONL file with N entries.
      */
-    private function writeDownloadList(int $count, ?string $file = null): string
+    private function writeFetchList(int $count, ?string $file = null): string
     {
-        $file = $file ?? $this->stateDir . '/.import-download-list.jsonl';
+        $file = $file ?? $this->stateDir . '/.import-fetch-list.jsonl';
         $handle = fopen($file, 'w');
         for ($i = 0; $i < $count; $i++) {
             fwrite($handle, json_encode(["path" => base64_encode("/file-{$i}.txt")]) . "\n");
@@ -120,8 +120,8 @@ class DownloadListProgressTest extends TestCase
     private function readCounters(\ImportClient $client, \ReflectionClass $reflection): array
     {
         return [
-            'total' => $reflection->getProperty('download_list_total')->getValue($client),
-            'done' => $reflection->getProperty('download_list_done')->getValue($client),
+            'total' => $reflection->getProperty('fetch_list_total')->getValue($client),
+            'done' => $reflection->getProperty('fetch_list_done')->getValue($client),
         ];
     }
 
@@ -142,7 +142,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testFreshDownloadShowsZeroDone()
     {
-        $listFile = $this->writeDownloadList(100);
+        $listFile = $this->writeFetchList(100);
 
         $this->writeState([
             "active_resumable_command" => [
@@ -154,7 +154,7 @@ class DownloadListProgressTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $method = $reflection->getMethod('download_files_from_list');
+        $method = $reflection->getMethod('fetch_files_from_list');
         try {
             $method->invoke($client, $listFile, 'fetch');
         } catch (\Exception $e) {
@@ -168,7 +168,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testResumedDownloadReflectsOffset()
     {
-        $listFile = $this->writeDownloadList(100);
+        $listFile = $this->writeFetchList(100);
         $offset = $this->byteOffsetAfterLines($listFile, 40);
 
         $this->writeState([
@@ -189,7 +189,7 @@ class DownloadListProgressTest extends TestCase
         [$client, $reflection] = $this->prepareClient();
 
         try {
-            $reflection->getMethod('download_files_from_list')
+            $reflection->getMethod('fetch_files_from_list')
                 ->invoke($client, $listFile, 'fetch');
         } catch (\Exception $e) {
             // Expected
@@ -202,7 +202,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testDoneNeverExceedsTotal()
     {
-        $listFile = $this->writeDownloadList(50);
+        $listFile = $this->writeFetchList(50);
 
         // Offset past the end of the file
         $pastEnd = filesize($listFile) + 1000;
@@ -225,7 +225,7 @@ class DownloadListProgressTest extends TestCase
         [$client, $reflection] = $this->prepareClient();
 
         try {
-            $reflection->getMethod('download_files_from_list')
+            $reflection->getMethod('fetch_files_from_list')
                 ->invoke($client, $listFile, 'fetch');
         } catch (\Exception $e) {
             // Expected
@@ -238,7 +238,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testCountersStableAcrossInvocations()
     {
-        $listFile = $this->writeDownloadList(100);
+        $listFile = $this->writeFetchList(100);
         $offset30 = $this->byteOffsetAfterLines($listFile, 30);
         $offset60 = $this->byteOffsetAfterLines($listFile, 60);
 
@@ -254,7 +254,7 @@ class DownloadListProgressTest extends TestCase
 
         [$client1, $ref1] = $this->prepareClient();
         try {
-            $ref1->getMethod('download_files_from_list')->invoke($client1, $listFile, 'fetch');
+            $ref1->getMethod('fetch_files_from_list')->invoke($client1, $listFile, 'fetch');
         } catch (\Exception $e) {}
 
         $c1 = $this->readCounters($client1, $ref1);
@@ -273,7 +273,7 @@ class DownloadListProgressTest extends TestCase
 
         [$client2, $ref2] = $this->prepareClient();
         try {
-            $ref2->getMethod('download_files_from_list')->invoke($client2, $listFile, 'fetch');
+            $ref2->getMethod('fetch_files_from_list')->invoke($client2, $listFile, 'fetch');
         } catch (\Exception $e) {}
 
         $c2 = $this->readCounters($client2, $ref2);
@@ -286,9 +286,9 @@ class DownloadListProgressTest extends TestCase
 
     public function testSkippedListHasOwnCounters()
     {
-        $this->writeDownloadList(50);
-        $skippedList = $this->stateDir . '/.import-download-list-skipped.jsonl';
-        $this->writeDownloadList(200, $skippedList);
+        $this->writeFetchList(50);
+        $skippedList = $this->stateDir . '/.import-fetch-list-skipped.jsonl';
+        $this->writeFetchList(200, $skippedList);
         $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
 
         $this->writeState([
@@ -303,7 +303,7 @@ class DownloadListProgressTest extends TestCase
         [$client, $reflection] = $this->prepareClient("skipped-earlier");
 
         try {
-            $reflection->getMethod('download_files_from_list')
+            $reflection->getMethod('fetch_files_from_list')
                 ->invoke($client, $skippedList, 'fetch_skipped');
         } catch (\Exception $e) {}
 
@@ -314,7 +314,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testCountNewlinesMatchesLineCount()
     {
-        $listFile = $this->writeDownloadList(500);
+        $listFile = $this->writeFetchList(500);
 
         [$client, $reflection] = $this->prepareClient();
         $method = $reflection->getMethod('count_newlines');
@@ -327,7 +327,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testPrepareFetchBatchReturnsEntryCount()
     {
-        $listFile = $this->writeDownloadList(10);
+        $listFile = $this->writeFetchList(10);
 
         $this->writeState([
             "active_resumable_command" => [
@@ -353,7 +353,7 @@ class DownloadListProgressTest extends TestCase
 
     public function testFilesDoneIncludesFilesImported()
     {
-        $listFile = $this->writeDownloadList(100);
+        $listFile = $this->writeFetchList(100);
         $offset40 = $this->byteOffsetAfterLines($listFile, 40);
 
         $this->writeState([
@@ -368,16 +368,16 @@ class DownloadListProgressTest extends TestCase
         [$client, $reflection] = $this->prepareClient();
 
         try {
-            $reflection->getMethod('download_files_from_list')
+            $reflection->getMethod('fetch_files_from_list')
                 ->invoke($client, $listFile, 'fetch');
         } catch (\Exception $e) {}
 
         // Simulate 5 files written in this invocation
         $reflection->getProperty('files_imported')->setValue($client, 5);
 
-        $done = $reflection->getProperty('download_list_done')->getValue($client);
+        $done = $reflection->getProperty('fetch_list_done')->getValue($client);
         $imported = $reflection->getProperty('files_imported')->getValue($client);
-        $total = $reflection->getProperty('download_list_total')->getValue($client);
+        $total = $reflection->getProperty('fetch_list_total')->getValue($client);
 
         // files_done as emitted in progress records = done + imported
         $filesDone = $done + $imported;

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -93,7 +93,7 @@ class FileBodyStreamingTest extends TestCase
      * surface is double-counting (server resends bytes already on disk) or
      * truncation (resume re-opens with "wb" and wipes the partial file). This
      * test pins the contract: feed a part's first half, simulate a crash,
-     * reopen the file in append mode the way download_file_data() does on
+     * reopen the file in append mode the way fetch_file_batch() does on
      * resume, then feed the second half as a continuation part with
      * x-first-chunk=0. The result must be byte-identical to the source —
      * no gap, no duplication.
@@ -159,7 +159,7 @@ class FileBodyStreamingTest extends TestCase
         $this->assertSame($halfwayPoint, $context1->file_bytes_written,
             'file_bytes_written must reflect actual on-disk bytes; that is the value we will save into state for resume.');
 
-        // Mimic the crash + reopen path from download_file_data():
+        // Mimic the crash + reopen path from fetch_file_batch():
         // close the in-flight handle, then on the next request reopen the
         // tracked file in append mode using the previously-saved byte count.
         if ($context1->file_handle) {

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -228,7 +228,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same target URL, state directory, and filesystem root',
+            'same remote Reprint API URL, state directory, and filesystem root',
             $result['output']
         );
     }
@@ -244,7 +244,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same target URL, state directory, and filesystem root',
+            'same remote Reprint API URL, state directory, and filesystem root',
             $result['output']
         );
     }

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * The files-diff user contract.
  *
- * files-diff compares the local document root with the pair's previous local index —
+ * files-diff compares the filesystem root with the pair's previous local index —
  * the index a completed files-push publishes — without contacting the target,
  * and reports the complete diff on every run. These tests pin that contract:
  * local-only operation, correct change records, arbitrary path bytes, the
@@ -228,7 +228,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same target URL, state directory, and local document root',
+            'same target URL, state directory, and filesystem root',
             $result['output']
         );
     }
@@ -244,7 +244,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same target URL, state directory, and local document root',
+            'same target URL, state directory, and filesystem root',
             $result['output']
         );
     }

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * The files-diff user contract.
  *
- * files-diff compares the local tree with the pair's previous local index —
+ * files-diff compares the local document root with the pair's previous local index —
  * the index a completed files-push publishes — without contacting the target,
  * and reports the complete diff on every run. These tests pin that contract:
  * local-only operation, correct change records, arbitrary path bytes, the
@@ -228,7 +228,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same target URL, state directory, and local tree',
+            'same target URL, state directory, and local document root',
             $result['output']
         );
     }
@@ -244,7 +244,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertCanonicalSingleJsonLine($result['stderr']);
         $this->assertStringContainsString('completed files-push', $result['output']);
         $this->assertStringContainsString(
-            'same target URL, state directory, and local tree',
+            'same target URL, state directory, and local document root',
             $result['output']
         );
     }
@@ -393,9 +393,9 @@ final class FilesDiffCommandTest extends TestCase
 
     private function pushStateDirectory(): string
     {
-        $canonicalLocalTree = realpath($this->localTree);
-        $this->assertIsString($canonicalLocalTree);
-        $pair = hash('sha256', rtrim($this->targetUrl, '?&') . "\0" . $canonicalLocalTree);
+        $resolvedLocalDocumentRoot = realpath($this->localTree);
+        $this->assertIsString($resolvedLocalDocumentRoot);
+        $pair = hash('sha256', rtrim($this->targetUrl, '?&') . "\0" . $resolvedLocalDocumentRoot);
         return realpath($this->stateDirectory) . '/push/' . $pair;
     }
 

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../../importer/import.php';
  * In preserve-local mode, previously-synced files that changed remotely
  * must still be re-downloaded (not skipped).
  */
-class FilesSyncStateTest extends TestCase
+class FilesPullStateTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
@@ -157,7 +157,7 @@ class FilesSyncStateTest extends TestCase
     /**
      * A completed files-pull should refuse to re-run.
      */
-    public function testCompletedFilesSyncRefusesToRerun()
+    public function testCompletedFilesPullRefusesToRerun()
     {
         $this->writeState([
             "active_resumable_command" => [
@@ -168,7 +168,7 @@ class FilesSyncStateTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $method = $reflection->getMethod('run_files_sync');
+        $method = $reflection->getMethod('run_files_pull');
         $method->invoke($client);
 
         $state = $this->readState();
@@ -267,11 +267,11 @@ class FilesSyncStateTest extends TestCase
         [$client, $reflection] = $this->prepareClient();
         $reflection->getMethod('handle_abort')->invoke($client, 'files-pull');
 
-        // Step 2: new client, try run_files_sync
+        // Step 2: new client, try run_files_pull
         [$client2, $reflection2] = $this->prepareClient();
 
         try {
-            $reflection2->getMethod('run_files_sync')->invoke($client2);
+            $reflection2->getMethod('run_files_pull')->invoke($client2);
         } catch (\Exception $e) {
             // Expected: will fail trying to contact the fake URL
         }
@@ -315,7 +315,7 @@ class FilesSyncStateTest extends TestCase
         $filterProp->setValue($client, 'skipped-earlier');
 
         try {
-            $reflection->getMethod('run_files_sync')->invoke($client);
+            $reflection->getMethod('run_files_pull')->invoke($client);
         } catch (\Exception $e) {
             // Expected: the fetch fails against the fake URL. The point is that
             // it got PAST the "no completed sync with skipped files" guard.

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -43,7 +43,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertNull(ImportClient::files_push_stop_cause(1000.0, PHP_INT_MAX, 0, -1, $chunkBytes));
     }
 
-    public function testPairContextUsesTheTrimmedTargetAndCanonicalLocalTree(): void
+    public function testPairContextUsesTheTrimmedTargetAndResolvedLocalDocumentRoot(): void
     {
         $targetUrl = 'https://example.test/?reprint-api=1&&';
         $context = ImportClient::prepare_files_push_context(
@@ -52,13 +52,13 @@ final class FilesPushCommandTest extends TestCase
             $this->localTree,
             ['secret' => 'token', 'force_http' => false]
         );
-        $canonicalLocalTree = realpath($this->localTree);
-        $this->assertIsString($canonicalLocalTree);
+        $resolvedLocalDocumentRoot = realpath($this->localTree);
+        $this->assertIsString($resolvedLocalDocumentRoot);
         $trimmedTargetUrl = rtrim($targetUrl, '?&');
-        $expectedPair = hash('sha256', $trimmedTargetUrl . "\0" . $canonicalLocalTree);
+        $expectedPair = hash('sha256', $trimmedTargetUrl . "\0" . $resolvedLocalDocumentRoot);
 
         $this->assertSame($trimmedTargetUrl, $context['target_url']);
-        $this->assertSame($canonicalLocalTree, $context['local_tree']);
+        $this->assertSame($resolvedLocalDocumentRoot, $context['local_document_root']);
         $this->assertSame($expectedPair, $context['pair']);
         $this->assertSame(
             realpath($this->stateDirectory) . '/push/' . $expectedPair,
@@ -184,7 +184,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $missingTreeResult['exit']);
         $missingTreeError = $this->lastJsonLine($missingTreeResult['stderr']);
         $this->assertSame(
-            'The local tree does not exist or is not a directory: ' . $missingTree . '.',
+            'The local document root does not exist or is not a directory: ' . $missingTree . '.',
             $missingTreeError['error'] ?? null
         );
         $this->assertDirectoryDoesNotExist($missingTree);
@@ -201,7 +201,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $symlinkResult['exit']);
         $symlinkError = $this->lastJsonLine($symlinkResult['stderr']);
         $this->assertSame(
-            'The local tree must not be a symlink: ' . $symlinkedTree . '.',
+            'The local document root must not be a symlink: ' . $symlinkedTree . '.',
             $symlinkError['error'] ?? null
         );
 
@@ -215,7 +215,7 @@ final class FilesPushCommandTest extends TestCase
         ]);
         $this->assertSame(1, $nestedStateResult['exit']);
         $nestedStateError = $this->lastJsonLine($nestedStateResult['stderr']);
-        $this->assertStringContainsString('must be outside the local tree', $nestedStateError['error'] ?? '');
+        $this->assertStringContainsString('must be outside the local document root', $nestedStateError['error'] ?? '');
         $this->assertStringContainsString( (string) realpath($this->localTree), $nestedStateError['error'] ?? '' );
 
         $this->assertNoSenderState($this->stateDirectory);

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -58,7 +58,7 @@ final class FilesPushCommandTest extends TestCase
         $expectedPair = hash('sha256', $trimmedTargetUrl . "\0" . $resolvedLocalDocumentRoot);
 
         $this->assertSame($trimmedTargetUrl, $context['target_url']);
-        $this->assertSame($resolvedLocalDocumentRoot, $context['local_document_root']);
+        $this->assertSame($resolvedLocalDocumentRoot, $context['filesystem_root']);
         $this->assertSame($expectedPair, $context['pair']);
         $this->assertSame(
             realpath($this->stateDirectory) . '/push/' . $expectedPair,
@@ -184,7 +184,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $missingTreeResult['exit']);
         $missingTreeError = $this->lastJsonLine($missingTreeResult['stderr']);
         $this->assertSame(
-            'The local document root does not exist or is not a directory: ' . $missingTree . '.',
+            'The filesystem root does not exist or is not a directory: ' . $missingTree . '.',
             $missingTreeError['error'] ?? null
         );
         $this->assertDirectoryDoesNotExist($missingTree);
@@ -201,7 +201,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame(1, $symlinkResult['exit']);
         $symlinkError = $this->lastJsonLine($symlinkResult['stderr']);
         $this->assertSame(
-            'The local document root must not be a symlink: ' . $symlinkedTree . '.',
+            'The filesystem root must not be a symlink: ' . $symlinkedTree . '.',
             $symlinkError['error'] ?? null
         );
 
@@ -215,7 +215,7 @@ final class FilesPushCommandTest extends TestCase
         ]);
         $this->assertSame(1, $nestedStateResult['exit']);
         $nestedStateError = $this->lastJsonLine($nestedStateResult['stderr']);
-        $this->assertStringContainsString('must be outside the local document root', $nestedStateError['error'] ?? '');
+        $this->assertStringContainsString('must be outside the filesystem root', $nestedStateError['error'] ?? '');
         $this->assertStringContainsString( (string) realpath($this->localTree), $nestedStateError['error'] ?? '' );
 
         $this->assertNoSenderState($this->stateDirectory);

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -43,22 +43,22 @@ final class FilesPushCommandTest extends TestCase
         $this->assertNull(ImportClient::files_push_stop_cause(1000.0, PHP_INT_MAX, 0, -1, $chunkBytes));
     }
 
-    public function testPairContextUsesTheTrimmedTargetAndResolvedLocalDocumentRoot(): void
+    public function testPairContextUsesTheTrimmedRemoteReprintApiUrlAndResolvedFilesystemRoot(): void
     {
-        $targetUrl = 'https://example.test/?reprint-api=1&&';
+        $remoteReprintApiUrl = 'https://example.test/?reprint-api=1&&';
         $context = ImportClient::prepare_files_push_context(
-            $targetUrl,
+            $remoteReprintApiUrl,
             $this->stateDirectory,
             $this->localTree,
             ['secret' => 'token', 'force_http' => false]
         );
-        $resolvedLocalDocumentRoot = realpath($this->localTree);
-        $this->assertIsString($resolvedLocalDocumentRoot);
-        $trimmedTargetUrl = rtrim($targetUrl, '?&');
-        $expectedPair = hash('sha256', $trimmedTargetUrl . "\0" . $resolvedLocalDocumentRoot);
+        $resolvedFilesystemRoot = realpath($this->localTree);
+        $this->assertIsString($resolvedFilesystemRoot);
+        $trimmedRemoteReprintApiUrl = rtrim($remoteReprintApiUrl, '?&');
+        $expectedPair = hash('sha256', $trimmedRemoteReprintApiUrl . "\0" . $resolvedFilesystemRoot);
 
-        $this->assertSame($trimmedTargetUrl, $context['target_url']);
-        $this->assertSame($resolvedLocalDocumentRoot, $context['filesystem_root']);
+        $this->assertSame($trimmedRemoteReprintApiUrl, $context['remote_reprint_api_url']);
+        $this->assertSame($resolvedFilesystemRoot, $context['filesystem_root']);
         $this->assertSame($expectedPair, $context['pair']);
         $this->assertSame(
             realpath($this->stateDirectory) . '/push/' . $expectedPair,
@@ -74,7 +74,7 @@ final class FilesPushCommandTest extends TestCase
         $otherTree = $this->root . '/other-tree';
         mkdir($otherTree);
         $differentTree = ImportClient::prepare_files_push_context(
-            $targetUrl,
+            $remoteReprintApiUrl,
             $this->stateDirectory,
             $otherTree,
             ['secret' => 'token', 'force_http' => false]
@@ -143,7 +143,7 @@ final class FilesPushCommandTest extends TestCase
         );
         $this->assertSame(1, $querySecret['exit']);
         $this->assertStringContainsString(
-            'files-push does not accept SECRET_KEY in the target URL; pass --secret=TOKEN.',
+            'files-push does not accept SECRET_KEY in the remote Reprint API URL; pass --secret=TOKEN.',
             $querySecret['output']
         );
         $this->assertStringNotContainsString('query-secret', $querySecret['output']);
@@ -225,8 +225,8 @@ final class FilesPushCommandTest extends TestCase
     public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void
     {
         $secret = 'shared-secret-' . bin2hex(random_bytes(6));
-        $targetUrl = 'https://127.0.0.1:1/?reprint-api=1';
-        $result = $this->runFilesPush($targetUrl, ['--secret=' . $secret]);
+        $remoteReprintApiUrl = 'https://127.0.0.1:1/?reprint-api=1';
+        $result = $this->runFilesPush($remoteReprintApiUrl, ['--secret=' . $secret]);
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertStringNotContainsString($secret, $result['output']);
@@ -241,9 +241,9 @@ final class FilesPushCommandTest extends TestCase
 
     public function testCorruptSenderStateUsesTheStructuredWorkflowErrorResult(): void
     {
-        $targetUrl = 'https://127.0.0.1:1/?reprint-api=1';
+        $remoteReprintApiUrl = 'https://127.0.0.1:1/?reprint-api=1';
         $context = ImportClient::prepare_files_push_context(
-            $targetUrl,
+            $remoteReprintApiUrl,
             $this->stateDirectory,
             $this->localTree,
             ['secret' => 'token', 'force_http' => false]
@@ -264,7 +264,7 @@ final class FilesPushCommandTest extends TestCase
             ], JSON_THROW_ON_ERROR)
         );
 
-        $result = $this->runFilesPush($targetUrl, ['--secret=token']);
+        $result = $this->runFilesPush($remoteReprintApiUrl, ['--secret=token']);
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $finalLine = $this->lastJsonLine($result['stdout']);
@@ -293,11 +293,11 @@ final class FilesPushCommandTest extends TestCase
     }
 
     /** @param list<string> $extraOptions */
-    private function runFilesPush(string $targetUrl, array $extraOptions): array
+    private function runFilesPush(string $remoteReprintApiUrl, array $extraOptions): array
     {
         return $this->runCli(array_merge([
             'files-push',
-            $targetUrl,
+            $remoteReprintApiUrl,
             '--state-dir=' . $this->stateDirectory,
             '--fs-root=' . $this->localTree,
         ], $extraOptions));

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -111,11 +111,11 @@ class FilesSyncStateTest extends TestCase
     }
 
     /**
-     * Read the download list file and return the list of paths.
+     * Read the fetch list file and return the list of paths.
      */
-    private function readDownloadList(): array
+    private function readFetchList(): array
     {
-        $file = $this->stateDir . '/.import-download-list.jsonl';
+        $file = $this->stateDir . '/.import-fetch-list.jsonl';
         if (!file_exists($file)) {
             return [];
         }
@@ -191,7 +191,7 @@ class FilesSyncStateTest extends TestCase
             "filter" => "essential-files",
         ]);
         file_put_contents(
-            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->stateDir . '/.import-fetch-list-skipped.jsonl',
             json_encode([
                 "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
             ], JSON_UNESCAPED_SLASHES) . "\n",
@@ -215,7 +215,7 @@ class FilesSyncStateTest extends TestCase
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
         $this->assertNull($state["active_resumable_command"]["current_stage"]);
         $this->assertEquals("skipped-earlier", $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-fetch-list-skipped.jsonl');
     }
 
     /**
@@ -295,7 +295,7 @@ class FilesSyncStateTest extends TestCase
     public function testSkippedEarlierAfterCompositePullAdoptsFilesPullState(): void
     {
         file_put_contents(
-            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->stateDir . '/.import-fetch-list-skipped.jsonl',
             $this->indexLine('/wp-content/uploads/2024/01/photo.jpg', 1000, 100),
         );
         $this->writeState([
@@ -338,7 +338,7 @@ class FilesSyncStateTest extends TestCase
 
     /**
      * In preserve-local mode, a file that is in the local index and changed
-     * remotely (different ctime) must be added to the download list.
+     * remotely (different ctime) must be added to the fetch list.
      *
      * Preserve-local protects pre-existing local files, not files we
      * previously synced. A changed file in the local index is ours to update.
@@ -371,7 +371,7 @@ class FilesSyncStateTest extends TestCase
         $diffMethod = $reflection->getMethod('diff_indexes_and_build_fetch_list');
         $diffMethod->invoke($client);
 
-        $downloads = $this->readDownloadList();
+        $downloads = $this->readFetchList();
         $this->assertContains(
             '/wp-content/themes/flavor/style.css',
             $downloads,
@@ -411,7 +411,7 @@ class FilesSyncStateTest extends TestCase
         $diffMethod = $reflection->getMethod('diff_indexes_and_build_fetch_list');
         $diffMethod->invoke($client);
 
-        $downloads = $this->readDownloadList();
+        $downloads = $this->readFetchList();
         $this->assertNotContains(
             '/wp-content/object-cache.php',
             $downloads,
@@ -421,7 +421,7 @@ class FilesSyncStateTest extends TestCase
 
     /**
      * handle_file_chunk must overwrite an existing local file in
-     * preserve-local mode when the file was placed in the download list
+     * preserve-local mode when the file was placed in the fetch list
      * by the diff stage (i.e., it's a file we previously synced that
      * changed remotely).
      *
@@ -469,7 +469,7 @@ class FilesSyncStateTest extends TestCase
         $this->assertEquals(
             'new content',
             file_get_contents($localFile),
-            "Fetch stage must overwrite existing files that were placed in the download list",
+            "Fetch stage must overwrite existing files that were placed in the fetch list",
         );
     }
 }

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -18,16 +18,16 @@ class FilesSyncStateTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-state-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -59,7 +59,7 @@ class FilesSyncStateTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
     }
 
     /**
@@ -200,7 +200,7 @@ class FilesSyncStateTest extends TestCase
         $client = new CompletedFileFetchClient(
             'http://fake.url',
             $this->stateDir,
-            $this->fs_root,
+            $this->import_root,
         );
 
         ob_start();
@@ -354,7 +354,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
-        $localFile = $this->fs_root . '/wp-content/themes/flavor/style.css';
+        $localFile = $this->import_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'old content');
 
@@ -394,7 +394,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)
-        $localFile = $this->fs_root . '/wp-content/object-cache.php';
+        $localFile = $this->import_root . '/wp-content/object-cache.php';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'local drop-in');
 
@@ -432,7 +432,7 @@ class FilesSyncStateTest extends TestCase
     public function testFetchStageOverwritesPreviouslySyncedFile()
     {
         // Create the file locally (simulates a prior sync)
-        $localFile = $this->fs_root . '/wp-content/themes/flavor/style.css';
+        $localFile = $this->import_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'old content');
 

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -18,16 +18,16 @@ class FilesSyncStateTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-state-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -59,7 +59,7 @@ class FilesSyncStateTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root);
     }
 
     /**
@@ -200,7 +200,7 @@ class FilesSyncStateTest extends TestCase
         $client = new CompletedFileFetchClient(
             'http://fake.url',
             $this->stateDir,
-            $this->import_root,
+            $this->filesystem_root,
         );
 
         ob_start();
@@ -354,7 +354,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
-        $localFile = $this->import_root . '/wp-content/themes/flavor/style.css';
+        $localFile = $this->filesystem_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'old content');
 
@@ -394,7 +394,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)
-        $localFile = $this->import_root . '/wp-content/object-cache.php';
+        $localFile = $this->filesystem_root . '/wp-content/object-cache.php';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'local drop-in');
 
@@ -432,7 +432,7 @@ class FilesSyncStateTest extends TestCase
     public function testFetchStageOverwritesPreviouslySyncedFile()
     {
         // Create the file locally (simulates a prior sync)
-        $localFile = $this->import_root . '/wp-content/themes/flavor/style.css';
+        $localFile = $this->filesystem_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'old content');
 

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -7,10 +7,10 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --follow-symlinks=<directory> ("symlink bundle") mode: resolving the bundle
- * destination, classifying escaping vs in-scope paths, and routing placement.
+ * --follow-symlinks=<directory> local followed symlinks root: resolving the
+ * root, classifying escaping vs in-scope paths, and routing placement.
  */
-class SymlinkBundleTest extends TestCase
+class FollowedSymlinksRootTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
@@ -20,7 +20,7 @@ class SymlinkBundleTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/symlink-bundle-' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/followed-symlinks-root-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/srv/htdocs';
         mkdir($this->stateDir, 0755, true);
@@ -54,22 +54,22 @@ class SymlinkBundleTest extends TestCase
         return new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
     }
 
-    // ── Resolving the bundle destination (:fs-root: grammar, within-root) ──
+    // ── Resolving the local followed symlinks root (:fs-root: grammar, within-root) ──
 
     private function resolve(string $raw): string
     {
         $c = $this->newClient();
-        return (new \ReflectionClass($c))->getMethod('resolve_symlink_bundle_directory')->invoke($c, $raw);
+        return (new \ReflectionClass($c))->getMethod('resolve_local_followed_symlinks_root')->invoke($c, $raw);
     }
 
     public function testFsRootTokenResolvesUnderRoot(): void
     {
-        $this->assertSame($this->root . '/.symlinks-bundle', $this->resolve(':fs-root:/.symlinks-bundle'));
+        $this->assertSame($this->root . '/.followed-symlinks-root', $this->resolve(':fs-root:/.followed-symlinks-root'));
     }
 
     public function testRawAbsoluteWithinRootIsKept(): void
     {
-        $this->assertSame($this->root . '/.symlinks-bundle', $this->resolve($this->root . '/.symlinks-bundle'));
+        $this->assertSame($this->root . '/.followed-symlinks-root', $this->resolve($this->root . '/.followed-symlinks-root'));
     }
 
     public function testFsRootItselfIsAccepted(): void
@@ -87,7 +87,7 @@ class SymlinkBundleTest extends TestCase
     public function testRelativeIsRejected(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->resolve('.symlinks-bundle');
+        $this->resolve('.followed-symlinks-root');
     }
 
     // ── "Escaping" classification against the original export scope ──
@@ -110,18 +110,18 @@ class SymlinkBundleTest extends TestCase
         $this->assertFalse($this->inScope(['/srv/site/wp-content'], '/home/master/shared/foo'));
     }
 
-    // ── Placement routing (bundle vs default vs remap) ──
+    // ── Placement routing (local followed symlinks root vs default vs remap) ──
 
     /**
-     * @param string|null $bundleSub Bundle dir as a suffix under fs-root (null = no bundle).
+     * @param string|null $followedSymlinksRootSub Root suffix under fs-root (null = filesystem root).
      * @param array<int,string> $scopePrefixes Original export scope (--only prefixes).
      * @param array<string,string> $remapRules source => absolute target.
      */
-    private function placeClient(?string $bundleSub, array $scopePrefixes, array $remapRules = []): \ImportClient
+    private function placeClient(?string $followedSymlinksRootSub, array $scopePrefixes, array $remapRules = []): \ImportClient
     {
         $c = $this->newClient();
         $rc = new \ReflectionClass($c);
-        $rc->getProperty('symlink_bundle_directory')->setValue($c, $bundleSub === null ? null : $this->root . $bundleSub);
+        $rc->getProperty('local_followed_symlinks_root')->setValue($c, $followedSymlinksRootSub === null ? null : $this->root . $followedSymlinksRootSub);
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $scopePrefixes);
         $rc->getProperty('resolved_path_mappings')->setValue($c, $remapRules);
         return $c;
@@ -132,25 +132,25 @@ class SymlinkBundleTest extends TestCase
         return (new \ReflectionClass($c))->getMethod('map_remote_absolute_path_to_local_absolute_path')->invoke($c, $path);
     }
 
-    public function testEscapingTargetRoutesIntoBundle(): void
+    public function testEscapingTargetRoutesIntoLocalFollowedSymlinksRoot(): void
     {
-        $c = $this->placeClient('/.symlinks-bundle', ['/var/www/html']);
+        $c = $this->placeClient('/.followed-symlinks-root', ['/var/www/html']);
         $this->assertSame(
-            $this->root . '/.symlinks-bundle/tmp/shared/foo/style.css',
+            $this->root . '/.followed-symlinks-root/tmp/shared/foo/style.css',
             $this->place($c, '/tmp/shared/foo/style.css')
         );
     }
 
-    public function testInScopePathNotBundled(): void
+    public function testInScopePathDoesNotUseLocalFollowedSymlinksRoot(): void
     {
-        $c = $this->placeClient('/.symlinks-bundle', ['/var/www/html']);
+        $c = $this->placeClient('/.followed-symlinks-root', ['/var/www/html']);
         $this->assertSame(
             $this->root . '/var/www/html/index.php',
             $this->place($c, '/var/www/html/index.php')
         );
     }
 
-    public function testDefaultPlacementWhenNoBundleDirectory(): void
+    public function testDefaultPlacementWhenNoLocalFollowedSymlinksRoot(): void
     {
         $c = $this->placeClient(null, []);
         $this->assertSame(
@@ -160,61 +160,61 @@ class SymlinkBundleTest extends TestCase
     }
 
     // Regression: an escaping root (/shared) that is an ANCESTOR of the scope
-    // (/shared/wp-content) must not bundle the in-scope subtree.
+    // (/shared/wp-content) must not move the in-scope subtree.
     public function testAncestorEscapingRootLeavesInScopeContentInPlace(): void
     {
-        $c = $this->placeClient('/.symlinks-bundle', ['/shared/wp-content']);
+        $c = $this->placeClient('/.followed-symlinks-root', ['/shared/wp-content']);
         $this->assertSame(
             $this->root . '/shared/wp-content/plugins/foo.php',
             $this->place($c, '/shared/wp-content/plugins/foo.php'),
-            'in-scope content must not be pulled into the bundle'
+            'in-scope content must not use the local followed symlinks root'
         );
         $this->assertSame(
-            $this->root . '/.symlinks-bundle/shared/other/bar.php',
+            $this->root . '/.followed-symlinks-root/shared/other/bar.php',
             $this->place($c, '/shared/other/bar.php'),
-            'genuinely escaping content is still bundled'
+            'genuinely escaping content uses the local followed symlinks root'
         );
     }
 
-    // Regression: an explicit --remap rule wins over bundling, so file placement
+    // Regression: an explicit --remap rule wins over followed-symlink placement, so file placement
     // and the symlink repoint (which share this seam) agree — no dangling link.
     public function testRemapWinsOverBundle(): void
     {
-        $c = $this->placeClient('/.symlinks-bundle', ['/var/www/html'], ['/escaped' => $this->root . '/x']);
+        $c = $this->placeClient('/.followed-symlinks-root', ['/var/www/html'], ['/escaped' => $this->root . '/x']);
         $this->assertSame(
             $this->root . '/x/foo',
             $this->place($c, '/escaped/foo'),
-            'remap target wins; the path is not diverted into the bundle'
+            'remap target wins; the path does not use the local followed symlinks root'
         );
     }
 
-    // ── Bundle-directory fingerprint guard ──
+    // ── Local followed symlinks root fingerprint guard ──
 
-    private function assertGuard(\ImportClient $c, ?string $bundleDir, ?string $persistedFingerprint): void
+    private function assertGuard(\ImportClient $c, ?string $localFollowedSymlinksRoot, ?string $persistedFingerprint): void
     {
         $rc = new \ReflectionClass($c);
-        $rc->getProperty('symlink_bundle_directory')->setValue($c, $bundleDir);
-        $rc->getProperty('state')->getValue($c)->symlink_bundle_directory_fingerprint = $persistedFingerprint;
-        $rc->getMethod('assert_symlink_bundle_directory_unchanged')->invoke($c);
+        $rc->getProperty('local_followed_symlinks_root')->setValue($c, $localFollowedSymlinksRoot);
+        $rc->getProperty('state')->getValue($c)->local_followed_symlinks_root_fingerprint = $persistedFingerprint;
+        $rc->getMethod('assert_local_followed_symlinks_root_unchanged')->invoke($c);
     }
 
-    public function testGuardRejectsChangedBundleDirectory(): void
+    public function testGuardRejectsChangedLocalFollowedSymlinksRoot(): void
     {
         $c = $this->newClient();
         $this->expectException(\RuntimeException::class);
         $this->assertGuard($c, $this->root . '/.bundle-a', hash('sha256', $this->root . '/.bundle-b'));
     }
 
-    public function testGuardAllowsUnchangedBundleDirectory(): void
+    public function testGuardAllowsUnchangedLocalFollowedSymlinksRoot(): void
     {
         $c = $this->newClient();
         $this->assertGuard($c, $this->root . '/.bundle-a', hash('sha256', $this->root . '/.bundle-a'));
         $this->addToAssertionCount(1); // no exception == pass
     }
 
-    public function testGuardRejectsDroppingTheBundleDirectory(): void
+    public function testGuardRejectsDroppingTheLocalFollowedSymlinksRoot(): void
     {
-        // A flag-less run after a bundled pull must error, not silently revert
+        // A flag-less run after a pull with a local followed symlinks root must error, not silently revert
         // to default placement.
         $c = $this->newClient();
         $this->expectException(\RuntimeException::class);
@@ -223,7 +223,7 @@ class SymlinkBundleTest extends TestCase
 
     public function testGuardTreatsBareFollowAndFsRootAsEquivalent(): void
     {
-        // Bare --follow-symlinks (no bundle dir) and --follow-symlinks=:fs-root:
+        // Bare --follow-symlinks (no explicit root) and --follow-symlinks=:fs-root:
         // fingerprint identically — both place at fs-root.
         $c = $this->newClient();
         $this->assertGuard($c, null, hash('sha256', $this->root));
@@ -261,14 +261,14 @@ class SymlinkBundleTest extends TestCase
 
     // ── Intermediate symlinks are repointed through the placement seam ──
 
-    public function testIntermediateSymlinkRepointsIntoBundle(): void
+    public function testIntermediateSymlinkRepointsIntoLocalFollowedSymlinksRoot(): void
     {
         // In-scope intermediate link whose relative target resolves to an
-        // escaping (bundled) location: the raw target would dangle at
-        // fs-root/opt/data; it must be repointed to the bundle placement.
+        // escaping location: the raw target would dangle at fs-root/opt/data;
+        // it must be repointed to the local followed symlinks root.
         $c = $this->newClient();
         $rc = new \ReflectionClass($c);
-        $rc->getProperty('symlink_bundle_directory')->setValue($c, $this->root . '/.symlinks-bundle');
+        $rc->getProperty('local_followed_symlinks_root')->setValue($c, $this->root . '/.followed-symlinks-root');
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, ['/src/wp-content']);
         $rc->getProperty('follow_symlinks')->setValue($c, true);
         $rc->getProperty('remote_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
@@ -285,7 +285,7 @@ class SymlinkBundleTest extends TestCase
 
         $link = $this->root . '/src/wp-content/data';
         $this->assertTrue(is_link($link), 'intermediate link is created');
-        $this->assertStringContainsString('.symlinks-bundle/opt/data', readlink($link),
-            'target is repointed to the bundled placement, not the raw source spelling');
+        $this->assertStringContainsString('.followed-symlinks-root/opt/data', readlink($link),
+            'target is repointed to the local followed symlinks root, not the raw source spelling');
     }
 }

--- a/tests/Import/LegacyCommandAliasTest.php
+++ b/tests/Import/LegacyCommandAliasTest.php
@@ -14,16 +14,16 @@ class LegacyCommandAliasTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-alias-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -62,7 +62,7 @@ class LegacyCommandAliasTest extends TestCase
      */
     public function testLegacyCommandNameIsAccepted(string $legacy_name, string $canonical_name): void
     {
-        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->import_root);
+        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->filesystem_root);
 
         // Write a preflight so commands that require it don't bail early.
         file_put_contents(
@@ -115,7 +115,7 @@ class LegacyCommandAliasTest extends TestCase
             ]),
         );
 
-        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->import_root);
+        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->filesystem_root);
         $reflection = new \ReflectionClass($client);
         $loadState = $reflection->getMethod('load_state');
         $state = $loadState->invoke($client)->to_array();

--- a/tests/Import/LegacyCommandAliasTest.php
+++ b/tests/Import/LegacyCommandAliasTest.php
@@ -14,16 +14,16 @@ class LegacyCommandAliasTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-alias-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -62,7 +62,7 @@ class LegacyCommandAliasTest extends TestCase
      */
     public function testLegacyCommandNameIsAccepted(string $legacy_name, string $canonical_name): void
     {
-        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->fs_root);
+        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->import_root);
 
         // Write a preflight so commands that require it don't bail early.
         file_put_contents(
@@ -115,7 +115,7 @@ class LegacyCommandAliasTest extends TestCase
             ]),
         );
 
-        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->fs_root);
+        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->import_root);
         $reflection = new \ReflectionClass($client);
         $loadState = $reflection->getMethod('load_state');
         $state = $loadState->invoke($client)->to_array();

--- a/tests/Import/LocalIndexWalTest.php
+++ b/tests/Import/LocalIndexWalTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../importer/import.php';
 
-final class IndexUpdateWalTest extends TestCase
+final class LocalIndexWalTest extends TestCase
 {
     private string $root;
     private string $stateDirectory;
@@ -18,7 +18,7 @@ final class IndexUpdateWalTest extends TestCase
     protected function setUp(): void
     {
         $this->root = sys_get_temp_dir()
-            . '/index-update-wal-'
+            . '/local-index-wal-'
             . bin2hex(random_bytes(6));
         $this->stateDirectory = $this->root . '/state';
         $this->fileRoot = $this->root . '/files';
@@ -31,29 +31,29 @@ final class IndexUpdateWalTest extends TestCase
         $this->removeTree($this->root);
     }
 
-    public function testAppliedBatchLeavesTheWalMarkerUntilCompletion(): void
+    public function testAppliedBatchLeavesTheLocalIndexWalMarkerUntilCompletion(): void
     {
         $client = $this->client();
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('record_index_update_file')->invoke(
+        $reflection->getMethod('record_local_index_wal_file')->invoke(
             $client,
             '/site/file.txt',
             42,
             5,
             'file'
         );
-        $reflection->getMethod('apply_index_update_wal')->invoke($client);
+        $reflection->getMethod('apply_local_index_wal')->invoke($client);
 
-        $walPath = $this->stateDirectory . '/.import-index-updates.wal';
-        $this->assertFileExists($walPath);
-        $this->assertSame('', file_get_contents($walPath));
+        $localIndexWalPath = $this->stateDirectory . '/.import-local-index.wal';
+        $this->assertFileExists($localIndexWalPath);
+        $this->assertSame('', file_get_contents($localIndexWalPath));
         $this->assertSame(
             '/site/file.txt',
             $this->firstIndexPath()
         );
 
-        $reflection->getMethod('remove_index_update_wal')->invoke($client);
-        $this->assertFileDoesNotExist($walPath);
+        $reflection->getMethod('remove_local_index_wal')->invoke($client);
+        $this->assertFileDoesNotExist($localIndexWalPath);
     }
 
     public function testReplayDiscardsAnUnterminatedFinalRecord(): void
@@ -66,19 +66,19 @@ final class IndexUpdateWalTest extends TestCase
             'type' => 'file',
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         file_put_contents(
-            $this->stateDirectory . '/.import-index-updates.wal',
+            $this->stateDirectory . '/.import-local-index.wal',
             $completeRecord . '{"op":"F","path":"'
         );
 
         $client = $this->client();
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('replay_index_update_wal')->invoke($client);
+        $reflection->getMethod('replay_local_index_wal')->invoke($client);
 
         $this->assertSame('/site/complete.txt', $this->firstIndexPath());
         $this->assertSame(
             '',
             file_get_contents(
-                $this->stateDirectory . '/.import-index-updates.wal'
+                $this->stateDirectory . '/.import-local-index.wal'
             )
         );
     }
@@ -86,10 +86,10 @@ final class IndexUpdateWalTest extends TestCase
     /**
      * @dataProvider abortCommandProvider
      */
-    public function testAbortReplaysAndRemovesTheWal(string $command): void
+    public function testAbortReplaysAndRemovesTheLocalIndexWal(string $command): void
     {
         file_put_contents(
-            $this->stateDirectory . '/.import-index-updates.wal',
+            $this->stateDirectory . '/.import-local-index.wal',
             json_encode([
                 'op' => 'F',
                 'path' => base64_encode('/site/aborted.txt'),
@@ -115,7 +115,7 @@ final class IndexUpdateWalTest extends TestCase
 
         $this->assertSame('/site/aborted.txt', $this->firstIndexPath());
         $this->assertFileDoesNotExist(
-            $this->stateDirectory . '/.import-index-updates.wal'
+            $this->stateDirectory . '/.import-local-index.wal'
         );
     }
 

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -22,7 +22,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 4,
@@ -156,7 +156,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -190,7 +190,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 64,
@@ -222,7 +222,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'max_bytes' => 512,
         ]);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'request_sizer' => $request_sizer,
@@ -257,7 +257,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('allow_http is true');
         new MultipartPushStreamClient([
-            'base_url' => 'http://example.test/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://example.test/?reprint-api=1',
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
         ]);
     }
@@ -270,7 +270,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -319,7 +319,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'max_bytes' => 2048,
         ]);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'request_sizer' => $request_sizer,
@@ -353,7 +353,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -398,7 +398,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -470,7 +470,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -541,7 +541,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -626,7 +626,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             }
 
             $client = new MultipartPushStreamClient([
-                'base_url' => 'http://' . $address . '/?reprint-api=1',
+                'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
                 'allow_http' => true,
                 'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
                 'connect_timeout' => 2,
@@ -639,7 +639,7 @@ final class MultipartPushStreamClientTest extends TestCase {
                 $this->assertSame('failed', $result['status']);
                 $this->assertSame('redirected', $result['reason']);
                 $this->assertSame(
-                    'The target redirected to http://example.test/final. Use that address as the push base_url.',
+                    'The remote redirected to http://example.test/final. Use that address as the remote Reprint API URL.',
                     $result['detail']
                 );
             } else {
@@ -665,7 +665,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 16 * 1024 * 1024,
@@ -708,7 +708,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -791,7 +791,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -872,7 +872,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 8 * 1024 * 1024,

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -162,7 +162,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // always look deleted-on-remote to the diff. The drains must not
         // delete them: that would recursively remove the very directories
         // the user asked to pull, while the matched children keep the
-        // download list empty — silent data loss.
+        // fetch list empty — silent data loss.
         $this->writeIndex('.import-index.jsonl',
             $this->indexLine('/wp-content/themes', 1000, 0, 'dir')
             . $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -17,16 +17,16 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/only-diff-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -69,7 +69,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     /** Create a local file under fs_root for a (source-absolute) index path. */
     private function seedLocalFile(string $path, string $contents = "x"): string
     {
-        $full = $this->import_root . $path;
+        $full = $this->filesystem_root . $path;
         if (!is_dir(dirname($full))) {
             mkdir(dirname($full), 0755, true);
         }
@@ -116,7 +116,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             json_encode($defaults, JSON_PRETTY_PRINT),
         );
 
-        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
+        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root);
         $r = new \ReflectionClass($client);
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
         $r->getProperty('is_tty')->setValue($client, false);
@@ -179,7 +179,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $r->getMethod('diff_indexes_and_build_fetch_list')->invoke($client);
 
         // The selected root, its matched contents, and its index entry survive…
-        $this->assertDirectoryExists($this->import_root . '/wp-content/themes');
+        $this->assertDirectoryExists($this->filesystem_root . '/wp-content/themes');
         $this->assertFileExists($kept);
         $this->assertContains('/wp-content/themes', $this->readLocalIndexPaths());
         // …while a genuine orphan inside it is still drained.

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -17,16 +17,16 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/only-diff-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -69,7 +69,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     /** Create a local file under fs_root for a (source-absolute) index path. */
     private function seedLocalFile(string $path, string $contents = "x"): string
     {
-        $full = $this->fs_root . $path;
+        $full = $this->import_root . $path;
         if (!is_dir(dirname($full))) {
             mkdir(dirname($full), 0755, true);
         }
@@ -116,7 +116,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             json_encode($defaults, JSON_PRETTY_PRINT),
         );
 
-        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
+        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
         $r = new \ReflectionClass($client);
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
         $r->getProperty('is_tty')->setValue($client, false);
@@ -179,7 +179,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $r->getMethod('diff_indexes_and_build_fetch_list')->invoke($client);
 
         // The selected root, its matched contents, and its index entry survive…
-        $this->assertDirectoryExists($this->fs_root . '/wp-content/themes');
+        $this->assertDirectoryExists($this->import_root . '/wp-content/themes');
         $this->assertFileExists($kept);
         $this->assertContains('/wp-content/themes', $this->readLocalIndexPaths());
         // …while a genuine orphan inside it is still drained.

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -98,7 +98,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         return $paths;
     }
 
-    /** Mirror FilesSyncStateTest: load state + preserve-local, then set the --only file path prefixes. */
+    /** Mirror FilesPullStateTest: load state + preserve-local, then set the --only file path prefixes. */
     private function prepareClient(array $pull_only_files_with_path_prefixes): array
     {
         $defaults = [

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -326,7 +326,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             ))),
         ));
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
-        $this->set($c, 'remap_rules', array(
+        $this->set($c, 'resolved_path_mappings', array(
             '/var/www/html/wp-admin' => '/srv/htdocs/wp-admin',
         ));
         $dirs = $this->call($c, 'get_export_directories');

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../../importer/import.php';
  *   - resolve_pull_only_files_with_path_prefixes(): :token: templates / absolute paths → real source
  *     prefixes (sharing --remap's WordPress path token table), with expansion for plugins, mu-plugins, and uploads
  *     directories outside WP_CONTENT_DIR and covered-prefix collapse.
- *   - is_file_path_selected_by_pull_only_files(): per-path membership (no --only ⇒ every file path).
+ *   - is_selected_for_pulling(): per-path membership (no --only ⇒ every file path).
  *   - get_export_directories(): with --only, a *replace* of the export roots.
  * Orthogonal to --remap (--only file prefixes decide what gets pulled, not where it lands).
  */
@@ -218,13 +218,13 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         // No --only: every file path is selected (keeps the diff deleting orphans).
-        $this->assertTrue($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/anything/at/all.php')));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/anything/at/all.php')));
 
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
-        $this->assertTrue($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-content/themes/a.css')));
-        $this->assertFalse($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-config.php')));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css')));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php')));
         // Byte-order sibling must not match the prefix.
-        $this->assertFalse($this->call($c, 'is_file_path_selected_by_pull_only_files', array('/var/www/html/wp-content.bak/x')));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content.bak/x')));
     }
 
     public function testChangingOnlyPrefixesWhileResumingFilesPullIsRejected(): void

--- a/tests/Import/PhpBuiltinRuntimeRoutingTest.php
+++ b/tests/Import/PhpBuiltinRuntimeRoutingTest.php
@@ -43,7 +43,7 @@ class PhpBuiltinRuntimeRoutingTest extends TestCase
         $manifest = new \RuntimeManifest('other');
         $applier = new \PhpBuiltinApplier();
         $applier->apply($manifest, $this->docRoot, $this->outputDir, [
-            'wordpress_index' => $this->coreRoot . '/index.php',
+            'wordpress_index_php' => $this->coreRoot . '/index.php',
         ]);
     }
 

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -84,7 +84,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $applier = new \PlaygroundCliApplier();
         $applier->apply($manifest, $this->fsRoot, $this->outputDir, [
             'port' => 9400,
-            'wordpress_index' => $this->fsRoot . '/index.php',
+            'wordpress_index_php' => $this->fsRoot . '/index.php',
         ]);
 
         $runtime = file_get_contents($this->outputDir . '/runtime.php');

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -29,7 +29,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
 
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
         $this->stateFile = $stateDir . '/.import-state.json';
-        $this->skippedFile = $stateDir . '/.import-download-list-skipped.jsonl';
+        $this->skippedFile = $stateDir . '/.import-fetch-list-skipped.jsonl';
         file_put_contents($this->stateFile, "{\"command\":\"files-pull\",\"status\":\"partial\"}\n");
         file_put_contents($this->skippedFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
     }
@@ -95,7 +95,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
             $runtime,
         );
         $this->assertStringContainsString(
-            "/tmp/reprint/.import-download-list-skipped.jsonl",
+            "/tmp/reprint/.import-fetch-list-skipped.jsonl",
             $runtime,
         );
         $this->assertStringNotContainsString($this->stateFile, $runtime);
@@ -104,7 +104,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
             $startSh,
         );
         $this->assertStringContainsString(
-            "--mount='" . $this->skippedFile . ":/tmp/reprint/.import-download-list-skipped.jsonl'",
+            "--mount='" . $this->skippedFile . ":/tmp/reprint/.import-fetch-list-skipped.jsonl'",
             $startSh,
         );
 
@@ -117,6 +117,6 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $this->assertContains($this->stateFile, $mount_sources);
         $this->assertContains($this->skippedFile, $mount_sources);
         $this->assertContains('/tmp/reprint/.import-state.json', $mount_targets);
-        $this->assertContains('/tmp/reprint/.import-download-list-skipped.jsonl', $mount_targets);
+        $this->assertContains('/tmp/reprint/.import-fetch-list-skipped.jsonl', $mount_targets);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -11,7 +11,7 @@ class PullFilterFakeClient extends \ImportClient
     private bool $create_skipped_list;
     public int $files_pulled = 0;
     public int $preflight_runs = 0;
-    public int $files_sync_runs = 0;
+    public int $files_pull_runs = 0;
     public int $db_sync_runs = 0;
     public int $db_apply_runs = 0;
     public array $progress_events = [];
@@ -90,7 +90,7 @@ class PullFilterFakeClient extends \ImportClient
         $this->save_import_state();
     }
 
-    public function run_files_sync(): void
+    public function run_files_pull(): void
     {
         $state = $this->get_import_state();
         if (
@@ -100,7 +100,7 @@ class PullFilterFakeClient extends \ImportClient
             return;
         }
 
-        $this->files_sync_runs++;
+        $this->files_pull_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
                 $this->state_dir . '/.import-fetch-list-skipped.jsonl',
@@ -278,7 +278,7 @@ class PullFilterOptionTest extends TestCase
 
         $state = $this->readState();
         $this->assertSame(1, $client->preflight_runs);
-        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->files_pull_runs);
         $this->assertNull($state["pull_pipeline"]["last_completed_stage"]);
 
         $error_events = array_values(array_filter(
@@ -323,7 +323,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->files_pull_runs);
         $this->assertSame(1, $client->db_sync_runs);
         $this->assertSame('pull', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
@@ -357,7 +357,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame(1, $client->files_sync_runs);
+        $this->assertSame(1, $client->files_pull_runs);
         $this->assertSame('pull', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
     }
@@ -486,7 +486,7 @@ class PullFilterOptionTest extends TestCase
 
         $state = $this->readState();
         $this->assertSame(1, $client->preflight_runs);
-        $this->assertSame(1, $client->files_sync_runs);
+        $this->assertSame(1, $client->files_pull_runs);
         $this->assertSame(0, $client->db_sync_runs);
         $this->assertSame(0, $client->db_apply_runs);
         $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
@@ -510,7 +510,7 @@ class PullFilterOptionTest extends TestCase
 
         $state = $this->readState();
         $this->assertSame(1, $client->preflight_runs);
-        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->files_pull_runs);
         $this->assertNull($state["pull_pipeline"]["last_completed_stage"]);
 
         $error_events = array_values(array_filter(
@@ -548,7 +548,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->files_pull_runs);
         $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
         $this->assertSame('files-pull', $state["active_resumable_command"]["command_name"]);
     }
@@ -574,7 +574,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame(1, $client->files_sync_runs);
+        $this->assertSame(1, $client->files_pull_runs);
         $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
     }
@@ -613,7 +613,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->files_pull_runs);
         $this->assertSame(0, $client->db_sync_runs);
     }
 
@@ -627,7 +627,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame(2, $client->files_sync_runs);
+        $this->assertSame(2, $client->files_pull_runs);
         $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
     }
@@ -645,7 +645,7 @@ class PullFilterOptionTest extends TestCase
         ob_end_clean();
 
         $state = $this->readState();
-        $this->assertSame(2, $client->files_sync_runs);
+        $this->assertSame(2, $client->files_pull_runs);
         $this->assertSame(1, $client->db_sync_runs);
         $this->assertSame('pull', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
@@ -664,7 +664,7 @@ class PullFilterOptionTest extends TestCase
 
         $state = $this->readState();
         $this->assertSame(1, $client->preflight_runs);
-        $this->assertSame(0, $client->files_sync_runs);
+        $this->assertSame(0, $client->files_pull_runs);
         $this->assertSame(1, $client->db_sync_runs);
         $this->assertSame(1, $client->db_apply_runs);
         $this->assertSame('pull-db', $state["pull_pipeline"]["started_by_command"]);

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -103,11 +103,11 @@ class PullFilterFakeClient extends \ImportClient
         $this->files_sync_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
-                $this->state_dir . '/.import-download-list-skipped.jsonl',
+                $this->state_dir . '/.import-fetch-list-skipped.jsonl',
                 "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
             );
         } else {
-            @unlink($this->state_dir . '/.import-download-list-skipped.jsonl');
+            @unlink($this->state_dir . '/.import-fetch-list-skipped.jsonl');
         }
 
         $state = $this->get_import_state();
@@ -817,7 +817,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertTrue($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
-        $this->assertFileExists($this->stateDir . '/.import-download-list-skipped.jsonl');
+        $this->assertFileExists($this->stateDir . '/.import-fetch-list-skipped.jsonl');
     }
 
     public function testPullWithoutFilterRecordsFullDownloadMode(): void
@@ -837,7 +837,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertFalse($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-fetch-list-skipped.jsonl');
     }
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -20,10 +20,10 @@ class PullFilterFakeClient extends \ImportClient
     /** @var resource|null */
     private $terminal_progress_stream = null;
 
-    public function __construct(string $state_directory, string $filesystem_root, bool $create_skipped_list)
+    public function __construct(string $state_dir, string $filesystem_root, bool $create_skipped_list)
     {
         $this->create_skipped_list = $create_skipped_list;
-        parent::__construct('http://fake.invalid', $state_directory, $filesystem_root);
+        parent::__construct('http://fake.invalid', $state_dir, $filesystem_root);
     }
 
     public function audit_log(string $message, bool $to_console = true): void
@@ -103,11 +103,11 @@ class PullFilterFakeClient extends \ImportClient
         $this->files_sync_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
-                $this->state_directory . '/.import-download-list-skipped.jsonl',
+                $this->state_dir . '/.import-download-list-skipped.jsonl',
                 "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
             );
         } else {
-            @unlink($this->state_directory . '/.import-download-list-skipped.jsonl');
+            @unlink($this->state_dir . '/.import-download-list-skipped.jsonl');
         }
 
         $state = $this->get_import_state();
@@ -121,7 +121,7 @@ class PullFilterFakeClient extends \ImportClient
     public function run_db_sync(): void
     {
         $this->db_sync_runs++;
-        file_put_contents($this->state_directory . '/db.sql', "SELECT 1;\n");
+        file_put_contents($this->state_dir . '/db.sql', "SELECT 1;\n");
         $state = $this->get_import_state();
         $state->active_resumable_command->command_name = "db-pull";
         $state->active_resumable_command->completion_state = "complete";

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -20,10 +20,10 @@ class PullFilterFakeClient extends \ImportClient
     /** @var resource|null */
     private $terminal_progress_stream = null;
 
-    public function __construct(string $state_dir, string $fs_root, bool $create_skipped_list)
+    public function __construct(string $state_directory, string $import_root, bool $create_skipped_list)
     {
         $this->create_skipped_list = $create_skipped_list;
-        parent::__construct('http://fake.invalid', $state_dir, $fs_root);
+        parent::__construct('http://fake.invalid', $state_directory, $import_root);
     }
 
     public function audit_log(string $message, bool $to_console = true): void
@@ -103,11 +103,11 @@ class PullFilterFakeClient extends \ImportClient
         $this->files_sync_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
-                $this->state_dir . '/.import-download-list-skipped.jsonl',
+                $this->state_directory . '/.import-download-list-skipped.jsonl',
                 "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
             );
         } else {
-            @unlink($this->state_dir . '/.import-download-list-skipped.jsonl');
+            @unlink($this->state_directory . '/.import-download-list-skipped.jsonl');
         }
 
         $state = $this->get_import_state();
@@ -121,7 +121,7 @@ class PullFilterFakeClient extends \ImportClient
     public function run_db_sync(): void
     {
         $this->db_sync_runs++;
-        file_put_contents($this->state_dir . '/db.sql', "SELECT 1;\n");
+        file_put_contents($this->state_directory . '/db.sql', "SELECT 1;\n");
         $state = $this->get_import_state();
         $state->active_resumable_command->command_name = "db-pull";
         $state->active_resumable_command->completion_state = "complete";
@@ -183,16 +183,16 @@ class PullFilterOptionTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/pull-filter-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -224,7 +224,7 @@ class PullFilterOptionTest extends TestCase
 
     private function makeClient(bool $create_skipped_list): PullFilterFakeClient
     {
-        return new PullFilterFakeClient($this->stateDir, $this->fs_root, $create_skipped_list);
+        return new PullFilterFakeClient($this->stateDir, $this->import_root, $create_skipped_list);
     }
 
     private function readState(): array
@@ -261,7 +261,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDoesNotAdvancePastFailedPreflight(): void
     {
-        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->fs_root, false);
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->import_root, false);
 
         try {
             ob_start();
@@ -496,7 +496,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullFilesDoesNotAdvancePastFailedPreflight(): void
     {
-        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->fs_root, false);
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->import_root, false);
 
         try {
             ob_start();
@@ -842,7 +842,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void
     {
-        $client = new PullBridgeFakeClient($this->stateDir, $this->fs_root, false);
+        $client = new PullBridgeFakeClient($this->stateDir, $this->import_root, false);
         $flatten_to = $this->tempDir . '/flattened-site';
 
         ob_start();

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -20,10 +20,10 @@ class PullFilterFakeClient extends \ImportClient
     /** @var resource|null */
     private $terminal_progress_stream = null;
 
-    public function __construct(string $state_directory, string $import_root, bool $create_skipped_list)
+    public function __construct(string $state_directory, string $filesystem_root, bool $create_skipped_list)
     {
         $this->create_skipped_list = $create_skipped_list;
-        parent::__construct('http://fake.invalid', $state_directory, $import_root);
+        parent::__construct('http://fake.invalid', $state_directory, $filesystem_root);
     }
 
     public function audit_log(string $message, bool $to_console = true): void
@@ -183,16 +183,16 @@ class PullFilterOptionTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/pull-filter-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -224,7 +224,7 @@ class PullFilterOptionTest extends TestCase
 
     private function makeClient(bool $create_skipped_list): PullFilterFakeClient
     {
-        return new PullFilterFakeClient($this->stateDir, $this->import_root, $create_skipped_list);
+        return new PullFilterFakeClient($this->stateDir, $this->filesystem_root, $create_skipped_list);
     }
 
     private function readState(): array
@@ -261,7 +261,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDoesNotAdvancePastFailedPreflight(): void
     {
-        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->import_root, false);
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root, false);
 
         try {
             ob_start();
@@ -496,7 +496,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullFilesDoesNotAdvancePastFailedPreflight(): void
     {
-        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->import_root, false);
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root, false);
 
         try {
             ob_start();
@@ -842,7 +842,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void
     {
-        $client = new PullBridgeFakeClient($this->stateDir, $this->import_root, false);
+        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root, false);
         $flatten_to = $this->tempDir . '/flattened-site';
 
         ob_start();

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -774,7 +774,7 @@ final class PushPlanTest extends TestCase
     }
 
     /**
-     * Makes the local tree match one test description while preserving unchanged paths.
+     * Makes the local document root match one test description while preserving unchanged paths.
      *
      * @param string $treeDescriptionPath JSONL path descriptions created by writeIndex().
      */

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -774,7 +774,7 @@ final class PushPlanTest extends TestCase
     }
 
     /**
-     * Makes the local document root match one test description while preserving unchanged paths.
+     * Makes the filesystem root match one test description while preserving unchanged paths.
      *
      * @param string $treeDescriptionPath JSONL path descriptions created by writeIndex().
      */

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -79,7 +79,7 @@ class RemapResolveTest extends TestCase
 
     private function assertRemapConsistent($c): void
     {
-        $this->call($c, 'assert_files_remap_consistent');
+        $this->call($c, 'assert_resolved_path_mappings_consistent');
     }
 
     private function writeLocalIndex(): void

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -210,12 +210,12 @@ class RemapResolveTest extends TestCase
     public function testRejectsChangedRemapRulesForSameState(): void
     {
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-        $this->set($c, 'remap_rules', array(
+        $this->set($c, 'resolved_path_mappings', array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
         $this->assertRemapConsistent($c);
 
-        $this->set($c, 'remap_rules', array(
+        $this->set($c, 'resolved_path_mappings', array(
             '/var/www/html/wp-content' => $this->root . '/content',
         ));
         $this->expectException(\RuntimeException::class);
@@ -227,7 +227,7 @@ class RemapResolveTest extends TestCase
     {
         $this->writeLocalIndex();
         $c = $this->client(array('content_dir' => '/var/www/html/wp-content'));
-        $this->set($c, 'remap_rules', array(
+        $this->set($c, 'resolved_path_mappings', array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
 

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -62,7 +62,7 @@ class RemapSeamTest extends TestCase
     private function clientWithRules(array $rules): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $this->set($c, 'remap_rules', $rules);
+        $this->set($c, 'resolved_path_mappings', $rules);
         return $c;
     }
 

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --remap: the single write seam (remote_path_to_local_path_within_import_root)
+ * --remap: the single write seam (map_target_filesystem_path_to_local_filesystem_path)
  * routes in-scope source paths to their target and leaves the rest nested.
  */
 class RemapSeamTest extends TestCase
@@ -71,7 +71,7 @@ class RemapSeamTest extends TestCase
         $c = $this->clientWithRules(array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
             '/var/www/html/wp-content/plugins/woo/woo.php',
         ));
         $this->assertSame($this->root . '/wp-content/plugins/woo/woo.php', $local);
@@ -86,7 +86,7 @@ class RemapSeamTest extends TestCase
             '/srv/wp-content' => $this->root . '/archive-of-everything',
             '/srv/wp-content/plugins' => $this->root . '/p',
         ));
-        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
             '/srv/wp-content/plugins/woo/woo.php',
         ));
         $this->assertSame($this->root . '/p/woo/woo.php', $local);
@@ -99,7 +99,7 @@ class RemapSeamTest extends TestCase
         $c = $this->clientWithRules(array(
             '/var/www/html/wp-content' => $this->root,
         ));
-        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
             '/var/www/html/wp-content/plugins/woo/woo.php',
         ));
         $this->assertSame($this->root . '/plugins/woo/woo.php', $local);
@@ -110,7 +110,7 @@ class RemapSeamTest extends TestCase
         $c = $this->clientWithRules(array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
             '/var/www/html/wp-admin/index.php',
         ));
         $this->assertSame($this->root . '/var/www/html/wp-admin/index.php', $local);
@@ -119,7 +119,7 @@ class RemapSeamTest extends TestCase
     public function testNoRulesIsLegacyMapping(): void
     {
         $c = $this->clientWithRules(array());
-        $local = $this->call($c, 'remote_path_to_local_path_within_import_root', array(
+        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
             '/var/www/html/wp-content/x.txt',
         ));
         $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local);

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --remap: the single write seam (map_target_filesystem_path_to_local_filesystem_path)
- * routes in-scope source paths to their target and leaves the rest nested.
+ * --remap: the single write seam (map_remote_absolute_path_to_local_absolute_path)
+ * routes remote absolute paths to local absolute paths and leaves the rest nested.
  */
 class RemapSeamTest extends TestCase
 {
@@ -66,43 +66,43 @@ class RemapSeamTest extends TestCase
         return $c;
     }
 
-    public function testInScopePathMapsToDest(): void
+    public function testRemoteAbsolutePathMapsToLocalAbsolutePath(): void
     {
         $c = $this->clientWithRules(array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
+        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
             '/var/www/html/wp-content/plugins/woo/woo.php',
         ));
-        $this->assertSame($this->root . '/wp-content/plugins/woo/woo.php', $local);
+        $this->assertSame($this->root . '/wp-content/plugins/woo/woo.php', $local_absolute_path);
     }
 
-    public function testDeeperSourceWinsRegardlessOfTargetLength(): void
+    public function testDeeperRemotePrefixWinsRegardlessOfLocalPrefixLength(): void
     {
-        // Two nested sources; the deeper (more specific) one has the SHORTER
-        // target. It must still win — specificity is ranked by source, not by
-        // target length.
+        // Two nested remote prefixes; the deeper (more specific) one has the
+        // shorter local prefix. It must still win — specificity is ranked by
+        // remote-prefix length, not local-prefix length.
         $c = $this->clientWithRules(array(
             '/srv/wp-content' => $this->root . '/archive-of-everything',
             '/srv/wp-content/plugins' => $this->root . '/p',
         ));
-        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
+        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
             '/srv/wp-content/plugins/woo/woo.php',
         ));
-        $this->assertSame($this->root . '/p/woo/woo.php', $local);
+        $this->assertSame($this->root . '/p/woo/woo.php', $local_absolute_path);
     }
 
-    public function testDocrootRootTargetPlacesFilesAtDocrootRoot(): void
+    public function testLocalAbsolutePrefixPlacesFilesAtItsRoot(): void
     {
-        // A target that is the docroot itself: files land directly at the root,
+        // A local absolute prefix that is the filesystem root: files land directly at the root,
         // no double slash.
         $c = $this->clientWithRules(array(
             '/var/www/html/wp-content' => $this->root,
         ));
-        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
+        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
             '/var/www/html/wp-content/plugins/woo/woo.php',
         ));
-        $this->assertSame($this->root . '/plugins/woo/woo.php', $local);
+        $this->assertSame($this->root . '/plugins/woo/woo.php', $local_absolute_path);
     }
 
     public function testOutOfScopePathFallsBackToNestedIdentity(): void
@@ -110,19 +110,19 @@ class RemapSeamTest extends TestCase
         $c = $this->clientWithRules(array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
+        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
             '/var/www/html/wp-admin/index.php',
         ));
-        $this->assertSame($this->root . '/var/www/html/wp-admin/index.php', $local);
+        $this->assertSame($this->root . '/var/www/html/wp-admin/index.php', $local_absolute_path);
     }
 
     public function testNoRulesIsLegacyMapping(): void
     {
         $c = $this->clientWithRules(array());
-        $local = $this->call($c, 'map_target_filesystem_path_to_local_filesystem_path', array(
+        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
             '/var/www/html/wp-content/x.txt',
         ));
-        $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local);
+        $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local_absolute_path);
     }
 
     /**

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -182,7 +182,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         );
     }
 
-    public function testApplyRuntimeAddsProxyWhileFilesSyncIsIncomplete(): void
+    public function testApplyRuntimeAddsProxyWhileFilesPullIsIncomplete(): void
     {
         $this->writeState([
             'active_resumable_command' => [
@@ -210,7 +210,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         );
     }
 
-    public function testApplyRuntimeOmitsProxyAfterFilesSyncCompletes(): void
+    public function testApplyRuntimeOmitsProxyAfterFilesPullCompletes(): void
     {
         $this->writeState([
             'active_resumable_command' => [

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -152,7 +152,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'filter' => 'essential-files',
         ]);
         file_put_contents(
-            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            $this->stateDir . '/.import-fetch-list-skipped.jsonl',
             json_encode(['path' => '/wp-content/uploads/2024/01/photo.jpg']) . "\n",
         );
 

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -22,16 +22,16 @@ class RuntimeFilesTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $import_root;
+    private $filesystem_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/runtime-files-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->import_root = $this->tempDir . '/fs-root';
+        $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->import_root, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -63,7 +63,7 @@ class RuntimeFilesTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root);
     }
 
     private function writeState(array $state): void

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -22,16 +22,16 @@ class RuntimeFilesTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $fs_root;
+    private $import_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/runtime-files-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->fs_root = $this->tempDir . '/fs-root';
+        $this->import_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->fs_root, 0755, true);
+        mkdir($this->import_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -63,7 +63,7 @@ class RuntimeFilesTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->import_root);
     }
 
     private function writeState(array $state): void

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -132,13 +132,13 @@ class RuntimeFilesTest extends TestCase
 
         $client = $this->makeClient();
         $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
+        $this->callPrivate($client, 'fetch_runtime_files');
 
         $this->assertDirectoryDoesNotExist($this->stateDir . '/runtime_files');
     }
 
     /**
-     * download_runtime_files() wipes the existing runtime_files/ directory
+     * fetch_runtime_files() wipes the existing runtime_files/ directory
      * on re-run.
      */
     public function testRuntimeFilesDirWipedOnRerun()
@@ -164,14 +164,14 @@ class RuntimeFilesTest extends TestCase
 
         $client = $this->makeClient();
         $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
+        $this->callPrivate($client, 'fetch_runtime_files');
 
         // The old stale file should be gone because the directory was wiped.
         $this->assertFileDoesNotExist($runtimeDir . '/old/stale.php');
     }
 
     /**
-     * download_runtime_files() tolerates fetch failures without throwing.
+     * fetch_runtime_files() tolerates fetch failures without throwing.
      */
     public function testDownloadToleratesFetchFailure()
     {
@@ -194,7 +194,7 @@ class RuntimeFilesTest extends TestCase
         $this->loadClientState($client);
 
         // This must not throw — failures are caught internally.
-        $this->callPrivate($client, 'download_runtime_files');
+        $this->callPrivate($client, 'fetch_runtime_files');
 
         // The directory should exist even though no files were downloaded.
         $this->assertDirectoryExists($this->stateDir . '/runtime_files');

--- a/tests/Import/SymlinkBundleTest.php
+++ b/tests/Import/SymlinkBundleTest.php
@@ -129,7 +129,7 @@ class SymlinkBundleTest extends TestCase
 
     private function place(\ImportClient $c, string $path): string
     {
-        return (new \ReflectionClass($c))->getMethod('map_target_filesystem_path_to_local_filesystem_path')->invoke($c, $path);
+        return (new \ReflectionClass($c))->getMethod('map_remote_absolute_path_to_local_absolute_path')->invoke($c, $path);
     }
 
     public function testEscapingTargetRoutesIntoBundle(): void
@@ -244,7 +244,7 @@ class SymlinkBundleTest extends TestCase
         $rc->getProperty('follow_symlinks')->setValue($c, true);
         $target = $this->root . '/wp-content/themes/x'; // realpath-clean, so it is its own cache key
         // Pretend the target subtree was followed + indexed.
-        $rc->getProperty('target_index_prefix_cache')->setValue($c, [$target => true]);
+        $rc->getProperty('remote_index_prefix_cache')->setValue($c, [$target => true]);
 
         $result = $rc->getMethod('map_symlink_target_for_local_mirror')->invoke(
             $c,
@@ -271,7 +271,7 @@ class SymlinkBundleTest extends TestCase
         $rc->getProperty('symlink_bundle_directory')->setValue($c, $this->root . '/.symlinks-bundle');
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, ['/src/wp-content']);
         $rc->getProperty('follow_symlinks')->setValue($c, true);
-        $rc->getProperty('target_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
+        $rc->getProperty('remote_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
 
         $entry = json_encode([
             'path' => base64_encode('/src/wp-content/data'),

--- a/tests/Import/SymlinkBundleTest.php
+++ b/tests/Import/SymlinkBundleTest.php
@@ -123,7 +123,7 @@ class SymlinkBundleTest extends TestCase
         $rc = new \ReflectionClass($c);
         $rc->getProperty('symlink_bundle_directory')->setValue($c, $bundleSub === null ? null : $this->root . $bundleSub);
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $scopePrefixes);
-        $rc->getProperty('remap_rules')->setValue($c, $remapRules);
+        $rc->getProperty('resolved_path_mappings')->setValue($c, $remapRules);
         return $c;
     }
 
@@ -240,11 +240,11 @@ class SymlinkBundleTest extends TestCase
     {
         $c = $this->newClient();
         $rc = new \ReflectionClass($c);
-        $rc->getProperty('remap_rules')->setValue($c, [$this->root . '/wp-content' => $this->root . '/custom']);
+        $rc->getProperty('resolved_path_mappings')->setValue($c, [$this->root . '/wp-content' => $this->root . '/custom']);
         $rc->getProperty('follow_symlinks')->setValue($c, true);
         $target = $this->root . '/wp-content/themes/x'; // realpath-clean, so it is its own cache key
         // Pretend the target subtree was followed + indexed.
-        $rc->getProperty('remote_index_prefix_cache')->setValue($c, [$target => true]);
+        $rc->getProperty('target_index_prefix_cache')->setValue($c, [$target => true]);
 
         $result = $rc->getMethod('map_symlink_target_for_local_mirror')->invoke(
             $c,
@@ -271,7 +271,7 @@ class SymlinkBundleTest extends TestCase
         $rc->getProperty('symlink_bundle_directory')->setValue($c, $this->root . '/.symlinks-bundle');
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, ['/src/wp-content']);
         $rc->getProperty('follow_symlinks')->setValue($c, true);
-        $rc->getProperty('remote_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
+        $rc->getProperty('target_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
 
         $entry = json_encode([
             'path' => base64_encode('/src/wp-content/data'),

--- a/tests/Import/SymlinkBundleTest.php
+++ b/tests/Import/SymlinkBundleTest.php
@@ -129,7 +129,7 @@ class SymlinkBundleTest extends TestCase
 
     private function place(\ImportClient $c, string $path): string
     {
-        return (new \ReflectionClass($c))->getMethod('remote_path_to_local_path_within_import_root')->invoke($c, $path);
+        return (new \ReflectionClass($c))->getMethod('map_target_filesystem_path_to_local_filesystem_path')->invoke($c, $path);
     }
 
     public function testEscapingTargetRoutesIntoBundle(): void

--- a/tests/Import/SymlinkBundleTest.php
+++ b/tests/Import/SymlinkBundleTest.php
@@ -246,7 +246,7 @@ class SymlinkBundleTest extends TestCase
         // Pretend the target subtree was followed + indexed.
         $rc->getProperty('remote_index_prefix_cache')->setValue($c, [$target => true]);
 
-        $result = $rc->getMethod('map_symlink_target_for_local_mirror')->invoke(
+        $result = $rc->getMethod('rewrite_symlink_target_for_local_filesystem')->invoke(
             $c,
             '/src/wp-content/plugins/p/link',            // source symlink path
             $this->root . '/wp-content/plugins/p/link',  // local path

--- a/tests/Import/TypeSwapTest.php
+++ b/tests/Import/TypeSwapTest.php
@@ -57,17 +57,17 @@ class TypeSwapTest extends TestCase
     }
 
     /**
-     * ensure_directory_path should remove a symlink that blocks directory creation.
+     * create_directory_if_missing should remove a symlink that blocks directory creation.
      */
     public function testEnsureDirectoryPathRemovesBlockingSymlink()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
-        $method = $reflection->getMethod('ensure_directory_path');
+        $method = $reflection->getMethod('create_directory_if_missing');
 
         // Resolve the fs-root path so it matches the realpath() check
-        // inside ensure_directory_path (on macOS, /var -> /private/var).
+        // inside create_directory_if_missing (on macOS, /var -> /private/var).
         $fsRoot = realpath($this->tempDir . '/fs-root');
 
         // Create a symlink at a path where we want a real directory
@@ -77,7 +77,7 @@ class TypeSwapTest extends TestCase
         symlink($targetDir, $symlinkPath);
         $this->assertTrue(is_link($symlinkPath), 'Precondition: symlink exists');
 
-        // ensure_directory_path for a child should replace the symlink with a real dir
+        // create_directory_if_missing for a child should replace the symlink with a real dir
         $method->invoke($client, $fsRoot . '/some-dir/child');
 
         $this->assertFalse(is_link($symlinkPath), 'Symlink should be removed');
@@ -218,7 +218,7 @@ class TypeSwapTest extends TestCase
     }
 
     /**
-     * ensure_directory_path should replace a symlink with a full real directory
+     * create_directory_if_missing should replace a symlink with a full real directory
      * hierarchy when creating deeply nested paths.
      */
     public function testNestedFileUnderExistingSymlinkViaEnsureDirectory()
@@ -226,7 +226,7 @@ class TypeSwapTest extends TestCase
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         // Resolve the fs-root path so it matches the realpath() check
-        // inside ensure_directory_path (on macOS, /var -> /private/var).
+        // inside create_directory_if_missing (on macOS, /var -> /private/var).
         $fsRoot = realpath($this->tempDir . '/fs-root');
 
         // Create a symlink at the top-level path component
@@ -236,9 +236,9 @@ class TypeSwapTest extends TestCase
         symlink($targetDir, $symlinkPath);
         $this->assertTrue(is_link($symlinkPath), 'Precondition: symlink exists');
 
-        // Call ensure_directory_path for a deeply nested path
+        // Call create_directory_if_missing for a deeply nested path
         $reflection = new \ReflectionClass($client);
-        $method = $reflection->getMethod('ensure_directory_path');
+        $method = $reflection->getMethod('create_directory_if_missing');
         $method->invoke($client, $fsRoot . '/top/sub/deep');
 
         $this->assertFalse(is_link($symlinkPath), 'Symlink should be removed');

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2425,7 +2425,7 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/malformed-state';
         mkdir($local_docroot, 0700, true);
         $sender = $this->startSender([
-            'docroot' => $local_docroot,
+            'filesystem_root' => $local_docroot,
             'push_state_directory' => $push_state_directory,
             'base_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
@@ -2931,12 +2931,12 @@ final class PushEndpointsTest extends TestCase {
      * @return array{exit:int,stdout:string,stderr:string,output:string}
      */
     private function runFilesPushCli(
-        string $local_docroot,
+        string $filesystem_root,
         string $state_directory,
         array $ini_settings = []
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
-            $local_docroot,
+            $filesystem_root,
             $state_directory,
             $ini_settings
         );
@@ -3028,11 +3028,11 @@ final class PushEndpointsTest extends TestCase {
 
     /** @return array<string,mixed> */
     private function filesPushSenderOptions(
-        string $local_docroot,
+        string $filesystem_root,
         string $push_state_directory
     ): array {
         return [
-            'docroot' => $local_docroot,
+            'filesystem_root' => $filesystem_root,
             'push_state_directory' => $push_state_directory,
             'base_url' => $this->base_url,
             'allow_http' => true,
@@ -3276,7 +3276,7 @@ final class PushEndpointsTest extends TestCase {
      * @return array<string,mixed> PushFilesSender start or resume options.
      */
     private function senderOptions(
-        string $local_docroot,
+        string $filesystem_root,
         string $push_state_directory
     ): array
     {
@@ -3285,7 +3285,7 @@ final class PushEndpointsTest extends TestCase {
             'maximum_part_bytes' => 64,
         ]);
         return [
-            'docroot' => $local_docroot,
+            'filesystem_root' => $filesystem_root,
             'push_state_directory' => $push_state_directory,
             'base_url' => $this->base_url,
             'allow_http' => true,

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -35,7 +35,7 @@ final class PushEndpointsTest extends TestCase {
     private string $gate_endpoint_configuration_path;
     private string $gate_ready_path;
     private string $gate_release_path;
-    private string $base_url;
+    private string $remote_reprint_api_url;
 
     protected function setUp(): void
     {
@@ -72,7 +72,7 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/remove.txt', 'old');
         mkdir($this->docroot . '/preserved');
         file_put_contents($this->docroot . '/preserved/value.txt', 'keep');
-        [$this->server_process, $this->server_pipes, $this->base_url] = $this->startServer(self::POST_MAX_BYTES);
+        [$this->server_process, $this->server_pipes, $this->remote_reprint_api_url] = $this->startServer(self::POST_MAX_BYTES);
     }
 
     protected function tearDown(): void
@@ -713,7 +713,7 @@ final class PushEndpointsTest extends TestCase {
     public function testUploadReportsDeclaredRequestBodyLimitOn413(): void
     {
         $push_session_id = str_repeat('d', 32);
-        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $url = $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: multipart/mixed; boundary=oversized-endpoint-test'];
         foreach ($headers as $name => $value) {
@@ -782,10 +782,10 @@ final class PushEndpointsTest extends TestCase {
             'document_root' => $this->docroot,
             'maximum_part_bytes' => $maximum_request_body_bytes,
         ]);
-        [$server_process, $server_pipes, $base_url] = $this->startServer($maximum_request_body_bytes);
+        [$server_process, $server_pipes, $remote_reprint_api_url] = $this->startServer($maximum_request_body_bytes);
 
         try {
-            $client = $this->newClient(self::SECRET, $base_url);
+            $client = $this->newClient(self::SECRET, $remote_reprint_api_url);
             $clean_push_session_id = str_repeat('0', 32);
             $clean_create = $client->send_push_request('POST', 'push_create', [
                 'push_session_id' => $clean_push_session_id,
@@ -810,7 +810,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($maximum_request_body_bytes, strlen($multipart_body));
 
             $clean_upload = $this->sendChunkedUploadRequest(
-                $base_url,
+                $remote_reprint_api_url,
                 $clean_push_session_id,
                 $boundary,
                 $multipart_body
@@ -824,7 +824,7 @@ final class PushEndpointsTest extends TestCase {
             ], ['created']);
             $this->assertSame('complete', $over_limit_create['status'], (string) json_encode($over_limit_create));
             $over_limit_upload = $this->sendChunkedUploadRequest(
-                $base_url,
+                $remote_reprint_api_url,
                 $over_limit_push_session_id,
                 $boundary,
                 $multipart_body,
@@ -840,9 +840,9 @@ final class PushEndpointsTest extends TestCase {
         }
 
         $larger_maximum_request_body_bytes = $maximum_request_body_bytes * 2;
-        [$server_process, $server_pipes, $base_url] = $this->startServer($larger_maximum_request_body_bytes);
+        [$server_process, $server_pipes, $remote_reprint_api_url] = $this->startServer($larger_maximum_request_body_bytes);
         try {
-            $client = $this->newClient(self::SECRET, $base_url);
+            $client = $this->newClient(self::SECRET, $remote_reprint_api_url);
             $trailing_byte_push_session_id = str_repeat('2', 32);
             $create = $client->send_push_request('POST', 'push_create', [
                 'push_session_id' => $trailing_byte_push_session_id,
@@ -851,7 +851,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($larger_maximum_request_body_bytes, $create['response']['post_max_bytes']);
 
             $trailing_byte_upload = $this->sendChunkedUploadRequest(
-                $base_url,
+                $remote_reprint_api_url,
                 $trailing_byte_push_session_id,
                 $boundary,
                 $multipart_body,
@@ -1194,7 +1194,7 @@ final class PushEndpointsTest extends TestCase {
     {
         file_put_contents($this->push_authorization_configuration_path, '');
         file_put_contents($this->reprint_configuration_path, $this->docroot . '/invalid-push-directory');
-        $url = $this->base_url . '&endpoint=preflight';
+        $url = $this->remote_reprint_api_url . '&endpoint=preflight';
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_curl_headers();
         $handle = curl_init($url);
         curl_setopt_array($handle, [
@@ -1281,7 +1281,7 @@ final class PushEndpointsTest extends TestCase {
         flock($push_lock, LOCK_UN);
         fclose($push_lock);
 
-        $url = $this->base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $url = $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: application/json'];
         foreach ($headers as $name => $value) {
@@ -2427,7 +2427,7 @@ final class PushEndpointsTest extends TestCase {
         $sender = $this->startSender([
             'filesystem_root' => $local_docroot,
             'push_state_directory' => $push_state_directory,
-            'base_url' => 'http://' . $address . '/?reprint-api=1',
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -2492,7 +2492,7 @@ final class PushEndpointsTest extends TestCase {
             . "Content-Length: 0\r\n\r\n\r\n"
             . '--' . $boundary . "--\r\n";
         $this->sendPostAndDiscardResponse(
-            $this->base_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'],
+            $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'],
             'multipart/mixed; boundary=' . $boundary,
             $delete_body
         );
@@ -2507,7 +2507,7 @@ final class PushEndpointsTest extends TestCase {
         }
         $this->assertIsArray($state);
         $this->sendPostAndDiscardResponse(
-            $this->base_url . '&endpoint=push_commit&push_session_id=' . $state['push_session_id'],
+            $this->remote_reprint_api_url . '&endpoint=push_commit&push_session_id=' . $state['push_session_id'],
             null,
             ''
         );
@@ -2584,7 +2584,7 @@ final class PushEndpointsTest extends TestCase {
                 PHP_BINARY,
                 __DIR__ . '/../importer/import.php',
                 'files-diff',
-                $this->base_url,
+                $this->remote_reprint_api_url,
                 '--state-dir=' . $state_directory,
                 '--fs-root=' . $local_docroot,
             ],
@@ -2789,7 +2789,7 @@ final class PushEndpointsTest extends TestCase {
             $this->markTestSkipped('files-push process-death coverage requires POSIX signals.');
         }
         $this->stopServer($this->server_process, $this->server_pipes);
-        [$this->server_process, $this->server_pipes, $this->base_url] = $this->startServer(16 * 1024 * 1024);
+        [$this->server_process, $this->server_pipes, $this->remote_reprint_api_url] = $this->startServer(16 * 1024 * 1024);
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
             'maximum_part_bytes' => 64,
@@ -2962,7 +2962,7 @@ final class PushEndpointsTest extends TestCase {
         $command = array_merge($command, [
             __DIR__ . '/../importer/import.php',
             'files-push',
-            $this->base_url,
+            $this->remote_reprint_api_url,
             '--state-dir=' . $state_directory,
             '--fs-root=' . $local_docroot,
             '--secret=' . self::SECRET,
@@ -3022,7 +3022,7 @@ final class PushEndpointsTest extends TestCase {
     ): string {
         $canonical_local_docroot = realpath($local_docroot);
         $this->assertIsString($canonical_local_docroot);
-        $pair = hash('sha256', rtrim($this->base_url, '?&') . "\0" . $canonical_local_docroot);
+        $pair = hash('sha256', rtrim($this->remote_reprint_api_url, '?&') . "\0" . $canonical_local_docroot);
         return $state_directory . '/push/' . $pair;
     }
 
@@ -3034,7 +3034,7 @@ final class PushEndpointsTest extends TestCase {
         return [
             'filesystem_root' => $filesystem_root,
             'push_state_directory' => $push_state_directory,
-            'base_url' => $this->base_url,
+            'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 4 * 1024 * 1024,
@@ -3109,13 +3109,13 @@ final class PushEndpointsTest extends TestCase {
      * @return array{http_code:int,response:array<string,mixed>} Decoded raw HTTP response.
      */
     private function sendChunkedUploadRequest(
-        string $base_url,
+        string $remote_reprint_api_url,
         string $push_session_id,
         string $boundary,
         string $multipart_body,
         string $trailing_bytes = ''
     ): array {
-        $request_url = $base_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $request_url = $remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
         $url = parse_url($request_url);
         $this->assertIsArray($url);
         $this->assertSame('http', $url['scheme'] ?? null);
@@ -3287,7 +3287,7 @@ final class PushEndpointsTest extends TestCase {
         return [
             'filesystem_root' => $filesystem_root,
             'push_state_directory' => $push_state_directory,
-            'base_url' => $this->base_url,
+            'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 64,
@@ -3563,10 +3563,10 @@ final class PushEndpointsTest extends TestCase {
         proc_close($process);
     }
 
-    private function newClient(string $secret, ?string $base_url = null): MultipartPushStreamClient
+    private function newClient(string $secret, ?string $remote_reprint_api_url = null): MultipartPushStreamClient
     {
         return new MultipartPushStreamClient([
-            'base_url' => $base_url ?? $this->base_url,
+            'remote_reprint_api_url' => $remote_reprint_api_url ?? $this->remote_reprint_api_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client($secret),
             'chunk_bytes' => 4,
@@ -3619,7 +3619,7 @@ final class PushEndpointsTest extends TestCase {
             '&',
             PHP_QUERY_RFC3986
         );
-        $url = $this->base_url . '&' . $query;
+        $url = $this->remote_reprint_api_url . '&' . $query;
         $authentication_headers = ( new Site_Export_HMAC_Client($secret) )->get_envelope_auth_headers($method, $url);
         $request_headers = [];
         foreach ($authentication_headers as $name => $value) {
@@ -3674,7 +3674,7 @@ final class PushEndpointsTest extends TestCase {
         ?string $body = null,
         ?string $content_type = null
     ): array {
-        $url = $this->base_url
+        $url = $this->remote_reprint_api_url
             . '&endpoint=' . rawurlencode($endpoint)
             . '&push_session_id=' . rawurlencode($push_session_id);
         $curl_headers = [];

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -131,7 +131,7 @@
     "edit-locks": {
       "port": 8122
     },
-    "symlink-bundle": {
+    "followed-symlinks-root": {
       "port": 8123
     },
     "adversarial-database": {

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -98,7 +98,7 @@ describe('Import: Basic File Sync', () => {
 
         // Transient files should be cleaned up
         assert.ok(!existsSync(join(tempDir, '.import-remote-index.jsonl')), 'Expected remote index to be deleted');
-        assert.ok(!existsSync(join(tempDir, '.import-download-list.jsonl')), 'Expected download list to be deleted');
+        assert.ok(!existsSync(join(tempDir, '.import-fetch-list.jsonl')), 'Expected fetch list to be deleted');
     });
 
     it('running after --abort performs a delta sync', () => {

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -82,14 +82,14 @@ describe('Import: Delta Sync with Deletions', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
     });
 
-    it('download list includes deleted files', () => {
-        const dlPath = join(tempDir, '.import-download-list.jsonl');
+    it('fetch list includes deleted files', () => {
+        const dlPath = join(tempDir, '.import-fetch-list.jsonl');
         if (existsSync(dlPath)) {
             const content = readFileSync(dlPath, 'utf-8');
-            // The download list should reference the deleted files
+            // The fetch list should reference the deleted files
             // (either as "deleted" entries or as files to re-sync)
             const lines = content.split('\n').filter(l => l.trim());
-            assert.ok(lines.length >= 0, 'Download list exists');
+            assert.ok(lines.length >= 0, 'Fetch list exists');
         }
     });
 

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -284,7 +284,7 @@ describe('Import: Follow Symlinks', () => {
 
     // ─── Intermediate symlinks ─────────────────────────────────
 
-    it('intermediate symlink /srv/e2e-via is recreated pointing at the local mirror', () => {
+    it('intermediate symlink /srv/e2e-via is recreated pointing at the local filesystem copy', () => {
         // Its target (/srv/e2e-external) was followed and mirrored locally, so
         // the link is repointed within fs-root — same treatment as regular
         // symlink chunks. Unindexed escaping targets are still blocked.

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -104,9 +104,9 @@ describe('Import: --filter', () => {
                 'Expected test-data/hello.txt to exist');
         });
 
-        it('skipped download list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-                'Expected skipped download list to remain on disk');
+        it('skipped fetch list remains on disk', () => {
+            assert.ok(existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
+                'Expected skipped fetch list to remain on disk');
         });
 
         it('audit log shows essential files complete', () => {
@@ -133,9 +133,9 @@ describe('Import: --filter', () => {
             }
         });
 
-        it('skipped download list was cleaned up', () => {
-            assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-                'Expected skipped download list to be cleaned up');
+        it('skipped fetch list was cleaned up', () => {
+            assert.ok(!existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
+                'Expected skipped fetch list to be cleaned up');
         });
 
         it('state shows complete after skipped-earlier (not left in_progress)', () => {
@@ -206,8 +206,8 @@ describe('Import: --filter', () => {
         });
 
         it('skipped list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-                'Expected skipped download list to remain');
+            assert.ok(existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
+                'Expected skipped fetch list to remain');
         });
     });
 
@@ -233,9 +233,9 @@ describe('Import: --filter', () => {
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
         });
 
-        it('no skipped download list was created', () => {
-            assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-                'Expected no skipped download list without --filter');
+        it('no skipped fetch list was created', () => {
+            assert.ok(!existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
+                'Expected no skipped fetch list without --filter');
         });
 
         it('uploads were downloaded normally', () => {

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -92,11 +92,11 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
         assert.equal(state.pull_pipeline.skipped_pending, true);
     });
 
-    it('skipped download list remains on disk', () => {
-        const skippedList = join(tempDir, '.import-download-list-skipped.jsonl');
-        assert.ok(existsSync(skippedList), 'Expected skipped download list to exist');
+    it('skipped fetch list remains on disk', () => {
+        const skippedList = join(tempDir, '.import-fetch-list-skipped.jsonl');
+        assert.ok(existsSync(skippedList), 'Expected skipped fetch list to exist');
         assert.ok(readFileSync(skippedList, 'utf-8').trim().length > 0,
-            'Expected skipped download list to be non-empty');
+            'Expected skipped fetch list to be non-empty');
     });
 
     it('uploads were deferred from the fs-root', () => {

--- a/tests/e2e/tests/import-52-followed-symlinks-root.test.js
+++ b/tests/e2e/tests/import-52-followed-symlinks-root.test.js
@@ -1,13 +1,13 @@
 /**
- * Test 52: symlink bundle — --follow-symlinks=<dir> bundles escaping targets (ARC-1814).
+ * Test 52: followed symlinks root — --follow-symlinks=<dir> places escaping paths under a local root (ARC-1814).
  *
  * Covers the {in-scope, escaping} x {relative, absolute} matrix of directory
  * symlinks under --only + --remap: escaping targets are consolidated into the
- * bundle (nested by source path, deduped), in-scope targets are left in place.
+ * local followed symlinks root (nested by source path, deduped), in-scope paths are left in place.
  * (Escaping *file* symlinks are a known limitation — not covered here.)
  *
  * Run: files-sync --only :wp-content: --remap :wp-content: :fs-root:/wp-content
- *                 --follow-symlinks=:fs-root:/.symlinks-bundle
+ *                 --follow-symlinks=:fs-root:/.followed-symlinks-root
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -22,12 +22,12 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-const SHARED_ROOT = '/tmp/e2e-symlink-bundle';
+const SHARED_ROOT = '/tmp/e2e-followed-symlinks-root';
 const SHARED_DIR = join(SHARED_ROOT, 'pub', 'indice');
-const BUNDLED_STYLE = join('.symlinks-bundle', SHARED_ROOT, 'pub', 'indice', 'style.css');
+const FOLLOWED_SYMLINKS_STYLE = join('.followed-symlinks-root', SHARED_ROOT, 'pub', 'indice', 'style.css');
 
-describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping targets', () => {
-    const site = 'symlink-bundle';
+describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places escaping paths', () => {
+    const site = 'followed-symlinks-root';
     let tempDir;
     let tempDir2;
 
@@ -48,11 +48,11 @@ describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping
                 writeFileSync(join(themes, 'indice-real', 'style.css'), '/* in-scope local theme */\n');
                 // The 2x2 matrix of {in-scope, escaping} x {relative, absolute}:
                 for (const [name, target] of [
-                    // escaping (target outside wp-content) — needs bundling
+                    // escaping (target outside wp-content) — uses the local followed symlinks root
                     ['indice', SHARED_DIR],                              // escaping, absolute
                     ['indice2', SHARED_DIR],                             // escaping, absolute (dedup)
                     ['esc-rel', relative(themes, SHARED_DIR)],           // escaping, relative
-                    // in-scope (target inside wp-content) — must NOT be bundled
+                    // in-scope (target inside wp-content) — must NOT use the local followed symlinks root
                     ['local', './indice-real'],                         // in-scope, relative
                     ['abs-local', join(themes, 'indice-real')],         // in-scope, absolute
                 ]) {
@@ -63,7 +63,7 @@ describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping
                 // A plugin that symlinks into themes — for the narrow `--only
                 // :wp-content:/plugins` run, themes/indice-real is OUTSIDE the
                 // --only scope but INSIDE the remapped wp-content, so remap (checked
-                // before bundle) should place it at wp-content/themes, not the bundle.
+                // before the local followed symlinks root) should place it at wp-content/themes.
                 const plugin = join(siteDir, 'wp-content', 'plugins', 'cross-plugin');
                 mkdirSync(plugin, { recursive: true });
                 writeFileSync(join(plugin, 'cross-plugin.php'), '<?php // cross plugin\n');
@@ -72,8 +72,8 @@ describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping
             },
         });
         prepareSharedTree();
-        tempDir = createTempDir('e2e-symlink-bundle');
-        tempDir2 = createTempDir('e2e-symlink-bundle-narrow');
+        tempDir = createTempDir('e2e-followed-symlinks-root');
+        tempDir2 = createTempDir('e2e-followed-symlinks-root-narrow');
     });
 
     afterAll(() => {
@@ -92,43 +92,43 @@ describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping
             extraArgs: [
                 '--only', ':wp-content:',
                 '--remap', ':wp-content:', ':fs-root:/wp-content',
-                '--follow-symlinks=:fs-root:/.symlinks-bundle',
+                '--follow-symlinks=:fs-root:/.followed-symlinks-root',
             ],
         });
         assert.equal(result.exitCode, 0, `sync failed:\n${result.stdout}\n${result.stderr}`);
     });
 
-    it('escaping target content lands in the bundle, nested by source path', () => {
-        assert.ok(existsSync(join(fsRoot(), BUNDLED_STYLE)),
-            `expected bundled content at ${join(fsRoot(), BUNDLED_STYLE)}`);
-        assert.ok(readFileSync(join(fsRoot(), BUNDLED_STYLE), 'utf-8').includes('Shared indice theme'));
+    it('escaping path content lands under the local followed symlinks root, nested by source path', () => {
+        assert.ok(existsSync(join(fsRoot(), FOLLOWED_SYMLINKS_STYLE)),
+            `expected followed symlinks content at ${join(fsRoot(), FOLLOWED_SYMLINKS_STYLE)}`);
+        assert.ok(readFileSync(join(fsRoot(), FOLLOWED_SYMLINKS_STYLE), 'utf-8').includes('Shared indice theme'));
     });
 
     it('escaping content is not left at its source path in the docroot', () => {
         assert.ok(!existsSync(join(fsRoot(), 'tmp')),
-            'with a bundle directory set, escaping content must not land at fs-root/tmp');
+            'with a local followed symlinks root set, escaping content must not land at fs-root/tmp');
     });
 
-    it('the escaping symlink resolves into the bundle', () => {
+    it('the escaping symlink resolves into the local followed symlinks root', () => {
         const link = join(fsRoot(), 'wp-content', 'themes', 'indice');
         assert.ok(lstatSync(link).isSymbolicLink(), 'indice is a symlink');
-        assert.ok(existsSync(join(link, 'style.css')), 'indice resolves to bundled style.css');
+        assert.ok(existsSync(join(link, 'style.css')), 'indice resolves to followed symlinks style.css');
     });
 
-    it('dedups: two symlinks to one target share one bundle copy', () => {
+    it('dedups: two symlinks to one path share one local followed symlinks copy', () => {
         const link2 = join(fsRoot(), 'wp-content', 'themes', 'indice2');
         assert.ok(existsSync(join(link2, 'style.css')), 'indice2 also resolves');
-        assert.ok(existsSync(join(fsRoot(), '.symlinks-bundle', SHARED_ROOT, 'pub', 'indice')));
+        assert.ok(existsSync(join(fsRoot(), '.followed-symlinks-root', SHARED_ROOT, 'pub', 'indice')));
     });
 
-    it('escaping RELATIVE symlink resolves (into the bundle)', () => {
+    it('escaping RELATIVE symlink resolves through the local followed symlinks root', () => {
         const link = join(fsRoot(), 'wp-content', 'themes', 'esc-rel');
         assert.ok(lstatSync(link).isSymbolicLink(), 'esc-rel is a symlink');
-        assert.ok(existsSync(join(link, 'style.css')), 'esc-rel resolves to the bundled theme');
+        assert.ok(existsSync(join(link, 'style.css')), 'esc-rel resolves to the followed symlinks theme');
         assert.ok(readFileSync(join(link, 'style.css'), 'utf-8').includes('Shared indice theme'));
     });
 
-    it('in-scope symlinks (relative AND absolute) are left in place, not bundled', () => {
+    it('in-scope symlinks (relative AND absolute) are left in place', () => {
         for (const name of ['local', 'abs-local']) {
             const link = join(fsRoot(), 'wp-content', 'themes', name);
             assert.ok(lstatSync(link).isSymbolicLink(), `${name} stays a symlink`);
@@ -136,34 +136,34 @@ describe('Import: symlink bundle (--follow-symlinks=<dir>) consolidates escaping
             assert.ok(readFileSync(join(link, 'style.css'), 'utf-8').includes('in-scope local theme'),
                 `${name} resolves to the in-scope theme`);
         }
-        assert.ok(!existsSync(join(fsRoot(), '.symlinks-bundle', 'wp-content')),
-            'in-scope targets must not be bundled');
+        assert.ok(!existsSync(join(fsRoot(), '.followed-symlinks-root', 'wp-content')),
+            'in-scope paths must not use the local followed symlinks root');
     });
 
     // ── Narrow --only: a plugin symlinks into themes (in wp-content, out of --only) ──
     // themes is OUTSIDE --only :wp-content:/plugins but INSIDE the remapped
-    // wp-content, so remap (checked before bundle) must place it at wp-content/themes,
-    // NOT the bundle — for both relative and absolute spellings.
+    // wp-content, so remap (checked before followed-symlink placement) must place it
+    // at wp-content/themes for both relative and absolute spellings.
     it('narrow --only :wp-content:/plugins files-sync completes', () => {
         const result = runImporter(importUrl(), tempDir2, 'files-sync', {
             secret: getSiteSecret(site),
             extraArgs: [
                 '--only', ':wp-content:/plugins',
                 '--remap', ':wp-content:', ':fs-root:/wp-content',
-                '--follow-symlinks=:fs-root:/.symlinks-bundle',
+                '--follow-symlinks=:fs-root:/.followed-symlinks-root',
             ],
         });
         assert.equal(result.exitCode, 0, `sync failed:\n${result.stdout}\n${result.stderr}`);
     });
 
-    it('cross-scope theme target lands under wp-content/themes (remapped), not the bundle', () => {
+    it('cross-scope theme path lands under wp-content/themes through remap', () => {
         // Followed from a plugin symlink; themes is out of --only but in wp-content.
         const themeStyle = join(fsRoot2(), 'wp-content', 'themes', 'indice-real', 'style.css');
         assert.ok(existsSync(themeStyle), `expected remapped theme at ${themeStyle}`);
         assert.ok(readFileSync(themeStyle, 'utf-8').includes('in-scope local theme'));
-        // It is NOT in the bundle (remap wins over bundling for in-wp-content targets).
-        assert.ok(!existsSync(join(fsRoot2(), '.symlinks-bundle')),
-            'a target inside the remapped wp-content must not be bundled');
+        // It is not under the local followed symlinks root because remap wins.
+        assert.ok(!existsSync(join(fsRoot2(), '.followed-symlinks-root')),
+            'a path inside remapped wp-content must not use the local followed symlinks root');
     });
 
     it('both relative and absolute plugin→theme symlinks resolve', () => {


### PR DESCRIPTION
The importer now distinguishes remote absolute paths, local absolute paths, local relative paths, and push-root-relative paths, so pull and push coordinates are explicit without assuming a document root.

## Glossary

| Previous term | New term | Concrete name or meaning |
| --- | --- | --- |
| target URL, base URL, remote URL | remote Reprint API URL | `$remote_reprint_api_url`; the configured URL used for Reprint requests. |
| local tree, import root, `fs_root` | filesystem root | `$filesystem_root`; the local directory whose contents Reprint compares, pulls, and pushes. |
| target filesystem path, generic remote path | remote absolute path | `$remote_absolute_path`; an absolute path on the remote machine. |
| local filesystem path, generic local path | local absolute path | `$local_absolute_path`; an absolute path on the local machine. |
| local document path, filesystem-root-relative path | local relative path | `$local_relative_path`; a path relative to the filesystem root. |
| target document path | push-root-relative path | `$push_root_relative_path`; a path relative to the receiving push session's push root. |
| canonical path | normalized path or resolved absolute path | Lexical normalization and `realpath()` resolution are named separately. |
| target index | remote index | `$remote_index_file`; the last remote filesystem state accepted by pull. |
| index-update WAL, `.import-index-updates.wal` | local index WAL, `.import-local-index.wal` | `$local_index_wal_path`; completed pull mutations waiting to be applied to the local index. |
| download list | fetch list | `$fetch_list_file`; `.import-fetch-list.jsonl` and `.import-fetch-list-skipped.jsonl`. |
| remap rules, files-remap fingerprint | resolved path mappings, resolved-path-mappings fingerprint | `$resolved_path_mappings` and `$resolved_path_mappings_fingerprint`; mappings from remote absolute prefixes to local absolute prefixes. |
| symlink bundle directory | local followed symlinks root | `$local_followed_symlinks_root`; the local root for content reached through escaping symlinks. |
| local mirror | local filesystem | Symlink targets are rewritten for the local filesystem rather than described as a separate mirror. |
| files-sync lifecycle | files-pull lifecycle | `run_files_pull()` and `run_files_pull_pipeline()` match the public `files-pull` command. |
| effective filesystem root | local document root | `$local_document_root`; the local WordPress document root used by runtime application. |
| WordPress index | WordPress index PHP | `$wordpress_index_php`; the `index.php` path used to locate WordPress core. |

The terminology now carries through importer state, pull and push helpers, runtime appliers, tests, and documentation. CLI flags and protocol keys are unchanged.

Validation: `php -l` passed for all importer source files and affected import tests. `git diff --check` passed. PHPUnit and Composer are unavailable in this workspace; CI has restarted.
