### PR TITLE
Name the downloaded filesystem snapshot the next remote index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ Always consult these when working on the respective components.
 Progress is computed client-side by reading state files (all in `--state-dir`):
 - `pull/state.json`: Current command, status, cursor, stage
 - `pull/local-index.jsonl`: Local file index (line count = files indexed)
-- `pull/remote-index.jsonl`: Remote file index (for delta comparison)
+- `pull/remote-index.next.jsonl`: Next remote index (for delta comparison)
 - `pull/fetch-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
 

--- a/README.md
+++ b/README.md
@@ -607,8 +607,10 @@ If the JSON is invalid on load, the importer renames it to
     "updated_at": "2025-01-15T10:30:00Z"
   },
   "diff": {
-    "remote_offset": 1024,        // byte offset into remote index
-    "local_after": "base64..."    // last compared local path
+    // Byte offset into the next remote index.
+    "next_remote_index_byte_offset": 1024,
+    // Last local index entry path consumed before that byte offset.
+    "last_consumed_local_index_entry_path": "base64..."
   },
   "index": {
     "cursor": "..."               // file_index cursor

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -46,12 +46,12 @@ local relative path to a push-root-relative path.
 
 ## Indexes and mappings
 
-- A **remote index** is the last remote filesystem state accepted by pull.
-  Its entries use remote absolute paths and remote-observed metadata. Use
-  `$remote_index_file`.
-- A **local index** is the locally accounted pull baseline. Its entries use
-  remote absolute paths as the merge key and locally observed metadata. Use
-  `$local_index_file`.
+- A **local index** is the pull baseline stored locally after remote operations
+  are applied. Its entries use remote absolute paths and remote-observed
+  metadata. Use `$local_index_file`.
+- A **next remote index** is the snapshot of the remote paths selected for the
+  current pull. Its entries use remote absolute paths and remote-observed
+  metadata. Use `$next_remote_index_file`.
 - A **fresh local index** is the current filesystem-root scan created while
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
@@ -160,9 +160,9 @@ development. There are no compatibility aliases or migration paths.
 The **state directory** is the caller-supplied `<state-dir>`; use `$state_dir`.
 Reprint uses it exactly as supplied and does not append `.reprint`. A consumer
 may choose `.reprint` or any other private directory name. The **pull state
-directory** is `<state-dir>/pull`; use `$pull_state_directory`. Shared and pull
-filenames inside the state directory do not begin with a dot or repeat the
-scope supplied by their parent directories.
+directory** is `<state-dir>/pull`; use `$pull_state_directory`. Filenames
+inside the state directory do not begin with a dot or repeat the scope supplied
+by their parent directories.
 
 ```text
 <state-dir>/
@@ -173,7 +173,7 @@ scope supplied by their parent directories.
 │   ├── state.json
 │   ├── local-index.jsonl
 │   ├── local-index.wal
-│   ├── remote-index.jsonl
+│   ├── remote-index.next.jsonl
 │   ├── fetch-list.jsonl
 │   ├── skipped-fetch-list.jsonl
 │   ├── volatile-files.json
@@ -193,7 +193,7 @@ Use these path names:
 | Pull state file | `$pull_state_file` |
 | Local index file | `$local_index_file` |
 | Local index WAL | `$local_index_wal_path` |
-| Remote index file | `$remote_index_file` |
+| Next remote index file | `$next_remote_index_file` |
 | Fetch list file | `$fetch_list_file` |
 | Skipped fetch list file | `$skipped_fetch_list_file` |
 | Volatile files file | `$volatile_files_file` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -249,7 +249,7 @@ class ImportClient
 
     /**
      * @var string Local index file pull/local-index.jsonl. It tracks each accounted
-     * path's ctime, size, and type for the next remote-index comparison.
+     * path's ctime, size, and type for comparison with the next remote index.
      */
     private $local_index_file;
 
@@ -287,10 +287,10 @@ class ImportClient
     private $last_local_index_wal_type = null;
 
     /**
-     * @var string Remote index file pull/remote-index.jsonl, including
+     * @var string Next remote index file pull/remote-index.next.jsonl, including
      * directory `empty` fields when available.
      */
-    private $remote_index_file;
+    private $next_remote_index_file;
 
     /** @var string Path to pull/fetch-list.jsonl — files to download, computed by diffing remote vs local index. */
     private $fetch_list_file;
@@ -377,10 +377,10 @@ class ImportClient
      * symlink, or directory that already exists at a path the remote tries to write
      * is skipped and never added to the local index.
      *
-     * On subsequent delta syncs, preserved paths survive because the importer only
-     * acts on paths listed in the remote index. Local-only hosting infrastructure
-     * (e.g. __wp__ symlinks, drop-in symlinks, shared plugin directories) is simply
-     * invisible to the diff and never touched.
+     * On subsequent delta syncs, preserved paths survive because the importer compares
+     * the next remote index only with paths it previously added to the local index.
+     * A preserved local path was never added to that baseline, so its absence from the
+     * next remote index cannot schedule it for deletion.
      *
      * Set via --on-fs-root-nonempty, persisted in state so it survives across invocations.
      */
@@ -443,15 +443,15 @@ class ImportClient
     private Pull $pull;
 
     /** @var int Cumulative count of index entries written (survives retries). */
-    private $index_entries_counted = 0;
+    private $next_remote_index_entries_counted = 0;
 
     /**
-     * Memoized lookups for "does remote index contain this path or any descendant path?"
+     * Memoized lookups for "does next remote index contain this path or any descendant path?"
      * keyed by normalized absolute path.
      *
      * @var array<string,bool>
      */
-    private $remote_index_prefix_cache = [];
+    private $next_remote_index_prefix_cache = [];
 
     /** @var int|null Current step in a multi-step pipeline (1-indexed). Set via --step. */
     private $pipeline_step = null;
@@ -520,8 +520,8 @@ class ImportClient
         $this->local_index_file = $this->state_dir . "/pull/local-index.jsonl";
         $this->local_index_wal_path =
             $this->state_dir . "/pull/local-index.wal";
-        $this->remote_index_file =
-            $this->state_dir . "/pull/remote-index.jsonl";
+        $this->next_remote_index_file =
+            $this->state_dir . "/pull/remote-index.next.jsonl";
         $this->fetch_list_file =
             $this->state_dir . "/pull/fetch-list.jsonl";
         $this->skipped_fetch_list_file =
@@ -1929,9 +1929,9 @@ class ImportClient
                 $this->get_state()->active_resumable_command->completion_state = null;
                 $this->get_state()->active_resumable_command->current_stage = null;
                 $this->get_state()->index = new RemoteFileIndexCursorState();
-                if (file_exists($this->remote_index_file)) {
-                    @unlink($this->remote_index_file);
-                    $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+                if (file_exists($this->next_remote_index_file)) {
+                    @unlink($this->next_remote_index_file);
+                    $this->audit_log("FILE DELETE | {$this->next_remote_index_file}");
                 }
                 $this->save_state();
                 break;
@@ -2018,9 +2018,9 @@ class ImportClient
         $this->local_index_wal_handle = null;
         $this->local_index_wal_record_count = 0;
 
-        if (file_exists($this->remote_index_file)) {
-            @unlink($this->remote_index_file);
-            $this->audit_log("FILE DELETE | {$this->remote_index_file}");
+        if (file_exists($this->next_remote_index_file)) {
+            @unlink($this->next_remote_index_file);
+            $this->audit_log("FILE DELETE | {$this->next_remote_index_file}");
         }
         if (file_exists($this->fetch_list_file)) {
             @unlink($this->fetch_list_file);
@@ -2923,7 +2923,7 @@ class ImportClient
         $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
 
         if ($stage === "index") {
-            $complete = $this->fetch_remote_index();
+            $complete = $this->fetch_next_remote_index();
             if (!$complete) {
                 $this->get_state()->active_resumable_command->completion_state = "partial";
                 $this->save_state();
@@ -2937,7 +2937,7 @@ class ImportClient
                     return;
                 }
             }
-            $this->sort_index_file($this->remote_index_file);
+            $this->sort_index_file($this->next_remote_index_file);
             $this->get_state()->active_resumable_command->current_stage = "diff";
             $this->get_state()->diff = new FileDiffProgressState();
             if (file_exists($this->fetch_list_file)) {
@@ -2988,7 +2988,7 @@ class ImportClient
                 $green = "\033[32m";
                 $dim = "\033[2m";
                 $r = "\033[0m";
-                $scanned = number_format($this->index_entries_counted);
+                $scanned = number_format($this->next_remote_index_entries_counted);
                 $this->progress->clear_progress_line();
                 $this->progress->print_line("  {$green}✓{$r} Scanned {$dim}— {$scanned} entries{$r}\n");
                 $total = $this->count_newlines($this->fetch_list_file);
@@ -3091,7 +3091,7 @@ class ImportClient
 
         // Recreate intermediate path symlinks so the full symlink chain
         // works locally.  The server discovers these (e.g. /srv/wordpress
-        // -> /wordpress) and includes them in the remote index.
+        // -> /wordpress) and includes them in the next remote index.
         if ($this->follow_symlinks) {
             $this->recreate_intermediate_symlinks();
         }
@@ -3101,9 +3101,9 @@ class ImportClient
      * Command: files-index
      *
      * Rules:
-     * - Streams the full remote index (DFS across directories) until complete
+     * - Streams the full next remote index (DFS across directories) until complete
      * - If already completed: require --abort flag
-     * - If abort flag: clear remote index file and index cursor
+     * - If abort flag: clear next remote index file and index cursor
      */
     private function run_files_index(): void
     {
@@ -3156,7 +3156,7 @@ class ImportClient
         $attempts = 0;
         $last_cursor = $this->get_state()->index->cursor ?? null;
         while (true) {
-            $complete = $this->fetch_remote_index();
+            $complete = $this->fetch_next_remote_index();
             if ($complete) {
                 break;
             }
@@ -3190,37 +3190,39 @@ class ImportClient
             $this->discover_symlink_targets();
         }
 
-        $this->sort_index_file($this->remote_index_file);
+        $this->sort_index_file($this->next_remote_index_file);
         $this->get_state()->active_resumable_command->completion_state = "complete";
         $this->get_state()->active_resumable_command->current_stage = null;
         $this->save_state();
 
-        $count = 0;
-        if (file_exists($this->remote_index_file)) {
-            $h = fopen($this->remote_index_file, "r");
-            if ($h) {
-                while (fgets($h) !== false) {
-                    $count++;
+        $next_remote_index_entry_count = 0;
+        if (file_exists($this->next_remote_index_file)) {
+            $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
+            if ($next_remote_index_file_handle) {
+                while (fgets($next_remote_index_file_handle) !== false) {
+                    $next_remote_index_entry_count++;
                 }
-                fclose($h);
+                fclose($next_remote_index_file_handle);
             }
         }
         $this->audit_log(
-            sprintf("files-index complete: %d entries indexed", $count),
+            sprintf("files-index complete: %d entries indexed", $next_remote_index_entry_count),
             true,
         );
 
-        $this->progress->show_lifecycle_line("files-index complete: {$count} entries indexed\n");
-        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_file}\n");
+        $this->progress->show_lifecycle_line(
+            "files-index complete: {$next_remote_index_entry_count} entries indexed\n"
+        );
+        $this->progress->show_lifecycle_line("Next remote index: {$this->next_remote_index_file}\n");
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log_file}\n");
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
             "command" => "files-index",
-            "entries_indexed" => $count,
-            "remote_index" => $this->remote_index_file,
+            "entries_indexed" => $next_remote_index_entry_count,
+            "next_remote_index_file" => $this->next_remote_index_file,
             "audit_log" => $this->audit_log_file,
-            "message" => "files-index complete: {$count} entries indexed",
+            "message" => "files-index complete: {$next_remote_index_entry_count} entries indexed",
         ], true);
     }
 
@@ -3228,7 +3230,7 @@ class ImportClient
      * Recursively discover directories that need indexing beyond the primary
      * export roots.
      *
-     * Scans the remote index for symlink entries with a "target" field,
+     * Scans the next remote index for symlink entries with a "target" field,
      * resolves relative targets to absolute paths, and indexes each target
      * directory. Repeats until the queue is drained, with cycle detection.
      */
@@ -3245,7 +3247,7 @@ class ImportClient
             $visited[$root] = true;
         }
 
-        $queue = $this->extract_symlink_dirs_from_index($visited);
+        $queue = $this->extract_symlink_directories_from_next_remote_index($visited);
 
         while (!empty($queue)) {
             $dir = array_shift($queue);
@@ -3281,7 +3283,7 @@ class ImportClient
                 "message" => "Following symlink target: {$dir}",
             ], true);
 
-            // Reset the index cursor so fetch_remote_index starts fresh
+            // Reset the index cursor so fetch_next_remote_index starts fresh
             // for this directory, but appends to the existing index file.
             // Note we are not losing the previous cursor position. This code
             // runs only after the previous directory was fully indexed so
@@ -3293,7 +3295,7 @@ class ImportClient
             $last_cursor = null;
             while (true) {
                 try {
-                $complete = $this->fetch_remote_index($dir);
+                $complete = $this->fetch_next_remote_index($dir);
                 } catch (RuntimeException $e) {
                     // We won't be able to follow every symlink. If
                     // the response seems like the remote server rejecting
@@ -3349,7 +3351,7 @@ class ImportClient
             }
 
             // Scan newly added entries for more symlink targets
-            $new_targets = $this->extract_symlink_dirs_from_index($visited);
+            $new_targets = $this->extract_symlink_directories_from_next_remote_index($visited);
             foreach ($new_targets as $target) {
                 if (!isset($visited[$target])) {
                     $queue[] = $target;
@@ -3359,37 +3361,37 @@ class ImportClient
     }
 
     /**
-     * Scan the remote index file for symlink entries whose targets are
+     * Scan the next remote index file for symlink entries whose targets are
      * directories not already in $visited.  Returns an array of real paths.
      *
      * Skips entries marked as "intermediate" — those are path-component
      * symlinks (e.g. /srv/wordpress -> /wordpress) emitted by the server's
      * discover_path_symlinks() for local recreation only, not for indexing.
      */
-    private function extract_symlink_dirs_from_index(array $visited): array
+    private function extract_symlink_directories_from_next_remote_index(array $visited): array
     {
         $symlink_targets = [];
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->next_remote_index_file)) {
             return $symlink_targets;
         }
 
-        $handle = fopen($this->remote_index_file, "r");
-        if (!$handle) {
+        $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
+        if (!$next_remote_index_file_handle) {
             return $symlink_targets;
         }
 
-        while (($line = fgets($handle)) !== false) {
-            $entry = json_decode($line, true);
-            if (!is_array($entry)) {
+        while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
+            $next_remote_index_entry = json_decode($next_remote_index_json_line, true);
+            if (!is_array($next_remote_index_entry)) {
                 continue;
             }
-            if (($entry["type"] ?? "") !== "link") {
+            if (($next_remote_index_entry["type"] ?? "") !== "link") {
                 continue;
             }
-            if (!empty($entry["intermediate"])) {
+            if (!empty($next_remote_index_entry["intermediate"])) {
                 continue;
             }
-            $symlink_target_encoded = $entry["target"] ?? null;
+            $symlink_target_encoded = $next_remote_index_entry["target"] ?? null;
             if (!is_string($symlink_target_encoded) || $symlink_target_encoded === "") {
                 continue;
             }
@@ -3418,7 +3420,7 @@ class ImportClient
 
             $symlink_targets[] = $symlink_target;
         }
-        fclose($handle);
+        fclose($next_remote_index_file_handle);
 
         return array_values(array_unique($symlink_targets));
     }
@@ -3441,32 +3443,32 @@ class ImportClient
      */
     private function recreate_intermediate_symlinks(): void
     {
-        if (!file_exists($this->remote_index_file)) {
+        if (!file_exists($this->next_remote_index_file)) {
             return;
         }
 
-        $h = fopen($this->remote_index_file, "r");
-        if (!$h) {
+        $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
+        if (!$next_remote_index_file_handle) {
             return;
         }
 
         $created = 0;
-        while (($line = fgets($h)) !== false) {
-            $entry = json_decode($line, true);
-            if (!is_array($entry)) {
+        while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
+            $next_remote_index_entry = json_decode($next_remote_index_json_line, true);
+            if (!is_array($next_remote_index_entry)) {
                 continue;
             }
-            if (($entry["type"] ?? "") !== "link") {
+            if (($next_remote_index_entry["type"] ?? "") !== "link") {
                 continue;
             }
-            if (empty($entry["intermediate"])) {
+            if (empty($next_remote_index_entry["intermediate"])) {
                 continue;
             }
-            $symlink_target_encoded = $entry["target"] ?? null;
+            $symlink_target_encoded = $next_remote_index_entry["target"] ?? null;
             if (!is_string($symlink_target_encoded) || $symlink_target_encoded === "") {
                 continue;
             }
-            $path_encoded = $entry["path"] ?? null;
+            $path_encoded = $next_remote_index_entry["path"] ?? null;
             if (!is_string($path_encoded) || $path_encoded === "") {
                 continue;
             }
@@ -3479,7 +3481,12 @@ class ImportClient
              */
             $remote_absolute_path = base64_decode($path_encoded, true);
             $symlink_target = base64_decode($symlink_target_encoded, true);
-            if ($remote_absolute_path === false || $remote_absolute_path === "" || $symlink_target === false || $symlink_target === "") {
+            if (
+                $remote_absolute_path === false ||
+                $remote_absolute_path === "" ||
+                $symlink_target === false ||
+                $symlink_target === ""
+            ) {
                 continue;
             }
 
@@ -3569,7 +3576,7 @@ class ImportClient
                 );
             }
         }
-        fclose($h);
+        fclose($next_remote_index_file_handle);
 
         if ($created > 0) {
             $this->audit_log(
@@ -3816,31 +3823,31 @@ class ImportClient
      * Print file index statistics: total indexed files and their size,
      * plus pending downloads and their size.
      *
-     * Reads pull/remote-index.jsonl for all indexed files and
+     * Reads pull/remote-index.next.jsonl for all indexed files and
      * pull/fetch-list.jsonl for files not yet downloaded.
      */
     private function run_files_stats(): void
     {
-        $remote_index = $this->remote_index_file;
+        $next_remote_index_file = $this->next_remote_index_file;
         $fetch_list = $this->fetch_list_file;
 
-        // Single pass over the remote index to build a path→size map.
+        // Single pass over the next remote index to build a path→size map.
         // Duplicates (from overlapping symlink targets) are collapsed
         // automatically because later entries overwrite earlier ones in
         // the map, so the counts we derive are always deduplicated.
         $size_by_path = [];
 
-        if (is_file($remote_index)) {
-            $handle = fopen($remote_index, "r");
-            if ($handle) {
-                while (($line = fgets($handle)) !== false) {
-                    $entry = $this->parse_index_line($line);
-                    if ($entry === null) {
+        if (is_file($next_remote_index_file)) {
+            $next_remote_index_file_handle = fopen($next_remote_index_file, "r");
+            if ($next_remote_index_file_handle) {
+                while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
+                    $next_remote_index_entry = $this->parse_index_line($next_remote_index_json_line);
+                    if ($next_remote_index_entry === null) {
                         continue;
                     }
-                    $size_by_path[$entry["path"]] = $entry["size"];
+                    $size_by_path[$next_remote_index_entry["path"]] = $next_remote_index_entry["size"];
                 }
-                fclose($handle);
+                fclose($next_remote_index_file_handle);
             }
         }
 
@@ -5982,7 +5989,7 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
-        // Always send directory[] – see comment in fetch_remote_index().
+        // Always send directory[] – see comment in fetch_next_remote_index().
         $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
@@ -6228,9 +6235,9 @@ class ImportClient
     }
 
     /**
-     * Download the remote index stream and write to disk.
+     * Download the next remote index stream and write to disk.
      */
-    private function fetch_remote_index(?string $list_dir_override = null): bool
+    private function fetch_next_remote_index(?string $list_dir_override = null): bool
     {
         $cursor = $this->get_state()->index->cursor;
 
@@ -6242,27 +6249,27 @@ class ImportClient
             );
         }
 
-        $mode = file_exists($this->remote_index_file) ? "a" : "w";
+        $next_remote_index_file_mode = file_exists($this->next_remote_index_file) ? "a" : "w";
         // Initialize the index counter from the existing file so resume
         // shows a monotonically increasing count.
-        if ($mode === "a" && $this->index_entries_counted === 0) {
-            $this->index_entries_counted = $this->count_newlines($this->remote_index_file);
+        if ($next_remote_index_file_mode === "a" && $this->next_remote_index_entries_counted === 0) {
+            $this->next_remote_index_entries_counted = $this->count_newlines($this->next_remote_index_file);
         }
-        if ($mode === "w") {
+        if ($next_remote_index_file_mode === "w") {
             $this->audit_log(
-                "FILE CREATE | {$this->remote_index_file} | downloading fresh remote index",
+                "FILE CREATE | {$this->next_remote_index_file} | downloading next remote index from the beginning",
             );
         } else {
             $this->audit_log(
-                "FILE APPEND | {$this->remote_index_file} | resuming remote index download",
+                "FILE APPEND | {$this->next_remote_index_file} | resuming next remote index download",
             );
         }
-        $handle = fopen($this->remote_index_file, $mode);
-        if (!$handle) {
-            throw new RuntimeException("Failed to open remote index file");
+        $next_remote_index_file_handle = fopen($this->next_remote_index_file, $next_remote_index_file_mode);
+        if (!$next_remote_index_file_handle) {
+            throw new RuntimeException("Failed to open next remote index file");
         }
 
-        $complete = false;
+        $next_remote_index_is_complete = false;
         $chunks_since_save = 0;
 
         $export_dirs = $this->get_export_directories();
@@ -6304,9 +6311,9 @@ class ImportClient
 
         $context->on_chunk = function ($chunk) use (
             &$cursor,
-            &$complete,
+            &$next_remote_index_is_complete,
             &$chunks_since_save,
-            $handle,
+            $next_remote_index_file_handle,
             $context
         ) {
             if ($this->shutdown_requested) {
@@ -6365,17 +6372,17 @@ class ImportClient
                     $size = (int) ($item["size"] ?? 0);
                     $type = (string) ($item["type"] ?? "file");
 
-                    $entry = [
+                    $next_remote_index_entry = [
                         "path" => base64_encode($path),
                         "ctime" => $ctime,
                         "size" => $size,
                         "type" => $type,
                     ];
                     if (isset($item["target"]) && is_string($item["target"]) && $item["target"] !== "") {
-                        $entry["target"] = $item["target"]; // already base64-encoded
+                        $next_remote_index_entry["target"] = $item["target"]; // already base64-encoded
                     }
                     if (!empty($item["intermediate"])) {
-                        $entry["intermediate"] = true;
+                        $next_remote_index_entry["intermediate"] = true;
                     }
                     if (array_key_exists("empty", $item) && !is_bool($item["empty"])) {
                         throw new RuntimeException(
@@ -6384,25 +6391,28 @@ class ImportClient
                         );
                     }
                     if (isset($item["empty"])) {
-                        $entry["empty"] = $item["empty"];
+                        $next_remote_index_entry["empty"] = $item["empty"];
                     }
-                    $line = json_encode(
-                        $entry,
+                    $next_remote_index_json_line = json_encode(
+                        $next_remote_index_entry,
                         JSON_UNESCAPED_SLASHES,
                     );
-                    if ($line === false) {
+                    if ($next_remote_index_json_line === false) {
                         continue;
                     }
-                    $bytes = fwrite($handle, $line . "\n");
-                    if ($bytes === false) {
-                        throw new RuntimeException("Failed to write to remote index file (disk full?)");
+                    $next_remote_index_bytes_written = fwrite(
+                        $next_remote_index_file_handle,
+                        $next_remote_index_json_line . "\n"
+                    );
+                    if ($next_remote_index_bytes_written === false) {
+                        throw new RuntimeException("Failed to write to next remote index file (disk full?)");
                     }
-                    $this->index_entries_counted++;
+                    $this->next_remote_index_entries_counted++;
                 }
-                if ($this->index_entries_counted > 0) {
+                if ($this->next_remote_index_entries_counted > 0) {
                     $this->progress->show_progress_line(
                         "Scanning remote files — " .
-                        number_format($this->index_entries_counted) . " scanned"
+                        number_format($this->next_remote_index_entries_counted) . " scanned"
                     );
                 } else {
                     $this->progress->show_progress_line("Scanning remote files");
@@ -6412,7 +6422,7 @@ class ImportClient
             } elseif ($chunk_type === "metadata") {
                 $this->handle_metadata_chunk($chunk);
             } elseif ($chunk_type === "completion") {
-                $complete =
+                $next_remote_index_is_complete =
                     ($chunk["headers"]["x-status"] ?? "") === "complete";
                 $context->saw_completion = true;
                 $context->response_stats = [
@@ -6450,7 +6460,7 @@ class ImportClient
                 $cursor,
                 $e,
             );
-            fclose($handle);
+            fclose($next_remote_index_file_handle);
             $this->get_state()->index->cursor = $cursor;
             $this->get_state()->active_resumable_command->completion_state = "partial";
             $this->save_state();
@@ -6463,27 +6473,27 @@ class ImportClient
             $wall_time,
             $context->response_stats ?? [],
         );
-        fclose($handle);
+        fclose($next_remote_index_file_handle);
 
-        $this->get_state()->index->cursor = $complete ? null : $cursor;
+        $this->get_state()->index->cursor = $next_remote_index_is_complete ? null : $cursor;
         $this->save_state();
 
-        return $complete;
+        return $next_remote_index_is_complete;
     }
 
     /**
-     * Diff local index against remote index and build fetch list.
+     * Diff local index against next remote index and build fetch list.
      */
     private function diff_indexes_and_build_fetch_list(): bool
     {
-        if (!file_exists($this->remote_index_file)) {
-            throw new RuntimeException("Remote index file not found");
+        if (!file_exists($this->next_remote_index_file)) {
+            throw new RuntimeException("Next remote index file not found");
         }
 
-        $diff = $this->get_state()->diff;
-        $remote_offset = $diff->remote_offset;
-        $last_local_index_entry_path = $diff->local_after;
-        $fetch_list_mode = $remote_offset > 0 ? "a" : "w";
+        $file_diff_progress = $this->get_state()->diff;
+        $next_remote_index_byte_offset = $file_diff_progress->next_remote_index_byte_offset;
+        $last_consumed_local_index_entry_path = $file_diff_progress->last_consumed_local_index_entry_path;
+        $fetch_list_mode = $next_remote_index_byte_offset > 0 ? "a" : "w";
         if ($fetch_list_mode === "w") {
             $this->audit_log(
                 "FILE CREATE | {$this->fetch_list_file} | building fetch list",
@@ -6523,32 +6533,32 @@ class ImportClient
             );
         }
 
-        $remote_index_handle = fopen($this->remote_index_file, "r");
-        if (!$remote_index_handle) {
+        $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
+        if (!$next_remote_index_file_handle) {
             fclose($fetch_list_handle);
-            throw new RuntimeException("Failed to open remote index file");
+            throw new RuntimeException("Failed to open next remote index file");
         }
-        if ($remote_offset > 0) {
-            fseek($remote_index_handle, $remote_offset);
+        if ($next_remote_index_byte_offset > 0) {
+            fseek($next_remote_index_file_handle, $next_remote_index_byte_offset);
         }
 
-        $local_index_handle = file_exists($this->local_index_file)
+        $local_index_file_handle = file_exists($this->local_index_file)
             ? fopen($this->local_index_file, "r")
             : null;
         // Local index entries retain remote absolute paths as the merge key.
-        $local_index_entry = $this->read_index_line($local_index_handle);
-        if ($last_local_index_entry_path) {
+        $local_index_entry = $this->read_index_line($local_index_file_handle);
+        if ($last_consumed_local_index_entry_path) {
             while (
                 $local_index_entry !== null &&
-                strcmp($local_index_entry["path"], $last_local_index_entry_path) <= 0
+                strcmp($local_index_entry["path"], $last_consumed_local_index_entry_path) <= 0
             ) {
-                $local_index_entry = $this->read_index_line($local_index_handle);
+                $local_index_entry = $this->read_index_line($local_index_file_handle);
             }
         }
         $this->open_local_index_wal();
-        $processed = 0;
+        $next_remote_index_entries_processed = 0;
 
-        while (($line = fgets($remote_index_handle)) !== false) {
+        while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
             if ($this->shutdown_requested) {
                 break;
             }
@@ -6557,15 +6567,15 @@ class ImportClient
                 pcntl_signal_dispatch();
             }
 
-            $remote_offset = ftell($remote_index_handle);
-            $remote_index_entry = $this->parse_index_line($line);
-            if (!$remote_index_entry) {
+            $next_remote_index_byte_offset = ftell($next_remote_index_file_handle);
+            $next_remote_index_entry = $this->parse_index_line($next_remote_index_json_line);
+            if (!$next_remote_index_entry) {
                 continue;
             }
 
             while (
                 $local_index_entry !== null &&
-                strcmp($local_index_entry["path"], $remote_index_entry["path"]) < 0
+                strcmp($local_index_entry["path"], $next_remote_index_entry["path"]) < 0
             ) {
                 // The local files index ends up being a union across files-pull --only runs.
                 if ($this->is_selected_for_pulling($local_index_entry["path"])) {
@@ -6573,15 +6583,15 @@ class ImportClient
                     $this->apply_remote_deletion_locally($remote_absolute_path);
                     $this->delete_index_entry($remote_absolute_path);
                 }
-                $last_local_index_entry_path = $local_index_entry["path"];
-                $local_index_entry = $this->read_index_line($local_index_handle);
+                $last_consumed_local_index_entry_path = $local_index_entry["path"];
+                $local_index_entry = $this->read_index_line($local_index_file_handle);
             }
 
-            if ($local_index_entry !== null && $local_index_entry["path"] === $remote_index_entry["path"]) {
+            if ($local_index_entry !== null && $local_index_entry["path"] === $next_remote_index_entry["path"]) {
                 if (
-                    $local_index_entry["ctime"] !== $remote_index_entry["ctime"] ||
-                    $local_index_entry["size"] !== $remote_index_entry["size"] ||
-                    $local_index_entry["type"] !== $remote_index_entry["type"]
+                    $local_index_entry["ctime"] !== $next_remote_index_entry["ctime"] ||
+                    $local_index_entry["size"] !== $next_remote_index_entry["size"] ||
+                    $local_index_entry["type"] !== $next_remote_index_entry["type"]
                 ) {
                     // File is in both indexes but changed on the remote.
                     // Always re-download — this file is in our local index,
@@ -6592,11 +6602,11 @@ class ImportClient
                         (
                             $uploads_basedir !== null
                                 ? path_is_within_root(
-                                    $remote_index_entry["path"],
+                                    $next_remote_index_entry["path"],
                                     $uploads_basedir
                                 )
                                 : strpos(
-                                    $remote_index_entry["path"],
+                                    $next_remote_index_entry["path"],
                                     "wp-content/uploads/"
                                 ) !== false
                         )
@@ -6604,45 +6614,45 @@ class ImportClient
                         ? $skipped_handle
                         : $fetch_list_handle;
                     $this->append_to_fetch_list(
-                        $remote_index_entry["path"],
+                        $next_remote_index_entry["path"],
                         $selected_fetch_list_handle,
                     );
                 }
-                $last_local_index_entry_path = $local_index_entry["path"];
-                $local_index_entry = $this->read_index_line($local_index_handle);
+                $last_consumed_local_index_entry_path = $local_index_entry["path"];
+                $local_index_entry = $this->read_index_line($local_index_file_handle);
             } elseif (
                 $local_index_entry === null ||
-                strcmp($local_index_entry["path"], $remote_index_entry["path"]) > 0
+                strcmp($local_index_entry["path"], $next_remote_index_entry["path"]) > 0
             ) {
-                $skip_reason = $this->should_skip_for_preserve_local($remote_index_entry["path"]);
+                $skip_reason = $this->should_skip_for_preserve_local($next_remote_index_entry["path"]);
                 if ($skip_reason) {
                     $this->audit_log($skip_reason, true);
-                    $this->emit_skip_progress($remote_index_entry["path"]);
+                    $this->emit_skip_progress($next_remote_index_entry["path"]);
                 } else {
                     $selected_fetch_list_handle = (
                         $skipped_handle !== null &&
                         (
                             $uploads_basedir !== null
                                 ? path_is_within_root(
-                                    $remote_index_entry["path"],
+                                    $next_remote_index_entry["path"],
                                     $uploads_basedir
                                 )
                                 : strpos(
-                                    $remote_index_entry["path"],
+                                    $next_remote_index_entry["path"],
                                     "wp-content/uploads/"
                                 ) !== false
                         )
                     )
                         ? $skipped_handle
                         : $fetch_list_handle;
-                    $this->append_to_fetch_list($remote_index_entry["path"], $selected_fetch_list_handle);
+                    $this->append_to_fetch_list($next_remote_index_entry["path"], $selected_fetch_list_handle);
                 }
             }
 
-            $processed++;
-            if ($processed % 200 === 0) {
-                $this->get_state()->diff->remote_offset = $remote_offset;
-                $this->get_state()->diff->local_after = $last_local_index_entry_path;
+            $next_remote_index_entries_processed++;
+            if ($next_remote_index_entries_processed % 200 === 0) {
+                $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
+                $this->get_state()->diff->last_consumed_local_index_entry_path = $last_consumed_local_index_entry_path;
                 if (
                     $this->local_index_wal_handle
                     && !fflush($this->local_index_wal_handle)
@@ -6660,21 +6670,21 @@ class ImportClient
                 $this->apply_remote_deletion_locally($remote_absolute_path);
                 $this->delete_index_entry($remote_absolute_path);
             }
-            $last_local_index_entry_path = $local_index_entry["path"];
-            $local_index_entry = $this->read_index_line($local_index_handle);
+            $last_consumed_local_index_entry_path = $local_index_entry["path"];
+            $local_index_entry = $this->read_index_line($local_index_file_handle);
         }
 
-        if ($local_index_handle) {
-            fclose($local_index_handle);
+        if ($local_index_file_handle) {
+            fclose($local_index_file_handle);
         }
-        fclose($remote_index_handle);
+        fclose($next_remote_index_file_handle);
         fclose($fetch_list_handle);
         if ($skipped_handle !== null) {
             fclose($skipped_handle);
         }
 
-        $this->get_state()->diff->remote_offset = $remote_offset;
-        $this->get_state()->diff->local_after = $last_local_index_entry_path;
+        $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
+        $this->get_state()->diff->last_consumed_local_index_entry_path = $last_consumed_local_index_entry_path;
         $this->apply_local_index_wal();
         $this->save_state();
 
@@ -7031,7 +7041,8 @@ class ImportClient
     }
 
     /**
-     * Remove the local filesystem entry for a deletion reported by the remote index.
+     * Remove a local filesystem entry whose local index entry is absent from the next
+     * remote index.
      */
     private function apply_remote_deletion_locally(string $remote_absolute_path): void
     {
@@ -8475,7 +8486,7 @@ class ImportClient
         // everything else keeps its original (portable) spelling.
         if (
             !$this->follow_symlinks ||
-            !$this->remote_index_contains_remote_absolute_path_prefix($remote_absolute_target)
+            !$this->next_remote_index_contains_remote_absolute_path_prefix($remote_absolute_target)
         ) {
             return $target;
         }
@@ -8499,10 +8510,10 @@ class ImportClient
     }
 
     /**
-     * Checks whether the remote index contains a remote absolute path or one
-     * of its descendants. Runs a memoized O(N) scan of pull/remote-index.jsonl.
+     * Checks whether the next remote index contains a remote absolute path or one
+     * of its descendants. Runs a memoized O(N) scan of pull/remote-index.next.jsonl.
      */
-    private function remote_index_contains_remote_absolute_path_prefix(
+    private function next_remote_index_contains_remote_absolute_path_prefix(
         string $remote_absolute_path
     ): bool {
         $remote_absolute_path = rtrim(normalize_path($remote_absolute_path), "/");
@@ -8510,42 +8521,48 @@ class ImportClient
             return false;
         }
 
-        if (isset($this->remote_index_prefix_cache[$remote_absolute_path])) {
-            return $this->remote_index_prefix_cache[$remote_absolute_path];
+        if (isset($this->next_remote_index_prefix_cache[$remote_absolute_path])) {
+            return $this->next_remote_index_prefix_cache[$remote_absolute_path];
         }
 
-        if (!file_exists($this->remote_index_file)) {
-            $this->remote_index_prefix_cache[$remote_absolute_path] = false;
+        if (!file_exists($this->next_remote_index_file)) {
+            $this->next_remote_index_prefix_cache[$remote_absolute_path] = false;
             return false;
         }
 
-        $h = fopen($this->remote_index_file, "r");
-        if (!$h) {
-            $this->remote_index_prefix_cache[$remote_absolute_path] = false;
+        $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
+        if (!$next_remote_index_file_handle) {
+            $this->next_remote_index_prefix_cache[$remote_absolute_path] = false;
             return false;
         }
 
-        $prefix = $remote_absolute_path . "/";
-        $found = false;
-        while (($line = fgets($h)) !== false) {
+        $remote_absolute_path_prefix = $remote_absolute_path . "/";
+        $path_prefix_found = false;
+        while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
             try {
-                $entry = $this->parse_index_line($line);
+                $next_remote_index_entry = $this->parse_index_line($next_remote_index_json_line);
             } catch (RuntimeException $e) {
                 continue;
             }
-            if ($entry === null) {
+            if ($next_remote_index_entry === null) {
                 continue;
             }
-            $entry_path = $entry["path"];
-            if ($entry_path === $remote_absolute_path || str_starts_with($entry_path, $prefix)) {
-                $found = true;
+            $next_remote_index_entry_path = $next_remote_index_entry["path"];
+            if (
+                $next_remote_index_entry_path === $remote_absolute_path ||
+                str_starts_with(
+                    $next_remote_index_entry_path,
+                    $remote_absolute_path_prefix
+                )
+            ) {
+                $path_prefix_found = true;
                 break;
             }
         }
-        fclose($h);
+        fclose($next_remote_index_file_handle);
 
-        $this->remote_index_prefix_cache[$remote_absolute_path] = $found;
-        return $found;
+        $this->next_remote_index_prefix_cache[$remote_absolute_path] = $path_prefix_found;
+        return $path_prefix_found;
     }
 
     /**
@@ -8620,7 +8637,7 @@ class ImportClient
     /**
      * Refuse to resume a files-pull after changing --only.
      *
-     * The in-progress remote index cursor/file was built from one directory[]
+     * The in-progress next remote index cursor/file was built from one directory[]
      * allowlist. Switching the selected source path prefixes mid-resume would
      * mix indexes from different traversals. Completed runs are allowed to use
      * different --only prefixes because the local index is intentionally a union
@@ -8859,7 +8876,7 @@ class ImportClient
     /**
      * Whether a remote absolute path is selected by the active --only file path
      * prefixes. With no --only flag, every path is selected. A selected root is
-     * excluded because a filtered remote index lists its contents, not the root.
+     * excluded because a filtered next remote index lists its contents, not the root.
      */
     private function is_selected_for_pulling(string $remote_absolute_path): bool
     {
@@ -11013,8 +11030,8 @@ class ImportClient
      */
     private function encode_state_paths(array $state): array
     {
-        $state["diff"]["local_after"] = $this->encode_state_path_value(
-            $state["diff"]["local_after"] ?? null,
+        $state["diff"]["last_consumed_local_index_entry_path"] = $this->encode_state_path_value(
+            $state["diff"]["last_consumed_local_index_entry_path"] ?? null,
         );
         $state["fetch"]["batch_file"] = $this->encode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
@@ -11045,8 +11062,8 @@ class ImportClient
      */
     private function decode_state_paths(array $state): array
     {
-        $state["diff"]["local_after"] = $this->decode_state_path_value(
-            $state["diff"]["local_after"] ?? null,
+        $state["diff"]["last_consumed_local_index_entry_path"] = $this->decode_state_path_value(
+            $state["diff"]["last_consumed_local_index_entry_path"] ?? null,
         );
         $state["fetch"]["batch_file"] = $this->decode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
@@ -12562,7 +12579,7 @@ if (
                 "Output files:\n" .
                 "  (filesystem root)/                       Downloaded files\n" .
                 "  pull/local-index.jsonl          Local index\n" .
-                "  pull/remote-index.jsonl         Remote index\n" .
+                "  pull/remote-index.next.jsonl    Next remote index\n" .
                 "  pull/fetch-list.jsonl           Files pending download\n" .
                 "  pull/skipped-fetch-list.jsonl   Files skipped by --filter=essential-files\n" .
                 "  pull/state.json                 Resumable pull state\n" .
@@ -12615,7 +12632,7 @@ if (
             "description" =>
                 "Streams the full remote directory tree over HTTP and writes each\n" .
                 "entry (path, size, ctime, type, and directory emptiness) to\n" .
-                "pull/remote-index.jsonl.\n" .
+                "pull/remote-index.next.jsonl.\n" .
                 "\n" .
                 "On the first run, builds the complete index. On subsequent runs,\n" .
                 "re-indexes and diffs against the prior snapshot to produce a\n" .
@@ -12629,9 +12646,9 @@ if (
         ],
         "files-stats" => [
             "level" => "low",
-            "short" => "Show file counts and sizes from the local index",
+            "short" => "Show file counts and sizes from the next remote index",
             "description" =>
-                "Reads local index files to report (no network calls):\n" .
+                "Reads the next remote index and fetch lists to report (no network calls):\n" .
                 "\n" .
                 "  - Total indexed files and their combined size\n" .
                 "  - Files not yet downloaded and their combined size\n" .

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -298,7 +298,7 @@ class Pull
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_state();
                 foreach ([
-                    "{$state_dir}/pull/remote-index.jsonl",
+                    "{$state_dir}/pull/remote-index.next.jsonl",
                     "{$state_dir}/pull/fetch-list.jsonl",
                     "{$state_dir}/pull/skipped-fetch-list.jsonl",
                 ] as $path) {
@@ -826,7 +826,7 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $state_dir . "/pull/remote-index.jsonl";
+            $paths[] = $state_dir . "/pull/remote-index.next.jsonl";
             $paths[] = $state_dir . "/pull/fetch-list.jsonl";
             $paths[] = $state_dir . "/pull/skipped-fetch-list.jsonl";
         }

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -88,26 +88,30 @@ class DatabaseTableIndexState
 
 class FileDiffProgressState
 {
-    /** @var int Offset into the remote index while diffing. */
-    public int $remote_offset = 0;
+    /** @var int Byte offset into the next remote index while diffing. */
+    public int $next_remote_index_byte_offset = 0;
 
-    /** @var string|null Last local path seen after the current remote offset. */
-    public ?string $local_after = null;
+    /** @var string|null Last local index entry path consumed at the current next remote index byte offset. */
+    public ?string $last_consumed_local_index_entry_path = null;
 
     public static function from_array(array $data): self
     {
         $state = new self();
         reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
-        $state->remote_offset = $data['remote_offset'];
-        $state->local_after = $data['local_after'];
+        $state->next_remote_index_byte_offset =
+            $data['next_remote_index_byte_offset'];
+        $state->last_consumed_local_index_entry_path =
+            $data['last_consumed_local_index_entry_path'];
         return $state;
     }
 
     public function to_array(): array
     {
         return [
-            'remote_offset' => $this->remote_offset,
-            'local_after' => $this->local_after,
+            'next_remote_index_byte_offset' =>
+                $this->next_remote_index_byte_offset,
+            'last_consumed_local_index_entry_path' =>
+                $this->last_consumed_local_index_entry_path,
         ];
     }
 }

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -24,6 +24,21 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--only=SOURCE', $output);
     }
 
+    public function testFilesIndexHelpNamesTheNextRemoteIndexFile(): void
+    {
+        $output = $this->runHelp('files-index');
+
+        $this->assertStringContainsString('pull/remote-index.next.jsonl', $output);
+    }
+
+    public function testFilesPullHelpNamesTheNextRemoteIndexFile(): void
+    {
+        $output = $this->runHelp('files-pull');
+
+        $this->assertStringContainsString('pull/remote-index.next.jsonl', $output);
+        $this->assertStringContainsString('Next remote index', $output);
+    }
+
     public function testPullDbHelpShowsRequiredAndDatabaseOptions(): void
     {
         $output = $this->runHelp('pull-db');

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * Verify recovery from cURL timeouts during streaming fetches.
  *
- * Each fetch method (fetch_sql, fetch_file_batch, fetch_remote_index,
+ * Each fetch method (fetch_sql, fetch_file_batch, fetch_next_remote_index,
  * fetch_database_index) is tested by injecting a CurlTimeoutException. SQL retries
  * in the same invocation; the other phases save partial state for a later run.
  *
@@ -279,10 +279,10 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // fetch_remote_index: timeout saves state and returns false
+    // fetch_next_remote_index: timeout saves state and returns false
     // ---------------------------------------------------------------
 
-    public function testRemoteIndexTimeoutSavesPartialState()
+    public function testNextRemoteIndexTimeoutSavesPartialState()
     {
         $this->writeState([
             "active_resumable_command" => [
@@ -308,12 +308,12 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $fetchRemoteIndex = $reflection->getMethod('fetch_remote_index');
-        $result = $fetchRemoteIndex->invoke($client);
+        $fetchNextRemoteIndex = $reflection->getMethod('fetch_next_remote_index');
+        $result = $fetchNextRemoteIndex->invoke($client);
 
         $this->assertFalse(
             $result,
-            "fetch_remote_index should return false on timeout"
+            "fetch_next_remote_index should return false on timeout"
         );
 
         $state = $this->readState();
@@ -550,8 +550,8 @@ class CurlTimeoutRecoveryTest extends TestCase
             SuccessTestClient::class,
         );
 
-        $fetchRemoteIndex = $reflection->getMethod('fetch_remote_index');
-        $fetchRemoteIndex->invoke($client);
+        $fetchNextRemoteIndex = $reflection->getMethod('fetch_next_remote_index');
+        $fetchNextRemoteIndex->invoke($client);
 
         $state = $this->readState();
         $this->assertEquals(

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -335,9 +335,9 @@ class FilesPullStateTest extends TestCase
         $localIndex = $this->stateDir . '/pull/local-index.jsonl';
         file_put_contents($localIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 1000, 200));
 
-        // Remote index: same file at ctime 2000 (changed)
-        $remoteIndex = $this->stateDir . '/pull/remote-index.jsonl';
-        file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
+        // Next remote index: same file at ctime 2000 (changed)
+        $nextRemoteIndexFile = $this->stateDir . '/pull/remote-index.next.jsonl';
+        file_put_contents($nextRemoteIndexFile, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
         $localFile = $this->filesystem_root . '/wp-content/themes/flavor/style.css';
@@ -375,9 +375,9 @@ class FilesPullStateTest extends TestCase
         $localIndex = $this->stateDir . '/pull/local-index.jsonl';
         file_put_contents($localIndex, '');
 
-        // Remote index: file exists on remote
-        $remoteIndex = $this->stateDir . '/pull/remote-index.jsonl';
-        file_put_contents($remoteIndex, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
+        // Next remote index: file exists on remote
+        $nextRemoteIndexFile = $this->stateDir . '/pull/remote-index.next.jsonl';
+        file_put_contents($nextRemoteIndexFile, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)
         $localFile = $this->filesystem_root . '/wp-content/object-cache.php';

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -244,7 +244,7 @@ class FollowedSymlinksRootTest extends TestCase
         $rc->getProperty('follow_symlinks')->setValue($c, true);
         $target = $this->root . '/wp-content/themes/x'; // realpath-clean, so it is its own cache key
         // Pretend the target subtree was followed + indexed.
-        $rc->getProperty('remote_index_prefix_cache')->setValue($c, [$target => true]);
+        $rc->getProperty('next_remote_index_prefix_cache')->setValue($c, [$target => true]);
 
         $result = $rc->getMethod('rewrite_symlink_target_for_local_filesystem')->invoke(
             $c,
@@ -271,7 +271,7 @@ class FollowedSymlinksRootTest extends TestCase
         $rc->getProperty('local_followed_symlinks_root')->setValue($c, $this->root . '/.followed-symlinks-root');
         $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, ['/src/wp-content']);
         $rc->getProperty('follow_symlinks')->setValue($c, true);
-        $rc->getProperty('remote_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
+        $rc->getProperty('next_remote_index_prefix_cache')->setValue($c, ['/opt/data' => true]);
 
         $entry = json_encode([
             'path' => base64_encode('/src/wp-content/data'),
@@ -279,7 +279,7 @@ class FollowedSymlinksRootTest extends TestCase
             'type' => 'link',
             'intermediate' => true,
         ]);
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', $entry . "\n");
+        file_put_contents($this->stateDir . '/pull/remote-index.next.jsonl', $entry . "\n");
 
         $rc->getMethod('recreate_intermediate_symlinks')->invoke($c);
 

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * --only: the diff must reconcile only within the --only file path prefixes. A remote index built
+ * --only: the diff must reconcile only within the --only file path prefixes. A next remote index built
  * with --only lists selected paths only, so the delete drains in
  * diff_indexes_and_build_fetch_list() would otherwise wrongly delete every
  * unselected local entry. Guard both drains so unselected local files +
@@ -129,7 +129,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     public function testOnlyFilesPrefixDiffKeepsUnselectedAndDeletesSelectedOrphan(): void
     {
         // Local index (sorted): an unselected entry, a matched selected file,
-        // and a selected orphan absent from the --only remote index. The
+        // and a selected orphan absent from the --only next remote index. The
         // delete drains must reconcile only within the --only file prefixes, so the local index
         // accumulates as a union across files-pull --only runs.
         $this->writeIndex('pull/local-index.jsonl',
@@ -137,7 +137,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
             . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // selected orphan
         );
-        $this->writeIndex('pull/remote-index.jsonl',
+        $this->writeIndex('pull/remote-index.next.jsonl',
             $this->indexLine('/wp-content/keep.txt', 1000, 10)
         );
 
@@ -158,7 +158,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
     public function testOnlyRootItselfSurvivesTheDeleteDrains(): void
     {
-        // A remote index built with --only lists each selected directory's
+        // A next remote index built with --only lists each selected directory's
         // *contents* but never the directory itself, so the --only roots
         // always look deleted-on-remote to the diff. The drains must not
         // delete them: that would recursively remove the very directories
@@ -169,7 +169,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             . $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
             . $this->indexLine('/wp-content/themes/old/orphan.css', 1000, 10)
         );
-        $this->writeIndex('pull/remote-index.jsonl',
+        $this->writeIndex('pull/remote-index.next.jsonl',
             $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
         );
 

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -268,7 +268,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', '');
+        file_put_contents($this->stateDir . '/pull/remote-index.next.jsonl', '');
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
@@ -285,7 +285,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunRecordsOnlyFingerprintForInProgressFilesPullState(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', '');
+        file_put_contents($this->stateDir . '/pull/remote-index.next.jsonl', '');
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => null,
         ));

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -43,6 +43,8 @@ class PullStateTest extends TestCase
         $state->active_resumable_command->command_name = 'db-pull';
         $state->active_resumable_command->completion_state = 'complete';
         $state->pull_pipeline->started_by_command = 'pull';
+        $state->diff->next_remote_index_byte_offset = 123;
+        $state->diff->last_consumed_local_index_entry_path = '/wp-content/index.php';
         $state->sql_statements_counted = 99;
 
         $array = $state->to_array();
@@ -50,6 +52,8 @@ class PullStateTest extends TestCase
         $this->assertSame('db-pull', $array['active_resumable_command']['command_name']);
         $this->assertSame('complete', $array['active_resumable_command']['completion_state']);
         $this->assertSame('pull', $array['pull_pipeline']['started_by_command']);
+        $this->assertSame(123, $array['diff']['next_remote_index_byte_offset']);
+        $this->assertSame('/wp-content/index.php', $array['diff']['last_consumed_local_index_entry_path']);
         $this->assertSame(99, $array['sql_statements_counted']);
     }
 
@@ -79,6 +83,22 @@ class PullStateTest extends TestCase
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('unexpected status');
+
+        \PullState::from_array($data);
+    }
+
+    public function testStateRejectsDiffFieldsFromThePreviousSchema(): void
+    {
+        $data = (new \PullState())->to_array();
+        $data['diff'] = [
+            'remote_offset' => 123,
+            'local_after' => '/wp-content/index.php',
+        ];
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'missing last_consumed_local_index_entry_path, next_remote_index_byte_offset; unexpected local_after, remote_offset'
+        );
 
         \PullState::from_array($data);
     }

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -45,7 +45,7 @@ final class ReprintProcessLockTest extends TestCase
             'pull_state_file' => $this->root . '/state/pull/state.json',
             'local_index_file' => $this->root . '/state/pull/local-index.jsonl',
             'local_index_wal_path' => $this->root . '/state/pull/local-index.wal',
-            'remote_index_file' => $this->root . '/state/pull/remote-index.jsonl',
+            'next_remote_index_file' => $this->root . '/state/pull/remote-index.next.jsonl',
             'fetch_list_file' => $this->root . '/state/pull/fetch-list.jsonl',
             'skipped_fetch_list_file' => $this->root . '/state/pull/skipped-fetch-list.jsonl',
             'volatile_files_file' => $this->root . '/state/pull/volatile-files.json',

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -97,7 +97,7 @@ describe('Import: Basic File Sync', () => {
         assert.ok(existsSync(indexFile), 'Expected local index to be preserved after --abort');
 
         // Transient files should be cleaned up
-        assert.ok(!existsSync(join(tempDir, 'pull/remote-index.jsonl')), 'Expected remote index to be deleted');
+        assert.ok(!existsSync(join(tempDir, 'pull/remote-index.next.jsonl')), 'Expected next remote index to be deleted');
         assert.ok(!existsSync(join(tempDir, 'pull/fetch-list.jsonl')), 'Expected fetch list to be deleted');
     });
 

--- a/tests/e2e/tests/import-04-files-index.test.js
+++ b/tests/e2e/tests/import-04-files-index.test.js
@@ -1,6 +1,6 @@
 /**
  * Test 04: Files Index via import.php
- * Tests files-index command produces pull/remote-index.jsonl.
+ * Tests files-index command produces pull/remote-index.next.jsonl.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -30,16 +30,27 @@ describe('Import: Files Index', () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('files-index produces pull/remote-index.jsonl', () => {
+    it('files-index produces pull/remote-index.next.jsonl', () => {
         const result = runImporter(importUrl(), tempDir, 'files-index', {
             secret: getSiteSecret(site),
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const indexFile = join(tempDir, 'pull/remote-index.jsonl');
-        assert.ok(existsSync(indexFile), 'Expected pull/remote-index.jsonl to exist');
+        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const completion = result.stdout
+            .split('\n')
+            .map(line => {
+                try {
+                    return JSON.parse(line);
+                } catch {
+                    return null;
+                }
+            })
+            .find(event => event?.command === 'files-index' && event?.event === 'complete');
+        assert.equal(completion?.next_remote_index_file, nextRemoteIndexFile);
+        assert.ok(existsSync(nextRemoteIndexFile), 'Expected pull/remote-index.next.jsonl to exist');
 
-        const lines = readFileSync(indexFile, 'utf-8').trim().split('\n').filter(l => l);
+        const lines = readFileSync(nextRemoteIndexFile, 'utf-8').trim().split('\n').filter(l => l);
         assert.ok(lines.length > 0, 'Expected at least one index entry');
 
         // Entries should include paths from the site directory
@@ -51,20 +62,20 @@ describe('Import: Files Index', () => {
         assert.ok(hasPaths, `Expected entries with file paths, got: ${JSON.stringify(entries.slice(0, 2))}`);
 
         const directories = entries.filter(e => e.type === 'dir');
-        assert.ok(directories.length > 0, 'Expected directory entries in remote index');
+        assert.ok(directories.length > 0, 'Expected directory entries in next remote index');
         for (const directory of directories) {
             assert.equal(
                 typeof directory.empty,
                 'boolean',
-                `Expected directory emptiness in remote index: ${JSON.stringify(directory)}`,
+                `Expected directory emptiness in next remote index: ${JSON.stringify(directory)}`,
             );
         }
     });
 
-    it('remote index has at least 3000 entries', () => {
-        const indexFile = join(tempDir, 'pull/remote-index.jsonl');
-        const count = countJsonlLines(indexFile);
+    it('next remote index has at least 3000 entries', () => {
+        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const count = countJsonlLines(nextRemoteIndexFile);
         assert.ok(count >= 3000,
-            `Expected at least 3000 entries in remote index, got ${count}`);
+            `Expected at least 3000 entries in next remote index, got ${count}`);
     });
 });

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -328,10 +328,10 @@ describe('Import: Follow Symlinks', () => {
 
     it('multiple symlinks to same target do not create duplicate index entries', () => {
         // After sort+dedup, each path should appear at most once
-        const remoteIndex = join(tempDir, 'pull/remote-index.jsonl');
-        if (!existsSync(remoteIndex)) return;
+        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        if (!existsSync(nextRemoteIndexFile)) return;
 
-        const lines = readFileSync(remoteIndex, 'utf-8').split('\n').filter(l => l.trim());
+        const lines = readFileSync(nextRemoteIndexFile, 'utf-8').split('\n').filter(l => l.trim());
         const paths = new Set();
         let duplicates = 0;
         for (const line of lines) {
@@ -348,7 +348,7 @@ describe('Import: Follow Symlinks', () => {
             }
         }
         assert.equal(duplicates, 0,
-            `Expected no duplicate paths in remote index, found ${duplicates}`);
+            `Expected no duplicate paths in next remote index, found ${duplicates}`);
     });
 
     it('shared-target files are downloaded exactly once', () => {

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -224,10 +224,10 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
         const statePath = join(tempDir, 'pull/state.json');
         const state = JSON.parse(readFileSync(statePath, 'utf-8'));
 
-        assert.equal(typeof state.diff.local_after, 'string', 'Expected diff.local_after to be persisted');
+        assert.equal(typeof state.diff.last_consumed_local_index_entry_path, 'string', 'Expected diff.last_consumed_local_index_entry_path to be persisted');
         assert.ok(
-            state.diff.local_after.startsWith('base64:'),
-            `Expected base64-encoded diff.local_after, got: ${state.diff.local_after}`,
+            state.diff.last_consumed_local_index_entry_path.startsWith('base64:'),
+            `Expected base64-encoded diff.last_consumed_local_index_entry_path, got: ${state.diff.last_consumed_local_index_entry_path}`,
         );
 
         if (typeof state.fetch.batch_file === 'string') {

--- a/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
+++ b/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
@@ -79,10 +79,10 @@ describe('Import: Symlink cycle detection', () => {
         // A WordPress site has ~4000-6000 files.  Without cycle detection
         // the self-symlink would double that on every depth level.  With
         // cycle detection the total should stay in the normal range.
-        const remoteIndex = join(tempDir, 'pull/remote-index.jsonl');
-        assert.ok(existsSync(remoteIndex), 'Remote index should exist');
+        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        assert.ok(existsSync(nextRemoteIndexFile), 'Next remote index should exist');
 
-        const count = countJsonlLines(remoteIndex);
+        const count = countJsonlLines(nextRemoteIndexFile);
         // The site has ~4-6K real files.  Allow up to 2x for one level
         // of symlink following, but not 3x+ which indicates a cycle leak.
         assert.ok(
@@ -93,8 +93,8 @@ describe('Import: Symlink cycle detection', () => {
     });
 
     it('the marker file is indexed exactly once per reachable path', () => {
-        const remoteIndex = join(tempDir, 'pull/remote-index.jsonl');
-        const content = readFileSync(remoteIndex, 'utf-8');
+        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const content = readFileSync(nextRemoteIndexFile, 'utf-8');
         const lines = content.split('\n').filter(l => l.trim());
 
         // Decode all paths and count how many end with /marker.txt


### PR DESCRIPTION
`files-index` and the index phase of `files-pull` now write the current selection of remote paths as the next remote index at `pull/remote-index.next.jsonl`.

This is the first vocabulary step. `pull/local-index.jsonl` remains the accounted pull baseline; the next stacked PR renames that baseline to the remote index.

The filename, identifiers, help text, progress output, and persisted diff positions use the same term. Pull state has no migration layer, so an existing state directory must be discarded before running this revision. Retaining the former byte position with the new empty filename could skip part of the snapshot.

## Testing

`cd tests && ../vendor/bin/phpunit Import`

`php ../composer.phar analyze -- --memory-limit=1G`

`vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-importer/src`