### PR TITLE
Expand pull filters into path selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,10 @@ php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
     --filter=essential-files
 ```
 
-The pipeline proceeds as usual through indexing and diffing, but skips uploads. When the essential
-files are done, the sync marks itself **complete**. The skipped file list stays on disk at
-`$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/skipped-fetch-list.jsonl`.
-At this point you can apply the database and bring the site online.
+The pipeline rewrites this preset to exclude the `:wp-uploads:` path prefix,
+then proceeds through the normal index, diff, and fetch stages. When the
+essential files are done, the sync marks itself **complete**. At this point you
+can apply the database and bring the site online.
 
 ```bash
 # Step 2: download the uploads
@@ -266,12 +266,15 @@ The three filter values:
 
 - `--filter=none` (default): download all files.
 - `--filter=essential-files`: skip uploads, download only code/config/themes/plugins.
-- `--filter=skipped-earlier`: download only files that a prior `--filter=essential-files` run skipped.
+- `--filter=skipped-earlier`: include only the `:wp-uploads:` path prefix. The
+  name is retained for compatibility; a prior `essential-files` run is not
+  required.
 
 The uploads directory is detected from preflight data (`uploads.basedir`), falling back to
 `wp-content/uploads/` if unavailable.
 
-`files-pull` and `pull-files` also accept repeatable path-prefix selections:
+The presets use the same repeatable path-prefix options available directly on
+`files-pull` and `pull-files`:
 
 ```bash
 php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
@@ -280,7 +283,9 @@ php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 `--only=SOURCE` supplies an included source prefix and `--exclude=SOURCE`
 supplies an excluded source prefix. Both accept WordPress path tokens or
-absolute source paths. Exclusions win when the prefixes overlap.
+absolute source paths, and exclusions win when the prefixes overlap. Switching
+filters after a completed run starts a new filtered delta against the shared
+remote index; there is no separate skipped-file list or fetch stage.
 
 #### Pull only files.
 
@@ -581,7 +586,7 @@ The file contains a flat JSON object:
 | `steps`   | `int \| null`     | Total pipeline steps. `null` when `--steps` is not passed. |
 | `command` | `string \| null`  | Current command name (`preflight`, `files-pull`, `db-pull`, etc.). |
 | `status`  | `string`          | One of `in_progress`, `partial`, `complete`, `error`, `aborted`. |
-| `phase`   | `string \| null`  | Sub-phase within the command (e.g. `index`, `diff`, `fetch`, `fetch-skipped`), or `null`. Derived from the internal state's `stage` field. |
+| `phase`   | `string \| null`  | Sub-phase within the command (e.g. `index`, `diff`, `fetch`), or `null`. Derived from the internal state's `stage` field. |
 | `error`   | `string \| null`  | Error message when `status` is `error`, otherwise `null`. |
 | `ts`      | `float`           | Unix timestamp with microsecond precision (`microtime(true)`). |
 
@@ -643,12 +648,6 @@ fresh.
     "next_offset": 1024,
     "batch_file": null,
     "cursor": "..."               // file_fetch cursor
-  },
-  "fetch_skipped": {              // used when --filter=skipped-earlier
-    "offset": 0,
-    "next_offset": 0,
-    "batch_file": null,
-    "cursor": null
   },
 
   // Crash recovery: if the importer dies mid-write, these let it

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -187,7 +187,6 @@ their parent directories.
         │   ├── remote-index.wal
         │   ├── remote-index.next.jsonl
         │   ├── fetch-list.jsonl
-        │   ├── skipped-fetch-list.jsonl
         │   ├── volatile-files.json
         │   ├── domains.json
         │   ├── sql-stats.json
@@ -208,7 +207,6 @@ Use these path names:
 | Remote index WAL | `$remote_index_wal_path` |
 | Next remote index file | `$next_remote_index_file` |
 | Fetch list file | `$fetch_list_file` |
-| Skipped fetch list file | `$skipped_fetch_list_file` |
 | Volatile files file | `$volatile_files_file` |
 | Domains file | `$domains_file` |
 | SQL statistics file | `$sql_stats_file` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -213,9 +213,6 @@ class ImportClient
     /** @var string Path to pull/fetch-list.jsonl — files to download, computed by comparing the next remote index with the remote index. */
     private $fetch_list_file;
 
-    /** @var string Path to pull/skipped-fetch-list.jsonl — files skipped by --filter, downloaded later with --filter=skipped-earlier. */
-    private $skipped_fetch_list_file;
-
     /** @var string Path to audit.log — append-only log of every operation for debugging. */
     private $audit_log_file;
 
@@ -305,14 +302,16 @@ class ImportClient
     private $fs_root_nonempty_behavior = 'error';
 
     /**
-     * Controls which files are downloaded during files-pull.
+     * Selects a path-filter preset for files-pull.
      *
      *   "none"             — download everything (default)
      *   "essential-files"  — skip uploads, download only code/config/themes/plugins
-     *   "skipped-earlier"  — download only files that a prior --filter=essential-files skipped
+     *   "skipped-earlier"  — download only uploads
      *
-     * Set via --filter=<value>, persisted in state so it survives across
-     * resume cycles within the same run.
+     * The presets are translated into the same include and exclude path
+     * prefixes used by --only and --exclude. Set via --filter=<value> and
+     * persisted in state so it survives across resume cycles within the same
+     * run.
      */
     private $filter = "none";
 
@@ -452,8 +451,6 @@ class ImportClient
             $this->pull_state_directory . "/remote-index.next.jsonl";
         $this->fetch_list_file =
             $this->pull_state_directory . "/fetch-list.jsonl";
-        $this->skipped_fetch_list_file =
-            $this->pull_state_directory . "/skipped-fetch-list.jsonl";
         $this->audit_log_file = $this->state_dir . "/audit.log";
         $this->volatile_files_file = $this->pull_state_directory . "/volatile-files.json";
         $this->progress_file = $this->state_dir . "/progress.json";
@@ -573,14 +570,6 @@ class ImportClient
         $this->save_state();
     }
 
-    /** Record the pull's file filter and whether deferred files remain. */
-    public function set_pull_files_state(string $filter, bool $skipped_pending): void
-    {
-        $this->get_state()->pull_pipeline->files_filter = $filter;
-        $this->get_state()->pull_pipeline->skipped_pending = $skipped_pending;
-        $this->save_state();
-    }
-
     /**
      * Resolve file-selection options after preflight is available.
      */
@@ -600,6 +589,12 @@ class ImportClient
             $excluded_raw = [$excluded_raw];
         }
 
+        if ($this->filter === "essential-files") {
+            $excluded_raw[] = ":wp-uploads:";
+        } elseif ($this->filter === "skipped-earlier") {
+            $only_raw[] = ":wp-uploads:";
+        }
+
         $this->pull_only_files_with_path_prefixes = [];
         $this->pull_excluded_files_with_path_prefixes = [];
         if (!empty($only_raw)) {
@@ -614,14 +609,6 @@ class ImportClient
         if ($assert_remap) {
             $this->assert_resolved_path_mappings_consistent();
         }
-    }
-
-    /** True when the skipped-fetch list exists and still has entries. */
-    public function has_skipped_files_pending(): bool
-    {
-        return
-            file_exists($this->skipped_fetch_list_file) &&
-            filesize($this->skipped_fetch_list_file) > 0;
     }
 
     /**
@@ -908,17 +895,14 @@ class ImportClient
             $this->fs_root_nonempty_behavior = $this->get_state()->fs_root_nonempty_behavior ?? 'error';
         }
 
-        // Persist filter in state so it survives across resume cycles.
+        // Persist the path-filter preset in state so it survives across resume cycles.
         //
         //   --filter=none             download everything (default)
         //   --filter=essential-files   skip uploads, download code/config/themes/plugins
-        //   --filter=skipped-earlier   download only files skipped by a prior essential-files run
+        //   --filter=skipped-earlier   download only uploads
         //
         // Changing the filter mid-flight is not allowed.  The user must either
         // start fresh (--abort) or finish the current sync before switching.
-        // Exceptions: essential-files may advance to skipped-earlier once
-        // complete, and skipped-earlier (a terminal tail-fetch) may always give
-        // way to a fresh full sync.
         if (isset($options["filter"])) {
             $next = $options["filter"];
             if (
@@ -932,12 +916,9 @@ class ImportClient
             }
             $prev = $this->get_state()->filter ?? null;
             $status = $this->get_state()->active_resumable_command->completion_state ?? null;
-            // Leaving a skipped-earlier tail-fetch for another sync is a fresh
-            // cycle, not a mid-flight filter change.
             $is_mid_flight =
                 $prev !== null &&
                 $prev !== $next &&
-                $prev !== "skipped-earlier" &&
                 $status !== null &&
                 $status !== "complete";
             if ($is_mid_flight) {
@@ -945,6 +926,11 @@ class ImportClient
                     "Cannot change --filter from '{$prev}' to '{$next}' while a sync is in progress. " .
                         "Finish the current sync or use --abort to start over.",
                 );
+            }
+            if ($prev !== null && $prev !== $next && $status === "complete") {
+                // A completed path selection can be followed by a different
+                // selection as a fresh delta against the shared remote index.
+                $this->clear_files_pull_progress();
             }
             $this->filter = $next;
             $this->get_state()->filter = $this->filter;
@@ -1983,17 +1969,12 @@ class ImportClient
             @unlink($this->fetch_list_file);
             $this->audit_log("FILE DELETE | {$this->fetch_list_file}");
         }
-        if (file_exists($this->skipped_fetch_list_file)) {
-            @unlink($this->skipped_fetch_list_file);
-            $this->audit_log("FILE DELETE | {$this->skipped_fetch_list_file}");
-        }
         if (file_exists($this->volatile_files_file)) {
             @unlink($this->volatile_files_file);
             $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
         }
         $this->get_state()->index = new RemoteFileIndexCursorState();
         $this->get_state()->fetch = new FetchListProgressState();
-        $this->get_state()->fetch_skipped = new FetchListProgressState();
 
         $this->save_state();
     }
@@ -2603,25 +2584,6 @@ class ImportClient
     {
         $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
 
-        // A full `pull` leaves active_resumable_command on its last stage
-        // (db-apply), not files-pull, so a standalone skipped-earlier run can't
-        // tell that files-pull finished with a deferred tail. Recover that from
-        // the pipeline's skipped_pending flag and restore the files-pull
-        // checkpoint. Once the fetch starts it persists command_name=files-pull,
-        // so on the resume passes this recovery is skipped and won't clobber the
-        // checkpoint.
-        if (
-            $this->filter === "skipped-earlier" &&
-            $state_command !== "files-pull" &&
-            $this->get_state()->pull_pipeline->skipped_pending
-        ) {
-            $this->get_state()->active_resumable_command->command_name = "files-pull";
-            $this->get_state()->active_resumable_command->completion_state = "complete";
-            $this->get_state()->active_resumable_command->current_stage = null;
-            $this->save_state();
-            $state_command = "files-pull";
-        }
-
         $current_status =
             $state_command === "files-pull"
                 ? $this->get_state()->active_resumable_command->completion_state ?? null
@@ -2638,94 +2600,24 @@ class ImportClient
         // Already completed.
         if ($current_status === "complete") {
             $this->remove_remote_index_wal();
-            $has_skipped =
-                file_exists($this->skipped_fetch_list_file) &&
-                filesize($this->skipped_fetch_list_file) > 0;
-
-            // --filter=skipped-earlier: download only the files that a prior
-            // --filter=essential-files run skipped.  This is the only way to
-            // resume downloading those files — no implicit behavior.
-            if ($this->filter === "skipped-earlier") {
-                if (!$has_skipped) {
-                    throw new RuntimeException(
-                        "--filter=skipped-earlier was requested but there is no skipped file list. " .
-                            "Run files-pull with --filter=essential-files first.",
-                    );
-                }
-                $this->audit_log(
-                    "FETCH SKIPPED | files-pull was complete — downloading previously skipped files",
-                    true,
-                );
-                $this->progress->show_lifecycle_line("Downloading previously skipped files\n");
-                $this->output_progress([
-                    "type" => "lifecycle",
-                    "event" => "starting",
-                    "command" => "files-pull",
-                    "stage" => "fetch-skipped",
-                    "message" => "Downloading previously skipped files",
-                ], true);
-                $this->get_state()->active_resumable_command->completion_state = "in_progress";
-                $this->get_state()->active_resumable_command->current_stage = "fetch-skipped";
-                $this->get_state()->files_pull_path_selection_fingerprint =
-                    $this->files_pull_path_selection_fingerprint();
-                $this->get_state()->files_pull_summary = new FilesPullSummaryState();
-                $this->save_state();
-                $this->open_remote_index_wal();
-                $this->run_files_pull_pipeline();
-                // The deferred tail reopens a completed files-pull. Once the
-                // tail finishes, restore the completed status so later filter
-                // changes are judged against the actual lifecycle state.
-                if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
-                    return;
-                }
-                $this->get_state()->active_resumable_command->completion_state = "complete";
-                $this->save_state();
-                $this->remove_remote_index_wal();
-                return;
-            }
-
             $remote_index_entry_count = $this->remote_index_entry_count();
             $this->progress->clear_progress_line();
 
-            $skipped_note = $has_skipped
-                ? " (some files were skipped — re-run with --filter=skipped-earlier to download them)"
-                : "";
             $this->audit_log(
-                sprintf("files-pull already complete: %d remote index entries%s", $remote_index_entry_count, $skipped_note),
+                sprintf("files-pull already complete: %d remote index entries", $remote_index_entry_count),
                 true,
             );
 
             $this->progress->show_lifecycle_line("files-pull already complete: {$remote_index_entry_count} remote index entries\n");
-            if ($has_skipped) {
-                $this->progress->show_lifecycle_line("Some files were skipped. Re-run with --filter=skipped-earlier to download them.\n");
-            } else {
-                $this->progress->show_lifecycle_line("To re-sync, run with --abort first to clear state.\n");
-            }
+            $this->progress->show_lifecycle_line("To re-sync, run with --abort first to clear state.\n");
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "already_complete",
                 "command" => "files-pull",
                 "files_indexed" => $remote_index_entry_count,
-                "has_skipped" => $has_skipped,
                 "message" => "files-pull already complete: {$remote_index_entry_count} remote index entries",
             ], true);
             return;
-        }
-
-        // --filter=skipped-earlier is only valid after a completed
-        // --filter=essential-files run. Reject it as a fresh start, but allow
-        // resuming a skipped-files fetch that is already under way: a
-        // multi-batch fetch returns status="partial" and is re-run, at which
-        // point stage is "fetch-skipped" and the resume flows through the
-        // $has_progress path below (and completes via the shared tail).
-        if (
-            $this->filter === "skipped-earlier" &&
-            ($this->get_state()->active_resumable_command->current_stage ?? null) !== "fetch-skipped"
-        ) {
-            throw new RuntimeException(
-                "--filter=skipped-earlier was requested but there is no completed sync with skipped files. " .
-                    "Run files-pull with --filter=essential-files first.",
-            );
         }
 
         // Filter out "." and ".." explicitly: standard PHP scandir() returns them,
@@ -2792,7 +2684,6 @@ class ImportClient
             $this->get_state()->diff = new FileDiffProgressState();
             $this->get_state()->index = new RemoteFileIndexCursorState();
             $this->get_state()->fetch = new FetchListProgressState();
-            $this->get_state()->fetch_skipped = new FetchListProgressState();
             $this->get_state()->files_pull_summary = new FilesPullSummaryState();
             $this->save_state();
 
@@ -2907,12 +2798,6 @@ class ImportClient
                     "FILE DELETE | {$this->fetch_list_file} | clearing before diff stage",
                 );
             }
-            if (file_exists($this->skipped_fetch_list_file)) {
-                @unlink($this->skipped_fetch_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_fetch_list_file} | clearing before diff stage",
-                );
-            }
             $this->save_state();
             $stage = "diff";
         }
@@ -2928,18 +2813,7 @@ class ImportClient
             $has_files_to_fetch =
                 file_exists($this->fetch_list_file) &&
                 filesize($this->fetch_list_file) > 0;
-            $has_skipped =
-                file_exists($this->skipped_fetch_list_file) &&
-                filesize($this->skipped_fetch_list_file) > 0;
-
-            // Determine the first fetch stage to run.
-            if ($has_files_to_fetch) {
-                $stage = "fetch";
-            } elseif ($has_skipped) {
-                $stage = "fetch-skipped";
-            } else {
-                $stage = null;
-            }
+            $stage = $has_files_to_fetch ? "fetch" : null;
             $this->get_state()->active_resumable_command->current_stage = $stage;
             $this->save_state();
 
@@ -2966,19 +2840,10 @@ class ImportClient
                     "FILE DELETE | {$this->fetch_list_file} | no files to fetch",
                 );
             }
-            if (!$has_skipped && file_exists($this->skipped_fetch_list_file)) {
-                @unlink($this->skipped_fetch_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_fetch_list_file} | no skipped files to fetch",
-                );
-            }
         }
 
         if ($stage === "fetch") {
-            $complete = $this->fetch_files_from_list(
-                $this->fetch_list_file,
-                "fetch",
-            );
+            $complete = $this->fetch_files_from_list($this->fetch_list_file);
             if (!$complete) {
                 $this->get_state()->active_resumable_command->completion_state = "partial";
                 $this->save_state();
@@ -2993,61 +2858,8 @@ class ImportClient
                 );
             }
 
-            $has_skipped =
-                file_exists($this->skipped_fetch_list_file) &&
-                filesize($this->skipped_fetch_list_file) > 0;
-
-            if ($has_skipped && $this->filter === "essential-files") {
-                // Essential files are done — mark the sync as complete.
-                // The skipped list stays on disk for a later
-                // --filter=skipped-earlier run.
-                $this->get_state()->active_resumable_command->current_stage = null;
-                $this->save_state();
-                $this->audit_log(
-                    "ESSENTIAL FILES COMPLETE | skipped files listed in {$this->skipped_fetch_list_file} — run with --filter=skipped-earlier to download them",
-                    true,
-                );
-                $stage = null;
-            } elseif ($has_skipped) {
-                // Skipped list exists but filter is "none" — download now.
-                $this->get_state()->active_resumable_command->current_stage = "fetch-skipped";
-                $this->save_state();
-                $stage = "fetch-skipped";
-                $this->audit_log(
-                    "ESSENTIAL FILES COMPLETE | transitioning to skipped files",
-                    true,
-                );
-                $this->write_progress_file();
-            } else {
-                $this->get_state()->active_resumable_command->current_stage = null;
-                $this->save_state();
-                $stage = null;
-            }
-        }
-
-        if ($stage === "fetch-skipped") {
-            $complete = $this->fetch_files_from_list(
-                $this->skipped_fetch_list_file,
-                "fetch_skipped",
-            );
-            if (!$complete) {
-                $this->get_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state();
-                return;
-            }
             $this->get_state()->active_resumable_command->current_stage = null;
-            $this->get_state()->fetch_skipped = new FetchListProgressState();
-            // Tail fully fetched; clear the flag so a later skipped-earlier run
-            // doesn't treat the now-empty tail as pending.
-            $this->get_state()->pull_pipeline->skipped_pending = false;
             $this->save_state();
-
-            if (file_exists($this->skipped_fetch_list_file)) {
-                @unlink($this->skipped_fetch_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->skipped_fetch_list_file} | skipped files fetch complete",
-                );
-            }
         }
 
         // Recreate intermediate path symlinks so the full symlink chain
@@ -3815,13 +3627,11 @@ class ImportClient
         $indexed_count = count($size_by_path);
         $indexed_bytes = array_sum($size_by_path);
 
-        // Walk the fetch list(s) to count pending files. The download
+        // Walk the fetch list to count pending files. The fetch
         // list only stores paths, so look up sizes from the map above.
         // Files before the fetch byte offset have already been downloaded.
         $pending_count = 0;
         $pending_bytes = 0;
-        $skipped_pending_count = 0;
-        $skipped_pending_bytes = 0;
 
         // Count pending in the main fetch list
         $fetch_offset = $this->get_state()->fetch->offset ?? 0;
@@ -3855,36 +3665,6 @@ class ImportClient
             }
         }
 
-        // Count pending in the skipped fetch list (uploads filtered out by --filter=essential-files)
-        $skipped_offset = $this->get_state()->fetch_skipped->offset ?? 0;
-        $skipped_list = $this->skipped_fetch_list_file;
-        if (is_file($skipped_list)) {
-            $handle = fopen($skipped_list, "r");
-            if ($handle) {
-                if ($skipped_offset > 0) {
-                    fseek($handle, $skipped_offset);
-                }
-                while (($line = fgets($handle)) !== false) {
-                    $line = trim($line);
-                    if ($line === "") {
-                        continue;
-                    }
-                    $data = json_decode($line, true);
-                    if (!is_array($data)) {
-                        continue;
-                    }
-                    $path_encoded = $data["path"] ?? "";
-                    $path = base64_decode($path_encoded, true);
-                    if ($path === false || $path === "") {
-                        continue;
-                    }
-                    $skipped_pending_count++;
-                    $skipped_pending_bytes += $size_by_path[$path] ?? 0;
-                }
-                fclose($handle);
-            }
-        }
-
         $result = [
             "indexed" => [
                 "files" => $indexed_count,
@@ -3895,13 +3675,6 @@ class ImportClient
                 "bytes" => $pending_bytes,
             ],
         ];
-        if ($skipped_pending_count > 0 || is_file($skipped_list)) {
-            $result["pending_skipped"] = [
-                "files" => $skipped_pending_count,
-                "bytes" => $skipped_pending_bytes,
-            ];
-        }
-
         echo json_encode($result, JSON_PRETTY_PRINT) . "\n";
     }
 
@@ -4277,7 +4050,7 @@ class ImportClient
      *
      * The proxy is active in two cases:
      * - files-pull is still incomplete
-     * - a prior --filter=essential-files run left skipped uploads on disk
+     * - the essential-files preset is active
      */
     private function maybe_enable_remote_upload_proxy(RuntimeManifest $manifest, array $preflight_data): void
     {
@@ -4300,8 +4073,6 @@ class ImportClient
             ?: $this->pull_state_directory;
         $manifest->constants["REPRINT_PULL_STATE_FILE"] =
             rtrim($pull_state_directory, "/") . "/state.json";
-        $manifest->constants["REPRINT_PULL_SKIPPED_FETCH_LIST_FILE"] =
-            rtrim($pull_state_directory, "/") . "/skipped-fetch-list.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -4317,15 +4088,12 @@ class ImportClient
     /**
      * Decide whether runtime should proxy missing uploads from the source.
      *
-     * Once files-pull is fully complete and no skipped uploads remain, the
-     * proxy is disabled so requests are served only from local files.
+     * Once files-pull is fully complete under another preset, the proxy is
+     * disabled so requests are served only from local files.
      */
     private function should_enable_remote_upload_proxy(): bool
     {
-        if (
-            file_exists($this->skipped_fetch_list_file) &&
-            filesize($this->skipped_fetch_list_file) > 0
-        ) {
+        if ($this->get_state()->filter === "essential-files") {
             return true;
         }
 
@@ -5918,10 +5686,9 @@ class ImportClient
      */
     private function fetch_file_batch(
         ?array $post_data,
-        ?string $cursor,
-        string $state_key = "fetch"
+        ?string $cursor
     ): bool {
-        $fetch_state = $this->get_fetch_list_progress_state($state_key);
+        $fetch_state = $this->get_state()->fetch;
         $cursor = $cursor ?? $fetch_state->cursor;
         $complete = false;
         $chunks_since_save = 0;
@@ -5990,8 +5757,7 @@ class ImportClient
             &$cursor,
             &$complete,
             &$chunks_since_save,
-            $context,
-            $state_key
+            $context
         ) {
             if ($this->shutdown_requested) {
                 throw new RuntimeException("Shutdown requested");
@@ -6129,7 +5895,7 @@ class ImportClient
                     ) {
                         throw new RuntimeException('Failed to flush the remote index WAL.');
                     }
-                    $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
+                    $this->get_state()->fetch->cursor = $cursor;
                     $this->save_state();
                     $chunks_since_save = 0;
                 }
@@ -6151,8 +5917,7 @@ class ImportClient
             // whose cursor is not durable yet. Keep the checkpoint saved by
             // the last complete part; the next invocation truncates any later
             // bytes before resuming.
-            $durable_cursor =
-                $this->get_fetch_list_progress_state($state_key)->cursor;
+            $durable_cursor = $this->get_state()->fetch->cursor;
             $this->assert_can_resume_after_interrupted_response(
                 "file_fetch",
                 $cursor_before,
@@ -6177,7 +5942,7 @@ class ImportClient
             $wall_time,
             $context->response_stats ?? [],
         );
-        $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
+        $this->get_state()->fetch->cursor = $cursor;
         $this->apply_remote_index_wal();
         // Update file tracking: track in-progress file, or clear if complete/no active file
         if ($context->file_handle && $context->file_path) {
@@ -6476,35 +6241,6 @@ class ImportClient
             throw new RuntimeException("Failed to open fetch list file");
         }
 
-        // When --filter=essential-files is active, uploads go to a separate
-        // "skipped" list so only essential files are fetched in this run.
-        $skipped_fetch_list_file_handle = null;
-        $remote_uploads_directory_absolute_path = null;
-        if ($this->filter === "essential-files") {
-            if ($fetch_list_file_mode === "w") {
-                $this->audit_log(
-                    "FILE CREATE | {$this->skipped_fetch_list_file} | building skipped fetch list (uploads)",
-                );
-            } else {
-                $this->audit_log(
-                    "FILE APPEND | {$this->skipped_fetch_list_file} | resuming skipped fetch list build",
-                );
-            }
-            $skipped_fetch_list_file_handle = fopen(
-                $this->skipped_fetch_list_file,
-                $fetch_list_file_mode,
-            );
-            if (!$skipped_fetch_list_file_handle) {
-                fclose($fetch_list_file_handle);
-                throw new RuntimeException("Failed to open skipped fetch list file");
-            }
-            $remote_uploads_directory_absolute_path = $this->get_uploads_basedir();
-            $this->audit_log(
-                "FILTER | essential-files | uploads_basedir=" .
-                    ($remote_uploads_directory_absolute_path ?? "(fallback: wp-content/uploads/)"),
-            );
-        }
-
         $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
         if (!$next_remote_index_file_handle) {
             fclose($fetch_list_file_handle);
@@ -6575,30 +6311,13 @@ class ImportClient
                     $remote_index_entry["size"] !== $next_remote_index_entry["size"] ||
                     $remote_index_entry["type"] !== $next_remote_index_entry["type"]
                 ) {
-                    // The path is represented in both indexes but changed on the remote.
                     // Re-download it when selected — the remote index confirms
                     // that an earlier files-pull accounted for this path, so
                     // preserve-local does not protect it.
                     if ($this->is_selected_for_pulling($next_remote_index_entry["path"], true)) {
-                        $selected_fetch_list_file_handle = (
-                            $skipped_fetch_list_file_handle !== null &&
-                            (
-                                $remote_uploads_directory_absolute_path !== null
-                                    ? path_is_within_root(
-                                        $next_remote_index_entry["path"],
-                                        $remote_uploads_directory_absolute_path
-                                    )
-                                    : strpos(
-                                        $next_remote_index_entry["path"],
-                                        "wp-content/uploads/"
-                                    ) !== false
-                            )
-                        )
-                            ? $skipped_fetch_list_file_handle
-                            : $fetch_list_file_handle;
                         $this->append_to_fetch_list(
                             $next_remote_index_entry["path"],
-                            $selected_fetch_list_file_handle,
+                            $fetch_list_file_handle,
                         );
                     }
                 }
@@ -6621,25 +6340,9 @@ class ImportClient
                     $this->audit_log($preserve_local_skip_reason, true);
                     $this->emit_skip_progress($next_remote_index_entry["path"]);
                 } else {
-                    $selected_fetch_list_file_handle = (
-                        $skipped_fetch_list_file_handle !== null &&
-                        (
-                            $remote_uploads_directory_absolute_path !== null
-                                ? path_is_within_root(
-                                    $next_remote_index_entry["path"],
-                                    $remote_uploads_directory_absolute_path
-                                )
-                                : strpos(
-                                    $next_remote_index_entry["path"],
-                                    "wp-content/uploads/"
-                                ) !== false
-                        )
-                    )
-                        ? $skipped_fetch_list_file_handle
-                        : $fetch_list_file_handle;
                     $this->append_to_fetch_list(
                         $next_remote_index_entry["path"],
-                        $selected_fetch_list_file_handle,
+                        $fetch_list_file_handle,
                     );
                 }
             }
@@ -6677,9 +6380,6 @@ class ImportClient
         }
         fclose($next_remote_index_file_handle);
         fclose($fetch_list_file_handle);
-        if ($skipped_fetch_list_file_handle !== null) {
-            fclose($skipped_fetch_list_file_handle);
-        }
 
         $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
         $this->get_state()->diff->last_consumed_remote_index_entry_path =
@@ -6690,13 +6390,6 @@ class ImportClient
         return !$this->shutdown_requested;
     }
 
-    /**
-     * Download files from a prepared list.
-     *
-     * @param string $list_file   Path to the JSONL fetch list to process.
-     * @param string $state_key   Key in $this->state that holds fetch progress
-     *                            (e.g. "fetch" or "fetch_skipped").
-     */
     /**
      * Count newlines in a file using buffered reads.  Much faster than
      * fgets() on large JSONL files because it never allocates per-line
@@ -6729,10 +6422,13 @@ class ImportClient
         return $count;
     }
 
-    private function fetch_files_from_list(
-        string $list_file,
-        string $state_key
-    ): bool {
+    /**
+     * Download files from a prepared list.
+     *
+     * @param string $list_file Path to the JSONL fetch list to process.
+     */
+    private function fetch_files_from_list(string $list_file): bool
+    {
         if (!file_exists($list_file)) {
             return true;
         }
@@ -6745,13 +6441,13 @@ class ImportClient
         // These survive across batches within one invocation and are
         // recomputed on restart from the state file's byte offset.
         if ($this->fetch_list_total === null) {
-            $offset = $this->get_fetch_list_progress_state($state_key)->offset;
+            $offset = $this->get_state()->fetch->offset;
             $this->fetch_list_total = $this->count_newlines($list_file);
             $this->fetch_list_done = $offset > 0
                 ? $this->count_newlines($list_file, $offset)
                 : 0;
         }
-        $fetch_state = $this->get_fetch_list_progress_state($state_key);
+        $fetch_state = $this->get_state()->fetch;
         $batch_file = $fetch_state->batch_file;
         $batch_offset = $fetch_state->offset;
         $next_offset = $fetch_state->next_offset;
@@ -6769,13 +6465,13 @@ class ImportClient
             $next_offset = $batch["next_offset"];
             $batch_entries = $batch["entries"];
             $cursor = null;
-            $this->set_fetch_list_progress_state($state_key, FetchListProgressState::from_array([
+            $this->get_state()->fetch = FetchListProgressState::from_array([
                 "offset" => $batch_offset,
                 "next_offset" => $next_offset,
                 "batch_file" => $batch_file,
                 "batch_entries" => $batch_entries,
                 "cursor" => null,
-            ]));
+            ]);
             $this->save_state();
         }
 
@@ -6787,7 +6483,7 @@ class ImportClient
             ),
         ];
 
-        $complete = $this->fetch_file_batch($post_data, $cursor, $state_key);
+        $complete = $this->fetch_file_batch($post_data, $cursor);
         if (!$complete) {
             return false;
         }
@@ -6807,40 +6503,16 @@ class ImportClient
         $this->get_state()->files_pull_summary->files_pulled += $batch_entries;
         $this->files_pulled = 0;
 
-        $this->set_fetch_list_progress_state($state_key, FetchListProgressState::from_array([
+        $this->get_state()->fetch = FetchListProgressState::from_array([
             "offset" => $next_offset,
             "next_offset" => $next_offset,
             "batch_file" => null,
             "batch_entries" => 0,
             "cursor" => null,
-        ]));
+        ]);
         $this->save_state();
 
         return $next_offset >= filesize($list_file);
-    }
-
-    private function get_fetch_list_progress_state(string $state_key): FetchListProgressState
-    {
-        if ($state_key === "fetch") {
-            return $this->get_state()->fetch;
-        }
-        if ($state_key === "fetch_skipped") {
-            return $this->get_state()->fetch_skipped;
-        }
-        throw new InvalidArgumentException("Unknown fetch state key: {$state_key}");
-    }
-
-    private function set_fetch_list_progress_state(string $state_key, FetchListProgressState $state): void
-    {
-        if ($state_key === "fetch") {
-            $this->get_state()->fetch = $state;
-            return;
-        }
-        if ($state_key === "fetch_skipped") {
-            $this->get_state()->fetch_skipped = $state;
-            return;
-        }
-        throw new InvalidArgumentException("Unknown fetch state key: {$state_key}");
     }
 
     /**
@@ -7005,23 +6677,6 @@ class ImportClient
         }
 
         return $max_request;
-    }
-
-    /**
-     * Return the uploads basedir from preflight data (e.g. "/wp-content/uploads").
-     *
-     */
-    private function get_uploads_basedir(): ?string
-    {
-        $paths_urls = $this->get_state()->preflight["data"]["database"]["wp"]["paths_urls"] ?? null;
-        if (!is_array($paths_urls)) {
-            return null;
-        }
-        $basedir = $paths_urls["uploads"]["basedir"] ?? null;
-        if (!is_string($basedir) || $basedir === "") {
-            return null;
-        }
-        return rtrim($basedir, "/");
     }
 
     /**
@@ -11324,6 +10979,19 @@ class ImportClient
             return new PullState();
         }
 
+        if (
+            array_key_exists("fetch_skipped", $state) &&
+            isset($state["pull_pipeline"]) &&
+            is_array($state["pull_pipeline"]) &&
+            array_key_exists("files_filter", $state["pull_pipeline"]) &&
+            array_key_exists("skipped_pending", $state["pull_pipeline"])
+        ) {
+            unset(
+                $state["fetch_skipped"],
+                $state["pull_pipeline"]["files_filter"],
+                $state["pull_pipeline"]["skipped_pending"]
+            );
+        }
         $state = $this->decode_state_paths($state);
 
         return PullState::from_array($state);
@@ -11769,7 +11437,7 @@ if (
             'target' => 'filter',
             'placeholder' => 'MODE',
             'valid_values' => ['none', 'essential-files', 'skipped-earlier'],
-            'help' => 'Filter which files to download (pull/pull-files: none|essential-files; files-pull also supports skipped-earlier)',
+            'help' => null,
             'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
         [
@@ -12443,9 +12111,6 @@ if (
                 "interrupted, re-run the same command to resume from where it left off.\n" .
                 "Running pull again after completion performs a delta sync.\n" .
                 "\n" .
-                "Use --filter=essential-files to defer uploads and other large wp-content\n" .
-                "entries while still completing the rest of the pull.\n" .
-                "\n" .
                 "The ?site-export-api query parameter is added automatically if missing,\n" .
                 "so you can pass just the site URL.\n",
             "extra" =>
@@ -12459,11 +12124,6 @@ if (
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-user=root --target-db=wp_local \\\n" .
                 "    --new-site-url=http://localhost:8881\n" .
-                "\n" .
-                "  # Complete the main pull now, defer the heavier file tail:\n" .
-                "  reprint pull https://example.com \\\n" .
-                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
-                "    --filter=essential-files --target-engine=sqlite --runtime=none\n" .
                 "\n" .
                 "  # Full clone with SQLite, flattened layout, and PHP built-in server:\n" .
                 "  reprint pull https://example.com \\\n" .
@@ -12575,12 +12235,6 @@ if (
                 "\n" .
                 "Runs files-index internally to write the next remote index.\n",
             "extra" =>
-                "Filter modes:\n" .
-                "  none             Pull all files (default)\n" .
-                "  essential-files   Skip uploads, pull only code/config/themes/plugins.\n" .
-                "                    The skipped file list is saved for later retrieval.\n" .
-                "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
-                "\n" .
                 "Path selection:\n" .
                 "  --only=SOURCE      Include only this source path prefix; repeatable.\n" .
                 "  --exclude=SOURCE   Exclude this source path prefix; repeatable.\n" .
@@ -12594,8 +12248,6 @@ if (
                 "                                           Next remote index\n" .
                 "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/fetch-list.jsonl\n" .
                 "                                           Files pending download\n" .
-                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/skipped-fetch-list.jsonl\n" .
-                "                                           Files skipped by --filter=essential-files\n" .
                 "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/state.json\n" .
                 "                                           Resumable pull state\n" .
                 "  audit.log                       Audit log\n",

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -298,14 +298,12 @@ class Pull
                 $state->diff = new FileDiffProgressState();
                 $state->index = new RemoteFileIndexCursorState();
                 $state->fetch = new FetchListProgressState();
-                $state->fetch_skipped = new FetchListProgressState();
                 $state->files_pull_summary = new FilesPullSummaryState();
                 $state->files_pull_path_selection_fingerprint = null;
                 $this->client->save_state();
                 foreach ([
                     "{$pull_state_directory}/remote-index.next.jsonl",
                     "{$pull_state_directory}/fetch-list.jsonl",
-                    "{$pull_state_directory}/skipped-fetch-list.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -442,10 +440,6 @@ class Pull
                 $this->run_until_complete('files-pull', function () {
                     $this->client->run_files_pull();
                 });
-                $skipped_pending =
-                    $options['filter'] === 'essential-files' &&
-                    $this->client->has_skipped_files_pending();
-                $this->client->set_pull_files_state($options['filter'], $skipped_pending);
                 $files_pulled = $this->client->get_state()->files_pull_summary->files_pulled;
                 $pulled_label = $files_pulled === 1 ? 'file' : 'files';
                 $summary = sprintf(
@@ -453,9 +447,6 @@ class Pull
                     number_format($files_pulled),
                     $pulled_label,
                 );
-                if ($skipped_pending) {
-                    $summary .= ", deferred files pending";
-                }
                 $this->print_done($stage, $summary);
                 break;
 
@@ -802,8 +793,6 @@ class Pull
         $state->pull_pipeline->started_by_command = $command;
         $state->pull_pipeline->stage_sequence = [];
         $state->pull_pipeline->last_completed_stage = null;
-        $state->pull_pipeline->files_filter = null;
-        $state->pull_pipeline->skipped_pending = false;
         $state->pull_pipeline->has_completed_once = true;
         $state->active_resumable_command->command_name = null;
         $state->active_resumable_command->completion_state = null;
@@ -815,7 +804,6 @@ class Pull
             $state->current_file_bytes = null;
             $state->diff = new FileDiffProgressState();
             $state->fetch = new FetchListProgressState();
-            $state->fetch_skipped = new FetchListProgressState();
             $state->files_pull_summary = new FilesPullSummaryState();
         }
         if ($reset_file_selection_state) {
@@ -834,7 +822,6 @@ class Pull
         if ($reset_file_transfer_state) {
             $paths[] = $pull_state_directory . "/remote-index.next.jsonl";
             $paths[] = $pull_state_directory . "/fetch-list.jsonl";
-            $paths[] = $pull_state_directory . "/skipped-fetch-list.jsonl";
         }
         if ($reset_db_state) {
             $paths[] = $state_dir . "/db.sql";
@@ -982,11 +969,6 @@ class Pull
         $this->progress->print_line(
             "\n{$green}{$bold}Done.{$r} {$dim}Files in {$filesystem_root}{$r}\n"
         );
-        if ($this->client->get_state()->pull_pipeline->skipped_pending) {
-            $this->progress->print_line(
-                "{$dim}Deferred files remain. The skipped fetch list was preserved on disk for a follow-up sync.{$r}\n"
-            );
-        }
     }
 
     /**

--- a/packages/reprint-importer/src/lib/state/class-pull-pipeline-checkpoint-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-pipeline-checkpoint-state.php
@@ -14,12 +14,6 @@ class PullPipelineCheckpointState {
     /** @var string|null Last whole pipeline stage saved as complete. */
     public ?string $last_completed_stage = null;
 
-    /** @var string|null Files filter used by the pipeline. */
-    public ?string $files_filter = null;
-
-    /** @var bool Whether deferred files are still pending. */
-    public bool $skipped_pending = false;
-
     /** @var bool Whether this pipeline completed at least once. */
     public bool $has_completed_once = false;
 
@@ -30,8 +24,6 @@ class PullPipelineCheckpointState {
         $state->started_by_command = $data['started_by_command'];
         $state->stage_sequence = array_values($data['stage_sequence']);
         $state->last_completed_stage = $data['last_completed_stage'];
-        $state->files_filter = $data['files_filter'];
-        $state->skipped_pending = $data['skipped_pending'];
         $state->has_completed_once = $data['has_completed_once'];
         return $state;
     }
@@ -42,8 +34,6 @@ class PullPipelineCheckpointState {
             'started_by_command' => $this->started_by_command,
             'stage_sequence' => $this->stage_sequence,
             'last_completed_stage' => $this->last_completed_stage,
-            'files_filter' => $this->files_filter,
-            'skipped_pending' => $this->skipped_pending,
             'has_completed_once' => $this->has_completed_once,
         ];
     }

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -45,7 +45,6 @@ class PullState
     public FileDiffProgressState $diff;
     public RemoteFileIndexCursorState $index;
     public FetchListProgressState $fetch;
-    public FetchListProgressState $fetch_skipped;
     /** @var string|null Path to the file being written for crash recovery. */
     public ?string $current_file = null;
     /** @var int|null Expected bytes written to the current file. */
@@ -83,7 +82,6 @@ class PullState
         $this->diff = new FileDiffProgressState();
         $this->index = new RemoteFileIndexCursorState();
         $this->fetch = new FetchListProgressState();
-        $this->fetch_skipped = new FetchListProgressState();
         $this->files_pull_summary = new FilesPullSummaryState();
         $this->apply = new DatabaseApplyCommandState();
         $this->tuning = new AdaptiveTuningState();
@@ -112,7 +110,6 @@ class PullState
         $state->diff = FileDiffProgressState::from_array($data['diff']);
         $state->index = RemoteFileIndexCursorState::from_array($data['index']);
         $state->fetch = FetchListProgressState::from_array($data['fetch']);
-        $state->fetch_skipped = FetchListProgressState::from_array($data['fetch_skipped']);
         $state->current_file = $data['current_file'];
         $state->current_file_bytes = $data['current_file_bytes'];
         $state->sql_bytes = $data['sql_bytes'];
@@ -150,7 +147,6 @@ class PullState
             'diff' => $this->diff->to_array(),
             'index' => $this->index->to_array(),
             'fetch' => $this->fetch->to_array(),
-            'fetch_skipped' => $this->fetch_skipped->to_array(),
             'current_file' => $this->current_file,
             'current_file_bytes' => $this->current_file_bytes,
             'sql_bytes' => $this->sql_bytes,

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -154,8 +154,6 @@ class PlaygroundCliApplier implements RuntimeApplier
         $runtime_file_mounts = [
             'REPRINT_PULL_STATE_FILE'
                 => '/tmp/reprint/state.json',
-            'REPRINT_PULL_SKIPPED_FETCH_LIST_FILE'
-                => '/tmp/reprint/skipped-fetch-list.jsonl',
         ];
 
         foreach ($runtime_file_mounts as $constant_name => $vfs_path) {

--- a/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -18,34 +18,27 @@ function remote_upload_proxy_code(): string
 (function() {
 	if (!defined('REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL')) return;
 	if (!defined('REPRINT_PULL_STATE_FILE')) return;
-	if (!defined('REPRINT_PULL_SKIPPED_FETCH_LIST_FILE')) return;
 	if (!function_exists('curl_init')) return;
 
 	$proxy_enabled = false;
-	$skipped_fetch_list_file = REPRINT_PULL_SKIPPED_FETCH_LIST_FILE;
+	$pull_state_file = REPRINT_PULL_STATE_FILE;
 	if (
-		is_string($skipped_fetch_list_file) &&
-		$skipped_fetch_list_file !== '' &&
-		file_exists($skipped_fetch_list_file) &&
-		filesize($skipped_fetch_list_file) > 0
+		is_string($pull_state_file) &&
+		$pull_state_file !== '' &&
+		is_readable($pull_state_file)
 	) {
-		$proxy_enabled = true;
-	} else {
-		$pull_state_file = REPRINT_PULL_STATE_FILE;
-		if (
-			is_string($pull_state_file) &&
-			$pull_state_file !== '' &&
-			is_readable($pull_state_file)
-		) {
-			$pull_state = json_decode((string) file_get_contents($pull_state_file), true);
-			if (is_array($pull_state)) {
-				$command = $pull_state['active_resumable_command']['command_name'] ?? null;
-				$status = $pull_state['active_resumable_command']['completion_state'] ?? null;
-				$proxy_enabled =
+		$pull_state = json_decode((string) file_get_contents($pull_state_file), true);
+		if (is_array($pull_state)) {
+			$filter = $pull_state['filter'] ?? 'none';
+			$command = $pull_state['active_resumable_command']['command_name'] ?? null;
+			$status = $pull_state['active_resumable_command']['completion_state'] ?? null;
+			$proxy_enabled =
+				$filter === 'essential-files' ||
+				(
 					$command === 'files-pull' &&
 					$status !== null &&
-					$status !== 'complete';
-			}
+					$status !== 'complete'
+				);
 		}
 	}
 

--- a/reprint-ui/lib/playground-uploads-proxy.php
+++ b/reprint-ui/lib/playground-uploads-proxy.php
@@ -51,7 +51,7 @@ add_filter('jetpack_implode_frontend_css', '__return_false');
 add_filter('jetpack_force_disable_site_accelerator', '__return_true');
 
 // Stream missing uploads from the source so media keeps rendering
-// until reprint files-pull --filter=skipped-earlier downloads them.
+// until an uploads-only files-pull downloads them.
 //
 // We PROXY here, not 302 to the source. Playground's service worker
 // post-processes Location headers to keep the iframe in scope, so a

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -468,7 +468,7 @@ function stream_pull(): void {
         // bytes and not strictly needed for the site to boot. The
         // uploads-proxy mu-plugin redirects missing /wp-content/uploads/*
         // to the source site so media still renders. Users can opt
-        // into a follow-up files-pull --filter=skipped-earlier later.
+        // into a follow-up uploads-only files-pull later.
         '--filter=essential-files',
         // /wordpress already has Playground's fresh WP install. The
         // flat-docroot stage symlinks the imported tree on top, and

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -19,7 +19,6 @@ class CliHelpTest extends TestCase
 
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
-        $this->assertStringContainsString('--filter=MODE', $output);
         $this->assertStringContainsString('--remap SOURCE TARGET', $output);
         $this->assertStringContainsString('--only=SOURCE', $output);
         $this->assertStringContainsString('--exclude=SOURCE', $output);
@@ -40,6 +39,17 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('pull/remote-index.next.jsonl', $output);
         $this->assertStringContainsString('Remote index', $output);
         $this->assertStringContainsString('Next remote index', $output);
+    }
+
+    public function testFilterOptionIsHiddenFromCommandHelp(): void
+    {
+        foreach (array('pull', 'pull-files', 'files-pull') as $command) {
+            $this->assertStringNotContainsString(
+                '--filter',
+                $this->runHelp($command),
+                $command
+            );
+        }
     }
 
     public function testPullDbHelpShowsRequiredAndDatabaseOptions(): void

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -8,9 +8,7 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
 
 /**
  * Verify that files_done and files_total progress counters are correct
- * across multiple invocations (exit-code-2 restarts), with and without
- * the essential-files filter (which splits the fetch list into a
- * main list and a skipped list).
+ * across multiple invocations (exit-code-2 restarts).
  */
 class FetchListProgressTest extends TestCase
 {
@@ -154,7 +152,7 @@ class FetchListProgressTest extends TestCase
 
         $method = $reflection->getMethod('fetch_files_from_list');
         try {
-            $method->invoke($client, $listFile, 'fetch');
+            $method->invoke($client, $listFile);
         } catch (\Exception $e) {
             // Expected: network error
         }
@@ -188,7 +186,7 @@ class FetchListProgressTest extends TestCase
 
         try {
             $reflection->getMethod('fetch_files_from_list')
-                ->invoke($client, $listFile, 'fetch');
+                ->invoke($client, $listFile);
         } catch (\Exception $e) {
             // Expected
         }
@@ -224,7 +222,7 @@ class FetchListProgressTest extends TestCase
 
         try {
             $reflection->getMethod('fetch_files_from_list')
-                ->invoke($client, $listFile, 'fetch');
+                ->invoke($client, $listFile);
         } catch (\Exception $e) {
             // Expected
         }
@@ -252,7 +250,7 @@ class FetchListProgressTest extends TestCase
 
         [$client1, $ref1] = $this->prepareClient();
         try {
-            $ref1->getMethod('fetch_files_from_list')->invoke($client1, $listFile, 'fetch');
+            $ref1->getMethod('fetch_files_from_list')->invoke($client1, $listFile);
         } catch (\Exception $e) {}
 
         $c1 = $this->readCounters($client1, $ref1);
@@ -271,7 +269,7 @@ class FetchListProgressTest extends TestCase
 
         [$client2, $ref2] = $this->prepareClient();
         try {
-            $ref2->getMethod('fetch_files_from_list')->invoke($client2, $listFile, 'fetch');
+            $ref2->getMethod('fetch_files_from_list')->invoke($client2, $listFile);
         } catch (\Exception $e) {}
 
         $c2 = $this->readCounters($client2, $ref2);
@@ -280,34 +278,6 @@ class FetchListProgressTest extends TestCase
 
         // done only goes up
         $this->assertGreaterThan($c1['done'], $c2['done']);
-    }
-
-    public function testSkippedListHasOwnCounters()
-    {
-        $this->writeFetchList(50);
-        $skippedList = $this->pullStateDirectory . '/skipped-fetch-list.jsonl';
-        $this->writeFetchList(200, $skippedList);
-        $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
-
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "files-pull",
-                "completion_state" => "in_progress",
-                "current_stage" => "fetch-skipped",
-            ],
-            "fetch_skipped" => ["offset" => $offset20, "next_offset" => $offset20, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
-        ]);
-
-        [$client, $reflection] = $this->prepareClient("skipped-earlier");
-
-        try {
-            $reflection->getMethod('fetch_files_from_list')
-                ->invoke($client, $skippedList, 'fetch_skipped');
-        } catch (\Exception $e) {}
-
-        $counters = $this->readCounters($client, $reflection);
-        $this->assertSame(200, $counters['total']);
-        $this->assertSame(20, $counters['done']);
     }
 
     public function testCountNewlinesMatchesLineCount()
@@ -367,7 +337,7 @@ class FetchListProgressTest extends TestCase
 
         try {
             $reflection->getMethod('fetch_files_from_list')
-                ->invoke($client, $listFile, 'fetch');
+                ->invoke($client, $listFile);
         } catch (\Exception $e) {}
 
         // Simulate 5 files written in this invocation

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -167,48 +167,6 @@ class FilesPullStateTest extends TestCase
     }
 
     /**
-     * The deferred skipped-files tail reopens a completed files-pull, and a
-     * successful tail must restore the completed status before returning.
-     */
-    public function testSkippedEarlierTailRestoresCompletedStatus()
-    {
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "files-pull",
-                "completion_state" => "complete",
-                "current_stage" => null,
-            ],
-            "filter" => "essential-files",
-        ]);
-        file_put_contents(
-            $this->pullStateDirectory . '/skipped-fetch-list.jsonl',
-            json_encode([
-                "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
-            ], JSON_UNESCAPED_SLASHES) . "\n",
-        );
-
-        $client = new CompletedFileFetchClient(
-            'http://fake.url',
-            $this->stateDir,
-            $this->filesystem_root,
-        );
-
-        ob_start();
-        $client->run([
-            "command" => "files-pull",
-            "filter" => "skipped-earlier",
-        ]);
-        ob_end_clean();
-
-        $state = $this->readState();
-        $this->assertEquals("complete", $state["active_resumable_command"]["completion_state"]);
-        $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
-        $this->assertNull($state["active_resumable_command"]["current_stage"]);
-        $this->assertEquals("skipped-earlier", $state["filter"]);
-        $this->assertFileDoesNotExist($this->pullStateDirectory . '/skipped-fetch-list.jsonl');
-    }
-
-    /**
      * After --abort, the state should not be "complete".
      */
     public function testAbortClearsCompletedStatus()
@@ -273,53 +231,6 @@ class FilesPullStateTest extends TestCase
             "After abort + re-run, the sync should start fresh, not report 'already complete'",
         );
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
-    }
-
-    /**
-     * After a full `pull`, active_resumable_command points at the last stage
-     * (db-apply), not files-pull, but pull_pipeline records a deferred tail. A
-     * standalone skipped-earlier run must recover the completed files-pull and
-     * fetch the tail rather than throwing "no completed sync with skipped
-     * files".
-     */
-    public function testSkippedEarlierAfterCompositePullAdoptsFilesPullState(): void
-    {
-        file_put_contents(
-            $this->pullStateDirectory . '/skipped-fetch-list.jsonl',
-            $this->indexLine('/wp-content/uploads/2024/01/photo.jpg', 1000, 100),
-        );
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "db-apply",
-                "completion_state" => "complete",
-            ],
-            "filter" => "skipped-earlier",
-            "pull_pipeline" => [
-                "files_filter" => "essential-files",
-                "skipped_pending" => true,
-            ],
-        ]);
-
-        [$client, $reflection] = $this->prepareClient();
-        $filterProp = $reflection->getProperty('filter');
-        $filterProp->setValue($client, 'skipped-earlier');
-
-        try {
-            $reflection->getMethod('run_files_pull')->invoke($client);
-        } catch (\Exception $e) {
-            // Expected: the fetch fails against the fake URL. The point is that
-            // it got PAST the "no completed sync with skipped files" guard.
-            $this->assertStringNotContainsString(
-                'no completed sync with skipped files',
-                $e->getMessage(),
-            );
-        }
-
-        // The checkpoint was restored to the completed files-pull and the
-        // deferred-tail fetch started.
-        $state = $this->readState();
-        $this->assertSame('files-pull', $state["active_resumable_command"]["command_name"]);
-        $this->assertSame('fetch-skipped', $state["active_resumable_command"]["current_stage"]);
     }
 
     // ---------------------------------------------------------------
@@ -461,27 +372,5 @@ class FilesPullStateTest extends TestCase
             file_get_contents($localFile),
             "Fetch stage must overwrite existing files that were placed in the fetch list",
         );
-    }
-}
-
-/**
- * Test double that completes a file_fetch request without real network I/O.
- */
-class CompletedFileFetchClient extends \ImportClient
-{
-    protected function fetch_streaming(
-        string $url,
-        ?string $cursor,
-        StreamingContext $context,
-        ?array $post_data = null,
-        ?string $endpoint = null
-    ): void {
-        ($context->on_chunk)([
-            "headers" => [
-                "x-chunk-type" => "completion",
-                "x-status" => "complete",
-            ],
-            "body" => "",
-        ]);
     }
 }

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -254,6 +254,24 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
     }
 
+    public function testFilterModesRewriteToUploadPathSelections(): void
+    {
+        $c = $this->withPaths(array(
+            'content_dir' => '/var/www/html/wp-content',
+            'uploads' => array('basedir' => '/mnt/uploads'),
+        ));
+
+        $this->set($c, 'filter', 'essential-files');
+        $this->call($c, 'prepare_files_pull_options', array(array(), false));
+        $this->assertSame(array(), (new \ReflectionClass($c))->getProperty('pull_only_files_with_path_prefixes')->getValue($c));
+        $this->assertSame(array('/mnt/uploads'), (new \ReflectionClass($c))->getProperty('pull_excluded_files_with_path_prefixes')->getValue($c));
+
+        $this->set($c, 'filter', 'skipped-earlier');
+        $this->call($c, 'prepare_files_pull_options', array(array(), false));
+        $this->assertSame(array('/mnt/uploads'), (new \ReflectionClass($c))->getProperty('pull_only_files_with_path_prefixes')->getValue($c));
+        $this->assertSame(array(), (new \ReflectionClass($c))->getProperty('pull_excluded_files_with_path_prefixes')->getValue($c));
+    }
+
     public function testChangingOnlyPrefixesWhileResumingFilesPullIsRejected(): void
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
@@ -348,6 +366,38 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
         $this->runFilesPull(array('exclude' => array(':wp-uploads:')));
+    }
+
+    public function testRunDropsSkippedFieldsWithoutChangingPathSelectionState(): void
+    {
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
+        $fingerprint = $this->pathSelectionFingerprint(
+            array(),
+            array('/var/www/html/wp-content/uploads')
+        );
+        $this->writeFilesPullState(array(
+            'filter' => 'essential-files',
+            'files_pull_path_selection_fingerprint' => $fingerprint,
+        ));
+        $state = $this->readState();
+        $state['fetch_skipped'] = (new \Reprint\Importer\State\FetchListProgressState())->to_array();
+        $state['pull_pipeline']['files_filter'] = 'essential-files';
+        $state['pull_pipeline']['skipped_pending'] = false;
+        file_put_contents(
+            $this->pullStateDirectory . '/state.json',
+            json_encode($state, JSON_PRETTY_PRINT)
+        );
+
+        $this->runFilesPull(array('filter' => 'essential-files'));
+
+        $state = $this->readState();
+        $this->assertSame(
+            $fingerprint,
+            $state['files_pull_path_selection_fingerprint'] ?? null
+        );
+        $this->assertArrayNotHasKey('fetch_skipped', $state);
+        $this->assertArrayNotHasKey('files_filter', $state['pull_pipeline']);
+        $this->assertArrayNotHasKey('skipped_pending', $state['pull_pipeline']);
     }
 
     public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -13,7 +13,6 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
     private $fsRoot;
     private $outputDir;
     private $pullStateFile;
-    private $skippedFetchListFile;
 
     protected function setUp(): void
     {
@@ -29,9 +28,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
 
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
         $this->pullStateFile = $stateDir . '/pull/state.json';
-        $this->skippedFetchListFile = $stateDir . '/pull/skipped-fetch-list.jsonl';
         file_put_contents($this->pullStateFile, "{\"command\":\"files-pull\",\"status\":\"partial\"}\n");
-        file_put_contents($this->skippedFetchListFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
     }
 
     protected function tearDown(): void
@@ -65,15 +62,13 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         rmdir($dir);
     }
 
-    public function testPlaygroundMountsProxyStateFilesIntoVfs(): void
+    public function testPlaygroundMountsProxyStateFileIntoVfs(): void
     {
         $manifest = new \RuntimeManifest('other');
         $manifest->constants['REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL'] =
             'https://source.example/wp-content/uploads';
         $manifest->constants['REPRINT_PULL_STATE_FILE'] =
             $this->pullStateFile;
-        $manifest->constants['REPRINT_PULL_SKIPPED_FETCH_LIST_FILE'] =
-            $this->skippedFetchListFile;
         $manifest->routes[] = [
             'handler' => 'remote-upload-proxy',
             'path_pattern' => '/wp-content/uploads/.*',
@@ -94,29 +89,18 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
             "/tmp/reprint/state.json",
             $runtime,
         );
-        $this->assertStringContainsString(
-            "/tmp/reprint/skipped-fetch-list.jsonl",
-            $runtime,
-        );
         $this->assertStringNotContainsString($this->pullStateFile, $runtime);
         $this->assertStringContainsString(
             "--mount='" . $this->pullStateFile . ":/tmp/reprint/state.json'",
             $startSh,
         );
-        $this->assertStringContainsString(
-            "--mount='" . $this->skippedFetchListFile . ":/tmp/reprint/skipped-fetch-list.jsonl'",
-            $startSh,
-        );
-
-        // start.json should contain the same mounts as structured data.
+        // start.json should contain the same mount as structured data.
         $startJson = json_decode(file_get_contents($this->outputDir . '/start.json'), true);
         $this->assertNotNull($startJson, 'start.json should be valid JSON');
 
         $mount_sources = array_column($startJson['mounts'], 'source');
         $mount_targets = array_column($startJson['mounts'], 'target');
         $this->assertContains($this->pullStateFile, $mount_sources);
-        $this->assertContains($this->skippedFetchListFile, $mount_sources);
         $this->assertContains('/tmp/reprint/state.json', $mount_targets);
-        $this->assertContains('/tmp/reprint/skipped-fetch-list.jsonl', $mount_targets);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -8,7 +8,6 @@ require_once __DIR__ . '/../../importer/import.php';
 
 class PullFilterFakeClient extends \ImportClient
 {
-    private bool $create_skipped_list;
     public int $files_pulled = 0;
     public int $preflight_runs = 0;
     public int $files_pull_runs = 0;
@@ -20,9 +19,8 @@ class PullFilterFakeClient extends \ImportClient
     /** @var resource|null */
     private $terminal_progress_stream = null;
 
-    public function __construct(string $state_dir, string $filesystem_root, bool $create_skipped_list)
+    public function __construct(string $state_dir, string $filesystem_root)
     {
-        $this->create_skipped_list = $create_skipped_list;
         parent::__construct('http://fake.invalid', $state_dir, $filesystem_root);
     }
 
@@ -79,6 +77,12 @@ class PullFilterFakeClient extends \ImportClient
                 "database" => [
                     "wp" => [
                         "wp_version" => "6.8",
+                        "paths_urls" => [
+                            "content_dir" => "/var/www/html/wp-content",
+                            "uploads" => [
+                                "basedir" => "/var/www/html/wp-content/uploads",
+                            ],
+                        ],
                     ],
                 ],
                 "runtime" => [
@@ -101,14 +105,6 @@ class PullFilterFakeClient extends \ImportClient
         }
 
         $this->files_pull_runs++;
-        if ($this->create_skipped_list) {
-            file_put_contents(
-                $this->pull_state_directory . '/skipped-fetch-list.jsonl',
-                "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
-            );
-        } else {
-            @unlink($this->pull_state_directory . '/skipped-fetch-list.jsonl');
-        }
 
         $state = $this->get_state();
         $state->active_resumable_command->command_name = "files-pull";
@@ -229,9 +225,9 @@ class PullFilterOptionTest extends TestCase
         rmdir($dir);
     }
 
-    private function makeClient(bool $create_skipped_list): PullFilterFakeClient
+    private function makeClient(): PullFilterFakeClient
     {
-        return new PullFilterFakeClient($this->stateDir, $this->filesystem_root, $create_skipped_list);
+        return new PullFilterFakeClient($this->stateDir, $this->filesystem_root);
     }
 
     private function readState(): array
@@ -244,12 +240,12 @@ class PullFilterOptionTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_pull_state($this->makeClient(false), $state);
+        \write_current_pull_state($this->makeClient(), $state);
     }
 
     public function testPullRejectsSkippedEarlierFilterBeforePersistingIt(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         try {
             ob_start();
@@ -273,7 +269,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDoesNotAdvancePastFailedPreflight(): void
     {
-        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root, false);
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root);
 
         try {
             ob_start();
@@ -322,7 +318,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -353,7 +349,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -384,7 +380,7 @@ class PullFilterOptionTest extends TestCase
         ]);
         file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         try {
             ob_start();
@@ -411,7 +407,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testInvalidPullOptionsFailBeforeStateIsPersisted(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         try {
             ob_start();
@@ -431,7 +427,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullFilesSummaryReportsNoChangedFilesPulled(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
         $client->captureTerminalProgress();
 
         $client->run([
@@ -445,7 +441,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullFilesSummaryReportsChangedFilePulled(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
         $client->files_pulled = 1;
         $client->captureTerminalProgress();
 
@@ -460,25 +456,9 @@ class PullFilterOptionTest extends TestCase
         );
     }
 
-    public function testPullFilesSummaryReportsDeferredFilesPending(): void
-    {
-        $client = $this->makeClient(true);
-        $client->captureTerminalProgress();
-
-        $client->run([
-            "command" => "pull-files",
-            "filter" => "essential-files",
-        ]);
-
-        $this->assertStringContainsString(
-            '0 changed files pulled, deferred files pending',
-            $client->terminalProgressOutput(),
-        );
-    }
-
     public function testPullFilesRunsOnlyPreflightAndFilesStages(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -494,12 +474,12 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame(0, $client->db_apply_runs);
         $this->assertSame('pull-files', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
-        $this->assertSame('essential-files', $state["pull_pipeline"]["files_filter"]);
+        $this->assertSame('essential-files', $state["filter"]);
     }
 
     public function testPullFilesDoesNotAdvancePastFailedPreflight(): void
     {
-        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root, false);
+        $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root);
 
         try {
             ob_start();
@@ -541,7 +521,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run(["command" => "pull-files"]);
@@ -564,7 +544,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run(["command" => "pull-files"]);
@@ -592,7 +572,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         try {
             ob_start();
@@ -613,7 +593,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testRerunningCompletedPullFilesStartsFreshFilesDelta(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run(["command" => "pull-files"]);
@@ -628,7 +608,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullAfterCompletedPullFilesStartsFreshFilesDelta(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run(["command" => "pull-files"]);
@@ -647,7 +627,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testPullDbRunsPreflightDownloadAndApplyStages(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -683,7 +663,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         try {
             ob_start();
@@ -719,7 +699,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -747,7 +727,7 @@ class PullFilterOptionTest extends TestCase
             "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
         ]);
 
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -766,7 +746,7 @@ class PullFilterOptionTest extends TestCase
 
     public function testInvalidPullDbOptionsFailBeforeStateIsPersisted(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         try {
             ob_start();
@@ -784,9 +764,9 @@ class PullFilterOptionTest extends TestCase
         $this->assertFileDoesNotExist($this->pullStateDirectory . '/state.json');
     }
 
-    public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
+    public function testPullWithEssentialFilesPersistsFilter(): void
     {
-        $client = $this->makeClient(true);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -798,16 +778,15 @@ class PullFilterOptionTest extends TestCase
 
         $state = $this->readState();
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
-        $this->assertSame('essential-files', $state["pull_pipeline"]["files_filter"]);
-        $this->assertTrue($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
-        $this->assertFileExists($this->pullStateDirectory . '/skipped-fetch-list.jsonl');
+        $this->assertArrayNotHasKey('files_filter', $state["pull_pipeline"]);
+        $this->assertArrayNotHasKey('skipped_pending', $state["pull_pipeline"]);
     }
 
     public function testPullWithoutFilterRecordsFullDownloadMode(): void
     {
-        $client = $this->makeClient(false);
+        $client = $this->makeClient();
 
         ob_start();
         $client->run([
@@ -818,16 +797,39 @@ class PullFilterOptionTest extends TestCase
 
         $state = $this->readState();
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
-        $this->assertSame('none', $state["pull_pipeline"]["files_filter"]);
-        $this->assertFalse($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
-        $this->assertFileDoesNotExist($this->pullStateDirectory . '/skipped-fetch-list.jsonl');
+        $this->assertArrayNotHasKey('files_filter', $state["pull_pipeline"]);
+        $this->assertArrayNotHasKey('skipped_pending', $state["pull_pipeline"]);
+    }
+
+    public function testCompletedPullCanChangeFileFilter(): void
+    {
+        $client = $this->makeClient();
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "filter" => "essential-files",
+            "runtime" => "none",
+        ]);
+        $client->run([
+            "command" => "pull",
+            "filter" => "none",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(2, $client->files_pull_runs);
+        $this->assertSame(2, $client->db_sync_runs);
+        $this->assertSame('none', $state["filter"]);
+        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
     }
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void
     {
-        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root, false);
+        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root);
         $flatten_to = $this->tempDir . '/flattened-site';
 
         ob_start();
@@ -847,77 +849,4 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame($flatten_to, $client->apply_runtime_options["flat_document_root"]);
     }
 
-    public function testRepullAfterSkippedEarlierTailUsesCompletedFilesPullState(): void
-    {
-        // The deferred "skipped-earlier" tail belongs to a files-pull that
-        // has finished. Once that lifecycle state is truthful, a completed
-        // pull can delta re-pull without bypassing the mid-flight guard.
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "files-pull",
-                "completion_state" => "complete",
-                "current_stage" => null,
-            ],
-            "filter" => "skipped-earlier",
-            "pull_pipeline" => [
-                "started_by_command" => "pull",
-                "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
-                "last_completed_stage" => "db-apply",
-                "files_filter" => "essential-files",
-                "skipped_pending" => true,
-            ],
-            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-        ]);
-
-        $client = $this->makeClient(false);
-
-        ob_start();
-        $client->run([
-            "command" => "pull",
-            "filter" => "essential-files",
-            "runtime" => "none",
-        ]);
-        ob_end_clean();
-
-        $state = $this->readState();
-        $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
-        $this->assertSame('essential-files', $state["filter"]);
-    }
-
-    public function testRepullAfterInterruptedSkippedEarlierTailIsNotBlocked(): void
-    {
-        // An interrupted skipped-earlier tail leaves completion_state="partial"
-        // with filter=skipped-earlier. A new essential-files pull must still be
-        // allowed: the filter-change guard must not treat the terminal tail as
-        // a mid-flight sync.
-        $this->writeState([
-            "active_resumable_command" => [
-                "command_name" => "files-pull",
-                "completion_state" => "partial",
-                "current_stage" => "fetch-skipped",
-            ],
-            "filter" => "skipped-earlier",
-            "pull_pipeline" => [
-                "started_by_command" => "pull",
-                "stage_sequence" => ["preflight", "files-pull", "db-pull", "db-apply"],
-                "last_completed_stage" => "db-apply",
-                "files_filter" => "essential-files",
-                "skipped_pending" => true,
-            ],
-            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
-        ]);
-
-        $client = $this->makeClient(false);
-
-        ob_start();
-        $client->run([
-            "command" => "pull",
-            "filter" => "essential-files",
-            "runtime" => "none",
-        ]);
-        ob_end_clean();
-
-        $state = $this->readState();
-        $this->assertSame('essential-files', $state["filter"]);
-    }
 }

--- a/tests/Import/PullMetadataTest.php
+++ b/tests/Import/PullMetadataTest.php
@@ -190,8 +190,6 @@ class PullMetadataTest extends TestCase
             'pull_pipeline' => [
                 'stage_sequence' => ['preflight', 'files-pull', 'db-pull', 'db-apply'],
                 'last_completed_stage' => 'db-apply',
-                'files_filter' => 'essential-files',
-                'skipped_pending' => true,
                 'has_completed_once' => true,
             ],
         ]);
@@ -213,8 +211,6 @@ class PullMetadataTest extends TestCase
             ],
             'pull_pipeline' => [
                 'last_completed_stage' => null,
-                'files_filter' => null,
-                'skipped_pending' => false,
                 'has_completed_once' => true,
             ],
         ]);

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -21,8 +21,6 @@ class PullStateTest extends TestCase
             'started_by_command' => 'pull',
             'stage_sequence' => ['preflight', 'files-pull'],
             'last_completed_stage' => 'preflight',
-            'files_filter' => 'essential-files',
-            'skipped_pending' => true,
             'has_completed_once' => false,
         ];
         $data['apply']['statements_executed'] = 12;

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -139,7 +139,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         return file_get_contents($this->outputDir . '/runtime.php');
     }
 
-    public function testApplyRuntimeAddsProxyWhenSkippedUploadsRemain(): void
+    public function testApplyRuntimeAddsProxyForEssentialFilesFilter(): void
     {
         $client = $this->makeClient();
         $this->writeState([
@@ -149,11 +149,6 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             ],
             'filter' => 'essential-files',
         ]);
-        file_put_contents(
-            $client->pull_state_directory . '/skipped-fetch-list.jsonl',
-            json_encode(['path' => '/wp-content/uploads/2024/01/photo.jpg']) . "\n",
-        );
-
         $this->loadClientState($client);
         $runtime = $this->runApplyRuntime($client);
         $resolvedPullStateDirectory =
@@ -170,10 +165,8 @@ class RemoteUploadProxyRuntimeTest extends TestCase
                 . "/state.json');",
             $runtime,
         );
-        $this->assertStringContainsString(
-            "define('REPRINT_PULL_SKIPPED_FETCH_LIST_FILE', '"
-                . $resolvedPullStateDirectory
-                . "/skipped-fetch-list.jsonl');",
+        $this->assertStringNotContainsString(
+            "REPRINT_PULL_SKIPPED_FETCH_LIST_FILE",
             $runtime,
         );
         $this->assertStringContainsString(

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -62,7 +62,6 @@ final class ReprintProcessLockTest extends TestCase
             'remote_index_wal_path' => $pull_state_directory . '/remote-index.wal',
             'next_remote_index_file' => $pull_state_directory . '/remote-index.next.jsonl',
             'fetch_list_file' => $pull_state_directory . '/fetch-list.jsonl',
-            'skipped_fetch_list_file' => $pull_state_directory . '/skipped-fetch-list.jsonl',
             'volatile_files_file' => $pull_state_directory . '/volatile-files.json',
             'audit_log_file' => $this->root . '/state/audit.log',
             'progress_file' => $this->root . '/state/progress.json',

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -1,8 +1,8 @@
 /**
  * Test 40: --filter=essential-files / --filter=skipped-earlier
  *
- * Tests that --filter=essential-files skips uploads during files-pull
- * and that --filter=skipped-earlier downloads them in a separate run.
+ * Tests that --filter=essential-files excludes uploads during files-pull
+ * and that --filter=skipped-earlier selects uploads in a separate run.
  *
  * The remote site has:
  *   - Standard WordPress files (wp-admin, wp-includes, wp-content/themes, etc.)
@@ -16,7 +16,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    assertTreesMatch, readAuditLog,
+    assertTreesMatch,
     fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
@@ -107,21 +107,7 @@ describe('Import: --filter', () => {
                 'Expected test-data/hello.txt to exist');
         });
 
-        it('skipped fetch list remains on disk', () => {
-            assert.ok(existsSync(join(
-                pullStateDirectory(tempDir, importUrl()),
-                'skipped-fetch-list.jsonl',
-            )),
-                'Expected skipped fetch list to remain on disk');
-        });
-
-        it('audit log shows essential files complete', () => {
-            const audit = readAuditLog(tempDir);
-            assert.ok(audit.includes('ESSENTIAL FILES COMPLETE'),
-                'Expected ESSENTIAL FILES COMPLETE in audit log');
-        });
-
-        // Now download the skipped files
+        // Now select and download uploads.
         it('--filter=skipped-earlier downloads the uploads', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
@@ -139,32 +125,18 @@ describe('Import: --filter', () => {
             }
         });
 
-        it('skipped fetch list was cleaned up', () => {
-            assert.ok(!existsSync(join(
-                pullStateDirectory(tempDir, importUrl()),
-                'skipped-fetch-list.jsonl',
-            )),
-                'Expected skipped fetch list to be cleaned up');
-        });
-
-        it('state shows complete after skipped-earlier (not left in_progress)', () => {
-            // Regression: the skipped-earlier fetch must mark the sync
-            // complete. If it leaves status="in_progress", the filter-change
-            // guard blocks the next delta re-pull below.
+        it('state shows the uploads-only filter completed', () => {
             const state = JSON.parse(readFileSync(
                 join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
                 'utf-8',
             ));
             assert.equal(state.active_resumable_command.completion_state, 'complete',
                 `Expected completion_state=complete after skipped-earlier, got ${state.active_resumable_command?.completion_state}`);
+            assert.equal(state.filter, 'skipped-earlier');
         });
 
         it('a subsequent essential-files delta re-pull succeeds', () => {
-            // Regression: switching the filter back to essential-files after a
-            // completed skipped-earlier fetch must be allowed (the guard only
-            // blocks filter changes mid-sync). Previously this threw
-            // "Cannot change --filter from 'skipped-earlier' to
-            // 'essential-files' while a sync is in progress."
+            // Switching filters after completion starts another filtered delta.
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=essential-files'],
@@ -220,13 +192,6 @@ describe('Import: --filter', () => {
             }
         });
 
-        it('skipped list remains on disk', () => {
-            assert.ok(existsSync(join(
-                pullStateDirectory(tempDir, importUrl()),
-                'skipped-fetch-list.jsonl',
-            )),
-                'Expected skipped fetch list to remain');
-        });
     });
 
     // ------------------------------------------------------------------
@@ -251,14 +216,6 @@ describe('Import: --filter', () => {
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
         });
 
-        it('no skipped fetch list was created', () => {
-            assert.ok(!existsSync(join(
-                pullStateDirectory(tempDir, importUrl()),
-                'skipped-fetch-list.jsonl',
-            )),
-                'Expected no skipped fetch list without --filter');
-        });
-
         it('uploads were downloaded normally', () => {
             const importedRoot = join(fsRootDir(tempDir), siteDir);
             for (const f of UPLOAD_FILES) {
@@ -269,9 +226,9 @@ describe('Import: --filter', () => {
     });
 
     // ------------------------------------------------------------------
-    // Test: --filter=skipped-earlier without prior essential-files errors
+    // Test: --filter=skipped-earlier is an independent uploads-only preset
     // ------------------------------------------------------------------
-    describe('skipped-earlier without prior essential-files errors', () => {
+    describe('skipped-earlier without prior essential-files', () => {
         let tempDir;
 
         beforeAll(() => {
@@ -282,18 +239,23 @@ describe('Import: --filter', () => {
             cleanupTempDir(tempDir);
         });
 
-        it('errors when no prior essential-files run exists', () => {
+        it('downloads uploads without a prior filtered run', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--filter=skipped-earlier'],
-                autoResume: false,
             });
-            assert.equal(result.exitCode, 1,
-                `Expected exit 1\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
-            assert.ok(
-                result.stderr.includes('skipped-earlier') || result.stderr.includes('essential-files'),
-                `Expected error about missing essential-files run, got: ${result.stderr}`,
-            );
+            assert.equal(result.exitCode, 0,
+                `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+        });
+
+        it('downloads only uploads', () => {
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
+            for (const f of UPLOAD_FILES) {
+                assert.ok(existsSync(join(importedRoot, f)),
+                    `Expected upload file to exist: ${f}`);
+            }
+            assert.ok(!existsSync(join(importedRoot, 'wp-load.php')),
+                'Expected wp-load.php to remain outside the uploads-only selection');
         });
     });
 });

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -2,8 +2,8 @@
  * Test 49: Pull --filter=essential-files
  *
  * Verifies that `reprint pull` accepts `--filter=essential-files`,
- * completes the main pull pipeline, imports the database, and leaves
- * the skipped-file tail recorded in pull state for later retrieval.
+ * completes the main pull pipeline, imports the database, and excludes
+ * uploads through the normal path-filter pipeline.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -84,30 +84,19 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
             `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
     });
 
-    it('state records deferred files in the pull metadata', () => {
+    it('state records the completed filter preset', () => {
         const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
-        assert.equal(state.pull_pipeline.files_filter, 'essential-files');
-        assert.equal(state.pull_pipeline.skipped_pending, true);
+        assert.equal(state.filter, 'essential-files');
     });
 
-    it('skipped fetch list remains on disk', () => {
-        const skippedList = join(
-            pullStateDirectory(tempDir, importUrl()),
-            'skipped-fetch-list.jsonl',
-        );
-        assert.ok(existsSync(skippedList), 'Expected skipped fetch list to exist');
-        assert.ok(readFileSync(skippedList, 'utf-8').trim().length > 0,
-            'Expected skipped fetch list to be non-empty');
-    });
-
-    it('uploads were deferred from the fs-root', () => {
+    it('uploads were excluded from the fs-root', () => {
         const importedRoot = join(fsRootDir(tempDir), siteDir);
         for (const file of UPLOAD_FILES) {
             assert.ok(!existsSync(join(importedRoot, file)),
-                `Expected deferred upload to be absent: ${file}`);
+                `Expected excluded upload to be absent: ${file}`);
         }
     });
 


### PR DESCRIPTION
`--filter=essential-files` now expands to `--exclude=:wp-uploads:`, while `--filter=skipped-earlier` expands to `--only=:wp-uploads:`.

This removes the secondary skipped-file list and checkpoint. `skipped-earlier` no longer requires a prior run, and completed pulls can switch filters as a new path-selected delta. The compatibility option remains accepted but is omitted from command help. On load, old skipped-list fields are discarded while the existing path-selection fingerprint remains unchanged.

## Testing

```sh
(cd tests && ../vendor/bin/phpunit Import)
php vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-importer/src
git diff --check
```

