### PR TITLE
Use canonical command names instead of aliases

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -894,7 +894,7 @@ class ImportClient
         }
         $command = $options["command"] ?? null;
 
-        // Apply legacy command aliases so callers using old names still work.
+        // Map accepted command aliases to the canonical command names.
         static $command_aliases = [
             "files-sync" => "files-pull",
             "db-sync" => "db-pull",
@@ -12818,7 +12818,7 @@ if (
 
     $command = $argv[1];
 
-    // Legacy command names that still work on the CLI.
+    // Map accepted command aliases to the canonical command names.
     $command_aliases = [
         "files-sync" => "files-pull",
         "db-sync" => "db-pull",

--- a/tests/Import/CommandAliasTest.php
+++ b/tests/Import/CommandAliasTest.php
@@ -7,10 +7,9 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Smoke test: old command names (files-sync, db-sync, flat-document-root)
- * must continue to work via the alias table.
+ * Smoke test: command aliases must continue to work through the alias table.
  */
-class LegacyCommandAliasTest extends TestCase
+class CommandAliasTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
@@ -54,13 +53,13 @@ class LegacyCommandAliasTest extends TestCase
     }
 
     /**
-     * Old command names must be accepted by run() without throwing
-     * "Invalid command". We can't actually complete the sync (no server),
+     * Command aliases must be accepted by run() without throwing
+     * "Invalid command". We can't actually complete the pull (no server),
      * but we verify the command is recognized and dispatched.
      *
-     * @dataProvider legacyCommandProvider
+     * @dataProvider commandAliasProvider
      */
-    public function testLegacyCommandNameIsAccepted(string $legacy_name, string $canonical_name): void
+    public function testCommandAliasIsAccepted(string $alias, string $canonical_name): void
     {
         $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->filesystem_root);
 
@@ -73,14 +72,14 @@ class LegacyCommandAliasTest extends TestCase
         );
 
         try {
-            $client->run(["command" => $legacy_name]);
+            $client->run(["command" => $alias]);
         } catch (\Exception $e) {
             // Expected: network errors, missing preflight fields, etc.
             // The key assertion is that we did NOT get "Invalid command".
             $this->assertStringNotContainsString(
                 "Invalid command",
                 $e->getMessage(),
-                "Legacy command '{$legacy_name}' should be accepted, not rejected as invalid",
+                "Command alias '{$alias}' should be accepted, not rejected as invalid",
             );
             return;
         }
@@ -89,7 +88,7 @@ class LegacyCommandAliasTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public static function legacyCommandProvider(): array
+    public static function commandAliasProvider(): array
     {
         return [
             'files-sync → files-pull' => ['files-sync', 'files-pull'],

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 01: Basic File Sync via import.php
- * Tests files-sync completes, files match source, and restart behavior.
+ * Tests files-pull completes, files match source, and restart behavior.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -32,8 +32,8 @@ describe('Import: Basic File Sync', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes successfully', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes successfully', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -72,7 +72,7 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('re-running after completion refuses without --abort', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             autoResume: false,
         });
@@ -86,7 +86,7 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('--abort clears sync progress and exits', () => {
-        const restart = runImporter(importUrl(), tempDir, 'files-sync', {
+        const restart = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
@@ -102,7 +102,7 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('running after --abort performs a delta sync', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-02-sql-sync.test.js
+++ b/tests/e2e/tests/import-02-sql-sync.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 02: SQL Sync via import.php
- * Tests db-sync and db-index commands produce correct output.
+ * Tests db-pull and db-index commands produce correct output.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -39,8 +39,8 @@ describe('Import: SQL Sync', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('db-sync completes and produces db.sql', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('db-pull completes and produces db.sql', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -93,8 +93,8 @@ describe('Import: SQL Sync', () => {
         }
     });
 
-    it('re-running db-sync without --abort fails with useful message', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('re-running db-pull without --abort fails with useful message', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.notEqual(result.exitCode, 0, 'Expected non-zero exit code');

--- a/tests/e2e/tests/import-03-delta-sync.test.js
+++ b/tests/e2e/tests/import-03-delta-sync.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 03: Delta File Sync via import.php
- * Tests files-sync after initial sync, with and without changes.
+ * Tests files-pull after initial sync, with and without changes.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -37,8 +37,8 @@ describe('Import: Delta Sync', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -54,13 +54,13 @@ describe('Import: Delta Sync', () => {
 
     it('abort + re-sync with no changes completes (delta)', () => {
         // Abort so we can re-run
-        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+        const abort = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
         assert.equal(abort.exitCode, 0);
 
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -69,9 +69,9 @@ describe('Import: Delta Sync', () => {
         assertTreesMatch(getSiteDir(site), join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
-    it('files-sync picks up new file via delta', () => {
+    it('files-pull picks up new file via delta', () => {
         // Abort previous completion so we can run a delta
-        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+        const abort = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
@@ -81,8 +81,8 @@ describe('Import: Delta Sync', () => {
         execSync(`echo "delta test content" | sudo tee ${JSON.stringify(addedFile)} > /dev/null`);
         execSync(`sudo chown nginx:nginx ${JSON.stringify(addedFile)}`);
 
-        // Run files-sync — delta detects and downloads the new file
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        // Run files-pull — delta detects and downloads the new file
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -95,10 +95,10 @@ describe('Import: Delta Sync', () => {
         execSync(`sudo rm -f ${JSON.stringify(addedFile)}`);
     });
 
-    it('files-sync on fresh dir without preflight fails with useful error', () => {
+    it('files-pull on fresh dir without preflight fails with useful error', () => {
         const freshDir = createTempDir('e2e-import-delta-fresh');
         try {
-            const result = runImporter(importUrl(), freshDir, 'files-sync', {
+            const result = runImporter(importUrl(), freshDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 skipPreflight: true,
             });

--- a/tests/e2e/tests/import-05-unicode-paths.test.js
+++ b/tests/e2e/tests/import-05-unicode-paths.test.js
@@ -54,8 +54,8 @@ describe('Import: Unicode Paths', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -104,10 +104,10 @@ describe('Import: Unicode Paths', () => {
         assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
-    it('db-sync completes with valid dump', () => {
+    it('db-pull completes with valid dump', () => {
         const sqlDir = createTempDir('e2e-import-unicode-sql');
         try {
-            const result = runImporter(importUrl(), sqlDir, 'db-sync', {
+            const result = runImporter(importUrl(), sqlDir, 'db-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}`);

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -46,7 +46,7 @@ describe('Import: Symlinks', () => {
         }
 
         it('file sync completes', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -98,7 +98,7 @@ describe('Import: Symlinks', () => {
         }
 
         it('file sync completes within timeout (no infinite loop)', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 timeout: 60000,
             });

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -46,7 +46,7 @@ describe('Import: Permission Errors', () => {
         }
 
         it('file sync completes', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -105,8 +105,8 @@ INSERT INTO wp_secret_table VALUES (1, 'top secret');
             return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
         }
 
-        it('db-sync completes', () => {
-            const result = runImporter(importUrl(), tempDir, 'db-sync', {
+        it('db-pull completes', () => {
+            const result = runImporter(importUrl(), tempDir, 'db-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-08-large-directory.test.js
+++ b/tests/e2e/tests/import-08-large-directory.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 08: Large Directory via import.php
- * Tests files-sync with 2000+ files.
+ * Tests files-pull with 2000+ files.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -42,8 +42,8 @@ describe('Import: Large Directory', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', { timeout: 120000 }, () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', { timeout: 120000 }, () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             timeout: 120000,
         });

--- a/tests/e2e/tests/import-09-resume-sql.test.js
+++ b/tests/e2e/tests/import-09-resume-sql.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 09: SQL Resume via import.php
- * Tests that db-sync resumes correctly when using short max_execution_time.
+ * Tests that db-pull resumes correctly when using short max_execution_time.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -38,10 +38,10 @@ describe('Import: Resume SQL', { timeout: 120000 }, () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('db-sync completes via multiple resumable requests', () => {
+    it('db-pull completes via multiple resumable requests', () => {
         // Use --max-exec=1 to force short server execution times.
         // The SQL dump spans multiple requests, each resuming from cursor.
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--max-exec=1'],
         });

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 10: File Resume via import.php
- * Tests that files-sync can resume after a partial transfer.
+ * Tests that files-pull can resume after a partial transfer.
  * Uses large-directory site (5000+ files) with --max-exec=10 to force short requests.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -43,11 +43,11 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes via multiple resumable requests', () => {
+    it('files-pull completes via multiple resumable requests', () => {
         // Use --max-exec=3 to force short server execution times,
         // which means each request only transfers a subset of files before returning partial.
         // The importer automatically resumes from the cursor.
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             timeout: 180000,
             extraArgs: ['--max-exec=10'],

--- a/tests/e2e/tests/import-11-error-messages.test.js
+++ b/tests/e2e/tests/import-11-error-messages.test.js
@@ -28,7 +28,7 @@ describe('Import: Error Messages', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
         const dir = createTempDir('e2e-import-wrong-hmac');
         try {
-            const result = runImporter(url, dir, 'files-sync', {
+            const result = runImporter(url, dir, 'files-pull', {
                 secret: 'wrong-secret-value',
             });
             assert.notEqual(result.exitCode, 0, 'Expected non-zero exit code for wrong HMAC');
@@ -46,7 +46,7 @@ describe('Import: Error Messages', () => {
         const url = 'http://127.0.0.1:19999/?reprint-api&directory=/tmp';
         const dir = createTempDir('e2e-import-unreachable');
         try {
-            const result = runImporter(url, dir, 'files-sync', {
+            const result = runImporter(url, dir, 'files-pull', {
                 secret: 'any-secret',
                 // runImporter auto-runs preflight first; under WASM PHP each
                 // invocation needs ~12s of boot before curl even attempts the
@@ -87,12 +87,12 @@ describe('Import: Error Messages', () => {
         }
     });
 
-    it('files-sync without preflight fails with useful error', () => {
+    it('files-pull without preflight fails with useful error', () => {
         const site = 'basic';
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
         const dir = createTempDir('e2e-import-delta-no-initial');
         try {
-            const result = runImporter(url, dir, 'files-sync', {
+            const result = runImporter(url, dir, 'files-pull', {
                 secret: getSiteSecret(site),
                 skipPreflight: true,
             });

--- a/tests/e2e/tests/import-12-gzip-corruption.test.js
+++ b/tests/e2e/tests/import-12-gzip-corruption.test.js
@@ -35,11 +35,11 @@ describe('Import: Gzip Corruption', () => {
         removeTestHooks(site);
     });
 
-    it('db-sync detects gzip corruption and fails gracefully', () => {
+    it('db-pull detects gzip corruption and fails gracefully', () => {
         const tempDir = createTempDir('e2e-import-gzip-sql');
         try {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'db-sync', {
+            const result = runImporter(url, tempDir, 'db-pull', {
                 secret: getSiteSecret(site),
                 // The corruption only fires after the full payload streams,
                 // so under WASM PHP the test must allow time for the entire
@@ -76,7 +76,7 @@ describe('Import: Gzip Corruption', () => {
         const tempDir = createTempDir('e2e-import-gzip-files');
         try {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 // The corruption only fires after the full payload streams,
                 // so under WASM PHP the test must allow time for the entire

--- a/tests/e2e/tests/import-13-sha1-integrity.test.js
+++ b/tests/e2e/tests/import-13-sha1-integrity.test.js
@@ -44,8 +44,8 @@ describe('Import: SHA1 Integrity', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-14-buffered-response.test.js
+++ b/tests/e2e/tests/import-14-buffered-response.test.js
@@ -32,8 +32,8 @@ describe('Import: Buffered Response', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync through buffered proxy completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull through buffered proxy completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -52,10 +52,10 @@ describe('Import: Buffered Response', () => {
         assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
-    it('db-sync through buffered proxy completes', () => {
+    it('db-pull through buffered proxy completes', () => {
         const sqlDir = createTempDir('e2e-import-buffered-sql');
         try {
-            const result = runImporter(importUrl(), sqlDir, 'db-sync', {
+            const result = runImporter(importUrl(), sqlDir, 'db-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}`);

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -63,7 +63,7 @@ describe('Import: Volatile Files', () => {
 
         it('file sync completes', () => {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 timeout: 120000,
             });
@@ -149,7 +149,7 @@ describe('Import: Volatile Files', () => {
 
         it('file sync completes', () => {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-16-custom-wp-content.test.js
+++ b/tests/e2e/tests/import-16-custom-wp-content.test.js
@@ -39,8 +39,8 @@ describe('Import: Custom WP Content', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -61,10 +61,10 @@ describe('Import: Custom WP Content', () => {
         assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
-    it('db-sync completes with valid dump', () => {
+    it('db-pull completes with valid dump', () => {
         const sqlDir = createTempDir('e2e-import-custom-wp-sql');
         try {
-            const result = runImporter(importUrl(), sqlDir, 'db-sync', {
+            const result = runImporter(importUrl(), sqlDir, 'db-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}`);

--- a/tests/e2e/tests/import-17-redirect.test.js
+++ b/tests/e2e/tests/import-17-redirect.test.js
@@ -35,12 +35,12 @@ describe('Import: 301 Redirect', () => {
         assert.ok(location.includes('8081'), 'Expected redirect to port 8081');
     });
 
-    it('importer reports HTTP 301 error for files-sync', () => {
+    it('importer reports HTTP 301 error for files-pull', () => {
         const tempDir = createTempDir('e2e-import-redirect-files');
         try {
             // Use the redirect site URL but with the basic site's directory
             const url = `${getSiteUrl('redirect-301')}&directory=/srv/e2e-sites/basic`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret('redirect-301'),
                 // The importer makes its own HTTP request after preflight; under
                 // WASM PHP, both phases need ~12s of boot plus the actual handshake.
@@ -61,11 +61,11 @@ describe('Import: 301 Redirect', () => {
         }
     });
 
-    it('importer reports HTTP 301 error for db-sync', () => {
+    it('importer reports HTTP 301 error for db-pull', () => {
         const tempDir = createTempDir('e2e-import-redirect-sql');
         try {
             const url = `${getSiteUrl('redirect-301')}&directory=/srv/e2e-sites/basic`;
-            const result = runImporter(url, tempDir, 'db-sync', {
+            const result = runImporter(url, tempDir, 'db-pull', {
                 secret: getSiteSecret('redirect-301'),
                 // The importer makes its own HTTP request after preflight; under
                 // WASM PHP, both phases need ~12s of boot plus the actual handshake.

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -46,9 +46,9 @@ describe('Import: Full Round-Trip', () => {
         }
     });
 
-    it('files-sync completes', () => {
+    it('files-pull completes', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-        const result = runImporter(url, tempDir, 'files-sync', {
+        const result = runImporter(url, tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -58,9 +58,9 @@ describe('Import: Full Round-Trip', () => {
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 
-    it('db-sync completes', () => {
+    it('db-pull completes', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-        const result = runImporter(url, tempDir, 'db-sync', {
+        const result = runImporter(url, tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-19-error-chunks.test.js
+++ b/tests/e2e/tests/import-19-error-chunks.test.js
@@ -50,7 +50,7 @@ describe('Import: Error Chunks', () => {
 
         it('file sync completes despite unreadable file', () => {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -114,7 +114,7 @@ describe('Import: Error Chunks', () => {
 
         it('file sync completes despite changed file', () => {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 timeout: 120000,
             });
@@ -184,7 +184,7 @@ describe('Import: Error Chunks', () => {
 
         it('file sync completes despite missing file', () => {
             const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-            const result = runImporter(url, tempDir, 'files-sync', {
+            const result = runImporter(url, tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 timeout: 120000,
             });

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -55,7 +55,7 @@ describe('Import: Request Cutoff', () => {
 
     it('first importer run exits partial after cutoff', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-        const result = runImporter(url, tempDir, 'files-sync', {
+        const result = runImporter(url, tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--max-exec=10'],
             autoResume: false,
@@ -92,7 +92,7 @@ describe('Import: Request Cutoff', () => {
 
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
         // Run the importer again — it should resume from saved state
-        const result = runImporter(url, tempDir, 'files-sync', {
+        const result = runImporter(url, tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--max-exec=10'],
         });

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 22: Delta Sync with Source Deletions via import.php
- * Tests that files-sync correctly detects when files have been
+ * Tests that files-pull correctly detects when files have been
  * deleted on the source between initial and delta syncs.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -43,7 +43,7 @@ describe('Import: Delta Sync with Deletions', () => {
     }
 
     it('initial sync includes the extra files', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -70,13 +70,13 @@ describe('Import: Delta Sync with Deletions', () => {
         execSync(`sudo rm -f ${JSON.stringify(extraFile1)} ${JSON.stringify(extraFile2)}`);
 
         // Abort previous completion so we can run a delta
-        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+        const abort = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
         assert.equal(abort.exitCode, 0);
 
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-23-sql-data-fidelity.test.js
+++ b/tests/e2e/tests/import-23-sql-data-fidelity.test.js
@@ -85,8 +85,8 @@ CREATE TABLE wp_edge_cases (
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('db-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('db-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
             // SQL streaming over WASM PHP needs extra time per invocation —
             // the curl pipeline is slower and the boot overhead adds ~12s on top.

--- a/tests/e2e/tests/import-24-large-single-file.test.js
+++ b/tests/e2e/tests/import-24-large-single-file.test.js
@@ -42,8 +42,8 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             timeout: 180000,
         });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -41,7 +41,7 @@ describe('Import: State Corruption', () => {
 
         it('importer recovers from corrupted state and completes', () => {
             // The importer detects corrupt JSON, renames the file, and starts fresh
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 (graceful recovery)\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -93,7 +93,7 @@ describe('Import: State Corruption', () => {
 
         it('running a different command starts fresh (ignores mismatched state)', () => {
             // The importer sees command mismatch and treats it as a fresh start
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -127,7 +127,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('--abort clears state and exits', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--abort'],
             });
@@ -140,7 +140,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('running after --abort completes fresh sync', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-28-concurrent-errors.test.js
+++ b/tests/e2e/tests/import-28-concurrent-errors.test.js
@@ -84,7 +84,7 @@ describe('Import: Concurrent Errors', { timeout: 180000 }, () => {
 
     it('file sync completes despite multiple concurrent errors', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-        const result = runImporter(url, tempDir, 'files-sync', {
+        const result = runImporter(url, tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             timeout: 180000,
         });

--- a/tests/e2e/tests/import-30-symlink-manifest.test.js
+++ b/tests/e2e/tests/import-30-symlink-manifest.test.js
@@ -48,8 +48,8 @@ describe('Import: Symlink Handling', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -196,14 +196,14 @@ describe('Import: Follow Symlinks', () => {
 
     // ─── Run the import ────────────────────────────────────────────
 
-    it('files-sync with --follow-symlinks completes', () => {
+    it('files-pull with --follow-symlinks completes', () => {
         // Clear any prior state first
-        runImporter(importUrl(), tempDir, 'files-sync', {
+        runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
 
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--follow-symlinks'],
             timeout: 120000,

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -143,8 +143,8 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
         execSync(`sudo rm -rf ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)} 2>/dev/null || true`);
     });
 
-    it('initial files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('initial files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -154,13 +154,13 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
         applyDeltaRemoteChanges();
 
         // Abort previous completion so we can run a delta
-        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+        const abort = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
         assert.equal(abort.exitCode, 0);
 
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -241,8 +241,8 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
         }
     });
 
-    it('subsequent files-sync still works with encoded state paths', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('subsequent files-pull still works with encoded state paths', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);

--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -101,7 +101,7 @@ chown -R nginx:nginx ${sh(remoteRoot)}
         const tempDir = createTempDir(tempPrefix);
         setupInitialRemoteLayout();
 
-        const initial = runImporter(importUrl(), tempDir, 'files-sync', {
+        const initial = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(initial.exitCode, 0, `Expected exit 0\nstderr: ${initial.stderr}\nstdout: ${initial.stdout}`);
@@ -109,13 +109,13 @@ chown -R nginx:nginx ${sh(remoteRoot)}
         applyDeltaRemoteChanges();
 
         // Abort previous completion so we can run a delta
-        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+        const abort = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
         });
         assert.equal(abort.exitCode, 0, `Expected abort exit 0\nstderr: ${abort.stderr}\nstdout: ${abort.stdout}`);
 
-        const delta = runImporter(importUrl(), tempDir, 'files-sync', {
+        const delta = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(delta.exitCode, 0, `Expected exit 0\nstderr: ${delta.stderr}\nstdout: ${delta.stdout}`);

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 35: SQL Output Modes
- * Tests --sql-output=stdout and --sql-output=mysql for db-sync.
+ * Tests --sql-output=stdout and --sql-output=mysql for db-pull.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -39,13 +39,13 @@ describe('Import: SQL Output Modes', () => {
             );
             assert.equal(pfResult.exitCode, 0, `Preflight failed: ${pfResult.stderr}`);
 
-            // Run db-sync in stdout mode. We can't use runImporter's auto-resume
+            // Run db-pull in stdout mode. We can't use runImporter's auto-resume
             // because stdout output is accumulated — instead we run php directly
             // and let the importer's own resume mechanism (exit code 2) handle
             // partial runs. The runImporter helper already handles this.
             const result = runImporter(
                 `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
-                tempDir, 'db-sync', {
+                tempDir, 'db-pull', {
                     secret: getSiteSecret(site),
                     extraArgs: ['--sql-output=stdout'],
                     skipPreflight: true,
@@ -88,7 +88,7 @@ describe('Import: SQL Output Modes', () => {
         it('streams SQL directly into MySQL and matches source', async () => {
             const result = runImporter(
                 `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
-                tempDir, 'db-sync', {
+                tempDir, 'db-pull', {
                     secret: getSiteSecret(site),
                     extraArgs: [
                         '--sql-output=mysql',

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -186,8 +186,8 @@ describe('Import: SQLite Export', () => {
         assert.equal(response.json.database.can_query, true);
     });
 
-    it('db-sync produces valid MySQL dump from SQLite source', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('db-pull produces valid MySQL dump from SQLite source', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0,

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -64,7 +64,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         it('completes via multiple resume cycles and database matches source', async () => {
             // Use --max-exec=1 to force the server to pause frequently,
             // creating many resume cycles. auto-resume handles exit code 2.
-            const result = runImporter(importUrl(), tempDir, 'db-sync', {
+            const result = runImporter(importUrl(), tempDir, 'db-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
                 maxResumeAttempts: 200,
@@ -110,19 +110,19 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         });
 
         it('loads .sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
-            // Run preflight so db-sync can proceed
+            // Run preflight so db-pull can proceed
             runImporter(importUrl(), tempDir, 'preflight', {
                 secret: getSiteSecret(site),
             });
 
-            // Seed a .sql-buffer file before running db-sync.
+            // Seed a .sql-buffer file before running db-pull.
             // The content is a harmless SQL comment that won't affect execution
             // — the point is to verify the importer reads it and logs recovery.
             const bufferFile = join(tempDir, '.sql-buffer');
             writeFileSync(bufferFile, '-- pre-seeded buffer\n');
 
-            // Run a fresh db-sync — the importer should detect the buffer file
-            const result = runImporter(importUrl(), tempDir, 'db-sync', {
+            // Run a fresh db-pull — the importer should detect the buffer file
+            const result = runImporter(importUrl(), tempDir, 'db-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: mysqlArgs(importDb),
                 skipPreflight: true,

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -3,7 +3,7 @@
  *
  * Tests the full round-trip:
  * 1. Create site with known content containing source URLs in various formats
- * 2. Run db-sync → verify .import-domains.json contains the source domain
+ * 2. Run db-pull → verify .import-domains.json contains the source domain
  * 3. Run db-apply with --rewrite-url to apply SQL to target database
  * 4. Verify URLs are rewritten in all value types, including serialized PHP
  */
@@ -87,8 +87,8 @@ describe('Import: URL Rewriting', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('db-sync completes and produces db.sql', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('db-pull completes and produces db.sql', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0,

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -113,7 +113,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('errors on non-empty directory without --preserve-local', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 autoResume: false,
             });
@@ -149,8 +149,8 @@ describe('Import: --preserve-local', () => {
             cleanupTempDir(tempDir);
         });
 
-        it('files-sync completes with --preserve-local', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        it('files-pull completes with --preserve-local', () => {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
@@ -315,7 +315,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('completes after forced resume with --max-exec=3', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--on-fs-root-nonempty=preserve-local', '--max-exec=3'],
                 timeout: 120000,
@@ -360,7 +360,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('initial import completes', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
@@ -379,14 +379,14 @@ describe('Import: --preserve-local', () => {
         it('delta sync completes', () => {
             // Abort previous completion, then re-run — triggers delta.
             // preserve_local is restored from persisted state.
-            const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+            const abort = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--abort'],
             });
             assert.equal(abort.exitCode, 0,
                 `Expected abort exit 0\nstderr: ${abort.stderr}\nstdout: ${abort.stdout}`);
 
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0,
@@ -479,8 +479,8 @@ describe('Import: --preserve-local', () => {
             cleanupTempDir(tempDir);
         });
 
-        it('files-sync completes without security errors', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        it('files-pull completes without security errors', () => {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });

--- a/tests/e2e/tests/import-38-db-apply-sqlite-target.test.js
+++ b/tests/e2e/tests/import-38-db-apply-sqlite-target.test.js
@@ -36,11 +36,11 @@ describe('Import: SQLite db-apply target', () => {
     }
 
     it('applies db.sql into SQLite via the upstream PDO-compatible driver', () => {
-        const syncResult = runImporter(importUrl(), tempDir, 'db-sync', {
+        const syncResult = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(syncResult.exitCode, 0,
-            `Expected db-sync exit 0, got ${syncResult.exitCode}\nstderr: ${syncResult.stderr}\nstdout: ${syncResult.stdout}`);
+            `Expected db-pull exit 0, got ${syncResult.exitCode}\nstderr: ${syncResult.stderr}\nstdout: ${syncResult.stdout}`);
 
         const applyResult = runImporter(importUrl(), tempDir, 'db-apply', {
             secret: getSiteSecret(site),

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -1,5 +1,5 @@
 /**
- * Test 38: flat-document-root with WP Cloud-like directory layout
+ * Test 38: flat-docroot with WP Cloud-like directory layout
  *
  * Simulates a WP Cloud hosting environment where:
  * - ABSPATH is the document root (/srv/e2e-sites/wpcloud-flatten/)
@@ -9,8 +9,8 @@
  *
  * Tests that:
  * 1. Preflight correctly resolves wp_admin_path / wp_includes_path via realpath()
- * 2. files-sync with --follow-symlinks downloads files at their resolved locations
- * 3. flat-document-root creates a standard WP layout by sourcing each component
+ * 2. files-pull with --follow-symlinks downloads files at their resolved locations
+ * 3. flat-docroot creates a standard WP layout by sourcing each component
  *    from where it physically lives
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -142,12 +142,12 @@ require_once ABSPATH . 'wp-settings.php';
         );
     });
 
-    it('files-sync completes with follow_symlinks', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes with follow_symlinks', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--follow-symlinks'],
         });
-        assert.equal(result.exitCode, 0, `files-sync failed:\n${result.stderr}`);
+        assert.equal(result.exitCode, 0, `files-pull failed:\n${result.stderr}`);
     });
 
     it('wp-admin files exist at the resolved core path in fs-root', () => {
@@ -182,18 +182,18 @@ require_once ABSPATH . 'wp-settings.php';
         );
     });
 
-    describe('flat-document-root', () => {
+    describe('flat-docroot', () => {
         let flattenTo;
 
         beforeAll(() => {
             flattenTo = join(tempDir, 'flattened');
-            const result = runImporter(importUrl(), tempDir, 'flat-document-root', {
+            const result = runImporter(importUrl(), tempDir, 'flat-docroot', {
                 secret: getSiteSecret(site),
                 extraArgs: [`--flatten-to=${flattenTo}`],
             });
             assert.equal(
                 result.exitCode, 0,
-                `flat-document-root failed:\n${result.stderr}\n${result.stdout}`,
+                `flat-docroot failed:\n${result.stderr}\n${result.stdout}`,
             );
         });
 

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -1,7 +1,7 @@
 /**
  * Test 40: --filter=essential-files / --filter=skipped-earlier
  *
- * Tests that --filter=essential-files skips uploads during files-sync
+ * Tests that --filter=essential-files skips uploads during files-pull
  * and that --filter=skipped-earlier downloads them in a separate run.
  *
  * The remote site has:
@@ -71,7 +71,7 @@ describe('Import: --filter', () => {
         });
 
         it('--filter=essential-files completes', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=essential-files'],
             });
@@ -117,7 +117,7 @@ describe('Import: --filter', () => {
 
         // Now download the skipped files
         it('--filter=skipped-earlier downloads the uploads', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=skipped-earlier'],
             });
@@ -153,7 +153,7 @@ describe('Import: --filter', () => {
             // blocks filter changes mid-sync). Previously this threw
             // "Cannot change --filter from 'skipped-earlier' to
             // 'essential-files' while a sync is in progress."
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=essential-files'],
             });
@@ -182,7 +182,7 @@ describe('Import: --filter', () => {
         });
 
         it('completes with forced resume via --max-exec=3', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=essential-files', '--max-exec=3'],
                 timeout: 120000,
@@ -225,8 +225,8 @@ describe('Import: --filter', () => {
             cleanupTempDir(tempDir);
         });
 
-        it('files-sync without --filter completes', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        it('files-pull without --filter completes', () => {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0,
@@ -262,7 +262,7 @@ describe('Import: --filter', () => {
         });
 
         it('errors when no prior essential-files run exists', () => {
-            const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=skipped-earlier'],
                 autoResume: false,

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -2,8 +2,8 @@
  * Test 41: Playground CLI runtime target
  *
  * Verifies the apply-runtime --runtime=playground-cli flow:
- * 1. files-sync downloads the remote site
- * 2. db-sync + db-apply import the database into SQLite
+ * 1. files-pull downloads the remote site
+ * 2. db-pull + db-apply import the database into SQLite
  * 3. apply-runtime --runtime=playground-cli generates runtime.php,
  *    blueprint.json, and start.sh with the correct structure
  */
@@ -64,23 +64,23 @@ describe('Import: Playground CLI runtime', () => {
         assert.equal(details.sqlite_driver_parser, 'verified');
     });
 
-    it('files-sync downloads the site', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull downloads the site', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0,
-            `files-sync failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
+            `files-pull failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
 
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 
-    it('db-sync downloads the SQL dump', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('db-pull downloads the SQL dump', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0,
-            `db-sync failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
+            `db-pull failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
 
         assert.ok(existsSync(join(tempDir, 'db.sql')), 'db.sql should exist');
     });

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -1,5 +1,5 @@
 /**
- * Test 42: flat-document-root when ABSPATH goes through a symlink
+ * Test 42: flat-docroot when ABSPATH goes through a symlink
  *
  * Simulates a WordPress.com Atomic-like environment where ABSPATH is
  * accessed through a symlink. On Atomic, /wordpress is a symlink, so
@@ -13,7 +13,7 @@
  *
  * Before the fix, the exporter reported the unresolved symlink path as
  * abspath. The importer would download files under the resolved real path
- * but flat-document-root would look at the unresolved symlink path in
+ * but flat-docroot would look at the unresolved symlink path in
  * fs-root and fail.
  *
  * The fix: the exporter now applies realpath() to ABSPATH, matching the
@@ -95,12 +95,12 @@ require ABSPATH . 'wp-blog-header.php';
         );
     });
 
-    it('files-sync completes with follow_symlinks', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes with follow_symlinks', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--follow-symlinks'],
         });
-        assert.equal(result.exitCode, 0, `files-sync failed:\n${result.stderr}`);
+        assert.equal(result.exitCode, 0, `files-pull failed:\n${result.stderr}`);
     });
 
     it('WP core files exist at the resolved path in fs-root', () => {
@@ -123,18 +123,18 @@ require ABSPATH . 'wp-blog-header.php';
         );
     });
 
-    describe('flat-document-root', () => {
+    describe('flat-docroot', () => {
         let flattenTo;
 
         beforeAll(() => {
             flattenTo = join(tempDir, 'flattened');
-            const result = runImporter(importUrl(), tempDir, 'flat-document-root', {
+            const result = runImporter(importUrl(), tempDir, 'flat-docroot', {
                 secret: getSiteSecret(site),
                 extraArgs: [`--flatten-to=${flattenTo}`],
             });
             assert.equal(
                 result.exitCode, 0,
-                `flat-document-root failed:\n${result.stderr}\n${result.stdout}`,
+                `flat-docroot failed:\n${result.stderr}\n${result.stdout}`,
             );
         });
 

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -129,7 +129,7 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
             try {
                 // autoResume=false requires this one importer invocation to
                 // recover instead of starting another process.
-                const result = runImporter(importUrl(), tempDir, 'db-sync', {
+                const result = runImporter(importUrl(), tempDir, 'db-pull', {
                     secret: getSiteSecret(site),
                     extraArgs: sqlOutputArgs(mode, importDb),
                     autoResume: false,

--- a/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
+++ b/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
@@ -64,14 +64,14 @@ describe('Import: Symlink cycle detection', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-sync completes without hanging', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes without hanging', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--follow-symlinks'],
         });
         assert.equal(
             result.exitCode, 0,
-            `files-sync should complete (not hang on cycle)\nstderr: ${result.stderr}`,
+            `files-pull should complete (not hang on cycle)\nstderr: ${result.stderr}`,
         );
     });
 

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -3,7 +3,7 @@
  *
  * Simulates a SiteGround hosting environment where sg-cachepress and
  * sg-security are installed and active.  Verifies that after the full
- * import pipeline (preflight -> files-sync -> db-sync -> db-apply ->
+ * import pipeline (preflight -> files-pull -> db-pull -> db-apply ->
  * apply-runtime), both plugins are:
  *   1. Deactivated in the target database during db-apply
  *   2. Removed from the local filesystem during apply-runtime
@@ -116,18 +116,18 @@ describe('Import: SiteGround plugin stripping', () => {
             `Expected webhost 'siteground', got '${state.webhost}'`);
     });
 
-    it('files-sync downloads the site', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull downloads the site', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
         });
-        assert.equal(result.exitCode, 0, `files-sync failed:\n${result.stderr}`);
+        assert.equal(result.exitCode, 0, `files-pull failed:\n${result.stderr}`);
     });
 
-    it('db-sync downloads the SQL dump', () => {
-        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+    it('db-pull downloads the SQL dump', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
         });
-        assert.equal(result.exitCode, 0, `db-sync failed:\n${result.stderr}`);
+        assert.equal(result.exitCode, 0, `db-pull failed:\n${result.stderr}`);
         assert.ok(existsSync(join(tempDir, 'db.sql')), 'db.sql should exist');
     });
 
@@ -197,12 +197,12 @@ describe('Import: SiteGround plugin stripping', () => {
     describe('apply-runtime removes SG plugin files', () => {
         beforeAll(() => {
             const flatDir = join(tempDir, 'flattened');
-            const flatResult = runImporter(importUrl(), tempDir, 'flat-document-root', {
+            const flatResult = runImporter(importUrl(), tempDir, 'flat-docroot', {
                 secret: getSiteSecret(site),
                 extraArgs: [`--flatten-to=${flatDir}`],
             });
             assert.equal(flatResult.exitCode, 0,
-                `flat-document-root failed:\n${flatResult.stderr}`);
+                `flat-docroot failed:\n${flatResult.stderr}`);
 
             execFileSync('php', [
                 IMPORTER_PATH,

--- a/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
+++ b/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
@@ -125,15 +125,15 @@ describe('Import: Shared theme symlink remains working', () => {
         );
     });
 
-    it('files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--follow-symlinks'],
         });
         assert.equal(
             result.exitCode,
             0,
-            `files-sync failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+            `files-pull failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
         );
     });
 

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -17,7 +17,7 @@
  * The source exits before it writes the boundary which would confirm the
  * first part. The importer must leave its cursor at the preceding boundary,
  * replay the unconfirmed bytes, and replace rather than append them. After
- * removing the hook, files-sync resumes and completes. Final assertion:
+ * removing the hook, files-pull resumes and completes. Final assertion:
  * SHA-256 of the imported file equals the source.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -117,7 +117,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
             "}",
         ].join('\n'));
 
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: [
                 '--file-chunk-start=262144',
@@ -156,7 +156,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
     it('resume completes after removing the hook', () => {
         removeTestHooks(site);
 
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: [
                 '--file-chunk-start=262144',

--- a/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
+++ b/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
@@ -5,7 +5,7 @@
  * site" flow, plus the scoped re-sync that follows it. It exercises the v1
  * invocation —
  *
- *   files-sync --only :wp-content: --remap :wp-content: :fs-root:/wp-content \
+ *   files-pull --only :wp-content: --remap :wp-content: :fs-root:/wp-content \
  *     --on-fs-root-nonempty=preserve-local --no-follow-symlinks
  *
  * — against a fs-root pre-populated with the realistic managed hosting layout
@@ -134,8 +134,8 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
     // ================================================================
     // Phase 1 — first migration: --only :wp-content:
     // ================================================================
-    it('files-sync completes with --only + --remap + preserve-local', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes with --only + --remap + preserve-local', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--only', ':wp-content:', ...remap, ...preserve],
         });
@@ -220,7 +220,7 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
         execSync(`sudo rm -rf ${JSON.stringify(join(siteDir, 'wp-content', 'plugins', 'custom-plugin'))}`);
         assert.ok(!existsSync(join(siteDir, 'wp-content', 'plugins', 'custom-plugin')),
             'precondition: source custom-plugin removed');
-        const abort = runImporter(importUrl(), tempDir, 'files-sync', {
+        const abort = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--abort'],
             autoResume: false,
@@ -229,7 +229,7 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
     });
 
     it('scoped delta re-sync completes (--only :wp-content:/plugins)', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: ['--only', ':wp-content:/plugins', ...remap, ...preserve],
         });

--- a/tests/e2e/tests/import-52-followed-symlinks-root.test.js
+++ b/tests/e2e/tests/import-52-followed-symlinks-root.test.js
@@ -6,7 +6,7 @@
  * local followed symlinks root (nested by source path, deduped), in-scope paths are left in place.
  * (Escaping *file* symlinks are a known limitation — not covered here.)
  *
- * Run: files-sync --only :wp-content: --remap :wp-content: :fs-root:/wp-content
+ * Run: files-pull --only :wp-content: --remap :wp-content: :fs-root:/wp-content
  *                 --follow-symlinks=:fs-root:/.followed-symlinks-root
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -86,8 +86,8 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
     const fsRoot = () => fsRootDir(tempDir);
     const fsRoot2 = () => fsRootDir(tempDir2);
 
-    it('files-sync completes with --follow-symlinks=<dir>', () => {
-        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+    it('files-pull completes with --follow-symlinks=<dir>', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: [
                 '--only', ':wp-content:',
@@ -144,8 +144,8 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
     // themes is OUTSIDE --only :wp-content:/plugins but INSIDE the remapped
     // wp-content, so remap (checked before followed-symlink placement) must place it
     // at wp-content/themes for both relative and absolute spellings.
-    it('narrow --only :wp-content:/plugins files-sync completes', () => {
-        const result = runImporter(importUrl(), tempDir2, 'files-sync', {
+    it('narrow --only :wp-content:/plugins files-pull completes', () => {
+        const result = runImporter(importUrl(), tempDir2, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: [
                 '--only', ':wp-content:/plugins',


### PR DESCRIPTION
The importer E2E suite now invokes `files-pull`, `db-pull`, and `flat-docroot` without changing what any command or option accepts.

The existing command aliases remain inline in both `ImportClient::run()` and the CLI. The alias test keeps the same scenarios under `CommandAliasTest`; every other command reference uses the canonical name. URL handling, option parsing, help output, symlink behavior, and test setup remain unchanged.

#420 remains stacked on this PR.

## Testing

The complete Import suite passes with 460 tests and 3,437 assertions; five tests are skipped. The focused alias, help, URL, and symlink suite passes with 35 tests and 92 assertions. PHPStan passes, PHPCS counts are unchanged, and Node syntax checks pass for all 45 changed E2E files.
