### PR TITLE
Add repeatable path exclusions to file pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,17 @@ The three filter values:
 The uploads directory is detected from preflight data (`uploads.basedir`), falling back to
 `wp-content/uploads/` if unavailable.
 
+`files-pull` and `pull-files` also accept repeatable path-prefix selections:
+
+```bash
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --only=:wp-content: --exclude=:wp-uploads:
+```
+
+`--only=SOURCE` supplies an included source prefix and `--exclude=SOURCE`
+supplies an excluded source prefix. Both accept WordPress path tokens or
+absolute source paths. Exclusions win when the prefixes overlap.
+
 #### Pull only files.
 
 `pull-files` runs the file side of the high-level pull pipeline:
@@ -287,11 +298,11 @@ php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 It accepts the `pull` file filters (`--filter=none` and
 `--filter=essential-files`) plus the same path selection options as
-`files-pull`, including repeated `--only` values:
+`files-pull`, including repeated `--only` and `--exclude` values:
 
 ```bash
 php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
-    --only=:wp-content: --only=:wp-plugins:
+    --only=:wp-content: --exclude=:wp-uploads:
 ```
 
 #### Pull only the database.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2753,7 +2753,7 @@ class ImportClient
                 ], true);
                 $this->get_state()->active_resumable_command->completion_state = "in_progress";
                 $this->get_state()->active_resumable_command->current_stage = "fetch-skipped";
-                $this->get_state()->files_pull_only_fingerprint =
+                $this->get_state()->files_pull_path_selection_fingerprint =
                     $this->files_pull_path_selection_fingerprint();
                 $this->get_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state();
@@ -2874,7 +2874,7 @@ class ImportClient
             $this->get_state()->active_resumable_command->command_name = "files-pull";
             $this->get_state()->active_resumable_command->completion_state = "in_progress";
             $this->get_state()->active_resumable_command->current_stage = "index";
-            $this->get_state()->files_pull_only_fingerprint =
+            $this->get_state()->files_pull_path_selection_fingerprint =
                 $this->files_pull_path_selection_fingerprint();
             $this->get_state()->diff = new FileDiffProgressState();
             $this->get_state()->index = new RemoteFileIndexCursorState();
@@ -8744,20 +8744,13 @@ class ImportClient
         }
 
         $fingerprint = $this->files_pull_path_selection_fingerprint();
-        $previous = $this->get_state()->files_pull_only_fingerprint ?? null;
+        $previous = $this->get_state()->files_pull_path_selection_fingerprint;
 
-        if ($previous !== null && $previous !== $fingerprint) {
+        if ($previous !== $fingerprint) {
             throw new RuntimeException(
                 "Cannot change --only or --exclude while resuming files-pull. " .
                     "Use the original path selections, or use --abort to start a new files-pull.",
             );
-        }
-
-        // Older in-progress state may not have this guard persisted yet. Record
-        // the current value so subsequent resumes cannot drift.
-        if ($previous === null) {
-            $this->get_state()->files_pull_only_fingerprint = $fingerprint;
-            $this->save_state();
         }
     }
 
@@ -8770,13 +8763,6 @@ class ImportClient
      */
     private function files_pull_path_selection_fingerprint(): string
     {
-        $only_fingerprint = $this->files_pull_only_fingerprint();
-        if (empty($this->pull_excluded_files_with_path_prefixes)) {
-            // Keep the original --only value so an in-progress pull started by
-            // an older importer can resume without rewriting its state.
-            return $only_fingerprint;
-        }
-
         $excluded_path_prefixes = $this->pull_excluded_files_with_path_prefixes;
         sort($excluded_path_prefixes, SORT_STRING);
 
@@ -8784,22 +8770,11 @@ class ImportClient
             "sha256",
             json_encode(
                 [
-                    "only_fingerprint" => $only_fingerprint,
-                    "exclude" => $excluded_path_prefixes,
+                    "only_path_prefixes" => $this->pull_only_files_with_path_prefixes,
+                    "excluded_path_prefixes" => $excluded_path_prefixes,
                 ],
                 JSON_UNESCAPED_SLASHES
             ),
-        );
-    }
-
-    /**
-     * Stable fingerprint for the resolved --only file path prefixes.
-     */
-    private function files_pull_only_fingerprint(): string
-    {
-        return hash(
-            "sha256",
-            json_encode($this->pull_only_files_with_path_prefixes, JSON_UNESCAPED_SLASHES),
         );
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -420,6 +420,12 @@ class ImportClient
      */
     private $pull_only_files_with_path_prefixes = [];
 
+    /**
+     * @var array<int,string> Resolved `--exclude` file paths: a list of real
+     * source absolute path prefixes omitted from files-pull.
+     */
+    private $pull_excluded_files_with_path_prefixes = [];
+
     /** @var AdaptiveTuner|null Adjusts request pacing based on server response times and errors. */
     private $tuner = null;
 
@@ -676,8 +682,20 @@ class ImportClient
         if (is_string($only_raw)) {
             $only_raw = [$only_raw];
         }
+        $excluded_raw = $options["exclude"] ?? [];
+        if (is_string($excluded_raw)) {
+            $excluded_raw = [$excluded_raw];
+        }
+
+        $this->pull_only_files_with_path_prefixes = [];
+        $this->pull_excluded_files_with_path_prefixes = [];
         if (!empty($only_raw)) {
-            $this->pull_only_files_with_path_prefixes = $this->resolve_pull_only_files_with_path_prefixes($only_raw);
+            $this->pull_only_files_with_path_prefixes =
+                $this->resolve_pull_files_path_prefixes($only_raw, "only");
+        }
+        if (!empty($excluded_raw)) {
+            $this->pull_excluded_files_with_path_prefixes =
+                $this->resolve_pull_files_path_prefixes($excluded_raw, "exclude");
         }
 
         if ($assert_remap) {
@@ -2701,7 +2719,7 @@ class ImportClient
             $current_status !== "complete";
 
         $this->replay_remote_index_wal();
-        $this->assert_files_pull_only_unchanged_while_resuming($has_progress);
+        $this->assert_files_pull_path_selection_unchanged_while_resuming($has_progress);
         $this->assert_local_followed_symlinks_root_unchanged();
 
         // Already completed.
@@ -2735,7 +2753,8 @@ class ImportClient
                 ], true);
                 $this->get_state()->active_resumable_command->completion_state = "in_progress";
                 $this->get_state()->active_resumable_command->current_stage = "fetch-skipped";
-                $this->get_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
+                $this->get_state()->files_pull_only_fingerprint =
+                    $this->files_pull_path_selection_fingerprint();
                 $this->get_state()->files_pull_summary = new FilesPullSummaryState();
                 $this->save_state();
                 $this->open_remote_index_wal();
@@ -2855,7 +2874,8 @@ class ImportClient
             $this->get_state()->active_resumable_command->command_name = "files-pull";
             $this->get_state()->active_resumable_command->completion_state = "in_progress";
             $this->get_state()->active_resumable_command->current_stage = "index";
-            $this->get_state()->files_pull_only_fingerprint = $this->files_pull_only_fingerprint();
+            $this->get_state()->files_pull_only_fingerprint =
+                $this->files_pull_path_selection_fingerprint();
             $this->get_state()->diff = new FileDiffProgressState();
             $this->get_state()->index = new RemoteFileIndexCursorState();
             $this->get_state()->fetch = new FetchListProgressState();
@@ -6620,7 +6640,8 @@ class ImportClient
                 $remote_index_entry !== null &&
                 strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) < 0
             ) {
-                // The remote index is a union across files-pull --only runs.
+                // The remote index is a union across files-pull path selections.
+                // Keep entries outside this run's selection.
                 if ($this->is_selected_for_pulling($remote_index_entry["path"])) {
                     $remote_absolute_path = $remote_index_entry["path"];
                     $this->apply_remote_deletion_locally($remote_absolute_path);
@@ -6642,37 +6663,42 @@ class ImportClient
                     $remote_index_entry["type"] !== $next_remote_index_entry["type"]
                 ) {
                     // The path is represented in both indexes but changed on the remote.
-                    // Always re-download — the remote index confirms that an earlier
-                    // files-pull accounted for this path, so preserve-local does not
-                    // protect it.
-                    $selected_fetch_list_file_handle = (
-                        $skipped_fetch_list_file_handle !== null &&
-                        (
-                            $remote_uploads_directory_absolute_path !== null
-                                ? path_is_within_root(
-                                    $next_remote_index_entry["path"],
-                                    $remote_uploads_directory_absolute_path
-                                )
-                                : strpos(
-                                    $next_remote_index_entry["path"],
-                                    "wp-content/uploads/"
-                                ) !== false
+                    // Re-download it when selected — the remote index confirms
+                    // that an earlier files-pull accounted for this path, so
+                    // preserve-local does not protect it.
+                    if (!$this->is_excluded_from_pulling($next_remote_index_entry["path"])) {
+                        $selected_fetch_list_file_handle = (
+                            $skipped_fetch_list_file_handle !== null &&
+                            (
+                                $remote_uploads_directory_absolute_path !== null
+                                    ? path_is_within_root(
+                                        $next_remote_index_entry["path"],
+                                        $remote_uploads_directory_absolute_path
+                                    )
+                                    : strpos(
+                                        $next_remote_index_entry["path"],
+                                        "wp-content/uploads/"
+                                    ) !== false
+                            )
                         )
-                    )
-                        ? $skipped_fetch_list_file_handle
-                        : $fetch_list_file_handle;
-                    $this->append_to_fetch_list(
-                        $next_remote_index_entry["path"],
-                        $selected_fetch_list_file_handle,
-                    );
+                            ? $skipped_fetch_list_file_handle
+                            : $fetch_list_file_handle;
+                        $this->append_to_fetch_list(
+                            $next_remote_index_entry["path"],
+                            $selected_fetch_list_file_handle,
+                        );
+                    }
                 }
                 $last_consumed_remote_index_entry_path =
                     $remote_index_entry["path"];
                 $remote_index_entry =
                     $this->read_remote_index_entry($remote_index_file_handle);
             } elseif (
-                $remote_index_entry === null ||
-                strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) > 0
+                !$this->is_excluded_from_pulling($next_remote_index_entry["path"]) &&
+                (
+                    $remote_index_entry === null ||
+                    strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) > 0
+                )
             ) {
                 $preserve_local_skip_reason =
                     $this->should_skip_for_preserve_local(
@@ -8703,27 +8729,27 @@ class ImportClient
     }
 
     /**
-     * Refuse to resume a files-pull after changing --only.
+     * Refuse to resume a files-pull after changing its path selection.
      *
-     * The in-progress next remote index cursor/file was built from one directory[]
-     * allowlist. Switching the selected source path prefixes mid-resume would
-     * mix indexes from different traversals. Completed runs are allowed to use
-     * different --only prefixes because the remote index is intentionally a union
-     * across files-pull --only runs.
+     * --only determines the next remote index traversal, while --exclude determines
+     * which entries enter the later fetch list. Keep both fixed for the complete
+     * in-progress lifecycle rather than allowing a resumed stage to cross a path-
+     * selection boundary. Completed runs may use a different selection because the
+     * remote index is intentionally a union across them.
      */
-    private function assert_files_pull_only_unchanged_while_resuming(bool $has_progress): void
+    private function assert_files_pull_path_selection_unchanged_while_resuming(bool $has_progress): void
     {
         if (!$has_progress) {
             return;
         }
 
-        $fingerprint = $this->files_pull_only_fingerprint();
+        $fingerprint = $this->files_pull_path_selection_fingerprint();
         $previous = $this->get_state()->files_pull_only_fingerprint ?? null;
 
         if ($previous !== null && $previous !== $fingerprint) {
             throw new RuntimeException(
-                "Cannot change --only while resuming files-pull. " .
-                    "Use the original --only values, or use --abort to start a new files-pull.",
+                "Cannot change --only or --exclude while resuming files-pull. " .
+                    "Use the original path selections, or use --abort to start a new files-pull.",
             );
         }
 
@@ -8736,10 +8762,38 @@ class ImportClient
     }
 
     /**
-     * Stable fingerprint for the resolved --only file path prefixes.
+     * Stable fingerprint for the resolved file path selection.
      *
-     * Prefix order is part of the fingerprint because it determines the first
-     * list_dir used to start the traversal.
+     * Included-prefix order is significant because it determines the first
+     * list_dir used to start the traversal. Excluded-prefix order is not, so
+     * it is normalized before hashing.
+     */
+    private function files_pull_path_selection_fingerprint(): string
+    {
+        $only_fingerprint = $this->files_pull_only_fingerprint();
+        if (empty($this->pull_excluded_files_with_path_prefixes)) {
+            // Keep the original --only value so an in-progress pull started by
+            // an older importer can resume without rewriting its state.
+            return $only_fingerprint;
+        }
+
+        $excluded_path_prefixes = $this->pull_excluded_files_with_path_prefixes;
+        sort($excluded_path_prefixes, SORT_STRING);
+
+        return hash(
+            "sha256",
+            json_encode(
+                [
+                    "only_fingerprint" => $only_fingerprint,
+                    "exclude" => $excluded_path_prefixes,
+                ],
+                JSON_UNESCAPED_SLASHES
+            ),
+        );
+    }
+
+    /**
+     * Stable fingerprint for the resolved --only file path prefixes.
      */
     private function files_pull_only_fingerprint(): string
     {
@@ -8860,8 +8914,9 @@ class ImportClient
      * Find plugins, mu-plugins, and uploads directories that WordPress reports
      * outside WP_CONTENT_DIR.
      *
-     * When wp-content is selected with --only or --remap, these directories are not
-     * covered by WP_CONTENT_DIR itself, so callers need to handle them separately.
+     * When wp-content is selected by a file path option or --remap, these
+     * directories are not covered by WP_CONTENT_DIR itself, so callers need
+     * to handle them separately.
      * Unknown paths are omitted because both WP_CONTENT_DIR and the directory path
      * are needed to decide whether the directory lives outside WP_CONTENT_DIR.
      *
@@ -8888,30 +8943,45 @@ class ImportClient
     }
 
     /**
-     * Resolve raw `--only` sources into a deduped list of real source absolute
-     * prefixes selected for files-pull. Each source is a `:token:` template (e.g.
+     * Resolve raw file path sources into a deduped list of real source absolute
+     * prefixes. Each source is a `:token:` template (e.g.
      * `:wp-content:`, `:wp-uploads:`) or a raw absolute path,
      * resolved through the same source token table (wp_source_path_tokens)
      * as --remap.
      *
-     * @param array<int,string> $only_raw Raw SOURCE values from the CLI.
+     * For example, when `:wp-plugins:` maps to `/custom/plugins`:
+     *
+     *     $prefixes = $this->resolve_pull_files_path_prefixes(
+     *         [':wp-plugins:', ':wp-plugins:/woocommerce', '/var/custom/data'],
+     *         'only'
+     *     );
+     *
+     *     // Returns ['/custom/plugins', '/var/custom/data'].
+     *
+     * @param array<int,string> $raw_sources Raw SOURCE values from the CLI.
+     * @param string            $option_name CLI option name used in errors.
      * @return array<int,string> Real source prefixes (deduped).
      */
-    private function resolve_pull_only_files_with_path_prefixes(array $only_raw): array
+    private function resolve_pull_files_path_prefixes(
+        array $raw_sources,
+        string $option_name
+    ): array
     {
         $source_tokens = $this->wp_source_path_tokens();
 
         $prefixes = [];
-        foreach ($only_raw as $src) {
+        foreach ($raw_sources as $src) {
             if ($src === "") {
-                throw new InvalidArgumentException("--only source cannot be empty");
+                throw new InvalidArgumentException(
+                    "--{$option_name} source cannot be empty"
+                );
             }
 
             $resolved = $this->resolve_token_path($src, $source_tokens);
             $prefixes[$resolved] = true;
 
-            // Selecting content_dir with --only also pulls in any plugins, mu-plugins,
-            // or uploads directory outside WP_CONTENT_DIR so files-pull enumerates it too.
+            // Selecting content_dir also selects any plugins, mu-plugins, or
+            // uploads directory outside WP_CONTENT_DIR.
             if ($resolved === $source_tokens["wp-content"]) {
                 foreach ($this->content_directories_outside_wp_content($source_tokens) as $source) {
                     $prefixes[$source] = true;
@@ -8919,8 +8989,8 @@ class ImportClient
             }
         }
 
-        // Drop any prefix already covered by a broader one (e.g. wp-content and wp-content/plugins)
-        // A files-pull --only run doesn't need to walk the same subtree twice.
+        // Drop any prefix already covered by a broader one (for example,
+        // wp-content and wp-content/plugins).
         $sources = array_keys($prefixes);
         $minimal = [];
         foreach ($sources as $path) {
@@ -8942,23 +9012,40 @@ class ImportClient
     }
 
     /**
-     * Whether a remote absolute path is selected by the active --only file path
-     * prefixes. With no --only flag, every path is selected. A selected root is
-     * excluded because a filtered next remote index lists its contents, not the root.
+     * Whether a path is selected by the active --only and --exclude prefixes.
+     *
+     * An included root itself is not selected because an --only next remote index
+     * lists its contents, not the root entry. Exclusions win over inclusions.
      */
-    private function is_selected_for_pulling(string $remote_absolute_path): bool
+    private function is_selected_for_pulling(string $path): bool
     {
-        if (empty($this->pull_only_files_with_path_prefixes)) {
-            return true;
-        }
+        $selected = empty($this->pull_only_files_with_path_prefixes);
 
-        $remote_absolute_path = rtrim($remote_absolute_path, "/");
-        foreach ($this->pull_only_files_with_path_prefixes as $pull_only_files_prefix) {
-            $pull_only_files_prefix = rtrim($pull_only_files_prefix, "/");
-            if ($remote_absolute_path === $pull_only_files_prefix) {
+        foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
+            $remainder = self::path_remainder_under($path, $prefix);
+            if ($remainder === "") {
                 return false;
             }
-            if (path_is_within_root($remote_absolute_path, $pull_only_files_prefix)) {
+            if ($remainder !== null) {
+                $selected = true;
+                break;
+            }
+        }
+
+        if (!$selected) {
+            return false;
+        }
+
+        return !$this->is_excluded_from_pulling($path);
+    }
+
+    /**
+     * Whether a path falls inside one of the active --exclude prefixes.
+     */
+    private function is_excluded_from_pulling(string $path): bool
+    {
+        foreach ($this->pull_excluded_files_with_path_prefixes as $prefix) {
+            if (self::path_remainder_under($path, $prefix) !== null) {
                 return true;
             }
         }
@@ -8967,7 +9054,7 @@ class ImportClient
     }
 
     /**
-     * The source site's real paths from preflight data, as remap/--only token
+     * The source site's real paths from preflight data, as remap/path-selection token
      * name => absolute path (wp-content, wp-plugins, wp-mu-plugins, wp-uploads,
      * abspath).
      *
@@ -9010,10 +9097,10 @@ class ImportClient
     }
 
     /**
-     * Resolve a --remap/--only path argument into an absolute path.
+     * Resolve a --remap/--only/--exclude path argument into an absolute path.
      *
      * Substitutes a known leading `:token:` (see the token tables in
-     * resolve_remap and resolve_pull_only_files_with_path_prefixes) with its
+     * resolve_remap and resolve_pull_files_path_prefixes) with its
      * value, then trims trailing slashes. The result must be a valid absolute
      * path with no `.`/`..` segments; a relative path or an unknown token (left
      * unsubstituted) fails that check. Referencing a token whose value is
@@ -12006,6 +12093,16 @@ if (
                 'repeat for several. Default pulls everything',
             'commands' => ['pull-files', 'files-pull'],
         ],
+        [
+            'name' => 'exclude',
+            'type' => 'value-or-next',
+            'target' => 'exclude',
+            'placeholder' => 'SOURCE',
+            'repeatable' => true,
+            'help' => 'Omit SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path) from the file pull; ' .
+                'repeat for several',
+            'commands' => ['pull-files', 'files-pull'],
+        ],
 
         // ── flat-docroot options ────────────────────────────────
         [
@@ -12558,7 +12655,7 @@ if (
                 "\n" .
                 "  reprint pull-files https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
-                "    --only=:wp-content: --only=:wp-plugins:\n",
+                "    --only=:wp-content: --exclude=:wp-uploads:\n",
         ],
         "pull-db" => [
             "level" => "high",
@@ -12643,6 +12740,11 @@ if (
                 "  essential-files   Skip uploads, pull only code/config/themes/plugins.\n" .
                 "                    The skipped file list is saved for later retrieval.\n" .
                 "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
+                "\n" .
+                "Path selection:\n" .
+                "  --only=SOURCE      Include only this source path prefix; repeatable.\n" .
+                "  --exclude=SOURCE   Exclude this source path prefix; repeatable.\n" .
+                "  Exclusions win when include and exclude prefixes overlap.\n" .
                 "\n" .
                 "Output files:\n" .
                 "  (filesystem root)/                       Downloaded files\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6642,7 +6642,7 @@ class ImportClient
             ) {
                 // The remote index is a union across files-pull path selections.
                 // Keep entries outside this run's selection.
-                if ($this->is_selected_for_pulling($remote_index_entry["path"])) {
+                if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
                     $remote_absolute_path = $remote_index_entry["path"];
                     $this->apply_remote_deletion_locally($remote_absolute_path);
                     $this->delete_remote_index_entry($remote_absolute_path);
@@ -6666,7 +6666,7 @@ class ImportClient
                     // Re-download it when selected — the remote index confirms
                     // that an earlier files-pull accounted for this path, so
                     // preserve-local does not protect it.
-                    if (!$this->is_excluded_from_pulling($next_remote_index_entry["path"])) {
+                    if ($this->is_selected_for_pulling($next_remote_index_entry["path"], true)) {
                         $selected_fetch_list_file_handle = (
                             $skipped_fetch_list_file_handle !== null &&
                             (
@@ -6694,7 +6694,7 @@ class ImportClient
                 $remote_index_entry =
                     $this->read_remote_index_entry($remote_index_file_handle);
             } elseif (
-                !$this->is_excluded_from_pulling($next_remote_index_entry["path"]) &&
+                $this->is_selected_for_pulling($next_remote_index_entry["path"], true) &&
                 (
                     $remote_index_entry === null ||
                     strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) > 0
@@ -6748,7 +6748,7 @@ class ImportClient
         }
 
         while ($remote_index_entry !== null) {
-            if ($this->is_selected_for_pulling($remote_index_entry["path"])) {
+            if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
                 $remote_absolute_path = $remote_index_entry["path"];
                 $this->apply_remote_deletion_locally($remote_absolute_path);
                 $this->delete_remote_index_entry($remote_absolute_path);
@@ -8985,43 +8985,46 @@ class ImportClient
     /**
      * Whether a path is selected by the active --only and --exclude prefixes.
      *
-     * An included root itself is not selected because an --only next remote index
-     * lists its contents, not the root entry. Exclusions win over inclusions.
+     * The exporter has already applied --only to entries in the next remote
+     * index, including followed symlink targets outside an --only prefix. Other
+     * paths are checked against --only locally. An included root itself is not
+     * selected because the next remote index lists its contents, not the root
+     * entry. Exclusions always win.
+     *
+     * @param bool $is_next_remote_index_entry Whether the path came from the
+     *                                         current next remote index.
      */
-    private function is_selected_for_pulling(string $path): bool
+    private function is_selected_for_pulling(
+        string $path,
+        bool $is_next_remote_index_entry
+    ): bool
     {
-        $selected = empty($this->pull_only_files_with_path_prefixes);
+        if (!$is_next_remote_index_entry) {
+            $selected = empty($this->pull_only_files_with_path_prefixes);
 
-        foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
-            $remainder = self::path_remainder_under($path, $prefix);
-            if ($remainder === "") {
+            foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
+                $remainder = self::path_remainder_under($path, $prefix);
+                if ($remainder === "") {
+                    return false;
+                }
+                if ($remainder !== null) {
+                    $selected = true;
+                    break;
+                }
+            }
+
+            if (!$selected) {
                 return false;
             }
-            if ($remainder !== null) {
-                $selected = true;
-                break;
-            }
         }
 
-        if (!$selected) {
-            return false;
-        }
-
-        return !$this->is_excluded_from_pulling($path);
-    }
-
-    /**
-     * Whether a path falls inside one of the active --exclude prefixes.
-     */
-    private function is_excluded_from_pulling(string $path): bool
-    {
         foreach ($this->pull_excluded_files_with_path_prefixes as $prefix) {
             if (self::path_remainder_under($path, $prefix) !== null) {
-                return true;
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -691,11 +691,11 @@ class ImportClient
         $this->pull_excluded_files_with_path_prefixes = [];
         if (!empty($only_raw)) {
             $this->pull_only_files_with_path_prefixes =
-                $this->resolve_pull_files_path_prefixes($only_raw, "only");
+                $this->resolve_remote_paths($only_raw, "only");
         }
         if (!empty($excluded_raw)) {
             $this->pull_excluded_files_with_path_prefixes =
-                $this->resolve_pull_files_path_prefixes($excluded_raw, "exclude");
+                $this->resolve_remote_paths($excluded_raw, "exclude");
         }
 
         if ($assert_remap) {
@@ -2548,7 +2548,7 @@ class ImportClient
              * Ask the exporter to omit source rows that should not enter the local clone.
              *
              * The protocol is intentionally data-shaped instead of exporter-defined
-             * tokens: table_name_without_prefix is resolved against the source site's table prefix,
+             * tokens: table_name_without_prefix is resolved against the remote site's table prefix,
              * column is matched against the source table metadata, and value_base64 lets
              * the exporter compare with FROM_BASE64(...) without interpolating the raw
              * value into SQL. _edit_lock is ephemeral editor session state and would
@@ -4083,7 +4083,7 @@ class ImportClient
      * Reads the detected webhost from state (set during preflight), runs the
      * appropriate host analyzer to produce a runtime manifest, then applies
      * it using the chosen runtime applier. The manifest captures what the
-     * source site needs (constants, INI directives, error handlers);
+     * remote site needs (constants, INI directives, error handlers);
      * the applier writes the files the target server needs to fulfill those
      * requirements.
      *
@@ -4115,7 +4115,7 @@ class ImportClient
         if (!is_array($entry) || empty($entry["data"])) {
             throw new RuntimeException(
                 "apply-runtime requires a prior preflight run. " .
-                "Run 'preflight' first to capture the source site's environment."
+                "Run 'preflight' first to capture the remote site's environment."
             );
         }
 
@@ -4393,7 +4393,7 @@ class ImportClient
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
             "condition" => "file_not_found",
-            "description" => "Proxy missing uploads from the source site until files-pull completes",
+            "description" => "Proxy missing uploads from the remote site until files-pull completes",
         ];
         $this->audit_log(
             "APPLY-RUNTIME | enabled remote upload proxy ({$base_url})",
@@ -4459,7 +4459,7 @@ class ImportClient
      * where each WordPress component actually lives, rather than blindly
      * scanning filesystem root top-level entries.
      *
-     * This is essential when the source site uses a non-standard layout
+     * This is essential when the remote site uses a non-standard layout
      * (e.g. WP Cloud with ABSPATH=/srv/htdocs and WP_CONTENT_DIR=/tmp/__wp__/wp-content)
      * and the target needs a conventional wp-admin/, wp-includes/,
      * wp-content/, wp-load.php structure.
@@ -5062,7 +5062,7 @@ class ImportClient
         $parsed_url = parse_url($this->remote_reprint_api_url);
         if (!$parsed_url || !isset($parsed_url['scheme'], $parsed_url['host'])) {
             throw new InvalidArgumentException(
-                "--new-site-url requires a valid export URL to derive the source site origin.",
+                "--new-site-url requires a valid export URL to derive the remote site origin.",
             );
         }
 
@@ -7725,7 +7725,7 @@ class ImportClient
         $sql_stats_file = $this->pull_state_directory . "/sql-stats.json";
         $sql_statements_counted = (int) ($this->get_state()->sql_statements_counted ?? 0);
 
-        // Auto-detect the source site domain from the export URL so it
+        // Auto-detect the remote site domain from the export URL so it
         // always appears in pull/domains.json even if the SQL dump
         // hasn't been fully scanned yet.
         if ($domain_collector) {
@@ -8538,7 +8538,7 @@ class ImportClient
      *
      * Example:
      *
-     * Source site:
+     * remote site:
      *
      *   /srv/source-site/
      *   `-- wp-content/
@@ -8874,7 +8874,7 @@ class ImportClient
     {
         $filesystem_root = rtrim($this->get_filesystem_root_path(), "/");
 
-        $source_tokens = $this->wp_source_path_tokens();
+        $source_tokens = $this->remote_path_tokens();
         $target_tokens = ["fs-root" => $filesystem_root];
 
         $rules = [];
@@ -8920,8 +8920,8 @@ class ImportClient
      * Unknown paths are omitted because both WP_CONTENT_DIR and the directory path
      * are needed to decide whether the directory lives outside WP_CONTENT_DIR.
      *
-     * @param array<string,string|null> $source_tokens From wp_source_path_tokens().
-     * @return array<string,string> Directory name => real source path, for
+     * @param array<string,string|null> $source_tokens From remote_path_tokens().
+     * @return array<string,string> Directory name => absolute remote path, for
      *                              directories outside WP_CONTENT_DIR only.
      */
     private function content_directories_outside_wp_content(array $source_tokens): array
@@ -8943,31 +8943,27 @@ class ImportClient
     }
 
     /**
-     * Resolve raw file path sources into a deduped list of real source absolute
-     * prefixes. Each source is a `:token:` template (e.g.
-     * `:wp-content:`, `:wp-uploads:`) or a raw absolute path,
-     * resolved through the same source token table (wp_source_path_tokens)
-     * as --remap.
+     * Resolves :token:-based path locators into absolute paths on the remote site.
      *
-     * For example, when `:wp-plugins:` maps to `/custom/plugins`:
+     * For example, when `:wp-plugins:` maps to `/htdocs/wp-content/plugins`:
      *
-     *     $prefixes = $this->resolve_pull_files_path_prefixes(
+     *     $prefixes = $this->resolve_remote_paths(
      *         [':wp-plugins:', ':wp-plugins:/woocommerce', '/var/custom/data'],
      *         'only'
      *     );
      *
-     *     // Returns ['/custom/plugins', '/var/custom/data'].
+     *     // Returns ['/htdocs/wp-content/plugins', '/var/custom/data'].
      *
      * @param array<int,string> $raw_sources Raw SOURCE values from the CLI.
      * @param string            $option_name CLI option name used in errors.
-     * @return array<int,string> Real source prefixes (deduped).
+     * @return array<int,string> Absolute remote path prefixes (deduped).
      */
-    private function resolve_pull_files_path_prefixes(
+    private function resolve_remote_paths(
         array $raw_sources,
         string $option_name
     ): array
     {
-        $source_tokens = $this->wp_source_path_tokens();
+        $source_tokens = $this->remote_path_tokens();
 
         $prefixes = [];
         foreach ($raw_sources as $src) {
@@ -9054,7 +9050,7 @@ class ImportClient
     }
 
     /**
-     * The source site's real paths from preflight data, as remap/path-selection token
+     * Remote site's real paths from preflight data, as remap/path-selection token
      * name => absolute path (wp-content, wp-plugins, wp-mu-plugins, wp-uploads,
      * abspath).
      *
@@ -9063,7 +9059,7 @@ class ImportClient
      * data-gatherer: any entry may be null when preflight lacks it (no
      * content_dir, abspath undetermined).
      */
-    private function wp_source_path_tokens(): array
+    private function remote_path_tokens(): array
     {
         $preflight = $this->get_state()->preflight["data"] ?? [];
         $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
@@ -9100,7 +9096,7 @@ class ImportClient
      * Resolve a --remap/--only/--exclude path argument into an absolute path.
      *
      * Substitutes a known leading `:token:` (see the token tables in
-     * resolve_remap and resolve_pull_files_path_prefixes) with its
+     * resolve_remap and resolve_remote_paths) with its
      * value, then trims trailing slashes. The result must be a valid absolute
      * path with no `.`/`..` segments; a relative path or an unknown token (left
      * unsubstituted) fails that check. Referencing a token whose value is

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -296,7 +296,7 @@ class Pull
                 $state->fetch = new FetchListProgressState();
                 $state->fetch_skipped = new FetchListProgressState();
                 $state->files_pull_summary = new FilesPullSummaryState();
-                $state->files_pull_only_fingerprint = null;
+                $state->files_pull_path_selection_fingerprint = null;
                 $this->client->save_state();
                 foreach ([
                     "{$pull_state_directory}/remote-index.next.jsonl",
@@ -816,7 +816,7 @@ class Pull
         }
         if ($reset_file_selection_state) {
             $state->index = new RemoteFileIndexCursorState();
-            $state->files_pull_only_fingerprint = null;
+            $state->files_pull_path_selection_fingerprint = null;
         }
         if ($reset_db_state) {
             $state->sql_bytes = null;

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -369,6 +369,7 @@ class PullState
     public ?int $max_allowed_packet = null;
     /** @var string|null Fingerprint of resolved path mappings; guards files-pull reuse. */
     public ?string $resolved_path_mappings_fingerprint = null;
+    /** @var string|null Files-pull path-selection fingerprint; the key name is retained for state-file compatibility. */
     public ?string $files_pull_only_fingerprint = null;
     public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -369,8 +369,8 @@ class PullState
     public ?int $max_allowed_packet = null;
     /** @var string|null Fingerprint of resolved path mappings; guards files-pull reuse. */
     public ?string $resolved_path_mappings_fingerprint = null;
-    /** @var string|null Files-pull path-selection fingerprint; the key name is retained for state-file compatibility. */
-    public ?string $files_pull_only_fingerprint = null;
+    /** @var string|null Files-pull path-selection fingerprint; guards resume. */
+    public ?string $files_pull_path_selection_fingerprint = null;
     public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;
     public FileDiffProgressState $diff;
@@ -437,7 +437,7 @@ class PullState
         $state->user_agent = $data['user_agent'];
         $state->max_allowed_packet = $data['max_allowed_packet'];
         $state->resolved_path_mappings_fingerprint = $data['resolved_path_mappings_fingerprint'];
-        $state->files_pull_only_fingerprint = $data['files_pull_only_fingerprint'];
+        $state->files_pull_path_selection_fingerprint = $data['files_pull_path_selection_fingerprint'];
         $state->files_pull_summary = FilesPullSummaryState::from_array($data['files_pull_summary']);
         $state->db_index = DatabaseTableIndexState::from_array($data['db_index']);
         $state->diff = FileDiffProgressState::from_array($data['diff']);
@@ -475,7 +475,7 @@ class PullState
             'user_agent' => $this->user_agent,
             'max_allowed_packet' => $this->max_allowed_packet,
             'resolved_path_mappings_fingerprint' => $this->resolved_path_mappings_fingerprint,
-            'files_pull_only_fingerprint' => $this->files_pull_only_fingerprint,
+            'files_pull_path_selection_fingerprint' => $this->files_pull_path_selection_fingerprint,
             'files_pull_summary' => $this->files_pull_summary->to_array(),
             'db_index' => $this->db_index->to_array(),
             'diff' => $this->diff->to_array(),

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -22,6 +22,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--filter=MODE', $output);
         $this->assertStringContainsString('--remap SOURCE TARGET', $output);
         $this->assertStringContainsString('--only=SOURCE', $output);
+        $this->assertStringContainsString('--exclude=SOURCE', $output);
     }
 
     public function testFilesIndexHelpNamesTheNextRemoteIndexFile(): void

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -5,11 +5,10 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 
 /**
- * --only reuses the existing `value-or-next` option type (like --new-site-url),
- * but is repeatable because commas are valid path bytes. The parser lives
- * inside the CLI bootstrap guard (not require-able), so this exercises the real
- * binary and asserts `--only` is recognized in both `--only=VAL` and
- * `--only VAL` forms.
+ * --only and --exclude reuse the existing `value-or-next` option type (like
+ * --new-site-url), but are repeatable because commas are valid path bytes. The
+ * parser lives inside the CLI bootstrap guard (not require-able), so this
+ * exercises the real binary.
  */
 class OnlyCliParseTest extends TestCase
 {
@@ -95,6 +94,7 @@ $log = %s;
 file_put_contents($log, json_encode(array(
     'endpoint' => $_GET['endpoint'] ?? null,
     'directory' => $_GET['directory'] ?? null,
+    'exclude_path' => $_GET['exclude_path'] ?? null,
 ), JSON_UNESCAPED_SLASHES) . "\n", FILE_APPEND);
 
 $boundary = 'reprint-test-boundary';
@@ -339,6 +339,37 @@ PHP, var_export($requestsLog, true)));
             '/var/www/html/wp-content/uploads/2025',
             '/var/www/html/wp-content/themes',
         ), $fileIndexRequest['directory'] ?? null);
+    }
+
+    public function testRepeatedExcludeOptionsStayOutOfFileIndexRequest(): void
+    {
+        $requestsLog = $this->tempDir . '/requests.jsonl';
+        $remoteUrl = $this->startDirectoryCaptureServer($requestsLog);
+        $this->writePreflightState($remoteUrl, true);
+
+        $output = $this->runCli(array(
+            'files-pull',
+            $remoteUrl,
+            '--exclude',
+            ':wp-content:/cache',
+            '--exclude',
+            ':wp-uploads:',
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+        ));
+
+        $this->assertStringNotContainsString('"status":"error"', $output);
+
+        $fileIndexRequest = null;
+        foreach ($this->capturedRequests($requestsLog) as $request) {
+            if (($request['endpoint'] ?? null) === 'file_index') {
+                $fileIndexRequest = $request;
+                break;
+            }
+        }
+
+        $this->assertNotNull($fileIndexRequest, "files-pull should request file_index. Output:\n{$output}");
+        $this->assertNull($fileIndexRequest['exclude_path'] ?? null);
     }
 
     public function testOnlyOptionKeepsCommaInsideSourcePath(): void

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -7,11 +7,11 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --only: the diff must reconcile only within the --only file path prefixes. A next remote index built
- * with --only lists selected paths only, so the delete drains in
- * compare_remote_indexes_and_build_fetch_list() would otherwise wrongly delete
- * every unselected remote index entry. Guard both drains so unselected local files +
- * index entries survive, while selected orphans are still deleted (delta).
+ * Path selection: the diff must reconcile only within the selected path
+ * prefixes. --only scopes the downloaded next remote index, while --exclude
+ * is applied locally to that index. The delete drains in
+ * compare_remote_indexes_and_build_fetch_list() must keep unselected local
+ * files and remote index entries while still deleting selected orphans.
  */
 class OnlyFilesPathPrefixDiffTest extends TestCase
 {
@@ -106,8 +106,11 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         return $paths;
     }
 
-    /** Mirror FilesPullStateTest: load state + preserve-local, then set the --only file path prefixes. */
-    private function prepareClient(array $pull_only_files_with_path_prefixes): array
+    /** Load state + preserve-local, then set the file path selection. */
+    private function prepareClient(
+        array $pull_only_files_with_path_prefixes,
+        array $pull_excluded_files_with_path_prefixes = []
+    ): array
     {
         $state = [
             "active_resumable_command" => [
@@ -130,6 +133,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $r->getProperty('is_tty')->setValue($client, false);
         $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
         $r->getProperty('pull_only_files_with_path_prefixes')->setValue($client, $pull_only_files_with_path_prefixes);
+        $r->getProperty('pull_excluded_files_with_path_prefixes')->setValue($client, $pull_excluded_files_with_path_prefixes);
         return [$client, $r];
     }
 
@@ -161,6 +165,90 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // Selected orphan file AND its index entry are deleted.
         $this->assertFileDoesNotExist($orphan);
         $this->assertNotContains('/wp-content/old/orphan.txt', $this->readRemoteIndexEntryPaths());
+    }
+
+    public function testExcludeFilesPrefixDiffKeepsExcludedOrphan(): void
+    {
+        $this->writeIndex(
+            'remote-index.jsonl',
+            $this->indexLine('/wp-content/uploads/local-only.jpg', 1000, 100)
+        );
+        $this->writeIndex('remote-index.next.jsonl', '');
+        $excluded = $this->seedLocalFile('/wp-content/uploads/local-only.jpg');
+
+        [$client, $reflection] = $this->prepareClient(
+            [],
+            ['/wp-content/uploads']
+        );
+        $reflection->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
+
+        $this->assertFileExists($excluded);
+        $this->assertContains(
+            '/wp-content/uploads/local-only.jpg',
+            $this->readRemoteIndexEntryPaths()
+        );
+    }
+
+    public function testExcludeFilesPrefixPrunesFetchListFromFullNextRemoteIndex(): void
+    {
+        $this->writeIndex('remote-index.jsonl', '');
+        $this->writeIndex(
+            'remote-index.next.jsonl',
+            $this->indexLine('/wp-content/themes/flavor/style.css', 1000, 100)
+            . $this->indexLine('/wp-content/uploads/photo.jpg', 1000, 100)
+        );
+
+        [$client, $reflection] = $this->prepareClient(
+            [],
+            ['/wp-content/uploads']
+        );
+        $reflection->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
+
+        $fetchListLines = file(
+            $this->pullStateDirectory . '/fetch-list.jsonl',
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $fetchPaths = array_map(
+            static function (string $line): string {
+                $entry = json_decode($line, true);
+                return base64_decode($entry['path'], true);
+            },
+            $fetchListLines
+        );
+
+        $this->assertSame(
+            ['/wp-content/themes/flavor/style.css'],
+            $fetchPaths
+        );
+        $this->assertStringContainsString(
+            base64_encode('/wp-content/uploads/photo.jpg'),
+            file_get_contents($this->pullStateDirectory . '/remote-index.next.jsonl')
+        );
+    }
+
+    public function testRemoteFollowedPathOutsideOnlyScopeIsFetched(): void
+    {
+        // The exporter applies the --only roots before building this index, but
+        // following a selected symlink may add its target outside those roots.
+        // The importer must fetch that target while still using --only to scope
+        // deletions from the prior remote index.
+        $this->writeIndex('remote-index.jsonl', '');
+        $this->writeIndex(
+            'remote-index.next.jsonl',
+            $this->indexLine('/shared/themes/indice/style.css', 1000, 10)
+        );
+
+        [$client, $reflection] = $this->prepareClient(['/wp-content/plugins']);
+        $reflection->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
+
+        $fetch_entry = json_decode(
+            trim(file_get_contents($this->pullStateDirectory . '/fetch-list.jsonl')),
+            true
+        );
+        $this->assertSame(
+            '/shared/themes/indice/style.css',
+            base64_decode($fetch_entry['path'], true)
+        );
     }
 
     public function testOnlyRootItselfSurvivesTheDeleteDrains(): void

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -230,13 +230,13 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         // No --only: every file path is selected (keeps the diff deleting orphans).
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/anything/at/all.php')));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/anything/at/all.php', false)));
 
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css')));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php')));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php', false)));
         // Byte-order sibling must not match the prefix.
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content.bak/x')));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content.bak/x', false)));
     }
 
     public function testIncludeAndExcludePathPrefixSelection(): void
@@ -245,13 +245,13 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
         $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css')));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads/a.jpg')));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php')));
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads.backup/a.jpg')));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads/a.jpg', false)));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php', false)));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads.backup/a.jpg', false)));
 
         $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/'));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css')));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
     }
 
     public function testChangingOnlyPrefixesWhileResumingFilesPullIsRejected(): void

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../../importer/import.php';
 
 /**
  * File-prefix resolution and enumeration (pure, preflight-injected):
- *   - resolve_pull_files_path_prefixes(): :token: templates / absolute paths → real source
+ *   - resolve_remote_paths(): :token: templates / absolute paths → remote absolute
  *     prefixes (sharing --remap's WordPress path token table), with expansion for plugins, mu-plugins, and uploads
  *     directories outside WP_CONTENT_DIR and covered-prefix collapse.
  *   - is_selected_for_pulling(): per-path --only/--exclude membership.
@@ -171,7 +171,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'plugins_dir' => '/var/www/html/wp-content/plugins', // nested → not added
             'uploads' => array('basedir' => '/mnt/uploads'),     // outside WP_CONTENT_DIR → added
         ));
-        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-content:'), 'only'));
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_remote_paths', array(array(':wp-content:'), 'only'));
         sort($pull_only_files_with_path_prefixes);
         $this->assertSame(array('/mnt/uploads', '/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
@@ -181,7 +181,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         // :wp-content:/plugins is nested under :wp-content: → dropped, so the
         // exporter never walks the subtree twice.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-content:', ':wp-content:/plugins'), 'only'));
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_remote_paths', array(array(':wp-content:', ':wp-content:/plugins'), 'only'));
         $this->assertSame(array('/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
 
@@ -201,7 +201,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         ))));
         $this->assertSame(
             array('/custom/plugins/woocommerce'),
-            $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-plugins:/woocommerce'), 'only'))
+            $this->call($c, 'resolve_remote_paths', array(array(':wp-plugins:/woocommerce'), 'only'))
         );
     }
 
@@ -211,7 +211,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->assertSame(
             array('/var/custom/data'),
-            $this->call($c, 'resolve_pull_files_path_prefixes', array(array('/var/custom/data'), 'only'))
+            $this->call($c, 'resolve_remote_paths', array(array('/var/custom/data'), 'only'))
         );
     }
 
@@ -221,7 +221,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         // not silently ignored.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
-        $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-content:', ''), 'only'));
+        $this->call($c, 'resolve_remote_paths', array(array(':wp-content:', ''), 'only'));
     }
 
     public function testResolvePullOnlyFilesPrefixRejectsUnavailableToken(): void
@@ -231,7 +231,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('preflight');
-        $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':abspath:/wp-admin'), 'only'));
+        $this->call($c, 'resolve_remote_paths', array(array(':abspath:/wp-admin'), 'only'));
     }
 
     public function testPullOnlyFilesPrefixSelectionDefaultsToTrueAndIsSlashAware(): void

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -86,18 +86,10 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     private function pathSelectionFingerprint(array $included, array $excluded = array()): string
     {
-        $onlyFingerprint = hash(
-            'sha256',
-            json_encode($included, JSON_UNESCAPED_SLASHES)
-        );
-        if ($excluded === array()) {
-            return $onlyFingerprint;
-        }
-
         sort($excluded, SORT_STRING);
         return hash('sha256', json_encode(array(
-            'only_fingerprint' => $onlyFingerprint,
-            'exclude' => $excluded,
+            'only_path_prefixes' => $included,
+            'excluded_path_prefixes' => $excluded,
         ), JSON_UNESCAPED_SLASHES));
     }
 
@@ -269,7 +261,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
         $original_fingerprint = $this->call($c, 'files_pull_path_selection_fingerprint');
 
-        $c->get_state()->files_pull_only_fingerprint = $original_fingerprint;
+        $c->get_state()->files_pull_path_selection_fingerprint = $original_fingerprint;
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->expectException(\RuntimeException::class);
@@ -282,7 +274,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
 
         $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
-        $c->get_state()->files_pull_only_fingerprint =
+        $c->get_state()->files_pull_path_selection_fingerprint =
             $this->call($c, 'files_pull_path_selection_fingerprint');
         $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
 
@@ -295,7 +287,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
 
-        $c->get_state()->files_pull_only_fingerprint = 'different';
+        $c->get_state()->files_pull_path_selection_fingerprint = 'different';
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->call($c, 'assert_files_pull_path_selection_unchanged_while_resuming', array(false));
@@ -306,7 +298,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     public function testRunRejectsChangingOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
         $this->writeFilesPullState(array(
-            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
+            'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
         $this->expectException(\RuntimeException::class);
@@ -318,7 +310,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
         $this->writeFilesPullState(array(
-            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
+            'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
         $this->runFilesPull(array('only' => array(':wp-content:/plugins')));
@@ -327,23 +319,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
         $this->assertSame(
             $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
-            $state['files_pull_only_fingerprint'] ?? null
-        );
-    }
-
-    public function testRunRecordsOnlyFingerprintForInProgressFilesPullState(): void
-    {
-        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
-        $this->writeFilesPullState(array(
-            'files_pull_only_fingerprint' => null,
-        ));
-
-        $this->runFilesPull(array('only' => array(':wp-content:/plugins')));
-
-        $state = $this->readState();
-        $this->assertSame(
-            $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
-            $state['files_pull_only_fingerprint'] ?? null
+            $state['files_pull_path_selection_fingerprint'] ?? null
         );
     }
 
@@ -354,7 +330,7 @@ class OnlyFilesPathPrefixTest extends TestCase
                 'completion_state' => 'complete',
                 'current_stage' => null,
             ),
-            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
+            'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
         $this->runFilesPull(array('only' => array(':wp-uploads:')));
@@ -366,7 +342,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     public function testRunRejectsAddingExclusionsToInProgressOnlyState(): void
     {
         $this->writeFilesPullState(array(
-            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array()),
+            'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array()),
         ));
 
         $this->expectException(\RuntimeException::class);

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -7,11 +7,11 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --only file-prefix resolution and enumeration (pure, preflight-injected):
- *   - resolve_pull_only_files_with_path_prefixes(): :token: templates / absolute paths → real source
+ * File-prefix resolution and enumeration (pure, preflight-injected):
+ *   - resolve_pull_files_path_prefixes(): :token: templates / absolute paths → real source
  *     prefixes (sharing --remap's WordPress path token table), with expansion for plugins, mu-plugins, and uploads
  *     directories outside WP_CONTENT_DIR and covered-prefix collapse.
- *   - is_selected_for_pulling(): per-path membership (no --only ⇒ every file path).
+ *   - is_selected_for_pulling(): per-path --only/--exclude membership.
  *   - get_export_directories(): with --only, a *replace* of the export roots.
  * Orthogonal to --remap (--only file prefixes decide what gets pulled, not where it lands).
  */
@@ -84,9 +84,21 @@ class OnlyFilesPathPrefixTest extends TestCase
         return $this->client(array('database' => array('wp' => array('paths_urls' => $pathsUrls))));
     }
 
-    private function onlyFingerprint(array $prefixes): string
+    private function pathSelectionFingerprint(array $included, array $excluded = array()): string
     {
-        return hash('sha256', json_encode($prefixes, JSON_UNESCAPED_SLASHES));
+        $onlyFingerprint = hash(
+            'sha256',
+            json_encode($included, JSON_UNESCAPED_SLASHES)
+        );
+        if ($excluded === array()) {
+            return $onlyFingerprint;
+        }
+
+        sort($excluded, SORT_STRING);
+        return hash('sha256', json_encode(array(
+            'only_fingerprint' => $onlyFingerprint,
+            'exclude' => $excluded,
+        ), JSON_UNESCAPED_SLASHES));
     }
 
     private function writeFilesPullState(array $state): void
@@ -125,7 +137,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         );
     }
 
-    private function runFilesPullWithOnly(array $only): void
+    private function runFilesPull(array $fileSelectionOptions): void
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
         $output = fopen('php://temp', 'w');
@@ -135,9 +147,9 @@ class OnlyFilesPathPrefixTest extends TestCase
         (new \ReflectionClass($progress))->getProperty('progress_fd')->setValue($progress, $output);
 
         try {
-            $c->run(array(
-                'command' => 'files-pull',
-                'only' => $only,
+            $c->run(array_merge(
+                array('command' => 'files-pull'),
+                $fileSelectionOptions
             ));
         } finally {
             fclose($output);
@@ -159,7 +171,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'plugins_dir' => '/var/www/html/wp-content/plugins', // nested → not added
             'uploads' => array('basedir' => '/mnt/uploads'),     // outside WP_CONTENT_DIR → added
         ));
-        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-content:')));
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-content:'), 'only'));
         sort($pull_only_files_with_path_prefixes);
         $this->assertSame(array('/mnt/uploads', '/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
@@ -169,7 +181,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         // :wp-content:/plugins is nested under :wp-content: → dropped, so the
         // exporter never walks the subtree twice.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-content:', ':wp-content:/plugins')));
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-content:', ':wp-content:/plugins'), 'only'));
         $this->assertSame(array('/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
 
@@ -189,7 +201,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         ))));
         $this->assertSame(
             array('/custom/plugins/woocommerce'),
-            $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-plugins:/woocommerce')))
+            $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-plugins:/woocommerce'), 'only'))
         );
     }
 
@@ -199,7 +211,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->assertSame(
             array('/var/custom/data'),
-            $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array('/var/custom/data')))
+            $this->call($c, 'resolve_pull_files_path_prefixes', array(array('/var/custom/data'), 'only'))
         );
     }
 
@@ -209,7 +221,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         // not silently ignored.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
-        $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':wp-content:', '')));
+        $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':wp-content:', ''), 'only'));
     }
 
     public function testResolvePullOnlyFilesPrefixRejectsUnavailableToken(): void
@@ -219,7 +231,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('preflight');
-        $this->call($c, 'resolve_pull_only_files_with_path_prefixes', array(array(':abspath:/wp-admin')));
+        $this->call($c, 'resolve_pull_files_path_prefixes', array(array(':abspath:/wp-admin'), 'only'));
     }
 
     public function testPullOnlyFilesPrefixSelectionDefaultsToTrueAndIsSlashAware(): void
@@ -235,19 +247,48 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content.bak/x')));
     }
 
+    public function testIncludeAndExcludePathPrefixSelection(): void
+    {
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
+        $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
+
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css')));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads/a.jpg')));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php')));
+        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads.backup/a.jpg')));
+
+        $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/'));
+        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css')));
+    }
+
     public function testChangingOnlyPrefixesWhileResumingFilesPullIsRejected(): void
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
 
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
-        $original_fingerprint = $this->call($c, 'files_pull_only_fingerprint');
+        $original_fingerprint = $this->call($c, 'files_pull_path_selection_fingerprint');
 
         $c->get_state()->files_pull_only_fingerprint = $original_fingerprint;
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --only while resuming files-pull');
-        $this->call($c, 'assert_files_pull_only_unchanged_while_resuming', array(true));
+        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->call($c, 'assert_files_pull_path_selection_unchanged_while_resuming', array(true));
+    }
+
+    public function testChangingExcludePrefixesWhileResumingFilesPullIsRejected(): void
+    {
+        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
+
+        $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
+        $c->get_state()->files_pull_only_fingerprint =
+            $this->call($c, 'files_pull_path_selection_fingerprint');
+        $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->call($c, 'assert_files_pull_path_selection_unchanged_while_resuming', array(true));
     }
 
     public function testChangingOnlyPrefixesAfterCompletedFilesPullIsAllowed(): void
@@ -257,7 +298,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c->get_state()->files_pull_only_fingerprint = 'different';
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
-        $this->call($c, 'assert_files_pull_only_unchanged_while_resuming', array(false));
+        $this->call($c, 'assert_files_pull_path_selection_unchanged_while_resuming', array(false));
         $this->addToAssertionCount(1);
     }
 
@@ -265,27 +306,27 @@ class OnlyFilesPathPrefixTest extends TestCase
     public function testRunRejectsChangingOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
         $this->writeFilesPullState(array(
-            'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --only while resuming files-pull');
-        $this->runFilesPullWithOnly(array(':wp-uploads:'));
+        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->runFilesPull(array('only' => array(':wp-uploads:')));
     }
 
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
         $this->writeFilesPullState(array(
-            'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
-        $this->runFilesPullWithOnly(array(':wp-content:/plugins'));
+        $this->runFilesPull(array('only' => array(':wp-content:/plugins')));
 
         $state = $this->readState();
         $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
         $this->assertSame(
-            $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
             $state['files_pull_only_fingerprint'] ?? null
         );
     }
@@ -297,11 +338,11 @@ class OnlyFilesPathPrefixTest extends TestCase
             'files_pull_only_fingerprint' => null,
         ));
 
-        $this->runFilesPullWithOnly(array(':wp-content:/plugins'));
+        $this->runFilesPull(array('only' => array(':wp-content:/plugins')));
 
         $state = $this->readState();
         $this->assertSame(
-            $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
             $state['files_pull_only_fingerprint'] ?? null
         );
     }
@@ -313,13 +354,24 @@ class OnlyFilesPathPrefixTest extends TestCase
                 'completion_state' => 'complete',
                 'current_stage' => null,
             ),
-            'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
+            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
-        $this->runFilesPullWithOnly(array(':wp-uploads:'));
+        $this->runFilesPull(array('only' => array(':wp-uploads:')));
 
         $state = $this->readState();
         $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
+    }
+
+    public function testRunRejectsAddingExclusionsToInProgressOnlyState(): void
+    {
+        $this->writeFilesPullState(array(
+            'files_pull_only_fingerprint' => $this->pathSelectionFingerprint(array()),
+        ));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->runFilesPull(array('exclude' => array(':wp-uploads:')));
     }
 
     public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void


### PR DESCRIPTION
`files-pull` and `pull-files` now accept repeatable `--exclude=SOURCE` path prefixes without changing the remote file-index protocol.

`--exclude` shares the existing `--only` token resolution and path-selection state. The importer downloads the normal next remote index, applies exclusions while diffing it, and sends only selected new or changed paths through the existing `file_list` upload to `file_fetch`. `--only` continues to select the exporter traversal roots through `directory[]`.

The retained remote index remains a union across differently scoped pulls. Missing paths are deleted only when selected by the current `--only` and `--exclude` values, so a narrow pull does not delete or forget paths outside its scope. Exclusions take precedence when prefixes overlap, and the selection fingerprint prevents an interrupted pull from resuming under different prefixes.

## Testing

Focused tests cover repeated option parsing, token resolution, overlapping prefixes, resume protection, selected deletion scope, a full next remote index with a locally pruned fetch list, and followed symlink targets outside an `--only` root. The importer suite, PHPStan, PHP compatibility checks, and whitespace checks pass locally.
