### PR TITLE
Preserve text-only post content during URL rewrites

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,10 +8,10 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/bytestream.git",
+                "url": "https://github.com/wp-php-toolkit/bytestream",
                 "reference": "38617382ea9cecd057202bed34739c53e804173b"
             },
             "dist": {
@@ -64,25 +64,25 @@
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "63e2035a5d9ef069d13b0285150e1cbc72fab407"
+                "url": "https://github.com/wp-php-toolkit/data-liberation",
+                "reference": "2bc03a21f92443af798d7942ec9918aafd112db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/63e2035a5d9ef069d13b0285150e1cbc72fab407",
-                "reference": "63e2035a5d9ef069d13b0285150e1cbc72fab407",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/2bc03a21f92443af798d7942ec9918aafd112db7",
+                "reference": "2bc03a21f92443af798d7942ec9918aafd112db7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.8.1",
-                "wp-php-toolkit/filesystem": "^0.8.1",
-                "wp-php-toolkit/html": "^0.8.1",
-                "wp-php-toolkit/http-client": "^0.8.1",
-                "wp-php-toolkit/xml": "^0.8.1"
+                "wp-php-toolkit/bytestream": "^0.9",
+                "wp-php-toolkit/filesystem": "^0.9",
+                "wp-php-toolkit/html": "^0.9",
+                "wp-php-toolkit/http-client": "^0.9",
+                "wp-php-toolkit/xml": "^0.9"
             },
             "type": "library",
             "autoload": {
@@ -123,14 +123,14 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-27T22:01:51+00:00"
+            "time": "2026-07-30T18:55:37+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/encoding.git",
+                "url": "https://github.com/wp-php-toolkit/encoding",
                 "reference": "0da853cd2ce08deee92dddaa0bd5c3fbf7507608"
             },
             "dist": {
@@ -182,21 +182,21 @@
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "a86e7a3916c48ac9d29bb13bdb15c1cf122800c1"
+                "url": "https://github.com/wp-php-toolkit/filesystem",
+                "reference": "700e8db0af393e4a3193e52c682cdc7821fbb0c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/a86e7a3916c48ac9d29bb13bdb15c1cf122800c1",
-                "reference": "a86e7a3916c48ac9d29bb13bdb15c1cf122800c1",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/700e8db0af393e4a3193e52c682cdc7821fbb0c2",
+                "reference": "700e8db0af393e4a3193e52c682cdc7821fbb0c2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.8.1"
+                "wp-php-toolkit/bytestream": "^0.9"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -238,14 +238,14 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-27T22:01:51+00:00"
+            "time": "2026-05-27T22:01:54+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/html.git",
+                "url": "https://github.com/wp-php-toolkit/html",
                 "reference": "6c845f71340cec388fac1dfabe7694712b94190a"
             },
             "dist": {
@@ -295,27 +295,27 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:06:45+00:00"
+            "time": "2026-05-18T15:06:33+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "4574ed51c15882190b46aee5564910bf4429f3c0"
+                "url": "https://github.com/wp-php-toolkit/http-client",
+                "reference": "7f0c0337c8298a86c631e5e0c1bb1464b5189441"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/4574ed51c15882190b46aee5564910bf4429f3c0",
-                "reference": "4574ed51c15882190b46aee5564910bf4429f3c0",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/7f0c0337c8298a86c631e5e0c1bb1464b5189441",
+                "reference": "7f0c0337c8298a86c631e5e0c1bb1464b5189441",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.8.1",
-                "wp-php-toolkit/data-liberation": "^0.8.1",
-                "wp-php-toolkit/filesystem": "^0.8.1"
+                "wp-php-toolkit/bytestream": "^0.9",
+                "wp-php-toolkit/data-liberation": "^0.9",
+                "wp-php-toolkit/filesystem": "^0.9"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -354,20 +354,20 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-27T22:01:51+00:00"
+            "time": "2026-05-27T22:01:54+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/authenticated-push-endpoints",
+            "version": "dev-adamziel/preserve-url-rewrite-text",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "2050e07227a82c058c6267c5e8b3e77d0cd4dbdc"
+                "reference": "7151918511fb0d146cb60115ae0f88796c70ed73"
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/data-liberation": "^0.8.0",
-                "wp-php-toolkit/html": "^0.8.0"
+                "wp-php-toolkit/data-liberation": "^0.9.0",
+                "wp-php-toolkit/html": "^0.9.0"
             },
             "suggest": {
                 "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
@@ -409,18 +409,18 @@
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "dev-f26d/exporter-php-72-support",
+            "version": "dev-adamziel/preserve-url-rewrite-text",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-importer",
-                "reference": "d76b96ae7385f7e97eff350bbe1f06c55e48e58b"
+                "reference": "c8c59f71664422576a55e6ed6cc66536e99de05b"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.8.0",
-                "wp-php-toolkit/html": "^0.8.0",
+                "wp-php-toolkit/data-liberation": "^0.9.0",
+                "wp-php-toolkit/html": "^0.9.0",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -438,21 +438,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.8.1",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "a6b49175d5bab2e76816dd7bf514b81f51cc1109"
+                "url": "https://github.com/wp-php-toolkit/xml",
+                "reference": "01bf4a5cf5f17730983c105a486c00ff4918d19a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/a6b49175d5bab2e76816dd7bf514b81f51cc1109",
-                "reference": "a6b49175d5bab2e76816dd7bf514b81f51cc1109",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/01bf4a5cf5f17730983c105a486c00ff4918d19a",
+                "reference": "01bf4a5cf5f17730983c105a486c00ff4918d19a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.8.1"
+                "wp-php-toolkit/encoding": "^0.9"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -491,7 +491,7 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-27T22:01:51+00:00"
+            "time": "2026-05-27T22:01:54+00:00"
         }
     ],
     "packages-dev": [

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -5,8 +5,8 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.2",
-        "wp-php-toolkit/data-liberation": "^0.8.0",
-        "wp-php-toolkit/html": "^0.8.0"
+        "wp-php-toolkit/data-liberation": "^0.9.0",
+        "wp-php-toolkit/html": "^0.9.0"
     },
     "suggest": {
         "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",

--- a/packages/reprint-importer/composer.json
+++ b/packages/reprint-importer/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.8.0",
-        "wp-php-toolkit/html": "^0.8.0",
+        "wp-php-toolkit/data-liberation": "^0.9.0",
+        "wp-php-toolkit/html": "^0.9.0",
         "wp-php-toolkit/reprint-exporter": "*@dev"
     },
     "bin": [

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -38,6 +38,9 @@ class StructuredDataUrlRewriter
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
 
+    /** @var array<string, string> Exact source base URLs and their JSON-escaped spellings. */
+    private array $literal_base_url_replacements;
+
     /**
      * Pre-parsed url_mapping: each entry is
      *   [ 'from_url' => <parsed URL>, 'to_url' => <parsed URL> ]
@@ -98,12 +101,21 @@ class StructuredDataUrlRewriter
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
+        $this->literal_base_url_replacements = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
             ];
+            $this->literal_base_url_replacements[$from_url_string] = $to_url_string;
+            $this->literal_base_url_replacements[str_replace('/', '\/', $from_url_string)] = str_replace('/', '\/', $to_url_string);
         }
+        uksort(
+            $this->literal_base_url_replacements,
+            static function (string $first_source_url, string $second_source_url): int {
+                return strlen($second_source_url) <=> strlen($first_source_url);
+            }
+        );
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
@@ -331,12 +343,9 @@ class StructuredDataUrlRewriter
     /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
-     * Block markup owns HTML attributes, block-comment JSON, CSS url() values,
-     * text URLs, entity decoding, URL casing, and IDN canonicalization. This
-     * intentionally routes through the structured parser instead of doing a
-     * literal source-base replacement, because one database value may contain
-     * multiple spellings of the same URL that only the parser can recognize as
-     * equivalent.
+     * In text-only values, exact source base URLs are replaced without
+     * reserializing surrounding CSS or shortcode syntax. Actual markup and
+     * any remaining source-domain spelling go through the block parser.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
@@ -457,6 +466,48 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
+                // The block processor selects known URL attributes in actual markup.
+                // Text-only post content has no such structure, and replacing an
+                // exact base URL directly avoids reserializing unrelated CSS or
+                // shortcode punctuation.
+                if (strpos($content, '<') === false) {
+                    $has_literal_url = false;
+                    $literal_urls_are_bounded = true;
+                    foreach (array_keys($this->literal_base_url_replacements) as $source_url) {
+                        $offset = 0;
+                        while (true) {
+                            $position = strpos($content, $source_url, $offset);
+                            if ($position === false) {
+                                break;
+                            }
+                            $previous_character = $position > 0 ? $content[$position - 1] : null;
+                            $next_position = $position + strlen($source_url);
+                            $next_character = $next_position < strlen($content) ? $content[$next_position] : null;
+                            $has_start_boundary = $previous_character === null
+                                || ctype_space($previous_character)
+                                || strpos('"\'([{,:>', $previous_character) !== false;
+                            $has_end_boundary = $next_character === null
+                                || $content[$next_position - 1] === '/'
+                                || ctype_space($next_character)
+                                || strpos('/\\?#"\'<)]},;', $next_character) !== false;
+                            if (!$has_start_boundary || !$has_end_boundary) {
+                                $literal_urls_are_bounded = false;
+                                break 2;
+                            }
+                            $has_literal_url = true;
+                            $offset = $next_position;
+                        }
+                    }
+
+                    if ($has_literal_url && $literal_urls_are_bounded) {
+                        $literal_rewrite = strtr($content, $this->literal_base_url_replacements);
+                        if (!$this->value_might_contain_source_domain($literal_rewrite)) {
+                            return $literal_rewrite;
+                        }
+                        $content = $literal_rewrite;
+                    }
+                }
+
                 $p = new BlockMarkupUrlProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
                     $raw_url = $p->get_raw_url();

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -193,6 +193,30 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
+    public function testPostContentPreservesCustomCssAndShortcodeFormatting(): void
+    {
+        $rewriter = $this->createRewriter();
+        $custom_css = '.hero { background: url(https://old-site.com/image.jpg) no-repeat; font-family: "Rubik"; }';
+        $shortcode = '[et_pb_section header_font="Rubik" header_font_size="64px"'
+            . ' background_image="https://old-site.com/image.jpg" module_id="hero"]';
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES"
+                . "(1, FROM_BASE64('%s')), (2, FROM_BASE64('%s'));",
+            base64_encode($custom_css),
+            base64_encode($shortcode)
+        );
+
+        $values = $this->collectValues($rewriter->rewrite($sql));
+
+        $this->assertSame(
+            [
+                str_replace('https://old-site.com', 'https://new-site.com', $custom_css),
+                str_replace('https://old-site.com', 'https://new-site.com', $shortcode),
+            ],
+            $values
+        );
+    }
+
     public function testUnknownColumnUsesPlainTextUrlScanning(): void
     {
         $rewriter = $this->createRewriter();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -367,6 +367,56 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
+    public function testKnownBlockMarkupPreservesCustomCssAroundLiteralUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '.page-id-68 .header-title-background {'
+            . ' background: url(https://old-site.com/wp-content/uploads/wanderlust.jpg) no-repeat center center fixed;'
+            . ' font-family: "Rubik";'
+            . ' }';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertSame(
+            str_replace('https://old-site.com', 'https://new-site.com', $input),
+            $result
+        );
+    }
+
+    public function testKnownBlockMarkupPreservesDiviShortcodeQuotesAroundLiteralUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '[et_pb_section header_font="Rubik" header_font_size="64px"'
+            . ' line_height="1.1em" background_image="https://old-site.com/image.jpg" module_id="hero"]';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertSame(
+            str_replace('https://old-site.com', 'https://new-site.com', $input),
+            $result
+        );
+    }
+
+    public function testKnownTextOnlyBlockMarkupDoesNotRewriteEmbeddedQueryUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = 'Archive: https://webarchive.org?url=https://old-site.com/about';
+
+        $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
+    }
+
+    public function testKnownTextOnlyBlockMarkupStillRewritesCaseVariantUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = 'Literal: https://old-site.com/literal; variant: HTTPS://OLD-SITE.COM/case-variant';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https://new-site.com/literal', $result);
+        $this->assertStringContainsString('https://new-site.com/case-variant', $result);
+        $this->assertStringNotContainsString('old-site.com', strtolower($result));
+    }
+
     public function testKnownBlockMarkupDoesNotRewriteEmbeddedQueryUrl(): void
     {
         $rewriter = $this->createRewriter();


### PR DESCRIPTION
## What

- Preserve surrounding CSS and shortcode bytes when an exact source URL can be replaced without reserializing the value.
- Keep the block processor for HTML attributes, block-comment JSON, and alternate URL spellings.
- Move the importer, exporter, and lock file to PHP Toolkit v0.9.0, which preserves CSS URL delimiters during text replacement.

## Why

`wp_posts.post_content` is not one format. It may contain block markup, HTML, CSS, shortcodes, or builder-specific hybrid payloads. Running a whole non-HTML value through the HTML text-node serializer can turn literal quotes into `&quot;`.

## Open design question

The current branch uses the absence of `<` as the gate for its byte-preserving path. That is not sufficient for CSS strings, shortcode payloads, or builder data that legitimately contains `<`. This PR stays in draft while that classification is replaced with a safer occurrence-level or row-context design.

## Testing

- `cd tests && ../vendor/bin/phpunit UrlRewriting Import/NewSiteUrlSqliteTest.php`
- `vendor/bin/phpstan analyze --memory-limit=1G`
- Composer package validation (the existing unbound local path-package warnings remain)
- PHP Toolkit v0.9.0 package smoke tests
