### PR TITLE
Remove retired Reprint UI transition hooks

### DIFF
--- a/reprint-ui/bootstrap.php
+++ b/reprint-ui/bootstrap.php
@@ -14,15 +14,6 @@ if (!defined('REPRINT_UI_URL_BASE')) {
 }
 
 /**
- * No-op kept for call-site compatibility. State is held in signed,
- * encrypted, HttpOnly cookies — see reprint_cookie_get/set/clear. We
- * deliberately avoid PHP sessions so nothing about the user (OAuth
- * tokens, OAuth state nonces, blog IDs) is ever persisted server-side
- * — not in /tmp session files and not in MySQL.
- */
-function reprint_session_start(): void {}
-
-/**
  * Returns a 32-byte symmetric key used to encrypt cookie payloads.
  * Derived from the WP.com client secret (already stored in wp_options
  * for OAuth) so it survives PHP-FPM restarts without any new server
@@ -157,4 +148,3 @@ function reprint_find_wp_load(): ?string {
     }
     return null;
 }
-

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -17,8 +17,6 @@
 
 require __DIR__ . '/bootstrap.php';
 
-reprint_session_start();
-
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 switch ($action) {

--- a/reprint-ui/oauth-redirect.php
+++ b/reprint-ui/oauth-redirect.php
@@ -4,13 +4,11 @@
  *
  * Registered redirect URI for our WP.com app. Exchanges the authorization
  * code for an access token (server-side, using the client secret stored
- * in wp_options), parks the token in the session, and bounces back to
+ * in wp_options), stores the token in an encrypted cookie, and bounces back to
  * the wizard.
  */
 
 require __DIR__ . '/reprint-ui/bootstrap.php';
-
-reprint_session_start();
 
 // Abort on OAuth error responses so the user sees something useful.
 if (!empty($_GET['error'])) {
@@ -78,7 +76,7 @@ if (!is_array($data) || empty($data['access_token'])) {
 }
 
 // Park the token in an encrypted, HttpOnly cookie. Nothing about this
-// session ever touches the database or session storage on disk.
+// token ever touches the database or server-side session storage.
 reprint_cookie_set('rp_tok', [
     'token'   => (string) $data['access_token'],
     'blog_id' => isset($data['blog_id']) ? (int) $data['blog_id'] : null,

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -631,9 +631,6 @@ function run_local_activation(): array {
     require_once __DIR__ . '/lib/playground-uploads-proxy.php';
     $mu = reprint_playground_uploads_proxy_code($source_origin);
     file_put_contents('/wordpress/wp-content/mu-plugins/0-reprint-playground-glue.php', $mu);
-    // Old name from the previous activation; remove if present so we
-    // don't double-register the uploads proxy.
-    @unlink('/wordpress/wp-content/mu-plugins/0-reprint-uploads-proxy.php');
 
     // Pull the tail of the audit log so the JS can show *why* the
     // import failed when it did. Without this, a partial db-apply


### PR DESCRIPTION
The Reprint UI no longer calls a no-op PHP session hook or removes a pre-release upload-proxy filename during activation.

OAuth state remains in encrypted cookies, and the redirect comments now describe that storage directly. The current upload proxy remains unchanged.

## Testing

All four changed PHP files pass syntax checks, and `git diff --check` passes.
