### PR TITLE
Store each remote Reprint API URL's push state under remotes/<hash>/push

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,9 @@ Reprint uses `$STATE_DIR` exactly as supplied. Consumers that want the state
 hidden can choose a directory named `.reprint`; Reprint does not append that
 name itself. Shared command progress and the audit log live directly in the
 state directory. Pull-owned state lives in `pull/`, while remote-specific push
-state lives in `push/<md5-of-trimmed-remote-reprint-api-url>/`. Shared and pull
-filenames do not begin with a dot or repeat the scope supplied by their parent
-directory.
+state lives in
+`remotes/<md5-of-trimmed-remote-reprint-api-url>/push/`. Shared and pull filenames
+do not begin with a dot or repeat the scope supplied by their parent directory.
 
 `pull/state.json` and `progress.json` are written atomically:
 a `.tmp` file is written first and then renamed to its final name so readers

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -85,8 +85,8 @@ The local machine keeps these files **per remote Reprint API URL**, overwritten
 after each successful commit. The state directory already selects one
 filesystem root:
 
-    <state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/previous_local_index.jsonl
-    <state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/previously_pushed_rows.jsonl   (phase two)
+    <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/previous_local_index.jsonl
+    <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/previously_pushed_rows.jsonl   (phase two)
 
 The previous local index records the local path type, size, and ctime as the
 completing push observed them. Besides planning the next push, it feeds the
@@ -285,7 +285,7 @@ prevents concurrent pull, push, diff, and other local Reprint processes from
 using that site state, regardless of their remote Reprint API URLs.
 
 An active push keeps these files under
-`<state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/`:
+`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/`:
 
 ```text
 previous_local_index.jsonl          index saved after the previous commit
@@ -417,7 +417,9 @@ write `pull/state.json`, show a plan, ask for confirmation, transfer a
 database, retry a failed request, or start a replacement sender after a
 `restart` outcome.
 
-The local push state directory is `<state-dir>/push/` followed by:
+The local push state directory is
+`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash
+directory name is:
 
 ```text
 md5(rtrim(<remote-reprint-api-url>, "?&"))

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -162,7 +162,10 @@ Reprint uses it exactly as supplied and does not append `.reprint`. A consumer
 may choose `.reprint` or any other private directory name. The **pull state
 directory** is `<state-dir>/pull`; use `$pull_state_directory`. Filenames
 inside the state directory do not begin with a dot or repeat the scope supplied
-by their parent directories.
+by their parent directories. A **remote state directory** contains state for
+one remote Reprint API URL. It is
+`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>`; use
+`$remote_state_directory`.
 
 ```text
 <state-dir>/
@@ -180,8 +183,9 @@ by their parent directories.
 │   ├── domains.json
 │   ├── sql-stats.json
 │   └── sql-buffer
-└── push/
+└── remotes/
     └── <md5-of-trimmed-remote-reprint-api-url>/
+        └── push/
 ```
 
 Use these path names:
@@ -190,6 +194,7 @@ Use these path names:
 | --- | --- |
 | State directory | `$state_dir` |
 | Pull state directory | `$pull_state_directory` |
+| Remote state directory | `$remote_state_directory` |
 | Pull state file | `$pull_state_file` |
 | Remote index file | `$remote_index_file` |
 | Remote index WAL | `$remote_index_wal_path` |
@@ -239,8 +244,8 @@ command; unrelated commands do not consume it.
 
 The local machine keeps planning and active state outside the receiver push
 directory. Under
-`<state-dir>/push/<md5-of-trimmed-remote-reprint-api-url>/`, use these names
-verbatim:
+`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/`, use these
+names verbatim:
 
 | Surface | Name |
 | --- | --- |
@@ -349,7 +354,9 @@ exporter API URL, and its `filesystem root` is the resolved absolute directory s
 `--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
 plain-HTTP opt-in.
 
-The **local push state directory** is `<state-dir>/push/` followed by:
+The **local push state directory** is
+`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash
+directory name is:
 
 ```text
 md5(rtrim(<remote-reprint-api-url>, "?&"))

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1814,7 +1814,9 @@ class ImportClient
         $resolved_local_filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
         $remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
         // Resolve an absolute physical path even when its final components do not exist.
-        $push_state_directory = $state_dir . '/push/' . md5($remote_reprint_api_url);
+        $remote_state_directory =
+            $state_dir . '/remotes/' . md5($remote_reprint_api_url);
+        $push_state_directory = $remote_state_directory . '/push';
         if (strpos($push_state_directory, '/') !== 0) {
             $working_directory = getcwd();
             if ($working_directory === false) {

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -394,8 +394,9 @@ final class FilesDiffCommandTest extends TestCase
     private function pushStateDirectory(): string
     {
         return realpath($this->stateDirectory)
-            . '/push/'
-            . md5(rtrim($this->targetUrl, '?&'));
+            . '/remotes/'
+            . md5(rtrim($this->targetUrl, '?&'))
+            . '/push';
     }
 
     /** @param list<string> $extraArguments

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -54,7 +54,10 @@ final class FilesPushCommandTest extends TestCase
         );
         $trimmedRemoteReprintApiUrl = rtrim($remoteReprintApiUrl, '?&');
         $expectedPushStateDirectory =
-            realpath($this->stateDirectory) . '/push/' . md5($trimmedRemoteReprintApiUrl);
+            realpath($this->stateDirectory)
+            . '/remotes/'
+            . md5($trimmedRemoteReprintApiUrl)
+            . '/push';
 
         $this->assertSame($trimmedRemoteReprintApiUrl, $context['remote_reprint_api_url']);
         $this->assertSame(realpath($this->localTree), $context['filesystem_root']);
@@ -82,7 +85,10 @@ final class FilesPushCommandTest extends TestCase
             $differentQuery['push_state_directory']
         );
         $this->assertSame(
-            realpath($otherStateDirectory) . '/push/' . md5($trimmedRemoteReprintApiUrl),
+            realpath($otherStateDirectory)
+                . '/remotes/'
+                . md5($trimmedRemoteReprintApiUrl)
+                . '/push',
             $differentFilesystemRootContext['push_state_directory']
         );
     }
@@ -354,7 +360,7 @@ final class FilesPushCommandTest extends TestCase
 
     private function assertNoSenderState(string $stateDirectory): void
     {
-        $senderPaths = glob($stateDirectory . '/push/*/sender.json');
+        $senderPaths = glob($stateDirectory . '/remotes/*/push/sender.json');
         $this->assertIsArray($senderPaths);
         $this->assertSame([], $senderPaths);
     }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -3017,7 +3017,10 @@ final class PushEndpointsTest extends TestCase {
 
     private function filesPushStateDirectory(string $state_directory): string
     {
-        return $state_directory . '/push/' . md5(rtrim($this->remote_reprint_api_url, '?&'));
+        return $state_directory
+            . '/remotes/'
+            . md5(rtrim($this->remote_reprint_api_url, '?&'))
+            . '/push';
     }
 
     /** @return array<string,mixed> */


### PR DESCRIPTION
`files-push` and `files-diff` now resolve their local push state directory as `<state-dir>/remotes/<hash>/push` instead of `<state-dir>/push/<hash>`.

| | Before | After |
| --- | --- | --- |
| Local push state directory | `<state-dir>/push/<hash>` | `<state-dir>/remotes/<hash>/push` |

`<hash>` keeps its existing definition:

```text
md5(rtrim(<remote-reprint-api-url>, "?&"))
```

The state directory still identifies one filesystem root, and the hash still identifies one trimmed remote Reprint API URL. This PR changes only their hierarchy: the directory for one remote Reprint API URL is now the parent, and the push-specific directory is its `push/` child.

## What the directories mean

`<state-dir>/remotes/<hash>` is the **remote state directory**. It is the common parent for local Reprint state keyed by one remote Reprint API URL.

Its `push/` child remains because `sender.json`, `excluded_paths.json`, and `plan/` describe planning, transferring, and resuming a push. This PR moves the existing local push state directory as one unit, so `previous_local_index.jsonl` also remains inside `push/`. It does not rename that index or change its ownership; later index work can review that separately.

Pull state does not move in this PR. It remains under `<state-dir>/pull`.

## Existing state

There is no migration from `<state-dir>/push/<hash>`. `files-push` and `files-diff` neither read nor move state from that former path. With the new layout, they start without that retained push state and write only beneath `<state-dir>/remotes/<hash>/push`.

The sender state format, push plan format, remote URL hash, filesystem-root rules, and receiver-side push state do not change.

## Testing

Run `files-diff` and `files-push` against two remote Reprint API URLs using one state directory. Confirm that each URL uses its own `remotes/<hash>/push` directory and that no sender state is written beneath the former `<state-dir>/push/<hash>` path.
