### PR TITLE
Expose pull state through get_state and pull-metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the i
 
 ### Progress Tracking
 
-During the file fetch phase, progress and heartbeat records include `files_done` (cumulative across restarts, derived from fetch list byte offset + current batch count) and `files_total` (total fetch list entries, fixed after the diff phase). Both are emitted together only when the fetch list exists. The `files_imported` field is still emitted for backward compatibility.
+During the file fetch phase, progress and heartbeat records include `files_done` (cumulative across restarts, derived from fetch list byte offset + current batch count) and `files_total` (total fetch list entries, fixed after the diff phase). Both are emitted together only when the fetch list exists.
 
 ## File Organization
 

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ structured file counters:
 
 | Field         | Type           | Description |
 |---------------|----------------|-------------|
-| `files_done`  | `int`          | Files already processed (cumulative across restarts). Derived from the fetch list byte offset plus the current batch's `files_imported`. |
+| `files_done`  | `int`          | Files already processed (cumulative across restarts). Derived from the fetch list byte offset plus the current batch count. |
 | `files_total` | `int`          | Total non-empty entries in the fetch list. Fixed once the diff phase completes. |
 
 Both fields are emitted together only when the fetch list exists — they
@@ -646,12 +646,12 @@ still running, completed, or needs resuming. The `command` + `status` fields
 tell you where the pipeline is. The `stage` field gives finer granularity
 (e.g., `"scanning"`, `"sorting"`, `"streaming"` for file sync).
 
-For pull lifecycle and source-site details, prefer `import-metadata` over
-reading `pull/state.json` directly. It exposes a small, stable JSON contract
-for host integrations:
+For pull lifecycle and source-site details, prefer `pull-metadata` over reading
+`pull/state.json` directly. It exposes a small, stable JSON contract for host
+integrations:
 
 ```bash
-php reprint.phar import-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
+php reprint.phar pull-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
 ```
 
 The `sourceSite` object contains the source WordPress home URL, site URL, table
@@ -714,7 +714,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `pull/domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
-* `import-metadata` — Prints pull lifecycle and source-site metadata as JSON. Requires only `--state-dir`; no network calls are made.
+* `pull-metadata` — Prints pull lifecycle and source-site metadata as JSON. Requires only `--state-dir`; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1,13 +1,13 @@
 #!/usr/bin/env php
 <?php
 /**
- * Import client for export.php.
+ * Reprint client for export.php.
  *
  * Downloads SQL and files from a remote export.php script, with support for:
  * - Resumable downloads using cursors
  * - Streaming multipart parsing (no buffering)
  * - Progress reporting via JSON lines to stdout
- * - Three-phase import: files, SQL, then file deltas
+ * - Three-phase pull: files, SQL, then file deltas
  */
 
 use function WordPress\Filesystem\wp_join_unix_paths;
@@ -61,8 +61,8 @@ require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
 require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
 
-// Typed state objects for the persisted import state.
-require_once __DIR__ . '/lib/state/class-import-state.php';
+// Typed state objects for the persisted pull state.
+require_once __DIR__ . '/lib/state/class-pull-state.php';
 
 // Adaptive sizing for push request bodies
 require_once __DIR__ . '/lib/upload/class-push-request-sizer.php';
@@ -145,7 +145,7 @@ function reprint_apply_curl_ca_bundle($ch): ?string {
  * multipart structure, header names, endpoint parameters, response format)
  * would break an older export plugin.
  */
-define('IMPORT_PROTOCOL_VERSION', 1);
+define('PULL_PROTOCOL_VERSION', 1);
 
 register_shutdown_function(function () {
     $error = error_get_last();
@@ -310,8 +310,8 @@ class ImportClient
     /** @var bool Whether stdout is a TTY (enables interactive progress display). */
     private $is_tty;
 
-    /** @var int Running count of files imported in the current invocation. */
-    private $files_imported = 0;
+    /** @var int Running count of files pulled in the current invocation. */
+    private $files_pulled = 0;
 
     /** @var int|null Total entries in the current fetch list.  Set once
      *  at the start of fetch_files_from_list() by counting newlines. */
@@ -323,8 +323,8 @@ class ImportClient
      *  that consumers should display as "files done". */
     private $fetch_list_done = null;
 
-    /** @var ImportState Persistent import state loaded from / saved to $pull_state_file. */
-    private ImportState $state;
+    /** @var PullState Persistent pull state loaded from / saved to $pull_state_file. */
+    private PullState $state;
 
     /** @var bool Set to true by SIGTERM/SIGINT handler to finish the current chunk and exit cleanly. */
     private $shutdown_requested = false;
@@ -366,7 +366,7 @@ class ImportClient
     private $include_caches = false;
 
     /**
-     * @var string Controls behavior when the filesystem root is non-empty at import start.
+     * @var string Controls behavior when the filesystem root is non-empty at pull start.
      *
      * 'error' (default): throw an error if the filesystem root is non-empty.
      * 'preserve-local': preserve existing files, symlinks, and directories in the
@@ -422,7 +422,7 @@ class ImportClient
     private $hmac_client = null;
 
     /**
-     * @var int|null MySQL max_allowed_packet value for the import database connection.
+     * @var int|null MySQL max_allowed_packet value for the target database connection.
      * Passed to the server so it can split SQL statements to fit within this limit.
      */
     private $max_allowed_packet = null;
@@ -484,7 +484,7 @@ class ImportClient
     private $progress_fd;
 
     /**
-     * @var int Process exit code. 0 = import complete, 2 = partial progress
+     * @var int Process exit code. 0 = pull complete, 2 = partial progress
      * (caller should invoke again to continue).
      */
     public $exit_code = 0;
@@ -549,7 +549,7 @@ class ImportClient
             }
         }
 
-        $this->state = new ImportState();
+        $this->state = new PullState();
     }
 
     /**
@@ -620,44 +620,32 @@ class ImportClient
         }
     }
 
-    /** Return the typed in-process import state. */
-    public function get_import_state(): ImportState
-    {
-        return $this->import_state();
-    }
-
-    /** Persist the current typed import state to disk. */
-    public function save_import_state(): void
-    {
-        $this->save_state($this->import_state());
-    }
-
     /** Mark a pull pipeline stage as completed in state. */
     public function mark_pull_stage_complete(string $stage, string $pipeline = 'pull', array $stage_sequence = []): void
     {
-        $this->import_state()->pull_pipeline->started_by_command = $pipeline;
-        $this->import_state()->pull_pipeline->last_completed_stage = $stage;
+        $this->get_state()->pull_pipeline->started_by_command = $pipeline;
+        $this->get_state()->pull_pipeline->last_completed_stage = $stage;
         if ($stage_sequence !== []) {
-            $this->import_state()->pull_pipeline->stage_sequence = $stage_sequence;
+            $this->get_state()->pull_pipeline->stage_sequence = $stage_sequence;
         }
-        $this->save_state($this->state);
+        $this->save_state();
     }
 
     /** Mark the pull pipeline as fully complete in state. */
     public function mark_pull_complete(string $pipeline = 'pull'): void
     {
-        $this->import_state()->pull_pipeline->started_by_command = $pipeline;
-        $this->import_state()->pull_pipeline->has_completed_once = true;
-        $this->import_state()->active_resumable_command->completion_state = 'complete';
-        $this->save_state($this->state);
+        $this->get_state()->pull_pipeline->started_by_command = $pipeline;
+        $this->get_state()->pull_pipeline->has_completed_once = true;
+        $this->get_state()->active_resumable_command->completion_state = 'complete';
+        $this->save_state();
     }
 
     /** Record the pull's file filter and whether deferred files remain. */
     public function set_pull_files_state(string $filter, bool $skipped_pending): void
     {
-        $this->import_state()->pull_pipeline->files_filter = $filter;
-        $this->import_state()->pull_pipeline->skipped_pending = $skipped_pending;
-        $this->save_state($this->state);
+        $this->get_state()->pull_pipeline->files_filter = $filter;
+        $this->get_state()->pull_pipeline->skipped_pending = $skipped_pending;
+        $this->save_state();
     }
 
     /**
@@ -835,7 +823,7 @@ class ImportClient
     }
 
     /**
-     * Runs one import command while holding the state directory's process lock.
+     * Runs one Reprint command while holding the state directory's process lock.
      *
      * CLI callers pass the lock acquired before local push state setup and
      * audit logging.
@@ -882,6 +870,7 @@ class ImportClient
             "db-sync" => "db-pull",
             "flat-document-root" => "flat-docroot",
             "flatten-docroot" => "flat-docroot",
+            "import-metadata" => "pull-metadata",
         ];
         if ($command && isset($command_aliases[$command])) {
             $command = $command_aliases[$command];
@@ -904,7 +893,7 @@ class ImportClient
             "db-index",
             "db-domains",
             "db-apply",
-            "import-metadata",
+            "pull-metadata",
             "preflight",
             "preflight-assert",
             "flat-docroot",
@@ -943,35 +932,35 @@ class ImportClient
 
         $this->state = $this->load_state();
 
-        if ($command === "import-metadata") {
-            $this->run_import_metadata();
+        if ($command === "pull-metadata") {
+            $this->run_pull_metadata();
             return;
         }
 
         // Persist follow_symlinks in state so it survives across invocations.
         // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
         if (isset($options["follow_symlinks"])) {
-            $this->import_state()->follow_symlinks = $this->follow_symlinks;
-            $this->save_state($this->state);
-        } elseif (isset($this->import_state()->follow_symlinks)) {
-            $this->follow_symlinks = $this->import_state()->follow_symlinks;
+            $this->get_state()->follow_symlinks = $this->follow_symlinks;
+            $this->save_state();
+        } elseif (isset($this->get_state()->follow_symlinks)) {
+            $this->follow_symlinks = $this->get_state()->follow_symlinks;
         }
 
         if (isset($options["local_followed_symlinks_root"])) {
             $this->local_followed_symlinks_root = $this->resolve_local_followed_symlinks_root($options["local_followed_symlinks_root"]);
             $this->follow_symlinks = true;
-            $this->import_state()->follow_symlinks = true;
-            $this->save_state($this->state);
+            $this->get_state()->follow_symlinks = true;
+            $this->save_state();
         }
 
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
         // 'preserve-local' preserves existing local files instead of overwriting
         // them, and gracefully skips non-writable directories.
         if (isset($options["fs_root_nonempty_behavior"])) {
-            $this->import_state()->fs_root_nonempty_behavior = $this->fs_root_nonempty_behavior;
-            $this->save_state($this->state);
+            $this->get_state()->fs_root_nonempty_behavior = $this->fs_root_nonempty_behavior;
+            $this->save_state();
         } else {
-            $this->fs_root_nonempty_behavior = $this->import_state()->fs_root_nonempty_behavior ?? 'error';
+            $this->fs_root_nonempty_behavior = $this->get_state()->fs_root_nonempty_behavior ?? 'error';
         }
 
         // Persist filter in state so it survives across resume cycles.
@@ -996,8 +985,8 @@ class ImportClient
                         "Valid values: none, essential-files",
                 );
             }
-            $prev = $this->import_state()->filter ?? null;
-            $status = $this->import_state()->active_resumable_command->completion_state ?? null;
+            $prev = $this->get_state()->filter ?? null;
+            $status = $this->get_state()->active_resumable_command->completion_state ?? null;
             // Leaving a skipped-earlier tail-fetch for another sync is a fresh
             // cycle, not a mid-flight filter change.
             $is_mid_flight =
@@ -1013,21 +1002,21 @@ class ImportClient
                 );
             }
             $this->filter = $next;
-            $this->import_state()->filter = $this->filter;
-            $this->save_state($this->state);
-        } elseif (isset($this->import_state()->filter)) {
-            $this->filter = $this->import_state()->filter;
+            $this->get_state()->filter = $this->filter;
+            $this->save_state();
+        } elseif (isset($this->get_state()->filter)) {
+            $this->filter = $this->get_state()->filter;
         }
 
         // Persist max_allowed_packet in state so it survives across invocations.
         // The client sends this to the server so SQL statements are capped to a
-        // size the client's MySQL instance can actually import.
+        // size the client's MySQL instance can actually accept.
         if (isset($options["max_allowed_packet"])) {
             $this->max_allowed_packet = (int) $options["max_allowed_packet"];
-            $this->import_state()->max_allowed_packet = $this->max_allowed_packet;
-            $this->save_state($this->state);
-        } elseif (isset($this->import_state()->max_allowed_packet)) {
-            $this->max_allowed_packet = (int) $this->import_state()->max_allowed_packet;
+            $this->get_state()->max_allowed_packet = $this->max_allowed_packet;
+            $this->save_state();
+        } elseif (isset($this->get_state()->max_allowed_packet)) {
+            $this->max_allowed_packet = (int) $this->get_state()->max_allowed_packet;
         }
 
         if (in_array($command, ["pull", "pull-db"], true)) {
@@ -1045,9 +1034,9 @@ class ImportClient
                 );
             }
             $this->sql_output_mode = $mode;
-            $this->import_state()->sql_output = $mode;
-        } elseif (isset($this->import_state()->sql_output)) {
-            $this->sql_output_mode = $this->import_state()->sql_output;
+            $this->get_state()->sql_output = $mode;
+        } elseif (isset($this->get_state()->sql_output)) {
+            $this->sql_output_mode = $this->get_state()->sql_output;
         }
 
         // In stdout mode, SQL goes to STDOUT, so progress/status output must
@@ -1062,33 +1051,33 @@ class ImportClient
         // MySQL connection parameters for --sql-output=mysql.
         if (isset($options["mysql_host"])) {
             $this->mysql_host = $options["mysql_host"];
-            $this->import_state()->mysql_host = $this->mysql_host;
-        } elseif (isset($this->import_state()->mysql_host)) {
-            $this->mysql_host = $this->import_state()->mysql_host;
+            $this->get_state()->mysql_host = $this->mysql_host;
+        } elseif (isset($this->get_state()->mysql_host)) {
+            $this->mysql_host = $this->get_state()->mysql_host;
         }
 
         if (isset($options["mysql_port"])) {
             $this->mysql_port = (int) $options["mysql_port"];
-            $this->import_state()->mysql_port = $this->mysql_port;
-        } elseif (isset($this->import_state()->mysql_port)) {
-            $this->mysql_port = (int) $this->import_state()->mysql_port;
+            $this->get_state()->mysql_port = $this->mysql_port;
+        } elseif (isset($this->get_state()->mysql_port)) {
+            $this->mysql_port = (int) $this->get_state()->mysql_port;
         }
 
         if (isset($options["mysql_user"])) {
             $this->mysql_user = $options["mysql_user"];
-            $this->import_state()->mysql_user = $this->mysql_user;
-        } elseif (isset($this->import_state()->mysql_user)) {
-            $this->mysql_user = $this->import_state()->mysql_user;
+            $this->get_state()->mysql_user = $this->mysql_user;
+        } elseif (isset($this->get_state()->mysql_user)) {
+            $this->mysql_user = $this->get_state()->mysql_user;
         }
 
         if (isset($options["mysql_database"])) {
             $this->mysql_database = $options["mysql_database"];
-            $this->import_state()->mysql_database = $this->mysql_database;
-        } elseif (isset($this->import_state()->mysql_database)) {
-            $this->mysql_database = $this->import_state()->mysql_database;
+            $this->get_state()->mysql_database = $this->mysql_database;
+        } elseif (isset($this->get_state()->mysql_database)) {
+            $this->mysql_database = $this->get_state()->mysql_database;
         }
 
-        $this->save_state($this->state);
+        $this->save_state();
 
         // Password is never persisted — must be supplied each run or via env.
         if (isset($options["mysql_password"])) {
@@ -1189,7 +1178,7 @@ class ImportClient
             }
             try {
                 $this->run_db_apply($options);
-                $final_status = $this->import_state()->active_resumable_command->completion_state ?? "complete";
+                $final_status = $this->get_state()->active_resumable_command->completion_state ?? "complete";
                 $this->output_progress(["status" => $final_status, "message" => "db-apply {$final_status}"]);
                 if ($final_status === "partial") {
                     $this->exit_code = 2;
@@ -1247,7 +1236,7 @@ class ImportClient
                     break;
             }
 
-            $final_status = $this->import_state()->active_resumable_command->completion_state ?? "complete";
+            $final_status = $this->get_state()->active_resumable_command->completion_state ?? "complete";
             $this->output_progress(["status" => $final_status, "message" => "{$command} {$final_status}"]);
 
             // Exit code 2 signals "partial progress, call me again" so
@@ -1675,7 +1664,7 @@ class ImportClient
         if ($detail !== null) {
             $result['detail'] = $detail;
         }
-        // Write the flat progress snapshot without consulting import state.
+        // Write the flat progress snapshot without consulting pull state.
         $progress_payload = [
             'command' => 'files-push',
             'status' => $status,
@@ -1936,15 +1925,15 @@ class ImportClient
                     "RESTART | Clearing files-index state",
                     true,
                 );
-                $this->import_state()->active_resumable_command->command_name = "files-index";
-                $this->import_state()->active_resumable_command->completion_state = null;
-                $this->import_state()->active_resumable_command->current_stage = null;
-                $this->import_state()->index = new RemoteFileIndexCursorState();
+                $this->get_state()->active_resumable_command->command_name = "files-index";
+                $this->get_state()->active_resumable_command->completion_state = null;
+                $this->get_state()->active_resumable_command->current_stage = null;
+                $this->get_state()->index = new RemoteFileIndexCursorState();
                 if (file_exists($this->remote_index_file)) {
                     @unlink($this->remote_index_file);
                     $this->audit_log("FILE DELETE | {$this->remote_index_file}");
                 }
-                $this->save_state($this->state);
+                $this->save_state();
                 break;
 
             case "db-pull":
@@ -1953,7 +1942,7 @@ class ImportClient
                     true,
                 );
                 $this->reset_state();
-                $this->save_state($this->state);
+                $this->save_state();
 
                 if ($this->sql_output_mode === "file") {
                     $sql_file = $this->state_dir . "/db.sql";
@@ -1986,7 +1975,7 @@ class ImportClient
                     true,
                 );
                 $this->reset_state();
-                $this->save_state($this->state);
+                $this->save_state();
 
                 $tables_file = $this->state_dir . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
@@ -2003,7 +1992,7 @@ class ImportClient
                     true,
                 );
                 $this->reset_state();
-                $this->save_state($this->state);
+                $this->save_state();
                 break;
         }
 
@@ -2045,11 +2034,11 @@ class ImportClient
             @unlink($this->volatile_files_file);
             $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
         }
-        $this->import_state()->index = new RemoteFileIndexCursorState();
-        $this->import_state()->fetch = new FetchListProgressState();
-        $this->import_state()->fetch_skipped = new FetchListProgressState();
+        $this->get_state()->index = new RemoteFileIndexCursorState();
+        $this->get_state()->fetch = new FetchListProgressState();
+        $this->get_state()->fetch_skipped = new FetchListProgressState();
 
-        $this->save_state($this->state);
+        $this->save_state();
     }
 
     /**
@@ -2057,18 +2046,18 @@ class ImportClient
      */
     private function initialize_tuner(array $options): void
     {
-        $config = $this->import_state()->tuning->config ?? [];
-        $state = $this->import_state()->tuning->state ?? [];
+        $config = $this->get_state()->tuning->config ?? [];
+        $state = $this->get_state()->tuning->state ?? [];
         $cli_config = $options["tuning_config"] ?? [];
 
         $config = array_merge($config, $cli_config);
 
         $this->tuner = new AdaptiveTuner($config, $state);
-        $this->import_state()->tuning->config = $this->tuner->get_config();
-        $this->import_state()->tuning->state = $this->tuner->get_state();
+        $this->get_state()->tuning->config = $this->tuner->get_config();
+        $this->get_state()->tuning->state = $this->tuner->get_state();
 
         $this->audit_log(
-            "TUNER CONFIG | " . json_encode($this->import_state()->tuning->config),
+            "TUNER CONFIG | " . json_encode($this->get_state()->tuning->config),
             false,
         );
     }
@@ -2087,7 +2076,7 @@ class ImportClient
         $result = null;
         $payload = null;
         foreach (self::USER_AGENTS as $ua) {
-            $this->import_state()->user_agent = $ua;
+            $this->get_state()->user_agent = $ua;
             $result = $this->fetch_json($url);
             $payload = $result["json"] ?? null;
             if ($payload !== null) {
@@ -2110,19 +2099,19 @@ class ImportClient
                 : null,
         ];
 
-        $this->import_state()->preflight = $entry;
+        $this->get_state()->preflight = $entry;
 
         // Store WordPress version at the top level for easy access
         $wp_version = $payload["database"]["wp"]["wp_version"] ?? null;
         if (is_string($wp_version) && $wp_version !== "") {
-            $this->import_state()->version = $wp_version;
+            $this->get_state()->version = $wp_version;
         }
 
         // Store the remote protocol version for the preflight assertion.
         if (isset($payload["protocol_version"])) {
-            $this->import_state()->remote_protocol_version = (int) $payload["protocol_version"];
+            $this->get_state()->remote_protocol_version = (int) $payload["protocol_version"];
         } else {
-            $this->import_state()->remote_protocol_version = null;
+            $this->get_state()->remote_protocol_version = null;
         }
 
         // Detect webhost environment from preflight data.
@@ -2133,10 +2122,10 @@ class ImportClient
         if ($detected_webhost === 'other' && is_link($this->filesystem_root . '/__wp__')) {
             $detected_webhost = 'wpcloud';
         }
-        $this->import_state()->webhost = $detected_webhost;
+        $this->get_state()->webhost = $detected_webhost;
         $this->audit_log("WEBHOST DETECTED | {$detected_webhost}", true);
 
-        $this->save_state($this->state);
+        $this->save_state();
 
         $this->audit_log(
             "PREFLIGHT RESULT | " . json_encode($entry),
@@ -2196,7 +2185,7 @@ class ImportClient
             $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
         }
 
-        $ini_all = $this->import_state()->preflight["data"]["runtime"]["ini_get_all"] ?? [];
+        $ini_all = $this->get_state()->preflight["data"]["runtime"]["ini_get_all"] ?? [];
         $files = [];
         foreach (["auto_prepend_file", "auto_append_file"] as $key) {
             $path = $ini_all[$key] ?? "";
@@ -2359,7 +2348,7 @@ class ImportClient
      */
     private function require_preflight(): void
     {
-        $entry = $this->import_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight ?? null;
         if (!is_array($entry) || empty($entry["data"])) {
             throw new RuntimeException(
                 "No preflight data found. Run 'preflight' or 'preflight-assert' first.",
@@ -2376,7 +2365,7 @@ class ImportClient
      */
     private function run_preflight_report(): void
     {
-        $entry = $this->import_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight ?? null;
         if ($entry === null) {
             echo "No preflight data available.\n";
             exit(1);
@@ -2397,7 +2386,7 @@ class ImportClient
      */
     private function run_preflight_assert(): void
     {
-        $entry = $this->import_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight ?? null;
         $data = $entry["data"] ?? null;
         $checks = [];
         $all_pass = true;
@@ -2429,19 +2418,19 @@ class ImportClient
         }
 
         // 3. Protocol version
-        $remote_ver = $this->import_state()->remote_protocol_version ?? null;
+        $remote_ver = $this->get_state()->remote_protocol_version ?? null;
         if ($remote_ver === null) {
             $proto_ok = false;
             $proto_detail = "Remote export plugin does not report a protocol version. Update the export plugin.";
-        } elseif ($remote_ver < IMPORT_PROTOCOL_VERSION) {
+        } elseif ($remote_ver < PULL_PROTOCOL_VERSION) {
             $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . IMPORT_PROTOCOL_VERSION . ". Update the export plugin.";
-        } elseif ($remote_ver > IMPORT_PROTOCOL_VERSION) {
+            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . PULL_PROTOCOL_VERSION . ". Update the export plugin.";
+        } elseif ($remote_ver > PULL_PROTOCOL_VERSION) {
             $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . IMPORT_PROTOCOL_VERSION . ". Update the importer.";
+            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . PULL_PROTOCOL_VERSION . ". Update the Reprint client.";
         } else {
             $proto_ok = true;
-            $proto_detail = "remote v{$remote_ver}, client v" . IMPORT_PROTOCOL_VERSION;
+            $proto_detail = "remote v{$remote_ver}, client v" . PULL_PROTOCOL_VERSION;
         }
         $checks[] = [
             "label" => "Protocol compatible",
@@ -2519,7 +2508,7 @@ class ImportClient
              * column is matched against the source table metadata, and value_base64 lets
              * the exporter compare with FROM_BASE64(...) without interpolating the raw
              * value into SQL. _edit_lock is ephemeral editor session state and would
-             * otherwise create stale "being edited" notices in the imported site.
+             * otherwise create stale "being edited" notices in the pulled site.
              */
             $params["skip_rows"] = [
                 [
@@ -2530,7 +2519,7 @@ class ImportClient
             ];
 
             // Tell the server about the client's max_allowed_packet so it can
-            // cap SQL statements to a size the client can actually import.
+            // cap SQL statements to a size the client can actually apply.
             if ($this->max_allowed_packet !== null) {
                 $params["max_allowed_packet"] = $this->max_allowed_packet;
             }
@@ -2655,7 +2644,7 @@ class ImportClient
      */
     public function run_files_pull(): void
     {
-        $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
+        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
 
         // A full `pull` leaves active_resumable_command on its last stage
         // (db-apply), not files-pull, so a standalone skipped-earlier run can't
@@ -2667,18 +2656,18 @@ class ImportClient
         if (
             $this->filter === "skipped-earlier" &&
             $state_command !== "files-pull" &&
-            $this->import_state()->pull_pipeline->skipped_pending
+            $this->get_state()->pull_pipeline->skipped_pending
         ) {
-            $this->import_state()->active_resumable_command->command_name = "files-pull";
-            $this->import_state()->active_resumable_command->completion_state = "complete";
-            $this->import_state()->active_resumable_command->current_stage = null;
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->command_name = "files-pull";
+            $this->get_state()->active_resumable_command->completion_state = "complete";
+            $this->get_state()->active_resumable_command->current_stage = null;
+            $this->save_state();
             $state_command = "files-pull";
         }
 
         $current_status =
             $state_command === "files-pull"
-                ? $this->import_state()->active_resumable_command->completion_state ?? null
+                ? $this->get_state()->active_resumable_command->completion_state ?? null
                 : null;
         $has_progress =
             $state_command === "files-pull" &&
@@ -2718,21 +2707,21 @@ class ImportClient
                     "stage" => "fetch-skipped",
                     "message" => "Downloading previously skipped files",
                 ], true);
-                $this->import_state()->active_resumable_command->completion_state = "in_progress";
-                $this->import_state()->active_resumable_command->current_stage = "fetch-skipped";
-                $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
-                $this->import_state()->files_pull_summary = new FilesPullSummaryState();
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "in_progress";
+                $this->get_state()->active_resumable_command->current_stage = "fetch-skipped";
+                $this->get_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
+                $this->get_state()->files_pull_summary = new FilesPullSummaryState();
+                $this->save_state();
                 $this->open_local_index_wal();
                 $this->run_files_pull_pipeline();
                 // The deferred tail reopens a completed files-pull. Once the
                 // tail finishes, restore the completed status so later filter
                 // changes are judged against the actual lifecycle state.
-                if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
+                if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
                     return;
                 }
-                $this->import_state()->active_resumable_command->completion_state = "complete";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "complete";
+                $this->save_state();
                 $this->remove_local_index_wal();
                 return;
             }
@@ -2773,7 +2762,7 @@ class ImportClient
         // $has_progress path below (and completes via the shared tail).
         if (
             $this->filter === "skipped-earlier" &&
-            ($this->import_state()->active_resumable_command->current_stage ?? null) !== "fetch-skipped"
+            ($this->get_state()->active_resumable_command->current_stage ?? null) !== "fetch-skipped"
         ) {
             throw new RuntimeException(
                 "--filter=skipped-earlier was requested but there is no completed sync with skipped files. " .
@@ -2797,14 +2786,14 @@ class ImportClient
 
         // Resuming an in-progress sync
         if ($has_progress) {
-            // Don't reset files_imported here — it counts files within
+            // Don't reset files_pulled here — it counts files within
             // the current batch and is only reset when a batch completes
             // (in fetch_files_from_list). Resetting it on entry would
             // cause the progress counter to dip between pull retries.
             $index_size = $this->index_count();
 
 
-            $stage = $this->import_state()->active_resumable_command->current_stage ?? "index";
+            $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
             $this->audit_log(
                 sprintf(
                     "RESUME files-pull | stage=%s | indexed_files=%d",
@@ -2836,19 +2825,19 @@ class ImportClient
                 );
             }
 
-            $this->import_state()->active_resumable_command->command_name = "files-pull";
-            $this->import_state()->active_resumable_command->completion_state = "in_progress";
-            $this->import_state()->active_resumable_command->current_stage = "index";
-            $this->import_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
-            $this->import_state()->diff = new FileDiffProgressState();
-            $this->import_state()->index = new RemoteFileIndexCursorState();
-            $this->import_state()->fetch = new FetchListProgressState();
-            $this->import_state()->fetch_skipped = new FetchListProgressState();
-            $this->import_state()->files_pull_summary = new FilesPullSummaryState();
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->command_name = "files-pull";
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->get_state()->active_resumable_command->current_stage = "index";
+            $this->get_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
+            $this->get_state()->diff = new FileDiffProgressState();
+            $this->get_state()->index = new RemoteFileIndexCursorState();
+            $this->get_state()->fetch = new FetchListProgressState();
+            $this->get_state()->fetch_skipped = new FetchListProgressState();
+            $this->get_state()->files_pull_summary = new FilesPullSummaryState();
+            $this->save_state();
 
             if ($is_delta) {
-                $this->files_imported = 0;
+                $this->files_pulled = 0;
                 $index_size = $this->index_count();
 
                 $this->audit_log(
@@ -2883,20 +2872,20 @@ class ImportClient
             }
         }
 
-        $this->import_state()->active_resumable_command->command_name = "files-pull";
-        $this->import_state()->active_resumable_command->completion_state = "in_progress";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->command_name = "files-pull";
+        $this->get_state()->active_resumable_command->completion_state = "in_progress";
+        $this->save_state();
 
         $this->open_local_index_wal();
         $this->run_files_pull_pipeline();
 
         // Pipeline returns early with partial status if interrupted
-        if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
+        if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
             return;
         }
 
-        $this->import_state()->active_resumable_command->completion_state = "complete";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->completion_state = "complete";
+        $this->save_state();
         $this->remove_local_index_wal();
 
         $this->progress->clear_progress_line();
@@ -2931,26 +2920,26 @@ class ImportClient
      */
     private function run_files_pull_pipeline(): void
     {
-        $stage = $this->import_state()->active_resumable_command->current_stage ?? "index";
+        $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
 
         if ($stage === "index") {
             $complete = $this->fetch_remote_index();
             if (!$complete) {
-                $this->import_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
                 return;
             }
             if ($this->follow_symlinks) {
                 $this->discover_symlink_targets();
                 if ($this->shutdown_requested) {
-                    $this->import_state()->active_resumable_command->completion_state = "partial";
-                    $this->save_state($this->state);
+                    $this->get_state()->active_resumable_command->completion_state = "partial";
+                    $this->save_state();
                     return;
                 }
             }
             $this->sort_index_file($this->remote_index_file);
-            $this->import_state()->active_resumable_command->current_stage = "diff";
-            $this->import_state()->diff = new FileDiffProgressState();
+            $this->get_state()->active_resumable_command->current_stage = "diff";
+            $this->get_state()->diff = new FileDiffProgressState();
             if (file_exists($this->fetch_list_file)) {
                 @unlink($this->fetch_list_file);
                 $this->audit_log(
@@ -2963,15 +2952,15 @@ class ImportClient
                     "FILE DELETE | {$this->skipped_fetch_list_file} | clearing before diff stage",
                 );
             }
-            $this->save_state($this->state);
+            $this->save_state();
             $stage = "diff";
         }
 
         if ($stage === "diff") {
             $complete = $this->diff_indexes_and_build_fetch_list();
             if (!$complete) {
-                $this->import_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
                 return;
             }
 
@@ -2990,8 +2979,8 @@ class ImportClient
             } else {
                 $stage = null;
             }
-            $this->import_state()->active_resumable_command->current_stage = $stage;
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->current_stage = $stage;
+            $this->save_state();
 
             // In pull mode, finalize the scanning line with a checkmark
             // and start the download progress on a fresh line.
@@ -3030,11 +3019,11 @@ class ImportClient
                 "fetch",
             );
             if (!$complete) {
-                $this->import_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
                 return;
             }
-            $this->import_state()->fetch = new FetchListProgressState();
+            $this->get_state()->fetch = new FetchListProgressState();
 
             if (file_exists($this->fetch_list_file)) {
                 @unlink($this->fetch_list_file);
@@ -3051,8 +3040,8 @@ class ImportClient
                 // Essential files are done — mark the sync as complete.
                 // The skipped list stays on disk for a later
                 // --filter=skipped-earlier run.
-                $this->import_state()->active_resumable_command->current_stage = null;
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->current_stage = null;
+                $this->save_state();
                 $this->audit_log(
                     "ESSENTIAL FILES COMPLETE | skipped files listed in {$this->skipped_fetch_list_file} — run with --filter=skipped-earlier to download them",
                     true,
@@ -3060,8 +3049,8 @@ class ImportClient
                 $stage = null;
             } elseif ($has_skipped) {
                 // Skipped list exists but filter is "none" — download now.
-                $this->import_state()->active_resumable_command->current_stage = "fetch-skipped";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->current_stage = "fetch-skipped";
+                $this->save_state();
                 $stage = "fetch-skipped";
                 $this->audit_log(
                     "ESSENTIAL FILES COMPLETE | transitioning to skipped files",
@@ -3069,8 +3058,8 @@ class ImportClient
                 );
                 $this->write_progress_file();
             } else {
-                $this->import_state()->active_resumable_command->current_stage = null;
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->current_stage = null;
+                $this->save_state();
                 $stage = null;
             }
         }
@@ -3081,16 +3070,16 @@ class ImportClient
                 "fetch_skipped",
             );
             if (!$complete) {
-                $this->import_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
                 return;
             }
-            $this->import_state()->active_resumable_command->current_stage = null;
-            $this->import_state()->fetch_skipped = new FetchListProgressState();
+            $this->get_state()->active_resumable_command->current_stage = null;
+            $this->get_state()->fetch_skipped = new FetchListProgressState();
             // Tail fully fetched; clear the flag so a later skipped-earlier run
             // doesn't treat the now-empty tail as pending.
-            $this->import_state()->pull_pipeline->skipped_pending = false;
-            $this->save_state($this->state);
+            $this->get_state()->pull_pipeline->skipped_pending = false;
+            $this->save_state();
 
             if (file_exists($this->skipped_fetch_list_file)) {
                 @unlink($this->skipped_fetch_list_file);
@@ -3118,10 +3107,10 @@ class ImportClient
      */
     private function run_files_index(): void
     {
-        $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
+        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
         $current_status =
             $state_command === "files-index"
-                ? $this->import_state()->active_resumable_command->completion_state ?? null
+                ? $this->get_state()->active_resumable_command->completion_state ?? null
                 : null;
 
         if ($current_status === "complete") {
@@ -3131,10 +3120,10 @@ class ImportClient
         }
 
         if ($current_status === null) {
-            $this->import_state()->active_resumable_command->command_name = "files-index";
-            $this->import_state()->active_resumable_command->completion_state = "in_progress";
-            $this->import_state()->active_resumable_command->current_stage = "index";
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->command_name = "files-index";
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->get_state()->active_resumable_command->current_stage = "index";
+            $this->save_state();
             $this->audit_log("START files-index", true);
             $this->progress->show_lifecycle_line("Starting files-index\n");
             $this->output_progress([
@@ -3144,7 +3133,7 @@ class ImportClient
                 "message" => "Starting files-index",
             ], true);
         } else {
-            $cursor = $this->import_state()->index->cursor ?? null;
+            $cursor = $this->get_state()->index->cursor ?? null;
             $this->audit_log(
                 sprintf(
                     "RESUME files-index | cursor=%s",
@@ -3161,11 +3150,11 @@ class ImportClient
             ], true);
         }
 
-        $this->import_state()->active_resumable_command->command_name = "files-index";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->command_name = "files-index";
+        $this->save_state();
 
         $attempts = 0;
-        $last_cursor = $this->import_state()->index->cursor ?? null;
+        $last_cursor = $this->get_state()->index->cursor ?? null;
         while (true) {
             $complete = $this->fetch_remote_index();
             if ($complete) {
@@ -3173,12 +3162,12 @@ class ImportClient
             }
 
             if ($this->shutdown_requested) {
-                $this->import_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
                 return;
             }
 
-            $current_cursor = $this->import_state()->index->cursor ?? null;
+            $current_cursor = $this->get_state()->index->cursor ?? null;
             if ($current_cursor === $last_cursor) {
                 throw new RuntimeException(
                     "files-index made no progress (cursor unchanged)",
@@ -3202,9 +3191,9 @@ class ImportClient
         }
 
         $this->sort_index_file($this->remote_index_file);
-        $this->import_state()->active_resumable_command->completion_state = "complete";
-        $this->import_state()->active_resumable_command->current_stage = null;
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->completion_state = "complete";
+        $this->get_state()->active_resumable_command->current_stage = null;
+        $this->save_state();
 
         $count = 0;
         if (file_exists($this->remote_index_file)) {
@@ -3297,8 +3286,8 @@ class ImportClient
             // Note we are not losing the previous cursor position. This code
             // runs only after the previous directory was fully indexed so
             // we won't need any prior cursor information again.
-            $this->import_state()->index->cursor = null;
-            $this->save_state($this->state);
+            $this->get_state()->index->cursor = null;
+            $this->save_state();
 
             $attempts = 0;
             $last_cursor = null;
@@ -3341,7 +3330,7 @@ class ImportClient
                     return;
                 }
 
-                $current_cursor = $this->import_state()->index->cursor ?? null;
+                $current_cursor = $this->get_state()->index->cursor ?? null;
                 if ($current_cursor === $last_cursor) {
                     throw new RuntimeException(
                         "files-index (symlink follow) made no progress (cursor unchanged)",
@@ -3601,15 +3590,15 @@ class ImportClient
      */
     public function run_db_sync(): void
     {
-        $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
+        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
         $sql_file = $this->state_dir . "/db.sql";
 
         $has_progress =
             $state_command === "db-pull" &&
-            ($this->import_state()->active_resumable_command->completion_state ?? null) === "in_progress";
+            ($this->get_state()->active_resumable_command->completion_state ?? null) === "in_progress";
         $current_status =
             $state_command === "db-pull"
-                ? $this->import_state()->active_resumable_command->completion_state ?? null
+                ? $this->get_state()->active_resumable_command->completion_state ?? null
                 : null;
 
         // Check if already completed
@@ -3633,13 +3622,13 @@ class ImportClient
         }
 
         if ($has_progress) {
-            $stage = $this->import_state()->active_resumable_command->current_stage ?? "db-index";
+            $stage = $this->get_state()->active_resumable_command->current_stage ?? "db-index";
             $this->audit_log(
                 sprintf(
                     "RESUME db-pull | stage=%s | cursor=%s",
                     $stage,
-                    !empty($this->import_state()->active_resumable_command->remote_cursor)
-                        ? substr($this->import_state()->active_resumable_command->remote_cursor, 0, 20) . "..."
+                    !empty($this->get_state()->active_resumable_command->remote_cursor)
+                        ? substr($this->get_state()->active_resumable_command->remote_cursor, 0, 20) . "..."
                         : "none",
                 ),
                 true,
@@ -3655,13 +3644,13 @@ class ImportClient
             ], true);
         } else {
             // Starting fresh
-            $this->import_state()->active_resumable_command->command_name = "db-pull";
-            $this->import_state()->active_resumable_command->completion_state = "in_progress";
-            $this->import_state()->active_resumable_command->remote_cursor = null;
-            $this->import_state()->active_resumable_command->current_stage = "db-index";
-            $this->import_state()->diff = new FileDiffProgressState();
-            $this->import_state()->db_index = new DatabaseTableIndexState();
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->command_name = "db-pull";
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->get_state()->active_resumable_command->remote_cursor = null;
+            $this->get_state()->active_resumable_command->current_stage = "db-index";
+            $this->get_state()->diff = new FileDiffProgressState();
+            $this->get_state()->db_index = new DatabaseTableIndexState();
+            $this->save_state();
 
             $this->audit_log("START db-pull", true);
 
@@ -3674,11 +3663,11 @@ class ImportClient
             ], true);
         }
 
-        $this->import_state()->active_resumable_command->command_name = "db-pull";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->command_name = "db-pull";
+        $this->save_state();
 
         // Stage 1: db-index (table metadata for progress estimation)
-        $stage = $this->import_state()->active_resumable_command->current_stage ?? "db-index";
+        $stage = $this->get_state()->active_resumable_command->current_stage ?? "db-index";
         if ($stage === "db-index") {
             $this->output_progress([
                 "status" => "starting",
@@ -3689,19 +3678,19 @@ class ImportClient
             $this->fetch_database_index();
 
             // Interrupted response during db-index — state already saved, exit partial.
-            if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
+            if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
                 return;
             }
 
-            $tables = (int) ($this->import_state()->db_index->tables ?? 0);
+            $tables = (int) ($this->get_state()->db_index->tables ?? 0);
             $this->audit_log(
                 sprintf("db-pull db-index stage complete: %d tables", $tables),
             );
 
             // Transition to sql stage
-            $this->import_state()->active_resumable_command->current_stage = "sql";
-            $this->import_state()->active_resumable_command->remote_cursor = null;
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->current_stage = "sql";
+            $this->get_state()->active_resumable_command->remote_cursor = null;
+            $this->save_state();
         }
 
         // Stage 2: SQL dump download
@@ -3714,13 +3703,13 @@ class ImportClient
         $this->fetch_sql();
 
         // Interrupted response during SQL download — state already saved, exit partial.
-        if (($this->import_state()->active_resumable_command->completion_state ?? null) === "partial") {
+        if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
             return;
         }
 
         // Mark as complete
-        $this->import_state()->active_resumable_command->completion_state = "complete";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->completion_state = "complete";
+        $this->save_state();
 
         $this->audit_log("db-pull complete", true);
 
@@ -3730,7 +3719,7 @@ class ImportClient
         } elseif ($this->sql_output_mode === "stdout") {
             $this->progress->show_lifecycle_line("SQL written to stdout\n");
         } elseif ($this->sql_output_mode === "mysql") {
-            $this->progress->show_lifecycle_line("SQL imported into {$this->mysql_database}\n");
+            $this->progress->show_lifecycle_line("SQL applied to {$this->mysql_database}\n");
         }
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log_file}\n");
         $db_sync_complete = [
@@ -3867,7 +3856,7 @@ class ImportClient
         $skipped_pending_bytes = 0;
 
         // Count pending in the main fetch list
-        $fetch_offset = $this->import_state()->fetch->offset ?? 0;
+        $fetch_offset = $this->get_state()->fetch->offset ?? 0;
         if (is_file($fetch_list)) {
             $handle = fopen($fetch_list, "r");
             if ($handle) {
@@ -3899,7 +3888,7 @@ class ImportClient
         }
 
         // Count pending in the skipped fetch list (uploads filtered out by --filter=essential-files)
-        $skipped_offset = $this->import_state()->fetch_skipped->offset ?? 0;
+        $skipped_offset = $this->get_state()->fetch_skipped->offset ?? 0;
         $skipped_list = $this->skipped_fetch_list_file;
         if (is_file($skipped_list)) {
             $handle = fopen($skipped_list, "r");
@@ -3949,12 +3938,12 @@ class ImportClient
     }
 
     /**
-     * Prints host-facing import metadata without mutating state.
+     * Prints host-facing pull metadata without mutating state.
      */
-    private function run_import_metadata(): void
+    private function run_pull_metadata(): void
     {
         echo json_encode(
-            $this->build_import_metadata(),
+            $this->build_pull_metadata(),
             JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
         ) . "\n";
     }
@@ -3966,7 +3955,7 @@ class ImportClient
      * callers do not need to persist a parallel flag that could drift.
      *
      * @return array {
-     *     Import metadata for host integrations.
+     *     Pull metadata for host integrations.
      *
      *     @type bool  $hasCompletedOnce Whether the pull pipeline has completed
      *                                   at least once.
@@ -3996,10 +3985,11 @@ class ImportClient
      *     }
      * }
      */
-    private function build_import_metadata(): array
+    private function build_pull_metadata(): array
     {
-        $pull = $this->import_state()->pull_pipeline;
-        $database = $this->import_state()->preflight["data"]["database"] ?? [];
+        $state = $this->get_state();
+        $pull = $state->pull_pipeline;
+        $database = $state->preflight["data"]["database"] ?? [];
         $wordpress = $database["wp"] ?? [];
 
         return [
@@ -4033,7 +4023,7 @@ class ImportClient
     }
 
     /**
-     * Generate runtime configuration for the imported site.
+     * Generate runtime configuration for the pulled site.
      *
      * Reads the detected webhost from state (set during preflight), runs the
      * appropriate host analyzer to produce a runtime manifest, then applies
@@ -4066,7 +4056,7 @@ class ImportClient
         }
 
         // Load state to get preflight data and detected webhost.
-        $entry = $this->import_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight ?? null;
         if (!is_array($entry) || empty($entry["data"])) {
             throw new RuntimeException(
                 "apply-runtime requires a prior preflight run. " .
@@ -4075,7 +4065,7 @@ class ImportClient
         }
 
         $preflight_data = $entry["data"];
-        $webhost = $this->import_state()->webhost ?? "other";
+        $webhost = $this->get_state()->webhost ?? "other";
 
         // Resolve the local document root from either --flat-document-root
         // (used as-is) or --fs-root (prefixed with the remote document_root).
@@ -4136,7 +4126,7 @@ class ImportClient
         // db-apply persists the target engine and connection details so that
         // apply-runtime can generate the matching DB_* constants and, for
         // SQLite targets, set up the database integration plugin.
-        $apply_state = $this->import_state()->apply;
+        $apply_state = $this->get_state()->apply;
         $target_engine = $apply_state->target_engine;
         if ($target_engine === "mysql") {
             $manifest->constants["DB_NAME"] = $apply_state->target_db ?? "";
@@ -4183,7 +4173,7 @@ class ImportClient
         $host = $options["host"] ?? null;
         $port = $options["port"] ?? null;
         if ($host === null || $port === null) {
-            $rewrite_map = $this->import_state()->apply->rewrite_url ?? [];
+            $rewrite_map = $this->get_state()->apply->rewrite_url ?? [];
             $first_target = !empty($rewrite_map) ? reset($rewrite_map) : null;
             if (is_string($first_target)) {
                 $parsed = parse_url($first_target);
@@ -4272,8 +4262,8 @@ class ImportClient
         }
 
         // Persist which paths were removed so callers can inspect state.
-        $this->import_state()->apply->remote_paths_removed_from_local_site = $manifest->paths_to_remove;
-        $this->save_state($this->state);
+        $this->get_state()->apply->remote_paths_removed_from_local_site = $manifest->paths_to_remove;
+        $this->save_state();
 
         // Read the structured start config if the applier wrote one.
         // Playground CLI writes start.json with mount paths as seen by
@@ -4369,11 +4359,11 @@ class ImportClient
             return true;
         }
 
-        if (($this->import_state()->active_resumable_command->command_name ?? null) !== "files-pull") {
+        if (($this->get_state()->active_resumable_command->command_name ?? null) !== "files-pull") {
             return false;
         }
 
-        $status = $this->import_state()->active_resumable_command->completion_state ?? null;
+        $status = $this->get_state()->active_resumable_command->completion_state ?? null;
         return $status !== null && $status !== "complete";
     }
 
@@ -4442,7 +4432,7 @@ class ImportClient
 
         // Require preflight data so we know where WP components live
         $this->require_preflight();
-        $preflight = $this->import_state()->preflight["data"] ?? [];
+        $preflight = $this->get_state()->preflight["data"] ?? [];
 
         // Extract WordPress directory paths from preflight
         $paths_urls = $preflight["database"]["wp"]["paths_urls"] ?? null;
@@ -5131,7 +5121,7 @@ class ImportClient
 
             if (!$target_path) {
                 $content_dir = rtrim(
-                    $this->import_state()->preflight["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
+                    $this->get_state()->preflight["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
                     "/",
                 );
                 if(!$content_dir) {
@@ -5145,9 +5135,9 @@ class ImportClient
             }
 
             // Persist target database configuration for apply-runtime.
-            $this->import_state()->apply->target_engine = "sqlite";
-            $this->import_state()->apply->target_db = $target_db;
-            $this->import_state()->apply->target_sqlite_path = $target_path;
+            $this->get_state()->apply->target_engine = "sqlite";
+            $this->get_state()->apply->target_db = $target_db;
+            $this->get_state()->apply->target_sqlite_path = $target_path;
 
             return [
                 $this->create_sqlite_target_pdo($target_path, $target_db),
@@ -5172,12 +5162,12 @@ class ImportClient
         }
 
         // Persist target database configuration for apply-runtime.
-        $this->import_state()->apply->target_engine = "mysql";
-        $this->import_state()->apply->target_db = $target_db;
-        $this->import_state()->apply->target_host = $target_host;
-        $this->import_state()->apply->target_port = $target_port;
-        $this->import_state()->apply->target_user = $target_user;
-        $this->import_state()->apply->target_pass = $target_pass;
+        $this->get_state()->apply->target_engine = "mysql";
+        $this->get_state()->apply->target_db = $target_db;
+        $this->get_state()->apply->target_host = $target_host;
+        $this->get_state()->apply->target_port = $target_port;
+        $this->get_state()->apply->target_user = $target_user;
+        $this->get_state()->apply->target_pass = $target_pass;
 
         $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
         try {
@@ -5255,8 +5245,8 @@ class ImportClient
         }
 
         // Check state for resume
-        $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
-        $current_status = $state_command === "db-apply" ? ($this->import_state()->active_resumable_command->completion_state ?? null) : null;
+        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
+        $current_status = $state_command === "db-apply" ? ($this->get_state()->active_resumable_command->completion_state ?? null) : null;
 
         if ($current_status === "complete") {
             throw new RuntimeException(
@@ -5264,7 +5254,7 @@ class ImportClient
             );
         }
 
-        $apply_state = $this->import_state()->apply;
+        $apply_state = $this->get_state()->apply;
         $statements_executed = $apply_state->statements_executed;
         $bytes_read = $apply_state->bytes_read;
         $is_resume = $current_status === "in_progress" && $statements_executed > 0;
@@ -5288,13 +5278,13 @@ class ImportClient
                 "message" => "Resuming db-apply (executed: {$statements_executed} statements)",
             ], true);
         } else {
-            $this->import_state()->active_resumable_command->command_name = "db-apply";
-            $this->import_state()->active_resumable_command->completion_state = "in_progress";
-            $this->import_state()->apply = new DatabaseApplyCommandState();
+            $this->get_state()->active_resumable_command->command_name = "db-apply";
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->get_state()->apply = new DatabaseApplyCommandState();
             if (!empty($url_mapping)) {
-                $this->import_state()->apply->rewrite_url = $url_mapping;
+                $this->get_state()->apply->rewrite_url = $url_mapping;
             }
-            $this->save_state($this->state);
+            $this->save_state();
             $statements_executed = 0;
             $bytes_read = 0;
 
@@ -5316,7 +5306,7 @@ class ImportClient
         // Set up SQL statement rewriter if we have URL mappings
         $stmt_rewriter = null;
         if (!empty($url_mapping)) {
-            $table_prefix = $this->import_state()->preflight["data"]["database"]["wp"]["table_prefix"] ?? 'wp_';
+            $table_prefix = $this->get_state()->preflight["data"]["database"]["wp"]["table_prefix"] ?? 'wp_';
             $stmt_rewriter = new SqlStatementRewriter(
                 new StructuredDataUrlRewriter($url_mapping),
                 $table_prefix,
@@ -5344,7 +5334,7 @@ class ImportClient
             && method_exists($pdo, 'get_connection')
         ) {
             $sqlite_prepared_pdo = $pdo->get_connection()->get_pdo();
-            // These are connection-local import hints. Avoid journal/sync/locking
+            // These are connection-local db-apply hints. Avoid journal/sync/locking
             // PRAGMAs because they alter durability or observable database state.
             $sqlite_prepared_pdo->exec('PRAGMA temp_store = MEMORY');
             $sqlite_prepared_pdo->exec('PRAGMA cache_size = -32768');
@@ -5493,9 +5483,9 @@ class ImportClient
                     // formed a complete query yet. This ensures resumption starts at
                     // the exact boundary between executed and un-executed queries.
                     if ($stmts_since_save >= $save_every) {
-                        $this->import_state()->apply->statements_executed = $statements_executed;
-                        $this->import_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
-                        $this->save_state($this->state);
+                        $this->get_state()->apply->statements_executed = $statements_executed;
+                        $this->get_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                        $this->save_state();
                         $stmts_since_save = 0;
 
                         // Progress output
@@ -5569,10 +5559,10 @@ class ImportClient
 
             if ($this->shutdown_requested) {
                 // Save partial progress
-                $this->import_state()->apply->statements_executed = $statements_executed;
-                $this->import_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
-                $this->import_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state($this->state);
+                $this->get_state()->apply->statements_executed = $statements_executed;
+                $this->get_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
                 $this->audit_log(
                     sprintf(
                         "PARTIAL db-apply | %d statements executed",
@@ -5614,10 +5604,10 @@ class ImportClient
                 }
 
                 // Mark complete
-                $this->import_state()->apply->statements_executed = $statements_executed;
-                $this->import_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
-                $this->import_state()->active_resumable_command->completion_state = "complete";
-                $this->save_state($this->state);
+                $this->get_state()->apply->statements_executed = $statements_executed;
+                $this->get_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                $this->get_state()->active_resumable_command->completion_state = "complete";
+                $this->save_state();
 
                 $this->audit_log(
                     sprintf(
@@ -5717,9 +5707,9 @@ class ImportClient
      */
     private function deactivate_host_plugins(PDO $pdo): array
     {
-        $webhost = $this->import_state()->webhost ?? "other";
+        $webhost = $this->get_state()->webhost ?? "other";
         $analyzer = host_analyzer_for($webhost);
-        $preflight_data = $this->import_state()->preflight["data"] ?? [];
+        $preflight_data = $this->get_state()->preflight["data"] ?? [];
         $manifest = $analyzer->analyze($preflight_data);
 
         $plugin_dirs = [];
@@ -5785,7 +5775,7 @@ class ImportClient
             return [];
         }
 
-        $preflight_data = $this->import_state()->preflight["data"] ?? [];
+        $preflight_data = $this->get_state()->preflight["data"] ?? [];
         $table_prefix = $preflight_data["database"]["wp"]["table_prefix"] ?? 'wp_';
         // Quote the table name to prevent SQL injection from a crafted prefix.
         $options_table = '`' . str_replace('`', '``', $table_prefix . 'options') . '`';
@@ -5858,15 +5848,15 @@ class ImportClient
      */
     private function run_db_index(): void
     {
-        $state_command = $this->import_state()->active_resumable_command->command_name ?? null;
+        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
         $tables_file = $this->state_dir . "/db-tables.jsonl";
 
         $has_cursor =
             $state_command === "db-index" &&
-            !empty($this->import_state()->active_resumable_command->remote_cursor ?? null);
+            !empty($this->get_state()->active_resumable_command->remote_cursor ?? null);
         $current_status =
             $state_command === "db-index"
-                ? $this->import_state()->active_resumable_command->completion_state ?? null
+                ? $this->get_state()->active_resumable_command->completion_state ?? null
                 : null;
         $tables_exists = file_exists($tables_file);
 
@@ -5883,13 +5873,13 @@ class ImportClient
         }
 
         if (!$has_cursor) {
-            $this->import_state()->active_resumable_command->command_name = "db-index";
-            $this->import_state()->active_resumable_command->completion_state = "in_progress";
-            $this->import_state()->active_resumable_command->remote_cursor = null;
-            $this->import_state()->active_resumable_command->current_stage = null;
-            $this->import_state()->diff = new FileDiffProgressState();
-            $this->import_state()->db_index = new DatabaseTableIndexState();
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->command_name = "db-index";
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->get_state()->active_resumable_command->remote_cursor = null;
+            $this->get_state()->active_resumable_command->current_stage = null;
+            $this->get_state()->diff = new FileDiffProgressState();
+            $this->get_state()->db_index = new DatabaseTableIndexState();
+            $this->save_state();
 
             $this->audit_log("START db-index", true);
             $this->progress->show_lifecycle_line("Starting db-index\n");
@@ -5903,7 +5893,7 @@ class ImportClient
             $this->audit_log(
                 sprintf(
                     "RESUME db-index | cursor=%s",
-                    substr($this->import_state()->active_resumable_command->remote_cursor, 0, 20) . "...",
+                    substr($this->get_state()->active_resumable_command->remote_cursor, 0, 20) . "...",
                 ),
                 true,
             );
@@ -5916,21 +5906,21 @@ class ImportClient
             ], true);
         }
 
-        $this->import_state()->active_resumable_command->command_name = "db-index";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->command_name = "db-index";
+        $this->save_state();
 
         $this->fetch_database_index();
         if (
-            $this->import_state()->active_resumable_command->completion_state ===
+            $this->get_state()->active_resumable_command->completion_state ===
             "partial"
         ) {
             return;
         }
 
-        $this->import_state()->active_resumable_command->completion_state = "complete";
-        $this->save_state($this->state);
+        $this->get_state()->active_resumable_command->completion_state = "complete";
+        $this->save_state();
 
-        $tables = (int) ($this->import_state()->db_index->tables ?? 0);
+        $tables = (int) ($this->get_state()->db_index->tables ?? 0);
         $this->audit_log(
             sprintf("db-index complete: %d tables", $tables),
             true,
@@ -5969,8 +5959,8 @@ class ImportClient
         // Crash recovery: if we have a tracked file that's larger than expected,
         // truncate it. This happens if we crashed after writing but before saving
         // the new cursor, so we'll re-fetch the same data.
-        $tracked_file = $this->import_state()->current_file ?? null;
-        $tracked_bytes = $this->import_state()->current_file_bytes ?? null;
+        $tracked_file = $this->get_state()->current_file ?? null;
+        $tracked_bytes = $this->get_state()->current_file_bytes ?? null;
         if ($tracked_file !== null && $tracked_bytes !== null && file_exists($tracked_file)) {
             $actual_size = filesize($tracked_file);
             if ($actual_size > $tracked_bytes) {
@@ -6145,9 +6135,9 @@ class ImportClient
                 $force_save = $is_streaming_close;
                 if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
                     if ($file_path_at_completed_part !== null) {
-                        $this->import_state()->current_file =
+                        $this->get_state()->current_file =
                             $file_path_at_completed_part;
-                        $this->import_state()->current_file_bytes =
+                        $this->get_state()->current_file_bytes =
                             $file_bytes_at_completed_part;
                     } elseif ($context->file_handle && $context->file_path) {
                         // Flush to ensure bytes are on disk before saving state.
@@ -6157,11 +6147,11 @@ class ImportClient
                             );
                         }
                         // Track the current file for crash recovery.
-                        $this->import_state()->current_file = $context->file_path;
-                        $this->import_state()->current_file_bytes = $context->file_bytes_written;
+                        $this->get_state()->current_file = $context->file_path;
+                        $this->get_state()->current_file_bytes = $context->file_bytes_written;
                     } else {
-                        $this->import_state()->current_file = null;
-                        $this->import_state()->current_file_bytes = null;
+                        $this->get_state()->current_file = null;
+                        $this->get_state()->current_file_bytes = null;
                     }
                     if (
                         $this->local_index_wal_handle
@@ -6170,7 +6160,7 @@ class ImportClient
                         throw new RuntimeException('Failed to flush the local index WAL.');
                     }
                     $this->get_fetch_list_progress_state($state_key)->cursor = $cursor;
-                    $this->save_state($this->state);
+                    $this->save_state();
                     $chunks_since_save = 0;
                 }
             }
@@ -6205,11 +6195,11 @@ class ImportClient
                 $context->file_handle = null;
             }
             $this->apply_local_index_wal();
-            $this->import_state()->active_resumable_command->completion_state = "partial";
-            $this->save_state($this->state);
+            $this->get_state()->active_resumable_command->completion_state = "partial";
+            $this->save_state();
             return false;
         }
-        $this->import_state()->consecutive_interrupted_responses = 0;
+        $this->get_state()->consecutive_interrupted_responses = 0;
         $wall_time = microtime(true) - $request_start;
 
         $this->finalize_tuned_request(
@@ -6226,13 +6216,13 @@ class ImportClient
                     'Failed to flush the pulled file before saving its fetch cursor.'
                 );
             }
-            $this->import_state()->current_file = $context->file_path;
-            $this->import_state()->current_file_bytes = $context->file_bytes_written;
+            $this->get_state()->current_file = $context->file_path;
+            $this->get_state()->current_file_bytes = $context->file_bytes_written;
         } else {
-            $this->import_state()->current_file = null;
-            $this->import_state()->current_file_bytes = null;
+            $this->get_state()->current_file = null;
+            $this->get_state()->current_file_bytes = null;
         }
-        $this->save_state($this->state);
+        $this->save_state();
 
         return $complete;
     }
@@ -6242,7 +6232,7 @@ class ImportClient
      */
     private function fetch_remote_index(?string $list_dir_override = null): bool
     {
-        $cursor = $this->import_state()->index->cursor;
+        $cursor = $this->get_state()->index->cursor;
 
         $roots = $this->get_root_directories_from_preflight();
         if (empty($roots)) {
@@ -6329,8 +6319,8 @@ class ImportClient
 
             $chunks_since_save++;
             if ($chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
-                $this->import_state()->index->cursor = $cursor;
-                $this->save_state($this->state);
+                $this->get_state()->index->cursor = $cursor;
+                $this->save_state();
                 $chunks_since_save = 0;
             }
 
@@ -6461,12 +6451,12 @@ class ImportClient
                 $e,
             );
             fclose($handle);
-            $this->import_state()->index->cursor = $cursor;
-            $this->import_state()->active_resumable_command->completion_state = "partial";
-            $this->save_state($this->state);
+            $this->get_state()->index->cursor = $cursor;
+            $this->get_state()->active_resumable_command->completion_state = "partial";
+            $this->save_state();
             return false;
         }
-        $this->import_state()->consecutive_interrupted_responses = 0;
+        $this->get_state()->consecutive_interrupted_responses = 0;
         $wall_time = microtime(true) - $request_start;
         $this->finalize_tuned_request(
             "file_index",
@@ -6475,8 +6465,8 @@ class ImportClient
         );
         fclose($handle);
 
-        $this->import_state()->index->cursor = $complete ? null : $cursor;
-        $this->save_state($this->state);
+        $this->get_state()->index->cursor = $complete ? null : $cursor;
+        $this->save_state();
 
         return $complete;
     }
@@ -6490,7 +6480,7 @@ class ImportClient
             throw new RuntimeException("Remote index file not found");
         }
 
-        $diff = $this->import_state()->diff;
+        $diff = $this->get_state()->diff;
         $remote_offset = $diff->remote_offset;
         $last_local_index_entry_path = $diff->local_after;
         $fetch_list_mode = $remote_offset > 0 ? "a" : "w";
@@ -6651,15 +6641,15 @@ class ImportClient
 
             $processed++;
             if ($processed % 200 === 0) {
-                $this->import_state()->diff->remote_offset = $remote_offset;
-                $this->import_state()->diff->local_after = $last_local_index_entry_path;
+                $this->get_state()->diff->remote_offset = $remote_offset;
+                $this->get_state()->diff->local_after = $last_local_index_entry_path;
                 if (
                     $this->local_index_wal_handle
                     && !fflush($this->local_index_wal_handle)
                 ) {
                     throw new RuntimeException('Failed to flush the local index WAL.');
                 }
-                $this->save_state($this->state);
+                $this->save_state();
                 $this->progress->tick_spinner();
             }
         }
@@ -6683,10 +6673,10 @@ class ImportClient
             fclose($skipped_handle);
         }
 
-        $this->import_state()->diff->remote_offset = $remote_offset;
-        $this->import_state()->diff->local_after = $last_local_index_entry_path;
+        $this->get_state()->diff->remote_offset = $remote_offset;
+        $this->get_state()->diff->local_after = $last_local_index_entry_path;
         $this->apply_local_index_wal();
-        $this->save_state($this->state);
+        $this->save_state();
 
         return !$this->shutdown_requested;
     }
@@ -6777,7 +6767,7 @@ class ImportClient
                 "batch_entries" => $batch_entries,
                 "cursor" => null,
             ]));
-            $this->save_state($this->state);
+            $this->save_state();
         }
 
         $post_data = [
@@ -6799,14 +6789,14 @@ class ImportClient
         }
 
         // Advance the done counter by the known batch size and reset
-        // the per-batch file counter. files_imported counted files within
+        // the per-batch file counter. files_pulled counted files within
         // this batch; now that the batch is complete, those files are
         // accounted for in fetch_list_done.
         if ($this->fetch_list_done !== null) {
             $this->fetch_list_done += $batch_entries;
         }
-        $this->import_state()->files_pull_summary->files_pulled += $batch_entries;
-        $this->files_imported = 0;
+        $this->get_state()->files_pull_summary->files_pulled += $batch_entries;
+        $this->files_pulled = 0;
 
         $this->set_fetch_list_progress_state($state_key, FetchListProgressState::from_array([
             "offset" => $next_offset,
@@ -6815,7 +6805,7 @@ class ImportClient
             "batch_entries" => 0,
             "cursor" => null,
         ]));
-        $this->save_state($this->state);
+        $this->save_state();
 
         return $next_offset >= filesize($list_file);
     }
@@ -6823,10 +6813,10 @@ class ImportClient
     private function get_fetch_list_progress_state(string $state_key): FetchListProgressState
     {
         if ($state_key === "fetch") {
-            return $this->import_state()->fetch;
+            return $this->get_state()->fetch;
         }
         if ($state_key === "fetch_skipped") {
-            return $this->import_state()->fetch_skipped;
+            return $this->get_state()->fetch_skipped;
         }
         throw new InvalidArgumentException("Unknown fetch state key: {$state_key}");
     }
@@ -6834,11 +6824,11 @@ class ImportClient
     private function set_fetch_list_progress_state(string $state_key, FetchListProgressState $state): void
     {
         if ($state_key === "fetch") {
-            $this->import_state()->fetch = $state;
+            $this->get_state()->fetch = $state;
             return;
         }
         if ($state_key === "fetch_skipped") {
-            $this->import_state()->fetch_skipped = $state;
+            $this->get_state()->fetch_skipped = $state;
             return;
         }
         throw new InvalidArgumentException("Unknown fetch state key: {$state_key}");
@@ -6995,7 +6985,7 @@ class ImportClient
      */
     private function get_max_request_bytes(): int
     {
-        $preflight = $this->import_state()->preflight["data"]["limits"] ?? null;
+        $preflight = $this->get_state()->preflight["data"]["limits"] ?? null;
         $max_request = null;
         if (is_array($preflight) && isset($preflight["max_request_bytes"])) {
             $max_request = (int) $preflight["max_request_bytes"];
@@ -7014,7 +7004,7 @@ class ImportClient
      */
     private function get_uploads_basedir(): ?string
     {
-        $paths_urls = $this->import_state()->preflight["data"]["database"]["wp"]["paths_urls"] ?? null;
+        $paths_urls = $this->get_state()->preflight["data"]["database"]["wp"]["paths_urls"] ?? null;
         if (!is_array($paths_urls)) {
             return null;
         }
@@ -7520,7 +7510,7 @@ class ImportClient
      */
     private function fetch_sql(): void
     {
-        $cursor = $this->import_state()->active_resumable_command->remote_cursor ?? null;
+        $cursor = $this->get_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
         $mode = $this->sql_output_mode;
 
@@ -7537,7 +7527,7 @@ class ImportClient
 
             // Crash recovery: if SQL file is larger than expected, truncate it.
             // This happens if we crashed after writing but before saving the new cursor.
-            $tracked_bytes = $this->import_state()->sql_bytes ?? null;
+            $tracked_bytes = $this->get_state()->sql_bytes ?? null;
             if ($tracked_bytes !== null && file_exists($sql_file)) {
                 $actual_size = filesize($sql_file);
                 if ($actual_size > $tracked_bytes) {
@@ -7566,10 +7556,10 @@ class ImportClient
             }
 
         } elseif ($mode === "stdout") {
-            $sql_bytes_written = $this->import_state()->sql_bytes ?? 0;
+            $sql_bytes_written = $this->get_state()->sql_bytes ?? 0;
 
         } elseif ($mode === "mysql") {
-            $sql_bytes_written = $this->import_state()->sql_bytes ?? 0;
+            $sql_bytes_written = $this->get_state()->sql_bytes ?? 0;
 
             $host = $this->mysql_host ?? "127.0.0.1";
             $user = $this->mysql_user ?? "root";
@@ -7630,7 +7620,7 @@ class ImportClient
             : null;
         $domains_file = $this->state_dir . "/pull/domains.json";
         $sql_stats_file = $this->state_dir . "/pull/sql-stats.json";
-        $sql_statements_counted = (int) ($this->import_state()->sql_statements_counted ?? 0);
+        $sql_statements_counted = (int) ($this->get_state()->sql_statements_counted ?? 0);
 
         // Auto-detect the source site domain from the export URL so it
         // always appears in pull/domains.json even if the SQL dump
@@ -7715,10 +7705,10 @@ class ImportClient
                         if ($sql_handle) {
                             fflush($sql_handle);
                         }
-                        $this->import_state()->active_resumable_command->remote_cursor = $cursor;
-                        $this->import_state()->sql_bytes = $sql_bytes_written;
-                        $this->import_state()->sql_statements_counted = $sql_statements_counted;
-                        $this->save_state($this->state);
+                        $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                        $this->get_state()->sql_bytes = $sql_bytes_written;
+                        $this->get_state()->sql_statements_counted = $sql_statements_counted;
+                        $this->save_state();
                         $chunks_since_save = 0;
 
                         // Also persist discovered domains so they survive crashes.
@@ -7759,7 +7749,7 @@ class ImportClient
                                 if ($bytes === false) {
                                     // Broken pipe — save state and exit cleanly so the
                                     // pipe reader (e.g. `mysql`) can finish on its own.
-                                    $this->save_state($this->state);
+                                    $this->save_state();
                                     exit(0);
                                 }
                                 $sql_bytes_written += $bytes;
@@ -7815,7 +7805,7 @@ class ImportClient
                         // but only if the estimate is larger than what we've
                         // already downloaded — INFORMATION_SCHEMA estimates
                         // can be wildly off (e.g. 7 KB for a 22 MB dump).
-                        $db_bytes_est = (int) ($this->import_state()->db_index->bytes ?? 0);
+                        $db_bytes_est = (int) ($this->get_state()->db_index->bytes ?? 0);
                         $est_is_useful = $db_bytes_est > $sql_bytes_written;
                         $sql_fraction = $est_is_useful
                             ? $sql_bytes_written / $db_bytes_est
@@ -7891,7 +7881,7 @@ class ImportClient
                     $this->audit_log($retry_log, true);
                     continue;
                 }
-                $this->import_state()->consecutive_interrupted_responses = 0;
+                $this->get_state()->consecutive_interrupted_responses = 0;
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "sql_chunk",
@@ -7904,10 +7894,10 @@ class ImportClient
                     fflush($sql_handle);
                 }
 
-                $this->import_state()->active_resumable_command->remote_cursor = $cursor;
+                $this->get_state()->active_resumable_command->remote_cursor = $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
-                $this->import_state()->sql_bytes = $complete ? null : $sql_bytes_written;
-                $this->save_state($this->state);
+                $this->get_state()->sql_bytes = $complete ? null : $sql_bytes_written;
+                $this->save_state();
             }
 
             // Drain any remaining statements after download completes
@@ -8225,11 +8215,11 @@ class ImportClient
      */
     private function fetch_database_index(): void
     {
-        $cursor = $this->import_state()->active_resumable_command->remote_cursor ?? null;
+        $cursor = $this->get_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
         $tables_file = $this->state_dir . "/db-tables.jsonl";
 
-        $stats = $this->import_state()->db_index;
+        $stats = $this->get_state()->db_index;
         $tables_written = $stats->tables;
         $rows_estimated = $stats->rows_estimated;
         $bytes_written = $stats->bytes;
@@ -8372,17 +8362,17 @@ class ImportClient
                         $e,
                     );
                     fflush($handle);
-                    $this->import_state()->active_resumable_command->remote_cursor = $cursor;
-                    $this->import_state()->db_index->file = $tables_file;
-                    $this->import_state()->db_index->tables = $tables_written;
-                    $this->import_state()->db_index->rows_estimated = $rows_estimated;
-                    $this->import_state()->db_index->bytes = $bytes_written;
-                    $this->import_state()->db_index->updated_at = (string) time();
-                    $this->import_state()->active_resumable_command->completion_state = "partial";
-                    $this->save_state($this->state);
+                    $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                    $this->get_state()->db_index->file = $tables_file;
+                    $this->get_state()->db_index->tables = $tables_written;
+                    $this->get_state()->db_index->rows_estimated = $rows_estimated;
+                    $this->get_state()->db_index->bytes = $bytes_written;
+                    $this->get_state()->db_index->updated_at = (string) time();
+                    $this->get_state()->active_resumable_command->completion_state = "partial";
+                    $this->save_state();
                     return;
                 }
-                $this->import_state()->consecutive_interrupted_responses = 0;
+                $this->get_state()->consecutive_interrupted_responses = 0;
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "db_index",
@@ -8391,13 +8381,13 @@ class ImportClient
                 );
 
                 fflush($handle);
-                $this->import_state()->active_resumable_command->remote_cursor = $cursor;
-                $this->import_state()->db_index->file = $tables_file;
-                $this->import_state()->db_index->tables = $tables_written;
-                $this->import_state()->db_index->rows_estimated = $rows_estimated;
-                $this->import_state()->db_index->bytes = $bytes_written;
-                $this->import_state()->db_index->updated_at = (string) time();
-                $this->save_state($this->state);
+                $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                $this->get_state()->db_index->file = $tables_file;
+                $this->get_state()->db_index->tables = $tables_written;
+                $this->get_state()->db_index->rows_estimated = $rows_estimated;
+                $this->get_state()->db_index->bytes = $bytes_written;
+                $this->get_state()->db_index->updated_at = (string) time();
+                $this->save_state();
             }
         } finally {
             fclose($handle);
@@ -8456,7 +8446,7 @@ class ImportClient
      *   |-- style.css
      *   `-- index.php
      *
-     * Local import state:
+     * Local pull state:
      *
      *   <state-dir>/filesystem root/
      *   |-- tmp/e2e-shared-themes/pub/indice/
@@ -8591,7 +8581,7 @@ class ImportClient
     private function assert_resolved_path_mappings_consistent(): void
     {
         $fingerprint = $this->resolved_path_mappings_fingerprint();
-        $previous = $this->import_state()->resolved_path_mappings_fingerprint ?? null;
+        $previous = $this->get_state()->resolved_path_mappings_fingerprint ?? null;
 
         $has_existing_index = file_exists($this->local_index_file) && filesize($this->local_index_file) > 0;
         if ($previous === null && $has_existing_index && !empty($this->resolved_path_mappings)) {
@@ -8609,8 +8599,8 @@ class ImportClient
         }
 
         if ($previous === null) {
-            $this->import_state()->resolved_path_mappings_fingerprint = $fingerprint;
-            $this->save_state($this->state);
+            $this->get_state()->resolved_path_mappings_fingerprint = $fingerprint;
+            $this->save_state();
         }
     }
 
@@ -8643,7 +8633,7 @@ class ImportClient
         }
 
         $fingerprint = $this->files_pull_only_fingerprint();
-        $previous = $this->import_state()->files_pull_only_fingerprint ?? null;
+        $previous = $this->get_state()->files_pull_only_fingerprint ?? null;
 
         if ($previous !== null && $previous !== $fingerprint) {
             throw new RuntimeException(
@@ -8655,8 +8645,8 @@ class ImportClient
         // Older in-progress state may not have this guard persisted yet. Record
         // the current value so subsequent resumes cannot drift.
         if ($previous === null) {
-            $this->import_state()->files_pull_only_fingerprint = $fingerprint;
-            $this->save_state($this->state);
+            $this->get_state()->files_pull_only_fingerprint = $fingerprint;
+            $this->save_state();
         }
     }
 
@@ -8683,7 +8673,7 @@ class ImportClient
     private function assert_local_followed_symlinks_root_unchanged(): void
     {
         $fingerprint = $this->local_followed_symlinks_root_fingerprint();
-        $previous = $this->import_state()->local_followed_symlinks_root_fingerprint ?? null;
+        $previous = $this->get_state()->local_followed_symlinks_root_fingerprint ?? null;
 
         if ($previous !== null && $previous !== $fingerprint) {
             throw new RuntimeException(
@@ -8693,8 +8683,8 @@ class ImportClient
         }
 
         if ($previous === null) {
-            $this->import_state()->local_followed_symlinks_root_fingerprint = $fingerprint;
-            $this->save_state($this->state);
+            $this->get_state()->local_followed_symlinks_root_fingerprint = $fingerprint;
+            $this->save_state();
         }
     }
 
@@ -8903,7 +8893,7 @@ class ImportClient
      */
     private function wp_source_path_tokens(): array
     {
-        $preflight = $this->import_state()->preflight["data"] ?? [];
+        $preflight = $this->get_state()->preflight["data"] ?? [];
         $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
 
         $content_dir = $this->clean_preflight_path( $paths["content_dir"] ?? null);
@@ -9098,7 +9088,7 @@ class ImportClient
             $local_size = $exists_locally ? filesize($local_absolute_path) : 0;
             $file_size = (int) ($headers["x-file-size"] ?? 0);
 
-            // Log file import with useful context
+            // Log file pull with useful context
             $this->audit_log(
                 sprintf(
                     "File: %s (remote_size=%d, ctime=%d, local_exists=%s, local_size=%d)",
@@ -9111,7 +9101,7 @@ class ImportClient
                 false,
             );
 
-            $files_done = ($this->fetch_list_done ?? 0) + $this->files_imported;
+            $files_done = ($this->fetch_list_done ?? 0) + $this->files_pulled;
             $files_total = $this->fetch_list_total;
             $file_fraction = ($files_total !== null && $files_total > 0)
                 ? $files_done / $files_total
@@ -9221,7 +9211,7 @@ class ImportClient
                     $file_size,
                     "file",
                 );
-                $this->files_imported++; // Count completed files only
+                $this->files_pulled++; // Count completed files only
                 $this->clear_volatile_file($path);
                 $this->audit_log(
                     sprintf("  Indexed (wrote %d bytes)", $final_size),
@@ -9239,8 +9229,8 @@ class ImportClient
             $context->file_ctime = null;
             $context->file_bytes_written = 0;
             // Clear crash recovery tracking - file is complete
-            $this->import_state()->current_file = null;
-            $this->import_state()->current_file_bytes = null;
+            $this->get_state()->current_file = null;
+            $this->get_state()->current_file_bytes = null;
         }
     }
 
@@ -9542,7 +9532,7 @@ class ImportClient
      * validates that the target stays within the filesystem root (preventing
      * directory traversal), then creates the symlink.  Failures are logged
      * to the audit log and reported as symlink_error progress events — they
-     * do not halt the import.
+     * do not halt the pull.
      *
      * @param array $chunk Multipart chunk with x-symlink-path, x-symlink-target,
      *                     and x-symlink-ctime headers (all base64-encoded).
@@ -9803,7 +9793,7 @@ class ImportClient
      */
     private function get_root_directories_from_preflight(): array
     {
-        $roots = $this->import_state()->preflight["data"]["wp_detect"]["roots"] ?? [];
+        $roots = $this->get_state()->preflight["data"]["wp_detect"]["roots"] ?? [];
         if (!is_array($roots) || empty($roots)) {
             return [];
         }
@@ -9872,7 +9862,7 @@ class ImportClient
             return $this->export_directories_cache;
         }
 
-        $preflight = $this->import_state()->preflight["data"] ?? [];
+        $preflight = $this->get_state()->preflight["data"] ?? [];
 
         // Collect extra paths that may live outside the wp_detect roots.
         $extra_paths = [
@@ -10164,7 +10154,7 @@ class ImportClient
 
     private function get_base_headers(string $accept): array
     {
-        $ua = $this->import_state()->user_agent ?? self::USER_AGENTS[0];
+        $ua = $this->get_state()->user_agent ?? self::USER_AGENTS[0];
         return [
             "User-Agent: {$ua}",
             "Accept: {$accept}",
@@ -10326,12 +10316,12 @@ class ImportClient
         TransientInterruptionException $exception
     ): void {
         if ($cursor_after !== null && $cursor_after !== $cursor_before) {
-            $this->import_state()->consecutive_interrupted_responses = 0;
+            $this->get_state()->consecutive_interrupted_responses = 0;
         } else {
-            $this->import_state()->consecutive_interrupted_responses++;
+            $this->get_state()->consecutive_interrupted_responses++;
         }
 
-        $count = $this->import_state()->consecutive_interrupted_responses;
+        $count = $this->get_state()->consecutive_interrupted_responses;
 
         $this->audit_log(
             "INTERRUPTED RESPONSE | {$phase} | " .
@@ -10901,7 +10891,7 @@ class ImportClient
                         // without files_total confuses consumers.
                         if ($this->fetch_list_total !== null) {
                             $heartbeat["files_done"] =
-                                ($this->fetch_list_done ?? 0) + $this->files_imported;
+                                ($this->fetch_list_done ?? 0) + $this->files_pulled;
                             $heartbeat["files_total"] = $this->fetch_list_total;
                         }
                         fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
@@ -11001,7 +10991,7 @@ class ImportClient
     private function reset_state(): void
     {
         $previous_state = $this->state;
-        $this->state = new ImportState();
+        $this->state = new PullState();
         $this->state->preflight = $previous_state->preflight;
         $this->state->version = $previous_state->version;
         $this->state->webhost = $previous_state->webhost;
@@ -11012,8 +11002,8 @@ class ImportClient
         $this->state->pull_pipeline = $previous_state->pull_pipeline;
     }
 
-    /** Return the in-process import state. */
-    private function import_state(): ImportState
+    /** Return the in-process pull state. */
+    public function get_state(): PullState
     {
         return $this->state;
     }
@@ -11237,31 +11227,31 @@ class ImportClient
         }
         if (!str_starts_with($value, self::STATE_PATH_ENCODING_PREFIX)) {
             throw new UnexpectedValueException(
-                "Import state path is missing the base64: encoding prefix."
+                "Pull state path is missing the base64: encoding prefix."
             );
         }
         $encoded = substr($value, strlen(self::STATE_PATH_ENCODING_PREFIX));
         $decoded = base64_decode($encoded, true);
         if ($decoded === false) {
             throw new UnexpectedValueException(
-                "Import state path contains invalid base64 after the base64: encoding prefix."
+                "Pull state path contains invalid base64 after the base64: encoding prefix."
             );
         }
         return $decoded;
     }
 
     /**
-     * Load import state from disk.
+     * Load pull state from disk.
      */
-    private function load_state(): ImportState
+    private function load_state(): PullState
     {
         if (!file_exists($this->pull_state_file)) {
-            return new ImportState();
+            return new PullState();
         }
 
         $contents = file_get_contents($this->pull_state_file);
         if ($contents === false) {
-            return new ImportState();
+            return new PullState();
         }
 
         $state = json_decode($contents, true);
@@ -11272,28 +11262,28 @@ class ImportClient
             );
             $corrupt_name = $this->pull_state_file . ".corrupt." . time();
             @rename($this->pull_state_file, $corrupt_name);
-            return new ImportState();
+            return new PullState();
         }
 
         $state = $this->decode_state_paths($state);
 
-        return ImportState::from_array($state);
+        return PullState::from_array($state);
     }
 
     /**
-     * Save import state to disk.
+     * Save pull state to disk.
      *
      * Uses atomic write (temp file + rename) to prevent corruption if
      * the process is killed mid-write.
      */
-    private function save_state(ImportState $state): void
+    public function save_state(): void
     {
         // Keep the spinner alive between curl requests. save_state is
         // called frequently during streaming operations, so this fills
         // the gaps where curl's progress callback doesn't fire.
         $this->progress->tick_spinner();
 
-        $state = $state->to_array();
+        $state = $this->state->to_array();
         if ($this->tuner instanceof AdaptiveTuner) {
             $state["tuning"] = [
                 "config" => $this->tuner->get_config(),
@@ -11317,7 +11307,7 @@ class ImportClient
         }
 
         $indexed = $this->index_count();
-        $files_imported = $this->files_imported; // Completed in this run
+        $files_pulled = $this->files_pulled; // Completed in this run
         $has_cursor =
             !empty($state["active_resumable_command"]["remote_cursor"] ?? null) ||
             !empty($state["index"]["cursor"] ?? null) ||
@@ -11328,7 +11318,7 @@ class ImportClient
             sprintf(
                 "SAVE CURSOR | total_indexed=%d | completed_this_run=%d | %s",
                 $indexed,
-                $files_imported,
+                $files_pulled,
                 $cursor_info,
             ),
             false,
@@ -11366,7 +11356,7 @@ class ImportClient
 
         $json = json_encode($payload, JSON_PRETTY_PRINT);
         if ($json === false) {
-            return; // Best-effort — don't crash the import over a progress file
+            return; // Best-effort — don't crash the pull over a progress file
         }
         $tmp = $this->progress_file . ".tmp";
         if (file_put_contents($tmp, $json) !== false) {
@@ -11411,15 +11401,15 @@ class ImportClient
 
         // Log final progress before exit
         $indexed = $this->index_count();
-        $files_imported = $this->files_imported; // Files completed in this run
-        $current_command = $this->import_state()->active_resumable_command->command_name ?? "unknown";
+        $files_pulled = $this->files_pulled; // Files completed in this run
+        $current_command = $this->get_state()->active_resumable_command->command_name ?? "unknown";
 
         $this->audit_log(
             sprintf(
                 "SHUTDOWN REQUESTED | command=%s | total_indexed=%d files | completed_this_run=%d files",
                 $current_command,
                 $indexed,
-                $files_imported,
+                $files_pulled,
             ),
             true,
         );
@@ -11427,18 +11417,18 @@ class ImportClient
         $this->progress->show_lifecycle_line("\nInterrupted - saving state...\n");
         $this->progress->show_lifecycle_line("  Command: {$current_command}\n");
         $this->progress->show_lifecycle_line("  Total files indexed: {$indexed}\n");
-        $this->progress->show_lifecycle_line("  Files completed in this run: {$files_imported}\n");
+        $this->progress->show_lifecycle_line("  Files completed in this run: {$files_pulled}\n");
         $this->output_progress([
             "type" => "interrupt",
             "command" => $current_command,
             "files_indexed" => $indexed,
-            "files_completed" => $files_imported,
+            "files_completed" => $files_pulled,
             "message" => "Interrupted - saving state...",
         ], true);
 
         // Save current state (with timeout protection)
         try {
-            $this->save_state($this->state);
+            $this->save_state();
             $this->progress->show_lifecycle_line("✓ State saved successfully\n");
             $this->output_progress([
                 "type" => "state_saved",
@@ -11493,7 +11483,7 @@ class ImportClient
             $written = @fwrite($this->progress_fd, json_encode($data) . "\n");
             if ($written === false) {
                 // Broken pipe — save state and exit cleanly
-                $this->save_state($this->state);
+                $this->save_state();
                 exit(0);
             }
             @flush();
@@ -11627,7 +11617,7 @@ if (
             'type' => 'value',
             'target' => 'state_dir',
             'placeholder' => 'DIR',
-            'help' => 'Directory for import state files and SQL dumps',
+            'help' => 'Directory for pull state files and SQL dumps',
             'help_section' => 'required',
             'commands' => [],
         ],
@@ -12414,7 +12404,7 @@ if (
     $command_info = [
         "pull" => [
             "level" => "high",
-            "short" => "Clone a remote site (preflight + files + database + import)",
+            "short" => "Clone a remote site (preflight + files + database + apply)",
             "description" =>
                 "Full site clone in a single command. Composes lower-level commands into\n" .
                 "a resumable pipeline:\n" .
@@ -12422,7 +12412,7 @@ if (
                 "  1. Preflight — probe the remote site environment\n" .
                 "  2. Files     — download all remote files into --fs-root\n" .
                 "  3. Database  — download the SQL dump\n" .
-                "  4. Import    — apply SQL to a local database (if --target-db)\n" .
+                "  4. Apply     — apply SQL to a local database (if --target-db)\n" .
                 "  5. Flatten   — reassemble into standard WP layout (if --flatten-to)\n" .
                 "  6. Runtime   — generate server config (default: php-builtin)\n" .
                 "  7. Start     — launch the selected runtime when supported\n" .
@@ -12438,11 +12428,11 @@ if (
                 "so you can pass just the site URL.\n",
             "extra" =>
                 "Examples:\n" .
-                "  # Download files and database (no import):\n" .
+                "  # Download files and database without applying SQL:\n" .
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files\n" .
                 "\n" .
-                "  # Full clone with MySQL import and URL rewriting:\n" .
+                "  # Full clone with MySQL database apply and URL rewriting:\n" .
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-user=root --target-db=wp_local \\\n" .
@@ -12493,11 +12483,11 @@ if (
                 "\n" .
                 "  1. Preflight — probe the remote site environment\n" .
                 "  2. db-pull — download the SQL dump into --state-dir/db.sql\n" .
-                "  3. db-apply — import the dump into a local database\n" .
+                "  3. db-apply — apply the dump to a local database\n" .
                 "\n" .
                 "This gives the database the same retry and resume behavior as pull,\n" .
                 "without running the file or runtime stages. With no MySQL target\n" .
-                "options, pull-db imports into SQLite by default.\n",
+                "options, pull-db applies the dump to SQLite by default.\n",
             "extra" =>
                 "Examples:\n" .
                 "  reprint pull-db https://example.com \\\n" .
@@ -12689,20 +12679,20 @@ if (
                 "  reprint db-domains - --state-dir=/path/to/state\n",
             "extra" => null,
         ],
-        "import-metadata" => [
+        "pull-metadata" => [
             "level" => "low",
-            "short" => "Print local metadata for host integrations as JSON",
-            "usage" => "reprint import-metadata --state-dir=DIR",
+            "short" => "Print local pull metadata for host integrations as JSON",
+            "usage" => "reprint pull-metadata --state-dir=DIR",
             "description" =>
                 "Reads --state-dir/pull/state.json and prints pull lifecycle and\n" .
                 "source-site metadata for host integrations. No network calls are made.\n",
             "extra" =>
                 "Example:\n" .
-                "  reprint import-metadata --state-dir=./state | jq '.hasCompletedOnce'\n",
+                "  reprint pull-metadata --state-dir=./state | jq '.hasCompletedOnce'\n",
         ],
         "db-apply" => [
             "level" => "low",
-            "short" => "Import the SQL dump into a local MySQL or SQLite database",
+            "short" => "Apply the SQL dump to a local MySQL or SQLite database",
             "description" =>
                 "Reads db.sql from --state-dir, optionally rewrites URLs, and executes\n" .
                 "all statements against a target database. Resumable. Saves target\n" .
@@ -12809,6 +12799,7 @@ if (
         "db-sync" => "db-pull",
         "flat-document-root" => "flat-docroot",
         "flatten-docroot" => "flat-docroot",
+        "import-metadata" => "pull-metadata",
     ];
     if (isset($command_aliases[$command])) {
         $command = $command_aliases[$command];
@@ -12827,10 +12818,10 @@ if (
         exit(0);
     }
 
-    // apply-runtime and import-metadata don't need a remote URL. Other
+    // apply-runtime and pull-metadata don't need a remote URL. Other
     // local-only commands (db-domains, db-apply, etc.) still accept it for
     // CLI consistency and backward compatibility with existing callers.
-    $local_only_commands = ["apply-runtime", "import-metadata"];
+    $local_only_commands = ["apply-runtime", "pull-metadata"];
     $is_local_only = in_array($command, $local_only_commands, true);
 
     if ($is_local_only) {
@@ -12897,7 +12888,7 @@ if (
         fwrite(STDERR, "Use --fs-root for the raw download directory, or --flat-document-root for a flattened layout.\n");
         exit(1);
     }
-    if (!$filesystem_root && !$flat_document_root && $command !== "import-metadata") {
+    if (!$filesystem_root && !$flat_document_root && $command !== "pull-metadata") {
         fwrite(STDERR, "Error: --fs-root=DIR is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
@@ -12905,7 +12896,7 @@ if (
     if (!$filesystem_root) {
         // For commands that need a filesystem root in the constructor, use the
         // flattened filesystem root. run_apply_runtime will resolve it properly.
-        // import-metadata reads only state, but ImportClient still expects
+        // pull-metadata reads only state, but ImportClient still expects
         // a filesystem root path. Point it at state-dir rather than requiring an
         // otherwise-unused CLI option.
         $filesystem_root = $flat_document_root ?: $state_dir;
@@ -12944,20 +12935,20 @@ if (
                     : ['files_diff_push_state_directory' => $reprint_files_diff_push_state_directory] ),
             $reprint_process_lock
         );
-        // EXIT_AFTER_IMPORT controls whether we hand control back to
+        // EXIT_AFTER_PULL controls whether we hand control back to
         // the caller after pull returns. Default true: standard CLI
         // invocations (reprint pull, the phar bin, e2e tests) get the
         // exit() they expect. Embedders that include the phar from a
         // web SAPI — the Playground wizard in reprint-import.php is
-        // the live case — define EXIT_AFTER_IMPORT=false so cleanup
+        // the live case — define EXIT_AFTER_PULL=false so cleanup
         // logic can run AFTER pull, in the same try/catch scope as
         // the include. Without that knob the bare exit() jumps the
         // embedder's stack and forces it to wire activation through
         // register_shutdown_function, where exceptions have no
         // channel to surface as ndjson events. Stash the exit code on
         // a global so the embedder can read it.
-        $GLOBALS['REPRINT_IMPORTER_EXIT_CODE'] = (int) $client->exit_code;
-        if (!defined('EXIT_AFTER_IMPORT') || EXIT_AFTER_IMPORT) {
+        $GLOBALS['REPRINT_PULL_EXIT_CODE'] = (int) $client->exit_code;
+        if (!defined('EXIT_AFTER_PULL') || EXIT_AFTER_PULL) {
             exit($client->exit_code);
         }
         return;
@@ -12980,11 +12971,11 @@ if (
             }
             fwrite(STDERR, $json . "\n");
         }
-        $GLOBALS['REPRINT_IMPORTER_EXIT_CODE'] = 1;
-        if (!defined('EXIT_AFTER_IMPORT') || EXIT_AFTER_IMPORT) {
+        $GLOBALS['REPRINT_PULL_EXIT_CODE'] = 1;
+        if (!defined('EXIT_AFTER_PULL') || EXIT_AFTER_PULL) {
             exit(1);
         }
-        // When EXIT_AFTER_IMPORT is false we still want the embedder
+        // When EXIT_AFTER_PULL is false we still want the embedder
         // to see the failure — re-throw so its try/catch around
         // `include $phar` can surface a proper `{type:'error'}` event.
         throw $e;

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -87,7 +87,7 @@ class Pull
             case 'preflight':     return 'Connecting';
             case 'files-pull':    return 'Pulling files';
             case 'db-pull':       return 'Pulling database';
-            case 'db-apply':      return 'Importing database';
+            case 'db-apply':      return 'Applying database';
             case 'flat-docroot':  return 'Flattening layout';
             case 'apply-runtime': return 'Preparing runtime';
             case 'start':         return 'Starting server';
@@ -122,7 +122,7 @@ class Pull
      */
     public function abort(string $command = 'pull'): void
     {
-        $state = $this->client->get_import_state();
+        $state = $this->client->get_state();
         if (
             $command === 'pull-files'
             || (
@@ -156,7 +156,7 @@ class Pull
         $this->progress->set_mode('pipeline');
 
         if (!isset($options['filter'])) {
-            $options['filter'] = $this->client->get_import_state()->filter ?? 'none';
+            $options['filter'] = $this->client->get_state()->filter ?? 'none';
         }
         if (!in_array($options['filter'], ['none', 'essential-files'], true)) {
             throw new InvalidArgumentException(
@@ -196,9 +196,9 @@ class Pull
     /**
      * Runs a named pull pipeline from the first unfinished stage.
      *
-     * ImportState::$pull_pipeline records orchestration progress: which
+     * PullState::$pull_pipeline records orchestration progress: which
      * user-facing command started the pipeline and which whole stage was last
-     * completed. ImportState::$active_resumable_command records the resumable
+     * completed. PullState::$active_resumable_command records the resumable
      * lower-level command, whether it was invoked directly or as a stage in
      * this pipeline, including its completion status, internal state, and
      * remote cursor.
@@ -213,7 +213,7 @@ class Pull
         array $options,
         string $title
     ): void {
-        $state = $this->client->get_import_state();
+        $state = $this->client->get_state();
         $pull_pipeline = $state->pull_pipeline->started_by_command;
         $pull_stage = $state->pull_pipeline->last_completed_stage;
         $stage_sequence = $state->pull_pipeline->stage_sequence;
@@ -282,7 +282,7 @@ class Pull
                 // Keep the local file index, but clear transient files-pull
                 // download state so this pipeline computes a fresh
                 // remote-vs-local delta.
-                $state = $this->client->get_import_state();
+                $state = $this->client->get_state();
                 $state->active_resumable_command->command_name = null;
                 $state->active_resumable_command->completion_state = null;
                 $state->active_resumable_command->remote_cursor = null;
@@ -296,7 +296,7 @@ class Pull
                 $state->fetch_skipped = new FetchListProgressState();
                 $state->files_pull_summary = new FilesPullSummaryState();
                 $state->files_pull_only_fingerprint = null;
-                $this->client->save_import_state();
+                $this->client->save_state();
                 foreach ([
                     "{$state_dir}/pull/remote-index.jsonl",
                     "{$state_dir}/pull/fetch-list.jsonl",
@@ -308,7 +308,7 @@ class Pull
                 }
             } elseif ($state_command === 'db-pull' && in_array('db-pull', $stages, true)) {
                 // Discard database dump artifacts from any previous runs.
-                $state = $this->client->get_import_state();
+                $state = $this->client->get_state();
                 $state->active_resumable_command->command_name = null;
                 $state->active_resumable_command->completion_state = null;
                 $state->active_resumable_command->remote_cursor = null;
@@ -316,7 +316,7 @@ class Pull
                 $state->consecutive_interrupted_responses = 0;
                 $state->sql_bytes = null;
                 $state->db_index = new DatabaseTableIndexState();
-                $this->client->save_import_state();
+                $this->client->save_state();
                 foreach ([
                     "{$state_dir}/db.sql",
                     "{$state_dir}/db-tables.jsonl",
@@ -409,7 +409,7 @@ class Pull
         switch ($stage) {
             case 'preflight':
                 $this->client->run_preflight();
-                $preflight = $this->client->get_import_state()->preflight;
+                $preflight = $this->client->get_state()->preflight;
                 $ok = ($preflight["http_code"] ?? 0) === 200 && !empty($preflight["data"]["ok"]);
                 if (!$ok) {
                     $this->client->exit_code = 1;
@@ -441,7 +441,7 @@ class Pull
                     $options['filter'] === 'essential-files' &&
                     $this->client->has_skipped_files_pending();
                 $this->client->set_pull_files_state($options['filter'], $skipped_pending);
-                $files_pulled = $this->client->get_import_state()->files_pull_summary->files_pulled;
+                $files_pulled = $this->client->get_state()->files_pull_summary->files_pulled;
                 $pulled_label = $files_pulled === 1 ? 'file' : 'files';
                 $summary = sprintf(
                     '%s changed %s pulled',
@@ -457,8 +457,8 @@ class Pull
             case 'db-pull':
                 // A completed db-pull is useful only when the downloaded SQL
                 // dump is still present. Without the dump, the following
-                // db-apply stage would have nothing safe to import.
-                $state = $this->client->get_import_state();
+                // db-apply stage would have nothing safe to apply.
+                $state = $this->client->get_state();
                 if (
                     $state->active_resumable_command->command_name !== 'db-pull' ||
                     $state->active_resumable_command->completion_state !== 'complete' ||
@@ -480,10 +480,10 @@ class Pull
                 break;
 
             case 'db-apply':
-                // Database import is not safe to run twice. If db-apply
+                // Database apply is not safe to run twice. If db-apply
                 // already reached lower-level completion, accept that result even
                 // when the pipeline checkpoint still needs to be advanced.
-                $state = $this->client->get_import_state();
+                $state = $this->client->get_state();
                 if (
                     $state->active_resumable_command->command_name !== 'db-apply' ||
                     $state->active_resumable_command->completion_state !== 'complete'
@@ -570,7 +570,7 @@ class Pull
         }
 
         if (!isset($options['filter'])) {
-            $options['filter'] = $this->client->get_import_state()->filter;
+            $options['filter'] = $this->client->get_state()->filter;
         }
         if (!in_array($options['filter'], ['none', 'essential-files'], true)) {
             throw new InvalidArgumentException(
@@ -657,8 +657,8 @@ class Pull
      * Applies the database target defaults for generated runtimes.
      *
      * php-builtin and playground-cli can run without a local MySQL server, so
-     * pull imports into SQLite by default for those runtimes. nginx-fpm does
-     * not imply a database target because it is normally used with an
+     * pull applies the dump to SQLite by default for those runtimes. nginx-fpm
+     * does not imply a database target because it is normally paired with an
      * externally managed server.
      */
     private function default_pull_target_options(array $options): array
@@ -693,10 +693,10 @@ class Pull
     }
 
     /**
-     * Validates database import target options.
+     * Validates database apply target options.
      *
-     * MySQL imports need a user and database name because Reprint connects to
-     * an existing server. SQLite imports can use the generated default path
+     * MySQL database apply needs a user and database name because Reprint connects to
+     * an existing server. SQLite database apply can use the generated default path
      * when no explicit target path is supplied.
      */
     private function validate_database_target_options(array $options): array
@@ -715,12 +715,12 @@ class Pull
         if (($options['target_engine'] ?? 'mysql') === 'mysql') {
             if (empty($options['target_user'])) {
                 throw new InvalidArgumentException(
-                    "--target-user is required for MySQL database import."
+                    "--target-user is required when db-apply targets MySQL."
                 );
             }
             if (empty($options['target_db'])) {
                 throw new InvalidArgumentException(
-                    "--target-db is required for MySQL database import."
+                    "--target-db is required when db-apply targets MySQL."
                 );
             }
         }
@@ -792,7 +792,7 @@ class Pull
         }
 
 
-        $state = $this->client->get_import_state();
+        $state = $this->client->get_state();
         $state->pull_pipeline->started_by_command = $command;
         $state->pull_pipeline->stage_sequence = [];
         $state->pull_pipeline->last_completed_stage = null;
@@ -822,7 +822,7 @@ class Pull
             $state->apply = new DatabaseApplyCommandState();
             $state->sql_output = null;
         }
-        $this->client->save_import_state();
+        $this->client->save_state();
 
         $paths = [];
         if ($reset_file_transfer_state) {
@@ -855,7 +855,7 @@ class Pull
     {
         for ($attempt = 0; $attempt < 1000; $attempt++) {
             $handler();
-            $state = $this->client->get_import_state();
+            $state = $this->client->get_state();
             if ($state->active_resumable_command->completion_state === 'complete') {
                 return;
             }
@@ -863,7 +863,7 @@ class Pull
                 throw new RuntimeException("Stage {$stage} stopped before completing.");
             }
             $state->active_resumable_command->completion_state = 'in_progress';
-            $this->client->save_import_state();
+            $this->client->save_state();
             $this->client->exit_code = 0;
             $this->progress->tick_spinner();
         }
@@ -894,11 +894,11 @@ class Pull
 
         // Mark pull complete BEFORE the server blocks so killing the
         // server (Ctrl-C) doesn't leave the pipeline mid-flight.
-        $state = $this->client->get_import_state();
+        $state = $this->client->get_state();
         $state->pull_pipeline->last_completed_stage = 'start';
         $state->pull_pipeline->has_completed_once = true;
         $state->active_resumable_command->completion_state = 'complete';
-        $this->client->save_import_state();
+        $this->client->save_state();
 
         $green = "\033[32m";
         $bold = "\033[1m";
@@ -976,7 +976,7 @@ class Pull
         $this->progress->print_line(
             "\n{$green}{$bold}Done.{$r} {$dim}Files in {$filesystem_root}{$r}\n"
         );
-        if ($this->client->get_import_state()->pull_pipeline->skipped_pending) {
+        if ($this->client->get_state()->pull_pipeline->skipped_pending) {
             $this->progress->print_line(
                 "{$dim}Deferred files remain. The skipped fetch list was preserved on disk for a follow-up sync.{$r}\n"
             );

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 
 /**
- * Typed import-state objects.
+ * Typed pull-state objects.
  *
- * The importer persists state as JSON, so these objects keep explicit
+ * Reprint persists pull state as JSON, so these objects keep explicit
  * in-process property names while to_array()/from_array() define the current
  * on-disk schema.
  */
@@ -26,7 +26,7 @@ class ResumableCommandCheckpointState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->command_name = $data['command_name'];
         $state->completion_state = $data['completion_state'];
         $state->current_stage = $data['current_stage'];
@@ -65,7 +65,7 @@ class DatabaseTableIndexState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->file = $data['file'];
         $state->tables = $data['tables'];
         $state->rows_estimated = $data['rows_estimated'];
@@ -97,7 +97,7 @@ class FileDiffProgressState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->remote_offset = $data['remote_offset'];
         $state->local_after = $data['local_after'];
         return $state;
@@ -120,7 +120,7 @@ class RemoteFileIndexCursorState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->cursor = $data['cursor'];
         return $state;
     }
@@ -151,7 +151,7 @@ class FetchListProgressState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->offset = $data['offset'];
         $state->next_offset = $data['next_offset'];
         $state->batch_file = $data['batch_file'];
@@ -180,7 +180,7 @@ class FilesPullSummaryState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->files_pulled = $data['files_pulled'];
         return $state;
     }
@@ -233,7 +233,7 @@ class DatabaseApplyCommandState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->statements_executed = $data['statements_executed'];
         $state->bytes_read = $data['bytes_read'];
         $state->rewrite_url = $data['rewrite_url'];
@@ -277,7 +277,7 @@ class AdaptiveTuningState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->config = $data['config'];
         $state->state = $data['state'];
         return $state;
@@ -315,7 +315,7 @@ class PullPipelineCheckpointState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->started_by_command = $data['started_by_command'];
         $state->stage_sequence = array_values($data['stage_sequence']);
         $state->last_completed_stage = $data['last_completed_stage'];
@@ -339,19 +339,19 @@ class PullPipelineCheckpointState
 }
 
 /**
- * In-process import state with typed properties for each persisted field.
+ * In-process pull state with typed properties for each persisted field.
  *
  * This object mirrors pull/state.json. Add new persistent state here first;
  * from_array() requires the complete current schema.
  */
-class ImportState
+class PullState
 {
     /** Resume checkpoint for a lower-level command run directly or inside a pull pipeline. */
     public ResumableCommandCheckpointState $active_resumable_command;
     /** @var array<string,mixed>|null */
     public ?array $preflight = null;
     public ?int $remote_protocol_version = null;
-    /** @var string|null Importer version saved with state. */
+    /** @var string|null Source WordPress version saved with state. */
     public ?string $version = null;
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
@@ -386,7 +386,7 @@ class ImportState
     /**
      * @var string|null MySQL host persisted for resume.
      *
-     * The password is deliberately excluded from import state.
+     * The password is deliberately excluded from pull state.
      */
     public ?string $mysql_host = null;
     /** @var int|null MySQL port persisted for resume. */
@@ -419,7 +419,7 @@ class ImportState
     public static function from_array(array $data): self
     {
         $state = new self();
-        reprint_assert_import_state_keys($data, array_keys($state->to_array()), self::class);
+        reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->active_resumable_command = ResumableCommandCheckpointState::from_array($data['active_resumable_command']);
         $state->preflight = $data['preflight'];
         $state->remote_protocol_version = $data['remote_protocol_version'];
@@ -495,12 +495,12 @@ class ImportState
 }
 
 /**
- * Reject import-state shapes other than the one written by the current code.
+ * Reject pull-state shapes other than the one written by the current code.
  *
  * @param array<string,mixed> $data          Observed state data.
  * @param string[]            $expected_keys Current field names.
  */
-function reprint_assert_import_state_keys(array $data, array $expected_keys, string $state_name): void
+function reprint_assert_state_keys(array $data, array $expected_keys, string $state_name): void
 {
     $actual_keys = array_keys($data);
     sort($actual_keys);

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -824,7 +824,7 @@ $('#start-btn')?.addEventListener('click', async () => {
     provisioned = await res.json();
   } catch (e) {
     setPhase('provision', 'error', e.message.slice(0, 80));
-    showImportError('Provision failed: ' + e.message);
+    showPullError('Provision failed: ' + e.message);
     return;
   }
 
@@ -884,7 +884,7 @@ function goToPlayground({ api_url, secret, site_url }) {
 }
 
 
-function showImportError(msg) {
+function showPullError(msg) {
   const banner = $('#error-banner');
   banner.textContent = msg;
   banner.classList.remove('hidden');

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -213,7 +213,7 @@ function handleEvent(ev) {
   }
 }
 
-async function runImport() {
+async function runPull() {
   // Credentials are baked into the page server-side by the wizard's
   // ?action=blueprint endpoint. We read them via tiny PHP echoes into
   // window globals, set just before this script runs.
@@ -327,7 +327,7 @@ async function runImport() {
   };
 }
 
-window.addEventListener('DOMContentLoaded', runImport);
+window.addEventListener('DOMContentLoaded', runPull);
 </script>
 </body>
 </html>
@@ -336,13 +336,13 @@ window.addEventListener('DOMContentLoaded', runImport);
 // ─────────────────────────────────────────────────────────────────
 
 function stream_pull_and_activate(): void {
-    // The phar checks EXIT_AFTER_IMPORT; setting it to false makes
+    // The phar checks EXIT_AFTER_PULL; setting it to false makes
     // it return control after pull instead of exit()ing. We run
     // activation in the same try/catch scope as the include, so
     // exceptions surface as proper {type:'error'} ndjson events
     // instead of disappearing into a shutdown handler.
-    if (!defined('EXIT_AFTER_IMPORT')) {
-        define('EXIT_AFTER_IMPORT', false);
+    if (!defined('EXIT_AFTER_PULL')) {
+        define('EXIT_AFTER_PULL', false);
     }
     stream_pull();
     $activate = run_local_activation();

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -35,6 +35,13 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--new-site-url=URL', $output);
     }
 
+    public function testImportMetadataAliasShowsPullMetadataHelp(): void
+    {
+        $output = $this->runHelp('import-metadata');
+
+        $this->assertStringContainsString('Usage: reprint pull-metadata --state-dir=DIR', $output);
+    }
+
     public function testFilesPushHelpShowsOnlyItsCommandOptions(): void
     {
         $output = $this->runHelp('files-push');

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -62,7 +62,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(), array_replace_recursive([
+        \write_current_pull_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -308,7 +308,7 @@ class DeactivateHostPluginsTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(), $state);
+        \write_current_pull_state($this->makeClient(), $state);
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -99,7 +99,7 @@ class ExportDirectoryAutoDetectTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        \write_current_import_state($this->makeClient(), array_replace_recursive($defaults, $state));
+        \write_current_pull_state($this->makeClient(), array_replace_recursive($defaults, $state));
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -77,7 +77,7 @@ class FetchListProgressTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(), array_replace_recursive([
+        \write_current_pull_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "follow_symlinks" => false,
         ], $state));
@@ -335,7 +335,7 @@ class FetchListProgressTest extends TestCase
         }
     }
 
-    public function testFilesDoneIncludesFilesImported()
+    public function testFilesDoneIncludesFilesPulled()
     {
         $listFile = $this->writeFetchList(100);
         $offset40 = $this->byteOffsetAfterLines($listFile, 40);
@@ -357,15 +357,15 @@ class FetchListProgressTest extends TestCase
         } catch (\Exception $e) {}
 
         // Simulate 5 files written in this invocation
-        $reflection->getProperty('files_imported')->setValue($client, 5);
+        $reflection->getProperty('files_pulled')->setValue($client, 5);
 
         $done = $reflection->getProperty('fetch_list_done')->getValue($client);
-        $imported = $reflection->getProperty('files_imported')->getValue($client);
+        $pulled = $reflection->getProperty('files_pulled')->getValue($client);
         $total = $reflection->getProperty('fetch_list_total')->getValue($client);
 
-        // files_done as emitted in progress records = done + imported
-        $filesDone = $done + $imported;
-        $this->assertSame(45, $filesDone); // 40 from offset + 5 imported
+        // files_done as emitted in progress records = done + pulled
+        $filesDone = $done + $pulled;
+        $this->assertSame(45, $filesDone); // 40 from offset + 5 pulled
         $this->assertSame(100, $total);
         $this->assertLessThanOrEqual($total, $filesDone);
     }

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -67,7 +67,7 @@ class FilesPullStateTest extends TestCase
      */
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(), array_replace_recursive([
+        \write_current_pull_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",

--- a/tests/Import/FlatDocrootWpConfigTest.php
+++ b/tests/Import/FlatDocrootWpConfigTest.php
@@ -140,7 +140,7 @@ class FlatDocrootWpConfigTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(), $state);
+        \write_current_pull_state($this->makeClient(), $state);
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/LocalIndexWalTest.php
+++ b/tests/Import/LocalIndexWalTest.php
@@ -98,7 +98,7 @@ final class LocalIndexWalTest extends TestCase
                 'type' => 'file',
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
         );
-        \write_current_import_state($this->client(), [
+        \write_current_pull_state($this->client(), [
             'preflight' => [
                 'data' => ['ok' => true],
                 'http_code' => 200,

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -99,11 +99,11 @@ class NewSiteUrlSqliteTest extends TestCase
     }
 
     /**
-     * Write the import state file that db-apply expects.
+     * Write the pull state file that db-apply expects.
      */
     private function writeState(array $extra = []): void
     {
-        \write_current_import_state(
+        \write_current_pull_state(
             new \ImportClient('http://example.invalid', $this->tempDir, $this->tempDir),
             $extra
         );
@@ -365,7 +365,7 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertSame(strtoupper(bin2hex($bytes)), $rows[0]['hex_value']);
     }
 
-    public function testSqliteImportPragmasDoNotChangeProgressCounters(): void
+    public function testSqlitePragmasDoNotChangeProgressCounters(): void
     {
         $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
         $drop = "DROP TABLE IF EXISTS `wp_options`;";

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -173,7 +173,7 @@ PHP, var_export($requestsLog, true)));
             );
         }
 
-        \write_current_import_state(
+        \write_current_pull_state(
             new \ImportClient(
                 'http://fake.invalid/',
                 $this->tempDir . '/state',

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -112,7 +112,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
         ];
-        \write_current_import_state(
+        \write_current_pull_state(
             new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root),
             $state
         );

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -66,7 +66,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     private function client(array $preflightData): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $c->get_import_state()->preflight = array('data' => $preflightData);
+        $c->get_state()->preflight = array('data' => $preflightData);
         $this->set($c, 'audit_log_file', $this->tempDir . '/audit.log');
         return $c;
     }
@@ -112,7 +112,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'filter' => 'none',
         );
 
-        \write_current_import_state(
+        \write_current_pull_state(
             new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot),
             array_replace_recursive($defaults, $state)
         );
@@ -235,7 +235,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
         $original_fingerprint = $this->call($c, 'files_pull_only_fingerprint');
 
-        $c->get_import_state()->files_pull_only_fingerprint = $original_fingerprint;
+        $c->get_state()->files_pull_only_fingerprint = $original_fingerprint;
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->expectException(\RuntimeException::class);
@@ -247,7 +247,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
 
-        $c->get_import_state()->files_pull_only_fingerprint = 'different';
+        $c->get_state()->files_pull_only_fingerprint = 'different';
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->call($c, 'assert_files_pull_only_unchanged_while_resuming', array(false));

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -116,7 +116,7 @@ class ProductionDropInRemovalTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        \write_current_import_state($this->makeClient(), array_replace_recursive($defaults, $state));
+        \write_current_pull_state($this->makeClient(), array_replace_recursive($defaults, $state));
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -71,7 +71,7 @@ class PullFilterFakeClient extends \ImportClient
     public function run_preflight(): void
     {
         $this->preflight_runs++;
-        $state = $this->get_import_state();
+        $state = $this->get_state();
         $state->preflight = [
             "http_code" => 200,
             "data" => [
@@ -87,12 +87,12 @@ class PullFilterFakeClient extends \ImportClient
             ],
         ];
         $state->active_resumable_command->completion_state = "complete";
-        $this->save_import_state();
+        $this->save_state();
     }
 
     public function run_files_pull(): void
     {
-        $state = $this->get_import_state();
+        $state = $this->get_state();
         if (
             ($state->active_resumable_command->command_name ?? null) === "files-pull" &&
             ($state->active_resumable_command->completion_state ?? null) === "complete"
@@ -110,34 +110,34 @@ class PullFilterFakeClient extends \ImportClient
             @unlink($this->state_dir . '/pull/skipped-fetch-list.jsonl');
         }
 
-        $state = $this->get_import_state();
+        $state = $this->get_state();
         $state->active_resumable_command->command_name = "files-pull";
         $state->active_resumable_command->completion_state = "complete";
         $state->active_resumable_command->current_stage = null;
         $state->files_pull_summary->files_pulled = $this->files_pulled;
-        $this->save_import_state();
+        $this->save_state();
     }
 
     public function run_db_sync(): void
     {
         $this->db_sync_runs++;
         file_put_contents($this->state_dir . '/db.sql', "SELECT 1;\n");
-        $state = $this->get_import_state();
+        $state = $this->get_state();
         $state->active_resumable_command->command_name = "db-pull";
         $state->active_resumable_command->completion_state = "complete";
         $state->active_resumable_command->current_stage = null;
-        $this->save_import_state();
+        $this->save_state();
     }
 
     public function run_db_apply(array $options): void
     {
         $this->db_apply_runs++;
-        $state = $this->get_import_state();
+        $state = $this->get_state();
         $state->active_resumable_command->command_name = "db-apply";
         $state->active_resumable_command->completion_state = "complete";
         $state->active_resumable_command->current_stage = null;
         $state->apply->statements_executed = 42;
-        $this->save_import_state();
+        $this->save_state();
     }
 }
 
@@ -147,13 +147,13 @@ class PullFailingPreflightFakeClient extends PullFilterFakeClient
     {
         $this->preflight_runs++;
         $this->last_error_code = 'HTTP_ERROR';
-        $state = $this->get_import_state();
+        $state = $this->get_state();
         $state->preflight = [
             "http_code" => 500,
             "error" => "Exporter unavailable",
         ];
         $state->active_resumable_command->completion_state = "complete";
-        $this->save_import_state();
+        $this->save_state();
     }
 }
 
@@ -238,7 +238,7 @@ class PullFilterOptionTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(false), $state);
+        \write_current_pull_state($this->makeClient(false), $state);
     }
 
     public function testPullRejectsSkippedEarlierFilterBeforePersistingIt(): void

--- a/tests/Import/PullMetadataTest.php
+++ b/tests/Import/PullMetadataTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../importer/import.php';
 
-class ImportMetadataTest extends TestCase
+class PullMetadataTest extends TestCase
 {
     private string $tempDir;
     private string $stateDir;
@@ -18,7 +18,7 @@ class ImportMetadataTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/reprint-import-metadata-' . uniqid('', true);
+        $this->tempDir = sys_get_temp_dir() . '/reprint-pull-metadata-' . uniqid('', true);
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
@@ -60,11 +60,11 @@ class ImportMetadataTest extends TestCase
     }
 
     /**
-     * Writes importer state directly so each test can model one lifecycle shape.
+     * Writes pull state directly so each test can model one lifecycle shape.
      */
     private function writeState(array $state): void
     {
-        \write_current_import_state(
+        \write_current_pull_state(
             new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot),
             $state
         );
@@ -73,12 +73,12 @@ class ImportMetadataTest extends TestCase
     /**
      * Runs the metadata command and returns its decoded JSON response.
      */
-    private function readMetadata(): array
+    private function readMetadata(string $command = 'pull-metadata'): array
     {
         $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
 
         ob_start();
-        $client->run(['command' => 'import-metadata']);
+        $client->run(['command' => $command]);
         $output = ob_get_clean();
 
         $metadata = json_decode($output, true);
@@ -88,9 +88,20 @@ class ImportMetadataTest extends TestCase
     }
 
     /**
+     * Verifies the previous command name remains an alias for pull metadata.
+     */
+    public function testImportMetadataAliasReportsPullMetadata(): void
+    {
+        $this->assertSame(
+            $this->readMetadata(),
+            $this->readMetadata('import-metadata')
+        );
+    }
+
+    /**
      * Verifies a missing state file is reported as a never-completed pull.
      */
-    public function testImportMetadataReportsNoCompletedPullForFreshState(): void
+    public function testPullMetadataReportsNoCompletedPullForFreshState(): void
     {
         $metadata = $this->readMetadata();
 
@@ -109,7 +120,7 @@ class ImportMetadataTest extends TestCase
     /**
      * Verifies source-site values are exposed without leaking the preflight schema.
      */
-    public function testImportMetadataReportsSourceSiteFields(): void
+    public function testPullMetadataReportsSourceSiteFields(): void
     {
         $this->writeState([
             'preflight' => [
@@ -141,7 +152,7 @@ class ImportMetadataTest extends TestCase
     /**
      * Verifies completed low-level commands do not imply a completed pull.
      */
-    public function testImportMetadataDoesNotTreatCompletedSubcommandAsCompletedPull(): void
+    public function testPullMetadataDoesNotTreatCompletedSubcommandAsCompletedPull(): void
     {
         $this->writeState([
             'active_resumable_command' => [
@@ -159,7 +170,7 @@ class ImportMetadataTest extends TestCase
     /**
      * Verifies a completed pull pipeline reports completion.
      */
-    public function testImportMetadataReportsCompletedPullState(): void
+    public function testPullMetadataReportsCompletedPullState(): void
     {
         $this->writeState([
             'active_resumable_command' => [
@@ -183,7 +194,7 @@ class ImportMetadataTest extends TestCase
     /**
      * Verifies delta re-pull state preserves that a pull completed previously.
      */
-    public function testImportMetadataReportsPriorCompletionDuringRepull(): void
+    public function testPullMetadataReportsPriorCompletionDuringRepull(): void
     {
         $this->writeState([
             'active_resumable_command' => [

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -6,11 +6,11 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
 
-class ImportStateTest extends TestCase
+class PullStateTest extends TestCase
 {
     public function testStateHydratesDocumentedNestedObjects(): void
     {
-        $data = (new \ImportState())->to_array();
+        $data = (new \PullState())->to_array();
         $data['active_resumable_command'] = [
             'command_name' => 'files-pull',
             'completion_state' => 'partial',
@@ -28,7 +28,7 @@ class ImportStateTest extends TestCase
         $data['apply']['statements_executed'] = 12;
         $data['apply']['bytes_read'] = 34;
         $data['apply']['target_engine'] = 'sqlite';
-        $state = \ImportState::from_array($data);
+        $state = \PullState::from_array($data);
 
         $this->assertSame('files-pull', $state->active_resumable_command->command_name);
         $this->assertSame('partial', $state->active_resumable_command->completion_state);
@@ -39,7 +39,7 @@ class ImportStateTest extends TestCase
 
     public function testStateRoundTripsToPersistedArraySchema(): void
     {
-        $state = new \ImportState();
+        $state = new \PullState();
         $state->active_resumable_command->command_name = 'db-pull';
         $state->active_resumable_command->completion_state = 'complete';
         $state->pull_pipeline->started_by_command = 'pull';
@@ -55,7 +55,7 @@ class ImportStateTest extends TestCase
 
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void
     {
-        $state = new \ImportState();
+        $state = new \PullState();
 
         $this->assertNotInstanceOf(\ArrayAccess::class, $state);
         $this->assertNotInstanceOf(\ArrayAccess::class, $state->active_resumable_command);
@@ -63,24 +63,24 @@ class ImportStateTest extends TestCase
 
     public function testStateRejectsAnIncompleteSchema(): void
     {
-        $data = (new \ImportState())->to_array();
+        $data = (new \PullState())->to_array();
         unset($data['webhost']);
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('missing webhost');
 
-        \ImportState::from_array($data);
+        \PullState::from_array($data);
     }
 
     public function testStateRejectsUnexpectedFields(): void
     {
-        $data = (new \ImportState())->to_array();
+        $data = (new \PullState())->to_array();
         $data['status'] = 'complete';
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('unexpected status');
 
-        \ImportState::from_array($data);
+        \PullState::from_array($data);
     }
 
     public function testStatePathRejectsInvalidBase64(): void

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -7,16 +7,16 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Test import symlink recreation
+ * Test pull symlink recreation
  */
-class ImportSymlinkTest extends TestCase
+class PullSymlinkTest extends TestCase
 {
     private $tempDir;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/import-symlink-test-' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/pull-symlink-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
         mkdir($this->tempDir . '/fs-root', 0755, true);
     }

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -67,7 +67,7 @@ class RemapResolveTest extends TestCase
     private function client(array $pathsUrls): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $c->get_import_state()->preflight = array('data' => array(
+        $c->get_state()->preflight = array('data' => array(
             'database' => array('wp' => array('paths_urls' => $pathsUrls)),
         ));
         return $c;

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -96,7 +96,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        \write_current_import_state($this->makeClient(), array_replace_recursive($defaults, $state));
+        \write_current_pull_state($this->makeClient(), array_replace_recursive($defaults, $state));
     }
 
     private function makeClient(): \ImportClient

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -69,7 +69,7 @@ class RuntimeFilesTest extends TestCase
 
     private function writeState(array $state): void
     {
-        \write_current_import_state($this->makeClient(), array_replace_recursive([
+        \write_current_pull_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "follow_symlinks" => false,
         ], $state));

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -93,7 +93,7 @@ class SqliteRuntimeConfigTest extends TestCase
             'max_allowed_packet' => null,
         ];
 
-        \write_current_import_state(
+        \write_current_pull_state(
             new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot),
             array_replace_recursive($defaults, $state)
         );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,19 +45,19 @@ if (!class_exists('Site_Export_Push_Session', false)) {
 }
 
 /**
- * Persist a complete current import-state schema for tests.
+ * Persist a complete current pull-state schema for tests.
  *
  * @param ImportClient         $client  Client whose state directory receives the file.
- * @param array<string, mixed> $changes Values to apply to a new ImportState.
+ * @param array<string, mixed> $changes Values to apply to a new PullState.
  */
-function write_current_import_state(ImportClient $client, array $changes): void
+function write_current_pull_state(ImportClient $client, array $changes): void
 {
-    $data = array_replace_recursive((new ImportState())->to_array(), $changes);
-    $state = ImportState::from_array($data);
+    $data = array_replace_recursive((new PullState())->to_array(), $changes);
+    $state = PullState::from_array($data);
     $property = (new ReflectionClass(ImportClient::class))->getProperty('state');
     $property->setAccessible(true);
     $property->setValue($client, $state);
-    $client->save_import_state();
+    $client->save_state();
 }
 
 // Load the test base class

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -93,7 +93,7 @@ describe('Import: Protocol Version Mismatch', () => {
         assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
         assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
         assert.ok(result.stdout.includes('does not match'), `Expected mismatch message:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('Update the importer'), `Expected update instruction:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('Update the Reprint client'), `Expected update instruction:\n${result.stdout}`);
     });
 
     it('fails when remote does not report a protocol version', () => {


### PR DESCRIPTION
Callers now access the persisted pull lifecycle through `get_state()` and `save_state()`, and host integrations use `pull-metadata`.

`PullState` replaces the old state type while keeping `pull/state.json` and its JSON fields unchanged. Related counters, protocol and embedder constants, tests, and docs now say pull or apply. The importer package, `ImportClient`, entrypoint paths, and namespaces remain unchanged.

`import-metadata` remains accepted as an alias for `pull-metadata`. The `sourceSite` fields added on trunk remain part of both command forms.

## Testing

- Affected PHPUnit and compatibility suite: 180 tests, 460 assertions; 4 skipped
- Confirmed `import-metadata` and `pull-metadata` return matching fresh-state JSON and exit 0
- `composer analyze -- --memory-limit=1G`
- `composer lint:php:compat`
- `git diff --check`
