### PR TITLE
Require matching importer and exporter protocol versions

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -21,9 +21,8 @@ if (!ob_get_level()) {
 /**
  * The wire-protocol version this export plugin speaks.
  *
- * Both the export plugin (server) and the importer (client) are deployed
- * independently.  These two constants let them detect incompatibility at
- * preflight time instead of producing silent corruption.
+ * The export plugin and importer report this value during preflight so a
+ * mismatched deployment fails before any content is transferred.
  *
  * EXPORT_PROTOCOL_VERSION is sent to the importer in the preflight JSON
  * response as `protocol_version`.  Bump it whenever a change to the wire
@@ -31,18 +30,6 @@ if (!ob_get_level()) {
  * parameters, response format) would break an older importer.
  */
 define('EXPORT_PROTOCOL_VERSION', 1);
-
-/**
- * The oldest *importer* protocol version this export plugin can talk to.
- *
- * Sent to the importer in the preflight response as `protocol_min_version`.
- * The importer checks that its own IMPORT_PROTOCOL_VERSION is >= this value;
- * if not, it tells the user to update the importer.
- *
- * Raise this when you drop backward-compatibility with old importers.
- * Keep it equal to EXPORT_PROTOCOL_VERSION if no backward compat is needed.
- */
-define('EXPORT_MIN_IMPORT_VERSION', 1);
 
 // File type mask + file type values (top bits of st_mode)
 define('STAT_TYPE_MASK',   0170000);
@@ -2099,7 +2086,6 @@ function endpoint_preflight(array $config): array
         "error" => $preflight_error,
         "timestamp" => time(),
         "protocol_version" => EXPORT_PROTOCOL_VERSION,
-        "protocol_min_version" => EXPORT_MIN_IMPORT_VERSION,
         "wp_detect" => [
             "found" => !empty($wp_detect["roots"]),
             "searched" => $wp_detect["searched"],

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -144,27 +144,14 @@ function reprint_apply_curl_ca_bundle($ch): ?string {
 /**
  * The wire-protocol version this importer speaks.
  *
- * Both the export plugin (server) and the importer (client) are deployed
- * independently.  These two constants let them detect incompatibility at
- * preflight time instead of producing silent corruption.
+ * The export plugin and importer report this value during preflight so a
+ * mismatched deployment fails before any content is transferred.
  *
  * Bump this whenever a change to the wire protocol (cursor encoding,
  * multipart structure, header names, endpoint parameters, response format)
  * would break an older export plugin.
  */
 define('IMPORT_PROTOCOL_VERSION', 1);
-
-/**
- * The oldest *export plugin* protocol version this importer can talk to.
- *
- * During preflight-assert the importer checks that the remote's
- * protocol_version is >= this value; if not, it tells the user to
- * update the export plugin.
- *
- * Raise this when you drop backward-compatibility with old export plugins.
- * Keep it equal to IMPORT_PROTOCOL_VERSION if no backward compat is needed.
- */
-define('IMPORT_MIN_EXPORT_VERSION', 1);
 
 register_shutdown_function(function () {
     $error = error_get_last();
@@ -2157,12 +2144,11 @@ class ImportClient
             $this->import_state()->version = $wp_version;
         }
 
-        // Store remote protocol version for compatibility checks
+        // Store the remote protocol version for the preflight assertion.
         if (isset($payload["protocol_version"])) {
             $this->import_state()->remote_protocol_version = (int) $payload["protocol_version"];
-        }
-        if (isset($payload["protocol_min_version"])) {
-            $this->import_state()->remote_protocol_min_version = (int) $payload["protocol_min_version"];
+        } else {
+            $this->import_state()->remote_protocol_version = null;
         }
 
         // Detect webhost environment from preflight data.
@@ -2468,18 +2454,17 @@ class ImportClient
             $all_pass = false;
         }
 
-        // 3. Protocol version compatibility
+        // 3. Protocol version
         $remote_ver = $this->import_state()->remote_protocol_version ?? null;
-        $remote_min = $this->import_state()->remote_protocol_min_version ?? null;
         if ($remote_ver === null) {
             $proto_ok = false;
             $proto_detail = "Remote export plugin does not report a protocol version. Update the export plugin.";
-        } elseif ($remote_ver < IMPORT_MIN_EXPORT_VERSION) {
+        } elseif ($remote_ver < IMPORT_PROTOCOL_VERSION) {
             $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} is too old (client requires >= v" . IMPORT_MIN_EXPORT_VERSION . "). Update the export plugin.";
-        } elseif (IMPORT_PROTOCOL_VERSION < $remote_min) {
+            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . IMPORT_PROTOCOL_VERSION . ". Update the export plugin.";
+        } elseif ($remote_ver > IMPORT_PROTOCOL_VERSION) {
             $proto_ok = false;
-            $proto_detail = "Client protocol v" . IMPORT_PROTOCOL_VERSION . " is too old (remote requires >= v{$remote_min}). Update the importer.";
+            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . IMPORT_PROTOCOL_VERSION . ". Update the importer.";
         } else {
             $proto_ok = true;
             $proto_detail = "remote v{$remote_ver}, client v" . IMPORT_PROTOCOL_VERSION;

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -351,7 +351,6 @@ class ImportState
     /** @var array<string,mixed>|null */
     public ?array $preflight = null;
     public ?int $remote_protocol_version = null;
-    public ?int $remote_protocol_min_version = null;
     /** @var string|null Importer version saved with state. */
     public ?string $version = null;
     /** @var string|null Webhost detected during preflight. */
@@ -424,7 +423,6 @@ class ImportState
         $state->active_resumable_command = ResumableCommandCheckpointState::from_array($data['active_resumable_command']);
         $state->preflight = $data['preflight'];
         $state->remote_protocol_version = $data['remote_protocol_version'];
-        $state->remote_protocol_min_version = $data['remote_protocol_min_version'];
         $state->version = $data['version'];
         $state->webhost = $data['webhost'];
         $state->follow_symlinks = $data['follow_symlinks'];
@@ -463,7 +461,6 @@ class ImportState
             'active_resumable_command' => $this->active_resumable_command->to_array(),
             'preflight' => $this->preflight,
             'remote_protocol_version' => $this->remote_protocol_version,
-            'remote_protocol_min_version' => $this->remote_protocol_min_version,
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,

--- a/tests/e2e/tests/import-21-preflight.test.js
+++ b/tests/e2e/tests/import-21-preflight.test.js
@@ -31,9 +31,6 @@ describe('Import: Preflight Endpoint', () => {
     it('reports protocol version', () => {
         assert.ok(Number.isInteger(preflight.protocol_version), `Expected integer protocol_version, got ${typeof preflight.protocol_version}`);
         assert.ok(preflight.protocol_version >= 1, `Expected protocol_version >= 1, got ${preflight.protocol_version}`);
-        assert.ok(Number.isInteger(preflight.protocol_min_version), `Expected integer protocol_min_version, got ${typeof preflight.protocol_min_version}`);
-        assert.ok(preflight.protocol_min_version >= 1, `Expected protocol_min_version >= 1, got ${preflight.protocol_min_version}`);
-        assert.ok(preflight.protocol_min_version <= preflight.protocol_version, 'Expected protocol_min_version <= protocol_version');
     });
 
     it('detects WordPress installation', () => {

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -3,8 +3,8 @@
  *
  * Verifies that preflight-assert correctly detects incompatible protocol
  * versions between the export plugin (remote) and the importer (client).
- * Tests all three failure modes: remote too old, client too old, and
- * remote not reporting a version at all.
+ * Tests all three failure modes: remote lower, remote higher, and no remote
+ * version.
  */
 import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import assert from 'node:assert/strict';
@@ -56,7 +56,7 @@ describe('Import: Protocol Version Mismatch', () => {
         if (tempDir) cleanupTempDir(tempDir);
     });
 
-    it('passes when versions are compatible', () => {
+    it('passes when versions match', () => {
         const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
             secret: getSiteSecret(site),
         });
@@ -66,7 +66,7 @@ describe('Import: Protocol Version Mismatch', () => {
         assert.match(result.stdout, /remote v\d+, client v\d+/);
     });
 
-    it('fails when remote protocol version is too old', () => {
+    it('fails when the remote protocol version is lower', () => {
         const state = readState();
         state.remote_protocol_version = 0;
         writeState(state);
@@ -77,13 +77,13 @@ describe('Import: Protocol Version Mismatch', () => {
 
         assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
         assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('too old'), `Expected "too old" message:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('does not match'), `Expected mismatch message:\n${result.stdout}`);
         assert.ok(result.stdout.includes('Update the export plugin'), `Expected update instruction:\n${result.stdout}`);
     });
 
-    it('fails when client protocol version is too old for remote', () => {
+    it('fails when the remote protocol version is higher', () => {
         const state = readState();
-        state.remote_protocol_min_version = 999;
+        state.remote_protocol_version = 999;
         writeState(state);
 
         const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
@@ -92,14 +92,13 @@ describe('Import: Protocol Version Mismatch', () => {
 
         assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
         assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('too old'), `Expected "too old" message:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('does not match'), `Expected mismatch message:\n${result.stdout}`);
         assert.ok(result.stdout.includes('Update the importer'), `Expected update instruction:\n${result.stdout}`);
     });
 
     it('fails when remote does not report a protocol version', () => {
         const state = readState();
         state.remote_protocol_version = null;
-        state.remote_protocol_min_version = null;
         writeState(state);
 
         const result = runImporter(importUrl(), tempDir, 'preflight-assert', {


### PR DESCRIPTION
The importer now accepts only the exporter's exact protocol version instead of treating earlier versions as compatible.

This removes the minimum-version state field and range checks. Preflight persists one protocol version, and mismatches report the two exact versions that cannot communicate.

This is PR 2 of 7. It is stacked on #416.

## Testing

`../vendor/bin/phpunit --no-progress Import/ImportStateTest.php ExportHttpServerTest.php` passes with 21 tests and 76 assertions. The full Import suite also passes at the stack tip.
