### PR TITLE
Restore Reprint state filenames consumed by WP Cloud

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `--state-dir/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
+When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `--state-dir/.sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
 
 ### Progress Tracking
 
@@ -240,10 +240,10 @@ Always consult these when working on the respective components.
 ### Progress Computation
 
 Progress is computed client-side by reading state files (all in `--state-dir`):
-- `pull/state.json`: Current command, status, cursor, stage
-- `pull/local-index.jsonl`: Local file index (line count = files indexed)
-- `pull/remote-index.jsonl`: Remote file index (for delta comparison)
-- `pull/fetch-list.jsonl`: Files pending download
+- `.import-state.json`: Current command, status, cursor, stage
+- `.import-index.jsonl`: Local file index (line count = files indexed)
+- `.import-remote-index.jsonl`: Remote file index (for delta comparison)
+- `.import-fetch-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
 
 And from `--fs-root`:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ First, we'll make sure the server is reachable and the environment is in a good 
 php reprint.phar preflight "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
-The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/pull/state.json` under the `preflight` key.
+The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/.import-state.json` under the `preflight` key.
 
 All other commands check that a preflight has been completed and refuse to start without one.
 
@@ -253,7 +253,7 @@ php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 The pipeline proceeds as usual through indexing and diffing, but skips uploads. When the essential
 files are done, the sync marks itself **complete**. The skipped file list stays on disk at
-`$STATE_DIR/pull/skipped-fetch-list.jsonl`. At this point you can apply the database and bring the site online.
+`$STATE_DIR/.import-fetch-list-skipped.jsonl`. At this point you can apply the database and bring the site online.
 
 ```bash
 # Step 2: download the uploads
@@ -346,7 +346,7 @@ All three modes recover from server crashes mid-stream (PHP fatal errors,
 OOM kills, `max_execution_time` expiry). When the server dies before sending
 a completion chunk, the importer detects the transport failure, saves its
 cursor, and exits with code 2 for automatic retry. Accumulated SQL is
-persisted in `$STATE_DIR/pull/sql-buffer` so the next run reloads it and continues.
+persisted in `$STATE_DIR/.sql-buffer` so the next run reloads it and continues.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
@@ -515,25 +515,24 @@ whatever tool was reading stdout (typically `mysql` CLI).
 
 Reprint uses `$STATE_DIR` exactly as supplied. Consumers that want the state
 hidden can choose a directory named `.reprint`; Reprint does not append that
-name itself. Shared command progress and the audit log live directly in the
-state directory. Pull-owned state lives in `pull/`, while pair-specific push
-state lives in `push/<pair-key>/`. Shared and pull filenames do not begin with
-a dot or repeat the scope supplied by their parent directory.
+name itself. Pull state, shared command progress, and the audit log use their
+established dot-prefixed filenames directly in the state directory.
+Pair-specific push state lives in `push/<pair-key>/`.
 
-`pull/state.json` and `progress.json` are written atomically:
+`.import-state.json` and `.import-status.json` are written atomically:
 a `.tmp` file is written first and then renamed to its final name so readers
 never see partially written state.
 
 While there's many of these files, most of them are for internal use only.
 The two that might be particularly useful for integrators are:
 
-* `progress.json` – the current progress
-* `pull/state.json` – the pull state store
+* `.import-status.json` – the current progress
+* `.import-state.json` – the pull state store
 
-#### `progress.json` – the current progress
+#### `.import-status.json` – the current progress
 
 When an external process (e.g. a web UI) needs to poll migration progress, it can read
-`$STATE_DIR/progress.json`.
+`$STATE_DIR/.import-status.json`.
 
 Pass `--step=N` and `--steps=N` to your `import.php` calls to embed the pipeline position in
 the progress file. For example, a four-step pipeline would pass `--step=1 --steps=4` for the
@@ -575,7 +574,7 @@ Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
-#### `pull/state.json` — the pull state store
+#### `.import-state.json` — the pull state store
 
 This is the pull state store. Pull commands read it on startup and write it
 back periodically and on shutdown. It stores everything needed to resume after
@@ -584,7 +583,7 @@ state, and per-phase bookmarks.
 
 Written atomically (temp file + rename) so a crash mid-write never corrupts it.
 If the JSON is invalid on load, the importer renames it to
-`pull/state.json.corrupt.<timestamp>` and starts fresh.
+`.import-state.json.corrupt.<timestamp>` and starts fresh.
 
 ```jsonc
 {
@@ -646,18 +645,18 @@ tell you where the pipeline is. The `stage` field gives finer granularity
 (e.g., `"scanning"`, `"sorting"`, `"streaming"` for file sync).
 
 For pull-level lifecycle checks, prefer `import-metadata` over reading
-`pull/state.json` directly. It exposes Reprint-owned pull state as a small,
+`.import-state.json` directly. It exposes Reprint-owned pull state as a small,
 stable JSON contract for host integrations:
 
 ```bash
 php reprint.phar import-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
 ```
 
-#### `pull/volatile-files.json` — files that changed during sync
+#### `.import-volatile-files.json` — files that changed during sync
 
 During `files-pull`, a file on the source may be modified while the importer is
 streaming it. When that happens, the server returns a different content hash than
-expected and the importer records the file in `pull/volatile-files.json`
+expected and the importer records the file in `.import-volatile-files.json`
 instead of failing.
 
 The file is a flat JSON object mapping paths to the number of times each file
@@ -675,9 +674,9 @@ the caller can decide what to do — re-run the sync, ignore them, or ask the us
 Files that are subsequently downloaded successfully are automatically removed
 from the tracker. The file is deleted entirely once all entries are cleared.
 
-#### `audit.log` — append-only event log
+#### `.import-audit.log` — append-only event log
 
-Every significant event during import is recorded in `audit.log` as a
+Every significant event during import is recorded in `.import-audit.log` as a
 timestamped line. This includes file downloads, deletions, volatile file
 detections, errors, and state transitions. The log is append-only — it's never
 truncated or rotated, so it provides a complete history of the migration.
@@ -685,7 +684,7 @@ truncated or rotated, so it provides a complete history of the migration.
 ```
 [2025-01-15 10:30:01] VOLATILE | path=/srv/htdocs/wp-content/debug.log | count=1
 [2025-01-15 10:30:05] VOLATILE CLEARED | path=/srv/htdocs/wp-content/debug.log
-[2025-01-15 10:31:12] FILE DELETE | pull/local-index.wal
+[2025-01-15 10:31:12] FILE DELETE | .import-local-index.wal
 ```
 
 Pass `--verbose` to also print audit log entries to the console as they happen.
@@ -707,7 +706,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
-* `db-domains` — Lists domains discovered in the SQL dump. Reads `pull/domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
+* `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
 * `import-metadata` — Prints local pull lifecycle metadata as JSON, including `hasCompletedOnce`. Requires only `--state-dir`; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -273,7 +273,7 @@ configuration; request parameters cannot select any of them.
 ## Local files sender
 
 `PushFilesSender` joins the durable `PushPlan` to the receiver's push session.
-Every local Reprint command workflow runs under `<state-dir>/process.lock`.
+Every local Reprint command workflow runs under `<state-dir>/.reprint.lock`.
 The production CLI acquires this non-blocking lock before it prepares pair
 context, constructs `ImportClient`, or writes the command audit entry. It
 passes the open lock to `ImportClient::run()` and releases it after the command.
@@ -410,7 +410,7 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 `PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
 It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
 the operator passes `--force-http`. It does not run pull preflight, read or
-write `pull/state.json`, show a plan, ask for confirmation, transfer a
+write `.import-state.json`, show a plan, ask for confirmation, transfer a
 database, retry a failed request, or start a replacement sender after a
 `restart` outcome.
 

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -159,27 +159,24 @@ development. There are no compatibility aliases or migration paths.
 
 The **state directory** is the caller-supplied `<state-dir>`; use `$state_dir`.
 Reprint uses it exactly as supplied and does not append `.reprint`. A consumer
-may choose `.reprint` or any other private directory name. The **pull state
-directory** is `<state-dir>/pull`; use `$pull_state_directory`. Shared and pull
-filenames inside the state directory do not begin with a dot or repeat the
-scope supplied by their parent directories.
+may choose `.reprint` or any other private directory name. Pull files keep
+their established dot-prefixed filenames directly in the state directory.
 
 ```text
 <state-dir>/
-├── process.lock
-├── progress.json
-├── audit.log
-├── pull/
-│   ├── state.json
-│   ├── local-index.jsonl
-│   ├── local-index.wal
-│   ├── remote-index.jsonl
-│   ├── fetch-list.jsonl
-│   ├── skipped-fetch-list.jsonl
-│   ├── volatile-files.json
-│   ├── domains.json
-│   ├── sql-stats.json
-│   └── sql-buffer
+├── .reprint.lock
+├── .import-status.json
+├── .import-audit.log
+├── .import-state.json
+├── .import-index.jsonl
+├── .import-local-index.wal
+├── .import-remote-index.jsonl
+├── .import-fetch-list.jsonl
+├── .import-fetch-list-skipped.jsonl
+├── .import-volatile-files.json
+├── .import-domains.json
+├── .import-sql-stats.json
+├── .sql-buffer
 └── push/
     └── <pair-key>/
 ```
@@ -189,7 +186,6 @@ Use these path names:
 | Surface | Name |
 | --- | --- |
 | State directory | `$state_dir` |
-| Pull state directory | `$pull_state_directory` |
 | Pull state file | `$pull_state_file` |
 | Local index file | `$local_index_file` |
 | Local index WAL | `$local_index_wal_path` |
@@ -210,7 +206,7 @@ files, and database files remain directly under the state directory.
 ## Local Reprint process lock
 
 Every local Reprint command workflow runs under the **Reprint process lock** at
-`<state-dir>/process.lock`. Use `process.lock`,
+`<state-dir>/.reprint.lock`. Use `.reprint.lock`,
 `$process_lock_path`, and `$process_lock`. The lock is non-blocking and
 state-directory-wide: pull, push, diff, and other local Reprint processes
 cannot run concurrently against the same state directory, even when their
@@ -227,7 +223,7 @@ lock is separate from the receiver's push-session and commit locks.
 ## Pull local index WAL
 
 Call the single pull-side write-ahead log the **local index WAL**. It lives at
-`<state-dir>/pull/local-index.wal`; use `pull/local-index.wal`,
+`<state-dir>/.import-local-index.wal`; use `.import-local-index.wal`,
 `$local_index_wal_path`, and `$local_index_wal_handle`.
 Applied batch records are cleared, but the empty WAL remains as a marker until
 files-pull completes. A retained WAL is consumed only while resuming or
@@ -353,8 +349,8 @@ sha256(rtrim(<remote-reprint-api-url>, "?&") + "\0" + <resolved-filesystem-root>
 The `local push state directory` is `<state-dir>/push/<pair-key>/`. `files-push`
 chooses `start` or `resume` only from whether `sender.json` exists there. The
 receiver-confirmed upload positions remain receiver-owned; they are not a
-files-push cursor and are not copied into `pull/state.json` or
-`progress.json`.
+files-push cursor and are not copied into `.import-state.json` or
+`.import-status.json`.
 
 Files-push lifecycle lines use these command-first names verbatim: `START
 files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -248,13 +248,13 @@ class ImportClient
     private $progress_throttle = 1.0;
 
     /**
-     * @var string Local index file pull/local-index.jsonl. It tracks each accounted
+     * @var string Local index file .import-index.jsonl. It tracks each accounted
      * path's ctime, size, and type for the next remote-index comparison.
      */
     private $local_index_file;
 
     /**
-     * @var string Path to pull/local-index.wal — the append-only write-ahead
+     * @var string Path to .import-local-index.wal — the append-only write-ahead
      * log for the current files-pull. Applied batches are cleared, but the file
      * remains until the lifecycle completes or is aborted.
      */
@@ -287,21 +287,21 @@ class ImportClient
     private $last_local_index_wal_type = null;
 
     /**
-     * @var string Remote index file pull/remote-index.jsonl, including
+     * @var string Remote index file .import-remote-index.jsonl, including
      * directory `empty` fields when available.
      */
     private $remote_index_file;
 
-    /** @var string Path to pull/fetch-list.jsonl — files to download, computed by diffing remote vs local index. */
+    /** @var string Path to .import-fetch-list.jsonl — files to download, computed by diffing remote vs local index. */
     private $fetch_list_file;
 
-    /** @var string Path to pull/skipped-fetch-list.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
+    /** @var string Path to .import-fetch-list-skipped.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
     private $skipped_fetch_list_file;
 
-    /** @var string Path to audit.log — append-only log of every operation for debugging. */
+    /** @var string Path to .import-audit.log — append-only log of every operation for debugging. */
     private $audit_log_file;
 
-    /** @var string Path to pull/volatile-files.json — files the server marks as frequently-changing. */
+    /** @var string Path to .import-volatile-files.json — files the server marks as frequently-changing. */
     private $volatile_files_file;
 
     /** @var bool When true, emit detailed operation logs to stdout. Set via --verbose. */
@@ -459,7 +459,7 @@ class ImportClient
     /** @var int|null Total number of pipeline steps. Set via --steps. */
     private $pipeline_steps = null;
 
-    /** @var string Path to progress.json — machine-readable progress for external readers. */
+    /** @var string Path to .import-status.json — machine-readable progress for external readers. */
     private $progress_file;
 
     /** @var string SQL output mode: 'file' (default), 'stdout', or 'mysql'. */
@@ -516,19 +516,19 @@ class ImportClient
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
         $this->filesystem_root = rtrim($filesystem_root, "/");
-        $this->pull_state_file = $this->state_dir . "/pull/state.json";
-        $this->local_index_file = $this->state_dir . "/pull/local-index.jsonl";
+        $this->pull_state_file = $this->state_dir . "/.import-state.json";
+        $this->local_index_file = $this->state_dir . "/.import-index.jsonl";
         $this->local_index_wal_path =
-            $this->state_dir . "/pull/local-index.wal";
+            $this->state_dir . "/.import-local-index.wal";
         $this->remote_index_file =
-            $this->state_dir . "/pull/remote-index.jsonl";
+            $this->state_dir . "/.import-remote-index.jsonl";
         $this->fetch_list_file =
-            $this->state_dir . "/pull/fetch-list.jsonl";
+            $this->state_dir . "/.import-fetch-list.jsonl";
         $this->skipped_fetch_list_file =
-            $this->state_dir . "/pull/skipped-fetch-list.jsonl";
-        $this->audit_log_file = $this->state_dir . "/audit.log";
-        $this->volatile_files_file = $this->state_dir . "/pull/volatile-files.json";
-        $this->progress_file = $this->state_dir . "/progress.json";
+            $this->state_dir . "/.import-fetch-list-skipped.jsonl";
+        $this->audit_log_file = $this->state_dir . "/.import-audit.log";
+        $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
+        $this->progress_file = $this->state_dir . "/.import-status.json";
 
         // Detect TTY for progress display. In stdout mode this is re-evaluated
         // against STDERR in run() once we know the output mode.
@@ -538,9 +538,9 @@ class ImportClient
         $this->pull = new Pull($this, $this->progress);
 
         // Create directories
-        if (!is_dir($this->state_dir . "/pull")) {
-            if (!mkdir($this->state_dir . "/pull", 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->state_dir}/pull");
+        if (!is_dir($this->state_dir)) {
+            if (!mkdir($this->state_dir, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->state_dir}");
             }
         }
         if (!is_dir($this->filesystem_root)) {
@@ -922,7 +922,7 @@ class ImportClient
         }
 
         // files-diff and files-push use local push state and must not load
-        // or write the pull command's pull/state.json file.
+        // or write the pull command's .import-state.json file.
         if ($command === "files-diff") {
             $this->run_files_diff($options);
             return;
@@ -1977,7 +1977,7 @@ class ImportClient
                         "FILE DELETE | {$tables_file} | abort db-pull",
                     );
                 }
-                $domains_file = $this->state_dir . "/pull/domains.json";
+                $domains_file = $this->state_dir . "/.import-domains.json";
                 if (file_exists($domains_file)) {
                     unlink($domains_file);
                     $this->audit_log(
@@ -3766,7 +3766,7 @@ class ImportClient
      */
     private function run_db_domains(): void
     {
-        $domains_file = $this->state_dir . "/pull/domains.json";
+        $domains_file = $this->state_dir . "/.import-domains.json";
         $sql_file = $this->state_dir . "/db.sql";
 
         if (file_exists($domains_file)) {
@@ -3833,8 +3833,8 @@ class ImportClient
      * Print file index statistics: total indexed files and their size,
      * plus pending downloads and their size.
      *
-     * Reads pull/remote-index.jsonl for all indexed files and
-     * pull/fetch-list.jsonl for files not yet downloaded.
+     * Reads .import-remote-index.jsonl for all indexed files and
+     * .import-fetch-list.jsonl for files not yet downloaded.
      */
     private function run_files_stats(): void
     {
@@ -4314,9 +4314,9 @@ class ImportClient
         $manifest->constants["REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL"] = $base_url;
         $state_dir = realpath($this->state_dir) ?: $this->state_dir;
         $manifest->constants["REPRINT_PULL_STATE_FILE"] =
-            rtrim($state_dir, "/") . "/pull/state.json";
+            rtrim($state_dir, "/") . "/.import-state.json";
         $manifest->constants["REPRINT_PULL_SKIPPED_FETCH_LIST_FILE"] =
-            rtrim($state_dir, "/") . "/pull/skipped-fetch-list.jsonl";
+            rtrim($state_dir, "/") . "/.import-fetch-list-skipped.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -5203,7 +5203,7 @@ class ImportClient
         }
 
         // Show discovered domains if available
-        $domains_file = $this->state_dir . "/pull/domains.json";
+        $domains_file = $this->state_dir . "/.import-domains.json";
         if (file_exists($domains_file)) {
             $domains = json_decode(file_get_contents($domains_file), true);
             if (is_array($domains) && !empty($domains)) {
@@ -5370,7 +5370,7 @@ class ImportClient
         $stmts_since_save = 0;
 
         // Load pre-computed statement count from db-pull for progress reporting
-        $sql_stats_file = $this->state_dir . "/pull/sql-stats.json";
+        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
         $statements_total = null;
         if (file_exists($sql_stats_file)) {
             $stats = json_decode(file_get_contents($sql_stats_file), true);
@@ -6108,7 +6108,7 @@ class ImportClient
              * early would make resume skip the missing suffix.
              *
              * On the closing callback, flush the file and local index WAL
-             * before storing the cursor in pull/state.json. If the response
+             * before storing the cursor in .import-state.json. If the response
              * stops first, state retains the preceding cursor; resume truncates
              * the later bytes and requests the multipart part again.
              */
@@ -6822,7 +6822,7 @@ class ImportClient
     /**
      * Builds a JSON batch file listing the next set of paths to download.
      *
-     * Reads from the fetch list (pull/fetch-list.jsonl) starting at
+     * Reads from the fetch list (.import-fetch-list.jsonl) starting at
      * $offset, accumulating paths into a JSON array until the batch approaches
      * 80% of the server's max request size.  Always includes at least one path,
      * even if it alone exceeds the limit.
@@ -7580,11 +7580,11 @@ class ImportClient
             // Each SQL chunk is appended to this file as it arrives; when the
             // query completes and executes, the file is truncated. If the process
             // dies at any point, the next run reloads whatever was accumulated.
-            $sql_buffer_file = $this->state_dir . "/pull/sql-buffer";
+            $sql_buffer_file = $this->state_dir . "/.sql-buffer";
             if (file_exists($sql_buffer_file)) {
                 $sql_buffer = file_get_contents($sql_buffer_file);
                 $this->audit_log(
-                    sprintf("CRASH RECOVERY | Restored %d bytes from pull/sql-buffer", strlen($sql_buffer)),
+                    sprintf("CRASH RECOVERY | Restored %d bytes from .sql-buffer", strlen($sql_buffer)),
                     true,
                 );
             }
@@ -7603,12 +7603,12 @@ class ImportClient
         $domain_collector = class_exists('DomainCollector')
             ? new \DomainCollector()
             : null;
-        $domains_file = $this->state_dir . "/pull/domains.json";
-        $sql_stats_file = $this->state_dir . "/pull/sql-stats.json";
+        $domains_file = $this->state_dir . "/.import-domains.json";
+        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
         $sql_statements_counted = (int) ($this->import_state()->sql_statements_counted ?? 0);
 
         // Auto-detect the source site domain from the export URL so it
-        // always appears in pull/domains.json even if the SQL dump
+        // always appears in .import-domains.json even if the SQL dump
         // hasn't been fully scanned yet.
         if ($domain_collector) {
             $parsed_url = parse_url($this->remote_reprint_api_url);
@@ -7903,7 +7903,7 @@ class ImportClient
                     );
                     $this->audit_log(
                         sprintf(
-                            "DOMAINS DISCOVERED | %d unique domains saved to pull/domains.json",
+                            "DOMAINS DISCOVERED | %d unique domains saved to .import-domains.json",
                             count($domains),
                         ),
                         false,
@@ -7942,7 +7942,7 @@ class ImportClient
                 $mysql_conn = null;
                 // Clean up buffer file — if we got here with an empty buffer,
                 // all queries were executed successfully.
-                $sql_buffer_file = $this->state_dir . "/pull/sql-buffer";
+                $sql_buffer_file = $this->state_dir . "/.sql-buffer";
                 if ($pending === "" && file_exists($sql_buffer_file)) {
                     unlink($sql_buffer_file);
                 }
@@ -7951,7 +7951,7 @@ class ImportClient
                         // An exception is already in flight (e.g. curl error,
                         // MySQL error). Don't mask it by throwing about the
                         // buffer — the buffer data is safely persisted in
-                        // pull/sql-buffer and will be recovered on the next run.
+                        // .sql-buffer and will be recovered on the next run.
                         $this->audit_log(
                             "BUFFER NOT FLUSHED | " . strlen($pending) .
                             " bytes in SQL buffer during exception unwind" .
@@ -8485,7 +8485,7 @@ class ImportClient
 
     /**
      * Checks whether the remote index contains a remote absolute path or one
-     * of its descendants. Runs a memoized O(N) scan of pull/remote-index.jsonl.
+     * of its descendants. Runs a memoized O(N) scan of .import-remote-index.jsonl.
      */
     private function remote_index_contains_remote_absolute_path_prefix(
         string $remote_absolute_path
@@ -12545,13 +12545,13 @@ if (
                 "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
                 "\n" .
                 "Output files:\n" .
-                "  (filesystem root)/                       Downloaded files\n" .
-                "  pull/local-index.jsonl          Local index\n" .
-                "  pull/remote-index.jsonl         Remote index\n" .
-                "  pull/fetch-list.jsonl           Files pending download\n" .
-                "  pull/skipped-fetch-list.jsonl   Files skipped by --filter=essential-files\n" .
-                "  pull/state.json                 Resumable pull state\n" .
-                "  audit.log                       Audit log\n",
+                "  (filesystem root)/                              Downloaded files\n" .
+                "  .import-index.jsonl                     Local file index\n" .
+                "  .import-remote-index.jsonl              Remote index snapshot\n" .
+                "  .import-fetch-list.jsonl                Files pending download\n" .
+                "  .import-fetch-list-skipped.jsonl        Skipped files (when --filter=essential-files)\n" .
+                "  .import-state.json                      Resumable state\n" .
+                "  .import-audit.log                       Audit log\n",
         ],
         "files-diff" => [
             "level" => "low",
@@ -12600,7 +12600,7 @@ if (
             "description" =>
                 "Streams the full remote directory tree over HTTP and writes each\n" .
                 "entry (path, size, ctime, type, and directory emptiness) to\n" .
-                "pull/remote-index.jsonl.\n" .
+                ".import-remote-index.jsonl.\n" .
                 "\n" .
                 "On the first run, builds the complete index. On subsequent runs,\n" .
                 "re-indexes and diffs against the prior snapshot to produce a\n" .
@@ -12656,7 +12656,7 @@ if (
             "description" =>
                 "Prints domains found in the SQL dump, one per line.\n" .
                 "\n" .
-                "If pull/domains.json exists (cached by db-pull), it is read\n" .
+                "If .import-domains.json exists (cached by db-pull), it is read\n" .
                 "directly. Otherwise, db.sql is scanned and the result is cached\n" .
                 "for future calls. No network calls.\n" .
                 "\n" .
@@ -12669,7 +12669,7 @@ if (
             "short" => "Print local pull lifecycle metadata as JSON",
             "usage" => "reprint import-metadata --state-dir=DIR",
             "description" =>
-                "Reads --state-dir/pull/state.json and prints metadata for\n" .
+                "Reads --state-dir/.import-state.json and prints metadata for\n" .
                 "host integrations. No network calls are made.\n",
             "extra" =>
                 "Example:\n" .

--- a/packages/reprint-importer/src/lib/class-reprint-process-lock.php
+++ b/packages/reprint-importer/src/lib/class-reprint-process-lock.php
@@ -8,7 +8,7 @@
  * Serializes local Reprint commands which share one state directory.
  *
  * Construction acquires the non-blocking exclusive lock at
- * `<state-dir>/process.lock`. The caller retains this object for the
+ * `<state-dir>/.reprint.lock`. The caller retains this object for the
  * complete command and calls close() when the command ends.
  */
 final class ReprintProcessLock
@@ -39,7 +39,7 @@ final class ReprintProcessLock
                 . $state_dir . '.'
             );
         }
-        $process_lock_path = rtrim($state_dir, '/') . '/process.lock';
+        $process_lock_path = rtrim($state_dir, '/') . '/.reprint.lock';
         $this->handle = fopen($process_lock_path, 'c+b');
         if (!is_resource($this->handle)) {
             throw new RuntimeException('Failed to open the Reprint process lock: ' . $process_lock_path . '.');

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -298,9 +298,9 @@ class Pull
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_import_state();
                 foreach ([
-                    "{$state_dir}/pull/remote-index.jsonl",
-                    "{$state_dir}/pull/fetch-list.jsonl",
-                    "{$state_dir}/pull/skipped-fetch-list.jsonl",
+                    "{$state_dir}/.import-remote-index.jsonl",
+                    "{$state_dir}/.import-fetch-list.jsonl",
+                    "{$state_dir}/.import-fetch-list-skipped.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -320,7 +320,7 @@ class Pull
                 foreach ([
                     "{$state_dir}/db.sql",
                     "{$state_dir}/db-tables.jsonl",
-                    "{$state_dir}/pull/domains.json",
+                    "{$state_dir}/.import-domains.json",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -826,14 +826,14 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $state_dir . "/pull/remote-index.jsonl";
-            $paths[] = $state_dir . "/pull/fetch-list.jsonl";
-            $paths[] = $state_dir . "/pull/skipped-fetch-list.jsonl";
+            $paths[] = $state_dir . "/.import-remote-index.jsonl";
+            $paths[] = $state_dir . "/.import-fetch-list.jsonl";
+            $paths[] = $state_dir . "/.import-fetch-list-skipped.jsonl";
         }
         if ($reset_db_state) {
             $paths[] = $state_dir . "/db.sql";
             $paths[] = $state_dir . "/db-tables.jsonl";
-            $paths[] = $state_dir . "/pull/domains.json";
+            $paths[] = $state_dir . "/.import-domains.json";
         }
 
         foreach ($paths as $path) {

--- a/packages/reprint-importer/src/lib/state/class-import-state.php
+++ b/packages/reprint-importer/src/lib/state/class-import-state.php
@@ -341,7 +341,7 @@ class PullPipelineCheckpointState
 /**
  * In-process import state with typed properties for each persisted field.
  *
- * This object mirrors pull/state.json. Add new persistent state here first;
+ * This object mirrors .import-state.json. Add new persistent state here first;
  * from_array() requires the complete current schema.
  */
 class ImportState

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -637,7 +637,7 @@ function run_local_activation(): array {
     // is a black box: the wizard reports the empty-schema SQLite as
     // "ok" and the user lands on the install wizard.
     $audit_tail = '';
-    $audit_log_file = '/internal/shared/reprint-state/audit.log';
+    $audit_log_file = '/internal/shared/reprint-state/.import-audit.log';
     if (is_file($audit_log_file)) {
         $size = filesize($audit_log_file);
         $offset = max(0, $size - 4000);

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -83,7 +83,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('files-diff', $output);
         $this->assertStringContainsString('Low-level commands:', $output);
         $this->assertStringNotContainsString('Low-level commands (used by pull internally):', $output);
-        $this->assertStringNotContainsString('State is stored in --state-dir/pull/state.json', $output);
+        $this->assertStringNotContainsString('State is stored in --state-dir/.import-state.json', $output);
         $this->assertStringNotContainsString('Use --abort to abort the current', $output);
     }
 }

--- a/tests/Import/CommandAliasTest.php
+++ b/tests/Import/CommandAliasTest.php
@@ -22,7 +22,6 @@ class CommandAliasTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -66,7 +65,7 @@ class CommandAliasTest extends TestCase
 
         // Write a preflight so commands that require it don't bail early.
         file_put_contents(
-            $this->stateDir . '/pull/state.json',
+            $this->stateDir . '/.import-state.json',
             json_encode([
                 "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             ]),
@@ -102,7 +101,7 @@ class CommandAliasTest extends TestCase
     public function testRetiredStateShapeIsRejected(): void
     {
         file_put_contents(
-            $this->stateDir . '/pull/state.json',
+            $this->stateDir . '/.import-state.json',
             json_encode([
                 "command" => "files-pull",
                 "status" => "in_progress",

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -29,7 +29,6 @@ class CurlTimeoutRecoveryTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -76,7 +75,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
     private function readState(): array
     {
-        $contents = file_get_contents($this->stateDir . '/pull/state.json');
+        $contents = file_get_contents($this->stateDir . '/.import-state.json');
         return json_decode($contents, true);
     }
 

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -28,7 +28,6 @@ class DeactivateHostPluginsTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -25,7 +25,6 @@ class ExportDirectoryAutoDetectTest extends TestCase
         $this->fsRoot = $this->tempDir . '/fs-root';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -25,7 +25,6 @@ class FetchListProgressTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -66,7 +65,7 @@ class FetchListProgressTest extends TestCase
      */
     private function writeFetchList(int $count, ?string $file = null): string
     {
-        $file = $file ?? $this->stateDir . '/pull/fetch-list.jsonl';
+        $file = $file ?? $this->stateDir . '/.import-fetch-list.jsonl';
         $handle = fopen($file, 'w');
         for ($i = 0; $i < $count; $i++) {
             fwrite($handle, json_encode(["path" => base64_encode("/file-{$i}.txt")]) . "\n");
@@ -271,7 +270,7 @@ class FetchListProgressTest extends TestCase
     public function testSkippedListHasOwnCounters()
     {
         $this->writeFetchList(50);
-        $skippedList = $this->stateDir . '/pull/skipped-fetch-list.jsonl';
+        $skippedList = $this->stateDir . '/.import-fetch-list-skipped.jsonl';
         $this->writeFetchList(200, $skippedList);
         $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
 

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -26,7 +26,7 @@ class FilesPullStateTest extends TestCase
         $this->tempDir = sys_get_temp_dir() . '/import-state-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->stateDir, 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -79,7 +79,7 @@ class FilesPullStateTest extends TestCase
      */
     private function readState(): array
     {
-        $contents = file_get_contents($this->stateDir . '/pull/state.json');
+        $contents = file_get_contents($this->stateDir . '/.import-state.json');
         return json_decode($contents, true);
     }
 
@@ -101,7 +101,7 @@ class FilesPullStateTest extends TestCase
      */
     private function readFetchList(): array
     {
-        $file = $this->stateDir . '/pull/fetch-list.jsonl';
+        $file = $this->stateDir . '/.import-fetch-list.jsonl';
         if (!file_exists($file)) {
             return [];
         }
@@ -177,7 +177,7 @@ class FilesPullStateTest extends TestCase
             "filter" => "essential-files",
         ]);
         file_put_contents(
-            $this->stateDir . '/pull/skipped-fetch-list.jsonl',
+            $this->stateDir . '/.import-fetch-list-skipped.jsonl',
             json_encode([
                 "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
             ], JSON_UNESCAPED_SLASHES) . "\n",
@@ -201,7 +201,7 @@ class FilesPullStateTest extends TestCase
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
         $this->assertNull($state["active_resumable_command"]["current_stage"]);
         $this->assertEquals("skipped-earlier", $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/skipped-fetch-list.jsonl');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-fetch-list-skipped.jsonl');
     }
 
     /**
@@ -209,7 +209,7 @@ class FilesPullStateTest extends TestCase
      */
     public function testAbortClearsCompletedStatus()
     {
-        $indexFile = $this->stateDir . '/pull/local-index.jsonl';
+        $indexFile = $this->stateDir . '/.import-index.jsonl';
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
@@ -239,7 +239,7 @@ class FilesPullStateTest extends TestCase
      */
     public function testAbortThenRerunStartsFresh()
     {
-        $indexFile = $this->stateDir . '/pull/local-index.jsonl';
+        $indexFile = $this->stateDir . '/.import-index.jsonl';
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
@@ -281,7 +281,7 @@ class FilesPullStateTest extends TestCase
     public function testSkippedEarlierAfterCompositePullAdoptsFilesPullState(): void
     {
         file_put_contents(
-            $this->stateDir . '/pull/skipped-fetch-list.jsonl',
+            $this->stateDir . '/.import-fetch-list-skipped.jsonl',
             $this->indexLine('/wp-content/uploads/2024/01/photo.jpg', 1000, 100),
         );
         $this->writeState([
@@ -332,11 +332,11 @@ class FilesPullStateTest extends TestCase
     public function testDeltaDiffRedownloadsChangedIndexedFile()
     {
         // Local index: file synced at ctime 1000
-        $localIndex = $this->stateDir . '/pull/local-index.jsonl';
+        $localIndex = $this->stateDir . '/.import-index.jsonl';
         file_put_contents($localIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 1000, 200));
 
         // Remote index: same file at ctime 2000 (changed)
-        $remoteIndex = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndex = $this->stateDir . '/.import-remote-index.jsonl';
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
@@ -372,11 +372,11 @@ class FilesPullStateTest extends TestCase
     public function testDeltaDiffSkipsPreExistingLocalFile()
     {
         // Local index: empty (file was never synced by us)
-        $localIndex = $this->stateDir . '/pull/local-index.jsonl';
+        $localIndex = $this->stateDir . '/.import-index.jsonl';
         file_put_contents($localIndex, '');
 
         // Remote index: file exists on remote
-        $remoteIndex = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndex = $this->stateDir . '/.import-remote-index.jsonl';
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -219,7 +219,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertStringContainsString( (string) realpath($this->localTree), $nestedStateError['error'] ?? '' );
 
         $this->assertNoSenderState($this->stateDirectory);
-        $this->assertFileDoesNotExist($this->stateDirectory . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->stateDirectory . '/.import-state.json');
     }
 
     public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void
@@ -236,7 +236,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame('files-push', $finalLine['command'] ?? null);
         $this->assertSame('failed', $finalLine['status'] ?? null);
         $this->assertSame(1, $result['exit']);
-        $this->assertFileDoesNotExist($this->stateDirectory . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->stateDirectory . '/.import-state.json');
     }
 
     public function testCorruptSenderStateUsesTheStructuredWorkflowErrorResult(): void
@@ -277,7 +277,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame('', $result['stderr']);
 
         $progress = json_decode(
-            (string) file_get_contents($this->stateDirectory . '/progress.json'),
+            (string) file_get_contents($this->stateDirectory . '/.import-status.json'),
             true,
             512,
             JSON_THROW_ON_ERROR
@@ -287,7 +287,7 @@ final class FilesPushCommandTest extends TestCase
             array_keys($progress)
         );
         $this->assertSame('error', $progress['status']);
-        $audit = (string) file_get_contents($this->stateDirectory . '/audit.log');
+        $audit = (string) file_get_contents($this->stateDirectory . '/.import-audit.log');
         $this->assertSame(1, substr_count($audit, 'ERROR files-push'));
         $this->assertStringContainsString('pair=' . $context['pair'], $audit);
     }

--- a/tests/Import/FlatDocrootWpConfigTest.php
+++ b/tests/Import/FlatDocrootWpConfigTest.php
@@ -23,7 +23,6 @@ class FlatDocrootWpConfigTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -279,7 +279,7 @@ class FollowedSymlinksRootTest extends TestCase
             'type' => 'link',
             'intermediate' => true,
         ]);
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', $entry . "\n");
+        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', $entry . "\n");
 
         $rc->getMethod('recreate_intermediate_symlinks')->invoke($c);
 

--- a/tests/Import/ImportMetadataTest.php
+++ b/tests/Import/ImportMetadataTest.php
@@ -22,7 +22,6 @@ class ImportMetadataTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 
@@ -95,7 +94,7 @@ class ImportMetadataTest extends TestCase
         $metadata = $this->readMetadata();
 
         $this->assertFalse($metadata['hasCompletedOnce']);
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
         $this->assertNull($metadata['pullStage']);
     }
 

--- a/tests/Import/LocalIndexWalTest.php
+++ b/tests/Import/LocalIndexWalTest.php
@@ -22,7 +22,7 @@ final class LocalIndexWalTest extends TestCase
             . bin2hex(random_bytes(6));
         $this->stateDirectory = $this->root . '/state';
         $this->fileRoot = $this->root . '/files';
-        mkdir($this->stateDirectory . '/pull', 0700, true);
+        mkdir($this->stateDirectory, 0700, true);
         mkdir($this->fileRoot, 0700, true);
     }
 
@@ -44,7 +44,7 @@ final class LocalIndexWalTest extends TestCase
         );
         $reflection->getMethod('apply_local_index_wal')->invoke($client);
 
-        $localIndexWalPath = $this->stateDirectory . '/pull/local-index.wal';
+        $localIndexWalPath = $this->stateDirectory . '/.import-local-index.wal';
         $this->assertFileExists($localIndexWalPath);
         $this->assertSame('', file_get_contents($localIndexWalPath));
         $this->assertSame(
@@ -66,7 +66,7 @@ final class LocalIndexWalTest extends TestCase
             'type' => 'file',
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         file_put_contents(
-            $this->stateDirectory . '/pull/local-index.wal',
+            $this->stateDirectory . '/.import-local-index.wal',
             $completeRecord . '{"op":"F","path":"'
         );
 
@@ -78,7 +78,7 @@ final class LocalIndexWalTest extends TestCase
         $this->assertSame(
             '',
             file_get_contents(
-                $this->stateDirectory . '/pull/local-index.wal'
+                $this->stateDirectory . '/.import-local-index.wal'
             )
         );
     }
@@ -89,7 +89,7 @@ final class LocalIndexWalTest extends TestCase
     public function testAbortReplaysAndRemovesTheLocalIndexWal(string $command): void
     {
         file_put_contents(
-            $this->stateDirectory . '/pull/local-index.wal',
+            $this->stateDirectory . '/.import-local-index.wal',
             json_encode([
                 'op' => 'F',
                 'path' => base64_encode('/site/aborted.txt'),
@@ -112,7 +112,7 @@ final class LocalIndexWalTest extends TestCase
 
         $this->assertSame('/site/aborted.txt', $this->firstIndexPath());
         $this->assertFileDoesNotExist(
-            $this->stateDirectory . '/pull/local-index.wal'
+            $this->stateDirectory . '/.import-local-index.wal'
         );
     }
 
@@ -137,7 +137,7 @@ final class LocalIndexWalTest extends TestCase
     private function firstIndexPath(): string
     {
         $lines = file(
-            $this->stateDirectory . '/pull/local-index.jsonl',
+            $this->stateDirectory . '/.import-index.jsonl',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($lines);

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -404,7 +404,7 @@ class NewSiteUrlSqliteTest extends TestCase
             'target_db' => 'wp_test',
         ]);
 
-        $state = json_decode(file_get_contents($this->tempDir . '/pull/state.json'), true);
+        $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
         $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
         $this->assertSame(3, $state['apply']['statements_executed']);
         $this->assertSame(strlen($sql), $state['apply']['bytes_read']);

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -24,7 +24,6 @@ class OnlyCliParseTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/only-cli-' . uniqid();
         mkdir($this->tempDir . '/state', 0755, true);
-        mkdir($this->tempDir . '/state/pull', 0755, true);
         mkdir($this->tempDir . '/fs', 0755, true);
     }
 
@@ -42,7 +41,7 @@ class OnlyCliParseTest extends TestCase
             $this->serverPipes = array();
         }
 
-        // The real CLI run may drop state files (pull/state.json, audit log)
+        // The real CLI run may drop state files (.import-state.json, audit log)
         // into the state dir, so a plain rmdir wouldn't clear it — recurse.
         $this->recursiveDelete($this->tempDir);
         parent::tearDown();

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -26,7 +26,6 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -85,7 +84,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
     private function readLocalIndexPaths(): array
     {
-        $file = $this->stateDir . '/pull/local-index.jsonl';
+        $file = $this->stateDir . '/.import-index.jsonl';
         if (!file_exists($file)) {
             return [];
         }
@@ -132,12 +131,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // and a selected orphan absent from the --only remote index. The
         // delete drains must reconcile only within the --only file prefixes, so the local index
         // accumulates as a union across files-pull --only runs.
-        $this->writeIndex('pull/local-index.jsonl',
+        $this->writeIndex('.import-index.jsonl',
             $this->indexLine('/wp-config.php', 1000, 10)               // unselected
             . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
             . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // selected orphan
         );
-        $this->writeIndex('pull/remote-index.jsonl',
+        $this->writeIndex('.import-remote-index.jsonl',
             $this->indexLine('/wp-content/keep.txt', 1000, 10)
         );
 
@@ -164,12 +163,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // delete them: that would recursively remove the very directories
         // the user asked to pull, while the matched children keep the
         // fetch list empty — silent data loss.
-        $this->writeIndex('pull/local-index.jsonl',
+        $this->writeIndex('.import-index.jsonl',
             $this->indexLine('/wp-content/themes', 1000, 0, 'dir')
             . $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
             . $this->indexLine('/wp-content/themes/old/orphan.css', 1000, 10)
         );
-        $this->writeIndex('pull/remote-index.jsonl',
+        $this->writeIndex('.import-remote-index.jsonl',
             $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
         );
 

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -28,7 +28,6 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/srv/htdocs';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 
@@ -67,7 +66,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
         $c->get_import_state()->preflight = array('data' => $preflightData);
-        $this->set($c, 'audit_log_file', $this->tempDir . '/audit.log');
+        $this->set($c, 'audit_log_file', $this->tempDir . '/.import-audit.log');
         return $c;
     }
 
@@ -139,7 +138,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     private function readState(): array
     {
-        return json_decode(file_get_contents($this->stateDir . '/pull/state.json'), true);
+        return json_decode(file_get_contents($this->stateDir . '/.import-state.json'), true);
     }
 
     public function testResolvePullOnlyFilesPrefixAddsDirectoriesOutsideWpContent(): void
@@ -268,7 +267,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', '');
+        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
@@ -285,7 +284,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunRecordsOnlyFingerprintForInProgressFilesPullState(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', '');
+        file_put_contents($this->stateDir . '/.import-remote-index.jsonl', '');
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => null,
         ));

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -25,11 +25,11 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
 
         mkdir($this->fsRoot, 0755, true);
         mkdir($this->outputDir, 0755, true);
-        mkdir($stateDir . '/pull', 0755, true);
+        mkdir($stateDir, 0755, true);
 
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
-        $this->pullStateFile = $stateDir . '/pull/state.json';
-        $this->skippedFetchListFile = $stateDir . '/pull/skipped-fetch-list.jsonl';
+        $this->pullStateFile = $stateDir . '/.import-state.json';
+        $this->skippedFetchListFile = $stateDir . '/.import-fetch-list-skipped.jsonl';
         file_put_contents($this->pullStateFile, "{\"command\":\"files-pull\",\"status\":\"partial\"}\n");
         file_put_contents($this->skippedFetchListFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
     }

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -26,7 +26,6 @@ class ProductionDropInRemovalTest extends TestCase
         $this->outputDir = $this->tempDir . '/runtime';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
         mkdir($this->outputDir, 0755, true);
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
@@ -302,7 +301,7 @@ class ProductionDropInRemovalTest extends TestCase
         $this->runApplyRuntime($client);
 
         // The audit log records every removal.
-        $auditLog = file_get_contents($this->stateDir . '/audit.log');
+        $auditLog = file_get_contents($this->stateDir . '/.import-audit.log');
 
         $this->assertStringContainsString(
             'removed wp-content/object-cache.php (production-only)',
@@ -333,7 +332,7 @@ class ProductionDropInRemovalTest extends TestCase
 
         // Re-read the state file to verify paths_removed was persisted.
         $state = json_decode(
-            file_get_contents($this->stateDir . '/pull/state.json'),
+            file_get_contents($this->stateDir . '/.import-state.json'),
             true,
         );
 
@@ -476,7 +475,7 @@ class ProductionDropInRemovalTest extends TestCase
         $this->loadClientState($client);
         $this->runApplyRuntime($client);
 
-        $auditLog = file_get_contents($this->stateDir . '/audit.log');
+        $auditLog = file_get_contents($this->stateDir . '/.import-audit.log');
 
         $this->assertStringContainsString(
             'removed wp-content/plugins/sg-cachepress (production-only)',
@@ -498,7 +497,7 @@ class ProductionDropInRemovalTest extends TestCase
         $this->runApplyRuntime($client);
 
         $state = json_decode(
-            file_get_contents($this->stateDir . '/pull/state.json'),
+            file_get_contents($this->stateDir . '/.import-state.json'),
             true,
         );
 

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -103,11 +103,11 @@ class PullFilterFakeClient extends \ImportClient
         $this->files_pull_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
-                $this->state_dir . '/pull/skipped-fetch-list.jsonl',
+                $this->state_dir . '/.import-fetch-list-skipped.jsonl',
                 "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
             );
         } else {
-            @unlink($this->state_dir . '/pull/skipped-fetch-list.jsonl');
+            @unlink($this->state_dir . '/.import-fetch-list-skipped.jsonl');
         }
 
         $state = $this->get_import_state();
@@ -192,7 +192,6 @@ class PullFilterOptionTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -231,7 +230,7 @@ class PullFilterOptionTest extends TestCase
     private function readState(): array
     {
         return json_decode(
-            file_get_contents($this->stateDir . '/pull/state.json'),
+            file_get_contents($this->stateDir . '/.import-state.json'),
             true,
         );
     }
@@ -262,7 +261,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
     }
 
     public function testPullDoesNotAdvancePastFailedPreflight(): void
@@ -420,7 +419,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
     }
 
     public function testPullFilesSummaryReportsNoChangedFilesPulled(): void
@@ -775,7 +774,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
     }
 
     public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
@@ -796,7 +795,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertTrue($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
-        $this->assertFileExists($this->stateDir . '/pull/skipped-fetch-list.jsonl');
+        $this->assertFileExists($this->stateDir . '/.import-fetch-list-skipped.jsonl');
     }
 
     public function testPullWithoutFilterRecordsFullDownloadMode(): void
@@ -816,7 +815,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertFalse($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/skipped-fetch-list.jsonl');
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-fetch-list-skipped.jsonl');
     }
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -28,7 +28,6 @@ class RemapResolveTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/srv/htdocs';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
         $this->root = realpath($this->fsRoot);
     }
@@ -85,7 +84,7 @@ class RemapResolveTest extends TestCase
 
     private function writeLocalIndex(): void
     {
-        file_put_contents($this->stateDir . '/pull/local-index.jsonl', "{}\n");
+        file_put_contents($this->stateDir . '/.import-index.jsonl', "{}\n");
     }
 
     // --- resolution: SOURCE TARGET → one source => target rule -------------

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -22,7 +22,6 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         $this->outputDir = $this->tempDir . '/runtime';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
     }
@@ -150,7 +149,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'filter' => 'essential-files',
         ]);
         file_put_contents(
-            $this->stateDir . '/pull/skipped-fetch-list.jsonl',
+            $this->stateDir . '/.import-fetch-list-skipped.jsonl',
             json_encode(['path' => '/wp-content/uploads/2024/01/photo.jpg']) . "\n",
         );
 

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -34,23 +34,22 @@ final class ReprintProcessLockTest extends TestCase
             $this->root . '/files'
         );
 
-        $this->assertFileExists($this->root . '/state/process.lock');
-        $this->assertDirectoryExists($this->root . '/state/pull');
+        $this->assertFileExists($this->root . '/state/.reprint.lock');
+        $this->assertDirectoryDoesNotExist($this->root . '/state/pull');
         $this->assertDirectoryDoesNotExist($this->root . '/state/.reprint');
-        $this->assertFileDoesNotExist($this->root . '/state/.reprint.lock');
 
         $reflection = new \ReflectionClass($client);
         $expected_paths = [
             'state_dir' => $this->root . '/state',
-            'pull_state_file' => $this->root . '/state/pull/state.json',
-            'local_index_file' => $this->root . '/state/pull/local-index.jsonl',
-            'local_index_wal_path' => $this->root . '/state/pull/local-index.wal',
-            'remote_index_file' => $this->root . '/state/pull/remote-index.jsonl',
-            'fetch_list_file' => $this->root . '/state/pull/fetch-list.jsonl',
-            'skipped_fetch_list_file' => $this->root . '/state/pull/skipped-fetch-list.jsonl',
-            'volatile_files_file' => $this->root . '/state/pull/volatile-files.json',
-            'audit_log_file' => $this->root . '/state/audit.log',
-            'progress_file' => $this->root . '/state/progress.json',
+            'pull_state_file' => $this->root . '/state/.import-state.json',
+            'local_index_file' => $this->root . '/state/.import-index.jsonl',
+            'local_index_wal_path' => $this->root . '/state/.import-local-index.wal',
+            'remote_index_file' => $this->root . '/state/.import-remote-index.jsonl',
+            'fetch_list_file' => $this->root . '/state/.import-fetch-list.jsonl',
+            'skipped_fetch_list_file' => $this->root . '/state/.import-fetch-list-skipped.jsonl',
+            'volatile_files_file' => $this->root . '/state/.import-volatile-files.json',
+            'audit_log_file' => $this->root . '/state/.import-audit.log',
+            'progress_file' => $this->root . '/state/.import-status.json',
         ];
         foreach ($expected_paths as $property_name => $expected_path) {
             $property = $reflection->getProperty($property_name);

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -31,7 +31,6 @@ class RuntimeFilesTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -23,7 +23,6 @@ class SqliteRuntimeConfigTest extends TestCase
         $this->outputDir = $this->tempDir . '/runtime';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot . '/wp-content/database', 0755, true);
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
     }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2641,10 +2641,10 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $this->assertFileDoesNotExist($state_directory . '/pull/state.json');
+        $this->assertFileDoesNotExist($state_directory . '/.import-state.json');
 
         $progress = json_decode(
-            (string) file_get_contents($state_directory . '/progress.json'),
+            (string) file_get_contents($state_directory . '/.import-status.json'),
             true,
             512,
             JSON_THROW_ON_ERROR
@@ -2654,7 +2654,7 @@ final class PushEndpointsTest extends TestCase {
             array_keys($progress)
         );
         $this->assertSame('complete', $progress['status']);
-        $audit = (string) file_get_contents($state_directory . '/audit.log');
+        $audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringNotContainsString(self::SECRET, $audit . $initial['output']);
         $this->assertStringNotContainsString('cursor', $audit . json_encode($progress));
         $files_push_lines = array_values(array_filter(
@@ -2721,7 +2721,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('starting_plan', $partial_result['phase'] ?? null);
         $this->assertSame($push_create_requests + 1, $this->countEndpointRequests('push_create'));
         $this->assertSame(0, $this->countEndpointRequests('push_upload'));
-        $partial_audit = (string) file_get_contents($state_directory . '/audit.log');
+        $partial_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'PARTIAL files-push | pair=' . $partial_result['pair']
                 . ' | phase=starting_plan | cause=time_limit',
@@ -2764,7 +2764,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('interrupted', $interrupted_result['status'] ?? null);
         $this->assertSame('signal', $interrupted_result['reason'] ?? null);
         $this->assertSame('starting_plan', $interrupted_result['phase'] ?? null);
-        $interrupted_audit = (string) file_get_contents($state_directory . '/audit.log');
+        $interrupted_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'INTERRUPTED files-push | pair=' . $interrupted_result['pair']
                 . ' | phase=starting_plan | signal=' . SIGTERM,
@@ -2870,7 +2870,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('lock_acquisition_failure', $failed_result['reason'] ?? null);
         $this->assertSame($status_requests + 1, $this->countEndpointRequests('push_status'));
         $this->assertFileExists($push_state_directory . '/sender.json');
-        $failed_audit = (string) file_get_contents($state_directory . '/audit.log');
+        $failed_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'FAILED files-push | pair=' . $failed_result['pair'],
             $failed_audit
@@ -2911,7 +2911,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame($push_create_requests, $this->countEndpointRequests('push_create'));
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $restart_audit = (string) file_get_contents($state_directory . '/audit.log');
+        $restart_audit = (string) file_get_contents($state_directory . '/.import-audit.log');
         $this->assertStringContainsString(
             'RESTART files-push | pair=' . $restart_result['pair'],
             $restart_audit

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -266,7 +266,7 @@ export function runImporter(url, outputDir, command, options = {}) {
     // Non-preflight commands require a prior preflight run.
     // Automatically run one if the state file doesn't already have preflight data.
     if (command !== 'preflight' && command !== 'preflight-assert' && options.skipPreflight !== true) {
-        const stateFile = join(outputDir, 'pull/state.json');
+        const stateFile = join(outputDir, '.import-state.json');
         let needsPreflight = true;
         try {
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
@@ -671,17 +671,17 @@ export function countJsonlLines(filePath) {
  * Read the audit log as a string.
  */
 export function readAuditLog(outputDir) {
-    const logPath = join(outputDir, 'audit.log');
+    const logPath = join(outputDir, '.import-audit.log');
     if (!existsSync(logPath)) return '';
     return readFileSync(logPath, 'utf-8');
 }
 
 /**
  * Assert that the import indexed at least minCount files.
- * Checks pull/local-index.jsonl line count.
+ * Checks .import-index.jsonl line count.
  */
 export function assertFileCount(outputDir, minCount = 3000) {
-    const indexPath = join(outputDir, 'pull/local-index.jsonl');
+    const indexPath = join(outputDir, '.import-index.jsonl');
     assert.ok(existsSync(indexPath), `Expected ${indexPath} to exist`);
     const count = countJsonlLines(indexPath);
     assert.ok(count >= minCount,

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -40,8 +40,8 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('state file shows complete', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
-        assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.command_name, 'files-pull');
         assert.equal(state.active_resumable_command.completion_state, 'complete');
@@ -56,9 +56,9 @@ describe('Import: Basic File Sync', () => {
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
-    it('pull/local-index.jsonl has entries', () => {
-        const indexFile = join(tempDir, 'pull/local-index.jsonl');
-        assert.ok(existsSync(indexFile), 'Expected pull/local-index.jsonl to exist');
+    it('.import-index.jsonl has entries', () => {
+        const indexFile = join(tempDir, '.import-index.jsonl');
+        assert.ok(existsSync(indexFile), 'Expected .import-index.jsonl to exist');
         const lines = readFileSync(indexFile, 'utf-8').trim().split('\n').filter(l => l);
         assert.ok(lines.length > 0, 'Expected at least one index entry');
     });
@@ -93,12 +93,12 @@ describe('Import: Basic File Sync', () => {
         assert.equal(restart.exitCode, 0, `Expected restart exit 0, got ${restart.exitCode}\nstderr: ${restart.stderr}\nstdout: ${restart.stdout}`);
 
         // Local index should still exist (restart preserves it)
-        const indexFile = join(tempDir, 'pull/local-index.jsonl');
+        const indexFile = join(tempDir, '.import-index.jsonl');
         assert.ok(existsSync(indexFile), 'Expected local index to be preserved after --abort');
 
         // Transient files should be cleaned up
-        assert.ok(!existsSync(join(tempDir, 'pull/remote-index.jsonl')), 'Expected remote index to be deleted');
-        assert.ok(!existsSync(join(tempDir, 'pull/fetch-list.jsonl')), 'Expected fetch list to be deleted');
+        assert.ok(!existsSync(join(tempDir, '.import-remote-index.jsonl')), 'Expected remote index to be deleted');
+        assert.ok(!existsSync(join(tempDir, '.import-fetch-list.jsonl')), 'Expected fetch list to be deleted');
     });
 
     it('running after --abort performs a delta sync', () => {
@@ -107,7 +107,7 @@ describe('Import: Basic File Sync', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-04-files-index.test.js
+++ b/tests/e2e/tests/import-04-files-index.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 04: Files Index via import.php
- * Tests files-index command produces pull/remote-index.jsonl.
+ * Tests files-index command produces .import-remote-index.jsonl.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -30,14 +30,14 @@ describe('Import: Files Index', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-index produces pull/remote-index.jsonl', () => {
+    it('files-index produces .import-remote-index.jsonl', () => {
         const result = runImporter(importUrl(), tempDir, 'files-index', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const indexFile = join(tempDir, 'pull/remote-index.jsonl');
-        assert.ok(existsSync(indexFile), 'Expected pull/remote-index.jsonl to exist');
+        const indexFile = join(tempDir, '.import-remote-index.jsonl');
+        assert.ok(existsSync(indexFile), 'Expected .import-remote-index.jsonl to exist');
 
         const lines = readFileSync(indexFile, 'utf-8').trim().split('\n').filter(l => l);
         assert.ok(lines.length > 0, 'Expected at least one index entry');
@@ -62,7 +62,7 @@ describe('Import: Files Index', () => {
     });
 
     it('remote index has at least 3000 entries', () => {
-        const indexFile = join(tempDir, 'pull/remote-index.jsonl');
+        const indexFile = join(tempDir, '.import-remote-index.jsonl');
         const count = countJsonlLines(indexFile);
         assert.ok(count >= 3000,
             `Expected at least 3000 entries in remote index, got ${count}`);

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -66,8 +66,8 @@ describe('Import: Symlinks', () => {
         });
 
         it('sync completed without error despite symlinks', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
-            assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
+            const stateFile = join(tempDir, '.import-state.json');
+            assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
         });

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -116,7 +116,7 @@ INSERT INTO wp_secret_table VALUES (1, 'top secret');
         });
 
         it('state shows complete', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-09-resume-sql.test.js
+++ b/tests/e2e/tests/import-09-resume-sql.test.js
@@ -47,7 +47,7 @@ describe('Import: Resume SQL', { timeout: 120000 }, () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
     });

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -56,7 +56,7 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
     });
 
     it('state shows complete', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected state file to exist');
 
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));

--- a/tests/e2e/tests/import-12-gzip-corruption.test.js
+++ b/tests/e2e/tests/import-12-gzip-corruption.test.js
@@ -87,7 +87,7 @@ describe('Import: Gzip Corruption', () => {
             // Same as above: must not hang. Either succeeds (partial data OK)
             // or fails with a clear error.
             if (result.exitCode === 0) {
-                const stateFile = join(tempDir, 'pull/state.json');
+                const stateFile = join(tempDir, '.import-state.json');
                 if (existsSync(stateFile)) {
                     const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
                     assert.ok(

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -154,7 +154,7 @@ describe('Import: Volatile Files', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -53,7 +53,7 @@ describe('Import: Full Round-Trip', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -66,7 +66,7 @@ describe('Import: Request Cutoff', () => {
             `Expected exit 2 after the interrupted file index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
         );
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(
             state.active_resumable_command.completion_state,
@@ -98,7 +98,7 @@ describe('Import: Request Cutoff', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0 on resume\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected complete status, got ${state.active_resumable_command.completion_state}`);
     });

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -83,7 +83,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('fetch list includes deleted files', () => {
-        const dlPath = join(tempDir, 'pull/fetch-list.jsonl');
+        const dlPath = join(tempDir, '.import-fetch-list.jsonl');
         if (existsSync(dlPath)) {
             const content = readFileSync(dlPath, 'utf-8');
             // The fetch list should reference the deleted files
@@ -94,7 +94,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('state shows complete after delta', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 25: State File Corruption via import.php
- * Tests importer behavior when pull/state.json is corrupted or contains
+ * Tests importer behavior when .import-state.json is corrupted or contains
  * unexpected data. Verifies the importer recovers gracefully.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -33,7 +33,7 @@ describe('Import: State Corruption', () => {
             tempDir = createTempDir('e2e-state-corrupt-json');
             mkdirSync(join(tempDir, 'pull'), { recursive: true });
             // Write invalid JSON to state file
-            writeFileSync(join(tempDir, 'pull/state.json'), '{invalid json here!!!');
+            writeFileSync(join(tempDir, '.import-state.json'), '{invalid json here!!!');
         });
 
         afterAll(() => {
@@ -47,7 +47,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 (graceful recovery)\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
@@ -81,7 +81,7 @@ describe('Import: State Corruption', () => {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Preflight failed:\n${result.stderr}`);
-            const statePath = join(tempDir, 'pull/state.json');
+            const statePath = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(statePath, 'utf-8'));
             state.active_resumable_command.command_name = 'db-pull';
             state.active_resumable_command.completion_state = 'complete';
@@ -99,7 +99,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.command_name, 'files-pull', 'Expected command to be updated');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
@@ -115,7 +115,7 @@ describe('Import: State Corruption', () => {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Preflight failed:\n${result.stderr}`);
-            const statePath = join(tempDir, 'pull/state.json');
+            const statePath = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(statePath, 'utf-8'));
             state.active_resumable_command.command_name = 'files-pull';
             state.active_resumable_command.completion_state = 'in_progress';
@@ -134,7 +134,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 with --abort\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.notEqual(state.active_resumable_command.completion_state, 'in_progress', 'Expected status to be cleared');
             assert.ok(!state.active_resumable_command.remote_cursor, 'Expected cursor to be cleared');
@@ -146,7 +146,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -213,7 +213,7 @@ describe('Import: Follow Symlinks', () => {
     });
 
     it('state shows complete', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
         assert.equal(state.follow_symlinks, true, 'follow_symlinks should be persisted in state');
     });
@@ -328,7 +328,7 @@ describe('Import: Follow Symlinks', () => {
 
     it('multiple symlinks to same target do not create duplicate index entries', () => {
         // After sort+dedup, each path should appear at most once
-        const remoteIndex = join(tempDir, 'pull/remote-index.jsonl');
+        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
         if (!existsSync(remoteIndex)) return;
 
         const lines = readFileSync(remoteIndex, 'utf-8').split('\n').filter(l => l.trim());

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -221,7 +221,7 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
     });
 
     it('state stores path fields in base64 form', () => {
-        const statePath = join(tempDir, 'pull/state.json');
+        const statePath = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(statePath, 'utf-8'));
 
         assert.equal(typeof state.diff.local_after, 'string', 'Expected diff.local_after to be persisted');

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -42,7 +42,7 @@ describe('Import: Preflight state path encoding', () => {
     });
 
     it('stores requested preflight path fields as base64 in state file', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const data = state.preflight?.data;
         assert.ok(data, 'Expected preflight.data in state');
 

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -19,7 +19,7 @@ import { ensureSite } from '../lib/site-setup.js';
 describe('Import: Protocol Version Mismatch', () => {
     const site = 'basic';
     let tempDir;
-    const stateFileName = 'pull/state.json';
+    const stateFileName = '.import-state.json';
 
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -114,7 +114,7 @@ describe('Import: SQL Output Modes', () => {
         });
 
         it('state file records sql_output mode', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             assert.ok(existsSync(stateFile), 'Expected state file to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.sql_output, 'mysql',

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -3,12 +3,12 @@
  *
  * When using --sql-output=mysql with short execution times, the server
  * may pause mid-query (x-query-complete: 0). The importer buffers the
- * partial SQL in memory and persists it to pull/sql-buffer on disk as each
+ * partial SQL in memory and persists it to .sql-buffer on disk as each
  * chunk arrives. If the process dies at any point, the next run reloads
  * whatever was accumulated.
  *
  * This test forces many resume cycles with --max-exec=1, verifies the
- * database is correct after completion, and confirms pull/sql-buffer is
+ * database is correct after completion, and confirms .sql-buffer is
  * cleaned up.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -79,9 +79,9 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('pull/sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(tempDir, 'pull/sql-buffer')),
-                'Expected pull/sql-buffer to be cleaned up after successful completion');
+        it('.sql-buffer is cleaned up after completion', () => {
+            assert.ok(!existsSync(join(tempDir, '.sql-buffer')),
+                'Expected .sql-buffer to be cleaned up after successful completion');
         });
 
         it('no db.sql on disk', () => {
@@ -90,7 +90,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         });
     });
 
-    describe('pre-seeded pull/sql-buffer is loaded on resume', () => {
+    describe('pre-seeded .sql-buffer is loaded on resume', () => {
         let tempDir;
         const importDb = 'e2e_basic_import_36_seeded';
 
@@ -109,16 +109,16 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
             await conn.end();
         });
 
-        it('loads pull/sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
+        it('loads .sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
             // Run preflight so db-pull can proceed
             runImporter(importUrl(), tempDir, 'preflight', {
                 secret: getSiteSecret(site),
             });
 
-            // Seed a pull/sql-buffer file before running db-pull.
+            // Seed a .sql-buffer file before running db-pull.
             // The content is a harmless SQL comment that won't affect execution
             // — the point is to verify the importer reads it and logs recovery.
-            const bufferFile = join(tempDir, 'pull/sql-buffer');
+            const bufferFile = join(tempDir, '.sql-buffer');
             writeFileSync(bufferFile, '-- pre-seeded buffer\n');
 
             // Run a fresh db-pull — the importer should detect the buffer file
@@ -132,12 +132,12 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
 
             // Verify recovery was logged
             const audit = readAuditLog(tempDir);
-            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('pull/sql-buffer'),
-                'Expected audit log to mention pull/sql-buffer crash recovery');
+            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('.sql-buffer'),
+                'Expected audit log to mention .sql-buffer crash recovery');
 
             // Buffer should be cleaned up
             assert.ok(!existsSync(bufferFile),
-                'Expected pull/sql-buffer to be removed after completion');
+                'Expected .sql-buffer to be removed after completion');
         });
     });
 });

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -3,7 +3,7 @@
  *
  * Tests the full round-trip:
  * 1. Create site with known content containing source URLs in various formats
- * 2. Run db-pull → verify pull/domains.json contains the source domain
+ * 2. Run db-pull → verify .import-domains.json contains the source domain
  * 3. Run db-apply with --rewrite-url to apply SQL to target database
  * 4. Verify URLs are rewritten in all value types, including serialized PHP
  */
@@ -98,9 +98,9 @@ describe('Import: URL Rewriting', () => {
         assert.ok(existsSync(sqlFile), 'Expected db.sql to exist');
     });
 
-    it('domain discovery produces pull/domains.json', () => {
-        const domainsFile = join(tempDir, 'pull/domains.json');
-        assert.ok(existsSync(domainsFile), 'Expected pull/domains.json to exist');
+    it('domain discovery produces .import-domains.json', () => {
+        const domainsFile = join(tempDir, '.import-domains.json');
+        assert.ok(existsSync(domainsFile), 'Expected .import-domains.json to exist');
 
         const domains = JSON.parse(readFileSync(domainsFile, 'utf-8'));
         assert.ok(Array.isArray(domains), 'Expected domains to be an array');

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -161,7 +161,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('state shows complete with preserve_local persisted', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
@@ -334,7 +334,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('state preserves preserve_local across resume cycles', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
     });

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -113,7 +113,7 @@ require_once ABSPATH . 'wp-settings.php';
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
@@ -151,7 +151,7 @@ require_once ABSPATH . 'wp-settings.php';
     });
 
     it('wp-admin files exist at the resolved core path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const wpAdminPath = state.preflight?.data?.database?.wp?.paths_urls?.wp_admin_path;
         assert.ok(wpAdminPath, 'wp_admin_path not found in state');
 
@@ -167,7 +167,7 @@ require_once ABSPATH . 'wp-settings.php';
     });
 
     it('wp-content files exist at the separate content path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const contentDir = state.preflight?.data?.database?.wp?.paths_urls?.content_dir;
         assert.ok(contentDir, 'content_dir not found in state');
 

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -39,7 +39,7 @@ describe('Import: Runtime files', () => {
     });
 
     it('preflight state contains ini_get_all with core PHP directives', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
         assert.ok(iniAll && typeof iniAll === 'object', 'runtime.ini_get_all should be an object');
 
@@ -55,7 +55,7 @@ describe('Import: Runtime files', () => {
     });
 
     it('ini_get_all includes auto_prepend_file and auto_append_file directives', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
 
         // These directives should always be present in ini_get_all,

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -80,7 +80,7 @@ describe('Import: --filter', () => {
         });
 
         it('state shows complete with filter persisted', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
             assert.equal(state.active_resumable_command.command_name, 'files-pull');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.filter, 'essential-files');
@@ -105,7 +105,7 @@ describe('Import: --filter', () => {
         });
 
         it('skipped fetch list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
                 'Expected skipped fetch list to remain on disk');
         });
 
@@ -134,7 +134,7 @@ describe('Import: --filter', () => {
         });
 
         it('skipped fetch list was cleaned up', () => {
-            assert.ok(!existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(!existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
                 'Expected skipped fetch list to be cleaned up');
         });
 
@@ -142,7 +142,7 @@ describe('Import: --filter', () => {
             // Regression: the skipped-earlier fetch must mark the sync
             // complete. If it leaves status="in_progress", the filter-change
             // guard blocks the next delta re-pull below.
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete',
                 `Expected completion_state=complete after skipped-earlier, got ${state.active_resumable_command?.completion_state}`);
         });
@@ -192,7 +192,7 @@ describe('Import: --filter', () => {
         });
 
         it('state preserves filter across resume cycles', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
             assert.equal(state.filter, 'essential-files');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
@@ -206,7 +206,7 @@ describe('Import: --filter', () => {
         });
 
         it('skipped list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
                 'Expected skipped fetch list to remain');
         });
     });
@@ -234,7 +234,7 @@ describe('Import: --filter', () => {
         });
 
         it('no skipped fetch list was created', () => {
-            assert.ok(!existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(!existsSync(join(tempDir, '.import-fetch-list-skipped.jsonl')),
                 'Expected no skipped fetch list without --filter');
         });
 

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -71,7 +71,7 @@ describe('Import: Playground CLI runtime', () => {
         assert.equal(result.exitCode, 0,
             `files-pull failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -77,7 +77,7 @@ require ABSPATH . 'wp-blog-header.php';
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
@@ -104,7 +104,7 @@ require ABSPATH . 'wp-blog-header.php';
     });
 
     it('WP core files exist at the resolved path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const abspath = state.preflight?.data?.database?.wp?.paths_urls?.abspath;
         assert.ok(abspath, 'abspath not found in state');
 

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -181,7 +181,7 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     }
                 }
 
-                const stateFile = join(tempDir, 'pull/state.json');
+                const stateFile = join(tempDir, '.import-state.json');
                 assert.ok(existsSync(stateFile), 'Expected state file to exist');
                 const state = JSON.parse(readFileSync(stateFile, 'utf8'));
                 assert.equal(state.active_resumable_command.completion_state, 'complete',
@@ -194,8 +194,8 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     `Expected ${mode} mode to retry the interrupted REST request`,
                 );
 
-                assert.ok(!existsSync(join(tempDir, 'pull/sql-buffer')),
-                    'Expected pull/sql-buffer to be absent after successful completion');
+                assert.ok(!existsSync(join(tempDir, '.sql-buffer')),
+                    'Expected .sql-buffer to be absent after successful completion');
             } finally {
                 cleanupTempDir(tempDir);
                 if (mode === 'mysql') {

--- a/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
+++ b/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
@@ -79,7 +79,7 @@ describe('Import: Symlink cycle detection', () => {
         // A WordPress site has ~4000-6000 files.  Without cycle detection
         // the self-symlink would double that on every depth level.  With
         // cycle detection the total should stay in the normal range.
-        const remoteIndex = join(tempDir, 'pull/remote-index.jsonl');
+        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
         assert.ok(existsSync(remoteIndex), 'Remote index should exist');
 
         const count = countJsonlLines(remoteIndex);
@@ -93,7 +93,7 @@ describe('Import: Symlink cycle detection', () => {
     });
 
     it('the marker file is indexed exactly once per reachable path', () => {
-        const remoteIndex = join(tempDir, 'pull/remote-index.jsonl');
+        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
         const content = readFileSync(remoteIndex, 'utf-8');
         const lines = content.split('\n').filter(l => l.trim());
 

--- a/tests/e2e/tests/import-45-runtime-file-download.test.js
+++ b/tests/e2e/tests/import-45-runtime-file-download.test.js
@@ -70,7 +70,7 @@ describe('Import: Runtime file download', () => {
             assert.equal(preflightResult.exitCode, 0,
                 `Expected exit 0\nstderr: ${preflightResult.stderr}\nstdout: ${preflightResult.stdout}`);
 
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
             const prepend = state.preflight?.data?.runtime?.ini_get_all?.auto_prepend_file ?? '';
             if (prepend.includes('scripts/env.php')) {
                 break;
@@ -93,7 +93,7 @@ describe('Import: Runtime file download', () => {
     });
 
     it('preflight state reports auto_prepend_file path', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
         const prepend = iniAll?.auto_prepend_file ?? '';
         assert.ok(

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -111,7 +111,7 @@ describe('Import: SiteGround plugin stripping', () => {
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assert.equal(state.webhost, 'siteground',
             `Expected webhost 'siteground', got '${state.webhost}'`);
     });
@@ -182,7 +182,7 @@ describe('Import: SiteGround plugin stripping', () => {
         });
 
         it('audit log records the deactivations', () => {
-            const auditLog = readFileSync(join(tempDir, 'audit.log'), 'utf-8');
+            const auditLog = readFileSync(join(tempDir, '.import-audit.log'), 'utf-8');
             assert.ok(
                 auditLog.includes('deactivated plugin') && auditLog.includes('sg-cachepress'),
                 'audit log should record sg-cachepress deactivation',

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -64,8 +64,8 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
     });
 
     it('state shows pull complete', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
-        assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
     });
@@ -98,7 +98,7 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0 on re-pull, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-47-pull-multi-request.test.js
+++ b/tests/e2e/tests/import-47-pull-multi-request.test.js
@@ -74,7 +74,7 @@ describe('Import: Pull Multi-Request', { timeout: 300000 }, () => {
     });
 
     it('state shows pull complete', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 

--- a/tests/e2e/tests/import-48-pull-crash-resume.test.js
+++ b/tests/e2e/tests/import-48-pull-crash-resume.test.js
@@ -70,7 +70,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 
@@ -84,12 +84,12 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
             `Expected abort exit 0, got ${result.exitCode}`);
 
         // The completed-stage marker should be cleared.
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assert.equal(state.pull_pipeline.last_completed_stage, null,
             'Expected pull_pipeline.last_completed_stage to be null after abort');
 
         // Local index should be preserved (for delta sync)
-        assert.ok(existsSync(join(tempDir, 'pull/local-index.jsonl')),
+        assert.ok(existsSync(join(tempDir, '.import-index.jsonl')),
             'Expected local index to be preserved after abort');
     });
 
@@ -104,7 +104,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 
@@ -138,7 +138,7 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected auto re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -84,8 +84,8 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
     });
 
     it('state records deferred files in the pull metadata', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
-        assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
         assert.equal(state.pull_pipeline.files_filter, 'essential-files');
@@ -93,7 +93,7 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
     });
 
     it('skipped fetch list remains on disk', () => {
-        const skippedList = join(tempDir, 'pull/skipped-fetch-list.jsonl');
+        const skippedList = join(tempDir, '.import-fetch-list-skipped.jsonl');
         assert.ok(existsSync(skippedList), 'Expected skipped fetch list to exist');
         assert.ok(readFileSync(skippedList, 'utf-8').trim().length > 0,
             'Expected skipped fetch list to be non-empty');

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -142,7 +142,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const localPath = join(importedRoot, fileRel);
         const serializedLocalPath = `base64:${Buffer.from(localPath).toString('base64')}`;
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected import state file to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.notEqual(
@@ -165,7 +165,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected resume to complete\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(tempDir, '.import-state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected status=complete after resume, got ${state.active_resumable_command.completion_state}`);
     });

--- a/tests/e2e/tests/import-50-pull-manual-start.test.js
+++ b/tests/e2e/tests/import-50-pull-manual-start.test.js
@@ -61,7 +61,7 @@ describe('Import: Pull start-runtime none', { timeout: 180000 }, () => {
     });
 
     it('marks the pull complete and generates playground runtime files', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         assertPullPipelineComplete(state);
         assert.equal(state.active_resumable_command.completion_state, 'complete');
 

--- a/tests/e2e/tests/import-53-adversarial-database-pull.test.js
+++ b/tests/e2e/tests/import-53-adversarial-database-pull.test.js
@@ -91,7 +91,7 @@ describe('Import: Adversarial database pull', { timeout: 300000 }, () => {
                 `${result.stdout.slice(-4000)}`,
         );
         const importState = JSON.parse(
-            readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'),
+            readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
         );
         assertPullPipelineComplete(importState, 'pull-db');
 

--- a/tests/e2e/tests/import-54-db-index-interruption.test.js
+++ b/tests/e2e/tests/import-54-db-index-interruption.test.js
@@ -64,7 +64,7 @@ describe('Import: Database Index Response Interruption', () => {
         );
 
         const state = JSON.parse(
-            readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'),
+            readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
         );
         assert.equal(
             state.active_resumable_command.completion_state,


### PR DESCRIPTION
WP Cloud migrations continue to read Reprint's established state files under `--state-dir`.

The deployed `wpcloud-reprint-adapter` reads `.import-state.json` after preflight and during full sync to select the database charset, build URL rewrites, and set `$table_prefix`. #424 moved that file, so those reads silently returned no state. Pull state also stores positions into the index, WAL, and path-list files, so this restores the complete on-disk filename set rather than making one persisted lifecycle span the old and new layouts. The state-directory-wide lock returns to `.reprint.lock` so every Reprint version using this layout serializes on the same file.

The internal lifecycle names from #424 and runtime constant names from #429 remain unchanged.

## Testing

`cd tests && ../vendor/bin/phpunit --colors=never Import`

`cd tests && ../vendor/bin/phpunit --colors=never PushEndpointsTest.php`

`vendor/bin/phpstan analyze --memory-limit=1G`

`vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-importer/src`

`php tests/run.php` in the WP Cloud adapter checkout
