### PR TITLE
Remove unused importer, exporter, UI, and test code

### DIFF
--- a/packages/reprint-exporter/src/class-hmac-client.php
+++ b/packages/reprint-exporter/src/class-hmac-client.php
@@ -12,35 +12,6 @@
  *   $headers = $client->get_auth_headers($request_body);
  *   // Add $headers to your HTTP request
  *
- * Usage with curl:
- *
- * ```php
- * // 1. First time: Generate and display a secret for the user
- * $secret = Site_Export_HMAC_Client::generate_secret();
- * echo "Please enter this secret in the Site Export plugin settings:\n";
- * echo $secret . "\n";
- *
- * // 2. For each request: Create client and sign requests
- * $client = new Site_Export_HMAC_Client($secret);
- *
- * // For GET requests:
- * $ch = curl_init('https://example.com/?reprint-api&endpoint=file_index&directory=/var/www/html');
- * $client->sign_curl_request($ch, '');
- * curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
- * $response = curl_exec($ch);
- *
- * // For POST requests with JSON body:
- * $body = json_encode(['paths' => ['/wp-content/uploads/image.jpg']]);
- * $ch = curl_init('https://example.com/?reprint-api&endpoint=file_fetch');
- * $client->sign_curl_request($ch, $body);
- * curl_setopt($ch, CURLOPT_POST, true);
- * curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
- * curl_setopt($ch, CURLOPT_HTTPHEADER, [
- *     'Content-Type: application/json',
- *     // Auth headers are added by sign_curl_request
- * ]);
- * $response = curl_exec($ch);
- * ```
  */
 class Site_Export_HMAC_Client {
 
@@ -56,11 +27,6 @@ class Site_Export_HMAC_Client {
 
     public function __construct(string $secret) {
         $this->secret = $secret;
-    }
-
-    /** Returns a hex-encoded random secret (64 chars = 256 bits by default). */
-    public static function generate_secret(int $length = 32): string {
-        return bin2hex(random_bytes($length));
     }
 
     /** @return string Hex-encoded 16-byte nonce. */
@@ -165,29 +131,5 @@ class Site_Export_HMAC_Client {
             $curl_headers[] = "{$name}: {$value}";
         }
         return $curl_headers;
-    }
-
-    /** Sets CURLOPT_HTTPHEADER with auth headers on a cURL handle. */
-    public function sign_curl_request($ch, string $body = ''): void {
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $this->get_curl_headers($body));
-    }
-
-    /** Returns a stream context with auth headers, for use with file_get_contents(). */
-    public function create_stream_context(string $body = '', string $method = 'GET', array $extra = []) {
-        $headers = $this->get_auth_headers($body);
-        $header_string = '';
-        foreach ($headers as $name => $value) {
-            $header_string .= "{$name}: {$value}\r\n";
-        }
-
-        $options = [
-            'http' => array_merge([
-                'method' => $method,
-                'header' => $header_string,
-                'content' => $body,
-            ], $extra['http'] ?? []),
-        ];
-
-        return stream_context_create($options);
     }
 }

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -1059,7 +1059,7 @@ final class Site_Export_Push_Session {
             $inflight['phase'] = 'completing';
             $this->write_json($this->work_inflight_path, $inflight);
             $this->ensure_private_parent($complete_path);
-            if (($existing = $this->lstat_path($complete_path)) !== null) {
+            if ($this->lstat_path($complete_path) !== null) {
                 $this->remove_work_path($complete_path);
             }
             if (!@rename($this->work_inflight_data_path, $complete_path)) {
@@ -2448,7 +2448,7 @@ final class Site_Export_Push_Session {
      * @param string $type Human-readable part type for errors.
      */
     private function require_only_headers(array $headers, array $allowed, string $type): void {
-        foreach ($headers as $name => $value) {
+        foreach (array_keys($headers) as $name) {
             if (!in_array($name, $allowed, true)) {
                 throw new InvalidArgumentException('Multipart ' . $type . ' part does not allow header ' . json_encode($name) . '.');
             }

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -250,14 +250,11 @@ function resolve_db_credentials(): array
 /**
  * Returns true when the current WordPress site uses the SQLite backend.
  *
- * Detection is based on the WP_SQLite_Driver class being loaded and
- * $wpdb->dbh being an instance of it. This is set up automatically by
- * the sqlite-database-integration plugin's db.php drop-in when WordPress
- * boots.
+ * The sqlite-database-integration plugin's db.php drop-in defines
+ * SQLITE_DB_DROPIN_VERSION and exposes its PDO handle through $GLOBALS['@pdo'].
  */
 function is_sqlite_site(): bool
 {
-    global $wpdb;
     // @TODO: Actually check for the WP_SQLite_Driver class being used here.
     return defined('SQLITE_DB_DROPIN_VERSION') && isset($GLOBALS['@pdo']);
 }
@@ -698,11 +695,6 @@ class GzipOutputStream
             echo $compressed;
         }
         flush();
-    }
-
-    public function flush(): void
-    {
-        $this->sync();
     }
 
     /**
@@ -2956,18 +2948,6 @@ function file_fetch_paths_should_gzip(array $paths): bool
         // 'no' — known binary. Skip; doesn't disqualify the batch.
     }
     return $any_compressible;
-}
-
-/**
- * Returns true if a path's basename suggests text content gzip will shrink.
- *
- * Files with no extension (`.htaccess`, `LICENSE`, `README`, dotfiles) are
- * treated as text by convention — that's almost always how they're stored
- * in WordPress installs.
- */
-function path_extension_is_compressible(string $path): bool
-{
-    return path_extension_compressibility($path) === 'yes';
 }
 
 /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5386,7 +5386,6 @@ class ImportClient
         $sql_file_size = filesize($sql_file);
         $total_bytes_read = 0;
         $stmt_count = 0;
-        $skipped = 0;
         $save_every = 100;
         $stmts_since_save = 0;
 
@@ -6065,7 +6064,7 @@ class ImportClient
             $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
             if ($chunk_type === "metadata") {
-                $this->handle_metadata_chunk($chunk, $context);
+                $this->handle_metadata_chunk($chunk);
             } elseif ($chunk_type === "file") {
                 $this->handle_file_chunk($chunk, $context);
             } elseif ($chunk_type === "directory") {
@@ -6416,7 +6415,7 @@ class ImportClient
             } elseif ($chunk_type === "progress") {
                 $this->handle_progress($chunk, "index");
             } elseif ($chunk_type === "metadata") {
-                $this->handle_metadata_chunk($chunk, $context);
+                $this->handle_metadata_chunk($chunk);
             } elseif ($chunk_type === "completion") {
                 $complete =
                     ($chunk["headers"]["x-status"] ?? "") === "complete";
@@ -7671,7 +7670,6 @@ class ImportClient
                 $url = $this->build_url("sql_chunk", $cursor, $params);
 
                 $context = new StreamingContext();
-                $context->chunk_fingerprints = [];
                 $context->on_chunk = function ($chunk) use (
                     $mode,
                     &$cursor,
@@ -9035,15 +9033,11 @@ class ImportClient
     /**
      * Handle a metadata chunk from multipart response.
      */
-    private function handle_metadata_chunk(
-        array $chunk,
-        StreamingContext $context
-    ): void {
+    private function handle_metadata_chunk(array $chunk): void {
         $headers = $chunk["headers"];
         $filesystem_root = base64_decode($headers["x-filesystem-root"] ?? "", true);
 
         if ($filesystem_root) {
-            $context->filesystem_root = $filesystem_root;
             $this->audit_log("Filesystem root: {$filesystem_root}", false);
         }
     }
@@ -11512,10 +11506,6 @@ class StreamingContext
     public $file_handle = null;
     public $file_path = null;
     public $file_ctime = null;
-    public $filesystem_root = null;
-    public $chunk_fingerprints = [];
-    public $need_client_slice = false;
-    public $next_client_offset = 0;
     // Crash recovery: track bytes written for current file
     public $file_bytes_written = 0;
     // Last response stats from completion chunk
@@ -12317,7 +12307,6 @@ if (
 
         $repo = "WordPress/reprint";
         $zip_url = "https://github.com/{$repo}/releases/download/{$version}/reprint-exporter-wp.zip";
-        $releases_url = "https://github.com/{$repo}/releases";
 
         echo "{$bold}Install the RePrint Exporter Plugin{$reset}\n";
         echo "\n";

--- a/packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php
+++ b/packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php
@@ -77,16 +77,6 @@ class TerminalProgress
         $this->verbose_mode = $verbose_mode;
     }
 
-    public function is_tty(): bool
-    {
-        return $this->is_tty;
-    }
-
-    public function is_verbose(): bool
-    {
-        return $this->verbose_mode;
-    }
-
     /**
      * Set the output mode. Pipeline mode suppresses lifecycle messages,
      * adds a spinner/bar prefix to progress lines, and lets tick_spinner()

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -301,13 +301,6 @@ class SqlStatementRewriter
      * }
      * @phpstan-return array{table: string, column_map: list<array{int, int, string}>}|null
      */
-    // Called via reflection in SqlStatementRewriterLexerWalkerTest.
-    // @phpstan-ignore method.unused
-    private function map_values_to_columns(string $sql): ?array
-    {
-        return $this->map_values_to_columns_from_tokens(self::significant_tokens($sql));
-    }
-
     /**
      * Consumes a pre-lexed token array. Lets callers that already lexed the
      * statement avoid a second WP_MySQL_Lexer pass.

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -344,26 +344,6 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Rewrite a decoded value known from schema context to be scalar text.
-     *
-     * This still routes through URLInTextProcessor; it only skips the
-     * serialized-PHP and JSON container probes that are impossible for narrow
-     * core URL columns such as wp_posts.guid or wp_users.user_url.
-     */
-    public function rewrite_known_plain_text_value(string $value): string
-    {
-        if ($value === '') {
-            return $value;
-        }
-
-        if (!$this->maybe_contains_rewritable_urls($value)) {
-            return $value;
-        }
-
-        return $this->rewrite_urls($value, self::PLAIN_TEXT);
-    }
-
-    /**
      * Return whether a decoded value may contain one of the configured source
      * domains. This intentionally checks hosts instead of full source URLs so
      * escaped spellings of `://` in block markup or JSON do not matter.

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -648,8 +648,6 @@ function setPhase(phase, state, meta) {
   if (state) el.classList.add(state);
   if (meta != null) el.querySelector('.meta').textContent = meta;
 }
-function fmtBytes(n){if(n<1024)return n+' B';if(n<1048576)return (n/1024).toFixed(1)+' KB';if(n<1073741824)return (n/1048576).toFixed(1)+' MB';return (n/1073741824).toFixed(2)+' GB';}
-
 let selectedSiteId = null;
 let selectedSiteUrl = null;
 

--- a/tests/FileFetchCompressionTest.php
+++ b/tests/FileFetchCompressionTest.php
@@ -306,7 +306,7 @@ final class FileFetchCompressionTest extends TestCase
     public function testPathExtensionClassifier(string $path, bool $expected): void
     {
         require_once __DIR__ . '/../packages/reprint-exporter/src/export.php';
-        $this->assertSame($expected, path_extension_is_compressible($path), "classifier for $path");
+        $this->assertSame($expected, path_extension_compressibility($path) === 'yes', "classifier for $path");
     }
 
     public static function pathExtensionCases(): array

--- a/tests/FileSyncProducer/FileSyncProducerTestBase.php
+++ b/tests/FileSyncProducer/FileSyncProducerTestBase.php
@@ -57,22 +57,6 @@ abstract class FileSyncProducerTestBase extends TestCase
     }
 
     /**
-     * Create a file in test directory
-     */
-    protected function createFile(string $dir, string $path, string $content): string
-    {
-        $fullPath = $dir . '/' . $path;
-        $pathDir = dirname($fullPath);
-
-        if (!is_dir($pathDir)) {
-            mkdir($pathDir, 0755, true);
-        }
-
-        file_put_contents($fullPath, $content);
-        return $fullPath;
-    }
-
-    /**
      * Delete a file from test directory
      */
     protected function deleteFile(string $dir, string $path): void

--- a/tests/MySQLDumpProducer/MySQLDumpProducerTestBase.php
+++ b/tests/MySQLDumpProducer/MySQLDumpProducerTestBase.php
@@ -122,20 +122,6 @@ abstract class MySQLDumpProducerTestBase extends TestCase
     }
 
     /**
-     * Splits SQL dump into individual statements.
-     */
-    protected function splitSQLStatements(string $sql): array
-    {
-        // Simple split on semicolon followed by newline
-        // This won't handle all edge cases but works for our dumps
-        $statements = preg_split('/;\s*\n/', $sql);
-        return array_filter($statements, function ($stmt) {
-            $trimmed = trim($stmt);
-            return $trimmed !== "" && strncmp($trimmed, "--", 2) !== 0;
-        });
-    }
-
-    /**
      * Compares data between two databases.
      */
     protected function assertDatabasesEqual(

--- a/tests/UrlRewriting/SqlStatementRewriterLexerWalkerTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterLexerWalkerTest.php
@@ -502,18 +502,21 @@ class SqlStatementRewriterLexerWalkerTest extends TestCase
      * couldn't tell whether the lexer walker actually fired or whether
      * the AST path produced the same output by coincidence — and in fact
      * a stray EOF token kept the walker from firing on the real
-     * benchmark even though all 26 indirect tests passed. Call the
-     * walker directly and assert it returns a non-null column_map for a
-     * canonical INSERT, plus the right table name and a column_map size
+     * benchmark even though all 26 indirect tests passed. Call the production
+     * tokenizer and walker directly and assert it returns a non-null column_map
+     * for a canonical INSERT, plus the right table name and a column_map size
      * that matches `<columns> × <rows>`.
      */
     private function invokeMapValuesToColumns(string $sql): ?array
     {
         $rewriter = $this->rewriter();
         $reflection = new \ReflectionClass(SqlStatementRewriter::class);
-        $method = $reflection->getMethod('map_values_to_columns');
+        $tokenizer = $reflection->getMethod('significant_tokens');
+        $tokenizer->setAccessible(true);
+        $tokens = $tokenizer->invoke(null, $sql);
+        $method = $reflection->getMethod('map_values_to_columns_from_tokens');
         $method->setAccessible(true);
-        return $method->invoke($rewriter, $sql);
+        return $method->invoke($rewriter, $tokens);
     }
 
     public function testWalkerEngagesOnCanonicalDumpedInsert(): void

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -151,7 +151,6 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true, phpBinar
 
     const start = performance.now();
     let attempts = 0;
-    let lastErr = null;
 
     // Stages other than preflight may exit 2 to request resumption. Loop
     // until the command runs to completion (exit 0) or fatally fails.
@@ -169,7 +168,6 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true, phpBinar
             return { stage, elapsedMs, attempts, ok: true };
         } catch (e) {
             const exitCode = e.status === null ? -1 : (e.status || 1);
-            lastErr = e;
             if (exitCode === 2 && attempts < 50) {
                 continue;
             }

--- a/tests/e2e/lib/global-setup.js
+++ b/tests/e2e/lib/global-setup.js
@@ -20,7 +20,7 @@ async function ensureWpCli() {
         const fd = openSync(WP_CLI_LOCK, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
         closeSync(fd);
         acquired = true;
-    } catch (e) {
+    } catch {
         // Another process holds the lock — wait for it
     }
 
@@ -38,7 +38,7 @@ async function ensureWpCli() {
             writeFileSync(WP_CLI_READY, 'ready\n');
             console.log(`WP-CLI ready at ${WP_CLI_PATH}`);
         } finally {
-            try { unlinkSync(WP_CLI_LOCK); } catch (e) {}
+            try { unlinkSync(WP_CLI_LOCK); } catch {}
         }
     } else {
         const deadline = Date.now() + 120000;

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -7,7 +7,6 @@
  */
 import {
     cpSync, existsSync, writeFileSync, mkdirSync,
-    symlinkSync, chmodSync,
     openSync, closeSync, unlinkSync, constants,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
@@ -19,7 +18,7 @@ import { randomBytes } from 'node:crypto';
 
 const REGISTRY = createRequire(import.meta.url)('../site-registry.json');
 
-export const SITE_ROOT = REGISTRY.siteRoot;
+const SITE_ROOT = REGISTRY.siteRoot;
 const DB_HOST = REGISTRY.dbHost;
 const DB_USER = REGISTRY.dbUser;
 const DB_PASS = REGISTRY.dbPass;
@@ -38,7 +37,7 @@ const MARKER = '.e2e-provisioned';
  * Download and extract WordPress once, caching at /tmp/wordpress-template.
  * Uses a lock file to prevent races when Node runs test files in parallel.
  */
-export async function ensureWpTemplate() {
+async function ensureWpTemplate() {
     if (existsSync(WP_READY)) {
         return;
     }
@@ -49,7 +48,7 @@ export async function ensureWpTemplate() {
         const fd = openSync(WP_LOCK, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
         closeSync(fd);
         acquired = true;
-    } catch (e) {
+    } catch {
         // Another process holds the lock — wait for it
     }
 
@@ -67,7 +66,7 @@ export async function ensureWpTemplate() {
             writeFileSync(WP_READY, `${WP_VERSION}\n`);
             console.log(`WordPress template ready at ${WP_TEMPLATE}`);
         } finally {
-            try { unlinkSync(WP_LOCK); } catch (e) {}
+            try { unlinkSync(WP_LOCK); } catch {}
         }
     } else {
         const deadline = Date.now() + 120000;
@@ -109,20 +108,6 @@ require_once ABSPATH . 'wp-settings.php';
 }
 
 /**
- * Write the minimal wp-config.php used by the export plugin.
- * Does NOT load wp-settings.php — the plugin reads DB creds and table prefix directly.
- */
-function writeMinimalWpConfig(siteDir, dbHost, dbName, dbUser, dbPass, tablePrefix = 'wp_') {
-    writeFileSync(join(siteDir, 'wp-config.php'), `<?php
-define('DB_HOST', '${dbHost}');
-define('DB_NAME', '${dbName}');
-define('DB_USER', '${dbUser}');
-define('DB_PASSWORD', '${dbPass}');
-$table_prefix = '${tablePrefix}';
-`);
-}
-
-/**
  * Run wp core install to create all real WordPress tables.
  */
 function wpCoreInstall(siteDir, siteUrl, siteName) {
@@ -157,7 +142,7 @@ function wpPluginActivate(siteDir, pluginSlug) {
 /**
  * Create standard sample test files using Node fs APIs.
  */
-export function createSampleFiles(siteDir) {
+function createSampleFiles(siteDir) {
     const dataDir = join(siteDir, 'test-data');
     mkdirSync(join(dataDir, 'subdir', 'nested'), { recursive: true });
     writeFileSync(join(dataDir, 'hello.txt'), 'Hello World\n');
@@ -196,7 +181,7 @@ export async function ensureSite(name, options = {}) {
         const fd = openSync(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
         closeSync(fd);
         acquired = true;
-    } catch (e) {
+    } catch {
         // Another process holds the lock — wait for marker
     }
 
@@ -213,7 +198,7 @@ export async function ensureSite(name, options = {}) {
 
     // Double-check after acquiring lock (another process may have finished first)
     if (existsSync(markerPath)) {
-        try { unlinkSync(lockPath); } catch (e) {}
+        try { unlinkSync(lockPath); } catch {}
         return;
     }
 
@@ -328,6 +313,6 @@ export async function ensureSite(name, options = {}) {
     log('Setup complete');
 
     } finally {
-        try { unlinkSync(lockPath); } catch (e) {}
+        try { unlinkSync(lockPath); } catch {}
     }
 }

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -2,9 +2,9 @@
  * E2E test helpers for the streaming site migration system.
  */
 import assert from 'node:assert/strict';
-import { execSync, execFileSync, spawn } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFileSync, readdirSync, statSync, existsSync, mkdirSync, writeFileSync, unlinkSync, lstatSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, mkdirSync, lstatSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createConnection } from 'mysql2/promise';
@@ -43,13 +43,6 @@ export function getSiteSecret(siteName) {
  */
 export function getSiteDir(siteName) {
     return join(SITE_ROOT, siteName);
-}
-
-/**
- * Get test data directory path.
- */
-export function getTestDataDir(siteName) {
-    return join(SITE_ROOT, siteName, 'test-data');
 }
 
 /**
@@ -280,7 +273,7 @@ export function runImporter(url, outputDir, command, options = {}) {
             if (state.preflight && state.preflight.data) {
                 needsPreflight = false;
             }
-        } catch (_) {
+        } catch {
             // No state file or invalid JSON — need preflight
         }
         if (needsPreflight) {
@@ -348,7 +341,7 @@ export function createTempDir(prefix = 'e2e-import') {
 export function cleanupTempDir(dir) {
     try {
         execSync(`rm -rf ${JSON.stringify(dir)}`, { timeout: 10000 });
-    } catch (e) {
+    } catch {
         // Ignore cleanup errors
     }
 }
@@ -372,7 +365,7 @@ export function hashDirectory(dirPath) {
         let entries;
         try {
             entries = readdirSync(currentDir);
-        } catch (e) {
+        } catch {
             return; // Skip unreadable directories
         }
 
@@ -381,7 +374,7 @@ export function hashDirectory(dirPath) {
             let stat;
             try {
                 stat = lstatSync(fullPath);
-            } catch (e) {
+            } catch {
                 continue;
             }
 
@@ -396,7 +389,7 @@ export function hashDirectory(dirPath) {
                     const relPath = relative(dirPath, fullPath);
                     const hash = sha1File(fullPath);
                     hashes.set(relPath, hash);
-                } catch (e) {
+                } catch {
                     // Skip unreadable files
                 }
             }
@@ -410,7 +403,7 @@ export function hashDirectory(dirPath) {
 /**
  * Compare two directory hashes and return differences.
  */
-export function compareDirectoryHashes(source, imported) {
+function compareDirectoryHashes(source, imported) {
     const missing = [];
     const extra = [];
     const different = [];
@@ -545,7 +538,7 @@ export function removeTestHooks(siteName) {
     const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'site-export', 'test-hooks.php');
     try {
         execSync(`sudo rm -f ${JSON.stringify(hookPath)}`);
-    } catch (e) {
+    } catch {
         // Ignore
     }
 }
@@ -575,7 +568,7 @@ export function readHookState(siteName) {
     const statePath = hookStatePath(siteName);
     try {
         return JSON.parse(readFileSync(statePath, 'utf-8'));
-    } catch (e) {
+    } catch {
         return null;
     }
 }
@@ -587,7 +580,7 @@ export function clearHookState(siteName) {
     const statePath = hookStatePath(siteName);
     try {
         execSync(`sudo rm -f ${JSON.stringify(statePath)}`);
-    } catch (e) {
+    } catch {
         // Ignore
     }
 }
@@ -770,5 +763,4 @@ export function assertPullPipelineComplete(state, command = 'pull') {
     );
 }
 
-// Re-export constants
-export { SITE_ROOT, PROJECT_ROOT, IMPORTER_PATH, PHP_BINARY, DB_HOST, DB_USER, DB_PASS };
+export { PHP_BINARY };

--- a/tests/e2e/tests/import-03-delta-sync.test.js
+++ b/tests/e2e/tests/import-03-delta-sync.test.js
@@ -4,7 +4,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {
@@ -25,12 +25,12 @@ describe('Import: Delta Sync', () => {
         await ensureSite(site);
         tempDir = createTempDir('e2e-import-delta');
         // Clean up any leftover test file
-        try { execSync(`sudo rm -f ${JSON.stringify(addedFile)}`); } catch (e) {}
+        try { execSync(`sudo rm -f ${JSON.stringify(addedFile)}`); } catch {}
     });
 
     afterAll(() => {
         cleanupTempDir(tempDir);
-        try { execSync(`sudo rm -f ${JSON.stringify(addedFile)}`); } catch (e) {}
+        try { execSync(`sudo rm -f ${JSON.stringify(addedFile)}`); } catch {}
     });
 
     function importUrl() {

--- a/tests/e2e/tests/import-05-unicode-paths.test.js
+++ b/tests/e2e/tests/import-05-unicode-paths.test.js
@@ -66,7 +66,6 @@ describe('Import: Unicode Paths', () => {
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         // Check for files with special names
-        const sourceHashes = hashDirectory(getSiteDir(site));
         const importedHashes = hashDirectory(importedRoot);
 
         // Check some known unicode filenames exist in imported set

--- a/tests/e2e/tests/import-12-gzip-corruption.test.js
+++ b/tests/e2e/tests/import-12-gzip-corruption.test.js
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    writeTestHooks, removeTestHooks, readAuditLog,
+    writeTestHooks, removeTestHooks,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {

--- a/tests/e2e/tests/import-17-redirect.test.js
+++ b/tests/e2e/tests/import-17-redirect.test.js
@@ -5,9 +5,8 @@
  *
  * The redirect-301 site (port 8097) redirects all requests to port 8081 (basic).
  */
-import { describe, it, beforeAll, afterAll } from 'vitest';
+import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret,

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -41,7 +41,7 @@ describe('Import: Full Round-Trip', () => {
             const conn = await createMysqlConnection();
             await conn.query(`DROP DATABASE IF EXISTS \`${importDbName}\``);
             await conn.end();
-        } catch (e) {
+        } catch {
             // Ignore cleanup errors
         }
     });
@@ -105,7 +105,7 @@ describe('Import: Full Round-Trip', () => {
             `  missing tables: ${comparison.missingTables.join(', ')}\n` +
             `  extra tables: ${comparison.extraTables.join(', ')}\n` +
             `  row count mismatches: ${JSON.stringify(
-                Object.entries(comparison.rowCounts).filter(([_, v]) => !v.match)
+                Object.entries(comparison.rowCounts).filter(([, value]) => !value.match)
             )}`
         );
     });

--- a/tests/e2e/tests/import-19-error-chunks.test.js
+++ b/tests/e2e/tests/import-19-error-chunks.test.js
@@ -10,7 +10,6 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -6,7 +6,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,

--- a/tests/e2e/tests/import-21-preflight.test.js
+++ b/tests/e2e/tests/import-21-preflight.test.js
@@ -7,7 +7,7 @@ import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     apiRequest,
-    getSiteUrl, getSiteSecret, getSiteDir,
+    getSiteDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {

--- a/tests/e2e/tests/import-23-sql-data-fidelity.test.js
+++ b/tests/e2e/tests/import-23-sql-data-fidelity.test.js
@@ -6,7 +6,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,

--- a/tests/e2e/tests/import-26-completion-headers.test.js
+++ b/tests/e2e/tests/import-26-completion-headers.test.js
@@ -7,7 +7,7 @@ import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     apiRequest,
-    getSiteUrl, getSiteSecret, getSiteDir,
+    getSiteDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 

--- a/tests/e2e/tests/import-27-invalid-params.test.js
+++ b/tests/e2e/tests/import-27-invalid-params.test.js
@@ -7,7 +7,7 @@ import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     apiRequest,
-    getSiteUrl, getSiteSecret, getSiteDir,
+    getSiteUrl, getSiteDir,
     createHmacClient,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';

--- a/tests/e2e/tests/import-28-concurrent-errors.test.js
+++ b/tests/e2e/tests/import-28-concurrent-errors.test.js
@@ -8,7 +8,6 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {

--- a/tests/e2e/tests/import-29-file-list-fetch.test.js
+++ b/tests/e2e/tests/import-29-file-list-fetch.test.js
@@ -10,8 +10,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     apiRequest, apiRequestWithFileList,
-    getSiteUrl, getSiteSecret, getSiteDir,
-    sha1File,
+    getSiteDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 

--- a/tests/e2e/tests/import-30-symlink-manifest.test.js
+++ b/tests/e2e/tests/import-30-symlink-manifest.test.js
@@ -8,14 +8,13 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, mkdirSync, writeFileSync, symlinkSync, lstatSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, symlinkSync, lstatSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    assertSiteMirror,
     fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -79,7 +79,7 @@ describe('Import: Follow Symlinks', () => {
         try {
             await fetch(apiUrl, { method: 'GET' });
             return;
-        } catch (_) {
+        } catch {
             // The configured e2e infrastructure may not expose port 8101 locally.
             // Start a PHP built-in server for this site as a fallback.
         }
@@ -97,7 +97,7 @@ describe('Import: Follow Symlinks', () => {
             try {
                 await fetch(apiUrl, { method: 'GET' });
                 return;
-            } catch (_) {
+            } catch {
                 await sleep(100);
             }
         }
@@ -343,7 +343,7 @@ describe('Import: Follow Symlinks', () => {
                 } else {
                     paths.add(path);
                 }
-            } catch (e) {
+            } catch {
                 // skip malformed lines
             }
         }

--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -53,7 +53,7 @@ describe('Import: Delta type swaps cache invalidation', () => {
                 if (res.status >= 200) {
                     return;
                 }
-            } catch (_) {
+            } catch {
                 // retry
             }
             await sleep(100);

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -8,7 +8,7 @@
  */
 import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -40,7 +40,7 @@ describe('Import: SQLite Export', () => {
                             ` -o "${pluginZip}"`,
                             { timeout: 120000 },
                         );
-                    } catch (e) {
+                    } catch {
                         // WordPress.org might not have it; try GitHub
                         execSync(
                             `curl -sfL "https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.tar.gz"` +
@@ -63,7 +63,7 @@ describe('Import: SQLite Export', () => {
                             `unzip -qo "${pluginZip}" -d "${pluginsDir}"`,
                             { timeout: 30000 },
                         );
-                    } catch (e) {
+                    } catch {
                         // unzip not available — fall back to PHP's ZipArchive
                         execSync(
                             `php -r "\\$z = new ZipArchive;` +

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -13,7 +13,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -14,7 +14,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    getDbName, createMysqlConnection,
+    createMysqlConnection,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -19,14 +19,14 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
-    existsSync, readFileSync, readdirSync,
+    existsSync, readdirSync,
     mkdirSync, writeFileSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {
     createTempDir, cleanupTempDir,
-    getSiteUrl, getSiteSecret, getSiteDir,
+    getSiteUrl, getSiteDir,
     apiRequest,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';

--- a/tests/e2e/tests/import-45-runtime-file-download.test.js
+++ b/tests/e2e/tests/import-45-runtime-file-download.test.js
@@ -18,7 +18,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir, readAuditLog,
 } from '../lib/test-helpers.js';
-import { ensureSite, SITE_ROOT } from '../lib/site-setup.js';
+import { ensureSite } from '../lib/site-setup.js';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
@@ -103,8 +103,6 @@ describe('Import: Runtime file download', () => {
     });
 
     it('downloads the prepend script into runtime_files/', () => {
-        const downloaded = join(tempDir, 'runtime_files', 'scripts', 'env.php');
-
         // Glob for any file under runtime_files/scripts/ if exact path differs
         assert.ok(
             existsSync(join(tempDir, 'runtime_files')),

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -17,7 +17,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir, getDbName, createMysqlConnection,
+    getDbName, createMysqlConnection,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 

--- a/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
+++ b/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
@@ -55,7 +55,7 @@ describe('Import: Shared theme symlink remains working', () => {
         try {
             await fetch(apiUrl, { method: 'GET' });
             return;
-        } catch (_) {
+        } catch {
             // If local infra does not expose this port yet, serve plugin API
             // directly via PHP built-in server for this test.
         }
@@ -73,7 +73,7 @@ describe('Import: Shared theme symlink remains working', () => {
             try {
                 await fetch(apiUrl, { method: 'GET' });
                 return;
-            } catch (_) {
+            } catch {
                 await sleep(100);
             }
         }

--- a/tests/e2e/tests/import-47-pull-multi-request.test.js
+++ b/tests/e2e/tests/import-47-pull-multi-request.test.js
@@ -9,7 +9,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -30,7 +30,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     writeTestHooks, removeTestHooks,
-    writeHookState, clearHookState,
+    clearHookState,
     fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
@@ -67,7 +67,6 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
             files: 'none',
             afterCreate: async (siteDir) => {
                 sourceFilePath = join(siteDir, fileRel);
-                const dir = join(siteDir, 'test-data');
                 // Use sudo via execSync — the site dir is owned by nginx
                 // by the time afterCreate runs in some site-setup paths,
                 // but for newly-created sites Node still has write access.
@@ -85,7 +84,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         clearHookState(site);
         try {
             execSync(`sudo rm -f /srv/e2e-sites/.e2e-hook-fired-${site}`);
-        } catch (e) { /* ignore */ }
+        } catch { /* ignore */ }
         cleanupTempDir(tempDir);
     });
 


### PR DESCRIPTION
Removes code with no repository callers from the importer, exporter, UI, and test suite.

The production cleanup removes unused streaming context fields, HMAC client utilities, progress getters, a gzip alias, URL-rewrite and compression wrappers, and the unused UI byte formatter. The SQL walker tests now call the production tokenizer and token walker directly instead of retaining a test-only production method.

The test cleanup removes stale helpers and exports, unused imports and locals, and unnecessary catch bindings.

## Testing

Run the focused file compression, URL rewriting, HMAC, and file synchronization PHPUnit suites. Run PHPStan, PHP compatibility checks, E2E unused-variable analysis, and the repository diff checks.