### PR TITLE
Use Reprint vocabulary in the E2E helper header

### DIFF
--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -1,5 +1,5 @@
 /**
- * E2E test helpers for the streaming site migration system.
+ * E2E test helpers for Reprint.
  */
 import assert from 'node:assert/strict';
 import { execSync, execFileSync } from 'node:child_process';


### PR DESCRIPTION
The E2E helper header now names Reprint instead of the retired project name.

A tracked-tree scan finds no remaining `STREAMING_SITE_MIGRATION`, `streaming-site-migration`, snake-case, camel-case, or prose variants. The canonical `Site_Export_*` PHP names remain unchanged as required by `markdown/PUSH-TERMINOLOGY.md`.

## Testing

JavaScript syntax, PHPStan, and `git diff --check` pass.
