### PR TITLE
Name remote-upload file constants after pull files

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4313,9 +4313,9 @@ class ImportClient
 
         $manifest->constants["REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL"] = $base_url;
         $state_dir = realpath($this->state_dir) ?: $this->state_dir;
-        $manifest->constants["REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
+        $manifest->constants["REPRINT_PULL_STATE_FILE"] =
             rtrim($state_dir, "/") . "/pull/state.json";
-        $manifest->constants["REPRINT_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
+        $manifest->constants["REPRINT_PULL_SKIPPED_FETCH_LIST_FILE"] =
             rtrim($state_dir, "/") . "/pull/skipped-fetch-list.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -142,10 +142,9 @@ class PlaygroundCliApplier implements RuntimeApplier
      * Rewrite host-side runtime helper files to VFS paths and return the
      * corresponding Playground mounts.
      *
-     * Some route handlers need importer metadata produced outside the mounted
-     * WordPress tree, for example the files-pull state used by the temporary
-     * remote uploads proxy. Playground can only see files that are mounted
-     * explicitly, so we map those constants to /tmp paths in the VM.
+     * Some route handlers need files produced outside the mounted WordPress
+     * tree. Playground can only see files that are mounted explicitly, so we
+     * map those constants to /tmp paths in the VM.
      *
      * @return string[]
      */
@@ -153,9 +152,9 @@ class PlaygroundCliApplier implements RuntimeApplier
     {
         $mounts = [];
         $runtime_file_mounts = [
-            'REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE'
+            'REPRINT_PULL_STATE_FILE'
                 => '/tmp/reprint/state.json',
-            'REPRINT_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'
+            'REPRINT_PULL_SKIPPED_FETCH_LIST_FILE'
                 => '/tmp/reprint/skipped-fetch-list.jsonl',
         ];
 

--- a/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -17,12 +17,12 @@ function remote_upload_proxy_code(): string
  */
 (function() {
 	if (!defined('REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL')) return;
-	if (!defined('REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE')) return;
-	if (!defined('REPRINT_REMOTE_UPLOAD_PROXY_SKIPPED_FILE')) return;
+	if (!defined('REPRINT_PULL_STATE_FILE')) return;
+	if (!defined('REPRINT_PULL_SKIPPED_FETCH_LIST_FILE')) return;
 	if (!function_exists('curl_init')) return;
 
 	$proxy_enabled = false;
-	$skipped_fetch_list_file = REPRINT_REMOTE_UPLOAD_PROXY_SKIPPED_FILE;
+	$skipped_fetch_list_file = REPRINT_PULL_SKIPPED_FETCH_LIST_FILE;
 	if (
 		is_string($skipped_fetch_list_file) &&
 		$skipped_fetch_list_file !== '' &&
@@ -31,7 +31,7 @@ function remote_upload_proxy_code(): string
 	) {
 		$proxy_enabled = true;
 	} else {
-		$pull_state_file = REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE;
+		$pull_state_file = REPRINT_PULL_STATE_FILE;
 		if (
 			is_string($pull_state_file) &&
 			$pull_state_file !== '' &&

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -70,9 +70,9 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $manifest = new \RuntimeManifest('other');
         $manifest->constants['REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL'] =
             'https://source.example/wp-content/uploads';
-        $manifest->constants['REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE'] =
+        $manifest->constants['REPRINT_PULL_STATE_FILE'] =
             $this->pullStateFile;
-        $manifest->constants['REPRINT_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'] =
+        $manifest->constants['REPRINT_PULL_SKIPPED_FETCH_LIST_FILE'] =
             $this->skippedFetchListFile;
         $manifest->routes[] = [
             'handler' => 'remote-upload-proxy',

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -163,11 +163,11 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             $runtime,
         );
         $this->assertStringContainsString(
-            "REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE",
+            "REPRINT_PULL_STATE_FILE",
             $runtime,
         );
         $this->assertStringContainsString(
-            "REPRINT_REMOTE_UPLOAD_PROXY_SKIPPED_FILE",
+            "REPRINT_PULL_SKIPPED_FETCH_LIST_FILE",
             $runtime,
         );
         $this->assertStringContainsString(
@@ -199,7 +199,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             $runtime,
         );
         $this->assertStringContainsString(
-            "REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE",
+            "REPRINT_PULL_STATE_FILE",
             $runtime,
         );
         $this->assertStringContainsString(
@@ -227,7 +227,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             $runtime,
         );
         $this->assertStringNotContainsString(
-            "REPRINT_REMOTE_UPLOAD_PROXY_STATE_FILE",
+            "REPRINT_PULL_STATE_FILE",
             $runtime,
         );
         $this->assertStringNotContainsString(


### PR DESCRIPTION
The file constants read by the remote-upload route now use the names of the pull files they reference: `REPRINT_PULL_STATE_FILE` and `REPRINT_PULL_SKIPPED_FETCH_LIST_FILE`.

`REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL` remains proxy-specific because it configures the proxy itself. No runtime behavior changes.

## Testing

`cd tests && ../vendor/bin/phpunit --colors=never Import`

`vendor/bin/phpstan analyze --memory-limit=1G`

PHPCompatibility for the importer on PHP 7.4+.
