### PR TITLE
Expose source-site values through import-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,13 +645,17 @@ still running, completed, or needs resuming. The `command` + `status` fields
 tell you where the pipeline is. The `stage` field gives finer granularity
 (e.g., `"scanning"`, `"sorting"`, `"streaming"` for file sync).
 
-For pull-level lifecycle checks, prefer `import-metadata` over reading
-`pull/state.json` directly. It exposes Reprint-owned pull state as a small,
-stable JSON contract for host integrations:
+For pull lifecycle and source-site details, prefer `import-metadata` over
+reading `pull/state.json` directly. It exposes a small, stable JSON contract
+for host integrations:
 
 ```bash
 php reprint.phar import-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
 ```
+
+The `sourceSite` object contains the source WordPress home URL, site URL, table
+prefix, WordPress database charset, and database server charset reported by
+preflight. Each field is `null` when preflight did not report it.
 
 #### `pull/volatile-files.json` — files that changed during sync
 
@@ -709,7 +713,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `pull/domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
-* `import-metadata` — Prints local pull lifecycle metadata as JSON, including `hasCompletedOnce`. Requires only `--state-dir`; no network calls are made.
+* `import-metadata` — Prints pull lifecycle and source-site metadata as JSON. Requires only `--state-dir`; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3955,7 +3955,7 @@ class ImportClient
     }
 
     /**
-     * Prints host-facing import lifecycle metadata without mutating state.
+     * Prints host-facing import metadata without mutating state.
      */
     private function run_import_metadata(): void
     {
@@ -3977,16 +3977,47 @@ class ImportClient
      *     @type bool  $hasCompletedOnce Whether the pull pipeline has completed
      *                                   at least once.
      *     @type mixed $pullStage        Last completed pull stage.
+     *     @type array $sourceSite {
+     *         Source-site values reported by preflight.
+     *
+     *         @type string|null $homeUrl                    WordPress home URL.
+     *         @type string|null $siteUrl                    WordPress site URL.
+     *         @type string|null $tablePrefix                WordPress database
+     *                                                       table prefix.
+     *         @type string|null $wordpressDatabaseCharset   Charset used by
+     *                                                       WordPress.
+     *         @type string|null $serverDatabaseCharset      Database server's
+     *                                                       default charset.
+     *     }
      * }
-     * @phpstan-return array{hasCompletedOnce: bool, pullStage: mixed}
+     * @phpstan-return array{
+     *     hasCompletedOnce: bool,
+     *     pullStage: mixed,
+     *     sourceSite: array{
+     *         homeUrl: string|null,
+     *         siteUrl: string|null,
+     *         tablePrefix: string|null,
+     *         wordpressDatabaseCharset: string|null,
+     *         serverDatabaseCharset: string|null
+     *     }
+     * }
      */
     private function build_import_metadata(): array
     {
         $pull = $this->import_state()->pull_pipeline;
+        $database = $this->import_state()->preflight["data"]["database"] ?? [];
+        $wordpress = $database["wp"] ?? [];
 
         return [
             "hasCompletedOnce" => $pull->has_completed_once,
             "pullStage" => $pull->last_completed_stage,
+            "sourceSite" => [
+                "homeUrl" => $wordpress["home"] ?? null,
+                "siteUrl" => $wordpress["siteurl"] ?? null,
+                "tablePrefix" => $wordpress["table_prefix"] ?? null,
+                "wordpressDatabaseCharset" => $wordpress["wpdb_charset"] ?? null,
+                "serverDatabaseCharset" => $database["server_charset"] ?? null,
+            ],
         ];
     }
 
@@ -12666,11 +12697,11 @@ if (
         ],
         "import-metadata" => [
             "level" => "low",
-            "short" => "Print local pull lifecycle metadata as JSON",
+            "short" => "Print local metadata for host integrations as JSON",
             "usage" => "reprint import-metadata --state-dir=DIR",
             "description" =>
-                "Reads --state-dir/pull/state.json and prints metadata for\n" .
-                "host integrations. No network calls are made.\n",
+                "Reads --state-dir/pull/state.json and prints pull lifecycle and\n" .
+                "source-site metadata for host integrations. No network calls are made.\n",
             "extra" =>
                 "Example:\n" .
                 "  reprint import-metadata --state-dir=./state | jq '.hasCompletedOnce'\n",

--- a/tests/Import/ImportMetadataTest.php
+++ b/tests/Import/ImportMetadataTest.php
@@ -97,6 +97,45 @@ class ImportMetadataTest extends TestCase
         $this->assertFalse($metadata['hasCompletedOnce']);
         $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
         $this->assertNull($metadata['pullStage']);
+        $this->assertSame([
+            'homeUrl' => null,
+            'siteUrl' => null,
+            'tablePrefix' => null,
+            'wordpressDatabaseCharset' => null,
+            'serverDatabaseCharset' => null,
+        ], $metadata['sourceSite']);
+    }
+
+    /**
+     * Verifies source-site values are exposed without leaking the preflight schema.
+     */
+    public function testImportMetadataReportsSourceSiteFields(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'server_charset' => 'latin1',
+                        'wp' => [
+                            'home' => 'https://example.com',
+                            'siteurl' => 'https://example.com/wordpress',
+                            'table_prefix' => 'wp_4_',
+                            'wpdb_charset' => 'utf8mb3',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $metadata = $this->readMetadata();
+
+        $this->assertSame([
+            'homeUrl' => 'https://example.com',
+            'siteUrl' => 'https://example.com/wordpress',
+            'tablePrefix' => 'wp_4_',
+            'wordpressDatabaseCharset' => 'utf8mb3',
+            'serverDatabaseCharset' => 'latin1',
+        ], $metadata['sourceSite']);
     }
 
     /**


### PR DESCRIPTION
`import-metadata` exposes the source-site values host integrations need without requiring them to read Reprint's state file.

The new `sourceSite` object reports the source WordPress home URL, site URL, table prefix, WordPress database charset, and database server charset. Every key is always present and is `null` when preflight did not report a string.

This keeps the persisted state layout and raw preflight schema private while extending the host-facing contract already used for pull lifecycle metadata.

## Testing

`cd tests && ../vendor/bin/phpunit --colors=never Import`

`vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-importer/src`

`composer analyze -- --memory-limit=1G`

`git diff --check`
