### PR TITLE
Use WordPress/reprint release and Blueprint URLs

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -12315,7 +12315,7 @@ if (
         $cyan  = $is_tty ? "\033[36m" : "";
         $reset = $is_tty ? "\033[0m" : "";
 
-        $repo = "adamziel/streaming-site-migration";
+        $repo = "WordPress/reprint";
         $zip_url = "https://github.com/{$repo}/releases/download/{$version}/reprint-exporter-wp.zip";
         $releases_url = "https://github.com/{$repo}/releases";
 

--- a/reprint-ui/blueprint.json
+++ b/reprint-ui/blueprint.json
@@ -14,7 +14,7 @@
       "path": "/wordpress/wp-content/mu-plugins/reprint-ui/index.php",
       "data": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/Automattic/streaming-site-migration/trunk/reprint-ui/index.php"
+        "url": "https://raw.githubusercontent.com/WordPress/reprint/trunk/reprint-ui/index.php"
       }
     },
     {
@@ -22,7 +22,7 @@
       "path": "/wordpress/wp-content/mu-plugins/reprint-ui/reprint.phar",
       "data": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/Automattic/streaming-site-migration/trunk/reprint.phar"
+        "url": "https://github.com/WordPress/reprint/releases/latest/download/reprint.phar"
       }
     }
   ]


### PR DESCRIPTION
The installer guide and Playground Blueprint now fetch Reprint releases and files from `WordPress/reprint`.

The Blueprint loads the UI from the repository and `reprint.phar` from the latest GitHub Release. This replaces the retired pre-rename locations without changing importer or exporter protocol behavior.

## Testing

`packages/reprint-importer/src/import.php` passes PHP syntax checks, the Blueprint parses as JSON, both Blueprint URLs return HTTP 200, and PHPStan passes.
